### PR TITLE
fix(sharepoint): accept tenant root URLs without /sites/ or /teams/

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -141,6 +141,18 @@ DEFAULT_AUTHORITY_HOST = "https://login.microsoftonline.com"
 DEFAULT_GRAPH_API_HOST = "https://graph.microsoft.com"
 DEFAULT_SHAREPOINT_DOMAIN_SUFFIX = "sharepoint.com"
 
+# All Microsoft cloud SharePoint host suffixes. Used to recognize valid
+# SharePoint URLs that don't include a /sites/ or /teams/ segment (e.g. tenant
+# root URLs). Covers commercial, GCC High, DoD, China (21Vianet), and the
+# legacy Germany cloud.
+SHAREPOINT_HOST_SUFFIXES: tuple[str, ...] = (
+    ".sharepoint.com",
+    ".sharepoint.us",
+    ".sharepoint-mil.us",
+    ".sharepoint.cn",
+    ".sharepoint.de",
+)
+
 GRAPH_API_BASE = f"{DEFAULT_GRAPH_API_HOST}/v1.0"
 GRAPH_API_MAX_RETRIES = 5
 GRAPH_API_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
@@ -1087,16 +1099,14 @@ class SharepointConnector(
         # Ensure sites are sharepoint urls. Tenant root URLs
         # (e.g. https://tenant.sharepoint.com or https://tenant.sharepoint.com/<drive>)
         # are also accepted: Graph resolves them via /sites/{hostname} and the
-        # parser below treats the trailing path as drive_name/folder_path.
+        # parser below treats the trailing path as drive_name/folder_path. The
+        # host-suffix check covers all Microsoft sovereign clouds, not just the
+        # commercial .sharepoint.com domain.
         for site_url in self.sites:
-            is_root_site = (
-                site_url.startswith("https://")
-                and ".sharepoint.com" in site_url
-                and "/sites/" not in site_url
-                and "/teams/" not in site_url
-            )
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url or is_root_site
+                "/sites/" in site_url
+                or "/teams/" in site_url
+                or any(suffix in site_url for suffix in SHAREPOINT_HOST_SUFFIXES)
             ):
                 raise ConnectorValidationError(
                     "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site, https://your-tenant.sharepoint.com/teams/your-team, or the tenant root https://your-tenant.sharepoint.com)"

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1084,13 +1084,22 @@ class SharepointConnector(
                 "Please check either 'Include Site Documents' or 'Include Site Pages' (or both)."
             )
 
-        # Ensure sites are sharepoint urls
+        # Ensure sites are sharepoint urls. Tenant root URLs
+        # (e.g. https://tenant.sharepoint.com or https://tenant.sharepoint.com/<drive>)
+        # are also accepted: Graph resolves them via /sites/{hostname} and the
+        # parser below treats the trailing path as drive_name/folder_path.
         for site_url in self.sites:
+            is_root_site = (
+                site_url.startswith("https://")
+                and ".sharepoint.com" in site_url
+                and "/sites/" not in site_url
+                and "/teams/" not in site_url
+            )
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url
+                "/sites/" in site_url or "/teams/" in site_url or is_root_site
             ):
                 raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
+                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site, https://your-tenant.sharepoint.com/teams/your-team, or the tenant root https://your-tenant.sharepoint.com)"
                 )
             try:
                 validate_outbound_http_url(site_url, https_only=True)
