### PR TITLE
fix: drive perm sync validation

### DIFF
--- a/backend/ee/onyx/connectors/perm_sync_valid.py
+++ b/backend/ee/onyx/connectors/perm_sync_valid.py
@@ -21,7 +21,12 @@ def validate_confluence_perm_sync(connector: ConfluenceConnector) -> None:
 def validate_drive_perm_sync(connector: GoogleDriveConnector) -> None:
     """
     Validate that the connector is configured correctly for permissions syncing.
+
+    Group sync calls `admin.directory.users.get` for the configured primary
+    admin. Probe it here so a misconfigured primary admin (403) fails at
+    connector creation instead of every external-group-sync tick.
     """
+    connector.probe_directory_admin_permission()
 
 
 def validate_sharepoint_perm_sync(connector: SharepointConnector) -> None:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -2086,6 +2086,14 @@ class GoogleDriveConnector(
             raise ConnectorValidationError(
                 f"Unexpected Google Workspace directory API error (status={status_code}): {e}"
             )
+        except Exception as e:
+            if MISSING_SCOPES_ERROR_STR in str(e):
+                raise InsufficientPermissionsError(
+                    f"Google Drive credentials are missing required scopes. {ONYX_SCOPE_INSTRUCTIONS} Full error: {e}"
+                )
+            raise ConnectorValidationError(
+                f"Unexpected error during Google Workspace directory API probe: {e}"
+            )
 
     @override
     def build_dummy_checkpoint(self) -> GoogleDriveCheckpoint:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -2054,6 +2054,39 @@ class GoogleDriveConnector(
                 f"Unexpected error during Google Drive validation: {e}"
             )
 
+    def probe_directory_admin_permission(self) -> None:
+        """Verify the configured primary admin can call the Workspace directory API.
+
+        Required for permission sync, which calls
+        `admin.directory.users.get` to enumerate Workspace users and groups.
+        A 403 here predicts the same 403 in `_get_drive_members` mid-sync, so
+        misconfigured connectors fail at creation time instead of generating a
+        steady stream of `PermissionError` log lines on every group-sync tick.
+        """
+        admin_service = get_admin_service(
+            creds=self.creds,
+            user_email=self.primary_admin_email,
+        )
+        try:
+            admin_service.users().get(  # ty: ignore[unresolved-attribute]
+                userKey=self.primary_admin_email
+            ).execute()
+        except HttpError as e:
+            status_code = e.resp.status if e.resp else None
+            if status_code == 403:
+                raise InsufficientPermissionsError(
+                    f"Primary admin {self.primary_admin_email} is not authorized "
+                    "on the Google Workspace directory API. Reconnect the connector "
+                    "with an account that has admin directory access."
+                )
+            if status_code == 401:
+                raise CredentialExpiredError(
+                    "Invalid or expired Google Drive credentials (401)."
+                )
+            raise ConnectorValidationError(
+                f"Unexpected Google Workspace directory API error (status={status_code}): {e}"
+            )
+
     @override
     def build_dummy_checkpoint(self) -> GoogleDriveCheckpoint:
         return GoogleDriveCheckpoint(


### PR DESCRIPTION
## Description

We were seeing some folks with perm sync connectors in perpetual error state due to misconfiguration: this prevents the footgun.

## How Has This Been Tested?

Tested in UI with non admin user attached to credential for perm sync connector -> fails, correct admin -> succeeds

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Google Drive permission sync at connector creation by probing Google Workspace Directory API with the configured primary admin. Misconfigured admins or missing scopes now fail fast with clear errors instead of causing recurring sync failures.

- **Bug Fixes**
  - Call `probe_directory_admin_permission()` during Drive perm-sync validation.
  - Perform `admin.directory.users.get` for the primary admin to verify Directory API access and scopes.
  - Map 403 to `InsufficientPermissionsError`, 401 to `CredentialExpiredError`, missing scopes to `InsufficientPermissionsError` with setup instructions, else `ConnectorValidationError`.

<sup>Written for commit 96fb5451ce7cf7993a7fd075d8af42bb9fa86274. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

