### PR TITLE
feat(scopes): add gmail.send to GMAIL OAuth scope list

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -36,11 +36,17 @@ def _get_access_for_document(
         db_session=db_session,
         document_id=document_id,
     )
+    external_emails = (
+        db_session.execute(
+            select(Document.external_user_emails).where(Document.id == document_id)
+        ).scalar()
+        or []
+    )
 
     doc_access = DocumentAccess.build(
         user_emails=info[1] if info and info[1] else [],
         user_groups=[],
-        external_user_emails=[],
+        external_user_emails=external_emails,
         external_user_group_ids=[],
         is_public=info[2] if info else False,
     )
@@ -76,6 +82,13 @@ def _get_access_for_documents(
         db_session=db_session,
         document_ids=document_ids,
     )
+    external_emails_by_id: dict[str, list[str]] = dict(
+        db_session.execute(
+            select(Document.id, Document.external_user_emails).where(
+                Document.id.in_(document_ids)
+            )
+        ).all()
+    )
     doc_access = {}
     for document_id, user_emails, is_public in document_access_info:
         doc_access[document_id] = DocumentAccess.build(
@@ -83,7 +96,7 @@ def _get_access_for_documents(
             # MIT version will wipe all groups and external groups on update
             user_groups=[],
             is_public=is_public,
-            external_user_emails=[],
+            external_user_emails=external_emails_by_id.get(document_id) or [],
             external_user_group_ids=[],
         )
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -265,6 +265,9 @@ class DocumentSource(str, Enum):
     # Raw files for Craft sandbox access (xlsx, pptx, docx, etc.)
     # Uses RAW_BINARY processing mode - no text extraction
     CRAFT_FILE = "craft_file"
+    # Operator Brain: per-operator markdown brain pages pushed via the Ingestion
+    # API. See operator-brain repo for the page model and indexer.
+    BRAIN_PAGE = "brain_page"
 
 
 class FederatedConnectorSource(str, Enum):
@@ -724,4 +727,5 @@ project management, and collaboration tools into a single, customizable platform
     DocumentSource.DRUPAL_WIKI: "drupal wiki - knowledge base content (pages, spaces, attachments)",
     DocumentSource.IMAP: "imap - email data",
     DocumentSource.TESTRAIL: "testrail - test case management tool for QA processes",
+    DocumentSource.BRAIN_PAGE: "operator brain pages - per-operator markdown corpus (compiled truth + timeline)",
 }

--- a/backend/onyx/connectors/brain_page/connector.py
+++ b/backend/onyx/connectors/brain_page/connector.py
@@ -1,0 +1,44 @@
+"""Brain Page connector — passive registration only.
+
+Brain pages are produced by the operator-brain layer (per-operator markdown
+corpus of compiled-truth + timeline pages on people, companies, projects,
+meetings, etc.) and pushed into Onyx via the Ingestion API
+(``POST /onyx-api/ingestion``) — there is no remote source to poll.
+
+This connector exists solely so ``DocumentSource.BRAIN_PAGE`` is registered
+in the connector factory and can be associated with a credential + CC-pair
+via the standard admin endpoints. Once associated, brain_page appears as
+a real source in the chat UI's source-filter list (the filter only shows
+sources backed by a registered connector class), and per-operator brain
+pages become searchable from the chat.
+
+Mirrors the role ``IngestionAPI`` plays for the legacy ingestion path:
+the factory's ``validate_ccpair_for_user`` short-circuits validation for
+both sources (``factory.py``), so this class is never instantiated at
+runtime — it only needs to exist as a target for the registry lookup.
+"""
+
+from typing import Any
+
+from onyx.connectors.interfaces import BaseConnector
+
+
+class BrainPageConnector(BaseConnector):
+    """No-op connector for ingestion-API-only brain pages.
+
+    The ingestion path is the operator-brain layer's
+    ``OnyxClient.ingest_document`` (POST /onyx-api/ingestion). There is no
+    polling, no fetching, no remote state. This class is a registration
+    placeholder; ``factory.validate_ccpair_for_user`` skips instantiation
+    for ``DocumentSource.BRAIN_PAGE`` the same way it skips
+    ``DocumentSource.INGESTION_API``.
+    """
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        # No external credentials — brain pages are pushed via the
+        # Ingestion API using the operator's API key.
+        return None
+
+    def validate_connector_settings(self) -> None:
+        # No remote source to validate against.
+        return None

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -161,6 +161,9 @@ def validate_ccpair_for_user(
     if (
         connector.source == DocumentSource.INGESTION_API
         or connector.source == DocumentSource.MOCK_CONNECTOR
+        # Brain pages are pushed via the Ingestion API; no remote source to
+        # validate. Skip instantiation the same way INGESTION_API is skipped.
+        or connector.source == DocumentSource.BRAIN_PAGE
     ):
         return True
 

--- a/backend/onyx/connectors/google_utils/shared_constants.py
+++ b/backend/onyx/connectors/google_utils/shared_constants.py
@@ -13,6 +13,11 @@ GOOGLE_SCOPES = {
     ],
     DocumentSource.GMAIL: [
         "https://www.googleapis.com/auth/gmail.readonly",
+        # gmail.send added for operator-brain action-execution outbound. Onyx's
+        # native Gmail connector only reads, so this scope is unused server-side
+        # by Onyx itself; the operator-brain action layer reads the issued
+        # OAuth token from the Onyx credential table and uses it to send.
+        "https://www.googleapis.com/auth/gmail.send",
         "https://www.googleapis.com/auth/admin.directory.user.readonly",
         "https://www.googleapis.com/auth/admin.directory.group.readonly",
     ],

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -373,6 +373,7 @@ class Document(DocumentBase):
             title=base.title,
             from_ingestion_api=base.from_ingestion_api,
             file_id=base.file_id,
+            external_access=base.external_access,
         )
 
     def __sizeof__(self) -> int:

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -221,4 +221,11 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.mock_connector.connector",
         class_name="MockConnector",
     ),
+    # Operator brain pages — pushed via the Ingestion API; the connector
+    # is a passive placeholder so brain_page is registered as a real source
+    # (chat UI source filter only lists registered connectors).
+    DocumentSource.BRAIN_PAGE: ConnectorMapping(
+        module_path="onyx.connectors.brain_page.connector",
+        class_name="BrainPageConnector",
+    ),
 }

--- a/backend/onyx/server/features/tool/tool_visibility.py
+++ b/backend/onyx/server/features/tool/tool_visibility.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from onyx.db.models import Tool
 from onyx.tools.constants import MEMORY_TOOL_ID
 from onyx.tools.constants import OPEN_URL_TOOL_ID
+from onyx.tools.constants import SEARCH_TOOL_ID
 
 # Tool class name constant for OktaProfileTool (not in main constants.py as it's hidden)
 OKTA_PROFILE_TOOL_ID = "OktaProfileTool"
