### PR TITLE
fix: confluence version endpoint

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/space_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/space_access.py
@@ -247,7 +247,7 @@ def _get_server_space_permissions(
         try:
             return _get_server_space_permissions_rest(confluence_client, space_key)
         except ConfluenceRestSpacePermissionsNotAvailableError as e:
-            # serverInfo lied / custom build / plugin disabled; fall back.
+            # server-information lied / custom build / plugin disabled; fall back.
             logger.info(
                 "Confluence reports a version that should support REST "
                 "space-permissions, but the endpoint is unavailable for "

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -94,6 +94,14 @@ _JSONRPC_ERROR_BODY_SNIPPET_CHARS = 1000
 # and is branched on `is_cloud` upstream of any version check.
 _MIN_DC_VERSION_FOR_REST_SPACE_PERMISSIONS: tuple[int, int] = (9, 1)
 
+# Atlassian's documented Confluence DC endpoint for build information,
+# under the "Server Information" REST API group. Returns a JSON object
+# whose top-level `version` field is the upstream Confluence version
+# (e.g. "10.2.10"). Confirmed present in the v8.4, v9.3, and v10.x
+# DC REST API references; we previously probed the Jira-style
+# `/rest/api/serverInfo` slug, which 404s on Confluence DC 10.x.
+_DC_SERVER_INFORMATION_PATH = "rest/api/server-information"
+
 
 class ConfluenceRateLimitError(Exception):
     pass
@@ -172,10 +180,10 @@ class OnyxConfluence:
             else None
         )
 
-        # Cached result of /rest/api/serverInfo, populated on first
-        # `get_server_version()` call. _server_version_probed=True with
-        # _server_version=None means "we tried and the probe failed", so
-        # we don't keep retrying every space-permissions sync.
+        # Cached result of the server-information probe, populated on
+        # first `get_server_version()` call. _server_version_probed=True
+        # with _server_version=None means "we tried and the probe
+        # failed", so we don't keep retrying every space-permissions sync.
         self._server_version: tuple[int, int] | None = None
         self._server_version_probed: bool = False
 
@@ -1066,15 +1074,21 @@ class OnyxConfluence:
         """Returns the (major, minor) version of the upstream Confluence
         Data Center instance, or None for Cloud or when the probe fails.
 
-        Probed once per OnyxConfluence instance via /rest/api/serverInfo
-        (the result is cached on the instance, including the negative
-        result, so a one-off network blip doesn't cause us to re-probe on
-        every space-permissions sync).
+        Probed once per OnyxConfluence instance via Atlassian's
+        documented "Server Information" endpoint
+        (/rest/api/server-information). The result is cached on the
+        instance, including the negative result, so a one-off network
+        blip doesn't cause us to re-probe on every space-permissions
+        sync.
 
         Used to gate features that only exist on newer DC versions, such
         as the REST space-permissions API introduced in DC 9.1.0
-        (CONFSERVER-78176). Most callers should prefer the higher-level
-        feature predicates (e.g. supports_rest_space_permissions) over
+        (CONFSERVER-78176). When the probe fails (returns None), callers
+        intentionally fall back to the legacy JSON-RPC path, on the
+        assumption that probe failure most often correlates with older
+        DC builds where the REST permissions API isn't available
+        anyway. Most callers should prefer the higher-level feature
+        predicates (e.g. supports_rest_space_permissions) over
         comparing the version tuple directly.
         """
         if self._is_cloud:
@@ -1094,7 +1108,7 @@ class OnyxConfluence:
 
     def _probe_server_version(self) -> tuple[int, int] | None:
         try:
-            info = self.get("rest/api/serverInfo")
+            info = self.get(_DC_SERVER_INFORMATION_PATH)
         except Exception as e:
             logger.warning("Failed to probe Confluence server version: %s", e)
             return None

--- a/backend/tests/unit/ee/onyx/external_permissions/confluence/test_space_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/confluence/test_space_access.py
@@ -148,9 +148,9 @@ def test_dispatcher_falls_back_to_jsonrpc_for_pre_91() -> None:
 
 
 def test_dispatcher_falls_back_to_jsonrpc_when_rest_signals_unavailable() -> None:
-    """If serverInfo lies (or a custom build doesn't have the REST plugin),
-    the REST call raises the typed unavailability signal and the dispatcher
-    must fall back rather than blow up.
+    """If the version probe lies (or a custom build doesn't have the REST
+    plugin), the REST call raises the typed unavailability signal and
+    the dispatcher must fall back rather than blow up.
     """
     client = _make_client(
         supports_rest=True,

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1089,9 +1089,12 @@ def test_jsonrpc_websudo_html_response_raises_validation_error(
 # ---------------------------------------------------------------------------
 
 
-def _serverinfo_payload(version: str) -> dict[str, Any]:
-    """Minimal /rest/api/serverInfo payload; we only consume `version`."""
-    return {"version": version, "buildNumber": "0"}
+def _server_information_payload(version: str) -> dict[str, Any]:
+    """Minimal /rest/api/server-information payload; we only consume
+    `version`. Schema documented in the Confluence DC REST API reference
+    under the "Server Information" group.
+    """
+    return {"version": version, "buildNumber": 0}
 
 
 def test_supports_rest_space_permissions_true_for_dc_91_plus(
@@ -1099,25 +1102,30 @@ def test_supports_rest_space_permissions_true_for_dc_91_plus(
 ) -> None:
     """DC 10.2.10 (the customer's actual deployed version) should report
     support for the REST API. Cached after first probe, so a subsequent
-    call must not hit /rest/api/serverInfo a second time.
+    call must not hit /rest/api/server-information a second time.
     """
-    serverinfo_mock = mock.Mock(return_value=_serverinfo_payload("10.2.10"))
+    server_info_mock = mock.Mock(return_value=_server_information_payload("10.2.10"))
     confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
-        serverinfo_mock
+        server_info_mock
     )
 
     assert confluence_server_client.supports_rest_space_permissions() is True
     assert confluence_server_client.get_server_version() == (10, 2)
     assert confluence_server_client.supports_rest_space_permissions() is True
-    assert serverinfo_mock.call_count == 1
+    assert server_info_mock.call_count == 1
+    # Regression-guard the path itself: the Jira-style /rest/api/serverInfo
+    # 404s on Confluence DC 10.x; the documented Confluence path is the
+    # hyphenated /rest/api/server-information.
+    (called_path, *_), _ = server_info_mock.call_args
+    assert called_path == "rest/api/server-information"
 
 
 def test_supports_rest_space_permissions_false_for_dc_pre_91(
     confluence_server_client: OnyxConfluence,
 ) -> None:
-    serverinfo_mock = mock.Mock(return_value=_serverinfo_payload("8.9.1"))
+    server_info_mock = mock.Mock(return_value=_server_information_payload("8.9.1"))
     confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
-        serverinfo_mock
+        server_info_mock
     )
 
     assert confluence_server_client.supports_rest_space_permissions() is False
@@ -1127,18 +1135,20 @@ def test_supports_rest_space_permissions_false_for_dc_pre_91(
 def test_supports_rest_space_permissions_false_when_probe_fails(
     confluence_server_client: OnyxConfluence,
 ) -> None:
-    """Negative probe is cached: a flaky serverInfo call doesn't make us
-    re-probe on every space-permissions sync.
+    """Negative probe is cached: a flaky server-information call doesn't
+    make us re-probe on every space-permissions sync. Also pins the
+    "version=None -> JSON-RPC fallback" contract that downstream
+    dispatchers rely on.
     """
-    serverinfo_mock = mock.Mock(side_effect=requests.ConnectionError("boom"))
+    server_info_mock = mock.Mock(side_effect=requests.ConnectionError("boom"))
     confluence_server_client._confluence.get = (  # ty: ignore[invalid-assignment]
-        serverinfo_mock
+        server_info_mock
     )
 
     assert confluence_server_client.supports_rest_space_permissions() is False
     assert confluence_server_client.get_server_version() is None
     confluence_server_client.supports_rest_space_permissions()
-    assert serverinfo_mock.call_count == 1
+    assert server_info_mock.call_count == 1
 
 
 def test_get_all_space_permissions_server_rest_404_raises_unavailable(


### PR DESCRIPTION
## Description

Fix the Confluence DC version probe to hit the actual documented endpoint (/rest/api/server-information) instead of the Jira-style /rest/api/serverInfo, which 404s on DC 10.x. Without this, DC 9.1+ instances silently fall through to the legacy JSON-RPC path and break on WebSudo for permission sync.

## How Has This Been Tested?

modified tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Confluence DC version probe to the documented `/rest/api/server-information` endpoint to prevent 404s on DC 10.x and stop bad fallbacks to JSON-RPC that break WebSudo permission sync.

- **Bug Fixes**
  - Use `/rest/api/server-information` instead of `/rest/api/serverInfo` for DC build info.
  - Restores correct gating of REST space-permissions for DC 9.1+ and avoids silent JSON-RPC fallback.
  - Updated tests to assert the new path, payload schema, and cached negative probe; minor comment/log tweak.

<sup>Written for commit eafa3803d84c4ec5b472d963c75e04cccb51cc36. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

