### PR TITLE
chore(devtools): make devcontainer firewall opt-in

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -10,7 +10,7 @@ A containerized development environment for working on Onyx.
 - Neovim, ripgrep, fd, fzf, jq, make, wget, unzip
 - Zsh as default shell (sources host `~/.zshrc` if available)
 - Python venv auto-activation
-- Network firewall (default-deny, whitelists npm, GitHub, Anthropic APIs, Sentry, and VS Code update servers)
+- Optional opt-in network firewall (default-deny, whitelists npm, GitHub, Anthropic APIs, Sentry, and VS Code update servers)
 
 ## Usage
 
@@ -75,7 +75,8 @@ user has read/write access to the bind-mounted workspace:
 
 ## Firewall
 
-The container starts with a default-deny firewall (`init-firewall.sh`) that only allows outbound traffic to:
+The container ships with an **opt-in** default-deny firewall (`init-firewall.sh`).
+When enabled, it only allows outbound traffic to:
 
 - npm registry
 - GitHub
@@ -83,4 +84,22 @@ The container starts with a default-deny firewall (`init-firewall.sh`) that only
 - Sentry
 - VS Code update servers
 
-This requires the `NET_ADMIN` and `NET_RAW` capabilities, which are added via `runArgs` in `devcontainer.json`.
+To enable it, set `ONYX_DEVCONTAINER_FIREWALL=1` in your host environment before
+starting the container (e.g. via `ods dev up`):
+
+```bash
+export ONYX_DEVCONTAINER_FIREWALL=1
+ods dev up
+```
+
+The variable is forwarded into the container via `containerEnv` and read by
+`postStartCommand`, which then runs `init-firewall.sh`. Without the variable set
+to `1`, the firewall script is skipped and the container has unrestricted
+outbound network access.
+
+You can also enable the firewall on a running container by running
+`sudo bash /workspace/.devcontainer/init-firewall.sh` from inside it.
+
+The firewall requires the `NET_ADMIN` and `NET_RAW` capabilities, which are
+always added via `runArgs` in `devcontainer.json` so the firewall can be
+toggled on after container start without recreating the container.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
     "COLORTERM": "truecolor",
     "GH_TOKEN": "${localEnv:GH_TOKEN}",
     "MODEL_SERVER_HOST": "inference_model_server",
+    "ONYX_DEVCONTAINER_FIREWALL": "${localEnv:ONYX_DEVCONTAINER_FIREWALL}",
     "OPENSEARCH_HOST": "opensearch",
     "POSTGRES_HOST": "relational_db",
     "REDIS_HOST": "cache",
@@ -33,6 +34,6 @@
   "initializeCommand": "docker network create onyx_default 2>/dev/null || true",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo bash /workspace/.devcontainer/init-dev-user.sh && sudo bash /workspace/.devcontainer/init-firewall.sh",
+  "postStartCommand": "sudo bash /workspace/.devcontainer/init-dev-user.sh && if [ \"${ONYX_DEVCONTAINER_FIREWALL:-}\" = \"1\" ]; then sudo bash /workspace/.devcontainer/init-firewall.sh; else echo 'Devcontainer firewall disabled. Set ONYX_DEVCONTAINER_FIREWALL=1 on the host before starting the container to enable it.'; fi",
   "waitFor": "postStartCommand"
 }


### PR DESCRIPTION
We can make this default/opt-out once it's more stable. Getting people to use the devcontainer at all is better than nothing.

## Summary
- Gate `init-firewall.sh` in `postStartCommand` on a new `ONYX_DEVCONTAINER_FIREWALL=1` env var (forwarded from the host via `containerEnv`), so the default-deny firewall is opt-in instead of always-on.
- Print a one-liner on container start when the firewall is skipped, telling the user how to enable it.
- Update `.devcontainer/README.md` to document the opt-in flow and note that `NET_ADMIN`/`NET_RAW` stay in `runArgs` so the firewall can still be toggled on inside a running container.

## Test plan
- [ ] `ods dev rebuild` with `ONYX_DEVCONTAINER_FIREWALL` unset — container starts, postStartCommand prints the "firewall disabled" message, and outbound traffic to e.g. `https://google.com` succeeds.
- [ ] `export ONYX_DEVCONTAINER_FIREWALL=1 && ods dev rebuild` — firewall is applied, blocked sites are unreachable, allowlisted ones still work.
- [ ] Inside a running container with the firewall disabled, `sudo bash /workspace/.devcontainer/init-firewall.sh` enables it on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the devcontainer network firewall opt-in via `ONYX_DEVCONTAINER_FIREWALL=1` instead of always-on. This avoids unexpected blocked traffic on first run while still allowing a default-deny policy when needed.

- **New Features**
  - Gate `init-firewall.sh` in `postStartCommand` on `ONYX_DEVCONTAINER_FIREWALL=1` (forwarded via `containerEnv`), and print a start-up hint when the firewall is skipped.
  - Update `.devcontainer/README.md` with the opt-in steps; keep `NET_ADMIN`/`NET_RAW` in `runArgs` so the firewall can be enabled inside a running container.

<sup>Written for commit f99cef731ba9c1440f1357b8deed2319de5c2ac0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

