### PR TITLE
fix(tools): Tool Name mismatch issue

### DIFF
--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -53,7 +53,7 @@ from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDone
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
 from onyx.tools.models import ToolCallKickoff
-from onyx.tools.utils import sanitize_tool_name
+from onyx.tools.tool_name import sanitize_tool_name
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span
 from onyx.utils.b64 import get_image_type_from_bytes

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -53,6 +53,7 @@ from onyx.server.query_and_chat.streaming_models import ReasoningDelta
 from onyx.server.query_and_chat.streaming_models import ReasoningDone
 from onyx.server.query_and_chat.streaming_models import ReasoningStart
 from onyx.tools.models import ToolCallKickoff
+from onyx.tools.utils import sanitize_tool_name
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import generation_span
 from onyx.utils.b64 import get_image_type_from_bytes
@@ -680,7 +681,7 @@ def _build_structured_assistant_message(msg: ChatMessageSimple) -> AssistantMess
                 id=tc.tool_call_id,
                 type="function",
                 function=FunctionCall(
-                    name=tc.tool_name,
+                    name=sanitize_tool_name(tc.tool_name),
                     arguments=json.dumps(tc.tool_arguments),
                 ),
             )

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -100,7 +100,9 @@ class CustomTool(Tool[None]):
 
     @property
     def display_name(self) -> str:
-        return self._name
+        # Show the original operationId in the UI, not the LLM-sanitized form
+        # (e.g. "ServiceNow.GetIncident" vs "ServiceNow_GetIncident").
+        return self._method_spec.raw_name
 
     def tool_definition(self) -> dict:
         return self._tool_definition

--- a/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
+++ b/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
@@ -3,7 +3,7 @@ from typing import cast
 
 from pydantic import BaseModel
 
-from onyx.tools.utils import sanitize_tool_name
+from onyx.tools.tool_name import sanitize_tool_name
 
 REQUEST_BODY = "requestBody"
 
@@ -14,7 +14,10 @@ class PathSpec(BaseModel):
 
 
 class MethodSpec(BaseModel):
+    # Sanitized, LLM-safe name; used in tool definitions and dispatch.
     name: str
+    # Original operationId, retained for user-visible display only.
+    raw_name: str
     summary: str
     path: str
     method: str
@@ -127,10 +130,11 @@ def openapi_to_method_specs(openapi_spec: dict[str, Any]) -> list[MethodSpec]:
     path_specs = openapi_to_path_specs(openapi_spec)
 
     method_specs = []
+    seen_names: dict[str, str] = {}
     for path_spec in path_specs:
         for method_name, method in path_spec.methods.items():
-            name = method.get("operationId")
-            if not name:
+            raw_name = method.get("operationId")
+            if not raw_name:
                 raise ValueError(
                     f"Operation ID is not specified for {method_name.upper()} {path_spec.path}"
                 )
@@ -141,9 +145,18 @@ def openapi_to_method_specs(openapi_spec: dict[str, Any]) -> list[MethodSpec]:
                     f"Summary is not specified for {method_name.upper()} {path_spec.path}"
                 )
 
