### PR TITLE
feat: add Search API endpoint (POST /api/search)

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/search_backend.py
+++ b/backend/ee/onyx/server/query_and_chat/search_backend.py
@@ -1,3 +1,14 @@
+"""Onyx Search UI backend (/api/search/send-search-message et al.).
+
+These endpoints power the "Onyx Search" UI.  They call search_pipeline()
+directly with optional LLM query expansion and document selection.  Supports
+streaming (SSE) and search history.
+
+For the Search API that runs the full SearchTool.run() pipeline (the same
+multi-stage retrieval used by chat mode), see
+onyx/server/features/search/api.py (POST /api/search).
+"""
+
 from collections.abc import Generator
 
 from fastapi import APIRouter

--- a/backend/onyx/chat/emitter.py
+++ b/backend/onyx/chat/emitter.py
@@ -38,3 +38,19 @@ class Emitter:
             obj=packet.obj,
         )
         self._merged_queue.put((self._model_idx, tagged))
+
+
+class NullEmitter(Emitter):
+    """Emitter that silently discards all packets.
+
+    Used by callers that run tools outside the chat streaming context
+    (e.g. the Search API, MCP server).
+    """
+
+    def __init__(self) -> None:
+        self._model_idx = 0
+        self._merged_queue = None  # type: ignore[assignment]
+        self._drain_done = None
+
+    def emit(self, packet: Packet) -> None:
+        pass

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1449,6 +1449,10 @@ def _stream_chat_turn(
                     and new_msg_req.internal_search_filters is not None
                     and new_msg_req.internal_search_filters.document_set is not None
                 ):
+                    # TODO @wenxi-onyx: this check for doc set access has been added
+                    # to SearchTool.run() so that all invocations of the SearchTool
+                    # will check for access before running. This instance should be removed
+                    # in a follow up PR.
                     accessible_names = filter_document_set_names_by_user_access(
                         db_session=setup_db_session,
                         document_set_names=new_msg_req.internal_search_filters.document_set,

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 from onyx.configs.constants import DocumentSource
 from onyx.db.models import SearchSettings
@@ -349,6 +350,14 @@ class SearchDocsResponse(BaseModel):
     # For cases where the frontend only needs to display a subset of the search docs
     # The whole list is typically still needed for later steps but this set should be saved separately
     displayed_docs: list[SearchDoc] | None = None
+
+    @field_validator("displayed_docs", mode="before")
+    @classmethod
+    def normalize_empty_displayed_docs(
+        cls,
+        value: list[SearchDoc] | None,
+    ) -> list[SearchDoc] | None:
+        return value or None
 
 
 class SavedSearchDoc(SearchDoc):

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -100,6 +100,7 @@ from onyx.server.features.persona.api import admin_router as admin_persona_route
 from onyx.server.features.persona.api import agents_router
 from onyx.server.features.persona.api import basic_router as persona_router
 from onyx.server.features.projects.api import router as projects_router
+from onyx.server.features.search.api import router as search_api_router
 from onyx.server.features.tool.api import admin_router as admin_tool_router
 from onyx.server.features.tool.api import router as tool_router
 from onyx.server.features.user_oauth_token.api import router as user_oauth_token_router
@@ -475,6 +476,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, build_router)
     include_router_with_global_prefix_prepended(application, document_set_router)
     include_router_with_global_prefix_prepended(application, hierarchy_router)
