### PR TITLE
chore(opal): bump version to 0.1.1 for first OIDC release

### DIFF
--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description

One-line version bump in `web/lib/opal/package.json`: `0.1.0` → `0.1.1`.

Required so the next `opal/v0.1.1` tag push satisfies the workflow's tag-vs-package.json verify step. (The first attempted tag push failed correctly: tag was `0.1.1` but `package.json` still read `0.1.0`.)

## How Has This Been Tested?

- Diff is one line.
- After merge: re-create tag `opal/v0.1.1` on the merge commit and push it; the release workflow will fire and publish to npm.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check