### PR TITLE
chore: unify integration tests to use shared fixtures

### DIFF
--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -183,6 +183,11 @@ def llm_provider(admin_user: DATestUser) -> DATestLLMProvider:
 
 
 @pytest.fixture
+def api_key(admin_user: DATestUser) -> DATestAPIKey:
+    return APIKeyManager.create(user_performing_action=admin_user)
+
+
+@pytest.fixture
 def image_generation_config(
     admin_user: DATestUser,
 ) -> DATestImageGenerationConfig:

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -21,11 +21,9 @@ from onyx.db.models import IndexAttempt
 from onyx.db.search_settings import get_current_search_settings
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
@@ -36,19 +34,14 @@ from tests.integration.common_utils.vespa import vespa_fixture
 def test_connector_deletion(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
     user_group_1: DATestUserGroup
     user_group_2: DATestUserGroup
 
     is_ee = (
         os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() == "true"
-    )
-
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-    # create api key
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
     )
 
     # create connectors
@@ -235,6 +228,8 @@ def test_connector_deletion(
 def test_connector_deletion_for_overlapping_connectors(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
     """Checks to make sure that connectors with overlapping documents work properly. Specifically, that the overlapping
     document (1) still exists and (2) has the right document set / group post-deletion of one of the connectors.
@@ -244,13 +239,6 @@ def test_connector_deletion_for_overlapping_connectors(
 
     is_ee = (
         os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() == "true"
-    )
-
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-    # create api key
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
     )
 
     # create connectors

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -2,11 +2,9 @@ from uuid import uuid4
 
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.vespa import vespa_fixture
@@ -15,14 +13,9 @@ from tests.integration.common_utils.vespa import vespa_fixture
 def test_multiple_document_sets_syncing_same_connnector(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
-    # create api key
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
-    )
 
     # create connector
     cc_pair_1 = CCPairManager.create_from_scratch(
@@ -72,14 +65,9 @@ def test_multiple_document_sets_syncing_same_connnector(
 def test_removing_connector(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
-    # create api key
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
-    )
 
     # create connectors
     cc_pair_1 = CCPairManager.create_from_scratch(
@@ -166,12 +154,9 @@ def test_removing_connector(
 def test_renaming_document_set(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
-    )
 
     cc_pair = CCPairManager.create_from_scratch(
         source=DocumentSource.INGESTION_API,

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -20,7 +20,6 @@ from pydantic import AnyUrl
 
 from onyx.db.enums import AccessType
 from tests.integration.common_utils.constants import MCP_SERVER_URL
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
@@ -128,12 +127,12 @@ def _seed_document_and_wait_for_indexing(
 def test_mcp_document_search_flow(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
     """Test the complete MCP search flow: initialization, resources, tools, and search."""
     # LLM provider is required for the document-search endpoint
     LLMProviderManager.create(user_performing_action=admin_user)
 
-    api_key = APIKeyManager.create(user_performing_action=admin_user)
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     doc_text = "MCP happy path search document"
@@ -195,6 +194,7 @@ def test_mcp_document_search_flow(
 def test_mcp_search_respects_acl_filters(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
     """Test that search respects ACL filters - privileged users can access, others cannot."""
     # LLM provider is required for the document-search endpoint
@@ -202,8 +202,6 @@ def test_mcp_search_respects_acl_filters(
 
     user_without_access = UserManager.create(name="mcp-acl-user-a")
     privileged_user = UserManager.create(name="mcp-acl-user-b")
-
-    api_key = APIKeyManager.create(user_performing_action=admin_user)
     restricted_cc_pair = CCPairManager.create_from_scratch(
         access_type=AccessType.PRIVATE,
         user_performing_action=admin_user,
@@ -248,11 +246,10 @@ def test_mcp_search_respects_acl_filters(
 def test_mcp_search_filters_by_document_set(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
     """Passing document_set_names should scope results to the named set."""
     LLMProviderManager.create(user_performing_action=admin_user)
-
-    api_key = APIKeyManager.create(user_performing_action=admin_user)
     cc_pair_in_set = CCPairManager.create_from_scratch(
         user_performing_action=admin_user,
     )

--- a/backend/tests/integration/tests/query_history/test_query_history.py
+++ b/backend/tests/integration/tests/query_history/test_query_history.py
@@ -9,22 +9,23 @@ import pytest
 
 from onyx.configs.constants import QAFeedbackType
 from onyx.configs.constants import SessionType
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.query_history import QueryHistoryManager
-from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
 
 @pytest.fixture
-def setup_chat_session(reset: None) -> tuple[DATestUser, str]:  # noqa: ARG001
-    # Create admin user and required resources
-    admin_user: DATestUser = UserManager.create(name="admin_user")
+def setup_chat_session(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
+) -> tuple[DATestUser, str]:
+    # Create required resources
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
-    api_key = APIKeyManager.create(user_performing_action=admin_user)
     LLMProviderManager.create(user_performing_action=admin_user)
 
     # Seed a document

--- a/backend/tests/integration/tests/query_history/test_query_history_pagination.py
+++ b/backend/tests/integration/tests/query_history/test_query_history_pagination.py
@@ -6,6 +6,7 @@ import pytest
 from onyx.configs.constants import QAFeedbackType
 from tests.integration.common_utils.managers.query_history import QueryHistoryManager
 from tests.integration.common_utils.test_models import DAQueryHistoryEntry
+from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.query_history.utils import (
     setup_chat_sessions_with_different_feedback,
@@ -54,11 +55,15 @@ def _verify_query_history_pagination(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Query history tests are enterprise only",
 )
-def test_query_history_pagination(reset: None) -> None:  # noqa: ARG001
-    (
-        admin_user,
-        chat_sessions_by_feedback_type,
-    ) = setup_chat_sessions_with_different_feedback()
+def test_query_history_pagination(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
+) -> None:
+    chat_sessions_by_feedback_type = setup_chat_sessions_with_different_feedback(
+        admin_user=admin_user,
+        api_key=api_key,
+    )
 
     all_chat_sessions = []
     for _, chat_sessions in chat_sessions_by_feedback_type.items():

--- a/backend/tests/integration/tests/query_history/utils.py
+++ b/backend/tests/integration/tests/query_history/utils.py
@@ -2,13 +2,12 @@ from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 
 from onyx.configs.constants import QAFeedbackType
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DAQueryHistoryEntry
+from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
 
@@ -73,13 +72,12 @@ def _create_chat_session_with_feedback(
     return feedback_type, test_session
 
 
-def setup_chat_sessions_with_different_feedback() -> (
-    tuple[DATestUser, dict[QAFeedbackType | None, list[DAQueryHistoryEntry]]]
-):
-    # Create admin user and required resources
-    admin_user: DATestUser = UserManager.create(name="admin_user")
+def setup_chat_sessions_with_different_feedback(
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
+) -> dict[QAFeedbackType | None, list[DAQueryHistoryEntry]]:
+    # Create required resources
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
-    api_key = APIKeyManager.create(user_performing_action=admin_user)
     LLMProviderManager.create(user_performing_action=admin_user)
 
     # Seed a document
@@ -128,4 +126,4 @@ def setup_chat_sessions_with_different_feedback() -> (
                 chat_session
             )
 
-    return admin_user, chat_sessions_by_feedback_type
+    return chat_sessions_by_feedback_type

--- a/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
+++ b/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
@@ -4,10 +4,8 @@ import pytest
 
 from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
-from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
@@ -22,15 +20,9 @@ from tests.integration.common_utils.vespa import vespa_fixture
 def test_removing_connector(
     reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
+    api_key: DATestAPIKey,
 ) -> None:
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
-    # create api key
-    api_key: DATestAPIKey = APIKeyManager.create(
-        user_performing_action=admin_user,
-    )
-
     # create connectors
     cc_pair_1 = CCPairManager.create_from_scratch(
         source=DocumentSource.INGESTION_API,


### PR DESCRIPTION
Adds shared `api_key` fixture to the root integration conftest and refactors 7 test files to use it (along with the existing `admin_user` fixture) instead of creating them inline. Reduces boilerplate and makes the test setup pattern consistent across connector, document_set, usergroup, MCP, and query_history tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check