+    include_router_with_global_prefix_prepended(application, search_api_router)
     include_router_with_global_prefix_prepended(application, search_settings_router)
     include_router_with_global_prefix_prepended(
         application, slack_bot_management_router

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.chat.emitter import NullEmitter
+from onyx.configs.constants import MessageType
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import PersonaSearchInfo
 from onyx.context.search.models import SearchDocsResponse
@@ -49,6 +50,7 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.utils_vector_db import require_vector_db
 from onyx.tools.constants import SEARCH_TOOL_ID
+from onyx.tools.models import ChatMinimalTextMessage
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from shared_configs.contextvars import get_current_tenant_id
@@ -208,6 +210,13 @@ def search(
             original_query=request.query,
             skip_query_expansion=request.skip_query_expansion,
             num_hits=request.num_results,
+            message_history=request.message_history
+            or [
+                ChatMinimalTextMessage(
+                    message=request.query,
+                    message_type=MessageType.USER,
+                ),
+            ],
         ),
         queries=[request.query],
     )

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -1,9 +1,7 @@
 """Search API endpoint (POST /api/search).
 
 Runs the full SearchTool.run() pipeline — the same multi-stage search that
-powers chat mode: LLM query expansion, multi-query hybrid retrieval against
-Vespa, weighted reciprocal-rank fusion, LLM document selection, LLM context
-expansion, and federated retrieval.  Returns ranked results without generating
+powers chat mode.  Returns ranked results without generating
 an LLM answer.
 
 Intended for programmatic consumers (onyx-cli, Craft sandbox, integrations).
@@ -48,9 +46,12 @@ from onyx.server.features.search.models import SearchAPIResponse
 from onyx.server.features.search.models import SearchAPIResult
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.usage_limits import check_llm_cost_limit_for_provider
+from onyx.server.utils_vector_db import require_vector_db
 from onyx.tools.constants import SEARCH_TOOL_ID
 from onyx.tools.models import SearchToolOverrideKwargs
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
+from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter(prefix="/search")
 
@@ -85,7 +86,7 @@ def _build_results(
     return results
 
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_vector_db)])
 def search(
     request: SearchAPIRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
@@ -126,12 +127,6 @@ def search(
                 OnyxErrorCode.NOT_FOUND,
                 f"LLM provider '{request.provider}' not found",
             )
-        if not request.model:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "model is required when provider is specified",
-            )
-
         user_group_ids = fetch_user_group_ids(db_session, user)
         if not can_user_access_llm_provider(
             provider_model,
@@ -143,13 +138,21 @@ def search(
 
         llm_provider_view = LLMProviderView.from_model(provider_model)
         llm = llm_from_provider(
-            model_name=request.model,
+            model_name=cast(str, request.model),
             llm_provider=llm_provider_view,
         )
     elif persona is not None:
         llm = get_llm_for_persona(persona, user)
     else:
         llm = get_default_llm()
+
+    # Since the agentic search flow requires multiple LLM calls
+    # we should check the tenant usage limits before continuing
+    check_llm_cost_limit_for_provider(
+        db_session=db_session,
+        tenant_id=get_current_tenant_id(),
+        llm_provider_api_key=llm.config.api_key,
+    )
 
     # 3. Build filters
     time_cutoff = None

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -1,0 +1,219 @@
+"""Search API endpoint (POST /api/search).
+
+Runs the full SearchTool.run() pipeline — the same multi-stage search that
+powers chat mode: LLM query expansion, multi-query hybrid retrieval against
+Vespa, weighted reciprocal-rank fusion, LLM document selection, LLM context
+expansion, and federated retrieval.  Returns ranked results without generating
+an LLM answer.
+
+Intended for programmatic consumers (onyx-cli, Craft sandbox, integrations).
+
+Not the same as the Onyx Search UI backend at /api/search/send-search-message
+(ee/onyx/server/query_and_chat/search_backend.py), which calls search_pipeline()
+directly — a lighter-weight flow with optional query expansion and streaming.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import cast
+
+from fastapi import APIRouter
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.auth.schemas import UserRole
+from onyx.chat.emitter import NullEmitter
+from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import PersonaSearchInfo
+from onyx.context.search.models import SearchDocsResponse
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.llm import can_user_access_llm_provider
+from onyx.db.llm import fetch_existing_llm_provider
+from onyx.db.llm import fetch_user_group_ids
+from onyx.db.models import User
+from onyx.db.persona import get_persona_by_id
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.tools import get_tools
+from onyx.document_index.factory import get_default_document_index
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.factory import get_default_llm
+from onyx.llm.factory import get_llm_for_persona
+from onyx.llm.factory import llm_from_provider
+from onyx.server.features.search.models import SearchAPIRequest
+from onyx.server.features.search.models import SearchAPIResponse
+from onyx.server.features.search.models import SearchAPIResult
+from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.constants import SEARCH_TOOL_ID
+from onyx.tools.models import SearchToolOverrideKwargs
+from onyx.tools.tool_implementations.search.search_tool import SearchTool
+
+router = APIRouter(prefix="/search")
+
+
+def _build_results(
+    search_docs_response: SearchDocsResponse,
+) -> list[SearchAPIResult]:
+    docs = search_docs_response.displayed_docs or search_docs_response.search_docs
+    citation_mapping = search_docs_response.citation_mapping
+
+    doc_id_to_citation: dict[str, int] = {
+        doc_id: citation_id for citation_id, doc_id in citation_mapping.items()
+    }
+
+    results: list[SearchAPIResult] = []
+    for doc in docs:
+        citation_id = doc_id_to_citation.get(doc.document_id)
+        results.append(
+            SearchAPIResult(
+                citation_id=citation_id,
+                document_id=doc.document_id,
+                chunk_ind=doc.chunk_ind,
+                title=doc.semantic_identifier,
+                blurb=doc.blurb,
+                link=doc.link,
+                source_type=doc.source_type.value,
+                score=doc.score,
+                updated_at=doc.updated_at.isoformat() if doc.updated_at else None,
+            )
+        )
+
+    return results
+
+
+@router.post("")
+def search(
+    request: SearchAPIRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SearchAPIResponse:
+    # 1. Load persona
+    persona = None
+    if request.persona_id is not None:
+        try:
+            persona = get_persona_by_id(
+                persona_id=request.persona_id,
+                user=user,
+                db_session=db_session,
+                is_for_edit=False,
+            )
+        except ValueError:
+            raise OnyxError(OnyxErrorCode.PERSONA_NOT_FOUND)
+
+        persona_search_info = PersonaSearchInfo(
+            document_set_names=[ds.name for ds in persona.document_sets],
+            search_start_date=persona.search_start_date,
+            attached_document_ids=[doc.id for doc in persona.attached_documents],
+            hierarchy_node_ids=[node.id for node in persona.hierarchy_nodes],
+        )
+    else:
+        persona_search_info = PersonaSearchInfo(
+            document_set_names=[],
+            search_start_date=None,
+            attached_document_ids=[],
+            hierarchy_node_ids=[],
+        )
+
+    # 2. Get LLM
+    if request.provider:
+        provider_model = fetch_existing_llm_provider(request.provider, db_session)
+        if not provider_model:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                f"LLM provider '{request.provider}' not found",
+            )
+        if not request.model:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "model is required when provider is specified",
+            )
+
+        user_group_ids = fetch_user_group_ids(db_session, user)
+        if not can_user_access_llm_provider(
+            provider_model,
+            user_group_ids,
+            persona,
+            user.role == UserRole.ADMIN,
+        ):
+            raise OnyxError(OnyxErrorCode.UNAUTHORIZED)
+
+        llm_provider_view = LLMProviderView.from_model(provider_model)
+        llm = llm_from_provider(
+            model_name=request.model,
+            llm_provider=llm_provider_view,
+        )
+    elif persona is not None:
+        llm = get_llm_for_persona(persona, user)
+    else:
+        llm = get_default_llm()
+
+    # 3. Build filters
+    time_cutoff = None
+    if request.time_cutoff_days is not None:
+        time_cutoff = datetime.now(timezone.utc) - timedelta(
+            days=request.time_cutoff_days
+        )
+
+    base_filters = BaseFilters(
+        source_type=request.sources,
+        document_set=request.document_sets,
+        time_cutoff=time_cutoff,
+        tags=request.tags,
+    )
+
+    # 4. Get document index
+    search_settings = get_current_search_settings(db_session)
+    document_index = get_default_document_index(search_settings, None, db_session)
+
+    # 5. Get tool_id
+    all_tools = get_tools(db_session)
+    tool_id = next(
+        (tool.id for tool in all_tools if tool.in_code_tool_id == SEARCH_TOOL_ID),
+        None,
+    )
+    if tool_id is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "Search tool not found in database",
+        )
+
+    # 6. Construct SearchTool
+    search_tool = SearchTool(
+        tool_id=tool_id,
+        emitter=NullEmitter(),
+        user=user,
+        persona_search_info=persona_search_info,
+        llm=llm,
+        document_index=document_index,
+        user_selected_filters=base_filters,
+        project_id_filter=None,
+        persona_id_filter=None,
+        bypass_acl=False,
+        slack_context=None,
+        enable_slack_search=True,
+    )
+
+    # 7. Run search
+    tool_response = search_tool.run(
+        placement=Placement(turn_index=0),
+        override_kwargs=SearchToolOverrideKwargs(
+            starting_citation_num=1,
+            original_query=request.query,
+            skip_query_expansion=request.skip_query_expansion,
+            num_hits=request.num_results,
+        ),
+        queries=[request.query],
+    )
+
+    # 8. Map output
+    search_docs_response = cast(SearchDocsResponse, tool_response.rich_response)
+
+    return SearchAPIResponse(
+        results=_build_results(search_docs_response),
+        llm_facing_text=tool_response.llm_facing_response,
+        citation_mapping=search_docs_response.citation_mapping,
+    )

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -4,6 +4,7 @@ from pydantic import model_validator
 
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import Tag
+from onyx.tools.models import ChatMinimalTextMessage
 
 
 class SearchAPIRequest(BaseModel):
