### PR TITLE
refactor(test): DocumentManager simpler document seeding behavior

### DIFF
--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -18,30 +18,6 @@ from tests.integration.common_utils.test_models import SimpleTestDocument
 from tests.integration.common_utils.vespa import vespa_fixture
 
 
-def _build_ingestion_payload(
-    document_id: str,
-    cc_pair_id: int,
-    content: str | None = None,
-    metadata: dict | None = None,
-) -> dict:
-    text = content or f"This is test document {document_id}"
-    doc_metadata: dict = {"document_id": document_id}
-    if metadata:
-        doc_metadata.update(metadata)
-
-    return {
-        "document": {
-            "id": document_id,
-            "sections": [{"text": text, "link": document_id}],
-            "source": DocumentSource.NOT_APPLICABLE,
-            "metadata": doc_metadata,
-            "semantic_identifier": f"Test Document {document_id}",
-            "from_ingestion_api": True,
-        },
-        "cc_pair_id": cc_pair_id,
-    }
-
-
 def _verify_document_permissions(
     retrieved_doc: dict,
     cc_pair: DATestCCPair,
@@ -79,6 +55,30 @@ def _verify_document_permissions(
             raise ValueError(
                 f"Document set names mismatch. \nFound: {found_doc_set_names}, \nExpected: {set(doc_set_names)}"
             )
+
+
+def _build_ingestion_payload(
+    document_id: str,
+    cc_pair_id: int,
+    content: str | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    text = content or f"This is test document {document_id}"
+    doc_metadata: dict = {"document_id": document_id}
+    if metadata:
+        doc_metadata.update(metadata)
+
+    return {
+        "document": {
+            "id": document_id,
+            "sections": [{"text": text, "link": document_id}],
+            "source": DocumentSource.NOT_APPLICABLE,
+            "metadata": doc_metadata,
+            "semantic_identifier": f"Test Document {document_id}",
+            "from_ingestion_api": True,
+        },
+        "cc_pair_id": cc_pair_id,
+    }
 
 
 class DocumentManager:

--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -81,9 +81,11 @@ def _build_ingestion_payload(
     }
 
 
-class DocumentManager:
+class DocumentIngestionManager:
+    """Manager for ingesting test documents via the ingestion API."""
+
     @staticmethod
-    def seed(
+    def ingest(
         cc_pair: DATestCCPair,
         api_key: DATestAPIKey,
         content: str | None = None,
@@ -112,7 +114,7 @@ class DocumentManager:
         )
 
     @staticmethod
-    def seed_multiple(
+    def ingest_multiple(
         cc_pair: DATestCCPair,
         api_key: DATestAPIKey,
         num_docs: int = NUM_DOCS,
@@ -122,7 +124,7 @@ class DocumentManager:
         if document_ids is None:
             document_ids = [f"test-doc-{uuid4()}" for _ in range(num_docs)]
         return [
-            DocumentManager.seed(
+            DocumentIngestionManager.ingest(
                 cc_pair=cc_pair,
                 api_key=api_key,
                 document_id=doc_id,
@@ -203,12 +205,11 @@ class DocumentManager:
 
         return final_docs
 
-
-class IngestionManager(DocumentManager):
     @staticmethod
-    def list_all_ingestion_docs(
+    def list_all(
         api_key: DATestAPIKey,
     ) -> list[dict]:
+        """List all documents seeded via the ingestion API."""
         response = requests.get(
             f"{API_SERVER_URL}/onyx-api/ingestion",
             headers=api_key.headers,

--- a/backend/tests/integration/common_utils/managers/document.py
+++ b/backend/tests/integration/common_utils/managers/document.py
@@ -18,6 +18,30 @@ from tests.integration.common_utils.test_models import SimpleTestDocument
 from tests.integration.common_utils.vespa import vespa_fixture
 
 
+def _build_ingestion_payload(
+    document_id: str,
+    cc_pair_id: int,
+    content: str | None = None,
+    metadata: dict | None = None,
+) -> dict:
+    text = content or f"This is test document {document_id}"
+    doc_metadata: dict = {"document_id": document_id}
+    if metadata:
+        doc_metadata.update(metadata)
+
+    return {
+        "document": {
+            "id": document_id,
+            "sections": [{"text": text, "link": document_id}],
+            "source": DocumentSource.NOT_APPLICABLE,
+            "metadata": doc_metadata,
+            "semantic_identifier": f"Test Document {document_id}",
+            "from_ingestion_api": True,
+        },
+        "cc_pair_id": cc_pair_id,
+    }
+
+
 def _verify_document_permissions(
     retrieved_doc: dict,
     cc_pair: DATestCCPair,
@@ -26,7 +50,6 @@ def _verify_document_permissions(
     group_names: list[str] | None = None,
 ) -> None:
     acl_keys = set(retrieved_doc.get("access_control_list", {}).keys())
-    print(f"ACL keys: {acl_keys}")
 
     if cc_pair.access_type == AccessType.PUBLIC:
         if "PUBLIC" not in acl_keys:
@@ -58,118 +81,60 @@ def _verify_document_permissions(
             )
 
 
-def _generate_dummy_document(
-    document_id: str,
-    cc_pair_id: int,
-    content: str | None = None,
-    extra_metadata: dict | None = None,
-) -> dict:
-    text = content if content else f"This is test document {document_id}"
-
-    metadata: dict = {"document_id": document_id}
-    if extra_metadata:
-        metadata.update(extra_metadata)
-
-    return {
-        "document": {
-            "id": document_id,
-            "sections": [
-                {
-                    "text": text,
-                    "link": f"{document_id}",
-                }
-            ],
-            "source": DocumentSource.NOT_APPLICABLE,
-            "metadata": metadata,
-            "semantic_identifier": f"Test Document {document_id}",
-            "from_ingestion_api": True,
-        },
-        "cc_pair_id": cc_pair_id,
-    }
-
-
 class DocumentManager:
-    """
-    Manager for seeding documents via the ingestion API.
-    Used to test various connector features.
-    """
+    @staticmethod
+    def seed(
+        cc_pair: DATestCCPair,
+        api_key: DATestAPIKey,
+        content: str | None = None,
+        document_id: str | None = None,
+        metadata: dict | None = None,
+    ) -> SimpleTestDocument:
+        """Seed a single document via the ingestion API.
+
+        The ingestion API indexes synchronously — the document is indexed
+        and searchable by the time this method returns.
+        """
+        if document_id is None:
+            document_id = f"test-doc-{uuid4()}"
+
+        payload = _build_ingestion_payload(document_id, cc_pair.id, content, metadata)
+        response = requests.post(
+            f"{API_SERVER_URL}/onyx-api/ingestion",
+            json=payload,
+            headers=api_key.headers,
+        )
+        response.raise_for_status()
+
+        return SimpleTestDocument(
+            id=payload["document"]["id"],
+            content=payload["document"]["sections"][0]["text"],
+        )
 
     @staticmethod
-    def seed_dummy_docs(
+    def seed_multiple(
         cc_pair: DATestCCPair,
         api_key: DATestAPIKey,
         num_docs: int = NUM_DOCS,
         document_ids: list[str] | None = None,
     ) -> list[SimpleTestDocument]:
-        # Use provided document_ids if available, otherwise generate random UUIDs
+        """Seed multiple documents with auto-generated content."""
         if document_ids is None:
             document_ids = [f"test-doc-{uuid4()}" for _ in range(num_docs)]
-        else:
-            num_docs = len(document_ids)
-        # Create and ingest some documents
-        documents: list[dict] = []
-        for document_id in document_ids:
-            document = _generate_dummy_document(document_id, cc_pair.id)
-            documents.append(document)
-            response = requests.post(
-                f"{API_SERVER_URL}/onyx-api/ingestion",
-                json=document,
-                headers=api_key.headers,
-            )
-            response.raise_for_status()
-
-        print(
-            f"Seeding docs for api_key_id={api_key.api_key_id} completed successfully."
-        )
         return [
-            SimpleTestDocument(
-                id=document["document"]["id"],
-                content=document["document"]["sections"][0]["text"],
+            DocumentManager.seed(
+                cc_pair=cc_pair,
+                api_key=api_key,
+                document_id=doc_id,
             )
-            for document in documents
+            for doc_id in document_ids
         ]
-
-    @staticmethod
-    def seed_doc_with_content(
-        cc_pair: DATestCCPair,
-        content: str,
-        api_key: DATestAPIKey,
-        document_id: str | None = None,
-        metadata: dict | None = None,
-    ) -> SimpleTestDocument:
-        # Use provided document_ids if available, otherwise generate random UUIDs
-        if document_id is None:
-            document_id = f"test-doc-{uuid4()}"
-        # Create and ingest some documents
-        document: dict = _generate_dummy_document(
-            document_id,
-            cc_pair.id,
-            content,
-            extra_metadata=metadata,
-        )
-        response = requests.post(
-            f"{API_SERVER_URL}/onyx-api/ingestion",
-            json=document,
-            headers=api_key.headers,
-        )
-        response.raise_for_status()
-
-        print(
-            f"Seeding doc for api_key_id={api_key.api_key_id} completed successfully."
-        )
-
-        return SimpleTestDocument(
-            id=document["document"]["id"],
-            content=document["document"]["sections"][0]["text"],
-        )
 
     @staticmethod
     def verify(
         vespa_client: vespa_fixture,
         cc_pair: DATestCCPair,
         doc_creating_user: DATestUser,
-        # If None, will not check doc sets or groups
-        # If empty list, will check for empty doc sets or groups
         doc_set_names: list[str] | None = None,
         group_names: list[str] | None = None,
         verify_deleted: bool = False,
@@ -181,26 +146,10 @@ class DocumentManager:
             doc["fields"]["document_id"]: doc["fields"] for doc in retrieved_docs_dict
         }
 
-        # NOTE(rkuo): too much log spam
-        # Left this here for debugging purposes.
-        # import json
-
-        # print("DEBUGGING DOCUMENTS")
-        # print(retrieved_docs)
-        # for doc in retrieved_docs.values():
-        #     printable_doc = doc.copy()
-        #     print(printable_doc.keys())
-        #     printable_doc.pop("embeddings")
-        #     printable_doc.pop("title_embedding")
-        #     print(json.dumps(printable_doc, indent=2))
-
         for document in cc_pair.documents:
             retrieved_doc = retrieved_docs.get(document.id)
             if not retrieved_doc:
                 if not verify_deleted:
-                    print(f"Document not found: {document.id}")
-                    print(retrieved_docs.keys())
-                    print(retrieved_docs.values())
                     raise ValueError(f"Document not found: {document.id}")
                 continue
             if verify_deleted:
@@ -242,12 +191,9 @@ class DocumentManager:
         retrieved_docs_dict = vespa_client.get_documents_by_id(doc_ids)["documents"]
 
         final_docs: list[SimpleTestDocument] = []
-        # NOTE: they are really chunks, but we're assuming that for these tests
-        # we only have one chunk per document for now
         for doc_dict in retrieved_docs_dict:
             doc_id = doc_dict["fields"]["document_id"]
             doc_content = doc_dict["fields"]["content"]
-            # still called `image_file_name` in Vespa for backwards compatibility
             image_file_id = doc_dict["fields"].get("image_file_name", None)
             final_docs.append(
                 SimpleTestDocument(
@@ -259,11 +205,6 @@ class DocumentManager:
 
 
 class IngestionManager(DocumentManager):
-    """
-    Manager for additional ingestion API endpoints not covered by DocumentManager.
-    Used specifically to test the ingestion API.
-    """
-
     @staticmethod
     def list_all_ingestion_docs(
         api_key: DATestAPIKey,
@@ -285,4 +226,3 @@ class IngestionManager(DocumentManager):
             headers=api_key.headers,
         )
         response.raise_for_status()
-        print(f"Deleted document {document_id} successfully.")

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -211,7 +211,7 @@ def document_builder(admin_user: DATestUser) -> DocumentBuilderType:
     def _document_builder(contents: list[str]) -> list[SimpleTestDocument]:
         # seed documents
         docs: list[SimpleTestDocument] = [
-            DocumentManager.seed_doc_with_content(
+            DocumentManager.seed(
                 cc_pair=cc_pair_1,
                 content=content,
                 api_key=api_key,

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -14,7 +14,7 @@ from onyx.db.search_settings import get_current_search_settings
 from tests.integration.common_utils.constants import ADMIN_USER_NAME
 from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.image_generation import (
     ImageGenerationConfigManager,
 )
@@ -211,7 +211,7 @@ def document_builder(admin_user: DATestUser) -> DocumentBuilderType:
     def _document_builder(contents: list[str]) -> list[SimpleTestDocument]:
         # seed documents
         docs: list[SimpleTestDocument] = [
-            DocumentManager.seed(
+            DocumentIngestionManager.ingest(
                 cc_pair=cc_pair_1,
                 content=content,
                 api_key=api_key,

--- a/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
+++ b/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
@@ -5,7 +5,7 @@ from onyx.db.models import UserRole
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestAPIKey
@@ -52,12 +52,12 @@ def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:  # noqa: ARG0
 
     # Seed documents for Tenant 1
     cc_pair_1.documents = []
-    doc1_tenant1 = DocumentManager.seed(
+    doc1_tenant1 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair_1,
         content="Tenant 1 Document Content",
         api_key=api_key_1,
     )
-    doc2_tenant1 = DocumentManager.seed(
+    doc2_tenant1 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair_1,
         content="Tenant 1 Document Content",
         api_key=api_key_1,
@@ -66,12 +66,12 @@ def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:  # noqa: ARG0
 
     # Seed documents for Tenant 2
     cc_pair_2.documents = []
-    doc1_tenant2 = DocumentManager.seed(
+    doc1_tenant2 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair_2,
         content="Tenant 2 Document Content",
         api_key=api_key_2,
     )
-    doc2_tenant2 = DocumentManager.seed(
+    doc2_tenant2 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair_2,
         content="Tenant 2 Document Content",
         api_key=api_key_2,

--- a/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
+++ b/backend/tests/integration/multitenant_tests/syncing/test_search_permissions.py
@@ -52,12 +52,12 @@ def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:  # noqa: ARG0
 
     # Seed documents for Tenant 1
     cc_pair_1.documents = []
-    doc1_tenant1 = DocumentManager.seed_doc_with_content(
+    doc1_tenant1 = DocumentManager.seed(
         cc_pair=cc_pair_1,
         content="Tenant 1 Document Content",
         api_key=api_key_1,
     )
-    doc2_tenant1 = DocumentManager.seed_doc_with_content(
+    doc2_tenant1 = DocumentManager.seed(
         cc_pair=cc_pair_1,
         content="Tenant 1 Document Content",
         api_key=api_key_1,
@@ -66,12 +66,12 @@ def setup_test_tenants(reset_multitenant: None) -> dict[str, Any]:  # noqa: ARG0
 
     # Seed documents for Tenant 2
     cc_pair_2.documents = []
-    doc1_tenant2 = DocumentManager.seed_doc_with_content(
+    doc1_tenant2 = DocumentManager.seed(
         cc_pair=cc_pair_2,
         content="Tenant 2 Document Content",
         api_key=api_key_2,
     )
-    doc2_tenant2 = DocumentManager.seed_doc_with_content(
+    doc2_tenant2 = DocumentManager.seed(
         cc_pair=cc_pair_2,
         content="Tenant 2 Document Content",
         api_key=api_key_2,

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -23,7 +23,7 @@ from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
@@ -62,12 +62,12 @@ def test_connector_deletion(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_multiple(
+    cc_pair_1.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
-    cc_pair_2.documents = DocumentManager.seed_multiple(
+    cc_pair_2.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -175,7 +175,7 @@ def test_connector_deletion(
     )
 
     # validate vespa documents
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[],
@@ -190,7 +190,7 @@ def test_connector_deletion(
             user_group_2.name  # ty: ignore[possibly-unresolved-reference]
         ]
 
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[doc_set_2.name],
@@ -264,26 +264,26 @@ def test_connector_deletion_for_overlapping_connectors(
     )
 
     doc_ids = [str(uuid4())]
-    cc_pair_1.documents = DocumentManager.seed_multiple(
+    cc_pair_1.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_1,
         document_ids=doc_ids,
         api_key=api_key,
     )
-    cc_pair_2.documents = DocumentManager.seed_multiple(
+    cc_pair_2.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_2,
         document_ids=doc_ids,
         api_key=api_key,
     )
 
     # verify vespa document exists and that it is not in any document sets or groups
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[],
         group_names=[],
         doc_creating_user=admin_user,
     )
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[],
@@ -305,13 +305,13 @@ def test_connector_deletion_for_overlapping_connectors(
     print("Document set 1 created and synced")
 
     # verify vespa document is in the document set
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[doc_set_1.name],
         doc_creating_user=admin_user,
     )
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_creating_user=admin_user,
@@ -347,13 +347,13 @@ def test_connector_deletion_for_overlapping_connectors(
         print("User group 2 created and synced")
 
         # verify vespa document is in the user group
-        DocumentManager.verify(
+        DocumentIngestionManager.verify(
             vespa_client=vespa_client,
             cc_pair=cc_pair_1,
             group_names=[user_group_1.name, user_group_2.name],
             doc_creating_user=admin_user,
         )
-        DocumentManager.verify(
+        DocumentIngestionManager.verify(
             vespa_client=vespa_client,
             cc_pair=cc_pair_2,
             group_names=[user_group_1.name, user_group_2.name],
@@ -397,7 +397,7 @@ def test_connector_deletion_for_overlapping_connectors(
             user_group_2.name  # ty: ignore[possibly-unresolved-reference]
         ]
 
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[],

--- a/backend/tests/integration/tests/connector/test_connector_deletion.py
+++ b/backend/tests/integration/tests/connector/test_connector_deletion.py
@@ -62,12 +62,12 @@ def test_connector_deletion(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_1.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
-    cc_pair_2.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_2.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -264,12 +264,12 @@ def test_connector_deletion_for_overlapping_connectors(
     )
 
     doc_ids = [str(uuid4())]
-    cc_pair_1.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_1.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_1,
         document_ids=doc_ids,
         api_key=api_key,
     )
-    cc_pair_2.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_2.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_2,
         document_ids=doc_ids,
         api_key=api_key,

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -31,7 +31,7 @@ def test_multiple_document_sets_syncing_same_connnector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_1.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -92,13 +92,13 @@ def test_removing_connector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_1.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
 
-    cc_pair_2.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_2.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -178,7 +178,7 @@ def test_renaming_document_set(
         user_performing_action=admin_user,
     )
 
-    cc_pair.documents = DocumentManager.seed_dummy_docs(
+    cc_pair.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair,
         num_docs=NUM_DOCS,
         api_key=api_key,

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -4,7 +4,7 @@ from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestAPIKey
@@ -31,7 +31,7 @@ def test_multiple_document_sets_syncing_same_connnector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_multiple(
+    cc_pair_1.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -61,7 +61,7 @@ def test_multiple_document_sets_syncing_same_connnector(
     )
 
     # make sure documents are as expected
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[doc_set_1.name, doc_set_2.name],
@@ -92,13 +92,13 @@ def test_removing_connector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_multiple(
+    cc_pair_1.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
 
-    cc_pair_2.documents = DocumentManager.seed_multiple(
+    cc_pair_2.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -120,7 +120,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_1 docs are doc_set_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[doc_set_1.name],
@@ -128,7 +128,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_2 docs are doc_set_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[doc_set_1.name],
@@ -147,7 +147,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_1 docs are doc_set_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         doc_set_names=[doc_set_1.name],
@@ -155,7 +155,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_2 docs have no doc set
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         doc_set_names=[],
@@ -178,7 +178,7 @@ def test_renaming_document_set(
         user_performing_action=admin_user,
     )
 
-    cc_pair.documents = DocumentManager.seed_multiple(
+    cc_pair.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -210,7 +210,7 @@ def test_renaming_document_set(
         user_performing_action=admin_user,
     )
 
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair,
         doc_set_names=[new_name],

--- a/backend/tests/integration/tests/image_indexing/test_indexing_images.py
+++ b/backend/tests/integration/tests/image_indexing/test_indexing_images.py
@@ -11,7 +11,7 @@ from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.connector import ConnectorManager
 from tests.integration.common_utils.managers.credential import CredentialManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.settings import SettingsManager
@@ -102,7 +102,7 @@ def test_image_indexing(
     with get_session_with_current_tenant() as db_session:
         # really gets the chunks from Vespa, which is why there are two;
         # one for the raw text and one for the summarized image.
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -197,7 +197,7 @@ def test_docx_image_indexing(
 
     with get_session_with_current_tenant() as db_session:
         # Fetch documents from Vespa - expect text content plus 3 images
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,

--- a/backend/tests/integration/tests/indexing/test_checkpointing.py
+++ b/backend/tests/integration/tests/indexing/test_checkpointing.py
@@ -15,7 +15,7 @@ from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.index_attempt import IndexAttemptManager
 from tests.integration.common_utils.test_document_utils import create_test_document
 from tests.integration.common_utils.test_document_utils import (
@@ -84,7 +84,7 @@ def test_mock_connector_basic_flow(
 
     # Verify results
     with get_session_with_current_tenant() as db_session:
-        chunks = DocumentManager.fetch_documents_for_cc_pair(
+        chunks = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -157,7 +157,7 @@ def test_mock_connector_with_failures(
 
     # Verify results: doc1 should be indexed and doc2 should have an error entry
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -248,7 +248,7 @@ def test_mock_connector_failure_recovery(
 
     # Verify initial state: doc1 indexed, doc2 failed
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -312,7 +312,7 @@ def test_mock_connector_failure_recovery(
 
     # Verify both documents are now indexed
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -434,7 +434,7 @@ def test_mock_connector_checkpoint_recovery(
 
     # Verify initial state: both docs should be indexed
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,
@@ -509,7 +509,7 @@ def test_mock_connector_checkpoint_recovery(
 
     # Verify results
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,

--- a/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
+++ b/backend/tests/integration/tests/indexing/test_initial_permission_sync.py
@@ -22,7 +22,7 @@ from onyx.db.models import DocPermissionSyncAttempt
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.index_attempt import IndexAttemptManager
 from tests.integration.common_utils.test_document_utils import create_test_document
 from tests.integration.common_utils.test_models import DATestCCPair
@@ -99,7 +99,7 @@ def test_mock_connector_initial_permission_sync(
     cc_pair, test_doc = _setup_mock_connector(mock_server_client, admin_user)
 
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -15,7 +15,7 @@ from onyx.db.enums import IndexingStatus
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_HOST
 from tests.integration.common_utils.constants import MOCK_CONNECTOR_SERVER_PORT
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.index_attempt import IndexAttemptManager
 from tests.integration.common_utils.test_document_utils import create_test_document
 from tests.integration.common_utils.test_models import DATestUser
@@ -182,7 +182,7 @@ def test_repeated_error_state_detection_and_recovery(
 
     # Verify the document was indexed
     with get_session_with_current_tenant() as db_session:
-        documents = DocumentManager.fetch_documents_for_cc_pair(
+        documents = DocumentIngestionManager.fetch_documents_for_cc_pair(
             cc_pair_id=cc_pair.id,
             db_session=db_session,
             vespa_client=vespa_client,

--- a/backend/tests/integration/tests/ingestion/test_ingestion_api.py
+++ b/backend/tests/integration/tests/ingestion/test_ingestion_api.py
@@ -31,7 +31,7 @@ def test_ingestion_api_crud(
     api_key.headers.update(admin_user.headers)
 
     # CREATE
-    doc = IngestionManager.seed_doc_with_content(
+    doc = IngestionManager.seed(
         cc_pair=cc_pair,
         content="Test document",
         document_id="test-doc-1",

--- a/backend/tests/integration/tests/ingestion/test_ingestion_api.py
+++ b/backend/tests/integration/tests/ingestion/test_ingestion_api.py
@@ -4,7 +4,7 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import Document
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import IngestionManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.vespa import vespa_fixture
@@ -31,7 +31,7 @@ def test_ingestion_api_crud(
     api_key.headers.update(admin_user.headers)
 
     # CREATE
-    doc = IngestionManager.seed(
+    doc = DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content="Test document",
         document_id="test-doc-1",
@@ -47,11 +47,11 @@ def test_ingestion_api_crud(
     assert len(vespa_docs) == 1
 
     # LIST
-    docs_list = IngestionManager.list_all_ingestion_docs(api_key=api_key)
+    docs_list = DocumentIngestionManager.list_all(api_key=api_key)
     assert any(d["document_id"] == doc.id for d in docs_list)
 
     # DELETE
-    IngestionManager.delete(document_id=doc.id, api_key=api_key)
+    DocumentIngestionManager.delete(document_id=doc.id, api_key=api_key)
 
     with get_session_with_current_tenant() as db_session:
         doc_db = db_session.query(Document).filter(Document.id == doc.id).first()

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -7,8 +7,6 @@ import json
 import os
 from collections.abc import Awaitable
 from collections.abc import Callable
-from datetime import datetime
-from datetime import timezone
 from typing import Any
 
 import pytest
@@ -28,8 +26,6 @@ from tests.integration.common_utils.managers.llm_provider import LLMProviderMana
 from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
-from tests.integration.common_utils.test_models import DATestAPIKey
-from tests.integration.common_utils.test_models import DATestCCPair
 from tests.integration.common_utils.test_models import DATestUser
 
 # Constants
@@ -105,26 +101,6 @@ def _auth_headers(user: DATestUser, name: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {pat.token}"}
 
 
-def _seed_document_and_wait_for_indexing(
-    cc_pair: DATestCCPair,
-    content: str,
-    api_key: DATestAPIKey,
-    user_performing_action: DATestUser,
-) -> None:
-    """Seed a document and wait for indexing to complete."""
-    before = datetime.now(timezone.utc)
-    DocumentManager.seed_doc_with_content(
-        cc_pair=cc_pair,
-        content=content,
-        api_key=api_key,
-    )
-    CCPairManager.wait_for_indexing_completion(
-        cc_pair=cc_pair,
-        after=before,
-        user_performing_action=user_performing_action,
-    )
-
-
 def test_mcp_document_search_flow(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
@@ -137,11 +113,10 @@ def test_mcp_document_search_flow(
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     doc_text = "MCP happy path search document"
-    _seed_document_and_wait_for_indexing(
+    DocumentManager.seed(
         cc_pair=cc_pair,
         content=doc_text,
         api_key=api_key,
-        user_performing_action=admin_user,
     )
 
     headers = _auth_headers(admin_user, name="mcp-search-flow")
@@ -219,11 +194,10 @@ def test_mcp_search_respects_acl_filters(
     )
 
     restricted_doc_content = "MCP restricted knowledge base document"
-    _seed_document_and_wait_for_indexing(
+    DocumentManager.seed(
         cc_pair=restricted_cc_pair,
         content=restricted_doc_content,
         api_key=api_key,
-        user_performing_action=admin_user,
     )
 
     privileged_headers = _auth_headers(privileged_user, "mcp-acl-allowed")
@@ -264,17 +238,15 @@ def test_mcp_search_filters_by_document_set(
     in_set_content = f"{shared_phrase} inside curated set"
     out_of_set_content = f"{shared_phrase} outside curated set"
 
-    _seed_document_and_wait_for_indexing(
+    DocumentManager.seed(
         cc_pair=cc_pair_in_set,
         content=in_set_content,
         api_key=api_key,
-        user_performing_action=admin_user,
     )
-    _seed_document_and_wait_for_indexing(
+    DocumentManager.seed(
         cc_pair=cc_pair_out_of_set,
         content=out_of_set_content,
         api_key=api_key,
-        user_performing_action=admin_user,
     )
 
     doc_set = DocumentSetManager.create(

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -20,7 +20,7 @@ from onyx.db.enums import AccessType
 from tests.integration.common_utils.constants import MCP_SERVER_URL
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.pat import PATManager
@@ -113,7 +113,7 @@ def test_mcp_document_search_flow(
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     doc_text = "MCP happy path search document"
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content=doc_text,
         api_key=api_key,
@@ -194,7 +194,7 @@ def test_mcp_search_respects_acl_filters(
     )
 
     restricted_doc_content = "MCP restricted knowledge base document"
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=restricted_cc_pair,
         content=restricted_doc_content,
         api_key=api_key,
@@ -238,12 +238,12 @@ def test_mcp_search_filters_by_document_set(
     in_set_content = f"{shared_phrase} inside curated set"
     out_of_set_content = f"{shared_phrase} outside curated set"
 
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=cc_pair_in_set,
         content=in_set_content,
         api_key=api_key,
     )
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=cc_pair_out_of_set,
         content=out_of_set_content,
         api_key=api_key,

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -33,7 +33,7 @@ from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.file import FileManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.persona import PersonaManager
@@ -472,7 +472,7 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
         source=DocumentSource.INGESTION_API,
         user_performing_action=admin_user,
     )
-    document = DocumentManager.seed(
+    document = DocumentIngestionManager.ingest(
         cc_pair=public_cc_pair,
         content="hello from connector",
         api_key=api_key,
@@ -510,7 +510,7 @@ def test_connector_file_denied_for_users_without_access(
         source=DocumentSource.INGESTION_API,
         user_performing_action=admin_user,
     )
-    document = DocumentManager.seed(
+    document = DocumentIngestionManager.ingest(
         cc_pair=private_cc_pair,
         content="private connector content",
         api_key=api_key,
@@ -601,7 +601,7 @@ def test_non_tabular_connector_file_is_accessible_via_chat_file_endpoint(
 
     # Document ingested against the cc_pair without `file_id` — the
     # "non-tabular" case under test.
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=public_cc_pair,
         content="non-tabular body text",
         api_key=api_key,
@@ -638,7 +638,7 @@ def test_non_tabular_connector_file_denied_for_users_without_access(
         file_id=file_id,
         access_type=AccessType.PRIVATE,
     )
-    DocumentManager.seed(
+    DocumentIngestionManager.ingest(
         cc_pair=private_cc_pair,
         content="non-tabular private content",
         api_key=api_key,

--- a/backend/tests/integration/tests/permissions/test_user_file_permissions.py
+++ b/backend/tests/integration/tests/permissions/test_user_file_permissions.py
@@ -472,7 +472,7 @@ def test_connector_file_is_accessible_via_chat_file_endpoint(
         source=DocumentSource.INGESTION_API,
         user_performing_action=admin_user,
     )
-    document = DocumentManager.seed_doc_with_content(
+    document = DocumentManager.seed(
         cc_pair=public_cc_pair,
         content="hello from connector",
         api_key=api_key,
@@ -510,7 +510,7 @@ def test_connector_file_denied_for_users_without_access(
         source=DocumentSource.INGESTION_API,
         user_performing_action=admin_user,
     )
-    document = DocumentManager.seed_doc_with_content(
+    document = DocumentManager.seed(
         cc_pair=private_cc_pair,
         content="private connector content",
         api_key=api_key,
@@ -601,7 +601,7 @@ def test_non_tabular_connector_file_is_accessible_via_chat_file_endpoint(
 
     # Document ingested against the cc_pair without `file_id` — the
     # "non-tabular" case under test.
-    DocumentManager.seed_doc_with_content(
+    DocumentManager.seed(
         cc_pair=public_cc_pair,
         content="non-tabular body text",
         api_key=api_key,
@@ -638,7 +638,7 @@ def test_non_tabular_connector_file_denied_for_users_without_access(
         file_id=file_id,
         access_type=AccessType.PRIVATE,
     )
-    DocumentManager.seed_doc_with_content(
+    DocumentManager.seed(
         cc_pair=private_cc_pair,
         content="non-tabular private content",
         api_key=api_key,

--- a/backend/tests/integration/tests/query_history/test_query_history.py
+++ b/backend/tests/integration/tests/query_history/test_query_history.py
@@ -12,7 +12,7 @@ from onyx.configs.constants import SessionType
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.query_history import QueryHistoryManager
 from tests.integration.common_utils.managers.user import UserManager
@@ -30,7 +30,7 @@ def setup_chat_session(reset: None) -> tuple[DATestUser, str]:  # noqa: ARG001
     # Seed a document
     cc_pair.documents = []
     cc_pair.documents.append(
-        DocumentManager.seed(
+        DocumentIngestionManager.ingest(
             cc_pair=cc_pair,
             content="The company's revenue in Q1 was $1M",
             api_key=api_key,

--- a/backend/tests/integration/tests/query_history/test_query_history.py
+++ b/backend/tests/integration/tests/query_history/test_query_history.py
@@ -30,7 +30,7 @@ def setup_chat_session(reset: None) -> tuple[DATestUser, str]:  # noqa: ARG001
     # Seed a document
     cc_pair.documents = []
     cc_pair.documents.append(
-        DocumentManager.seed_doc_with_content(
+        DocumentManager.seed(
             cc_pair=cc_pair,
             content="The company's revenue in Q1 was $1M",
             api_key=api_key,

--- a/backend/tests/integration/tests/query_history/utils.py
+++ b/backend/tests/integration/tests/query_history/utils.py
@@ -85,7 +85,7 @@ def setup_chat_sessions_with_different_feedback() -> (
     # Seed a document
     cc_pair.documents = []
     cc_pair.documents.append(
-        DocumentManager.seed_doc_with_content(
+        DocumentManager.seed(
             cc_pair=cc_pair,
             content="The company's revenue in Q1 was $1M",
             api_key=api_key,

--- a/backend/tests/integration/tests/query_history/utils.py
+++ b/backend/tests/integration/tests/query_history/utils.py
@@ -5,7 +5,7 @@ from onyx.configs.constants import QAFeedbackType
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.chat import ChatSessionManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DAQueryHistoryEntry
@@ -85,7 +85,7 @@ def setup_chat_sessions_with_different_feedback() -> (
     # Seed a document
     cc_pair.documents = []
     cc_pair.documents.append(
-        DocumentManager.seed(
+        DocumentIngestionManager.ingest(
             cc_pair=cc_pair,
             content="The company's revenue in Q1 was $1M",
             api_key=api_key,

--- a/backend/tests/integration/tests/tags/test_tags.py
+++ b/backend/tests/integration/tests/tags/test_tags.py
@@ -44,7 +44,7 @@ def test_tag_creation_and_update(reset: None) -> None:  # noqa: ARG001
         ("multiple_list", "c", True),
         ("single_list", "x", True),
     }
-    doc1 = DocumentManager.seed_doc_with_content(
+    doc1 = DocumentManager.seed(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -87,7 +87,7 @@ def test_tag_creation_and_update(reset: None) -> None:  # noqa: ARG001
         ("multiple_list", "d", True),
         ("new_value", "new_val", False),
     }
-    doc1_new = DocumentManager.seed_doc_with_content(
+    doc1_new = DocumentManager.seed(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -152,7 +152,7 @@ def test_tag_sharing(reset: None) -> None:  # noqa: ARG001
         ("list", "b", True),
         ("same_key", "x", False),
     }
-    doc1 = DocumentManager.seed_doc_with_content(
+    doc1 = DocumentManager.seed(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -171,7 +171,7 @@ def test_tag_sharing(reset: None) -> None:  # noqa: ARG001
         ("list", "c", True),
         ("same_key", "x", True),
     }
-    doc2 = DocumentManager.seed_doc_with_content(
+    doc2 = DocumentManager.seed(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc2",

--- a/backend/tests/integration/tests/tags/test_tags.py
+++ b/backend/tests/integration/tests/tags/test_tags.py
@@ -5,7 +5,7 @@ from onyx.db.models import Document
 from onyx.db.tag import get_structured_tags_for_document
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
@@ -44,7 +44,7 @@ def test_tag_creation_and_update(reset: None) -> None:  # noqa: ARG001
         ("multiple_list", "c", True),
         ("single_list", "x", True),
     }
-    doc1 = DocumentManager.seed(
+    doc1 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -87,7 +87,7 @@ def test_tag_creation_and_update(reset: None) -> None:  # noqa: ARG001
         ("multiple_list", "d", True),
         ("new_value", "new_val", False),
     }
-    doc1_new = DocumentManager.seed(
+    doc1_new = DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -152,7 +152,7 @@ def test_tag_sharing(reset: None) -> None:  # noqa: ARG001
         ("list", "b", True),
         ("same_key", "x", False),
     }
-    doc1 = DocumentManager.seed(
+    doc1 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc1",
@@ -171,7 +171,7 @@ def test_tag_sharing(reset: None) -> None:  # noqa: ARG001
         ("list", "c", True),
         ("same_key", "x", True),
     }
-    doc2 = DocumentManager.seed(
+    doc2 = DocumentIngestionManager.ingest(
         cc_pair=cc_pair,
         content="Dummy content",
         document_id="doc2",

--- a/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
+++ b/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
@@ -6,7 +6,7 @@ from onyx.server.documents.models import DocumentSource
 from tests.integration.common_utils.constants import NUM_DOCS
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
-from tests.integration.common_utils.managers.document import DocumentManager
+from tests.integration.common_utils.managers.document import DocumentIngestionManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
 from tests.integration.common_utils.test_models import DATestAPIKey
@@ -42,13 +42,13 @@ def test_removing_connector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_multiple(
+    cc_pair_1.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
 
-    cc_pair_2.documents = DocumentManager.seed_multiple(
+    cc_pair_2.documents = DocumentIngestionManager.ingest_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,
@@ -70,7 +70,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_1 docs are user_group_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         group_names=[user_group_1.name],
@@ -78,7 +78,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_2 docs are user_group_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         group_names=[user_group_1.name],
@@ -97,7 +97,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_1 docs are user_group_1 only
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_1,
         group_names=[user_group_1.name],
@@ -105,7 +105,7 @@ def test_removing_connector(
     )
 
     # make sure cc_pair_2 docs have no user group
-    DocumentManager.verify(
+    DocumentIngestionManager.verify(
         vespa_client=vespa_client,
         cc_pair=cc_pair_2,
         group_names=[],

--- a/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
+++ b/backend/tests/integration/tests/usergroup/test_usergroup_syncing.py
@@ -42,13 +42,13 @@ def test_removing_connector(
     )
 
     # seed documents
-    cc_pair_1.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_1.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_1,
         num_docs=NUM_DOCS,
         api_key=api_key,
     )
 
-    cc_pair_2.documents = DocumentManager.seed_dummy_docs(
+    cc_pair_2.documents = DocumentManager.seed_multiple(
         cc_pair=cc_pair_2,
         num_docs=NUM_DOCS,
         api_key=api_key,


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified test document ingestion by introducing `DocumentIngestionManager` with synchronous `ingest` (single) and `ingest_multiple` (batch). Updated tests to drop indexing waits and cut log noise.

- **Refactors**
  - Added `_build_ingestion_payload` and centralized ingestion logic.
  - Replaced `DocumentManager` with `DocumentIngestionManager`; renamed `seed_doc_with_content` → `ingest`, `seed_dummy_docs` → `ingest_multiple`, `list_all_ingestion_docs` → `list_all`.
  - Kept `verify` and `fetch_documents_for_cc_pair` under the new manager; removed debug prints and unused comments.

<sup>Written for commit e94c776d41c18d52044815efc2b59429cb56f1a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

