### PR TITLE
feat(targeted-reindex): plumb HierarchyNode yields through reindex

### DIFF
--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -290,6 +290,11 @@ def process_targets_for_cc_pair(
             tenant_id=tenant_id,
             db_session=db_session,
         )
+        logger.debug(
+            "Persisted and cached %s hierarchy nodes for cc_pair_id=%s",
+            len(hierarchy_nodes),
+            cc_pair_id,
+        )
 
     # Per-attempt pipeline run. Each attempt commits to its own
     # search_settings's document_indices.

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -28,9 +28,13 @@ from onyx.connectors.factory import instantiate_connector
 from onyx.connectors.interfaces import Resolver
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import IndexAttemptMetadata
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.enums import AccessType
+from onyx.db.hierarchy import upsert_hierarchy_node_cc_pair_entries
+from onyx.db.hierarchy import upsert_hierarchy_nodes_batch
+from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import TargetedReindexJobTarget
 from onyx.db.targeted_reindex import targets_to_connector_failures
@@ -41,8 +45,12 @@ from onyx.indexing.adapters.document_indexing_adapter import (
 )
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
+from onyx.redis.redis_hierarchy import cache_hierarchy_nodes_batch
+from onyx.redis.redis_hierarchy import HierarchyNodeCacheEntry
+from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger
 from onyx.utils.middleware import make_randomized_onyx_request_id
+from onyx.utils.postgres_sanitization import sanitize_hierarchy_nodes_for_postgres
 
 logger = setup_logger()
 
@@ -164,6 +172,41 @@ def _flush_batch(
     return landed_ids, failed_ids
 
 
+def _persist_hierarchy_nodes(
+    *,
+    nodes: list[HierarchyNode],
+    cc_pair: ConnectorCredentialPair,
+    tenant_id: str,
+    db_session: Session,
+) -> None:
+    """Mirror the docfetching hierarchy upsert path for the targeted
+    reindex flow. Without this, ancestor folders/spaces yielded by a
+    Resolver during reindex would never land in Postgres or the redis
+    cache, so KG ancestor lookups for newly-reindexed docs would fall
+    back to "source-type root" until the next full crawl.
+    """
+    sanitized = sanitize_hierarchy_nodes_for_postgres(nodes)
+    upserted = upsert_hierarchy_nodes_batch(
+        db_session=db_session,
+        nodes=sanitized,
+        source=cc_pair.connector.source,
+        commit=True,
+        is_connector_public=cc_pair.access_type == AccessType.PUBLIC,
+    )
+    upsert_hierarchy_node_cc_pair_entries(
+        db_session=db_session,
+        hierarchy_node_ids=[n.id for n in upserted],
+        connector_id=cc_pair.connector.id,
+        credential_id=cc_pair.credential.id,
+        commit=True,
+    )
+    cache_hierarchy_nodes_batch(
+        redis_client=get_redis_client(tenant_id=tenant_id),
+        source=cc_pair.connector.source,
+        entries=[HierarchyNodeCacheEntry.from_db_model(n) for n in upserted],
+    )
+
+
 def process_targets_for_cc_pair(
     *,
     cc_pair_id: int,
@@ -224,6 +267,7 @@ def process_targets_for_cc_pair(
     # Materialize the connector output once. MAX_TARGETS_PER_REQUEST caps
     # the universe at 100 docs total per job, so this is bounded.
     docs: list[Document] = []
+    hierarchy_nodes: list[HierarchyNode] = []
     failed_from_connector: set[str] = set()
     for item in connector.reindex(
         errors=failures, include_permissions=include_permissions
@@ -235,13 +279,17 @@ def process_targets_for_cc_pair(
         if isinstance(item, Document):
             docs.append(item)
             continue
-        # TODO(targeted-reindex follow-up): plumb HierarchyNode yields
-        # through the same path the indexing pipeline uses for full
-        # crawls. Skipping is safe today (a missing ancestor folder
-        # node falls back to "source-type root" in KG selection), but
-        # for cases like "admin restored a folder's permissions and
-        # reindexed its docs" the new ancestor relationship would
-        # otherwise stay missing until the next full crawl.
+        if isinstance(item, HierarchyNode):
+            hierarchy_nodes.append(item)
+            continue
+
+    if hierarchy_nodes:
+        _persist_hierarchy_nodes(
+            nodes=hierarchy_nodes,
+            cc_pair=cc_pair,
+            tenant_id=tenant_id,
+            db_session=db_session,
+        )
 
     # Per-attempt pipeline run. Each attempt commits to its own
     # search_settings's document_indices.


### PR DESCRIPTION
## Description

`process_targets_for_cc_pair` was discarding `HierarchyNode` items the Resolver yields (TODO since the connector wiring landed in #10864). Mirror the docfetching path: collect ancestor nodes from `connector.reindex(...)`, sanitize, upsert via `upsert_hierarchy_nodes_batch`, link to the cc_pair, and cache in redis for fast ancestor resolution.

Without this, an admin restoring folder permissions and reindexing the affected docs would leave the new ancestor relationship stuck on "source-type root" until the next full crawl.

Single new helper `_persist_hierarchy_nodes` in `run_targeted_reindex.py`. Reuses every helper docfetching uses — same sanitization, same upsert, same redis cache call. Bounded: `MAX_TARGETS_PER_REQUEST=100` caps the universe of yielded nodes.

## How Has This Been Tested?

Manual code path verification + ty/ruff/black green. End-to-end coverage will land via the existing daily Drive integration suite (`backend/tests/daily/targeted_reindex/test_drive_targeted_reindex_integration.py`) on the next nightly — Drive's Resolver already yields hierarchy nodes for ancestors via `_get_new_ancestors_for_files`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check