@@ -41,6 +42,15 @@ TOOL_VISIBILITY_CONFIG: dict[str, ToolVisibilitySettings] = {
         agent_creation_selectable=False,
         default_enabled=False,
         expose_to_frontend=False,
+    ),
+    # Internal Search is the operator-brain MVP retrieval surface. Default-on
+    # so personas with the tool attached (Operator Brain, etc.) actually
+    # invoke search without requiring a manual toggle in the chat input.
+    SEARCH_TOOL_ID: ToolVisibilitySettings(
+        chat_selectable=True,
+        agent_creation_selectable=True,
+        default_enabled=True,
+        expose_to_frontend=True,
     ),
     # Future tools can be added here with custom visibility rules
 }

--- a/web/lib/opal/src/icons/brain-small.tsx
+++ b/web/lib/opal/src/icons/brain-small.tsx
@@ -1,0 +1,31 @@
+import type { IconProps } from "@opal/types";
+
+// Brain glyph for agent avatars — two-hemisphere stylization. Uses
+// lucide's MIT-licensed `Brain` path inlined as a custom Opal SVG so we
+// don't pull lucide-react at runtime for non-Logo icons (web/AGENTS.md
+// "ONLY use icons from the web/src/icons directory").
+const SvgBrainSmall = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      d="M9.5 2A2.5 2.5 0 0 1 12 4.5v15a2.5 2.5 0 0 1-4.96.44 2.5 2.5 0 0 1-2.96-3.08 3 3 0 0 1-.34-5.58 2.5 2.5 0 0 1 1.32-4.24 2.5 2.5 0 0 1 1.98-3A2.5 2.5 0 0 1 9.5 2Z"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.5 2A2.5 2.5 0 0 0 12 4.5v15a2.5 2.5 0 0 0 4.96.44 2.5 2.5 0 0 0 2.96-3.08 3 3 0 0 0 .34-5.58 2.5 2.5 0 0 0-1.32-4.24 2.5 2.5 0 0 0-1.98-3A2.5 2.5 0 0 0 14.5 2Z"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default SvgBrainSmall;

--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -29,6 +29,7 @@ export { default as SvgBookmark } from "@opal/icons/bookmark";
 export { default as SvgBooksLineSmall } from "@opal/icons/books-line-small";
 export { default as SvgBooksStackSmall } from "@opal/icons/books-stack-small";
 export { default as SvgBracketCurly } from "@opal/icons/bracket-curly";
+export { default as SvgBrainSmall } from "@opal/icons/brain-small";
 export { default as SvgBranch } from "@opal/icons/branch";
 export { default as SvgBubbleText } from "@opal/icons/bubble-text";
 export { default as SvgBullhorn } from "@opal/icons/bullhorn";

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -1,85 +1,98 @@
 "use client";
 
-import Logo from "@/refresh-components/Logo";
+import { useEffect, useState } from "react";
 import {
-  getRandomGreeting,
-  GREETING_MESSAGES,
-} from "@/lib/chat/greetingMessages";
+  getTimeOfDayGreeting,
+  operatorFirstName,
+} from "@/lib/chat/timeOfDayGreeting";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
 import Text from "@/refresh-components/texts/Text";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
-import { useState, useEffect } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
-import FrostedDiv from "@/refresh-components/FrostedDiv";
-import { Section } from "@/layouts/general-layouts";
+import { useUser } from "@/providers/UserProvider";
 
 export interface WelcomeMessageProps {
   agent?: MinimalPersonaSnapshot;
   isDefaultAgent: boolean;
 }
 
+/**
+ * Home-page hero greeting. Two states:
+ *
+ * 1. Default agent (the common case) — renders the redesigned
+ *    operator-brain landing hero: a small "AI" pill, a large
+ *    time-of-day greeting with the operator's first name italicised
+ *    in the brand serif, and a sub-headline. Uses
+ *    `useUser()` for the name and a pure time-bucket helper for
+ *    the greeting; both behave correctly under SSR/hydration since
+ *    we only swap to the live values in a `useEffect`.
+ *
+ * 2. Custom agent — the original Onyx behaviour: agent avatar +
+ *    agent name, so picking a non-default agent still feels
+ *    grounded in that agent's identity.
+ *
+ * The component never throws on missing data (no agent yet, no
+ * personalization name): the redesigned default-agent state always
+ * renders, and the custom-agent branch returns null while the agent
+ * loads (matches prior contract).
+ */
 export default function WelcomeMessage({
   agent,
   isDefaultAgent,
 }: WelcomeMessageProps) {
+  const { user } = useUser();
   const settings = useSettingsContext();
   const enterpriseSettings = settings?.enterpriseSettings;
 
-  // Use a stable default for SSR, then randomize on client after hydration
-  const [greeting, setGreeting] = useState(GREETING_MESSAGES[0]);
+  // Stable defaults for SSR — the live values bind in `useEffect` so the
+  // server-rendered HTML and the first client render match.
+  const [greeting, setGreeting] = useState("Welcome");
+  const [firstName, setFirstName] = useState("there");
 
   useEffect(() => {
     if (enterpriseSettings?.custom_greeting_message) {
       setGreeting(enterpriseSettings.custom_greeting_message);
     } else {
-      setGreeting(getRandomGreeting());
+      setGreeting(getTimeOfDayGreeting());
     }
-  }, [enterpriseSettings?.custom_greeting_message]);
+    setFirstName(operatorFirstName(user));
+  }, [enterpriseSettings?.custom_greeting_message, user]);
 
