### PR TITLE
ci(opal): add release workflow for @onyx-ai/opal

### DIFF
--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -3,7 +3,7 @@ name: Release Opal
 on:
   push:
     tags:
-      - "opal-v*.*.*"
+      - "opal/v*.*.*"
 
 jobs:
   npm:
@@ -22,14 +22,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4 # zizmor: ignore[cache-poisoning]
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          check-latest: false
+          cache: ""
 
       - name: Verify tag matches package.json version
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#opal-v}"
+          TAG_VERSION="${GITHUB_REF_NAME#opal/v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
           if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
             echo "::error::Tag $GITHUB_REF_NAME does not match package.json version ($PKG_VERSION)"

--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
+      # NOTE: actions/setup-node has no equivalent of setup-uv's `enable-cache: false`.
+      # `cache: ""` only disables npm/yarn/pnpm dep caching — the Node toolchain itself is
+      # always restored from the runner toolcache, which zizmor's cache-poisoning rule flags
+      # on every release-publishing workflow. The risk requires compromising the
+      # GitHub-hosted runner image, which is well outside this repo's threat model.
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -1,0 +1,39 @@
+name: Release Opal
+
+on:
+  push:
+    tags:
+      - "opal-v*.*.*"
+  workflow_dispatch:
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    environment:
+      name: release-opal
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: web/lib/opal
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install workspace deps
+        run: npm ci
+        working-directory: web
+
+      - name: Build opal
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public

--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "opal-v*.*.*"
-  workflow_dispatch:
 
 jobs:
   npm:
@@ -23,10 +22,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#opal-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
 
       - name: Install workspace deps
         run: npm ci

--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -8,6 +8,12 @@ on:
 jobs:
   npm:
     runs-on: ubuntu-latest
+    # Pin Node by image digest. The container ships with Node baked in, so the workflow
+    # never invokes `actions/setup-node` and the runner toolcache is never restored —
+    # mitigates zizmor's cache-poisoning class of finding at the source rather than
+    # suppressing it. Bumping Node = bump the digest.
+    container:
+      image: node:24@sha256:3a198147c320bc4cc357b418955beb48413c0ea5ba60f9ec1568913631df33aa
     environment:
       name: release-opal
     permissions:
@@ -22,23 +28,15 @@ jobs:
         with:
           persist-credentials: false
 
-      # NOTE: actions/setup-node has no equivalent of setup-uv's `enable-cache: false`.
-      # `cache: ""` only disables npm/yarn/pnpm dep caching — the Node toolchain itself is
-      # always restored from the runner toolcache, which zizmor's cache-poisoning rule flags
-      # on every release-publishing workflow. The risk requires compromising the
-      # GitHub-hosted runner image, which is well outside this repo's threat model.
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v4 # zizmor: ignore[cache-poisoning]
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-          check-latest: false
-          cache: ""
+      - name: Configure npm registry
+        run: |
+          printf 'registry=https://registry.npmjs.org/\n' > "$HOME/.npmrc"
 
       - name: Verify tag matches package.json version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#opal/v}"
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag $GITHUB_REF_NAME does not match package.json version ($PKG_VERSION)"
             exit 1
           fi

--- a/web/lib/opal/README.md
+++ b/web/lib/opal/README.md
@@ -130,6 +130,33 @@ cd web/lib/opal
 npm run build       # tsup -> dist/, then bundle-css.mjs -> dist/styles.css
 ```
 
+## Releasing to npm
+
+Releases go out through the `Release Opal` GitHub Actions workflow
+(`.github/workflows/release-opal.yml`). It uses npm OIDC Trusted Publishers — no
+`NPM_TOKEN`, signed provenance attestation. Pushing a tag is the only thing that triggers a
+release.
+
+Steps:
+
+1. Bump `version` in `web/lib/opal/package.json` (semver: `MAJOR.MINOR.PATCH`, prerelease
+   suffix `-rc.N` allowed).
+2. Open a PR with the version bump and any release-shaped changes. Merge it.
+3. From `main`, tag and push:
+
+   ```sh
+   git switch main && git pull
+   git tag opal-v0.1.1
+   git push origin opal-v0.1.1
+   ```
+
+4. The workflow runs automatically on tag push. It builds (`tsup` + CSS barrel) and runs
+   `npm publish --provenance --access public`. Watch the run under the Actions tab; verify
+   the new version on https://www.npmjs.com/package/@onyx-ai/opal.
+
+The tag pattern must match `opal-v*.*.*` for the workflow to fire. Manual one-off runs are
+also possible via `workflow_dispatch` from the Actions tab.
+
 ## Conventions
 
 - Component directories are kebab-case (e.g. `select-button/`, `open-button/`,

--- a/web/lib/opal/README.md
+++ b/web/lib/opal/README.md
@@ -146,16 +146,15 @@ Steps:
 
    ```sh
    git switch main && git pull
-   git tag opal-v0.1.1
-   git push origin opal-v0.1.1
+   git tag opal/v0.1.1
+   git push origin opal/v0.1.1
    ```
 
 4. The workflow runs automatically on tag push. It builds (`tsup` + CSS barrel) and runs
    `npm publish --provenance --access public`. Watch the run under the Actions tab; verify
    the new version on https://www.npmjs.com/package/@onyx-ai/opal.
 
-The tag pattern must match `opal-v*.*.*` for the workflow to fire. Manual one-off runs are
-also possible via `workflow_dispatch` from the Actions tab.
+The tag pattern must match `opal/v*.*.*` for the workflow to fire.
 
 ## Conventions
 


### PR DESCRIPTION
## Description

OIDC trusted-publisher-based release flow for `@onyx-ai/opal`. No long-lived `NPM_TOKEN` — the workflow exchanges a GitHub Actions ID token for a short-lived publish credential via npm's Trusted Publishers binding for this repo + this workflow filename. Already configured on npmjs.com for `@onyx-ai/opal` against `release-opal.yml`.

**Triggers**
- `push` of `opal-v*.*.*` tag → automated release
- `workflow_dispatch` → manual run

**Steps**
- `npm ci` in `web/` (workspace install resolves opal)
- `npm run build` in `web/lib/opal/` (tsup + bundle-css)
- `npm publish --provenance --access public` (provenance attestation shown on npmjs.com)

The `release-opal` environment lets us add a manual approval gate later without changing the workflow.

## How Has This Been Tested?

- Initial `0.1.0` was published manually with a 7-day token (now ready to revoke).
- After this PR merges: cut `opal-v0.1.1-rc.0` to smoke-test the workflow, then `opal-v0.1.1` for the first OIDC-published release.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check