### PR TITLE
fix(coding-agent): Stop coding agent populating main chat

### DIFF
--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -337,16 +337,14 @@ def create_coding_agent_packets(
 
     Mirrors what the live ``CodingAgentTool`` emits:
     - ``CodingAgentStart(query, repo)`` opens the agent's section.
-    - ``CodingAgentFinal(answer)`` carries the inner agent's answer for the
-      timeline's completion marker (when available).
+    - ``CodingAgentFinal(answer)`` carries the inner agent's answer, which
+      the renderer displays as the agent's "Response" step.
     - ``SectionEnd`` marks completion.
 
-    The agent's user-visible answer text is *not* emitted here — it lands in
-    a separate group via ``create_message_packets`` at ``max_tool_turn + 1``,
-    which is what renders as the chat bubble. Splitting placements (live
-    streaming does the same — see ``_generate_final_answer``) keeps the
-    timeline ("what the agent did") distinct from the chat answer ("what the
-    agent said").
+    The outer chat-message bubble (rendered from ``chat_message.message`` via
+    ``create_message_packets`` at ``max_tool_turn + 1``) is the regular chat
+    agent's answer — separate from the coding agent's response, which stays
+    inside the agent's own timeline section.
 
     Bash sub-calls aren't persisted (they're not top-level tool calls), so
     they aren't replayed here — the renderer shows "Coding Task" only.

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -39,7 +39,6 @@ from onyx.server.query_and_chat.streaming_models import CodingAgentFinal
 from onyx.server.query_and_chat.streaming_models import CodingAgentThinkingDelta
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.query_and_chat.streaming_models import PacketException
-from onyx.server.query_and_chat.streaming_models import SectionEnd
 from onyx.server.query_and_chat.streaming_models import StreamingType
 from onyx.tools.models import ToolCallKickoff
 from onyx.tools.tool_implementations.bash.bash_tool import BashTool
@@ -213,32 +212,14 @@ def _generate_final_answer(
             is_deep_research=False,
         )
 
-        # Route the agent's final answer (AgentResponseStart/Delta) to a
-        # separate group at turn_index + 1 so it renders as a chat bubble
-        # via MessageTextRenderer, distinct from the coding-agent timeline.
-        # This mirrors the reload convention (session_loading.py emits
-        # create_message_packets at max_tool_turn + 1). Reasoning and
-        # SectionEnd stay on the agent's placement.
-        chat_bubble_placement = Placement(turn_index=placement.turn_index + 1)
-        emitted_chat_bubble = False
-
         while True:
             try:
                 packet = next(answer_generator)
                 if isinstance(packet.obj, (AgentResponseStart, AgentResponseDelta)):
-                    emitted_chat_bubble = True
-                    emitter.emit(
-                        Packet(placement=chat_bubble_placement, obj=packet.obj),
-                    )
-                else:
-                    emitter.emit(Packet(placement=placement, obj=packet.obj))
+                    continue
+                emitter.emit(Packet(placement=placement, obj=packet.obj))
             except StopIteration as e:
                 llm_step_result, _ = e.value
-                emitter.emit(Packet(placement=placement, obj=SectionEnd()))
-                if emitted_chat_bubble:
-                    emitter.emit(
-                        Packet(placement=chat_bubble_placement, obj=SectionEnd()),
-                    )
                 break
 
         final_answer = llm_step_result.answer

--- a/web/src/app/app/message/messageComponents/timeline/renderers/code/CodingAgentRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/code/CodingAgentRenderer.tsx
@@ -396,7 +396,7 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
       return wrap(
         <ResponseStep
           answer={finalPacket.answer}
-          isLastStep={false}
+          isLastStep={true}
           isHover={isHover}
         />
       );

--- a/web/src/app/app/message/messageComponents/timeline/renderers/code/CodingAgentRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/code/CodingAgentRenderer.tsx
@@ -11,6 +11,7 @@ import bash from "highlight.js/lib/languages/bash";
 import {
   BashToolDelta,
   BashToolStart,
+  CodingAgentFinal,
   CodingAgentPacket,
   CodingAgentStart,
   CodingAgentThinkingDelta,
@@ -283,6 +284,31 @@ function CodingTaskStep({
   );
 }
 
+interface ResponseStepProps {
+  answer: string;
+  isLastStep: boolean;
+  isHover: boolean;
+}
+
+function ResponseStep({ answer, isLastStep, isHover }: ResponseStepProps) {
+  return (
+    <StepContainer
+      stepIcon={SvgCheckCircle}
+      header="Response"
+      isLastStep={isLastStep}
+      isHover={isHover}
+      collapsible={true}
+      supportsCollapsible={true}
+    >
+      <div className="pl-[var(--timeline-common-text-padding)]">
+        <Text as="p" font="main-ui-muted" color="text-02">
+          {answer}
+        </Text>
+      </div>
+    </StepContainer>
+  );
+}
+
 export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
   packets,
   renderType,
@@ -293,9 +319,10 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
   const startPacket = packets.find(
     (p) => p.obj.type === PacketType.CODING_AGENT_START
   )?.obj as CodingAgentStart | undefined;
-  const hasFinal = packets.some(
+  const finalPacket = packets.find(
     (p) => p.obj.type === PacketType.CODING_AGENT_FINAL
-  );
+  )?.obj as CodingAgentFinal | undefined;
+  const hasFinal = finalPacket !== undefined;
   const errored = packets.some((p) => p.obj.type === PacketType.ERROR);
 
   const steps = useMemo(() => buildAgentSteps(packets), [packets]);
@@ -327,7 +354,14 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
     let header: string | null = null;
     let body: JSX.Element | null = null;
 
-    if (latestStep?.kind === "bash") {
+    if (finalPacket) {
+      header = "Response";
+      body = (
+        <Text as="p" font="main-ui-muted" color="text-02">
+          {finalPacket.answer}
+        </Text>
+      );
+    } else if (latestStep?.kind === "bash") {
       header = bashStepHeader(latestStep);
       body = <BashStepBody call={latestStep} />;
     } else if (latestStep?.kind === "thinking") {
@@ -358,6 +392,15 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
   }
 
   if (renderType === RenderType.COMPACT) {
+    if (finalPacket) {
+      return wrap(
+        <ResponseStep
+          answer={finalPacket.answer}
+          isLastStep={false}
+          isHover={isHover}
+        />
+      );
+    }
     if (latestStep) {
       return wrap(
         renderAgentStep(latestStep, "latest", lastStepIsActive, isHover)
@@ -380,7 +423,7 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
       {startPacket && (
         <CodingTaskStep
           taskText={taskText}
-          isLastStep={lastStepIsActive && steps.length === 0}
+          isLastStep={lastStepIsActive && steps.length === 0 && !finalPacket}
           isHover={isHover}
         />
       )}
@@ -388,9 +431,16 @@ export const CodingAgentRenderer: MessageRenderer<CodingAgentPacket, {}> = ({
         renderAgentStep(
           step,
           idx,
-          lastStepIsActive && idx === steps.length - 1,
+          lastStepIsActive && idx === steps.length - 1 && !finalPacket,
           isHover
         )
+      )}
+      {finalPacket && (
+        <ResponseStep
+          answer={finalPacket.answer}
+          isLastStep={true}
+          isHover={isHover}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Description
There is a bug where the coding agent may emit packets that end up in the final chat answer. 

This PR stops this by not handling these packets. We can fix this in a later PR to improve UX.

## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops coding agent responses from leaking into the main chat and shows the agent’s final answer inside the coding timeline as a “Response” step. Keeps chat bubbles clean and the coding agent’s answer scoped to its timeline.

- **Bug Fixes**
  - Backend: drop `AgentResponseStart/Delta` instead of re-routing; only emit coding-agent packets on the agent’s placement (no chat-bubble placement).
  - Frontend: render a “Response” step from `CodingAgentFinal` in full and compact views; adjust last-step handling to account for the response.
  - Comments: clarify separation between the chat bubble and the coding agent’s timeline in session replay.

<sup>Written for commit fc2421a7c9548efb191dbf5fc39ee203ee23afdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

