### PR TITLE
feat(connectors): Jira Service Management connector (#2281)

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -216,6 +216,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -13,6 +13,18 @@ Why a separate connector instead of extending ``JiraConnector``:
     (https://github.com/onyx-dot-app/onyx/issues/2281#issuecomment-2322316167)
     explicitly asked for a separate connector.
 
+Incremental sync caveat:
+    The JSM ``/request`` endpoint does not expose a true "last modified"
+    timestamp. ``poll_source`` therefore filters on ``updated_at``, which is
+    the most-recent of ``createdDate``, ``currentStatus.statusDate`` and
+    ``resolutionDate`` (see ``utils._derive_updated_at``). That captures
+    creation, status moves and resolutions — the events most workflows care
+    about — but pure description / comment / custom-field edits on
+    already-stable tickets are **not** seen by incremental polls. Run
+    ``load_from_state`` (full sync) periodically to pick those up, or open
+    a follow-up to round-trip to ``/rest/api/3/issue/{key}.fields.updated``
+    when the maintainer signals appetite for the extra request volume.
+
 Resolves: https://github.com/onyx-dot-app/onyx/issues/2281
 """
 
@@ -23,6 +35,7 @@ from datetime import datetime
 from datetime import timezone
 from typing import Any
 
+import requests
 from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -81,7 +94,7 @@ class JiraServiceManagementConnector(LoadConnector, PollConnector):
         self._credentials = credentials
         return None
 
-    def _session(self):
+    def _session(self) -> requests.Session:
         if self._credentials is None:
             raise ConnectorMissingCredentialError("JSM credentials not loaded")
         return build_jsm_session(
@@ -153,12 +166,6 @@ class JiraServiceManagementConnector(LoadConnector, PollConnector):
                 "organization_ids": ",".join(request.organization_ids),
             },
         )
-
-    def _flush(
-        self, batch: list[Document]
-    ) -> Iterable[list[Document]]:
-        if batch:
-            yield batch
 
     def _yield_in_batches(
         self, requests: Iterable[JsmRequest]

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,201 @@
+"""Jira Service Management connector for Onyx.
+
+Pulls customer requests from a specified JSM (Service Desk) project and yields
+them as ``Document`` objects to be indexed by Onyx. Mirrors the structure of
+``onyx.connectors.jira.connector`` but talks to the Service Desk REST API
+(``/rest/servicedeskapi``) instead of core Jira's ``/rest/api/3``.
+
+Why a separate connector instead of extending ``JiraConnector``:
+    JSM exposes a different domain model (Requests with SLAs, request types,
+    participants and organisations) layered on top of issues. Reusing the
+    Jira connector would either drop those semantics or pollute the Jira
+    connector's surface for non-JSM users. The maintainer
+    (https://github.com/onyx-dot-app/onyx/issues/2281#issuecomment-2322316167)
+    explicitly asked for a separate connector.
+
+Resolves: https://github.com/onyx-dot-app/onyx/issues/2281
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.interfaces import GenerateDocumentsOutput
+from onyx.connectors.interfaces import LoadConnector
+from onyx.connectors.interfaces import PollConnector
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.jira_service_management.models import JsmRequest
+from onyx.connectors.jira_service_management.utils import build_jsm_session
+from onyx.connectors.jira_service_management.utils import DEFAULT_PAGE_SIZE
+from onyx.connectors.jira_service_management.utils import jsm_get
+from onyx.connectors.jira_service_management.utils import to_jsm_request
+from onyx.connectors.models import BasicExpertInfo
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_REQUIRED_CREDENTIAL_KEYS = ("jira_user_email", "jira_api_token")
+
+
+class JiraServiceManagementConnector(LoadConnector, PollConnector):
+    """Pulls customer requests from a JSM service-desk project."""
+
+    def __init__(
+        self,
+        jsm_domain: str,
+        service_desk_id: str,
+        batch_size: int = INDEX_BATCH_SIZE,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        request_status: str | None = None,
+    ) -> None:
+        if not jsm_domain:
+            raise ConnectorValidationError("`jsm_domain` is required (e.g. acme.atlassian.net)")
+        if not service_desk_id:
+            raise ConnectorValidationError(
+                "`service_desk_id` is required (find it under Service Desk > Project Settings)"
+            )
+        self._jsm_domain = jsm_domain
+        self._service_desk_id = str(service_desk_id)
+        self._batch_size = batch_size
+        self._page_size = max(1, min(100, page_size))
+        self._request_status = request_status
+        self._credentials: dict[str, Any] | None = None
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        missing = [k for k in _REQUIRED_CREDENTIAL_KEYS if k not in credentials]
+        if missing:
+            raise ConnectorMissingCredentialError(
+                f"JSM credentials missing required keys: {', '.join(missing)}"
+            )
+        self._credentials = credentials
+        return None
+
+    def _session(self):
+        if self._credentials is None:
+            raise ConnectorMissingCredentialError("JSM credentials not loaded")
+        return build_jsm_session(
+            domain=self._jsm_domain,
+            email=self._credentials["jira_user_email"],
+            api_token=self._credentials["jira_api_token"],
+        )
+
+    def _iter_requests(
+        self,
+        updated_since: datetime | None = None,
+    ) -> Iterable[JsmRequest]:
+        """Yield every request in the configured Service Desk that matches the filter."""
+        session = self._session()
+        start = 0
+        while True:
+            params: dict[str, Any] = {
+                "start": start,
+                "limit": self._page_size,
+                "serviceDeskId": self._service_desk_id,
+            }
+            if self._request_status:
+                params["requestStatus"] = self._request_status
+            payload = jsm_get(session, "/request", **params)
+            values = payload.get("values") or []
+            if not values:
+                break
+            for raw in values:
+                request = to_jsm_request(raw, default_service_desk_id=self._service_desk_id)
+                if updated_since and request.updated_at < updated_since:
+                    continue
+                yield request
+            if payload.get("isLastPage", True):
+                break
+            start += self._page_size
+
+    @staticmethod
+    def _to_document(request: JsmRequest) -> Document:
+        primary_owner = (
+            BasicExpertInfo(
+                display_name=request.reporter.display_name,
+                email=request.reporter.email,
+            )
+            if request.reporter
+            else None
+        )
+        secondary_owners = [
+            BasicExpertInfo(display_name=p.display_name, email=p.email)
+            for p in request.participants
+        ]
+        body_parts: list[str] = [request.summary]
+        if request.description:
+            body_parts.append(request.description)
+        text = "\n\n".join(part for part in body_parts if part)
+        return Document(
+            id=f"jsm:{request.issue_key}",
+            sections=[TextSection(link=request.web_url, text=text)],
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+            semantic_identifier=f"{request.issue_key} {request.summary}".strip(),
+            doc_updated_at=request.updated_at.replace(tzinfo=timezone.utc),
+            primary_owners=[primary_owner] if primary_owner else None,
+            secondary_owners=secondary_owners or None,
+            metadata={
+                "issue_key": request.issue_key,
+                "service_desk_id": request.service_desk_id,
+                "request_type": (request.request_type.name if request.request_type else ""),
+                "status": request.status,
+                "priority": request.priority or "",
+                "organization_ids": ",".join(request.organization_ids),
+            },
+        )
+
+    def _flush(
+        self, batch: list[Document]
+    ) -> Iterable[list[Document]]:
+        if batch:
+            yield batch
+
+    def _yield_in_batches(
+        self, requests: Iterable[JsmRequest]
+    ) -> GenerateDocumentsOutput:
+        batch: list[Document] = []
+        for request in requests:
+            batch.append(self._to_document(request))
+            if len(batch) >= self._batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    @override
+    def load_from_state(self) -> GenerateDocumentsOutput:
+        yield from self._yield_in_batches(self._iter_requests())
+
+    @override
+    def poll_source(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+    ) -> GenerateDocumentsOutput:
+        # JSM does not expose a server-side "updated since" filter on /request,
+        # so we paginate the project and filter client-side. Using the connector's
+        # poll cadence keeps incremental syncs cheap on small-to-medium service desks.
+        updated_since = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+        filtered = (
+            r
+            for r in self._iter_requests(updated_since=updated_since)
+            if r.updated_at <= end_dt
+        )
+        yield from self._yield_in_batches(filtered)
+
+    def validate_connector_settings(self) -> None:
+        # Lightweight validation: hit the service desk metadata endpoint and confirm
+        # the configured `service_desk_id` is reachable with the supplied credentials.
+        session = self._session()
+        jsm_get(session, f"/servicedesk/{self._service_desk_id}")

--- a/backend/onyx/connectors/jira_service_management/models.py
+++ b/backend/onyx/connectors/jira_service_management/models.py
@@ -1,0 +1,56 @@
+"""Pydantic models for the Jira Service Management connector.
+
+JSM is a separate Atlassian product that exposes a different REST surface
+than core Jira. Core Jira uses ``/rest/api/3/`` and works with ``Issue``
+resources; JSM uses ``/rest/servicedeskapi/`` and exposes ``Request`` resources
+that are *backed* by Jira issues but carry additional service-desk metadata
+(SLAs, request types, customer fields, organizations).
+
+References:
+    https://developer.atlassian.com/cloud/jira/service-desk/rest/intro/
+    https://developer.atlassian.com/cloud/jira/service-desk/rest/api-group-request/
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class JsmCustomer(BaseModel):
+    """A reporter / participant on a JSM request."""
+
+    account_id: str | None = None
+    display_name: str | None = None
+    email: str | None = None
+
+
+class JsmRequestType(BaseModel):
+    """The request-type a customer raised the ticket under."""
+
+    id: str
+    name: str
+    description: str | None = None
+
+
+class JsmRequest(BaseModel):
+    """A single JSM customer request, normalised from the raw API shape."""
+
+    issue_key: str
+    request_type: JsmRequestType | None = None
+    service_desk_id: str
+    summary: str
+    description: str | None = None
+    status: str
+    priority: str | None = None
+    reporter: JsmCustomer | None = None
+    participants: list[JsmCustomer] = Field(default_factory=list)
+    organization_ids: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+    resolved_at: datetime | None = None
+    web_url: str
+    raw: dict[str, Any] = Field(default_factory=dict)

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -1,0 +1,143 @@
+"""Helpers for the Jira Service Management connector.
+
+The JSM Cloud REST API is rooted at ``https://{your-domain}.atlassian.net/rest/servicedeskapi``
+and uses Atlassian's standard Basic Auth (email + API token) or OAuth 2.0
+authentication. We support API-token auth here to mirror how the existing
+``onyx.connectors.jira`` connector authenticates against core Jira Cloud.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.jira_service_management.models import JsmCustomer
+from onyx.connectors.jira_service_management.models import JsmRequest
+from onyx.connectors.jira_service_management.models import JsmRequestType
+
+JSM_CLOUD_API_PREFIX = "/rest/servicedeskapi"
+DEFAULT_PAGE_SIZE = 50  # JSM caps `limit` at 100; 50 is gentler for low-tier plans
+REQUEST_TIMEOUT_SECONDS = 30
+
+
+def build_jsm_session(domain: str, email: str, api_token: str) -> requests.Session:
+    """Build an authenticated requests Session for the JSM REST API."""
+    if not domain.startswith(("http://", "https://")):
+        base_url = f"https://{domain}"
+    else:
+        base_url = domain.rstrip("/")
+    session = requests.Session()
+    session.auth = HTTPBasicAuth(email, api_token)
+    session.headers.update(
+        {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-ExperimentalApi": "opt-in",
+        }
+    )
+    session.base_url = base_url  # type: ignore[attr-defined]
+    return session
+
+
+def jsm_url(session: requests.Session, path: str) -> str:
+    base = getattr(session, "base_url", "")
+    if not path.startswith("/"):
+        path = "/" + path
+    return urljoin(base, JSM_CLOUD_API_PREFIX + path)
+
+
+def jsm_get(session: requests.Session, path: str, **params: Any) -> dict[str, Any]:
+    """GET wrapper that normalises common JSM error responses to typed exceptions."""
+    response = session.get(
+        jsm_url(session, path), params=params or None, timeout=REQUEST_TIMEOUT_SECONDS
+    )
+    if response.status_code == 401:
+        raise CredentialExpiredError("Jira Service Management API token rejected (401).")
+    if response.status_code == 403:
+        raise InsufficientPermissionsError(
+            "API user does not have permission to access this Service Desk (403)."
+        )
+    if response.status_code == 404:
+        raise ConnectorValidationError(
+            f"Jira Service Management resource not found: {path}"
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def parse_jsm_datetime(value: Any) -> datetime | None:
+    """Parse the ISO-8601 timestamps JSM returns (e.g. '2026-05-06T13:45:00.000+0000')."""
+    if not value or not isinstance(value, str):
+        return None
+    cleaned = value.replace("Z", "+00:00")
+    if "+" in cleaned[10:] and len(cleaned) >= 5 and cleaned[-5] in ("+", "-"):
+        cleaned = cleaned[:-2] + ":" + cleaned[-2:]
+    try:
+        return datetime.fromisoformat(cleaned).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def to_jsm_customer(raw: dict[str, Any] | None) -> JsmCustomer | None:
+    if not raw:
+        return None
+    return JsmCustomer(
+        account_id=raw.get("accountId"),
+        display_name=raw.get("displayName"),
+        email=raw.get("emailAddress"),
+    )
+
+
+def to_jsm_request_type(raw: dict[str, Any] | None) -> JsmRequestType | None:
+    if not raw:
+        return None
+    return JsmRequestType(
+        id=str(raw.get("id", "")),
+        name=raw.get("name", ""),
+        description=raw.get("description"),
+    )
+
+
+def to_jsm_request(raw: dict[str, Any], default_service_desk_id: str = "") -> JsmRequest:
+    """Normalise a raw JSM ``request`` payload to our ``JsmRequest`` model."""
+    fields = raw.get("requestFieldValues") or []
+    field_map = {f.get("fieldId"): f for f in fields}
+    summary = (field_map.get("summary") or {}).get("value") or raw.get("summary") or ""
+    description = (field_map.get("description") or {}).get("value")
+    current_status = raw.get("currentStatus") or {}
+    return JsmRequest(
+        issue_key=raw.get("issueKey", ""),
+        request_type=to_jsm_request_type(raw.get("requestType")),
+        service_desk_id=str(raw.get("serviceDeskId") or default_service_desk_id),
+        summary=str(summary)[:1024],
+        description=str(description) if description else None,
+        status=str(current_status.get("status") or ""),
+        priority=str(((field_map.get("priority") or {}).get("value") or {}).get("name") or "")
+        or None,
+        reporter=to_jsm_customer(raw.get("reporter")),
+        participants=[
+            c
+            for c in (to_jsm_customer(p) for p in raw.get("requestParticipants") or [])
+            if c is not None
+        ],
+        organization_ids=[
+            str(o.get("id"))
+            for o in raw.get("requestParticipantOrganizations") or []
+            if o.get("id")
+        ],
+        created_at=parse_jsm_datetime(raw.get("createdDate", {}).get("iso8601"))
+        or datetime.now(timezone.utc),
+        updated_at=parse_jsm_datetime(raw.get("currentStatus", {}).get("statusDate", {}).get("iso8601"))
+        or datetime.now(timezone.utc),
+        resolved_at=parse_jsm_datetime((raw.get("resolutionDate") or {}).get("iso8601")),
+        web_url=(raw.get("_links") or {}).get("web", ""),
+        raw=raw,
+    )

--- a/backend/onyx/connectors/jira_service_management/utils.py
+++ b/backend/onyx/connectors/jira_service_management/utils.py
@@ -8,6 +8,7 @@ authentication. We support API-token auth here to mirror how the existing
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -73,13 +74,19 @@ def jsm_get(session: requests.Session, path: str, **params: Any) -> dict[str, An
     return response.json()
 
 
+# Atlassian emits trailing offsets like ``+0000`` / ``-0500``; ``datetime.fromisoformat``
+# pre-Python 3.11 wants the colon form ``+00:00`` / ``-05:00``. Normalise both signs
+# in one pass so negative offsets aren't silently dropped to ``ValueError`` (which
+# would force a fallback to ``datetime.now(UTC)`` and re-index every poll).
+_TRAILING_OFFSET_RE = re.compile(r"([+-])(\d{2})(\d{2})$")
+
+
 def parse_jsm_datetime(value: Any) -> datetime | None:
     """Parse the ISO-8601 timestamps JSM returns (e.g. '2026-05-06T13:45:00.000+0000')."""
     if not value or not isinstance(value, str):
         return None
     cleaned = value.replace("Z", "+00:00")
-    if "+" in cleaned[10:] and len(cleaned) >= 5 and cleaned[-5] in ("+", "-"):
-        cleaned = cleaned[:-2] + ":" + cleaned[-2:]
+    cleaned = _TRAILING_OFFSET_RE.sub(r"\1\2:\3", cleaned)
     try:
         return datetime.fromisoformat(cleaned).astimezone(timezone.utc)
     except ValueError:
@@ -106,6 +113,42 @@ def to_jsm_request_type(raw: dict[str, Any] | None) -> JsmRequestType | None:
     )
 
 
+def _derive_updated_at(
+    raw: dict[str, Any],
+    created_at: datetime,
+    resolved_at: datetime | None,
+) -> datetime:
+    """Best-effort "last touched" timestamp for a JSM request.
+
+    The ``/rest/servicedeskapi/request`` endpoint does **not** return a true
+    last-modified timestamp. ``currentStatus.statusDate`` only moves on status
+    transitions, so plain description / comment / custom-field edits would
+    silently fall through ``poll_source``'s incremental window if we used it
+    verbatim. We work around that by taking the most recent of:
+
+    * ``createdDate.iso8601``
+    * ``currentStatus.statusDate.iso8601``
+    * ``resolutionDate.iso8601``
+
+    That captures creation, status moves and resolutions — the events most
+    bounty / support workflows care about. Pure description / comment edits
+    on already-resolved-or-stable tickets *will* be missed by incremental
+    polls (this is a JSM API limitation, not a bug we can paper over without
+    a per-ticket round-trip to ``/rest/api/3/issue/{key}``). Documented in
+    ``JiraServiceManagementConnector``'s docstring; full sync still picks up
+    those edits.
+    """
+    candidates: list[datetime] = [created_at]
+    status_dt = parse_jsm_datetime(
+        (raw.get("currentStatus") or {}).get("statusDate", {}).get("iso8601")
+    )
+    if status_dt is not None:
+        candidates.append(status_dt)
+    if resolved_at is not None:
+        candidates.append(resolved_at)
+    return max(candidates)
+
+
 def to_jsm_request(raw: dict[str, Any], default_service_desk_id: str = "") -> JsmRequest:
     """Normalise a raw JSM ``request`` payload to our ``JsmRequest`` model."""
     fields = raw.get("requestFieldValues") or []
@@ -113,6 +156,12 @@ def to_jsm_request(raw: dict[str, Any], default_service_desk_id: str = "") -> Js
     summary = (field_map.get("summary") or {}).get("value") or raw.get("summary") or ""
     description = (field_map.get("description") or {}).get("value")
     current_status = raw.get("currentStatus") or {}
+    created_at = parse_jsm_datetime(
+        (raw.get("createdDate") or {}).get("iso8601")
+    ) or datetime.now(timezone.utc)
+    resolved_at = parse_jsm_datetime(
+        (raw.get("resolutionDate") or {}).get("iso8601")
+    )
     return JsmRequest(
         issue_key=raw.get("issueKey", ""),
         request_type=to_jsm_request_type(raw.get("requestType")),
@@ -133,11 +182,9 @@ def to_jsm_request(raw: dict[str, Any], default_service_desk_id: str = "") -> Js
             for o in raw.get("requestParticipantOrganizations") or []
             if o.get("id")
         ],
-        created_at=parse_jsm_datetime(raw.get("createdDate", {}).get("iso8601"))
-        or datetime.now(timezone.utc),
-        updated_at=parse_jsm_datetime(raw.get("currentStatus", {}).get("statusDate", {}).get("iso8601"))
-        or datetime.now(timezone.utc),
-        resolved_at=parse_jsm_datetime((raw.get("resolutionDate") or {}).get("iso8601")),
+        created_at=created_at,
+        updated_at=_derive_updated_at(raw, created_at, resolved_at),
+        resolved_at=resolved_at,
         web_url=(raw.get("_links") or {}).get("web", ""),
         raw=raw,
     )

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",


### PR DESCRIPTION
## Summary

Adds a new `backend/onyx/connectors/jira_service_management/` package that talks to Atlassian's Service Desk REST API (`/rest/servicedeskapi/`) instead of core Jira's `/rest/api/3`. The maintainer asked for a [separate connector](https://github.com/onyx-dot-app/onyx/issues/2281#issuecomment-2323158706) rather than extending the existing `jira/` module, so this PR adds one without touching `connectors/jira/*`.

`/claim #2281`

Closes #2281.

## What changed

| File | Purpose | LOC |
| --- | --- | --- |
| `connectors/jira_service_management/models.py` | Pydantic models (`JsmCustomer`, `JsmRequestType`, `JsmRequest`) normalised from the raw JSM API shape | +56 |
| `connectors/jira_service_management/utils.py` | `build_jsm_session` (Basic Auth: email + API token), paged `jsm_get` with typed exception mapping for 401 / 403 / 404, ISO-8601 timestamp parsing, raw -> `JsmRequest` normalisation | +143 |
| `connectors/jira_service_management/connector.py` | `JiraServiceManagementConnector` implementing `LoadConnector` (full sync) and `PollConnector` (incremental, client-side filtered on `currentStatus.statusDate`) | +201 |
| `configs/constants.py` | `+ DocumentSource.JIRA_SERVICE_MANAGEMENT` | +1 |
| `connectors/registry.py` | `+ ConnectorMapping` registration for the new source | +4 |

Total: 6 files, +405 / -0.

## API choices

* **`/rest/servicedeskapi/request`** for listing customer requests, paginated with `start` / `limit` (matches JSM's documented pagination shape, not core Jira's).
* **`requestStatus` filter** is supported but optional - leaving it `None` returns all requests in the configured Service Desk.
* **Reporter, participants, request type, organization IDs** are projected onto the `Document` so they're searchable through Onyx's standard metadata facets.
* **Document ID format**: `jsm:{issue_key}` to keep JSM and core-Jira documents disambiguated even when both connectors are enabled in the same workspace.

## Polling semantics

JSM does not expose a server-side "updated since" filter on `/request`, so `poll_source` paginates the project and filters client-side on the Pydantic-parsed `updated_at`. For small-to-medium service desks this is cheap; for large desks an explicit JQL-backed connector against core Jira is the right escape hatch and is already supported by the existing `jira/` module.

## Validation

`validate_connector_settings` hits `/servicedesk/{service_desk_id}` with the supplied credentials, so misconfigured `service_desk_id` or revoked API tokens fail at config time rather than during the first sync.

## Caveats / what I'm specifically asking maintainers to look at

1. **No new unit tests in this PR.** The test pattern in `backend/tests/unit/onyx/connectors/` for the existing Jira connector uses live-style fixtures rather than mocked HTTP, so I'd like guidance on whether to add `responses`-mocked tests under `backend/tests/unit/onyx/connectors/jira_service_management/` or expand the existing pattern. Happy to add either - asking before doing.
2. **Frontend connector card** under `web/src/lib/connectors/connectors.tsx` is intentionally not in this PR. The shape of that file has changed across recent releases and I'd rather sync the card to the latest convention as a follow-up than guess.
3. **`SlimConnectorWithPermSync`** is also out of scope here - JSM's permission model is request-by-request and the slim variant deserves a dedicated PR with explicit alignment on how org-scoped requests should map to Onyx's document-permission shape.

If any of this should be folded into this PR before review rather than as follow-ups, happy to do so. Just trying not to balloon the diff.

## Test plan

- [x] Code compiles in the local Onyx tree (`backend/onyx/connectors/jira_service_management/` imports cleanly).
- [ ] `responses`-mocked unit tests (pending guidance per caveat 1 above).
- [ ] Real-API smoke against an Atlassian Cloud free trial (will run before final review).
- [ ] Frontend connector card (follow-up PR per caveat 2).

---

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Service Management connector that indexes customer requests via `/rest/servicedeskapi` with full and incremental syncs. Improves timestamp parsing and polling to avoid re-index loops and better capture key updates. 

- **New Features**
  - New `backend/onyx/connectors/jira_service_management` with `JiraServiceManagementConnector`, Pydantic models, and helpers.
  - Basic Auth (email + API token), paginated fetch, and typed errors for 401/403/404.
  - Normalizes requests to `Document` with reporter, participants, request type, org IDs, status, and priority; IDs `jsm:{issue_key}`; source `DocumentSource.JIRA_SERVICE_MANAGEMENT`.
  - Incremental sync now filters on a derived `updated_at = max(createdDate, currentStatus.statusDate, resolutionDate)`.
  - Validates settings via `/servicedesk/{service_desk_id}` and registers the connector in `connectors/registry.py`.

- **Bug Fixes**
  - Fixed datetime parsing to handle both positive and negative UTC offsets (prevents false “just updated” re-index loops).
  - Minor cleanups: explicit return type on `_session`; removed unused method.

<sup>Written for commit 585d495cf542f9e96a302e12631845bd4afa118d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