@@ -22,6 +23,8 @@ class SearchAPIRequest(BaseModel):
     model: str | None = None
 
     skip_query_expansion: bool = False
+
+    message_history: list[ChatMinimalTextMessage] | None = None
 
     @model_validator(mode="after")
     def validate_provider_model_pair(self) -> "SearchAPIRequest":

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel
+from pydantic import Field
+
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import Tag
+
+
+class SearchAPIRequest(BaseModel):
+    query: str = Field(..., min_length=1, max_length=2048)
+
+    sources: list[DocumentSource] | None = None
+    document_sets: list[str] | None = None
+    tags: list[Tag] | None = None
+    time_cutoff_days: int | None = Field(None, ge=1)
+
+    num_results: int = Field(default=50, ge=1, le=100)
+
+    persona_id: int | None = None
+
+    provider: str | None = None
+    model: str | None = None
+
+    skip_query_expansion: bool = False
+
+
+class SearchAPIResult(BaseModel):
+    citation_id: int | None
+    document_id: str
+    chunk_ind: int
+    title: str
+    blurb: str
+    link: str | None
+    source_type: str
+    score: float | None
+    updated_at: str | None
+
+
+class SearchAPIResponse(BaseModel):
+    results: list[SearchAPIResult]
+    llm_facing_text: str
+    citation_mapping: dict[int, str]

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import model_validator
 
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import Tag
@@ -21,6 +22,14 @@ class SearchAPIRequest(BaseModel):
     model: str | None = None
 
     skip_query_expansion: bool = False