@@ -1325,7 +1334,32 @@ class SharepointConnector(
                     site_type_index = lower_parts.index(site_token)
                     break
 
-            if site_type_index is None or len(parts) <= site_type_index + 1:
+            if site_type_index is None:
+                # Tenant root site: no /sites/<name> or /teams/<name> segment.
+                # Graph resolves base_url via sites.get_by_url(<hostname>) to
+                # the root site; the remaining path is treated as
+                # drive_name (+ optional folder_path).
+                site_url = base_url
+                if parts:
+                    drive_name = unquote(parts[0])
+                    folder_path = (
+                        "/".join(unquote(part) for part in parts[1:])
+                        if len(parts) > 1
+                        else None
+                    )
+                else:
+                    drive_name = None
+                    folder_path = None
+                site_data_list.append(
+                    SiteDescriptor(
+                        url=site_url,
+                        drive_name=drive_name,
+                        folder_path=folder_path,
+                    )
+                )
+                continue
+
+            if len(parts) <= site_type_index + 1:
                 logger.warning(
                     "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name> or /teams/<name>)",
                     url,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py
@@ -27,3 +27,43 @@ def test_extract_site_and_drive_info_standard_url() -> None:
     assert descriptor.url == "https://tenant.sharepoint.com/sites/SampleSite"
     assert descriptor.drive_name == "Shared Documents"
     assert descriptor.folder_path == "Nested/Path"
+
+
+def test_extract_site_and_drive_info_tenant_root_url() -> None:
+    """Tenant root URL (no /sites/ or /teams/) resolves to the root site
+    with the trailing path treated as drive_name + folder_path."""
+    url = "https://tenant.sharepoint.com/Shared%20Documents/Nested/Path"
+
+    site_descriptors = SharepointConnector._extract_site_and_drive_info([url])
+
+    assert len(site_descriptors) == 1
+    descriptor = site_descriptors[0]
+    assert descriptor.url == "https://tenant.sharepoint.com"
+    assert descriptor.drive_name == "Shared Documents"
+    assert descriptor.folder_path == "Nested/Path"
+
+
+def test_extract_site_and_drive_info_tenant_root_url_drive_only() -> None:
+    """Tenant root URL with only a drive name (no folder path)."""
+    url = "https://tenant.sharepoint.com/Shared%20Documents"
+
+    site_descriptors = SharepointConnector._extract_site_and_drive_info([url])
+
+    assert len(site_descriptors) == 1
+    descriptor = site_descriptors[0]
+    assert descriptor.url == "https://tenant.sharepoint.com"
+    assert descriptor.drive_name == "Shared Documents"
+    assert descriptor.folder_path is None
+
+
+def test_extract_site_and_drive_info_tenant_root_url_no_drive() -> None:
+    """Bare tenant root URL: no drive, no folder."""
+    url = "https://tenant.sharepoint.com"
+
+    site_descriptors = SharepointConnector._extract_site_and_drive_info([url])
+
+    assert len(site_descriptors) == 1
+    descriptor = site_descriptors[0]
+    assert descriptor.url == "https://tenant.sharepoint.com"
+    assert descriptor.drive_name is None
+    assert descriptor.folder_path is None

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py
@@ -67,3 +67,18 @@ def test_extract_site_and_drive_info_tenant_root_url_no_drive() -> None:
     assert descriptor.url == "https://tenant.sharepoint.com"
     assert descriptor.drive_name is None
     assert descriptor.folder_path is None
+
+
+def test_extract_site_and_drive_info_sovereign_cloud_root_url() -> None:
+    """Tenant root URL on a non-commercial Microsoft cloud (e.g. GCC High,
+    DoD, 21Vianet) — the parser is host-agnostic, so the same root-site
+    handling applies."""
+    url = "https://tenant.sharepoint.us/Shared%20Documents/Folder"
+
+    site_descriptors = SharepointConnector._extract_site_and_drive_info([url])
+
+    assert len(site_descriptors) == 1
+    descriptor = site_descriptors[0]
+    assert descriptor.url == "https://tenant.sharepoint.us"
+    assert descriptor.drive_name == "Shared Documents"
+    assert descriptor.folder_path == "Folder"


### PR DESCRIPTION
## Description

Closes #10936.

The SharePoint connector previously rejected URLs that don't include a `/sites/<name>` or `/teams/<name>` segment, even though Microsoft Graph supports the tenant root site directly via `sites.get_by_url(<hostname>)`. Tenants whose document libraries hang off the root (rather than a subsite) couldn't be configured.

This PR:

- **Validator** (`validate_connector_settings`): accepts `https://tenant.sharepoint.com[/<drive>[/<folder>]]` in addition to the existing `/sites/<name>` and `/teams/<name>` URL shapes. Updates the error message to mention the new shape.
- **Parser** (`_extract_site_and_drive_info`): when the URL contains no `/sites/` or `/teams/` segment, treats `parts[0]` as `drive_name` and `parts[1:]` as `folder_path`, with `site_url = base_url`. Graph resolves the tenant root via `sites.get_by_url(<hostname>)` exactly as it does for subsite URLs.

## How Has This Been Tested?

- Three new unit tests in `backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py`:
  - root URL with drive + folder (`/Drive/Folder/Subfolder`)
  - root URL with drive only (`/Drive`)
  - bare root URL (no path)
- Existing tests in `test_url_parsing.py` and `test_slim_and_validation.py` continue to pass (`pytest backend/tests/unit/onyx/connectors/sharepoint/test_url_parsing.py backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py` → 18 passed).
- `black --check` and `ruff check` clean on both touched files.
- Validated end-to-end on a tenant whose document library is on the root site: connector now ingests successfully.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow SharePoint tenant root URLs (e.g. https://tenant.sharepoint.com) in the connector, including Microsoft sovereign clouds, so root-site document libraries can be configured and ingested. Validation and URL parsing now resolve the root site via Microsoft Graph.

- **Bug Fixes**
  - Validator accepts root URLs with optional drive/folder and supports host suffixes: .sharepoint.com, .sharepoint.us, .sharepoint-mil.us, .sharepoint.cn, .sharepoint.de. Error message updated.
  - Parser handles URLs without /sites/ or /teams/: uses the host as site_url, treats the first path part as drive_name and the rest as folder_path.
  - Added unit tests for root with drive+folder, drive only, bare root, and a sovereign-cloud root URL; existing tests still pass.

<sup>Written for commit a2489a3849e7f219f44568a181299677c9941ad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

