### PR TITLE
feat(craft-sandbox): add Helm foundation for per-session Jobs namespace

### DIFF
--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-limitrange.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-limitrange.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: sandbox-jobs-limits
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-policy
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: {{ .Values.sandboxJobs.limitRange.default.cpu | quote }}
+        memory: {{ .Values.sandboxJobs.limitRange.default.memory | quote }}
+      defaultRequest:
+        cpu: {{ .Values.sandboxJobs.limitRange.defaultRequest.cpu | quote }}
+        memory: {{ .Values.sandboxJobs.limitRange.defaultRequest.memory | quote }}
+      max:
+        cpu: {{ .Values.sandboxJobs.limitRange.max.cpu | quote }}
+        memory: {{ .Values.sandboxJobs.limitRange.max.memory | quote }}
+      min:
+        cpu: {{ .Values.sandboxJobs.limitRange.min.cpu | quote }}
+        memory: {{ .Values.sandboxJobs.limitRange.min.memory | quote }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-namespace.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-namespace.yaml
@@ -3,6 +3,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.sandboxJobs.namespace }}
+  annotations:
+    # Keep the namespace across helm upgrade/uninstall — otherwise disabling
+    # the feature flag or uninstalling the chart cascade-deletes every
+    # in-flight sandbox Job and its session PVC. Cleanup is a deliberate
+    # `kubectl delete namespace` step instead.
+    "helm.sh/resource-policy": keep
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-execution

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-namespace.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-execution
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-networkpolicy.yaml
@@ -31,7 +31,7 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
-              kubernetes.io/metadata.name: {{ .Values.sandboxJobs.networkPolicy.allowFromNamespace }}
+              kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.sandboxJobs.networkPolicy.allowFromNamespace }}
           podSelector:
             matchLabels:
               {{ .Values.sandboxJobs.networkPolicy.allowFromPodLabel.key }}: {{ .Values.sandboxJobs.networkPolicy.allowFromPodLabel.value }}