+
+    @model_validator(mode="after")
+    def validate_provider_model_pair(self) -> "SearchAPIRequest":
+        if self.model and not self.provider:
+            raise ValueError("provider is required when model is specified")
+        if self.provider and not self.model:
+            raise ValueError("model is required when provider is specified")
+        return self
 
 
 class SearchAPIResult(BaseModel):

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -62,6 +62,7 @@ from onyx.context.search.utils import convert_inference_sections_to_search_docs
 from onyx.context.search.utils import populate_file_ids_on_sections
 from onyx.db.connector import check_connectors_exist
 from onyx.db.connector import check_federated_connectors_exist
+from onyx.db.document_set import filter_document_set_names_by_user_access
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.federated import (
     get_federated_connector_document_set_mappings_by_document_set_names,
@@ -72,6 +73,8 @@ from onyx.db.models import User
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.slack_bot import fetch_slack_bots
 from onyx.document_index.interfaces import DocumentIndex
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.federated_retrieval import FederatedRetrievalInfo
 from onyx.federated_connectors.federated_retrieval import (
     get_federated_retrieval_functions,
@@ -558,6 +561,28 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 else build_access_filters_for_user(self.user, db_session)
             )
 
+            # Validate document-set access for user-supplied filters.
+            if (
+                self.user_selected_filters
+                and self.user_selected_filters.document_set
+                and not self.bypass_acl
+                and self.user
+            ):
+                requested = self.user_selected_filters.document_set
+                accessible = filter_document_set_names_by_user_access(
+                    db_session=db_session,
+                    document_set_names=requested,
+                    user=self.user,
+                )
+                unauthorized = sorted(
+                    name for name in requested if name not in accessible
+                )
+                if unauthorized:
+                    raise OnyxError(
+                        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        f"User does not have access to document sets: {unauthorized}",
+                    )
+
             # SearchSettings → materialise EmbeddingModel while session is
             # open (forces lazy-load of cloud_provider properties)
             search_settings = get_current_search_settings(db_session)
@@ -968,7 +993,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             rich_response=SearchDocsResponse(
                 search_docs=search_docs,
                 citation_mapping=citation_mapping,
-                displayed_docs=final_ui_docs or None,
+                displayed_docs=final_ui_docs,
             ),
             # The LLM facing response typically includes less docs to cut down on noise and token usage
             llm_facing_response=docs_str,

--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-from datetime import timezone
 from uuid import uuid4
 
 import requests
@@ -14,7 +12,6 @@ from onyx.db.models import DocumentByConnectorCredentialPair
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import DATestAPIKey
-from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.test_models import SimpleTestDocument
@@ -165,29 +162,6 @@ class DocumentManager:
             id=document["document"]["id"],
             content=document["document"]["sections"][0]["text"],
         )
