### PR TITLE
fix(files): Stop persona file blockages

### DIFF
--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -21,6 +21,9 @@ from onyx.db.models import Connector
 from onyx.db.models import Document
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import FileRecord
+from onyx.db.models import Persona
+from onyx.db.models import Persona__User
+from onyx.db.models import Persona__UserFile
 from onyx.db.models import User
 from onyx.db.models import UserFile
 from onyx.db.user_file import fetch_user_files_with_access_relationships
@@ -214,6 +217,8 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
     JSONB scan in `_documents_from_file_connector_config`):
 
     - `UserFile` owned by the user.
+    - `UserFile` attached to a `Persona` the user can read (public, owned,
+      or directly shared via `Persona.users`).
     - `ChatMessage.files` of a session the user owns or that is shared as
       `ChatSessionSharedStatus.PUBLIC`.
     - `FileRecord` with origin `CHAT_IMAGE_GEN` (see inline TODO).
@@ -229,6 +234,9 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
         .exists()
     ).scalar()
     if owns_user_file:
+        return True
+
+    if _user_can_access_persona_attached_file(file_id, user, db_session):
         return True
 
     chat_file_stmt = (
@@ -262,6 +270,36 @@ def user_can_access_chat_file(file_id: str, user: User, db_session: Session) -> 
         return True
 
     return _user_can_access_connector_file(file_id, user, db_session)
+
+
+def _user_can_access_persona_attached_file(
+    file_id: str, user: User, db_session: Session
+) -> bool:
+    """Grant access if `file_id` belongs to a `UserFile` attached to a
+    `Persona` the user can read (public, owned, or directly shared via
+    `Persona.users`).
+    """
+    stmt = (
+        select(UserFile.id)
+        .join(Persona__UserFile, Persona__UserFile.user_file_id == UserFile.id)
+        .join(Persona, Persona.id == Persona__UserFile.persona_id)
+        .outerjoin(
+            Persona__User,
+            (Persona__User.persona_id == Persona.id)
+            & (Persona__User.user_id == user.id),
+        )
+        .where(
+            UserFile.file_id == file_id,
+            Persona.deleted.is_(False),
+            or_(
+                Persona.is_public.is_(True),
+                Persona.user_id == user.id,
+                Persona__User.user_id.is_not(None),
+            ),
+        )
+        .limit(1)
+    )
+    return db_session.execute(stmt).first() is not None
 
 
 def _user_can_access_connector_file(

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -108,14 +108,14 @@ def update_last_accessed_at_for_user_files(
     db_session.commit()
 
 
-def get_file_id_by_user_file_id(
-    user_file_id: str, user_id: UUID, db_session: Session
-) -> str | None:
-    user_file = (
-        db_session.query(UserFile)
-        .filter(UserFile.id == user_file_id, UserFile.user_id == user_id)
-        .first()
-    )
+def get_file_id_by_user_file_id(user_file_id: str, db_session: Session) -> str | None:
+    """Resolve a `UserFile.id` to its underlying `FileRecord.file_id`.
+
+    Returns None when the input is not a known `UserFile.id` (e.g. when the
+    caller is already passing a storage `file_id`), so the caller can fall
+    through to a direct file-store lookup.
+    """
+    user_file = db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
     if user_file:
         return user_file.file_id
     return None

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -862,10 +862,11 @@ def fetch_chat_file(
     db_session: Session = Depends(get_session),
 ) -> Response:
     # For user files, we need to get the file id from the user file id
-    file_id_from_user_file = get_file_id_by_user_file_id(file_id, user.id, db_session)
+    file_id_from_user_file = get_file_id_by_user_file_id(file_id, db_session)
     if file_id_from_user_file:
         file_id = file_id_from_user_file
-    elif not user_can_access_chat_file(file_id, user, db_session):
+
+    if not user_can_access_chat_file(file_id, user, db_session):
         # Return 404 (rather than 403) so callers cannot probe for file
         # existence across ownership boundaries.
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "File not found")

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -146,9 +146,14 @@ def test_public_assistant_with_user_files(
     ), "Expected at least 2 messages (user message and assistant response)"
 
 
-def test_cannot_download_other_users_file_via_chat_file_endpoint(
+def test_public_assistant_attached_file_downloadable_by_non_owner(
     user_file_setup: UserFileTestSetup,
 ) -> None:
+    """A user file attached to a public persona must be downloadable by any
+    user, mirroring the indexing-time ACL in `collect_user_file_access`.
+    Without this, citations to the agent's knowledge files surface in chat
+    but 404 on click. Both URL forms (storage `file_id` and `UserFile.id`)
+    must work because citation links carry the latter."""
     storage_file_id = user_file_setup.user1_file_descriptor["id"]
     user_file_id = user_file_setup.user1_file_id
 
@@ -160,18 +165,117 @@ def test_cannot_download_other_users_file_via_chat_file_endpoint(
     assert owner_response.content, "Owner should receive the file contents"
 
     for file_id in (storage_file_id, user_file_id):
-        user2_response = requests.get(
+        non_owner_response = requests.get(
             f"{API_SERVER_URL}/chat/file/{file_id}",
             headers=user_file_setup.user2_non_owner.headers,
         )
-        assert user2_response.status_code in (
-            403,
-            404,
-        ), (
-            f"Expected access denied for non-owner, got {user2_response.status_code} "
-            f"when fetching file_id={file_id}"
+        assert non_owner_response.status_code == 200, (
+            "Non-owner should be able to download a file attached to a "
+            f"public persona via {file_id=}, got "
+            f"{non_owner_response.status_code}"
         )
-        assert user2_response.content != owner_response.content
+        assert non_owner_response.content == owner_response.content
+
+
+def test_private_persona_attached_file_downloadable_by_shared_user(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """A user file attached to a *private* persona must be downloadable by a
+    user who is on `Persona.users` (directly shared), but still denied for
+    third parties. Mirrors the `Persona__User` branch of the indexing-time
+    ACL in `collect_user_file_access`."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+    LLMProviderManager.create(user_performing_action=admin_user)
+    file_owner: DATestUser = UserManager.create(name="file_owner")
+    shared_user: DATestUser = UserManager.create(name="shared_user")
+    outsider: DATestUser = UserManager.create(name="outsider")
+
+    file_descriptors, error = FileManager.upload_files(
+        files=[("shared.txt", io.BytesIO(b"shared persona file"))],
+        user_performing_action=file_owner,
+    )
+    assert not error, f"Failed to upload file: {error}"
+    storage_file_id = file_descriptors[0]["id"]
+    user_file_id = file_descriptors[0].get("user_file_id")
+    assert user_file_id is not None
+
+    PersonaManager.create(
+        name="Private Shared Assistant",
+        description="Private persona shared with one specific user",
+        is_public=False,
+        users=[shared_user.id],
+        user_file_ids=[user_file_id],
+        user_performing_action=admin_user,
+    )
+
+    owner_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{storage_file_id}",
+        headers=file_owner.headers,
+    )
+    assert owner_response.status_code == 200
+    assert owner_response.content, "Owner should receive the file contents"
+
+    for file_id in (storage_file_id, user_file_id):
+        shared_response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=shared_user.headers,
+        )
+        assert shared_response.status_code == 200, (
+            "User on Persona.users should be able to download a file "
+            f"attached to the shared private persona via {file_id=}, got "
+            f"{shared_response.status_code}"
+        )
+        assert shared_response.content == owner_response.content
+
+        outsider_response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=outsider.headers,
+        )
+        assert outsider_response.status_code in (403, 404), (
+            "Outsider not on Persona.users must not access a private "
+            f"persona's attached file via {file_id=}, got "
+            f"{outsider_response.status_code}"
+        )
+        assert outsider_response.content != owner_response.content
+
+
+def test_cannot_download_unattached_file_via_chat_file_endpoint(
+    reset: None,  # noqa: ARG001
+) -> None:
+    """Files that are *not* exposed via any accessible persona, public chat
+    session, or chat-image-gen output must still 404 for non-owners. This
+    pins the negative case so the persona-attached relaxation above does not
+    silently grant access to arbitrary files."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+    LLMProviderManager.create(user_performing_action=admin_user)
+    owner: DATestUser = UserManager.create(name="owner")
+    intruder: DATestUser = UserManager.create(name="intruder")
+
+    file_descriptors, error = FileManager.upload_files(
+        files=[("private.txt", io.BytesIO(b"private contents"))],
+        user_performing_action=owner,
+    )
+    assert not error, f"Failed to upload file: {error}"
+    storage_file_id = file_descriptors[0]["id"]
+    user_file_id = file_descriptors[0].get("user_file_id")
+    assert user_file_id is not None
+
+    owner_response = requests.get(
+        f"{API_SERVER_URL}/chat/file/{storage_file_id}",
+        headers=owner.headers,
+    )
+    assert owner_response.status_code == 200
+
+    for file_id in (storage_file_id, user_file_id):
+        intruder_response = requests.get(
+            f"{API_SERVER_URL}/chat/file/{file_id}",
+            headers=intruder.headers,
+        )
+        assert intruder_response.status_code in (403, 404), (
+            f"Expected access denied for non-owner of an unattached file, "
+            f"got {intruder_response.status_code} when fetching file_id={file_id}"
+        )
+        assert intruder_response.content != owner_response.content
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Currently user files associated with a persona are not viewable. This changes that to make them viewable if the persona has those user files and the user has access to the persona.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blocked downloads of persona-attached user files. Users can now open knowledge files linked to personas they can access, and citation links work.

- **Bug Fixes**
  - Allow access to `UserFile`s attached to a readable `Persona` (public, owned, or shared via `Persona.users`) via `_user_can_access_persona_attached_file`.
  - Update `GET /chat/file/{file_id}` to resolve `UserFile.id` to storage `file_id` without a user check, then apply unified access control; still returns 404 on denial.
  - Add tests: public persona files downloadable by non-owners (via storage `file_id` or `UserFile.id`); private persona files accessible to shared users only; unattached files remain blocked.

<sup>Written for commit 0dded9bf76940955cca77696ed721d822cc59d76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

