### PR TITLE
feat(craft-sandbox): add Job/Service/PVC/Secret templates for per-session sandboxes

### DIFF
--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-storageclass.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-storageclass.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.sandboxJobs.enabled .Values.sandboxJobs.storage.createStorageClass }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.sandboxJobs.storage.storageClass.name }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-storage
+provisioner: {{ .Values.sandboxJobs.storage.storageClass.provisioner }}
+reclaimPolicy: {{ .Values.sandboxJobs.storage.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.sandboxJobs.storage.storageClass.volumeBindingMode }}
+allowVolumeExpansion: {{ .Values.sandboxJobs.storage.storageClass.allowVolumeExpansion }}
+{{- with .Values.sandboxJobs.storage.storageClass.parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-templates-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-templates-configmap.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.sandboxJobs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.sandboxJobs.jobTemplate.configMapName }}
+  namespace: {{ .Values.sandboxJobs.namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-template
+data:
+  # The backend reads these YAML strings at startup and substitutes ${placeholders}
+  # via Python's string.Template before POSTing the rendered manifests to the K8s API.
+  # Placeholders used: ${job_name}, ${session_id}, ${user_id}, ${tenant_id},
+  # ${workspace_pvc_name}, ${knowledge_pvc_name}, ${auth_secret_name},
+  # ${service_name}, ${auth_token}.
+
+  job.yaml: |
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: ${job_name}
+      namespace: {{ .Values.sandboxJobs.namespace }}
+      labels:
+        app.kubernetes.io/component: sandbox
+        app.kubernetes.io/part-of: onyx
+        onyx.app/session-id: "${session_id}"
+        onyx.app/user-id: "${user_id}"
+        onyx.app/tenant-id: "${tenant_id}"
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: {{ .Values.sandboxJobs.jobTemplate.activeDeadlineSeconds }}
+      ttlSecondsAfterFinished: {{ .Values.sandboxJobs.jobTemplate.ttlSecondsAfterFinished }}
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: sandbox
+            app.kubernetes.io/part-of: onyx
+            onyx.app/session-id: "${session_id}"
+        spec:
+          restartPolicy: Never
+          terminationGracePeriodSeconds: {{ .Values.sandboxJobs.jobTemplate.terminationGracePeriodSeconds }}
+          serviceAccountName: {{ .Values.sandboxJobs.runtimeServiceAccount.name }}
+          automountServiceAccountToken: false
+          {{- with .Values.sandboxJobs.jobTemplate.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.sandboxJobs.jobTemplate.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sandbox
+              image: {{ .Values.sandboxJobs.jobTemplate.sandboxImage | quote }}
+              imagePullPolicy: {{ .Values.sandboxJobs.jobTemplate.imagePullPolicy }}
+              env:
+                - name: SESSION_ID
+                  value: "${session_id}"
+                - name: USER_ID
+                  value: "${user_id}"
+                - name: TENANT_ID
+                  value: "${tenant_id}"
+              resources:
+                {{- toYaml .Values.sandboxJobs.jobTemplate.sandboxContainer | nindent 16 }}
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+                - name: knowledge
+                  mountPath: /workspace/files
+                  readOnly: true
+            - name: sidecar
+              image: {{ .Values.sandboxJobs.jobTemplate.sidecarImage | quote }}
+              imagePullPolicy: {{ .Values.sandboxJobs.jobTemplate.imagePullPolicy }}
+              env:
+                - name: SIDECAR_PORT
+                  value: "{{ .Values.sandboxJobs.jobTemplate.sidecarPort }}"
+                - name: SIDECAR_WORKSPACE_ROOT
+                  value: /workspace
+                - name: SIDECAR_AUTH_TOKEN_FILE
+                  value: /etc/sidecar/auth-token
+                - name: SIDECAR_IDLE_TIMEOUT_SECONDS
+                  value: "{{ .Values.sandboxJobs.jobTemplate.idleTimeoutSeconds }}"
+              ports:
+                - name: sidecar-http
+                  containerPort: {{ .Values.sandboxJobs.jobTemplate.sidecarPort }}
+              resources:
+                {{- toYaml .Values.sandboxJobs.jobTemplate.sidecarContainer | nindent 16 }}
+              volumeMounts:
+                - name: workspace
+                  mountPath: /workspace
+                - name: sidecar-auth
+                  mountPath: /etc/sidecar
+                  readOnly: true
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: sidecar-http
+                initialDelaySeconds: 3
+                periodSeconds: 10
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: sidecar-http
+                initialDelaySeconds: 1
+                periodSeconds: 5
+          volumes:
+            - name: workspace
+              persistentVolumeClaim:
+                claimName: ${workspace_pvc_name}
+            - name: knowledge
+              persistentVolumeClaim:
+                claimName: ${knowledge_pvc_name}
+            - name: sidecar-auth
+              secret:
+                secretName: ${auth_secret_name}
+                defaultMode: 0400
+
+  service.yaml: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${service_name}
+      namespace: {{ .Values.sandboxJobs.namespace }}
+      labels:
+        app.kubernetes.io/component: sandbox
+        app.kubernetes.io/part-of: onyx
+        onyx.app/session-id: "${session_id}"
+    spec:
+      type: ClusterIP
+      selector:
+        onyx.app/session-id: "${session_id}"
+      ports:
+        - name: sidecar
+          port: {{ .Values.sandboxJobs.jobTemplate.sidecarPort }}
+          targetPort: sidecar-http
+          protocol: TCP
+        - name: preview
+          port: {{ .Values.sandboxJobs.jobTemplate.previewPort }}
+          targetPort: {{ .Values.sandboxJobs.jobTemplate.previewPort }}
+          protocol: TCP
+
+  workspace-pvc.yaml: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ${workspace_pvc_name}
+      namespace: {{ .Values.sandboxJobs.namespace }}
+      labels:
+        app.kubernetes.io/component: sandbox-workspace
+        onyx.app/session-id: "${session_id}"
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.sandboxJobs.storage.workspaceSize }}
+      {{- with .Values.sandboxJobs.storage.storageClassName }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+
+  knowledge-pvc.yaml: |
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ${knowledge_pvc_name}
+      namespace: {{ .Values.sandboxJobs.namespace }}
+      labels:
+        app.kubernetes.io/component: sandbox-knowledge
+        onyx.app/user-id: "${user_id}"
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.sandboxJobs.storage.knowledgeSize }}
+      {{- with .Values.sandboxJobs.storage.storageClassName }}
+      storageClassName: {{ . | quote }}
+      {{- end }}
+
+  auth-secret.yaml: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${auth_secret_name}
+      namespace: {{ .Values.sandboxJobs.namespace }}
+      labels:
+        app.kubernetes.io/component: sandbox-auth
+        onyx.app/session-id: "${session_id}"
+    type: Opaque
+    stringData:
+      auth-token: "${auth_token}"
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-templates-configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-templates-configmap.yaml
@@ -11,8 +11,7 @@ data:
   # The backend reads these YAML strings at startup and substitutes ${placeholders}
   # via Python's string.Template before POSTing the rendered manifests to the K8s API.
   # Placeholders used: ${job_name}, ${session_id}, ${user_id}, ${tenant_id},
-  # ${workspace_pvc_name}, ${knowledge_pvc_name}, ${auth_secret_name},
-  # ${service_name}, ${auth_token}.
+  # ${workspace_pvc_name}, ${auth_secret_name}, ${service_name}, ${auth_token}.
 
   job.yaml: |
     apiVersion: batch/v1
@@ -72,9 +71,6 @@ data:
               volumeMounts:
                 - name: workspace
                   mountPath: /workspace
-                - name: knowledge
-                  mountPath: /workspace/files
-                  readOnly: true
             - name: sidecar
               image: {{ .Values.sandboxJobs.jobTemplate.sidecarImage | quote }}
               imagePullPolicy: {{ .Values.sandboxJobs.jobTemplate.imagePullPolicy }}
@@ -114,9 +110,6 @@ data:
             - name: workspace
               persistentVolumeClaim:
                 claimName: ${workspace_pvc_name}
-            - name: knowledge
-              persistentVolumeClaim:
-                claimName: ${knowledge_pvc_name}
             - name: sidecar-auth
               secret:
                 secretName: ${auth_secret_name}
@@ -161,25 +154,6 @@ data:
       resources:
         requests:
           storage: {{ .Values.sandboxJobs.storage.workspaceSize }}
-      {{- with .Values.sandboxJobs.storage.storageClassName }}
-      storageClassName: {{ . | quote }}
-      {{- end }}
-
-  knowledge-pvc.yaml: |
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      name: ${knowledge_pvc_name}
-      namespace: {{ .Values.sandboxJobs.namespace }}
-      labels:
-        app.kubernetes.io/component: sandbox-knowledge
-        onyx.app/user-id: "${user_id}"
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: {{ .Values.sandboxJobs.storage.knowledgeSize }}
       {{- with .Values.sandboxJobs.storage.storageClassName }}
       storageClassName: {{ . | quote }}
       {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-jobs-volumesnapshotclass.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-jobs-volumesnapshotclass.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.sandboxJobs.enabled .Values.sandboxJobs.storage.createVolumeSnapshotClass }}
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ .Values.sandboxJobs.storage.volumeSnapshotClass.name }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-storage
+driver: {{ .Values.sandboxJobs.storage.volumeSnapshotClass.driver }}
+deletionPolicy: {{ .Values.sandboxJobs.storage.volumeSnapshotClass.deletionPolicy }}
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1477,14 +1477,13 @@ sandboxJobs:
     sidecarPort: 8080
     previewPort: 3000
 
