### PR TITLE
feat(ods): `ods deploy wiki` command

### DIFF
--- a/tools/ods/cmd/deploy.go
+++ b/tools/ods/cmd/deploy.go
@@ -14,6 +14,7 @@ func NewDeployCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewDeployEdgeCommand())
+	cmd.AddCommand(NewDeployWikiCommand())
 
 	return cmd
 }

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -16,7 +16,7 @@ const (
 	wikiDeployRepo      = "onyx-dot-app/cloud-deployment-yamls"
 	wikiDeployWorkflow  = "dev-wiki-deploy.yml"
 	wikiBuildPollLimit  = 30 * time.Minute
-	wikiDeployPollLimit = 10 * time.Minute
+	wikiDeployPollLimit = 20 * time.Minute
 )
 
 // DeployWikiOptions holds options for the deploy wiki command.
@@ -144,6 +144,7 @@ func runDeploy(versionTag string, noWait bool) {
 		log.Fatalf("Failed to dispatch deploy workflow: %v", err)
 	}
 
+	log.Info("Waiting for deploy workflow to start...")
 	deployRun, err := waitForNewRun(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find dispatched deploy run: %v", err)

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+)
+
+const (
+	wikiBuildRepo       = "onyx-dot-app/agent-wiki"
+	wikiBuildWorkflow   = "nightly-build.yml"
+	wikiDeployRepo      = "onyx-dot-app/cloud-deployment-yamls"
+	wikiDeployWorkflow  = "dev-wiki-deploy.yml"
+	wikiBuildPollLimit  = 30 * time.Minute
+	wikiDeployPollLimit = 10 * time.Minute
+)
+
+// DeployWikiOptions holds options for the deploy wiki command.
+type DeployWikiOptions struct {
+	DryRun       bool
+	Yes          bool
+	NoWaitDeploy bool
+	NoBuild      bool
+}
+
+// NewDeployWikiCommand creates the `ods deploy wiki` command.
+func NewDeployWikiCommand() *cobra.Command {
+	opts := &DeployWikiOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "wiki",
+		Short: "Build a fresh nightly image and deploy it to dev-wiki.onyx.app",
+		Long: `Build a fresh nightly image of agent-wiki and deploy it to dev-wiki.
+
+This command will:
+  1. Dispatch the nightly-build.yml workflow in onyx-dot-app/agent-wiki
+     (builds and pushes onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD)
+  2. Wait for the build workflow to finish
+  3. Dispatch the dev-wiki-deploy.yml workflow in onyx-dot-app/cloud-deployment-yamls
+     with version_tag=nightly-latest-YYYYMMDD (today's UTC date)
+  4. Wait for the deploy workflow to finish
+
+All GitHub operations run through the gh CLI, so authorization is enforced
+by your gh credentials and GitHub's repo/workflow permissions. A kickoff
+Slack message will appear in #monitor-deployments.
+
+Pass --no-build to skip step 1 and just deploy whatever's already on
+Docker Hub for today's tag.
+
+Example usage:
+
+    $ ods deploy wiki`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			deployWiki(opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform local operations only; skip dispatching workflows")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&opts.NoWaitDeploy, "no-wait-deploy", false, "Do not wait for the deploy workflow to finish after dispatching it")
+	cmd.Flags().BoolVar(&opts.NoBuild, "no-build", false, "Skip the build step; deploy whatever's already on Docker Hub for today's tag")
+
+	return cmd
+}
+
+func deployWiki(opts *DeployWikiOptions) {
+	git.CheckGitHubCLI()
+
+	if opts.DryRun {
+		log.Warning("=== DRY RUN MODE: workflow dispatches will be skipped ===")
+	}
+
+	versionTag := "nightly-latest-" + time.Now().UTC().Format("20060102")
+	log.Infof("Target version tag: %s", versionTag)
+
+	if !opts.Yes {
+		var msg string
+		if opts.NoBuild {
+			msg = "About to deploy " + versionTag + " to dev-wiki.onyx.app (no rebuild). Continue? (Y/n): "
+		} else {
+			msg = "About to build a fresh agent-wiki image and deploy it to dev-wiki.onyx.app. Continue? (Y/n): "
+		}
+		if !prompt.Confirm(msg) {
+			log.Info("Exiting...")
+			return
+		}
+	}
+
+	if !opts.NoBuild {
+		if opts.DryRun {
+			log.Warnf("[DRY RUN] Would dispatch %s in %s", wikiBuildWorkflow, wikiBuildRepo)
+		} else {
+			runBuild()
+		}
+	}
+
+	if opts.DryRun {
+		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, wikiDeployRepo, versionTag)
+		return
+	}
+
+	runDeploy(versionTag, opts.NoWaitDeploy)
+}
+
+func runBuild() {
+	priorRunID, err := latestWorkflowRunID(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "")
+	if err != nil {
+		log.Fatalf("Failed to query existing build runs: %v", err)
+	}
+	log.Debugf("Most recent prior build run id: %d", priorRunID)
+
+	log.Infof("Dispatching %s in %s...", wikiBuildWorkflow, wikiBuildRepo)
+	if err := dispatchWorkflow(wikiBuildRepo, wikiBuildWorkflow, nil); err != nil {
+		log.Fatalf("Failed to dispatch build workflow: %v", err)
+	}
+
+	log.Info("Waiting for build workflow to start...")
+	buildRun, err := waitForNewRun(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "", priorRunID)
+	if err != nil {
+		log.Fatalf("Failed to find triggered build run: %v", err)
+	}
+	log.Infof("Build run started: %s", buildRun.URL)
+
+	if err := waitForRunCompletion(wikiBuildRepo, buildRun.DatabaseID, wikiBuildPollLimit, "build"); err != nil {
+		log.Fatalf("Build did not complete successfully: %v", err)
+	}
+	log.Info("Build completed successfully.")
+}
+
+func runDeploy(versionTag string, noWait bool) {
+	priorRunID, err := latestWorkflowRunID(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
+	if err != nil {
+		log.Fatalf("Failed to query existing deploy runs: %v", err)
+	}
+	log.Debugf("Most recent prior deploy run id: %d", priorRunID)
+
+	log.Infof("Dispatching %s with version_tag=%s...", wikiDeployWorkflow, versionTag)
+	if err := dispatchWorkflow(wikiDeployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
+		log.Fatalf("Failed to dispatch deploy workflow: %v", err)
+	}
+
+	deployRun, err := waitForNewRun(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
+	if err != nil {
+		log.Fatalf("Failed to find dispatched deploy run: %v", err)
+	}
+	log.Infof("Deploy run started: %s", deployRun.URL)
+	log.Info("A kickoff Slack message will appear in #monitor-deployments.")
+
+	if noWait {
+		log.Info("--no-wait-deploy set; not waiting for deploy completion.")
+		return
+	}
+
+	if err := waitForRunCompletion(wikiDeployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
+		log.Fatalf("Deploy did not complete successfully: %v", err)
+	}
+	log.Info("Deploy completed successfully.")
+}


### PR DESCRIPTION
## Description

Adds `ods deploy wiki` analogous to `ods deploy edge`. Wraps the new agent-wiki dogfood deploy chain into one CLI command:

1. Dispatches `nightly-build.yml` in `onyx-dot-app/agent-wiki` to build a fresh `:nightly-latest-YYYYMMDD` image (UTC date).
2. Waits for the build to finish.
3. Dispatches `dev-wiki-deploy.yml` in `onyx-dot-app/cloud-deployment-yamls` with `version_tag=<computed>`.
4. Waits for the deploy to finish (default; `--no-wait-deploy` to skip).

Differences from `ods deploy edge`:

- **No git tag pushed.** agent-wiki's build is `workflow_dispatch`-only; image tag is computed per-run from UTC date. (`deploy edge` force-pushes the `edge` git tag to trigger onyx's build.)
- **Targets are hardcoded** — single dogfood cluster, no first-run prompt for repo/workflow names like `deploy edge` has.
- **`--no-build` flag** skips step 1 and deploys whatever's already on Docker Hub for today's tag. Useful when iterating on the deploy workflow itself.

Reused unchanged from `deploy_edge.go`: `latestWorkflowRunID`, `waitForNewRun`, `waitForRunCompletion`, `dispatchWorkflow`. New: `deploy_wiki.go` (~135 lines) + one-line registration in `deploy.go`.

ods version is intentionally not bumped here — followup PR.

## How Has This Been Tested?

- `go build ./...` and `go vet ./...` clean.
- `ods deploy wiki --help` shows the command and flags.
- `ods deploy wiki --dry-run --yes` prints the expected dispatch plan with today's UTC date as the version tag.
- The underlying chain was exercised end-to-end via direct `gh workflow run` against the same workflows ([build run 25585487947](https://github.com/onyx-dot-app/agent-wiki/actions/runs/25585487947), [deploy run 25585820759](https://github.com/onyx-dot-app/cloud-deployment-yamls/actions/runs/25585820759)) — both green; cluster rolled to `:nightly-latest-20260509` and pods are healthy on https://dev-wiki.onyx.app.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check