### PR TITLE
refactor(modals): use `InputSelectField` for auth method pickers

### DIFF
--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -153,12 +153,7 @@ function BedrockModalInternals({
             title="Authentication Method"
             subDescription="Choose how Onyx should authenticate with Bedrock."
           >
-            <InputSelect
-              value={authMethod || AUTH_METHOD_ACCESS_KEY}
-              onValueChange={(value) =>
-                formikProps.setFieldValue(FIELD_BEDROCK_AUTH_METHOD, value)
-              }
-            >
+            <InputSelectField name={FIELD_BEDROCK_AUTH_METHOD}>
               <InputSelect.Trigger defaultValue={AUTH_METHOD_IAM} />
               <InputSelect.Content>
                 <InputSelect.Item
@@ -180,7 +175,7 @@ function BedrockModalInternals({
                   Long-term API Key
                 </InputSelect.Item>
               </InputSelect.Content>
-            </InputSelect>
+            </InputSelectField>
           </InputVertical>
         </Section>
       </InputPadder>

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -276,7 +276,7 @@ export default function BedrockModal({
         (existingLlmProvider?.custom_config?.AWS_REGION_NAME as string) ?? "",
       BEDROCK_AUTH_METHOD:
         (existingLlmProvider?.custom_config?.BEDROCK_AUTH_METHOD as string) ??
-        "access_key",
+        AUTH_METHOD_ACCESS_KEY,
       AWS_ACCESS_KEY_ID:
         (existingLlmProvider?.custom_config?.AWS_ACCESS_KEY_ID as string) ?? "",
       AWS_SECRET_ACCESS_KEY:

--- a/web/src/sections/modals/languageModels/BedrockModal.tsx
+++ b/web/src/sections/modals/languageModels/BedrockModal.tsx
@@ -154,7 +154,7 @@ function BedrockModalInternals({
             subDescription="Choose how Onyx should authenticate with Bedrock."
           >
             <InputSelectField name={FIELD_BEDROCK_AUTH_METHOD}>
-              <InputSelect.Trigger defaultValue={AUTH_METHOD_IAM} />
+              <InputSelect.Trigger />
               <InputSelect.Content>
                 <InputSelect.Item
                   value={AUTH_METHOD_IAM}

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -5,6 +5,7 @@ import { useSWRConfig } from "swr";
 import { useFormikContext } from "formik";
 import { FileUploadFormField } from "@/components/Field";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
+import InputSelectField from "@/refresh-components/form/InputSelectField";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Card, MessageCard } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
@@ -86,12 +87,7 @@ function VertexAIModalInternals({
               title="Authentication Method"
               subDescription="Choose how Onyx should authenticate with Google Vertex AI."
             >
-              <InputSelect
-                value={authMethod || AUTH_METHOD_SERVICE_ACCOUNT}
-                onValueChange={(value) =>
-                  formikProps.setFieldValue(FIELD_VERTEX_AUTH_METHOD, value)
-                }
-              >
+              <InputSelectField name={FIELD_VERTEX_AUTH_METHOD}>
                 <InputSelect.Trigger
                   defaultValue={AUTH_METHOD_SERVICE_ACCOUNT}
                 />
@@ -109,7 +105,7 @@ function VertexAIModalInternals({
                     Workload Identity (GKE)
                   </InputSelect.Item>
                 </InputSelect.Content>
-              </InputSelect>
+              </InputSelectField>
             </InputVertical>
           )}
 

--- a/web/src/sections/modals/languageModels/VertexAIModal.tsx
+++ b/web/src/sections/modals/languageModels/VertexAIModal.tsx
@@ -88,9 +88,7 @@ function VertexAIModalInternals({
               subDescription="Choose how Onyx should authenticate with Google Vertex AI."
             >
               <InputSelectField name={FIELD_VERTEX_AUTH_METHOD}>
-                <InputSelect.Trigger
-                  defaultValue={AUTH_METHOD_SERVICE_ACCOUNT}
-                />
+                <InputSelect.Trigger />
                 <InputSelect.Content>
                   <InputSelect.Item
                     value={AUTH_METHOD_SERVICE_ACCOUNT}


### PR DESCRIPTION
## Description

In `BedrockModal` and `VertexAIModal`, the auth method picker was using a raw `InputSelect` with a manual `onValueChange` that called `formikProps.setFieldValue` directly. Both modals already use Formik (via `ModalWrapper`), so these selects should use `InputSelectField` — the same pattern already used for the region picker in `BedrockModal`.

Changes:
- `BedrockModal`: auth method `InputSelect` → `InputSelectField`
- `VertexAIModal`: auth method `InputSelect` → `InputSelectField` (also adds the missing `InputSelectField` import)

## Screenshots + Videos

No UI changes; no screenshots / videos required.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored auth method pickers in Bedrock and Vertex AI modals to use `InputSelectField` with Formik, removing misleading defaults and a hardcoded value. This standardizes form handling and aligns with Formik `initialValues`.

- **Refactors**
  - `BedrockModal`: switched `InputSelect` → `InputSelectField` for the auth method.
  - `VertexAIModal`: switched `InputSelect` → `InputSelectField` for the auth method and added the missing `InputSelectField` import.

- **Bug Fixes**
  - Removed dead `defaultValue` on `InputSelect.Trigger` in both modals and replaced raw `"access_key"` with `AUTH_METHOD_ACCESS_KEY` in `BedrockModal` initial values.

<sup>Written for commit 514b6a78970a45c45b4ac9a4cdb3342986e3425a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