-  # Per-session workspace + per-user knowledge PVC config. Defaults assume the
-  # cluster has a sensible default StorageClass; override storageClassName to
-  # pin a specific one (e.g. sandbox-gp3 below).
+  # Per-session workspace PVC config. Defaults assume the cluster has a sensible
+  # default StorageClass; override storageClassName to pin a specific one (e.g.
+  # sandbox-gp3 below).
   storage:
     storageClassName: ""
     snapshotClassName: ""
     workspaceSize: 50Gi
-    knowledgeSize: 5Gi
 
     # Optionally create a gp3 StorageClass managed by this chart. Off by default
     # because StorageClass is cluster-scoped; opt in per cluster via overlay if

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1426,6 +1426,89 @@ sandboxJobs:
   podDisruptionBudget:
     maxUnavailable: 1
 
+  # Job manifest template stored as a ConfigMap. The backend reads this at startup
+  # and renders per-session Jobs by substituting ${placeholders} via string.Template.
+  # No Job is created at chart install time — this just provides the static template.
+  jobTemplate:
+    configMapName: sandbox-job-templates
+
+    # Image references for the two containers in each sandbox Pod.
+    sandboxImage: "onyxdotapp/sandbox:latest"
+    sidecarImage: "onyxdotapp/sandbox-sidecar:latest"
+    imagePullPolicy: IfNotPresent
+
+    # Pod-level placement.
+    nodeSelector:
+      onyx.app/workload: sandbox
+    tolerations:
+      - key: onyx.app/workload
+        operator: Equal
+        value: sandbox
+        effect: NoSchedule
+
+    # Lifecycle knobs — hybrid termination: pod-internal idle exit (primary,
+    # via SIDECAR_IDLE_TIMEOUT_SECONDS) plus activeDeadlineSeconds as a 24h
+    # backstop. backoffLimit=0 because we don't auto-retry crashed sandboxes —
+    # the user should restore from snapshot rather than blindly restart.
+    activeDeadlineSeconds: 86400
+    terminationGracePeriodSeconds: 120
+    ttlSecondsAfterFinished: 300
+    idleTimeoutSeconds: 3600
+
+    # Per-container resource requests/limits. Container max must stay within
+    # the namespace LimitRange (4 CPU / 16Gi mem) configured above.
+    sandboxContainer:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        cpu: "4"
+        memory: "10Gi"
+    sidecarContainer:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+
+    # Ports exposed by the sandbox Pod. sidecarPort is the HTTP API; previewPort
+    # is the Next.js dev server the backend proxies to for browser previews.
+    sidecarPort: 8080
+    previewPort: 3000
+
+  # Per-session workspace + per-user knowledge PVC config. Defaults assume the
+  # cluster has a sensible default StorageClass; override storageClassName to
+  # pin a specific one (e.g. sandbox-gp3 below).
+  storage:
+    storageClassName: ""
+    snapshotClassName: ""
+    workspaceSize: 50Gi
+    knowledgeSize: 5Gi
+
+    # Optionally create a gp3 StorageClass managed by this chart. Off by default
+    # because StorageClass is cluster-scoped; opt in per cluster via overlay if
+    # the cluster doesn't already have one wired to the EBS CSI driver.
+    createStorageClass: false
+    storageClass:
+      name: sandbox-gp3
+      provisioner: ebs.csi.aws.com
+      reclaimPolicy: Delete
+      volumeBindingMode: WaitForFirstConsumer
+      allowVolumeExpansion: true
+      parameters:
+        type: gp3
+        fsType: ext4
+        encrypted: "true"
+
+    # Optionally create a VolumeSnapshotClass. Same reasoning. Required for the
+    # resume-from-snapshot path landing in a later PR.
+    createVolumeSnapshotClass: false
+    volumeSnapshotClass:
+      name: sandbox-ebs
+      driver: ebs.csi.aws.com
+      deletionPolicy: Delete
+
 # -- Additional arbitrary manifests to render as part of the release. Each entry
 # may be either a YAML mapping (a single Kubernetes object) or a multi-line
 # string that will be passed through `tpl` so it can reference release values.


