### PR TITLE
fix(files): Code interpreter files not appearing during chat streaming

### DIFF
--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -263,7 +263,7 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
                         onyx_file_id = file_store.save_file(
                             content=BytesIO(file_content),
                             display_name=filename,
-                            file_origin=FileOrigin.CHAT_UPLOAD,
+                            file_origin=FileOrigin.CHAT_IMAGE_GEN,
                             file_type=mime_type,
                         )
 


### PR DESCRIPTION
## Description
Currently code interpreter files will only appear once the chat is done streaming. This requires a reload to occur which is bad UX. The reason has to do with Chat_upload files are handled. Let's treat these images like Chat_Gen images

## How Has This Been Tested?
Manual

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code interpreter files not appearing until streaming ends by saving them as generated images so they show up in real time. Removes the need to reload the chat to see files.

- **Bug Fixes**
  - Save interpreter outputs with `FileOrigin.CHAT_IMAGE_GEN` instead of `FileOrigin.CHAT_UPLOAD` so the client surfaces files during streaming.

<sup>Written for commit 4b8710c99c8177a98f23f9ea5812fc0bd6f89421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