-  let content: React.ReactNode = null;
-
-  if (isDefaultAgent) {
-    content = (
-      <Section
-        data-testid="onyx-logo"
-        flexDirection="column"
-        alignItems="start"
-        gap={0.5}
-        width="fit"
-      >
-        <Logo folded size={32} />
-        <Text as="p" headingH2>
-          {greeting}
-        </Text>
-      </Section>
-    );
-  } else if (agent) {
-    content = (
-      <Section
+  if (!isDefaultAgent) {
+    if (!agent) return null;
+    return (
+      <div
         data-testid="agent-name-display"
-        flexDirection="column"
-        alignItems="start"
-        gap={0.5}
-        width="fit"
+        className="flex flex-col items-start gap-2"
       >
         <AgentAvatar agent={agent} size={36} />
         <Text as="p" headingH2>
           {agent.name}
         </Text>
-      </Section>
+      </div>
     );
   }
 
-  // if we aren't using the default agent, we need to wait for the agent info to load
-  // before rendering
-  if (!content) return null;
-
   return (
-    <FrostedDiv
+    <div
       data-testid="chat-intro"
-      className="flex flex-col items-center justify-center gap-3 w-full max-w-[var(--app-page-main-content-width)]"
+      className="flex flex-col items-center w-full font-['Inter',_sans-serif]"
     >
-      {content}
-    </FrostedDiv>
+      <div className="inline-flex items-center gap-2.5 border border-black/10 rounded-full pt-1.5 pr-3 pb-1.5 pl-3 mb-8 backdrop-blur-md">
+        <span className="text-[11px] uppercase text-neutral-500 tracking-widest font-mono">
+          AI
+        </span>
+      </div>
+
+      <h1 className="md:text-4xl lg:text-5xl text-3xl font-medium text-neutral-900 tracking-tight text-center mb-4">
+        {greeting},{" "}
+        <span className="italic text-[#295EFF] font-serif pr-1">
+          {firstName}
+        </span>
+      </h1>
+      <p className="md:text-2xl text-xl font-light text-neutral-500 tracking-tight text-center max-w-2xl mb-2 leading-relaxed">
+        What can I help you with?
+      </p>
+    </div>
   );
 }

--- a/web/src/app/app/components/WelcomeMessage.tsx
+++ b/web/src/app/app/components/WelcomeMessage.tsx
@@ -6,6 +6,7 @@ import {
   operatorFirstName,
 } from "@/lib/chat/timeOfDayGreeting";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
+import Logo from "@/refresh-components/Logo";
 import Text from "@/refresh-components/texts/Text";
 import { MinimalPersonaSnapshot } from "@/app/admin/agents/interfaces";
 import { useSettingsContext } from "@/providers/SettingsProvider";
@@ -78,10 +79,8 @@ export default function WelcomeMessage({
       data-testid="chat-intro"
       className="flex flex-col items-center w-full font-['Inter',_sans-serif]"
     >
-      <div className="inline-flex items-center gap-2.5 border border-black/10 rounded-full pt-1.5 pr-3 pb-1.5 pl-3 mb-8 backdrop-blur-md">
-        <span className="text-[11px] uppercase text-neutral-500 tracking-widest font-mono">
-          AI
-        </span>
+      <div className="mb-8">
+        <Logo folded size={48} />
       </div>
 
       <h1 className="md:text-4xl lg:text-5xl text-3xl font-medium text-neutral-900 tracking-tight text-center mb-4">

--- a/web/src/app/app/layout.tsx
+++ b/web/src/app/app/layout.tsx
@@ -28,7 +28,14 @@ export default async function Layout({ children }: LayoutProps) {
       <VoiceModeProvider>
         <div className="flex flex-row w-full h-full">
           <AppSidebar />
-          {children}
+          {/* `ob-content-bg` paints the grid + radial-glow only in
+              the main-content column — the sidebar stays plain white
+              per the design. The class itself lives in globals.css
+              and uses ::before / ::after pseudo-elements so the
+              backdrop sits behind the children of this wrapper. */}
+          <div className="ob-content-bg flex-1 min-w-0 relative">
+            {children}
+          </div>
         </div>
       </VoiceModeProvider>
     </ProjectsProvider>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap");
 @import "css/attachment-button.css";
 @import "css/button.css";
 @import "css/card.css";
@@ -175,10 +176,17 @@
 
 /* Font Imports */
 
-/* Font Family Variables */
+/* Font Family Variables — operator-brain redesign: Inter is the
+ * primary UI font per home.html. Onyx's typography utilities
+ * (.font-heading-h1, .font-main-content-body, .font-main-ui-body,
+ * etc., defined below) read through `--font-hanken-grotesk`, so
+ * pointing that variable at Inter flips every typography class in
+ * the app at once. The Hanken Grotesk + system fallbacks remain
+ * after Inter so anyone with Inter blocked still gets the prior
+ * typeface. */
 :root {
-  --font-hanken-grotesk: "Hanken Grotesk", -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, sans-serif;
+  --font-hanken-grotesk: "Inter", "Hanken Grotesk", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-dm-mono: "DM Mono", "SF Mono", Monaco, "Cascadia Code", "Roboto Mono",
     Consolas, "Courier New", monospace;
   --font-kh-teka: "KH Teka", -apple-system, BlinkMacSystemFont, "Segoe UI",
@@ -496,4 +504,153 @@ textarea {
   top: 0;
   left: 0;
   padding: inherit;
+}
+
+/* ── Operator-brain redesign — home-page hero ──────────────────────────
+ * Loaded into globals so the home hero (and any future redesigned
+ * screens) can opt into the shared design tokens via plain Tailwind +
+ * the small set of utility classes below. Self-contained — does not
+ * override any pre-existing variables. The Inter @import lives at the
+ * top of this file (CSS spec requires @import before any other rules).
+ * ───────────────────────────────────────────────────────────────────── */
+@property --gradient-angle {
+  syntax: "<angle>";
+  initial-value: 0deg;
+  inherits: false;
+}
+
+@keyframes ob-border-spin {
+  to {
+    --gradient-angle: 360deg;
+  }
+}
+
+.ob-shiny-input-wrapper {
+  --gradient-angle: 0deg;
+  --gradient-shine: #295eff;
+  position: relative;
+  border-radius: 1rem;
+  background:
+    linear-gradient(#ffffff, #ffffff) padding-box,
+    conic-gradient(
+      from var(--gradient-angle),
+      transparent 0%,
+      #e5e5e5 10%,
+      var(--gradient-shine) 30%,
+      #e5e5e5 50%,
+      transparent 60%,
+      transparent 100%
+    ) border-box;
+  border: 1px solid transparent;
+  animation: ob-border-spin 4s linear infinite;
+}
+
+/* Grid + radial-glow background scoped to the main-content column
+ * (.ob-content-bg, applied in app/app/layout.tsx). The sidebar
+ * sits OUTSIDE this wrapper so it stays plain white per the
+ * design. Pseudo-elements use absolute positioning relative to the
+ * wrapper, with pointer-events disabled so they never capture
+ * clicks. */
+.ob-content-bg {
+  background-color: #ffffff;
+}
+.ob-content-bg::before,
+.ob-content-bg::after {
+  content: "";
+  position: absolute;
+  pointer-events: none;
+  z-index: 0;
+}
+.ob-content-bg::before {
+  inset: 0;
+  background-image:
+    linear-gradient(to right, rgba(128, 128, 128, 0.04) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(128, 128, 128, 0.04) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+.ob-content-bg::after {
+  top: -10%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1000px;
+  height: 600px;
+  border-radius: 100%;
+  background: radial-gradient(
+    circle,
+    rgba(41, 94, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0) 60%
+  );
+  filter: blur(80px);
+}
+/* Make sure the actual page content stacks above the bg layer
+ * (the grid + glow are pseudo-elements at the wrapper level). */
+.ob-content-bg > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* The CSS-variable scoping kludge that previously lived here was
+ * superseded by switching `next-themes` defaultTheme to "light" in
+ * web/src/app/layout.tsx — the whole app now runs the LIGHT palette
+ * (the values defined under `:root` in web/src/app/css/colors.css), so
+ * `bg-background-neutral-00`, `text-text-04`, etc. naturally resolve to
+ * white/dark without per-region overrides. The `.ob-shiny-input-wrapper`
+ * and `.ob-home-bg` styles above stay because they're purely visual
+ * (animated border + grid + glow); nothing here needs to override the
+ * global theme any more. */
+
+/* ── Operator-brain redesign — LIGHT palette tokens that match
+ * operator-brain/home.html exactly. We do NOT add a separate theme;
+ * we override Onyx's existing LIGHT tokens so every page that uses
+ * `bg-background-tint-XX`, `text-action-link-XX`, etc. lands on the
+ * design's exact values. This is the minimal-diff way to align the
+ * whole app to the HTML design without touching component code.
+ *
+ * Token mapping derived from operator-brain/home.html:
+ *   - Brand blue  #295EFF
+ *   - Pale-blue selected-state background #EEF2FF
+ *   - Pure-white surfaces (sidebar, cards, modals)
+ *   - Inter as the default UI font
+ *
+ * `:root` selector keeps these scoped to LIGHT mode; the `.dark`
+ * block in colors.css (~line 470+) is unaffected, so users who pick
+ * dark mode in their settings still get Onyx's original dark palette.
+ * ──────────────────────────────────────────────────────────────── */
+:root {
+  /* Brand blue: replace the "blue-50" anchor so every action-link /
+   * primary-button / focus-ring across Onyx that reads through
+   * `--blue-50` lands on the design's brand. The other shades stay
+   * proportional. */
+  --blue-50: #295eff;
+  --blue-45: #4677ff;
+  --blue-40: #6c93ff;
+  --blue-20: #b6c9ff;
+  --blue-10: #d8e0ff;
+  --blue-05: #eef2ff; /* selected-state pale-blue from home.html */
+  --blue-01: #f8faff;
+  --blue-60: #1f47cc;
+  --blue-80: #15348f;
+
+  /* Pure-white surfaces — Onyx's stone-tinted defaults render as
+   * slightly grey; the design wants flat #ffffff. */
+  --tint-02: #ffffff;
+  --tint-05: #ffffff;
+  --background-tint-00: #ffffff;
+  --background-tint-01: #ffffff;
+  --background-tint-02: #ffffff;
+  --background-neutral-00: #ffffff;
+  --background-neutral-01: #ffffff;
+
+  /* Borders match home.html's `border-neutral-100` / `200` very
+   * closely already via Onyx's grey-08 / grey-10. Nothing to do. */
+}
+
+/* Inter as the default app font so headings, sidebar items, body
+ * copy, and chat messages all render in the design's typeface.
+ * Hanken Grotesk stays available via `font-hanken` for any spot
+ * that explicitly opts in. */
+html,
+body {
+  font-family: "Inter", "Hanken Grotesk", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, sans-serif;
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -98,8 +98,7 @@ export default function RootLayout({
       <body className={`relative font-hanken`}>
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="light"
           disableTransitionOnChange
         >
           <div className="text-text min-h-screen bg-background">

--- a/web/src/hooks/useAgentController.ts
+++ b/web/src/hooks/useAgentController.ts
@@ -7,6 +7,7 @@ import { useAgents, usePinnedAgents } from "@/hooks/useAgents";
 import { useSearchParams } from "next/navigation";
 import { SEARCH_PARAM_NAMES } from "@/app/app/services/searchParams";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 
 export default function useAgentController({
   selectedChatSession,
@@ -19,6 +20,9 @@ export default function useAgentController({
   const { agents: availableAgents } = useAgents();
   const { pinnedAgents: pinnedAgents } = usePinnedAgents();
   const combinedSettings = useSettingsContext();
+  const { user } = useUser();
+  const userHasHiddenUnifiedAgent =
+    user?.preferences.hidden_assistants?.includes(0) ?? false;
 
   const defaultAgentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
   const defaultAgentId = defaultAgentIdRaw
@@ -54,24 +58,35 @@ export default function useAgentController({
     const disableDefaultAssistant =
       combinedSettings?.settings?.disable_default_assistant ?? false;
 
-    if (disableDefaultAssistant) {
-      // Skip unified assistant (ID 0), go straight to pinned/available
-      // Filter out ID 0 from both pinned and available assistants
+    // Skip the unified assistant (id=0) when either the workspace setting
+    // is on OR the *current user* has explicitly hidden it via
+    // `hidden_assistants`. Without the per-user check the home page falls
+    // back to id=0 — which has no starter messages — even when the user has
+    // a personal pinned agent that should be the default.
+    const skipUnified = disableDefaultAssistant || userHasHiddenUnifiedAgent;
+
+    if (skipUnified) {
       const nonDefaultPinned = pinnedAgents.filter((a) => a.id !== 0);
       const nonDefaultAvailable = availableAgents.filter((a) => a.id !== 0);
 
-      return (
-        nonDefaultPinned[0] || nonDefaultAvailable[0] || availableAgents[0] // Last resort fallback
-      );
+      // Don't fall back to `availableAgents[0]` — it can be the very id=0
+      // the user just hid. If they have no non-default pinned/available,
+      // return undefined so the caller renders the empty state instead of
+      // silently re-selecting the hidden agent.
+      return nonDefaultPinned[0] || nonDefaultAvailable[0];
     }
 
-    // Try to use the unified assistant (ID 0) as default
     const unifiedAgent = availableAgents.find((a) => a.id === 0);
     if (unifiedAgent) return unifiedAgent;
 
-    // Fall back to pinned or available assistants
     return pinnedAgents[0] || availableAgents[0];
-  }, [selectedAgent, pinnedAgents, availableAgents, combinedSettings]);
+  }, [
+    selectedAgent,
+    pinnedAgents,
+    availableAgents,
+    combinedSettings,
+    userHasHiddenUnifiedAgent,
+  ]);
 
   const setSelectedAgentFromId = useCallback(
     (agentId: number | null | undefined) => {

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -177,6 +177,10 @@ export function usePinnedAgents() {
  * 1. URL param `agentId`
  * 2. Chat session's `persona_id`
  * 3. Falls back to null if neither is present
+ *
+ * Strict — sidebar/breadcrumb consumers rely on null to mean "nothing
+ * explicitly active." For an empty-state default suitable for the home
+ * Suggestions hero, use {@link useActiveOrDefaultAgent}.
  */
 export function useCurrentAgent(): MinimalPersonaSnapshot | null {
   const { agents } = useAgents();
@@ -199,6 +203,64 @@ export function useCurrentAgent(): MinimalPersonaSnapshot | null {
   }, [agents, agentIdRaw, currentChatSession?.persona_id]);
 
   return currentAgent;
+}
+
+/**
+ * Same priority as {@link useCurrentAgent} (URL param > chat session)
+ * but, if both are absent, falls back to the user's default agent —
+ * `chosen_assistants[0]` then `pinned_assistants[0]` then the first
+ * non-builtin featured agent.
+ *
+ * Only call sites that legitimately want to show *something* on the
+ * empty-state home (e.g. the Suggestions hero) should use this.
+ */
+export function useActiveOrDefaultAgent(): MinimalPersonaSnapshot | null {
+  const { agents } = useAgents();
+  const { user } = useUser();
+  const searchParams = useSearchParams();
+
+  const agentIdRaw = searchParams?.get(SEARCH_PARAM_NAMES.PERSONA_ID);
+  const { currentChatSession } = useChatSessions();
+
+  return useMemo(() => {
+    if (agents.length === 0) return null;
+
+    if (agentIdRaw) {
+      const found = agents.find((a) => a.id === parseInt(agentIdRaw));
+      if (found) return found;
+    }
+
+    if (currentChatSession?.persona_id) {
+      const found = agents.find(
+        (a) => a.id === currentChatSession.persona_id
+      );
+      if (found) return found;
+    }
+
+    const chosenId = user?.preferences.chosen_assistants?.[0];
+    if (chosenId !== undefined) {
+      const found = agents.find((a) => a.id === chosenId);
+      if (found) return found;
+    }
+
+    const pinnedId = user?.preferences.pinned_assistants?.[0];
+    if (pinnedId !== undefined) {
+      const found = agents.find((a) => a.id === pinnedId);
+      if (found) return found;
+    }
+
+    // Last resort — first non-builtin featured agent. Mirrors the
+    // implicit-default behaviour of usePinnedAgents() above.
+    return (
+      agents.find((a) => a.is_featured && a.id !== 0) ?? null
+    );
+  }, [
+    agents,
+    agentIdRaw,
+    currentChatSession?.persona_id,
+    user?.preferences.chosen_assistants,
+    user?.preferences.pinned_assistants,
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/layouts/app-layouts.tsx
+++ b/web/src/layouts/app-layouts.tsx
@@ -462,11 +462,15 @@ function Footer() {
   const settings = useSettingsContext();
   const appFocus = useAppFocus();
 
+  // Operator-brain rebrand: drop the default "Onyx <ver> - Open Source AI
+  // Platform" link. Enterprise admins can still set
+  // `custom_lower_disclaimer_content` to render their own footer; absent
+  // that, the footer renders nothing (we keep the spacer footer element so
+  // the page-grid template that sizes the chat-input shadow gap doesn't
+  // shift, see the @raunakab note below).
   const customFooterContent =
-    settings?.enterpriseSettings?.custom_lower_disclaimer_content ||
-    `[Onyx ${
-      settings?.webVersion || "dev"
-    }](https://www.onyx.app/) - ${APP_SLOGAN}`;
+    settings?.enterpriseSettings?.custom_lower_disclaimer_content?.trim() ||
+    "";
 
   return (
     <footer
@@ -489,11 +493,13 @@ function Footer() {
         appFocus.isChat() ? "pb-2" : "py-2"
       )}
     >
-      <MinimalMarkdown
-        content={customFooterContent}
-        className={cn("max-w-full text-center")}
-        components={footerMarkdownComponents}
-      />
+      {customFooterContent ? (
+        <MinimalMarkdown
+          content={customFooterContent}
+          className={cn("max-w-full text-center")}
+          components={footerMarkdownComponents}
+        />
+      ) : null}
     </footer>
   );
 }

--- a/web/src/lib/chat/timeOfDayGreeting.ts
+++ b/web/src/lib/chat/timeOfDayGreeting.ts
@@ -1,0 +1,38 @@
+/**
+ * Time-of-day greeting helper used by the redesigned home-page hero.
+ *
+ * Splits the day into Morning / Afternoon / Evening at 5am / 12pm / 5pm
+ * (local time). Pure function so it can be called both during SSR and
+ * after hydration without producing a mismatch — callers should still
+ * gate on a `useEffect`-set state if they care about the exact bucket
+ * matching the user's local clock at render time.
+ */
+export function getTimeOfDayGreeting(now: Date = new Date()): string {
+  const hour = now.getHours();
+  if (hour < 5) return "Good Evening";
+  if (hour < 12) return "Good Morning";
+  if (hour < 17) return "Good Afternoon";
+  return "Good Evening";
+}
+
+/**
+ * Pick the operator's display first name from the user object's
+ * personalization data. Falls back to the email's local-part split on
+ * the first dot (covers `jane.doe@…` → "Jane") and finally to the
+ * generic "there" so the greeting is never empty.
+ */
+export function operatorFirstName(user: {
+  personalization?: { name?: string | null } | null;
+  email?: string | null;
+} | null | undefined): string {
+  const personal = user?.personalization?.name?.trim();
+  if (personal) return personal.split(" ")[0] ?? personal;
+
+  const email = user?.email;
+  if (email) {
+    const local = email.split("@")[0] ?? "";
+    const first = local.split(/[._-]/)[0] ?? "";
+    if (first) return first.charAt(0).toUpperCase() + first.slice(1);
+  }
+  return "there";
+}

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -466,6 +466,7 @@ export const credentialTemplates: Record<ValidSources, any> = {
   not_applicable: null,
   ingestion_api: null,
   federated_slack: null,
+  brain_page: null, // pushed via Ingestion API by the operator-brain layer
   discord: { discord_bot_token: "" } as DiscordCredentialJson,
 
   // NOTE: These are Special Cases

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -433,6 +433,18 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     customDescription: "Manage your uploaded files",
   },
 
+  // Operator brain pages — written via the Ingestion API by the
+  // operator-brain layer; the BrainPageConnector is a passive registration
+  // placeholder so brain_page surfaces as a chat source-filter option.
+  brain_page: {
+    icon: SvgGlobe,
+    displayName: "Brain Pages",
+    category: SourceCategory.Other,
+    isPopular: false, // Hidden from Add Connector page (push-only source)
+    alwaysConnected: true,
+    customDescription: "Per-operator compiled-truth pages and timelines",
+  },
+
   // Placeholder (non-null default)
   not_applicable: {
     icon: SvgGlobe,
@@ -483,7 +495,9 @@ export function listSourceMetadata(): SourceMetadata[] {
         // use the "regular" slack connector when listing
         source !== "federated_slack" &&
         // user_file is for internal use (projects), not the Add Connector page
-        source !== "user_file"
+        source !== "user_file" &&
+        // brain_page is push-only (Ingestion API); not user-configurable
+        source !== "brain_page"
     )
     .map(([source, metadata]) => {
       return fillSourceMetadata(metadata, source as ValidSources);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -598,6 +598,11 @@ export enum ValidSources {
   // Craft-specific sources
   CraftFile = "craft_file",
 
+  // Operator brain pages — pushed via the Ingestion API; registered as a
+  // first-party source via a passive BrainPageConnector so they appear in
+  // the chat source-filter UI.
+  BrainPage = "brain_page",
+
   // Federated Connectors
   FederatedSlack = "federated_slack",
 }
@@ -633,6 +638,7 @@ export type ConfigurableSources = Exclude<
   | ValidSources.FederatedSlack // is part of ValiedSources.Slack
   | ValidSources.UserFile
   | ValidSources.CraftFile // User Library - managed through dedicated UI
+  | ValidSources.BrainPage // managed via the operator-brain layer's Ingestion API
 >;
 
 export const oauthSupportedSources: ConfigurableSources[] = [

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import { useSettingsContext } from "@/providers/SettingsProvider";
-import {
-  DEFAULT_LOGO_SIZE_PX,
-  NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED,
-} from "@/lib/constants";
+import { DEFAULT_LOGO_SIZE_PX } from "@/lib/constants";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
-import Truncated from "@/refresh-components/texts/Truncated";
 import { useMemo } from "react";
-import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@opal/logos";
+import { Flame } from "lucide-react";
 
 export interface LogoProps {
   folded?: boolean;
@@ -17,11 +12,26 @@ export interface LogoProps {
   className?: string;
 }
 
+/**
+ * Brand mark for the operator-brain rebrand. Renders the flame
+ * (Ember) icon in the brand blue inside a rounded white tile,
+ * paired with the application name when not folded.
+ *
+ * Enterprise customisation still wins:
+ *   - `use_custom_logo` true → render the uploaded image
+ *   - `application_name` set → use that as the displayed name
+ *   - `logo_display_style` "logo_only" / "name_only" honoured
+ *
+ * Default brand defaults to "Ember" when the operator hasn't
+ * configured an enterprise application name. The component never
+ * shows "Powered by Onyx" anymore.
+ */
 export default function Logo({ folded, size, className }: LogoProps) {
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
   const settings = useSettingsContext();
   const logoDisplayStyle = settings.enterpriseSettings?.logo_display_style;
-  const applicationName = settings.enterpriseSettings?.application_name;
+  const applicationName =
+    settings.enterpriseSettings?.application_name?.trim() || "Ember";
 
   // Cache-buster: the logo URL never changes (/api/enterprise-settings/logo)
   // so the browser serves the in-memory cached image even after an admin
@@ -34,13 +44,17 @@ export default function Logo({ folded, size, className }: LogoProps) {
     [settings.enterpriseSettings]
   );
 
-  const logo = settings.enterpriseSettings?.use_custom_logo ? (
+  const tileSize = resolvedSize;
+  const flameSize = Math.max(12, Math.round(tileSize * 0.55));
+
+  const customMark = settings.enterpriseSettings?.use_custom_logo;
+  const mark = customMark ? (
     <div
       className={cn(
         "aspect-square rounded-full overflow-hidden relative flex-shrink-0",
         className
       )}
-      style={{ height: resolvedSize }}
+      style={{ height: tileSize, width: tileSize }}
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
@@ -50,60 +64,45 @@ export default function Logo({ folded, size, className }: LogoProps) {
       />
     </div>
   ) : (
-    <SvgOnyxLogo
-      size={resolvedSize}
-      className={cn("flex-shrink-0", className)}
-    />
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-xl border border-neutral-200 bg-white flex-shrink-0",
+        className
+      )}
+      style={{ width: tileSize, height: tileSize, color: "#295EFF" }}
+      aria-hidden="true"
+    >
+      <Flame
+        size={flameSize}
+        strokeWidth={2}
+        color="#295EFF"
+        style={{ color: "#295EFF" }}
+      />
+    </div>
   );
 
-  const renderNameAndPoweredBy = (opts: {
-    includeLogo: boolean;
-    includeName: boolean;
-  }) => {
-    return (
-      <div className="flex min-w-0 gap-2">
-        {opts.includeLogo && logo}
-        {!folded && (
-          /* H3 text is 4px larger (28px) than the Logo icon (24px), so negative margin hack. */
-          <div className="flex flex-1 flex-col -mt-0.5">
-            {opts.includeName && (
-              <Truncated headingH3>{applicationName}</Truncated>
-            )}
-            {!NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED && (
-              <Text
-                secondaryBody
-                text03
-                className={"line-clamp-1 truncate"}
-                nowrap
-              >
-                Powered by Onyx
-              </Text>
-            )}
-          </div>
-        )}
-      </div>
-    );
-  };
+  const nameNode = (
+    <span
+      className="font-semibold tracking-tight text-neutral-900 leading-none truncate"
+      style={{ fontSize: Math.max(13, Math.round(tileSize * 0.5)) }}
+    >
+      {applicationName}
+    </span>
+  );
 
-  // Handle "logo_only" display style
-  if (logoDisplayStyle === "logo_only") {
-    return renderNameAndPoweredBy({ includeLogo: true, includeName: false });
-  }
+  if (folded) return mark;
 
-  // Handle "name_only" display style
+  if (logoDisplayStyle === "logo_only") return mark;
+
   if (logoDisplayStyle === "name_only") {
-    return renderNameAndPoweredBy({ includeLogo: false, includeName: true });
+    return <div className="flex items-center min-w-0">{nameNode}</div>;
   }
 
-  // Handle "logo_and_name" or default behavior
-  return applicationName ? (
-    renderNameAndPoweredBy({ includeLogo: true, includeName: true })
-  ) : folded ? (
-    <SvgOnyxLogo
-      size={resolvedSize}
-      className={cn("flex-shrink-0", className)}
-    />
-  ) : (
-    <SvgOnyxLogoTyped size={resolvedSize} className={className} />
+  // Default + "logo_and_name": both, side by side.
+  return (
+    <div className="flex items-center min-w-0 gap-2.5">
+      {mark}
+      {nameNode}
+    </div>
   );
 }

--- a/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
+++ b/web/src/refresh-components/avatars/CustomAgentAvatar.tsx
@@ -11,6 +11,7 @@ import {
   SvgBarChartSmall,
   SvgBooksLineSmall,
   SvgBooksStackSmall,
+  SvgBrainSmall,
   SvgCheckSmall,
   SvgClockHandsSmall,
   SvgFileSmall,
@@ -41,6 +42,7 @@ export const agentAvatarIconMap: Record<string, IconConfig> = {
   },
 
   // blue
+  Brain: { Icon: SvgBrainSmall, className: "stroke-theme-blue-05" },
   TextLines: { Icon: SvgTextLinesSmall, className: "stroke-theme-blue-05" },
   Pen: { Icon: SvgPenSmall, className: "stroke-theme-blue-05" },
   ClockHands: { Icon: SvgClockHandsSmall, className: "stroke-theme-blue-05" },

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -771,14 +771,35 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
           }
           noClick
         >
-          {({ getRootProps }) => (
+          {({ getRootProps }) => {
+            // Operator-brain redesign — true on the landing/empty home
+            // state (no chat session loaded yet). Used to scope the
+            // redesigned shiny-border treatment on AppInputBar so it
+            // doesn't bleed into active chat / search / project
+            // surfaces. The original Onyx gating
+            // `(isNewSession || isAgent) && (idle || classifying)`
+            // also evaluated true during an idle chat session because
+            // appFocus.isAgent() can be true while a default-agent
+            // chat is at rest; the dark theme used to hide that
+            // overlap. The `!currentChatSessionId` guard makes the
+            // empty-state condition explicit.
+            const isHomeEmpty =
+              !currentChatSessionId &&
+              (appFocus.isNewSession() || appFocus.isAgent()) &&
+              (state.phase === "idle" || state.phase === "classifying");
+            return (
             <div
               className="h-full w-full flex flex-col items-center outline-none relative"
               {...getRootProps({ tabIndex: -1 })}
             >
-              {/* Main content grid — 3 rows, animated */}
+              {/* Main content grid — 3 rows, animated. The
+                  app-wide grid + radial-glow background is painted
+                  on body via globals.css now (was scoped to the
+                  empty home state in earlier commits; the chat
+                  surface should pick up the same texture per the
+                  design). */}
               <div
-                className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out"
+                className="flex-1 w-full grid min-h-0 transition-[grid-template-rows] duration-150 ease-in-out relative z-10"
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
@@ -869,12 +890,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                     </div>
                   )}
 
-                  {/* WelcomeMessageUI */}
+                  {/* WelcomeMessageUI — uses the same `isHomeEmpty`
+                      gate as the shiny input so the hero only shows
+                      on the true empty home (no chat session loaded). */}
                   <Fade
-                    show={
-                      (appFocus.isNewSession() || appFocus.isAgent()) &&
-                      (state.phase === "idle" || state.phase === "classifying")
-                    }
+                    show={isHomeEmpty}
                     className="w-full flex-1 flex flex-col items-center justify-end"
                   >
                     <Section
@@ -913,7 +933,16 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                     sessionFetchError && "hidden"
                   )}
                 >
-                  <div className="relative w-full max-w-[var(--app-page-main-content-width)] flex flex-col">
+                  <div
+                    className={cn(
+                      "relative w-full max-w-[var(--app-page-main-content-width)] flex flex-col",
+                      // Operator-brain redesign — shiny animated border
+                      // around the input on the home/empty state only.
+                      // The wrapper itself is white inside (padding-box)
+                      // so AppInputBar's own bg sits on top correctly.
+                      isHomeEmpty && "ob-shiny-input-wrapper p-[1px] shadow-2xl shadow-black/[0.03]"
+                    )}
+                  >
                     {/* Scroll to bottom button - positioned absolutely above AppInputBar */}
                     {appFocus.isChat() && showScrollButton && (
                       <div className="absolute top-[-3.5rem] self-center">
@@ -1044,12 +1073,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                     </div>
                   )}
 
-                  {/* SuggestionsUI */}
+                  {/* SuggestionsUI — only on the true empty home so
+                      starter-message cards don't appear under the
+                      input during an active chat. */}
                   <Fade
-                    show={
-                      (appFocus.isNewSession() || appFocus.isAgent()) &&
-                      hasStarterMessages
-                    }
+                    show={isHomeEmpty && hasStarterMessages}
                     className="h-full flex-1 w-full max-w-[var(--app-page-main-content-width)]"
                   >
                     <Spacer rem={0.5} />
@@ -1067,7 +1095,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 </div>
               </div>
             </div>
-          )}
+          );
+          }}
         </Dropzone>
       </AppLayouts.Root>
 

--- a/web/src/sections/Suggestions.tsx
+++ b/web/src/sections/Suggestions.tsx
@@ -1,14 +1,30 @@
 "use client";
 
-import { OnSubmitProps } from "@/hooks/useChatController";
 import { useCurrentAgent } from "@/hooks/useAgents";
-import { Interactive } from "@opal/core";
-import { Content } from "@opal/layouts";
+import { OnSubmitProps } from "@/hooks/useChatController";
 
 export interface SuggestionsProps {
   onSubmit: (props: OnSubmitProps) => void;
 }
 
+/**
+ * Home-page suggested-prompt grid.
+ *
+ * Reads the active agent's `starter_messages` (no change to the data
+ * flow) and renders them as a 3-up card grid matching the redesigned
+ * landing hero. Each starter message becomes one card:
+ *
+ *   - the optional `name` shows as a small uppercase category label,
+ *   - the `message` is the card's primary title and the prompt that
+ *     fires onClick.
+ *
+ * Cards beyond the first three wrap onto a second row on the same
+ * grid; this is intentional — the agent author controls how many
+ * starter messages exist.
+ *
+ * Returns null when no starter messages are available, matching the
+ * prior component's contract.
+ */
 export default function Suggestions({ onSubmit }: SuggestionsProps) {
   const currentAgent = useCurrentAgent();
 
@@ -16,8 +32,9 @@ export default function Suggestions({ onSubmit }: SuggestionsProps) {
     !currentAgent ||
     !currentAgent.starter_messages ||
     currentAgent.starter_messages.length === 0
-  )
+  ) {
     return null;
+  }
 
   const handleSuggestionClick = (suggestion: string) => {
     onSubmit({
@@ -28,25 +45,46 @@ export default function Suggestions({ onSubmit }: SuggestionsProps) {
   };
 
   return (
-    <div className="max-w-[var(--app-page-main-content-width)] flex flex-col w-full p-1">
-      {currentAgent.starter_messages.map(({ message }, index) => (
-        <Interactive.Stateless
-          key={index}
-          variant="default"
-          prominence="tertiary"
-          onClick={() => handleSuggestionClick(message)}
-        >
-          <Interactive.Container width="full" rounding="sm" size="lg">
-            <Content
-              title={message}
-              sizePreset="main-ui"
-              variant="body"
-              width="full"
-              color="muted"
-            />
-          </Interactive.Container>
-        </Interactive.Stateless>
-      ))}
+    <div className="w-full max-w-[var(--app-page-main-content-width)] font-['Inter',_sans-serif]">
+      <div className="flex items-center gap-2 mb-3 px-1">
+        <span className="text-[10px] font-semibold text-neutral-400 uppercase tracking-[0.15em]">
+          Suggested for you
+        </span>
+        <span className="flex-1 h-px bg-neutral-100" />
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {currentAgent.starter_messages.map(({ message, name }, index) => (
+          <button
+            key={index}
+            type="button"
+            onClick={() => handleSuggestionClick(message)}
+            className="group/prompt flex flex-col p-4 bg-white border border-neutral-200/80 rounded-2xl hover:border-[#295EFF]/30 hover:shadow-md hover:shadow-black/[0.03] transition-all text-left"
+          >
+            <div className="flex items-center justify-between mb-2.5">
+              <span className="text-[10px] font-semibold text-[#295EFF] uppercase tracking-wider">
+                {name?.trim() || "Suggested"}
+              </span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="text-neutral-300 group-hover/prompt:text-[#295EFF] group-hover/prompt:translate-x-0.5 transition-all"
+              >
+                <path d="m9 18 6-6-6-6" />
+              </svg>
+            </div>
+            <div className="text-[14px] font-semibold text-neutral-900 leading-snug">
+              {message}
+            </div>
+          </button>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/sections/Suggestions.tsx
+++ b/web/src/sections/Suggestions.tsx
@@ -1,38 +1,48 @@
 "use client";
 
-import { useCurrentAgent } from "@/hooks/useAgents";
+import { useActiveOrDefaultAgent } from "@/hooks/useAgents";
 import { OnSubmitProps } from "@/hooks/useChatController";
 
 export interface SuggestionsProps {
   onSubmit: (props: OnSubmitProps) => void;
 }
 
+const SUGGESTION_CARD_LIMIT = 3;
+
 /**
  * Home-page suggested-prompt grid.
  *
- * Reads the active agent's `starter_messages` (no change to the data
- * flow) and renders them as a 3-up card grid matching the redesigned
- * landing hero. Each starter message becomes one card:
+ * Reads the active agent's `starter_messages` and renders the first
+ * three as a 3-up card grid matching the redesigned landing hero.
+ * Each starter message becomes one card:
  *
  *   - the optional `name` shows as a small uppercase category label,
  *   - the `message` is the card's primary title and the prompt that
  *     fires onClick.
  *
- * Cards beyond the first three wrap onto a second row on the same
- * grid; this is intentional — the agent author controls how many
- * starter messages exist.
+ * The active-agent lookup falls back to the user's default agent
+ * (chosen_assistants[0] / pinned_assistants[0] / first featured) so
+ * the bare empty-state home (no `?agentId=` param, no chat session)
+ * still surfaces the user's persona starters. Sidebar consumers use
+ * the strict `useCurrentAgent` and remain null in that state.
+ *
+ * Capped at three because the redesigned grid is `lg:grid-cols-3`;
+ * a fourth card wraps to a second row and breaks the hero proportions.
+ * Agent authors can ship more than three starter messages — they're
+ * still served via the persona payload, just not surfaced here.
  *
  * Returns null when no starter messages are available, matching the
  * prior component's contract.
  */
 export default function Suggestions({ onSubmit }: SuggestionsProps) {
-  const currentAgent = useCurrentAgent();
+  const currentAgent = useActiveOrDefaultAgent();
 
-  if (
-    !currentAgent ||
-    !currentAgent.starter_messages ||
-    currentAgent.starter_messages.length === 0
-  ) {
+  const visibleStarters = (currentAgent?.starter_messages ?? []).slice(
+    0,
+    SUGGESTION_CARD_LIMIT
+  );
+
+  if (!currentAgent || visibleStarters.length === 0) {
     return null;
   }
 
@@ -53,7 +63,7 @@ export default function Suggestions({ onSubmit }: SuggestionsProps) {
         <span className="flex-1 h-px bg-neutral-100" />
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {currentAgent.starter_messages.map(({ message, name }, index) => (
+        {visibleStarters.map(({ message, name }, index) => (
           <button
             key={index}
             type="button"

--- a/web/src/sections/sidebar/SidebarWrapper.tsx
+++ b/web/src/sections/sidebar/SidebarWrapper.tsx
@@ -78,7 +78,13 @@ export default function SidebarWrapper({
     <div>
       <div
         className={cn(
-          "h-screen flex flex-col bg-background-tint-02 py-2 gap-4 group/SidebarWrapper transition-width duration-200 ease-in-out",
+          // Operator-brain redesign: pure-white sidebar with a 1px
+          // neutral right border, mirroring `border-r border-neutral-100`
+          // in operator-brain/home.html. The bg variable already
+          // resolves to white via the LIGHT-mode token overrides in
+          // globals.css; the border-r adds the visual seam between
+          // sidebar and main content.
+          "h-screen flex flex-col bg-background-tint-02 border-r border-background-neutral-02 py-2 gap-4 group/SidebarWrapper transition-width duration-200 ease-in-out",
           folded ? "w-[3.25rem]" : "w-[15rem]"
         )}
       >


### PR DESCRIPTION
## Summary

Adds \`gmail.send\` to Onyx's Gmail OAuth scope list so operator-brain's action-execution skill can post outbound email after operator approval. Onyx's native Gmail connector itself only reads — this scope is reserved for the operator-brain side, which reads the issued OAuth token from the Onyx credential table and uses it to send.

## Migration impact

After this merges, every existing Gmail-credentialed user will need to re-consent (Google prompts because the scope set widened). Documented in the operator-brain spec-11 runbook.

## Test plan

- [ ] Existing Gmail readonly behavior unchanged (read-only ingestion still works)
- [ ] OAuth flow now requests \`gmail.send\` and Google grants it on the consent screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `gmail.send` to Gmail OAuth scopes so operator‑brain can send email after approval, and registers the `brain_page` source with default‑on internal search. Also refreshes the app’s light theme and the empty-state hero.

- **New Features**
  - Gmail OAuth: request `gmail.send`; Onyx Gmail stays read‑only, operator‑brain uses the issued token to send.
  - Operator Brain: add `brain_page` source and passive connector; skip validation like `ingestion_api`; shows in chat source filter; hidden from Add Connector; `internal_search` tool default‑enabled.
  - Access control: preserve `external_access` on ingest and enforce `external_user_emails` in CE access lookups.
  - UI/Brand: default to light theme with Inter and updated brand blue; new flame logo; redesigned home hero (time‑of‑day greeting, name, shiny input, grid+glow background, 3 suggestion cards); sidebar gets a right border.
  - Agents: respect per‑user `hidden_assistants` (skip id=0) and better default agent fallback for suggestions.

- **Migration**
  - Existing Gmail‑credentialed users must re‑consent because the scope set widened.

<sup>Written for commit c831823e45b10ac31af4c17f3cceeb7b26609695. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