+            sanitized_name = sanitize_tool_name(raw_name)
+            if sanitized_name in seen_names and seen_names[sanitized_name] != raw_name:
+                raise ValueError(
+                    f"Operation IDs '{seen_names[sanitized_name]}' and '{raw_name}' both "
+                    f"sanitize to '{sanitized_name}'. Rename one so the LLM-facing names stay distinct."
+                )
+            seen_names[sanitized_name] = raw_name
+
             method_specs.append(
                 MethodSpec(
-                    name=sanitize_tool_name(name),
+                    name=sanitized_name,
+                    raw_name=raw_name,
                     summary=summary,
                     path=path_spec.path,
                     method=method_name,

--- a/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
+++ b/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
@@ -146,10 +146,15 @@ def openapi_to_method_specs(openapi_spec: dict[str, Any]) -> list[MethodSpec]:
                 )
 
             sanitized_name = sanitize_tool_name(raw_name)
-            if sanitized_name in seen_names and seen_names[sanitized_name] != raw_name:
+            if sanitized_name in seen_names:
+                prior_raw = seen_names[sanitized_name]
+                if prior_raw == raw_name:
+                    raise ValueError(
+                        f"Duplicate operation ID '{raw_name}'. Each operation must have a unique operationId."
+                    )
                 raise ValueError(
-                    f"Operation IDs '{seen_names[sanitized_name]}' and '{raw_name}' both "
-                    f"sanitize to '{sanitized_name}'. Rename one so the LLM-facing names stay distinct."
+                    f"Operation IDs '{prior_raw}' and '{raw_name}' both sanitize to "
+                    f"'{sanitized_name}'. Rename one so the LLM-facing names stay distinct."
                 )
             seen_names[sanitized_name] = raw_name
 

--- a/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
+++ b/backend/onyx/tools/tool_implementations/custom/openapi_parsing.py
@@ -3,6 +3,8 @@ from typing import cast
 
 from pydantic import BaseModel
 
+from onyx.tools.utils import sanitize_tool_name
+
 REQUEST_BODY = "requestBody"
 
 
@@ -141,7 +143,7 @@ def openapi_to_method_specs(openapi_spec: dict[str, Any]) -> list[MethodSpec]:
 
             method_specs.append(
                 MethodSpec(
-                    name=name,
+                    name=sanitize_tool_name(name),
                     summary=summary,
                     path=path_spec.path,
                     method=method_name,

--- a/backend/onyx/tools/tool_name.py
+++ b/backend/onyx/tools/tool_name.py
@@ -1,0 +1,10 @@
+import re
+
+# Bedrock rejects toolUse.name values that don't match [a-zA-Z0-9_-]+, and
+# OpenAI imposes the same constraint on function names. User-supplied Tool.name
+# and OpenAPI operationId can contain spaces, dots, etc.
+_INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_tool_name(name: str) -> str:
+    return _INVALID_TOOL_NAME_CHARS.sub("_", name)

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from sqlalchemy.orm import Session
 
@@ -11,6 +12,17 @@ from onyx.llm.utils import find_model_obj
 from onyx.llm.utils import get_model_map
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.tools.interface import Tool
+
+_INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def sanitize_tool_name(name: str) -> str:
+    # Bedrock rejects toolUse.name values that don't match [a-zA-Z0-9_-]+, and
+    # OpenAI imposes the same constraint on function names. User-supplied
+    # Tool.name and OpenAPI operationId can contain spaces, dots, etc. — replace
+    # anything outside the allowed set with an underscore so the value is safe
+    # to send in tool definitions and in message-history toolUse blocks.
+    return _INVALID_TOOL_NAME_CHARS.sub("_", name)
 
 
 def explicit_tool_calling_supported(model_provider: str, model_name: str) -> bool:

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 from sqlalchemy.orm import Session
 
@@ -12,17 +11,6 @@ from onyx.llm.utils import find_model_obj
 from onyx.llm.utils import get_model_map
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.tools.interface import Tool
-
-_INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
-
-
-def sanitize_tool_name(name: str) -> str:
-    # Bedrock rejects toolUse.name values that don't match [a-zA-Z0-9_-]+, and
-    # OpenAI imposes the same constraint on function names. User-supplied
-    # Tool.name and OpenAPI operationId can contain spaces, dots, etc. — replace
-    # anything outside the allowed set with an underscore so the value is safe
-    # to send in tool definitions and in message-history toolUse blocks.
-    return _INVALID_TOOL_NAME_CHARS.sub("_", name)
 
 
 def explicit_tool_calling_supported(model_provider: str, model_name: str) -> bool:

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -477,6 +477,40 @@ class TestTranslateHistoryToLlmFormat:
         assert isinstance(translated[1], ToolMessage)
         assert translated[1].tool_call_id == "51381e0b0"
 
+    def test_sanitizes_tool_call_name_for_bedrock(self) -> None:
+        # Custom OpenAPI Action tools are stored with the user-supplied
+        # Tool.name (e.g. "ServiceNow API"), which gets injected into the
+        # assistant message's toolUse.name on follow-up turns. Bedrock rejects
+        # names that don't match [a-zA-Z0-9_-]+, so we must sanitize.
+        history = [
+            ChatMessageSimple(
+                message="",
+                token_count=5,
+                message_type=MessageType.ASSISTANT,
+                tool_calls=[
+                    ToolCallSimple(
+                        tool_call_id="call-1",
+                        tool_name="ServiceNow API",
+                        tool_arguments={"q": "incident"},
+                    ),
+                ],
+            ),
+            ChatMessageSimple(
+                message="tool result body",
+                token_count=5,
+                message_type=MessageType.TOOL_CALL_RESPONSE,
+                tool_call_id="call-1",
+            ),
+        ]
+        translated = translate_history_to_llm_format(
+            history=history,
+            llm_config=self._llm_config(LlmProviderNames.BEDROCK),
+        )
+        assert isinstance(translated, list)
+        assert isinstance(translated[0], AssistantMessage)
+        assert translated[0].tool_calls is not None
+        assert translated[0].tool_calls[0].function.name == "ServiceNow_API"
+
     def test_flattens_tool_history_for_ollama(self) -> None:
         translated = translate_history_to_llm_format(
             history=self._tool_history(),

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -467,6 +467,25 @@ class TestSanitizeToolName(unittest.TestCase):
         with pytest.raises(ValueError, match="sanitize to 'foo_bar'"):
             openapi_to_method_specs(schema)
 
+    def test_duplicate_operation_id_raises(self) -> None:
+        # The OpenAPI spec requires operationIds to be unique; a repeated
+        # operationId would also collide in tools_by_name.
+        schema: dict[str, Any] = {
+            "openapi": "3.0.0",
+            "info": {"title": "t", "description": "d", "version": "1.0.0"},
+            "servers": [{"url": "http://x"}],
+            "paths": {
+                "/a": {
+                    "get": {"summary": "a", "operationId": "doThing"},
+                },
+                "/b": {
+                    "get": {"summary": "b", "operationId": "doThing"},
+                },
+            },
+        }
+        with pytest.raises(ValueError, match="Duplicate operation ID 'doThing'"):
+            openapi_to_method_specs(schema)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -13,6 +13,10 @@ from onyx.tools.tool_implementations.custom.custom_tool import (
 )
 from onyx.tools.tool_implementations.custom.custom_tool import CustomToolCallSummary
 from onyx.tools.tool_implementations.custom.custom_tool import validate_openapi_schema
+from onyx.tools.tool_implementations.custom.openapi_parsing import (
+    openapi_to_method_specs,
+)
+from onyx.tools.utils import sanitize_tool_name
 from onyx.utils.headers import HeaderItemDict
 
 
@@ -395,6 +399,50 @@ class TestCustomTool(unittest.TestCase):
             final_result,
             {"id": "789", "name": "Final Assistant"},
             "Final result does not match expected output",
+        )
+
+
+class TestSanitizeToolName(unittest.TestCase):
+    """Tool names sent to Bedrock as toolUse.name must match [a-zA-Z0-9_-]+.
+    User-supplied Tool.name and OpenAPI operationId can contain spaces or dots,
+    so anything outside that set must be replaced with an underscore before the
+    name reaches the LLM (in tool definitions or in message-history replay)."""
+
+    def test_replaces_dots_and_spaces(self) -> None:
+        self.assertEqual(
+            sanitize_tool_name("ServiceNow.GetIncident"),
+            "ServiceNow_GetIncident",
+        )
+        self.assertEqual(
+            sanitize_tool_name("ServiceNow API"),
+            "ServiceNow_API",
+        )
+
+    def test_preserves_valid_characters(self) -> None:
+        self.assertEqual(
+            sanitize_tool_name("get_assistant-v2"),
+            "get_assistant-v2",
+        )
+
+    def test_operation_id_with_invalid_chars_is_sanitized(self) -> None:
+        schema: dict[str, Any] = {
+            "openapi": "3.0.0",
+            "info": {"title": "t", "description": "d", "version": "1.0.0"},
+            "servers": [{"url": "http://x"}],
+            "paths": {
+                "/incidents": {
+                    "get": {
+                        "summary": "get incidents",
+                        "operationId": "ServiceNow.list incidents",
+                    }
+                }
+            },
+        }
+        specs = openapi_to_method_specs(schema)
+        self.assertEqual(specs[0].name, "ServiceNow_list_incidents")
+        self.assertEqual(
+            specs[0].to_tool_definition()["function"]["name"],
+            "ServiceNow_list_incidents",
         )
 
 

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -16,7 +16,7 @@ from onyx.tools.tool_implementations.custom.custom_tool import validate_openapi_
 from onyx.tools.tool_implementations.custom.openapi_parsing import (
     openapi_to_method_specs,
 )
-from onyx.tools.utils import sanitize_tool_name
+from onyx.tools.tool_name import sanitize_tool_name
 from onyx.utils.headers import HeaderItemDict
 
 
@@ -440,10 +440,32 @@ class TestSanitizeToolName(unittest.TestCase):
         }
         specs = openapi_to_method_specs(schema)
         self.assertEqual(specs[0].name, "ServiceNow_list_incidents")
+        # raw_name preserves the original operationId so the UI keeps showing
+        # what the user wrote, even though the LLM sees the sanitized form.
+        self.assertEqual(specs[0].raw_name, "ServiceNow.list incidents")
         self.assertEqual(
             specs[0].to_tool_definition()["function"]["name"],
             "ServiceNow_list_incidents",
         )
+
+    def test_colliding_sanitized_names_raise(self) -> None:
+        # Two distinct operationIds that sanitize to the same value would
+        # silently overwrite each other in tools_by_name; surface a clear error.
+        schema: dict[str, Any] = {
+            "openapi": "3.0.0",
+            "info": {"title": "t", "description": "d", "version": "1.0.0"},
+            "servers": [{"url": "http://x"}],
+            "paths": {
+                "/a": {
+                    "get": {"summary": "a", "operationId": "foo.bar"},
+                },
+                "/b": {
+                    "get": {"summary": "b", "operationId": "foo_bar"},
+                },
+            },
+        }
+        with pytest.raises(ValueError, match="sanitize to 'foo_bar'"):
+            openapi_to_method_specs(schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Fixing an issue where the LLM-facing name comes from two different sources depending on the turn the calls are on.

This fix is to sanitize the tool names so we can prevent any issues that might arise.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->
Added new unit tests and tested with Bedrock model to ensure we are not hitting this anymore

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes tool names to ensure provider-safe function/toolUse names, fixing Bedrock rejections. Applies to assistant tool call replay and OpenAPI-derived custom tools while keeping UI labels unchanged.

- **Bug Fixes**
  - Introduced `sanitize_tool_name` in `onyx.tools.tool_name` to produce `[a-zA-Z0-9_-]+` names.
  - Preserved original `operationId` as `MethodSpec.raw_name` and used for `CustomTool.display_name`; sanitized names are used for tool definitions/dispatch.
  - Reject duplicate `operationId`s and cases where distinct IDs sanitize to the same name with clear errors.
  - Added tests for Bedrock history translation, OpenAPI name handling, UI display names, and duplicate/collision errors.

<sup>Written for commit 613a842e5f6a7e3968b7a0c958d12f85367f380d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

