### PR TITLE
chore(deps): bump path-to-regexp to 8.4.2 in sandbox web template

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/package-lock.json
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/package-lock.json
@@ -10206,9 +10206,9 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/package.json
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/package.json
@@ -39,5 +39,10 @@
     "eslint-config-next": "16.1.4",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "router": {
+      "path-to-regexp": "^8.4.2"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Resolves **CVE-2026-4926** (vulnerable range: `path-to-regexp >=8.0.0, <8.4.0`).
- The vulnerable `path-to-regexp@8.3.0` was pulled in transitively: `shadcn` → `@modelcontextprotocol/sdk` → `express` → `router` → `path-to-regexp`.
- Adds a scoped npm `overrides` entry on `router` so only that chain gets bumped to `^8.4.2`, leaving `msw`'s `path-to-regexp@^6.3.0` (incompatible API) untouched.

## Test plan
- [ ] `npm audit` in the sandbox web template no longer flags `path-to-regexp`
- [ ] `npm install` in the template still resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped bump of transitive `path-to-regexp` under `router` to `8.4.2` in the sandbox web template to address CVE-2026-4926. Uses npm `overrides` so `msw`’s `path-to-regexp@^6` stays untouched.

- **Dependencies**
  - Added `overrides` in template `package.json` to force `router` → `path-to-regexp` to `^8.4.2`.
  - Updated lockfile entry from `8.3.0` to `8.4.2` for `router`’s `path-to-regexp`.

<sup>Written for commit 5a0ac564cc78659bf013855742645ca543c854f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