@@ -52,7 +52,9 @@ spec:
     - Egress
   egress:
     - to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-networkpolicy.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-jobs-default-deny
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-network
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-jobs-allow-from-api-server
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-network
+spec:
+  podSelector:
+    matchLabels:
+      {{ .Values.sandboxJobs.networkPolicy.podSelectorLabel.key }}: {{ .Values.sandboxJobs.networkPolicy.podSelectorLabel.value }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.sandboxJobs.networkPolicy.allowFromNamespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.sandboxJobs.networkPolicy.allowFromPodLabel.key }}: {{ .Values.sandboxJobs.networkPolicy.allowFromPodLabel.value }}
+      ports:
+        {{- toYaml .Values.sandboxJobs.networkPolicy.ingressPorts | nindent 8 }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: sandbox-jobs-allow-egress
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-network
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              {{- toYaml .Values.sandboxJobs.networkPolicy.egressBlockedCidrs | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-pdb.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sandbox-jobs-pdb
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-policy
+spec:
+  maxUnavailable: {{ .Values.sandboxJobs.podDisruptionBudget.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{ .Values.sandboxJobs.networkPolicy.podSelectorLabel.key }}: {{ .Values.sandboxJobs.networkPolicy.podSelectorLabel.value }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-resourcequota.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-resourcequota.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: sandbox-jobs-quota
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-policy
+spec:
+  hard:
+    pods: {{ .Values.sandboxJobs.resourceQuota.pods | quote }}
+    requests.cpu: {{ .Values.sandboxJobs.resourceQuota.requestsCpu | quote }}
+    requests.memory: {{ .Values.sandboxJobs.resourceQuota.requestsMemory | quote }}
+    limits.cpu: {{ .Values.sandboxJobs.resourceQuota.limitsCpu | quote }}
+    limits.memory: {{ .Values.sandboxJobs.resourceQuota.limitsMemory | quote }}
+    persistentvolumeclaims: {{ .Values.sandboxJobs.resourceQuota.persistentVolumeClaims | quote }}
+    services: {{ .Values.sandboxJobs.resourceQuota.services | quote }}
+    count/jobs.batch: {{ .Values.sandboxJobs.resourceQuota.jobsBatch | quote }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-role.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-role.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sandbox-job-manager
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-rbac
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-rolebinding.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-rolebinding.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.sandboxJobs.enabled }}
+{{- $subjects := list -}}
+{{- if .Values.sandboxJobs.jobManager.bindChartServiceAccount -}}
+{{- $chartSaName := include "onyx.serviceAccountName" . -}}
+{{- $chartSaNs := default .Release.Namespace .Values.sandboxJobs.jobManager.chartServiceAccountNamespace -}}
+{{- $subjects = append $subjects (dict "name" $chartSaName "namespace" $chartSaNs "bindingName" "chart-sa") -}}
+{{- end -}}
+{{- range .Values.sandboxJobs.jobManager.additionalSubjects -}}
+{{- $subjects = append $subjects (merge (dict "bindingName" .name) .) -}}
+{{- end -}}
+{{- range $i, $subject := $subjects }}
+{{- if $i }}
+---
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sandbox-job-manager-{{ $subject.bindingName }}
+  namespace: {{ $.Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: sandbox-rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: sandbox-job-manager
+subjects:
+  - kind: ServiceAccount
+    name: {{ $subject.name }}
+    namespace: {{ $subject.namespace }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-rolebinding.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-rolebinding.yaml
@@ -6,7 +6,7 @@
 {{- $subjects = append $subjects (dict "name" $chartSaName "namespace" $chartSaNs "bindingName" "chart-sa") -}}
 {{- end -}}
 {{- range .Values.sandboxJobs.jobManager.additionalSubjects -}}
-{{- $subjects = append $subjects (merge (dict "bindingName" .name) .) -}}
+{{- $subjects = append $subjects (merge (dict "bindingName" (printf "%s-%s" .namespace .name)) .) -}}
 {{- end -}}
 {{- range $i, $subject := $subjects }}
 {{- if $i }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-serviceaccount.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-serviceaccount.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.sandboxJobs.runtimeServiceAccount.name }}
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-runtime
+automountServiceAccountToken: {{ .Values.sandboxJobs.runtimeServiceAccount.automountServiceAccountToken }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.sandboxJobs.fileSyncServiceAccount.name }}
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-file-sync
+  {{- with .Values.sandboxJobs.fileSyncServiceAccount.irsaRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ . | quote }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.sandboxJobs.fileSyncServiceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-serviceaccount.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-serviceaccount.yaml
@@ -8,18 +8,4 @@ metadata:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-runtime
 automountServiceAccountToken: {{ .Values.sandboxJobs.runtimeServiceAccount.automountServiceAccountToken }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.sandboxJobs.fileSyncServiceAccount.name }}
-  namespace: {{ .Values.sandboxJobs.namespace }}
-  labels:
-    {{- include "onyx.labels" . | nindent 4 }}
-    app.kubernetes.io/component: sandbox-file-sync
-  {{- with .Values.sandboxJobs.fileSyncServiceAccount.irsaRoleArn }}
-  annotations:
-    eks.amazonaws.com/role-arn: {{ . | quote }}
-  {{- end }}
-automountServiceAccountToken: {{ .Values.sandboxJobs.fileSyncServiceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1332,6 +1332,107 @@ configMap:
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
 
+# Sandbox Jobs — foundation for the Craft sandbox redesign (per-session Kubernetes
+# Jobs in a dedicated namespace). When enabled, creates the namespace plus its RBAC,
+# NetworkPolicies, ResourceQuota, LimitRange, and PDB. No workloads are deployed here;
+# Job templates and the backend Job CRUD path land in subsequent PRs.
+sandboxJobs:
+  enabled: false
+  namespace: onyx-sandboxes-jobs
+
+  # ServiceAccount for the sandbox container itself. No IRSA — the agent process must
+  # have zero AWS credentials. K8s API token is not auto-mounted as defense-in-depth.
+  runtimeServiceAccount:
+    name: sandbox-runtime
+    automountServiceAccountToken: false
+
+  # ServiceAccount for the file-sync init container. Holds IRSA for S3 access.
+  # The IAM role's trust policy must list this SA before the backend's SANDBOX_BACKEND
+  # flag is flipped — set irsaRoleArn per-cluster via values overlay.
+  fileSyncServiceAccount:
+    name: sandbox-file-sync
+    automountServiceAccountToken: true
+    irsaRoleArn: ""
+
+  # Identities that should be granted Job-management permissions on the sandbox namespace.
+  # In Helm-deployed clusters the api-server and celery-worker pods share a single
+  # ServiceAccount computed via `onyx.serviceAccountName`, so by default we bind that.
+  # Set `bindChartServiceAccount: false` and use `additionalSubjects` for clusters where
+  # api-server / celery use distinct externally-managed SAs (e.g. the managed-services
+  # kustomize tree's `api-server-sa` / `celery-worker-sandbox-sa` in the `danswer` namespace).
+  jobManager:
+    bindChartServiceAccount: true
+    # Namespace where the chart's SA lives. Empty defaults to the release namespace.
+    chartServiceAccountNamespace: ""
+    additionalSubjects: []
+    # Example for managed-services cluster overlay:
+    # additionalSubjects:
+    #   - name: api-server-sa
+    #     namespace: danswer
+    #   - name: celery-worker-sandbox-sa
+    #     namespace: danswer
+
+  # Hard caps on namespace resource consumption. Sized generously for craft-dev; tighten
+  # per cluster via values overlay.
+  resourceQuota:
+    pods: "200"
+    requestsCpu: "100"
+    requestsMemory: "400Gi"
+    limitsCpu: "200"
+    limitsMemory: "800Gi"
+    persistentVolumeClaims: "500"
+    services: "200"
+    jobsBatch: "200"
+
+  # Per-container defaults applied to anything without explicit requests/limits.
+  # Prevents BestEffort pods and bounds per-container resource use.
+  limitRange:
+    default:
+      cpu: "1"
+      memory: "2Gi"
+    defaultRequest:
+      cpu: "500m"
+      memory: "1Gi"
+    max:
+      cpu: "4"
+      memory: "16Gi"
+    min:
+      cpu: "100m"
+      memory: "128Mi"
+
+  # NetworkPolicy: default-deny baseline + selective allow rules.
+  networkPolicy:
+    # Pod label used to identify "sandbox" workloads — the Job spec in a later PR will
+    # set this label on its pod template so these policies match.
+    podSelectorLabel:
+      key: app.kubernetes.io/component
+      value: sandbox
+    # Ingress: allow from pods with the given label in the given namespace.
+    allowFromNamespace: danswer
+    allowFromPodLabel:
+      key: app
+      value: api-server
+    # Ports the sandbox pod listens on (sidecar HTTP for I/O + Next.js preview).
+    ingressPorts:
+      - protocol: TCP
+        port: 8080
+      - protocol: TCP
+        port: 3000
+    # Egress: allow public HTTPS/HTTP for S3 / package fetches; block IMDS and VPC ranges
+    # to prevent metadata-service exfiltration and cross-tenant lateral movement.
+    egressBlockedCidrs:
+      - 169.254.169.254/32
+      - 169.254.170.2/32
+      - 10.0.0.0/8
+      - 172.16.0.0/12
+      - 192.168.0.0/16
+
+  # Voluntary-disruption budget. With per-session pods, at most this fraction can be
+  # voluntarily evicted at once — protects against node-pool rolling upgrades wiping
+  # all active sandboxes simultaneously.
+  podDisruptionBudget:
+    maxUnavailable: 25%
+
 # -- Additional arbitrary manifests to render as part of the release. Each entry
 # may be either a YAML mapping (a single Kubernetes object) or a multi-line
 # string that will be passed through `tpl` so it can reference release values.

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1346,14 +1346,6 @@ sandboxJobs:
     name: sandbox-runtime
     automountServiceAccountToken: false
 
-  # ServiceAccount for the file-sync init container. Holds IRSA for S3 access.
-  # The IAM role's trust policy must list this SA before the backend's SANDBOX_BACKEND
-  # flag is flipped — set irsaRoleArn per-cluster via values overlay.
-  fileSyncServiceAccount:
-    name: sandbox-file-sync
-    automountServiceAccountToken: true
-    irsaRoleArn: ""
-
   # Identities that should be granted Job-management permissions on the sandbox namespace.
   # In Helm-deployed clusters the api-server and celery-worker pods share a single
   # ServiceAccount computed via `onyx.serviceAccountName`, so by default we bind that.

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1408,7 +1408,8 @@ sandboxJobs:
       key: app.kubernetes.io/component
       value: sandbox
     # Ingress: allow from pods with the given label in the given namespace.
-    allowFromNamespace: danswer
+    # Empty defaults to the release namespace; override per-cluster via values overlay.
+    allowFromNamespace: ""
     allowFromPodLabel:
       key: app
       value: api-server
@@ -1427,11 +1428,11 @@ sandboxJobs:
       - 172.16.0.0/12
       - 192.168.0.0/16
 
-  # Voluntary-disruption budget. With per-session pods, at most this fraction can be
-  # voluntarily evicted at once — protects against node-pool rolling upgrades wiping
-  # all active sandboxes simultaneously.
+  # Voluntary-disruption budget. Default of 1 works at any pod count — percentage values
+  # like 25% round down via floor(p × n) and silently become 0 with fewer than 4 pods,
+  # which would block every node drain. At scale, overlays can switch to a percentage.
   podDisruptionBudget:
-    maxUnavailable: 25%
+    maxUnavailable: 1
 
 # -- Additional arbitrary manifests to render as part of the release. Each entry
 # may be either a YAML mapping (a single Kubernetes object) or a multi-line


### PR DESCRIPTION
## Description

PR 1 of the Craft sandbox redesign (per-session Kubernetes Jobs replacing imperative `kubernetes_sandbox_manager.py` pod creation).

Adds a `sandboxJobs` section to the onyx Helm chart, gated `enabled: false` by default. When a values overlay enables it, the chart creates:

- `Namespace`: `onyx-sandboxes-jobs`
- `ServiceAccount`: `sandbox-runtime` (no IRSA, K8s API token not mounted) — the sandbox container runs with no AWS creds and no K8s API access
- `Role`: `sandbox-job-manager` — `jobs.batch` CRUD + read-only on pods + services + PVCs + VolumeSnapshots (**no `pods/exec`**)
- `RoleBinding`s — binds the chart's main SA by default; supports `additionalSubjects` for overlays where api-server / celery use distinct externally-managed SAs
- `NetworkPolicy`s — default-deny, allow ingress from api-server pods in the application namespace on configured ports, allow egress to DNS + public HTTPS/HTTP with IMDS and VPC ranges blocked
- `ResourceQuota` — hard caps on pods, CPU, memory, PVCs, Services, Jobs
- `LimitRange` — per-container default/min/max requests and limits
- `PodDisruptionBudget` — `maxUnavailable: 1` so node-pool rolling upgrades can't wipe all active sandboxes simultaneously (and so the PDB doesn't round to 0 at low pod counts)

**No workloads** are deployed here. The Job manifest, sidecar HTTP server, and backend `SANDBOX_BACKEND=jobs` code path land in subsequent PRs.

### Downstream prerequisites (not in this PR)

- NetworkPolicy ingress ports default to 8080 (sidecar HTTP) and 3000 (Next.js preview); revise alongside the Job manifest in a later PR.
- A follow-up values-overlay change will set `sandboxJobs.enabled: true` on craft-dev.

## How Has This Been Tested?

- `helm lint deployment/helm/charts/onyx/` passes (unrelated opensearch warning only).
- `helm template ... --set sandboxJobs.enabled=false` (default) renders zero new resources — confirmed no-op default.
- `helm template ... --set sandboxJobs.enabled=true` renders all 11 expected resources (Namespace, 1 SA, Role, 1 RoleBinding via chart SA, 3 NetworkPolicies, ResourceQuota, LimitRange, PDB).
- Verified managed-services-style overlay (`bindChartServiceAccount=false`, explicit `additionalSubjects`) — produces RoleBindings against externally-managed SAs.
- Spot-checked rendered NetworkPolicy and RoleBinding subject lists.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check