### PR DESCRIPTION
## Description

PR 3 of the Craft sandbox redesign. Adds a Helm-rendered `ConfigMap` holding the per-session Job, Service, workspace PVC, knowledge PVC, and auth Secret manifests as string templates. The backend (PR 4) reads this ConfigMap at startup and substitutes `${session_id}`-style placeholders via Python's `string.Template` to render concrete K8s resources for each session.

**Base branch:** `jtahara/craft-sandbox-jobs-helm-foundation` (PR #10993). GitHub will auto-retarget to `main` once that PR merges.

### What gets created (when `sandboxJobs.enabled=true`)

- **`ConfigMap/sandbox-job-templates`** — five `data:` keys:
  - `job.yaml` — per-session Job with two containers (`sandbox` + `sidecar` from PR #10994), three volumes (workspace PVC, knowledge PVC, auth Secret), pod-level `securityContext` (non-root UID 1000, `seccompProfile: RuntimeDefault`, `automountServiceAccountToken: false`), liveness/readiness probes on the sidecar's `/healthz` and `/readyz`.
  - `service.yaml` — `ClusterIP` Service exposing the sidecar HTTP port (8080) and Next.js preview port (3000), selecting on `onyx.app/session-id`.
  - `workspace-pvc.yaml` — per-session 50Gi PVC, ephemeral.
  - `knowledge-pvc.yaml` — per-user 5Gi PVC, sticky across sessions.
  - `auth-secret.yaml` — `Opaque` Secret carrying the sidecar bearer token (filled in per session).

### Hybrid termination (per the plan)

- `backoffLimit: 0` — no auto-retry on crash; the user restores from snapshot.
- `restartPolicy: Never` — Job semantics.
- `activeDeadlineSeconds: 86400` — 24h hard backstop.
- `terminationGracePeriodSeconds: 120` — room for the sidecar's shutdown routine.
- `ttlSecondsAfterFinished: 300` — auto-cleanup once the Pod has exited.
- Primary idle-exit lives in the sidecar via `SIDECAR_IDLE_TIMEOUT_SECONDS` (default 3600s).

### Optional storage templates (default off)

- **`StorageClass/sandbox-gp3`** — provisioner `ebs.csi.aws.com`, `WaitForFirstConsumer`, encrypted, `allowVolumeExpansion`. Gated on `sandboxJobs.storage.createStorageClass`.
- **`VolumeSnapshotClass/sandbox-ebs`** — driver `ebs.csi.aws.com`, deletion policy `Delete`. Gated on `sandboxJobs.storage.createVolumeSnapshotClass`. Required for the resume-from-snapshot path landing in a later PR.

Both are cluster-scoped resources, so they default off — opt in per cluster via values overlay if the cluster doesn't already have equivalents.

### Out of scope (deferred)

- File-sync init container / preceding Pod to populate the knowledge PVC from S3. PR 4 will add this; PR 3's sandbox container has zero AWS creds and the knowledge PVC mounts empty.
- Backend code that reads the ConfigMap and creates Jobs (PR 4).
- Real snapshot-creation logic in the sidecar's `run_shutdown_routine` (PR 5).

## How Has This Been Tested?

- `helm lint deployment/helm/charts/onyx/` passes (unrelated opensearch secret warning only).
- `helm template ... --set sandboxJobs.enabled=false` (default) renders **zero** PR-3 resources.
- `helm template ... --set sandboxJobs.enabled=true` renders the ConfigMap with all 5 data keys; storage classes stay off.
- `helm template ... --set sandboxJobs.enabled=true --set sandboxJobs.storage.createStorageClass=true --set sandboxJobs.storage.createVolumeSnapshotClass=true` renders `StorageClass/sandbox-gp3` and `VolumeSnapshotClass/sandbox-ebs` with the expected provisioner / driver.
- 4 of the 5 rendered template strings parsed cleanly as valid Kubernetes YAML after substituting test values for `${placeholders}` (5th confirmed valid by inspection — awk extraction noise only).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Helm-rendered ConfigMap (`sandbox-job-templates`) with string templates for per-session Job, Service, workspace PVC, and auth Secret. The backend fills ${...} placeholders at runtime to create sandbox resources; nothing is created at install time.

- **New Features**
  - Job template with `sandbox` and `sidecar` containers, workspace PVC mount, non-root `securityContext` with `RuntimeDefault`, liveness/readiness probes, and hybrid termination (backoffLimit=0, activeDeadlineSeconds=86400, ttlSecondsAfterFinished=300; idle timeout via sidecar).
  - Service template exposes sidecar (8080) and preview (3000) as `ClusterIP`, selecting on `onyx.app/session-id`.
  - PVC + Secret templates: per-session workspace (50Gi) and an `Opaque` auth Secret for the sidecar token; optional `storageClassName`.
  - Optional, gated storage: `StorageClass` (gp3 on `ebs.csi.aws.com`, encrypted, `WaitForFirstConsumer`) and `VolumeSnapshotClass` for future resume-from-snapshot; both off by default.

<sup>Written for commit c4cbde9f3f5ebe38be3679a41839a89eef917fe8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/10997?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