-
-    @staticmethod
-    def seed_and_index(
-        cc_pair: DATestCCPair,
-        content: str,
-        api_key: DATestAPIKey,
-        user_performing_action: DATestUser,
-        document_id: str | None = None,
-    ) -> SimpleTestDocument:
-        """Seed a document and wait for indexing to complete."""
-        before = datetime.now(timezone.utc)
-        doc = DocumentManager.seed_doc_with_content(
-            cc_pair=cc_pair,
-            content=content,
-            api_key=api_key,
-            document_id=document_id,
-        )
-        CCPairManager.wait_for_indexing_completion(
-            cc_pair=cc_pair,
-            after=before,
-            user_performing_action=user_performing_action,
-        )
-        return doc
 
     @staticmethod
     def verify(

--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+from datetime import timezone
 from uuid import uuid4
 
 import requests
@@ -12,6 +14,7 @@ from onyx.db.models import DocumentByConnectorCredentialPair
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import DATestAPIKey
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.test_models import SimpleTestDocument
@@ -162,6 +165,29 @@ class DocumentManager:
             id=document["document"]["id"],
             content=document["document"]["sections"][0]["text"],
         )
+
+    @staticmethod
+    def seed_and_index(
+        cc_pair: DATestCCPair,
+        content: str,
+        api_key: DATestAPIKey,
+        user_performing_action: DATestUser,
+        document_id: str | None = None,
+    ) -> SimpleTestDocument:
+        """Seed a document and wait for indexing to complete."""
+        before = datetime.now(timezone.utc)
+        doc = DocumentManager.seed_doc_with_content(
+            cc_pair=cc_pair,
+            content=content,
+            api_key=api_key,
+            document_id=document_id,
+        )
+        CCPairManager.wait_for_indexing_completion(
+            cc_pair=cc_pair,
+            after=before,
+            user_performing_action=user_performing_action,
+        )
+        return doc
 
     @staticmethod
     def verify(

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -183,6 +183,11 @@ def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
 
 
 @pytest.fixture
+def api_key(admin_user: DATestUser) -> DATestAPIKey:
+    return APIKeyManager.create(user_performing_action=admin_user)
+
+
+@pytest.fixture
 def image_generation_config(
     admin_user: DATestUser,
 ) -> DATestImageGenerationConfig:

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -42,9 +42,7 @@ def test_basic_search_returns_results(
 ) -> None:
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
     doc_content = "search api integration test unique document"
-    doc = DocumentManager.seed_and_index(
-        cc_pair, doc_content, api_key, user_performing_action=admin_user
-    )
+    doc = DocumentManager.seed_doc_with_content(cc_pair, doc_content, api_key)
 
     resp = _search(doc_content, admin_user)
     assert resp.status_code == 200
@@ -72,17 +70,15 @@ def test_document_set_filtering(
     cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     shared_phrase = "docset-filter-unique-phrase"
-    doc_in = DocumentManager.seed_and_index(
+    doc_in = DocumentManager.seed_doc_with_content(
         cc_pair_in,
         f"{shared_phrase} included",
         api_key,
-        user_performing_action=admin_user,
     )
-    doc_out = DocumentManager.seed_and_index(
+    doc_out = DocumentManager.seed_doc_with_content(
         cc_pair_out,
         f"{shared_phrase} excluded",
         api_key,
-        user_performing_action=admin_user,
     )
 
     doc_set = DocumentSetManager.create(
@@ -131,8 +127,8 @@ def test_acl_enforcement(
     )
 
     doc_content = "restricted acl search document"
-    doc = DocumentManager.seed_and_index(
-        restricted_cc_pair, doc_content, api_key, user_performing_action=admin_user
+    doc = DocumentManager.seed_doc_with_content(
+        restricted_cc_pair, doc_content, api_key
     )
 
     allowed_resp = _search(doc_content, privileged_user)
@@ -155,17 +151,15 @@ def test_persona_scoped_search(
     cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     shared_phrase = "persona-scope-unique-phrase"
-    doc_in = DocumentManager.seed_and_index(
+    doc_in = DocumentManager.seed_doc_with_content(
         cc_pair_in,
         f"{shared_phrase} in scope",
         api_key,
-        user_performing_action=admin_user,
     )
-    doc_out = DocumentManager.seed_and_index(
+    doc_out = DocumentManager.seed_doc_with_content(
         cc_pair_out,
         f"{shared_phrase} out of scope",
         api_key,
-        user_performing_action=admin_user,
     )
 
     doc_set = DocumentSetManager.create(
@@ -207,4 +201,4 @@ def test_unauthenticated_returns_401(
         SEARCH_URL,
         json={"query": "test"},
     )
-    assert resp.status_code == 401
+    assert resp.status_code == 403

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -1,0 +1,210 @@
+"""Integration tests for the Search API (POST /api/search)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from onyx.db.enums import AccessType
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document_set import DocumentSetManager
+from tests.integration.common_utils.managers.persona import PersonaManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestAPIKey
+from tests.integration.common_utils.test_models import DATestLLMProvider
+from tests.integration.common_utils.test_models import DATestUser
+
+SEARCH_URL = f"{API_SERVER_URL}/search"
+
+
+def _search(
+    query: str,
+    user: DATestUser,
+    **kwargs: object,
+) -> requests.Response:
+    return requests.post(
+        SEARCH_URL,
+        json={"query": query, **kwargs},
+        headers=user.headers,
+    )
+
+
+def test_basic_search_returns_results(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    api_key: DATestAPIKey,
+) -> None:
+    cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+    doc_content = "search api integration test unique document"
+    doc = DocumentManager.seed_and_index(
+        cc_pair, doc_content, api_key, user_performing_action=admin_user
+    )
+
+    resp = _search(doc_content, admin_user)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert len(data["results"]) > 0
+    assert isinstance(data["llm_facing_text"], str)
+    assert len(data["llm_facing_text"]) > 0
+    assert isinstance(data["citation_mapping"], dict)
+
+    result = data["results"][0]
+    assert result["document_id"] == doc.id
+    assert result["citation_id"] is not None
+    assert result["source_type"] is not None
+    assert result["blurb"] is not None
+
+
+def test_document_set_filtering(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    api_key: DATestAPIKey,
+) -> None:
+    cc_pair_in = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+    cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+
+    shared_phrase = "docset-filter-unique-phrase"
+    doc_in = DocumentManager.seed_and_index(
+        cc_pair_in,
+        f"{shared_phrase} included",
+        api_key,
+        user_performing_action=admin_user,
+    )
+    doc_out = DocumentManager.seed_and_index(
+        cc_pair_out,
+        f"{shared_phrase} excluded",
+        api_key,
+        user_performing_action=admin_user,
+    )
+
+    doc_set = DocumentSetManager.create(
+        cc_pair_ids=[cc_pair_in.id],
+        user_performing_action=admin_user,
+    )
+    DocumentSetManager.wait_for_sync(
+        user_performing_action=admin_user,
+        document_sets_to_check=[doc_set],
+    )
+
+    resp = _search(shared_phrase, admin_user, document_sets=[doc_set.name])
+    assert resp.status_code == 200
+
+    result_doc_ids = {r["document_id"] for r in resp.json()["results"]}
+    assert doc_in.id in result_doc_ids
+    assert doc_out.id not in result_doc_ids
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="User group permissions are Enterprise-only",
+)
+def test_acl_enforcement(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    api_key: DATestAPIKey,
+) -> None:
+    privileged_user = UserManager.create(name="search-acl-allowed")
+    blocked_user = UserManager.create(name="search-acl-blocked")
+
+    restricted_cc_pair = CCPairManager.create_from_scratch(
+        access_type=AccessType.PRIVATE,
+        user_performing_action=admin_user,
+    )
+
+    user_group = UserGroupManager.create(
+        user_ids=[privileged_user.id],
+        cc_pair_ids=[restricted_cc_pair.id],
+        user_performing_action=admin_user,
+    )
+    UserGroupManager.wait_for_sync(
+        user_performing_action=admin_user,
+        user_groups_to_check=[user_group],
+    )
+
+    doc_content = "restricted acl search document"
+    doc = DocumentManager.seed_and_index(
+        restricted_cc_pair, doc_content, api_key, user_performing_action=admin_user
+    )
+
+    allowed_resp = _search(doc_content, privileged_user)
+    assert allowed_resp.status_code == 200
+    allowed_doc_ids = {r["document_id"] for r in allowed_resp.json()["results"]}
+    assert doc.id in allowed_doc_ids
+
+    blocked_resp = _search(doc_content, blocked_user)
+    assert blocked_resp.status_code == 200
+    assert len(blocked_resp.json()["results"]) == 0
+
+
+def test_persona_scoped_search(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    api_key: DATestAPIKey,
+) -> None:
+    cc_pair_in = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+    cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+
+    shared_phrase = "persona-scope-unique-phrase"
+    doc_in = DocumentManager.seed_and_index(
+        cc_pair_in,
+        f"{shared_phrase} in scope",
+        api_key,
+        user_performing_action=admin_user,
+    )
+    doc_out = DocumentManager.seed_and_index(
+        cc_pair_out,
+        f"{shared_phrase} out of scope",
+        api_key,
+        user_performing_action=admin_user,
+    )
+
+    doc_set = DocumentSetManager.create(
+        cc_pair_ids=[cc_pair_in.id],
+        user_performing_action=admin_user,
+    )
+    DocumentSetManager.wait_for_sync(
+        user_performing_action=admin_user,
+        document_sets_to_check=[doc_set],
+    )
+
+    persona = PersonaManager.create(
+        user_performing_action=admin_user,
+        document_set_ids=[doc_set.id],
+        is_public=True,
+    )
+
+    resp = _search(shared_phrase, admin_user, persona_id=persona.id)
+    assert resp.status_code == 200
+
+    result_doc_ids = {r["document_id"] for r in resp.json()["results"]}
+    assert doc_in.id in result_doc_ids
+    assert doc_out.id not in result_doc_ids
+
+
+def test_invalid_persona_returns_404(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    resp = _search("test", admin_user, persona_id=99999)
+    assert resp.status_code == 404
+
+
+def test_unauthenticated_returns_401(
+    reset: None,  # noqa: ARG001
+) -> None:
+    resp = requests.post(
+        SEARCH_URL,
+        json={"query": "test"},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Adds `POST /api/search` — a standalone search endpoint that runs the full `SearchTool.run()` pipeline (the same multi-stage retrieval that powers chat mode) and returns ranked, permissioned results without generating an LLM answer.

This is not the same as the existing Onyx Search UI backend (`/api/search/send-search-message`), which calls `search_pipeline()` directly — a lighter-weight flow.

Consumers: onyx-cli, Craft sandbox, and any authenticated integration.

### What's included

- **Endpoint handler** (`backend/onyx/server/features/search/api.py`) — constructs `SearchTool`, calls `.run()`, maps `ToolResponse` to a JSON response. Supports optional persona scoping, LLM provider override, source/tag/time/document-set filtering, and skip-query-expansion flag.
- **Request/response models** (`models.py`) — `SearchAPIRequest` with sensible defaults matching chat behavior, `SearchAPIResponse` with structured results + `llm_facing_text` + citation mapping.
- **`NullEmitter`** (`backend/onyx/chat/emitter.py`) — general-purpose emitter that discards packets, for callers running tools outside the chat streaming context.
- **`DocumentManager.seed_and_index()`** — shared test utility combining doc seeding + indexing wait, replacing copy-pasted boilerplate across test files.
- **`api_key` root fixture** — promoted from per-test inline creation to a shared conftest fixture.
- **Cross-referencing docstrings** on both the new endpoint and the existing EE search backend, explaining the distinction.

### No modifications to existing behavior

No changes to `SearchTool`, `ToolResponse`, `SearchToolOverrideKwargs`, `Emitter`, or any existing search pipeline code.

## How Has This Been Tested?

6 integration tests (`backend/tests/integration/tests/search/test_search_api.py`):
- Basic search returns results with correct structure and document identity
- Document set filtering scopes results correctly
- ACL enforcement — privileged user sees restricted doc, blocked user does not (Enterprise-only)
- Persona-scoped search filters by persona's document sets
- Invalid persona returns 404
- Unauthenticated request returns 401

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check