### PR TITLE
fix(index): remove progress stall check in favor of heartbeat monitor

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -10,6 +10,7 @@ from datetime import timezone
 from typing import Any
 
 from celery import Celery
+from celery import current_app
 from celery import shared_task
 from celery import Task
 from celery.exceptions import SoftTimeLimitExceeded
@@ -88,7 +89,6 @@ from onyx.db.index_attempt_metrics import IndexAttemptStage
 from onyx.db.index_attempt_metrics import safe_record_single_event
 from onyx.db.index_attempt_metrics import time_stage
 from onyx.db.indexing_coordination import CoordinationStatus
-from onyx.db.indexing_coordination import INDEXING_PROGRESS_TIMEOUT_HOURS
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.db.models import IndexAttempt
 from onyx.db.models import SearchSettings
@@ -136,10 +136,14 @@ from shared_configs.contextvars import INDEX_ATTEMPT_INFO_CONTEXTVAR
 
 logger = setup_logger()
 
-DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER = 4
 # Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead.
 # This should be much longer than INDEXING_WORKER_HEARTBEAT_INTERVAL (30s).
 HEARTBEAT_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
+# How long a NOT_STARTED attempt must sit before we scan the broker.
+# After this window we check Redis directly — if the task is still there we
+# leave it alone, so this threshold does not cause false positives for
+# legitimately queued tasks under heavy load.
+NOT_STARTED_SCAN_THRESHOLD_HOURS = 6
 INDEX_ATTEMPT_BATCH_SIZE = 500
 
 
@@ -324,6 +328,66 @@ def validate_active_indexing_attempts(
                     f"Failed to mark attempt {fresh_attempt.id} as failed due to heartbeat timeout"
                 )
 
