### PR TITLE
refactor(share-modal): replace `LineItem` with `ContentAction` + `SvgCheck`

### DIFF
--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -3,6 +3,7 @@ import type { PaddingVariants, RoundingVariants } from "@opal/types";
 import { paddingVariants, cardRoundingVariants } from "@opal/shared";
 import { cn } from "@opal/utils";
 import { Interactive, type InteractiveStatefulProps } from "@opal/core";
+import type { BorderVariant } from "../card/components";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,12 +41,16 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
   rounding?: RoundingVariants;
 
   /**
-   * Whether to render a border. When `true`, a 1px border is applied and
-   * changes to `border-action-link-05` in the selected state.
+   * Border style.
+   * - `"none"`: no border.
+   * - `"dashed"`: dashed border.
+   * - `"solid"`: solid border.
    *
-   * @default true
+   * In the selected state, the border color changes to `border-action-link-05`.
+   *
+   * @default "solid"
    */
-  border?: boolean;
+  border?: BorderVariant;
 
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
@@ -82,7 +87,7 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
 function SelectCard({
   padding: paddingProp = "md",
   rounding: roundingProp = "md",
-  border = true,
+  border = "solid",
   ref,
   children,
   ...statefulProps
@@ -95,7 +100,7 @@ function SelectCard({
       <div
         ref={ref}
         className={cn("opal-select-card", padding, rounding)}
-        data-border={border ? "true" : undefined}
+        data-border={border}
       >
         {children}
       </div>

--- a/web/lib/opal/src/components/cards/select-card/components.tsx
+++ b/web/lib/opal/src/components/cards/select-card/components.tsx
@@ -39,6 +39,14 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
    */
   rounding?: RoundingVariants;
 
+  /**
+   * Whether to render a border. When `true`, a 1px border is applied and
+   * changes to `border-action-link-05` in the selected state.
+   *
+   * @default true
+   */
+  border?: boolean;
+
   /** Ref forwarded to the root `<div>`. */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -74,6 +82,7 @@ type SelectCardProps = Omit<InteractiveStatefulProps, "variant"> & {
 function SelectCard({
   padding: paddingProp = "md",
   rounding: roundingProp = "md",
+  border = true,
   ref,
   children,
   ...statefulProps
@@ -83,7 +92,11 @@ function SelectCard({
 
   return (
     <Interactive.Stateful {...statefulProps} variant="select-card">
-      <div ref={ref} className={cn("opal-select-card", padding, rounding)}>
+      <div
+        ref={ref}
+        className={cn("opal-select-card", padding, rounding)}
+        data-border={border ? "true" : undefined}
+      >
         {children}
       </div>
     </Interactive.Stateful>

--- a/web/lib/opal/src/components/cards/select-card/styles.css
+++ b/web/lib/opal/src/components/cards/select-card/styles.css
@@ -4,10 +4,19 @@
   @apply w-full overflow-clip;
 }
 
-.opal-select-card[data-border="true"] {
+.opal-select-card[data-border="none"] {
+  border: none;
+}
+
+.opal-select-card[data-border="dashed"] {
+  @apply border border-dashed;
+}
+
+.opal-select-card[data-border="solid"] {
   @apply border;
 }
 
-.opal-select-card[data-interactive-state="selected"] {
+.opal-select-card[data-border="solid"][data-interactive-state="filled"],
+.opal-select-card[data-border="dashed"][data-interactive-state="filled"] {
   @apply border-action-link-05;
 }

--- a/web/lib/opal/src/components/cards/select-card/styles.css
+++ b/web/lib/opal/src/components/cards/select-card/styles.css
@@ -1,7 +1,11 @@
 /* SelectCard — structural styles; colors handled by Interactive.Stateful */
 
 .opal-select-card {
-  @apply w-full overflow-clip border;
+  @apply w-full overflow-clip;
+}
+
+.opal-select-card[data-border="true"] {
+  @apply border;
 }
 
 .opal-select-card[data-interactive-state="selected"] {

--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -1,9 +1,10 @@
 "use client";
 
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
+  AgentLabel,
   FullAgent,
   MinimalAgent,
   Agent,
@@ -368,6 +369,87 @@ export function useAgentPreferences() {
   return {
     agentPreferences: data ?? null,
     setSpecificAgentPreferences,
+  };
+}
+
+// ── Labels ────────────────────────────────────────────────────────────────────
+
+export function useLabels() {
+  const { mutate } = useSWRConfig();
+  const { data: labels, error } = useSWR<AgentLabel[]>(
+    SWR_KEYS.personaLabels,
+    errorHandlingFetcher
+  );
+
+  const refreshLabels = async () => {
+    return mutate(SWR_KEYS.personaLabels);
+  };
+
+  const createLabel = async (name: string): Promise<AgentLabel | null> => {
+    const response = await fetch(SWR_KEYS.personaLabels, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const newLabel: AgentLabel = await response.json();
+    mutate(
+      SWR_KEYS.personaLabels,
+      (currentLabels: AgentLabel[] | undefined) => [
+        ...(currentLabels || []),
+        newLabel,
+      ],
+      false
+    );
+    return newLabel;
+  };
+
+  const updateLabel = async (id: number, name: string) => {
+    const response = await fetch(`/api/admin/persona/label/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ label_name: name }),
+    });
+
+    if (response.ok) {
+      mutate(
+        SWR_KEYS.personaLabels,
+        labels?.map((label) => (label.id === id ? { ...label, name } : label)),
+        false
+      );
+    }
+
+    return response;
+  };
+
+  const deleteLabel = async (id: number) => {
+    const response = await fetch(`/api/admin/persona/label/${id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (response.ok) {
+      mutate(
+        SWR_KEYS.personaLabels,
+        labels?.filter((label) => label.id !== id),
+        false
+      );
+    }
+
+    return response;
+  };
+
+  return {
+    labels,
+    error,
+    refreshLabels,
+    createLabel,
+    updateLabel,
+    deleteLabel,
   };
 }
 

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -27,7 +27,7 @@ import { parseLlmDescriptor } from "@/lib/languageModels/utils";
 import { ChatSession } from "@/app/app/interfaces";
 import { Credential } from "./connectors/credentials";
 import { SettingsContext } from "@/providers/SettingsProvider";
-import { MinimalAgent, AgentLabel } from "@/lib/agents/types";
+import { MinimalAgent } from "@/lib/agents/types";
 import { DefaultModel, LLMProviderDescriptor } from "@/interfaces/llm";
 import { isAnthropic } from "@/lib/languageModels/svc";
 import { getSourceMetadataForSources } from "./sources";
@@ -244,85 +244,6 @@ export const useFederatedConnectors = () => {
   return {
     ...swrResponse,
     refreshFederatedConnectors: () => mutate(url),
-  };
-};
-
-export const useLabels = () => {
-  const { mutate } = useSWRConfig();
-  const { data: labels, error } = useSWR<AgentLabel[]>(
-    SWR_KEYS.personaLabels,
-    errorHandlingFetcher
-  );
-
-  const refreshLabels = async () => {
-    return mutate(SWR_KEYS.personaLabels);
-  };
-
-  const createLabel = async (name: string): Promise<AgentLabel | null> => {
-    const response = await fetch(SWR_KEYS.personaLabels, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name }),
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const newLabel: AgentLabel = await response.json();
-    mutate(
-      SWR_KEYS.personaLabels,
-      (currentLabels: AgentLabel[] | undefined) => [
-        ...(currentLabels || []),
-        newLabel,
-      ],
-      false
-    );
-    return newLabel;
-  };
-
-  const updateLabel = async (id: number, name: string) => {
-    const response = await fetch(`/api/admin/persona/label/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ label_name: name }),
-    });
-
-    if (response.ok) {
-      mutate(
-        SWR_KEYS.personaLabels,
-        labels?.map((label) => (label.id === id ? { ...label, name } : label)),
-        false
-      );
-    }
-
-    return response;
-  };
-
-  const deleteLabel = async (id: number) => {
-    const response = await fetch(`/api/admin/persona/label/${id}`, {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-    });
-
-    if (response.ok) {
-      mutate(
-        SWR_KEYS.personaLabels,
-        labels?.filter((label) => label.id !== id),
-        false
-      );
-    }
-
-    return response;
-  };
-
-  return {
-    labels,
-    error,
-    refreshLabels,
-    createLabel,
-    updateLabel,
-    deleteLabel,
   };
 };
 

--- a/web/src/sections/modals/ShareAgentModal.test.tsx
+++ b/web/src/sections/modals/ShareAgentModal.test.tsx
@@ -15,9 +15,6 @@ jest.mock("@/hooks/useShareableGroups", () => ({
 
 jest.mock("@/lib/agents/hooks", () => ({
   useAgent: jest.fn(() => ({ agent: null })),
-}));
-
-jest.mock("@/lib/hooks", () => ({
   useLabels: jest.fn(() => ({
     labels: [],
     createLabel: jest.fn(),

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -333,7 +333,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
 
                 {canUpdateFeaturedStatus && (
                   <>
-                    <div className="border-t border-border-02" />
+                    <Divider paddingParallel="fit" />
 
                     <InputHorizontal
                       title="Feature This Agent"

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -22,10 +22,9 @@ import useShareableGroups from "@/hooks/useShareableGroups";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import { useUser } from "@/providers/UserProvider";
 import { Formik, useFormikContext } from "formik";
-import { useAgent } from "@/lib/agents/hooks";
+import { useAgent, useLabels } from "@/lib/agents/hooks";
 import { Button, Card, Divider, MessageCard, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
-import { useLabels } from "@/lib/hooks";
 import { AgentLabel } from "@/lib/agents/types";
 import { FetchError } from "@/lib/fetcher";
 

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -13,19 +13,17 @@ import {
 } from "@opal/icons";
 import InputChipField from "@/refresh-components/inputs/InputChipField";
 import Tabs from "@/refresh-components/Tabs";
-import { Card } from "@/refresh-components/cards";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboBox";
 import { ContentAction, InputHorizontal } from "@opal/layouts";
 import SwitchField from "@/refresh-components/form/SwitchField";
 import { Section } from "@/layouts/general-layouts";
-import Text from "@/refresh-components/texts/Text";
 import useShareableUsers from "@/hooks/useShareableUsers";
 import useShareableGroups from "@/hooks/useShareableGroups";
 import { useModal } from "@/refresh-components/contexts/ModalContext";
 import { useUser } from "@/providers/UserProvider";
 import { Formik, useFormikContext } from "formik";
 import { useAgent } from "@/lib/agents/hooks";
-import { Button, MessageCard } from "@opal/components";
+import { Button, Card, Divider, MessageCard, Text } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { useLabels } from "@/lib/hooks";
 import { AgentLabel } from "@/lib/agents/types";
@@ -204,7 +202,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
       <Modal.Header icon={SvgShare} title="Share Agent" onClose={handleClose} />
 
       <Modal.Body padding={0.5}>
-        <Card variant="borderless" padding={0.5}>
+        <Card padding="sm">
           <Tabs
             defaultValue={
               values.isPublic ? YOUR_ORGANIZATION_TAB : USERS_AND_GROUPS_TAB
@@ -264,7 +262,6 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                           title={user.email}
                           description={isCurrentUser ? "You" : undefined}
                           padding="sm"
-                          center
                           rightChildren={
                             isOwner || (isCurrentUser && !agentId) ? (
                               // Owner will always have the agent "shared" with it.
@@ -273,7 +270,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                               // Note:
                               // This user, during creation, is assumed to be the "owner".
                               // That is why the `(isCurrentUser && !agentId)` condition exists.
-                              <Text secondaryBody text03>
+                              <Text font="secondary-body" color="text-03">
                                 Owner
                               </Text>
                             ) : (
@@ -300,7 +297,6 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                         icon={SvgUsers}
                         title={group.name}
                         padding="sm"
-                        center
                         rightChildren={
                           <Button
                             prominence="tertiary"
@@ -358,7 +354,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                   placeholder="Add labels..."
                   icon={SvgTag}
                 />
-                <Text secondaryBody text04>
+                <Text font="secondary-body" color="text-04">
                   Add labels and categories to help people better discover this
                   agent.
                 </Text>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -254,37 +254,38 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                       const isCurrentUser = currentUser?.id === user.id;
 
                       return (
-                        <ContentAction
-                          key={`user-${user.id}`}
-                          sizePreset="main-ui"
-                          variant="section"
-                          icon={SvgUser}
-                          title={user.email}
-                          description={isCurrentUser ? "You" : undefined}
-                          padding="sm"
-                          rightChildren={
-                            isOwner || (isCurrentUser && !agentId) ? (
-                              // Owner will always have the agent "shared" with it.
-                              // Therefore, we never render any SvgX button to remove it.
-                              //
-                              // Note:
-                              // This user, during creation, is assumed to be the "owner".
-                              // That is why the `(isCurrentUser && !agentId)` condition exists.
-                              <Text font="secondary-body" color="text-03">
-                                Owner
-                              </Text>
-                            ) : (
-                              // For all other cases (including for "self-unsharing"),
-                              // we render a Button with SvgX to remove a person from the list.
-                              <Button
-                                prominence="tertiary"
-                                size="sm"
-                                icon={SvgX}
-                                onClick={() => handleRemoveUser(user.id)}
-                              />
-                            )
-                          }
-                        />
+                        <div key={`user-${user.id}`} className="p-1">
+                          <ContentAction
+                            sizePreset="main-ui"
+                            variant="section"
+                            icon={SvgUser}
+                            title={user.email}
+                            description={isCurrentUser ? "You" : undefined}
+                            padding="fit"
+                            rightChildren={
+                              isOwner || (isCurrentUser && !agentId) ? (
+                                // Owner will always have the agent "shared" with it.
+                                // Therefore, we never render any SvgX button to remove it.
+                                //
+                                // Note:
+                                // This user, during creation, is assumed to be the "owner".
+                                // That is why the `(isCurrentUser && !agentId)` condition exists.
+                                <Text font="secondary-body" color="text-03">
+                                  Owner
+                                </Text>
+                              ) : (
+                                // For all other cases (including for "self-unsharing"),
+                                // we render a Button with SvgX to remove a person from the list.
+                                <Button
+                                  prominence="tertiary"
+                                  size="sm"
+                                  icon={SvgX}
+                                  onClick={() => handleRemoveUser(user.id)}
+                                />
+                              )
+                            }
+                          />
+                        </div>
                       );
                     })}
 
@@ -333,7 +334,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
 
                 {canUpdateFeaturedStatus && (
                   <>
-                    <Divider paddingParallel="fit" />
+                    <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
                     <InputHorizontal
                       title="Feature This Agent"
@@ -345,19 +346,21 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                   </>
                 )}
 
-                <InputChipField
-                  chips={chipItems}
-                  onRemoveChip={(id) => handleRemoveLabel(Number(id))}
-                  onAdd={addLabel}
-                  value={labelInputValue}
-                  onChange={setLabelInputValue}
-                  placeholder="Add labels..."
-                  icon={SvgTag}
-                />
-                <Text font="secondary-body" color="text-04">
-                  Add labels and categories to help people better discover this
-                  agent.
-                </Text>
+                <Section gap={0.25} alignItems="stretch">
+                  <InputChipField
+                    chips={chipItems}
+                    onRemoveChip={(id) => handleRemoveLabel(Number(id))}
+                    onAdd={addLabel}
+                    value={labelInputValue}
+                    onChange={setLabelInputValue}
+                    placeholder="Add labels..."
+                    icon={SvgTag}
+                  />
+                  <Text font="secondary-body" color="text-03">
+                    Add labels and categories to help people better discover
+                    this agent.
+                  </Text>
+                </Section>
               </Section>
             </Tabs.Content>
           </Tabs>

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import {
+  SvgCheck,
   SvgLink,
   SvgOrganization,
   SvgShare,
@@ -15,9 +16,8 @@ import InputChipField from "@/refresh-components/inputs/InputChipField";
 import Tabs from "@/refresh-components/Tabs";
 import { Card } from "@/refresh-components/cards";
 import InputComboBox from "@/refresh-components/inputs/InputComboBox/InputComboBox";
-import { InputHorizontal } from "@opal/layouts";
+import { ContentAction, InputHorizontal } from "@opal/layouts";
 import SwitchField from "@/refresh-components/form/SwitchField";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import useShareableUsers from "@/hooks/useShareableUsers";
@@ -257,24 +257,27 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                       const isCurrentUser = currentUser?.id === user.id;
 
                       return (
-                        <LineItem
+                        <ContentAction
                           key={`user-${user.id}`}
+                          sizePreset="main-ui"
+                          variant="section"
                           icon={SvgUser}
+                          title={user.email}
                           description={isCurrentUser ? "You" : undefined}
+                          padding="sm"
+                          center
                           rightChildren={
                             isOwner || (isCurrentUser && !agentId) ? (
                               // Owner will always have the agent "shared" with it.
-                              // Therefore, we never render any `IconButton SvgX` to remove it.
+                              // Therefore, we never render any SvgX button to remove it.
                               //
                               // Note:
                               // This user, during creation, is assumed to be the "owner".
-                              // That is why the `(isCurrentUser && !agent)` condition exists.
-                              <Text secondaryBody text03>
-                                Owner
-                              </Text>
+                              // That is why the `(isCurrentUser && !agentId)` condition exists.
+                              <SvgCheck size={16} className="text-text-03" />
                             ) : (
                               // For all other cases (including for "self-unsharing"),
-                              // we render an `IconButton SvgX` to remove a person from the list.
+                              // we render a Button with SvgX to remove a person from the list.
                               <Button
                                 prominence="tertiary"
                                 size="sm"
@@ -283,17 +286,20 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                               />
                             )
                           }
-                        >
-                          {user.email}
-                        </LineItem>
+                        />
                       );
                     })}
 
                     {/* Shared Groups */}
                     {displayedGroups.map((group) => (
-                      <LineItem
+                      <ContentAction
                         key={`group-${group.id}`}
+                        sizePreset="main-ui"
+                        variant="section"
                         icon={SvgUsers}
+                        title={group.name}
+                        padding="sm"
+                        center
                         rightChildren={
                           <Button
                             prominence="tertiary"
@@ -302,9 +308,7 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                             onClick={() => handleRemoveGroup(group.id)}
                           />
                         }
-                      >
-                        {group.name}
-                      </LineItem>
+                      />
                     ))}
                   </Section>
                 )}

--- a/web/src/sections/modals/ShareAgentModal.tsx
+++ b/web/src/sections/modals/ShareAgentModal.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import {
-  SvgCheck,
   SvgLink,
   SvgOrganization,
   SvgShare,
@@ -274,7 +273,9 @@ function ShareAgentFormContent({ agentId }: ShareAgentFormContentProps) {
                               // Note:
                               // This user, during creation, is assumed to be the "owner".
                               // That is why the `(isCurrentUser && !agentId)` condition exists.
-                              <SvgCheck size={16} className="text-text-03" />
+                              <Text secondaryBody text03>
+                                Owner
+                              </Text>
                             ) : (
                               // For all other cases (including for "self-unsharing"),
                               // we render a Button with SvgX to remove a person from the list.

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -7,14 +7,12 @@ import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 import { copyAll } from "@/app/app/message/copyingUtils";
 import { Section } from "@/layouts/general-layouts";
 import Modal from "@/refresh-components/Modal";
-import { Button } from "@opal/components";
+import { Button, LineItemButton } from "@opal/components";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { SvgLink, SvgShare, SvgUsers } from "@opal/icons";
 import SvgCheck from "@opal/icons/check";
 import SvgLock from "@opal/icons/lock";
-import { Interactive } from "@opal/core";
-import { ContentAction } from "@opal/layouts";
 
 import type { IconProps } from "@opal/types";
 import useChatSessions from "@/hooks/useChatSessions";
@@ -65,30 +63,24 @@ function PrivacyOption({
   ariaLabel,
 }: PrivacyOptionProps) {
   return (
-    <Interactive.Stateful
-      state={selected ? "selected" : "empty"}
-      variant="select-heavy"
-      onClick={onClick}
-      aria-label={ariaLabel}
-    >
-      <div className="w-full rounded-08">
-        <ContentAction
-          sizePreset="main-ui"
-          variant="section"
-          icon={Icon}
-          title={title}
-          description={description}
-          padding="sm"
-          center
-          color="interactive"
-          rightChildren={
-            selected ? (
-              <SvgCheck size={16} className="shrink-0 stroke-action-link-05" />
-            ) : undefined
-          }
-        />
-      </div>
-    </Interactive.Stateful>
+    <div aria-label={ariaLabel}>
+      <LineItemButton
+        selectVariant="select-heavy"
+        state={selected ? "selected" : "empty"}
+        rounding="sm"
+        onClick={onClick}
+        sizePreset="main-ui"
+        variant="section"
+        icon={Icon}
+        title={title}
+        description={description}
+        rightChildren={
+          selected ? (
+            <SvgCheck size={16} className="shrink-0 stroke-action-link-05" />
+          ) : undefined
+        }
+      />
+    </div>
   );
 }
 

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -66,7 +66,7 @@ function PrivacyOption({
   return (
     <SelectCard
       state={selected ? "filled" : "empty"}
-      padding="sm"
+      padding="md"
       rounding="sm"
       border={false}
       onClick={onClick}

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -68,6 +68,7 @@ function PrivacyOption({
       state={selected ? "filled" : "empty"}
       padding="sm"
       rounding="sm"
+      border={false}
       onClick={onClick}
       aria-label={ariaLabel}
     >
@@ -78,7 +79,6 @@ function PrivacyOption({
         title={title}
         description={description}
         padding="fit"
-        center
         color="interactive"
         rightChildren={
           selected ? (

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -7,7 +7,8 @@ import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
 import { copyAll } from "@/app/app/message/copyingUtils";
 import { Section } from "@/layouts/general-layouts";
 import Modal from "@/refresh-components/Modal";
-import { Button, LineItemButton } from "@opal/components";
+import { Button, SelectCard } from "@opal/components";
+import { ContentAction } from "@opal/layouts";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { SvgLink, SvgShare, SvgUsers } from "@opal/icons";
@@ -63,24 +64,29 @@ function PrivacyOption({
   ariaLabel,
 }: PrivacyOptionProps) {
   return (
-    <div aria-label={ariaLabel}>
-      <LineItemButton
-        selectVariant="select-heavy"
-        state={selected ? "filled" : "empty"}
-        rounding="sm"
-        onClick={onClick}
+    <SelectCard
+      state={selected ? "filled" : "empty"}
+      padding="sm"
+      rounding="sm"
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      <ContentAction
         sizePreset="main-ui"
         variant="section"
         icon={Icon}
         title={title}
         description={description}
+        padding="fit"
+        center
+        color="interactive"
         rightChildren={
           selected ? (
             <SvgCheck size={16} className="shrink-0 stroke-action-link-05" />
           ) : undefined
         }
       />
-    </div>
+    </SelectCard>
   );
 }
 

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -68,7 +68,7 @@ function PrivacyOption({
       state={selected ? "filled" : "empty"}
       padding="sm"
       rounding="sm"
-      border={false}
+      border="none"
       onClick={onClick}
       aria-label={ariaLabel}
     >

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -180,7 +180,7 @@ export default function ShareChatSessionModal({
             justifyContent="start"
             alignItems="stretch"
             height="auto"
-            gap={0.12}
+            gap={0.25}
           >
             <PrivacyOption
               icon={SvgLock}

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -66,7 +66,7 @@ function PrivacyOption({
   return (
     <SelectCard
       state={selected ? "filled" : "empty"}
-      padding="md"
+      padding="sm"
       rounding="sm"
       border={false}
       onClick={onClick}

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -66,7 +66,7 @@ function PrivacyOption({
     <div aria-label={ariaLabel}>
       <LineItemButton
         selectVariant="select-heavy"
-        state={selected ? "selected" : "empty"}
+        state={selected ? "filled" : "empty"}
         rounding="sm"
         onClick={onClick}
         sizePreset="main-ui"

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -118,14 +118,16 @@ export default function ShareChatSessionModal({
 
   const isShared = shareLink && selectedPrivacy === "public";
 
-  let submitButtonText = "Done";
-  if (wantsPublic && !isCurrentlyPublic && !shareLink) {
-    submitButtonText = "Create Share Link";
-  } else if (!wantsPublic && isCurrentlyPublic) {
-    submitButtonText = "Make Private";
-  } else if (isShared) {
+  let submitButtonText: string;
+  if (isShared) {
     submitButtonText = "Copy Link";
+  } else if (isCurrentlyPublic && !wantsPublic) {
+    submitButtonText = "Make Private";
+  } else {
+    submitButtonText = "Create Share Link";
   }
+
+  const submitDisabled = isLoading || (!isCurrentlyPublic && !wantsPublic);
 
   async function handleSubmit() {
     setIsLoading(true);
@@ -227,7 +229,7 @@ export default function ShareChatSessionModal({
             </Button>
           )}
           <Button
-            disabled={isLoading}
+            disabled={submitDisabled}
             onClick={handleSubmit}
             icon={isShared ? SvgLink : undefined}
             width={isShared ? "full" : undefined}

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -66,7 +66,7 @@ function PrivacyOption({
     <div aria-label={ariaLabel}>
       <LineItemButton
         selectVariant="select-heavy"
-        state={selected ? "filled" : "empty"}
+        state={selected ? "selected" : "empty"}
         rounding="sm"
         onClick={onClick}
         sizePreset="main-ui"

--- a/web/src/sections/modals/ShareChatSessionModal.tsx
+++ b/web/src/sections/modals/ShareChatSessionModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { cn } from "@opal/utils";
 import { ChatSession, ChatSessionSharedStatus } from "@/app/app/interfaces";
 import { toast } from "@/hooks/useToast";
 import { useChatSessionStore } from "@/app/app/stores/useChatSessionStore";
@@ -11,10 +10,11 @@ import Modal from "@/refresh-components/Modal";
 import { Button } from "@opal/components";
 import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
-import Text from "@/refresh-components/texts/Text";
 import { SvgLink, SvgShare, SvgUsers } from "@opal/icons";
 import SvgCheck from "@opal/icons/check";
 import SvgLock from "@opal/icons/lock";
+import { Interactive } from "@opal/core";
+import { ContentAction } from "@opal/layouts";
 
 import type { IconProps } from "@opal/types";
 import useChatSessions from "@/hooks/useChatSessions";
@@ -65,37 +65,30 @@ function PrivacyOption({
   ariaLabel,
 }: PrivacyOptionProps) {
   return (
-    <div
-      className={cn(
-        "p-1.5 rounded-08 cursor-pointer ",
-        selected ? "bg-background-tint-00" : "bg-transparent",
-        "hover:bg-background-tint-02"
-      )}
+    <Interactive.Stateful
+      state={selected ? "selected" : "empty"}
+      variant="select-heavy"
       onClick={onClick}
       aria-label={ariaLabel}
     >
-      <div className="flex flex-row gap-1 items-center">
-        <div className="flex w-5 p-[2px] self-stretch justify-center">
-          <Icon
-            size={16}
-            className={cn(selected ? "stroke-text-05" : "stroke-text-03")}
-          />
-        </div>
-        <div className="flex flex-col flex-1 px-0.5">
-          <Text mainUiBody text05={selected} text03={!selected}>
-            {title}
-          </Text>
-          <Text secondaryBody text03>
-            {description}
-          </Text>
-        </div>
-        {selected && (
-          <div className="flex w-5 self-stretch justify-center">
-            <SvgCheck size={16} className="stroke-action-link-05" />
-          </div>
-        )}
+      <div className="w-full rounded-08">
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={Icon}
+          title={title}
+          description={description}
+          padding="sm"
+          center
+          color="interactive"
+          rightChildren={
+            selected ? (
+              <SvgCheck size={16} className="shrink-0 stroke-action-link-05" />
+            ) : undefined
+          }
+        />
       </div>
-    </div>
+    </Interactive.Stateful>
   );
 }
 

--- a/web/tests/e2e/chat/share_chat.spec.ts
+++ b/web/tests/e2e/chat/share_chat.spec.ts
@@ -51,7 +51,8 @@ test.describe("Share Chat Session Modal", () => {
     await expect(privateOption.locator("svg").last()).toBeVisible();
 
     const submitButton = dialog.locator('[aria-label="share-modal-submit"]');
-    await expect(submitButton).toHaveText("Done");
+    await expect(submitButton).toHaveText("Create Share Link");
+    await expect(submitButton).toBeDisabled();
 
     const cancelButton = dialog.locator('[aria-label="share-modal-cancel"]');
     await expect(cancelButton).toBeVisible();


### PR DESCRIPTION
## Description

Migrates both share modals to use proper opal primitives, cleans up agent-related code, and moves label hooks to their canonical home.

**`ShareChatSessionModal`**
- `PrivacyOption` rebuilt with `SelectCard` + `ContentAction` — borderless, filled state when selected, `SvgCheck` aligned top-right
- Footer button states unified: private sessions always show "Cancel" + "Create Share Link" (disabled when "Private" is selected)
- Gap between options set to `gap-1` (4px)

**`ShareAgentModal`**
- User/group rows migrated from banned `refresh-components/buttons/LineItem` → `ContentAction`
- `Text` (deprecated refresh) → `Text` from `@opal/components`
- `Card` (refresh) → `Card` from `@opal/components`
- Raw `<div className="border-t ...">` divider → opal `Divider`
- `center` removed from `ContentAction` rows; `key` moved to correct outermost element

**`@opal/components` — `SelectCard`**
- Exposed `border` prop as `BorderVariant = "none" | "dashed" | "solid"` (default `"solid"`), aligning with `Card`'s API

**Agent lib consolidation**
- `useLabels` (+ `createLabel`, `updateLabel`, `deleteLabel`, `refreshLabels`) moved from `lib/hooks.ts` → `lib/agents/hooks.ts` where it belongs alongside other agent data hooks
- Updated all consumers and test mocks accordingly

## Screenshots + Videos

### `ShareChatSessionModal`

https://github.com/user-attachments/assets/7d1e1664-0131-40b7-9834-b5aff3ae5678

### `ShareAgentModal`

https://github.com/user-attachments/assets/906cce44-bd45-44dd-9c84-92e0da8e7451

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check