### PR TITLE
fix(onyx-cli): build go binary for each GOOS/GOARCH

### DIFF
--- a/cli/hatch_build.py
+++ b/cli/hatch_build.py
@@ -30,13 +30,12 @@ class CustomBuildHook(BuildHookInterface):
         tag = os.getenv("GITHUB_REF_NAME", "dev").removeprefix(f"{tag_prefix}/")
         commit = os.getenv("GITHUB_SHA", "none")
 
-        # Build the Go binary if it doesn't exist
-        # Build the Go binary (always rebuild to ensure correct version injection)
-        if not os.path.exists(binary_name):
-            print(f"Building Go binary '{binary_name}'...")
-            ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
-            subprocess.check_call(  # noqa: S603
-                ["go", "build", f"-ldflags={ldflags}", "-o", binary_name],
-            )
+        # Always rebuild: release builds invoke this hook once per wheel with different
+        # GOOS/GOARCH
+        print(f"Building Go binary '{binary_name}'...")
+        ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
+        subprocess.check_call(  # noqa: S603
+            ["go", "build", f"-ldflags={ldflags}", "-o", binary_name],
+        )
 
         build_data["shared_scripts"] = {binary_name: binary_name}


### PR DESCRIPTION
## Description

PyPI wheels for `onyx-cli` were built in a single CI loop over `GOOS`/`GOARCH`, but `hatch_build.py` **only ran `go build` when the `onyx-cli` output file was missing**. 

After the first platform built (e.g. Linux `amd64`), later wheels reused that same binary while still getting the correct **wheel** platform tag—so e.g. the macOS ARM64 wheel could contain a Linux ELF, causing `zsh: exec format error` on Mac.

This change **always** runs `go build` for each wheel so the packaged binary matches the intended OS/arch. Version/commit `-ldflags` injection still applies on every build.

## How Has This Been Tested?

- Local: `cd cli && go build -o /tmp/onyx-cli-test . && file /tmp/onyx-cli-test` → `Mach-O 64-bit executable arm64` on Apple Silicon.
- After merge, the **Release CLI** workflow should be re-run via a new `cli/v*` tag; spot-check the published macOS wheel with `file` on the installed `onyx-cli` (expect Mach-O, not ELF).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