+        # Separately handle NOT_STARTED attempts. Their heartbeat_counter never
+        # advances (the task hasn't started), so the heartbeat loop above cannot
+        # be used. Docfetching tasks have no expires= so a task can legitimately
+        # sit in the queue for hours under heavy load — we gate on
+        # NOT_STARTED_SCAN_THRESHOLD_HOURS before scanning Redis, then confirm
+        # the Celery task is truly gone before marking failed.
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            hours=NOT_STARTED_SCAN_THRESHOLD_HOURS
+        )
+        stale_not_started = (
+            db_session.execute(
+                select(IndexAttempt).where(
+                    IndexAttempt.status == IndexingStatus.NOT_STARTED,
+                    IndexAttempt.celery_task_id.isnot(None),
+                    IndexAttempt.time_created < cutoff,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if stale_not_started:
+            redis_celery = celery_get_broker_client(current_app)
+            unacked_ids = set(
+                celery_get_unacked_task_ids(
+                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, redis_celery
+                )
+            )
+            for attempt in stale_not_started:
+                lock_beat.reacquire()
+                if attempt.celery_task_id is None:
+                    continue
+                task_exists = celery_find_task(
+                    attempt.celery_task_id,
+                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING,
+                    redis_celery,
+                )
+                if task_exists or attempt.celery_task_id in unacked_ids:
+                    continue
+                # Brief sleep to rule out the race where the task was just
+                # dequeued but the status flip to IN_PROGRESS hasn't committed.
+                time.sleep(1)
+                fresh = get_index_attempt(db_session, attempt.id)
+                if not fresh or fresh.status != IndexingStatus.NOT_STARTED:
+                    continue
+                task_logger.error(
+                    f"Attempt {attempt.id} has been NOT_STARTED for over "
+                    f"{NOT_STARTED_SCAN_THRESHOLD_HOURS}h and its Celery task "
+                    f"{attempt.celery_task_id} no longer exists — marking failed."
+                )
+                try:
+                    mark_attempt_failed(
+                        attempt.id,
+                        db_session,
+                        failure_reason="Task never started — Celery task lost before pickup",
+                    )
+                except Exception:
+                    task_logger.exception(
+                        f"Failed to mark lost NOT_STARTED attempt {attempt.id} as failed"
+                    )
+
 
 class ConnectorIndexingLogBuilder:
     def __init__(self, ctx: DocProcessingContext):
@@ -347,7 +411,7 @@ class ConnectorIndexingLogBuilder:
 
 
 def monitor_indexing_attempt_progress(
-    attempt: IndexAttempt, tenant_id: str, db_session: Session, task: Task
+    attempt: IndexAttempt, tenant_id: str, db_session: Session
 ) -> None:
     """
     TODO: rewrite this docstring
@@ -411,9 +475,7 @@ def monitor_indexing_attempt_progress(
 
     # Check task completion using Celery
     try:
-        check_indexing_completion(
-            attempt.id, coordination_status, storage, tenant_id, task
-        )
+        check_indexing_completion(attempt.id, coordination_status, storage, tenant_id)
     except Exception as e:
         logger.exception(
             "Failed to monitor document processing completion: attempt=%s error=%s",
@@ -463,7 +525,6 @@ def check_indexing_completion(
     coordination_status: CoordinationStatus,
     storage: DocumentBatchStorage,
     tenant_id: str,
-    task: Task,
 ) -> None:
     logger.info(
         "Checking for indexing completion: attempt=%s tenant=%s",
@@ -487,94 +548,6 @@ def check_indexing_completion(
         coordination_status.total_chunks,
         coordination_status.total_failures,
     )
-
-    # Update progress tracking and check for stalls
-    with get_session_with_current_tenant() as db_session:
-        stalled_timeout_hours = INDEXING_PROGRESS_TIMEOUT_HOURS
-        # Two phases get the generous stalling timeout, since neither produces
-        # forward motion in `batches_processed`:
-        #   1. Docfetching is still running (batches_total is None). A slow-but-
-        #      alive connector (large directory walks, paginated APIs, big
-        #      checkpoint resumption) can legitimately go hours before queueing
-        #      its first batch.
-        #   2. Docfetching has finished but no batches have been processed yet
-        #      (batches_total set, batches_processed == 0). This is the existing
-        #      "waiting between docfetching and docprocessing" case.
-        if batches_total is None or batches_processed == 0:
-            stalled_timeout_hours = (
-                stalled_timeout_hours * DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER
-            )
-
-        timed_out = not IndexingCoordination.update_progress_tracking(
-            db_session,
-            index_attempt_id,
-            batches_processed,
-            timeout_hours=stalled_timeout_hours,
-        )
-
-        # Check for stalls. Only applies to in-progress attempts. The actual
-        # window is `stalled_timeout_hours / 2` to `stalled_timeout_hours`.
-        attempt = get_index_attempt(db_session, index_attempt_id)
-        if attempt and timed_out:
-            if attempt.status == IndexingStatus.IN_PROGRESS:
-                logger.error(
-                    "Indexing attempt %s has been indexing for %s-%s hours without progress. Marking it as failed.",
-                    index_attempt_id,
-                    stalled_timeout_hours // 2,
-                    stalled_timeout_hours,
-                )
-                mark_attempt_failed(
-                    index_attempt_id, db_session, failure_reason="Stalled indexing"
-                )
-            elif (
-                attempt.status == IndexingStatus.NOT_STARTED and attempt.celery_task_id
-            ):
-                # Check if the task exists in the celery queue
-                # This handles the case where Redis dies after task creation but before task execution
-                redis_celery = celery_get_broker_client(task.app)
-                task_exists = celery_find_task(
-                    attempt.celery_task_id,
-                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING,
-                    redis_celery,
-                )
-                unacked_task_ids = celery_get_unacked_task_ids(
-                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, redis_celery
-                )
-
-                if not task_exists and attempt.celery_task_id not in unacked_task_ids:
-                    # there is a race condition where the docfetching task has been taken off
-                    # the queues (i.e. started) but the indexing attempt still has a status of
-                    # Not Started because the switch to in progress takes like 0.1 seconds.
-                    # sleep a bit and confirm that the attempt is still not in progress.
-                    time.sleep(1)
-                    attempt = get_index_attempt(db_session, index_attempt_id)
-                    if attempt and attempt.status == IndexingStatus.NOT_STARTED:
-                        logger.error(
-                            "Task %s attached to indexing attempt %s does not exist in the queue. Marking indexing attempt as failed.",
-                            attempt.celery_task_id,
-                            index_attempt_id,
-                        )
-                        mark_attempt_failed(
-                            index_attempt_id,
-                            db_session,
-                            failure_reason="Task not in queue",
-                        )
-            else:
-                logger.info(
-                    "Indexing attempt %s is %s. %s-%s hours without heartbeat but task is in the queue. Likely underprovisioned docfetching worker.",
-                    index_attempt_id,
-                    attempt.status,
-                    stalled_timeout_hours // 2,
-                    stalled_timeout_hours,
-                )
-                # Update last progress time so we won't time out again for
-                # another `stalled_timeout_hours / 2` window.
-                IndexingCoordination.update_progress_tracking(
-                    db_session,
-                    index_attempt_id,
-                    batches_processed,
-                    force_update_progress=True,
-                )
 
     # check again on the next check_for_indexing task
     # TODO: on the cloud this is currently 25 minutes at most, which
@@ -1193,9 +1166,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
 
             for attempt in active_attempts:
                 try:
-                    monitor_indexing_attempt_progress(
-                        attempt, tenant_id, db_session, self
-                    )
+                    monitor_indexing_attempt_progress(attempt, tenant_id, db_session)
                 except Exception:
                     task_logger.exception(f"Error monitoring attempt {attempt.id}")
 

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -80,6 +80,7 @@ from onyx.db.enums import SwitchoverType
 from onyx.db.index_attempt import create_index_attempt_error
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_index_attempt_errors_for_cc_pair
+from onyx.db.index_attempt import get_stale_not_started_index_attempts
 from onyx.db.index_attempt import IndexAttemptError
 from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.db.index_attempt import mark_attempt_failed
@@ -143,7 +144,7 @@ HEARTBEAT_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 # After this window we check Redis directly — if the task is still there we
 # leave it alone, so this threshold does not cause false positives for
 # legitimately queued tasks under heavy load.
-NOT_STARTED_SCAN_THRESHOLD_HOURS = 6
+NOT_STARTED_SCAN_THRESHOLD_HOURS = 12
 INDEX_ATTEMPT_BATCH_SIZE = 500
 
 
@@ -337,17 +338,7 @@ def validate_active_indexing_attempts(
         cutoff = datetime.now(timezone.utc) - timedelta(
             hours=NOT_STARTED_SCAN_THRESHOLD_HOURS
         )
-        stale_not_started = (
-            db_session.execute(
-                select(IndexAttempt).where(
-                    IndexAttempt.status == IndexingStatus.NOT_STARTED,
-                    IndexAttempt.celery_task_id.isnot(None),
-                    IndexAttempt.time_created < cutoff,
-                )
-            )
-            .scalars()
-            .all()
-        )
+        stale_not_started = get_stale_not_started_index_attempts(db_session, cutoff)
         if stale_not_started:
             redis_celery = celery_get_broker_client(current_app)
             queued_ids = celery_get_queued_task_ids(

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -22,8 +22,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
-from onyx.background.celery.celery_redis import celery_find_task
 from onyx.background.celery.celery_redis import celery_get_broker_client
+from onyx.background.celery.celery_redis import celery_get_queued_task_ids
 from onyx.background.celery.celery_redis import celery_get_unacked_task_ids
 from onyx.background.celery.celery_utils import httpx_init_vespa_pool
 from onyx.background.celery.memory_monitoring import emit_process_memory
@@ -350,21 +350,16 @@ def validate_active_indexing_attempts(
         )
         if stale_not_started:
             redis_celery = celery_get_broker_client(current_app)
-            unacked_ids = set(
-                celery_get_unacked_task_ids(
-                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, redis_celery
-                )
+            queued_ids = celery_get_queued_task_ids(
+                OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, redis_celery
             )
+            unacked_ids = celery_get_unacked_task_ids(
+                OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, redis_celery
+            )
+            live_ids = queued_ids | unacked_ids
             for attempt in stale_not_started:
                 lock_beat.reacquire()
-                if attempt.celery_task_id is None:
-                    continue
-                task_exists = celery_find_task(
-                    attempt.celery_task_id,
-                    OnyxCeleryQueues.CONNECTOR_DOC_FETCHING,
-                    redis_celery,
-                )
-                if task_exists or attempt.celery_task_id in unacked_ids:
+                if not attempt.celery_task_id or attempt.celery_task_id in live_ids:
                     continue
                 # Brief sleep to rule out the race where the task was just
                 # dequeued but the status flip to IN_PROGRESS hasn't committed.

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -108,6 +108,24 @@ def get_index_attempt(
     return db_session.scalars(stmt).first()
 
 
+def get_stale_not_started_index_attempts(
+    db_session: Session,
+    cutoff: datetime,
+) -> list[IndexAttempt]:
+    """Returns NOT_STARTED attempts with a task ID that were created before cutoff."""
+    return list(
+        db_session.execute(
+            select(IndexAttempt).where(
+                IndexAttempt.status == IndexingStatus.NOT_STARTED,
+                IndexAttempt.celery_task_id.isnot(None),
+                IndexAttempt.time_created < cutoff,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
 def count_error_rows_for_index_attempt(
     index_attempt_id: int,
     db_session: Session,

--- a/backend/onyx/db/indexing_coordination.py
+++ b/backend/onyx/db/indexing_coordination.py
@@ -5,7 +5,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.enums import IndexingStatus
 from onyx.db.index_attempt import count_error_rows_for_index_attempt
 from onyx.db.index_attempt import create_index_attempt
@@ -14,8 +13,6 @@ from onyx.db.models import IndexAttempt
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-INDEXING_PROGRESS_TIMEOUT_HOURS = 6
 
 
 class CoordinationStatus(BaseModel):
@@ -266,50 +263,3 @@ class IndexingCoordination:
         )
 
         return [attempt.id for attempt in active_attempts]
-
-    @staticmethod
-    def update_progress_tracking(
-        db_session: Session,
-        index_attempt_id: int,
-        current_batches_completed: int,
-        timeout_hours: int = INDEXING_PROGRESS_TIMEOUT_HOURS,
-        force_update_progress: bool = False,
-    ) -> bool:
-        """
-        Update progress tracking for stall detection.
-        Returns True if sufficient progress was made, False if stalled.
-        """
-
-        attempt = get_index_attempt(db_session, index_attempt_id)
-        if not attempt:
-            logger.error("Index attempt %s not found in database", index_attempt_id)
-            return False
-
-        current_time = get_db_current_time(db_session)
-
-        # No progress - check if this is the first time tracking
-        # or if the caller wants to simulate guaranteed progress
-        if attempt.last_progress_time is None or force_update_progress:
-            # First time tracking - initialize
-            attempt.last_progress_time = current_time
-            attempt.last_batches_completed_count = current_batches_completed
-            db_session.commit()
-            return True
-
-        time_elapsed = (current_time - attempt.last_progress_time).total_seconds()
-        # only actually write to db every timeout_hours/2
-        # this ensure thats at most timeout_hours will pass with no activity
-        if time_elapsed < timeout_hours * 1800:
-            return True
-
-        # Check if progress has been made
-        if current_batches_completed <= attempt.last_batches_completed_count:
-            # if between timeout_hours/2 and timeout_hours has passed
-            # without an update, we consider the attempt stalled
-            return False
-
-        # Progress made - update tracking
-        attempt.last_progress_time = current_time
-        attempt.last_batches_completed_count = current_batches_completed
-        db_session.commit()
-        return True


### PR DESCRIPTION
## Description

Removes the check_indexing_completion progress stall check (the "3-6 hours without progress" path) in favor of the heartbeat monitor introduced in #10768.

The stall check had three branches, all superseded:

IN_PROGRESS stall: fired when completed_batches didn't advance for 3-6 hours. Redundant — the heartbeat monitor catches all the underlying failure modes within 30 minutes using the pending/in_flight counters. The in_flight=0, pending>0 case was an outright false positive (workers saturated, not stuck).
NOT_STARTED + missing task: detected orphaned attempts whose Celery task disappeared from the queue. Covered by the heartbeat monitor — a NOT_STARTED attempt with heartbeat_counter permanently at 0 goes stale in 30 minutes and is invalidated.
else reset: just logged and reset the timer. No longer needed.
Also removes all associated dead code: update_progress_tracking method, INDEXING_PROGRESS_TIMEOUT_HOURS, DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER, three unused Celery queue inspection imports, the task parameter from check_indexing_completion and monitor_indexing_attempt_progress, and the last_progress_time/last_batches_completed_count columns (with migration to drop them from the DB).

https://docs.google.com/document/d/1uhL54rzkwJVW3ZBFZlw3_v00-pPZAZ1AeUWP4GobmCE/edit?tab=t.0
https://linear.app/onyx-app/issue/ENG-4092/improve-the-doc-processing-robustness

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
local test
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the progress-stall check. Heartbeat now owns liveness, with a 12-hour Redis scan for long-waiting NOT_STARTED attempts that checks queued and unacked sets to catch lost Celery tasks and reduce false “stuck” alerts.

- **Bug Fixes**
  - Removed stall check that misfired when in_flight=0 and pending>0; heartbeat detects failures within ~30 minutes.
  - Added NOT_STARTED watchdog: after 12 hours, the heartbeat validator scans Redis via `celery.current_app`; if the task ID isn’t in queued or unacked (with a 1s recheck), mark the attempt failed.
  - Aligns with Linear ENG-4092 to improve doc-processing robustness.

- **Refactors**
  - Deleted progress-tracking path: removed `IndexingCoordination.update_progress_tracking`, `INDEXING_PROGRESS_TIMEOUT_HOURS`, and `DOCPROCESSING_STALL_TIMEOUT_MULTIPLIER`.
  - Simplified signatures: removed `task` param from `monitor_indexing_attempt_progress` and `check_indexing_completion`; broker access now uses `celery.current_app` and `celery_get_queued_task_ids`/`celery_get_unacked_task_ids`.

<sup>Written for commit 38da295f7e68461ca73d383a550e2dfe1fabf72d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



