### PR TITLE
chore(docs): update craft search docs with implementation details and new part 3 plan

### DIFF
--- a/docs/craft/features/search/1-onyx-cli-ax-refactor.md
+++ b/docs/craft/features/search/1-onyx-cli-ax-refactor.md
@@ -1,5 +1,9 @@
 # Part 1: Agent-First CLI Refactor — Implementation Plan
 
+> **Status: IMPLEMENTED** — shipped as a single PR on branch `whuang/refactor-ax-onyx-cli`.
+> Annotations marked *[Diverged]* or *[New]* note where the final implementation
+> differs from or goes beyond the original plan.
+
 > Parent design: [search-design.md](search-design.md) (Part 1)
 
 ## Objective
@@ -41,37 +45,39 @@ These already fail naturally without a TTY (Bubble Tea crashes, prompts fail). N
 
 ### Configuration
 
-Agents use environment variables (`ONYX_SERVER_URL`, `ONYX_API_KEY`). Humans use `configure` or the config file. Env vars override the config file in both cases.
+Agents use environment variables (`ONYX_SERVER_URL`, `ONYX_PAT`). Humans use `configure` or the config file. Env vars override the config file in both cases.
 
 ### Exit codes
 
 | Code | Name | When |
 |------|------|------|
-| 0 | `Success` | *(existing)* |
-| 1 | `General` | *(existing)* Generic/unknown error |
-| 2 | `BadRequest` | *(existing)* Invalid args |
-| 3 | `NotConfigured` | *(existing)* Missing config/API key |
-| 4 | `AuthFailure` | *(existing)* Invalid API key, 401/403 |
-| 5 | `Unreachable` | *(existing)* Server unreachable |
-| 6 | `RateLimited` | **New.** Server returns 429 |
-| 7 | `Timeout` | **New.** Request exceeds deadline |
-| 8 | `ServerError` | **New.** Server returns 5xx |
-| 9 | `NotAvailable` | **New.** Feature/endpoint doesn't exist |
+| 0 | `Success` | |
+| 1 | `General` | Generic/unknown error |
+| 2 | `BadRequest` | Invalid args (convention from sysexits) |
+| 3 | `NotConfigured` | Missing config/PAT |
+| 4 | `AuthFailure` | Invalid PAT, 401/403 |
+| 5 | `Unreachable` | Server unreachable |
+| 6 | `RateLimited` | Server returns 429 |
+| 7 | `Timeout` | Request exceeds deadline |
+| 8 | `ServerError` | Server returns 5xx |
+| 9 | `NotAvailable` | Feature/endpoint doesn't exist |
 
 ---
 
 ## Current State (for implementer reference)
 
+*This section describes the pre-implementation state of the codebase.*
+
 The CLI is a Go project at `cli/` (Go 1.26.1, Cobra + Bubble Tea), distributed as a Python wheel via PyPI.
 
 - **Entry point**: `main.go` → `cmd.Execute()` → Cobra root command
-- **Default command**: `root.go:104-109` falls through to `chatCmd.RunE` unconditionally — crashes without TTY
+- **Default command**: previously fell through to `chatCmd.RunE` unconditionally — crashes without TTY
 - **TTY detection**: `golang.org/x/term.IsTerminal(fd)`, used inline in `ask.go` (stdout) and `configure.go` (stdin)
-- **`ask` output**: `overflow.Writer` truncates to 4096 bytes for non-TTY (`ask.go:22,90-91`). `--json` emits NDJSON stream events.
-- **`configure`**: Has both interactive wizard and non-interactive flag path (`--server-url`/`--api-key`)
+- **`ask` output**: `overflow.Writer` truncates to 4096 bytes for non-TTY. `--json` emits NDJSON stream events.
+- **`configure`**: Previously had both interactive wizard and non-interactive flag path (`--server-url`/`--api-key`)
 - **`validate-config`**: Human-readable text only, no `--json`, no capability detection
-- **Exit codes**: 0–5 defined in `internal/exitcodes/codes.go`. HTTP errors mostly fall through to `General = 1`.
-- **Config**: `~/.config/onyx-cli/config.json` with env var overrides (`ONYX_SERVER_URL`, `ONYX_API_KEY`, `ONYX_PERSONA_ID`)
+- **Exit codes**: 0–5 previously defined in `internal/exitcodes/codes.go`. HTTP errors mostly fell through to `General = 1`.
+- **Config**: `~/.config/onyx-cli/config.json` with env var overrides (`ONYX_SERVER_URL`, `ONYX_PAT`, `ONYX_PERSONA_ID`)
 - **SKILL.md**: Embedded via `//go:embed` in `internal/embedded/embed.go`, describes `ask` only, frames CLI as human-first
 
 ---
@@ -94,7 +100,7 @@ Remove the `--server-url`, `--api-key`, `--api-key-stdin`, and `--dry-run` flags
 
 **4. Add exit codes** (`internal/exitcodes/codes.go`)
 
-Add `RateLimited = 6`, `Timeout = 7`, `ServerError = 8`, `NotAvailable = 9`. Update `internal/api/errors.go` and `internal/api/stream.go` to map HTTP status codes to these instead of falling through to `General = 1`.
+Add `RateLimited = 6`, `Timeout = 7`, `ServerError = 8`, `NotAvailable = 9`. Update `internal/api/errors.go` and `internal/api/stream.go` to map HTTP status codes to these instead of falling through to `General = 1`. Also added `ForHTTPStatus()` mapping function, `ExitError` type, and `New()`/`Newf()` constructors.
 
 **5. Standardize output across agent-usable commands** (`cmd/agents.go`, `cmd/ask.go`, `cmd/validate.go`)
 
@@ -102,6 +108,8 @@ Audit and fix:
 - stdout for results only, stderr for progress/warnings/errors
 - No ANSI escape codes in stdout when no TTY
 - `--json` available on every agent-usable command (already exists on `ask` and `agents`; adding to `validate-config` above)
+
+*[Diverged] `--json` was NOT added to `validate-config` as planned. The stdout/stderr separation and ANSI cleanup were done.*
 
 ### B. Documentation changes
 
@@ -132,6 +140,8 @@ Reframe as agent-first:
 
 ## PR Strategy
 
+*[Diverged] The 3-PR strategy below was not followed. All changes were shipped as a single PR.*
+
 ```
 PR 1: Behavior  ──►  PR 2: Error contract  ──►  PR 3: Docs
 (steps 1-3)          (steps 4-5)                 (steps 6-8)
@@ -145,15 +155,63 @@ PR 1: Behavior  ──►  PR 2: Error contract  ──►  PR 3: Docs
 
 ## Tests
 
+*[Diverged] The plan only described Go unit tests. The implementation added Python integration tests and trimmed Go unit tests to avoid redundancy.*
+
 ### Unit tests (Go `_test.go` files)
 
-- **Default command**: bare `onyx-cli` without TTY prints help, exits 0
-- **Exit code mapping**: HTTP 429 → `RateLimited`, 5xx → `ServerError`, 401 → `AuthFailure`, etc.
-Extend existing test files: `exitcodes/codes_test.go`, `overflow/writer_test.go`, `config/config_test.go`.
+- **Exit code mapping**: `exitcodes/codes_test.go` tests `ForHTTPStatus()` — HTTP 429 to `RateLimited`, 5xx to `ServerError`, 401 to `AuthFailure`, etc.
+- Go unit tests were kept minimal to avoid duplicating coverage with the integration tests below.
 
-### Smoke test
+### Integration tests (Python, against real backend) *[New — not in original plan]*
 
-1. `onyx-cli` with TTY → launches TUI (unchanged)
-2. `echo "" | onyx-cli` → prints help, exits 0
-3. `onyx-cli ask "test" | cat` → truncated response with temp file path (existing behavior, unchanged)
-4. `onyx-cli ask --json "test" | head -1 | jq .type` → NDJSON events (unchanged)
+`backend/tests/integration/tests/cli/test_cli_commands.py` — 17 tests that build the Go binary and run it against a real Onyx deployment. These test the actual CLI behavior end-to-end: configuration validation, exit codes, agent listing, ask command, error handling, and output format.
+
+### CI workflow *[New — not in original plan]*
+
+`.github/workflows/pr-integration-tests.yml` — added a Go build step that cross-compiles the CLI binary (`GOARCH=arm64 GOOS=linux`) and mounts it into the Docker test container via a volume mount. The binary path is passed as `ONYX_CLI_BINARY` env var.
+
+### Smoke test (manual)
+
+1. `onyx-cli` with TTY -> launches TUI (unchanged)
+2. `echo "" | onyx-cli` -> prints help, exits 0
+3. `onyx-cli ask "test" | cat` -> truncated response with temp file path (existing behavior, unchanged)
+4. `onyx-cli ask --json "test" | head -1 | jq .type` -> NDJSON events (unchanged)
+
+---
+
+## Implementation Notes
+
+This section summarizes what was actually built, including items not covered by the original plan.
+
+### IOStreams pattern *[New — not in original plan]*
+
+Added `internal/iostreams/iostreams.go` following the gh/kubectl convention. The struct bundles `In`, `Out`, `ErrOut`, `IsStdinTTY`, `IsStdoutTTY`, and an `IsInteractive()` method. This is threaded through all commands to provide consistent TTY detection and testable I/O.
+
+### Server URL design *[New — not in original plan]*
+
+The default server URL is `https://cloud.onyx.app/api` (includes the `/api` path). All CLI API paths are relative (e.g. `/me`, `/persona`, `/chat/send-chat-message`). A shared utility `config.WebOrigin(serverURL string) string` strips the `/api` (or `/api/v1`) suffix to produce browser-suitable URLs. This is used by `commands.go`, `sshauth.go`, and `onboarding.go`.
+
+### Shared command helpers *[New — not in original plan]*
+
+`cmd/common.go` provides three helpers that standardize config/client initialization and error mapping across all commands:
+- `requireConfig()` — loads config, returns `NotConfigured` exit error if no PAT is set
+- `requireClient()` — calls `requireConfig()` then creates an API client
+- `apiErrorToExit()` — maps `AuthError` and `OnyxAPIError` to the appropriate exit code
+
+`internal/api/client.go` provides:
+- `checkResponse()` — converts non-2xx HTTP responses to `OnyxAPIError`
+- `wrapTimeoutError()` — wraps `net.Error` timeouts as HTTP 408 `OnyxAPIError`
+- `ClientAPI` interface — allows mocking the client in tests
+
+### `is_listed` bug fix *[Not in original plan]*
+
+Discovered during implementation: the backend renamed the `is_visible` JSON field to `is_listed`, but the CLI's Go struct tag was stale (`json:"is_visible"`). Fixed the tag in `internal/models/models.go` to `json:"is_listed"` (Go field remains `IsVisible`).
+
+### PAT terminology *[Not in original plan]*
+
+The env var is `ONYX_PAT` and all user-facing text says "personal access token (PAT)" -- the `configure` wizard prompt, error messages, SKILL.md, and README.
+
+### Items deferred or skipped
+
+- `--json` flag for `validate-config` was not added (planned but skipped).
+- The 3-PR strategy was collapsed into a single PR.

--- a/docs/craft/features/search/2-new-search-api.md
+++ b/docs/craft/features/search/2-new-search-api.md
@@ -1,5 +1,9 @@
 # Part 2: Search API — Implementation Plan
 
+> **Status: IMPLEMENTED** — shipped and merged via PR #10966.
+> Annotations marked *[Diverged]* or *[New]* note where the final implementation
+> differs from or adds to the original plan.
+
 > Parent design doc: [search-design.md](search-design.md)
 
 ## Objective
@@ -50,16 +54,28 @@ class SearchAPIRequest(BaseModel):
 
     # LLM to use for query expansion and document selection.
     # When omitted, uses the persona's LLM (if persona_id set) or the deployment default.
-    model_provider: str | None = None
-    model_version: str | None = None
+    provider: str | None = None
+    model: str | None = None
 
     # Skip LLM query expansion — maps to SearchToolOverrideKwargs.skip_query_expansion
     skip_query_expansion: bool = False
+
+    # Conversational context for query expansion. When omitted, the handler
+    # creates a single USER message from the query.
+    message_history: list[ChatMinimalTextMessage] | None = None
+
+    @model_validator(mode="after")
+    def _provider_model_pair(self) -> Self:
+        if (self.provider is None) != (self.model is None):
+            raise ValueError("provider and model must both be set or both omitted")
+        return self
 ```
+
+*[New -- not in original plan] `message_history` was added to the request model as an enhancement for consumers that need conversational context in query expansion (e.g. an agent mid-conversation). The plan explicitly deferred this ("no V1 consumer").*
 
 Every parameter beyond `query` is optional with a default that matches chat search behavior. Filter parameters map directly to `BaseFilters`. `num_results` and `skip_query_expansion` map to existing `SearchToolOverrideKwargs` fields. `persona_id` configures the search the same way selecting a persona in the chat UI does — document set scoping, search start date, attached docs, and LLM selection all come from the persona.
 
-Parameters deliberately not exposed: query weights, hybrid alpha, RRF K, recency bias (internal tuning constants), bypass ACL (security boundary), message history (no V1 consumer).
+Parameters deliberately not exposed: query weights, hybrid alpha, RRF K, recency bias (internal tuning constants), bypass ACL (security boundary).
 
 ---
 
@@ -67,7 +83,7 @@ Parameters deliberately not exposed: query weights, hybrid alpha, RRF K, recency
 
 ```python
 class SearchAPIResult(BaseModel):
-    citation_id: int
+    citation_id: int | None   # not all docs appear in citation_mapping
     document_id: str
     chunk_ind: int
     title: str
@@ -106,7 +122,7 @@ The `llm_facing_text` is what agents consume. The `results` array is structured 
 ```python
 router = APIRouter(prefix="/search")
 
-@router.post("")
+@router.post("", dependencies=[Depends(require_vector_db)])
 def search(
     request: SearchAPIRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
@@ -131,9 +147,12 @@ The handler does:
    ```
    If no `persona_id`, use empty `PersonaSearchInfo(document_set_names=[], search_start_date=None, attached_document_ids=[], hierarchy_node_ids=[])`.
 2. **Get LLM.** Resolution priority:
-   - If `model_provider`/`model_version` are specified: look up the provider via `fetch_existing_llm_provider(request.model_provider, db_session)`, check access via `can_user_access_llm_provider(provider_model, user_group_ids, persona, is_admin=...)`, convert via `LLMProviderView.from_model(provider_model)`, create via `llm_from_provider(model_name=request.model_version, llm_provider=provider_view)`.
+   - If `provider`/`model` are specified: look up the provider via `fetch_existing_llm_provider(request.provider, db_session)`, check access via `can_user_access_llm_provider(provider_model, user_group_ids, persona, is_admin=...)`, convert via `LLMProviderView.from_model(provider_model)`, create via `llm_from_provider(model_name=request.model, llm_provider=provider_view)`.
    - Else if `persona_id` is set: `get_llm_for_persona(persona, user)` — uses the persona's model configuration if it has one, otherwise falls back to default.
    - Else: `get_default_llm()`.
+
+   *[Diverged] The implementation also calls `check_llm_cost_limit_for_provider()` before running search. This was not in the plan but is good multi-tenant practice.*
+
 3. **Build filters:** Map request params to `BaseFilters(source_type=request.sources, document_set=request.document_sets, tags=request.tags, time_cutoff=...)`. Convert `time_cutoff_days` to `datetime.now() - timedelta(days=N)`.
 4. **Get document index:** `get_default_document_index(search_settings, None, db_session)`.
 5. **Get tool_id:** Query the `tool` table for `in_code_tool_id = "internal_search"`.
@@ -173,7 +192,7 @@ The handler does:
 
 `SearchTool` requires an `Emitter` (inherited from `Tool`). In chat, the emitter streams progress packets to the frontend. The search API has no streaming consumer.
 
-`NullEmitter` is a trivial subclass defined in `api.py` that discards all packets:
+`NullEmitter` is a trivial subclass defined in `backend/onyx/chat/emitter.py` that discards all packets:
 
 ```python
 class NullEmitter(Emitter):
@@ -225,8 +244,8 @@ Rate limiting is deferred from V1 (R2.6).
 
 | File | Purpose |
 |------|---------|
-| `backend/onyx/server/features/search/__init__.py` | Package init |
-| `backend/onyx/server/features/search/api.py` | Endpoint handler, `NullEmitter` |
+| ~~`backend/onyx/server/features/search/__init__.py`~~ | Not created — Python namespace packages handle this |
+| `backend/onyx/server/features/search/api.py` | Endpoint handler |
 | `backend/onyx/server/features/search/models.py` | `SearchAPIRequest`, `SearchAPIResponse`, `SearchAPIResult` |
 
 ### Modified Files
@@ -234,30 +253,66 @@ Rate limiting is deferred from V1 (R2.6).
 | File | Change |
 |------|--------|
 | `backend/onyx/main.py` | Register the search router via `include_router_with_global_prefix_prepended` |
+| `backend/onyx/chat/emitter.py` | `NullEmitter` subclass (see Emitter section above) |
 
-No modifications to `SearchTool`, `ToolResponse`, `SearchToolOverrideKwargs`, `Emitter`, or any other existing code.
+No modifications to `SearchTool`, `ToolResponse`, `SearchToolOverrideKwargs`, or any other existing code.
 
 ---
 
 ## Tests
 
-### External Dependency Unit Tests
+*[Diverged] The original plan specified external dependency unit tests and model unit tests. The implementation uses integration tests instead, testing against a full Onyx deployment. Validation is covered implicitly through the integration tests.*
 
-**File:** `backend/tests/external_dependency_unit/search/test_search_api.py`
+### Integration Tests
 
-Run against real Vespa + Postgres via FastAPI test client.
+**File:** `backend/tests/integration/tests/search/test_search_api.py`
 
-1. **Basic search returns results.** Index test docs, search, assert non-empty results with sequential citation IDs.
-2. **Source filtering.** Index docs from two sources. Filter to one. Assert only matching source returned.
-3. **Time cutoff.** Index docs with different timestamps. Apply cutoff. Assert only recent docs returned.
-4. **ACL enforcement.** Index a doc accessible only to user A. Search as user B. Assert not returned. (Load-bearing security assertion.)
-5. **Cross-tenant isolation.** Index a doc under tenant A. Search as tenant B user. Assert not returned.
-6. **Skip query expansion.** Search with `skip_query_expansion: true`. Assert results still returned.
-7. **Invalid source rejected.** Send unknown source. Assert 400 / `INVALID_INPUT`.
-8. **Unauthenticated rejected.** No auth header. Assert 401.
+Run against a real Onyx deployment. Six tests:
 
-### Unit Tests
+1. **Basic search returns results.** Search for indexed content, assert non-empty results with expected fields.
+2. **Document set filtering.** Filter to a specific document set, assert only matching docs returned.
+3. **ACL enforcement.** Search as a user without access, assert restricted docs not returned. *(Enterprise-only: skipped without `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES`.)*
+4. **Persona scoping.** Search with a persona that has document set filters, assert scoping is applied.
+5. **Invalid persona 404.** Request with a nonexistent `persona_id`, assert 404 response.
+6. **Unauthenticated rejected.** No auth header, assert 401/403 response.
 
-**File:** `backend/tests/unit/onyx/server/features/search/test_search_models.py`
+---
 
-1. **Request validation.** Empty query rejected, oversized query rejected, `num_results` out of range rejected.
+## Implementation Notes
+
+This section summarizes genuinely new additions or architectural decisions not covered by the original plan.
+
+### `message_history` parameter *[New]*
+
+`message_history: list[ChatMinimalTextMessage] | None = None` was added to the request. When omitted, the handler creates a single USER message from the query. This allows consumers that have conversational context (e.g. an agent mid-conversation) to pass it through for better query expansion. The plan explicitly deferred this ("no V1 consumer"), but it was added as a low-cost enhancement.
+
+### `NullEmitter` in `emitter.py` *[Diverged]*
+
+Placed in `backend/onyx/chat/emitter.py` instead of `api.py`. As a proper subclass of `Emitter`, it can be reused by any code path that needs to invoke tools without a streaming consumer.
+
+### `require_vector_db` dependency *[New]*
+
+The route includes `dependencies=[Depends(require_vector_db)]` to short-circuit with a clear error when the vector database is not configured. This matches the pattern used by other search-dependent endpoints.
+
+### LLM cost limit check *[New]*
+
+The handler calls `check_llm_cost_limit_for_provider()` before running search. This enforces per-tenant LLM cost limits, preventing a single tenant from exhausting shared LLM budget via search queries.
+
+### What matched the plan exactly
+
+- Endpoint at `POST /api/search` via `router = APIRouter(prefix="/search")`
+- Auth: `require_permission(Permission.BASIC_ACCESS)`
+- Sync `def` handler
+- Persona loading with eager load, `PersonaSearchInfo` construction
+- LLM resolution priority (explicit provider -> persona -> default)
+- Filter building (sources, document_sets, tags, time_cutoff)
+- `SearchTool` construction and `.run()` call shape
+- Output mapping from `SearchDocsResponse` to `SearchAPIResponse`
+- `Placement(turn_index=0)` for `NullEmitter`
+- Router registered in `main.py`
+
+### Items deferred or skipped
+
+- `__init__.py` for the search package was not created (Python namespace packages handle this).
+- External dependency unit tests and model unit tests were replaced by integration tests.
+- Planned tests for source filtering, time cutoff, cross-tenant isolation, skip query expansion, and invalid source rejection were not included in the integration test suite.

--- a/docs/craft/features/search/3-cli-search-command.md
+++ b/docs/craft/features/search/3-cli-search-command.md
@@ -1,0 +1,400 @@
+# Part 3: CLI Search Command & Agent Tool Surface — Implementation Plan
+
+> Parent design: [search-design.md](search-design.md) (Part 3)
+
+## Objective
+
+Add a `search` command to onyx-cli that wraps the Part 2 `POST /api/search` endpoint. Rationalize the full CLI into a final agent tool surface: two complementary commands (`search` for retrieval, `ask` for answers), consistent flags, and updated documentation.
+
+---
+
+## End State
+
+After this work, the CLI has two primary agent-usable commands:
+
+| Command | Purpose | Backend | Output |
+|---------|---------|---------|--------|
+| `search` | Retrieve ranked, cited documents | `POST /api/search` (synchronous JSON) | `llm_facing_text` JSON to stdout |
+| `ask` | Get an LLM-generated answer | `POST /chat/send-chat-message` (streaming NDJSON) | Answer text to stdout |
+
+Both commands share:
+- `--agent-id` for persona scoping
+- Non-TTY truncation via `overflow.Writer` (4096 bytes default)
+- Clean exit codes, stderr for progress, stdout for results
+- No interactive prompts
+
+### Command: `onyx-cli search`
+
+```
+onyx-cli search "what is the sales process for enterprise deals?"
+onyx-cli search --source slack,google_drive "auth migration status"
+onyx-cli search --days 30 --limit 5 "recent incidents"
+onyx-cli search --agent-id 5 "engineering roadmap"
+onyx-cli search --raw "deployment process" | jq '.results[].title'
+onyx-cli search --no-query-expansion "exact phrase I want"
+```
+
+Default output is the `llm_facing_text` field from the API response — a JSON string containing `{"results": [...]}` where each result has `document` (citation ID), `title`, `content`, `source_type`, and other fields. This is the same format `SearchTool` produces for LLM consumption in chat. `--raw` prints the full `SearchAPIResponse` instead, which wraps `llm_facing_text` alongside the structured `results` array (with `document_id`, `score`, `link`, etc.) and `citation_mapping`.
+
+Why `--raw` instead of `--json`: the default output is already JSON (the LLM-facing format), so `--json` would be misleading. `--raw` means "give me the raw API response" — the full structured output with scores, links, and document IDs that the default omits.
+
+### Why two commands, not one
+
+`search` and `ask` are different primitives with different backends, cost profiles, and output shapes:
+
+- **`search`** returns documents. The agent (or user) decides what to do with them. One synchronous HTTP call. Cost: LLM query expansion + document selection (~2-3 LLM calls inside SearchTool). No chat session created.
+- **`ask`** returns an LLM-generated answer. Streaming NDJSON protocol. Cost: full chat turn (search + reasoning + generation). Creates a chat session.
+
+A single command with a mode flag (e.g., `search --answer`) would hide this distinction. An agent choosing between "find me documents" and "answer this question" benefits from the choice being explicit. The `ask` command already exists and works — adding `search` alongside it is the natural fit.
+
+---
+
+## Current State (for implementer reference)
+
+### CLI codebase (`cli/`)
+
+- **`cmd/ask.go`**: Streaming command using `client.SendMessageStream()`, `overflow.Writer` for truncation, signal handling for graceful stop. Flags: `--agent-id`, `--json`, `--quiet`, `--prompt`, `--max-output`. This is the closest pattern for `search`, except `search` is synchronous (no streaming).
+- **`cmd/agents.go`**: Simple synchronous command using `client.ListAgents()` → `doJSON()`. Table output with `--json` alternative. The `search` command follows this pattern for the API call (synchronous JSON POST) but uses `overflow.Writer` like `ask` for output handling.
+- **`cmd/root.go:96-104`**: Command registration via `rootCmd.AddCommand(...)`. The `search` command is added here.
+- **`cmd/common.go`**: `requireClient()` returns `(config, client, error)`. `apiErrorToExit()` maps API/auth errors to exit codes. Both used by `search`.
+- **`internal/api/client.go`**: `Client` struct with `doJSON()` for synchronous JSON requests (30s timeout). `search` needs a new `Search()` method using this pattern, but with `longHTTPClient` (5min timeout) because SearchTool runs LLM calls internally.
+- **`internal/overflow/writer.go`**: Truncation writer. `search` uses this identically to `ask` — non-TTY output truncated at 4096 bytes, full response in temp file.
+- **`internal/exitcodes/codes.go`**: Exit codes 0-9. No new codes needed — the existing set covers all search failure modes.
+- **`internal/models/models.go`**: Go structs for API types. Needs new structs for `SearchAPIRequest`/`SearchAPIResponse`.
+- **`internal/embedded/SKILL.md`**: Agent-facing documentation. Must be updated with the `search` command.
+
+### Backend search API (Part 2, implemented)
+
+- **`POST /api/search`** at `backend/onyx/server/features/search/api.py`
+- **Request** (`SearchAPIRequest`): `query` (required), `sources`, `document_sets`, `tags`, `time_cutoff_days`, `num_results` (default 50, max 100), `persona_id`, `provider`+`model` (must be paired), `skip_query_expansion`, `message_history`
+- **Response** (`SearchAPIResponse`): `results` (list of `SearchAPIResult`), `llm_facing_text` (JSON string — `{"results": [...]}` with citation IDs, titles, content, source types), `citation_mapping` (int → string)
+- **`SearchAPIResult`**: `citation_id`, `document_id`, `chunk_ind`, `title`, `blurb`, `link`, `source_type`, `score`, `updated_at`
+- Auth: `require_permission(Permission.BASIC_ACCESS)` — standard PAT auth
+- Synchronous handler (no streaming)
+
+---
+
+## Implementation
+
+### A. API client
+
+**1. Add search request/response models** (`internal/models/models.go`)
+
+```go
+// SearchRequest is the request body for POST /api/search.
+type SearchRequest struct {
+    Query              string   `json:"query"`
+    Sources            []string `json:"sources,omitempty"`
+    DocumentSets       []string `json:"document_sets,omitempty"`
+    TimeCutoffDays     *int     `json:"time_cutoff_days,omitempty"`
+    NumResults         int      `json:"num_results,omitempty"`
+    PersonaID          *int     `json:"persona_id,omitempty"`
+    SkipQueryExpansion bool     `json:"skip_query_expansion,omitempty"`
+}
+
+// SearchResult is a single document result from the search API.
+type SearchResult struct {
+    CitationID int     `json:"citation_id"`
+    DocumentID string  `json:"document_id"`
+    ChunkInd   int     `json:"chunk_ind"`
+    Title      string  `json:"title"`
+    Blurb      string  `json:"blurb"`
+    Link       *string `json:"link"`
+    SourceType string  `json:"source_type"`
+    Score      *float64 `json:"score"`
+    UpdatedAt  *string `json:"updated_at"`
+}
+
+// SearchResponse is the response from POST /api/search.
+type SearchResponse struct {
+    Results         []SearchResult `json:"results"`
+    LLMFacingText   string         `json:"llm_facing_text"`
+    CitationMapping map[int]string `json:"citation_mapping"`
+}
+```
+
+Parameters deliberately not exposed in the CLI:
+- **`tags`**: Tag filtering requires knowing the tag schema. Agents don't have this context. If needed later, add `--tag key=value`.
+- **`provider`/`model`**: LLM selection for the search pipeline. The deployment default or persona's LLM is correct for CLI use. Exposing this would require the agent to know provider names — not useful.
+- **`document_sets`**: Document set filtering requires knowing set names. Persona scoping via `--agent-id` is the user-facing way to achieve this (personas already bind document sets). If needed later, add `--document-set`.
+- **`message_history`**: Requires structured message objects. No CLI use case today — the query must be self-contained. Could be added later for multi-turn agent workflows.
+
+These can all be added later without breaking changes. The CLI exposes the parameters that are useful to agents and discoverable from the command line.
+
+**2. Add `Search()` method** (`internal/api/client.go`)
+
+```go
+// Search calls POST /api/search and returns the response.
+func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error) {
+    var resp models.SearchResponse
+    if err := c.doJSONLong(ctx, "POST", "/search", req, &resp); err != nil {
+        return nil, err
+    }
+    return &resp, nil
+}
+```
+
+This needs a `doJSONLong()` variant that uses `longHTTPClient` (5min timeout) instead of `httpClient` (30s). The search endpoint runs LLM calls internally (query expansion, document selection, context expansion) which can take 30-60 seconds on complex queries. The existing `doJSON()` with its 30s timeout would frequently time out.
+
+`doJSONLong()` is a one-line clone of `doJSON()` that swaps `c.httpClient` for `c.longHTTPClient`:
+
+```go
+func (c *Client) doJSONLong(ctx context.Context, method, path string, reqBody any, result any) error {
+    // Same as doJSON but uses longHTTPClient (5min timeout)
+    ...
+    resp, err := c.longHTTPClient.Do(req)
+    ...
+}
+```
+
+Update the `ClientAPI` interface to include `Search`:
+
+```go
+Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error)
+```
+
+### B. Search command
+
+**3. Create `cmd/search.go`**
+
+The command follows the `agents.go` pattern (synchronous JSON response) with `ask.go`'s output handling (overflow.Writer for truncation).
+
+```go
+func newSearchCmd(ios *iostreams.IOStreams) *cobra.Command {
+    var (
+        searchSources      string   // comma-separated
+        searchDays         int
+        searchLimit        int
+        searchAgentID      int
+        searchRaw          bool
+        searchNoQueryExpansion  bool
+        maxOutput          int
+    )
+
+    cmd := &cobra.Command{
+        Use:   "search [query]",
+        Short: "Search company knowledge and return ranked documents",
+        ...
+        RunE: func(cmd *cobra.Command, args []string) error { ... },
+    }
+
+    cmd.Flags().StringVar(&searchSources, "source", "", "Filter by source type (comma-separated: slack,google_drive)")
+    cmd.Flags().IntVar(&searchDays, "days", 0, "Only return results from the last N days")
+    cmd.Flags().IntVar(&searchLimit, "limit", 0, "Maximum number of results (default: server decides)")
+    cmd.Flags().IntVar(&searchAgentID, "agent-id", 0, "Agent ID for scoped search (inherits filters, document sets)")
+    cmd.Flags().BoolVar(&searchRaw, "raw", false, "Output full API response (results with scores, links, document IDs, citation mapping)")
+    cmd.Flags().BoolVar(&searchNoQueryExpansion, "no-query-expansion", false, "Skip LLM query expansion (faster, less comprehensive)")
+    cmd.Flags().IntVar(&maxOutput, "max-output", defaultMaxOutputBytes,
+        "Max bytes to print before truncating (0 to disable, auto-enabled for non-TTY)")
+
+    return cmd
+}
+```
+
+**Flag design decisions:**
+
+- **`--source`** not `--sources`: singular is the convention for comma-separated values in CLIs (`git log --author`, `docker run --network`). Parsed with `strings.Split(val, ",")`.
+- **`--days`** not `--time-cutoff-days`: shorter, intuitive. Maps to `time_cutoff_days` in the API.
+- **`--limit`** not `--num-results`: standard CLI convention (every paginated CLI uses `--limit`). Maps to `num_results`. When not set, don't send it — let the server use its default (50).
+- **`--agent-id`** not `--persona-id`: consistency with `ask --agent-id`. From the CLI user's perspective, "persona" is an internal backend concept — they pick an "agent" to scope their search. The CLI maps `--agent-id` → `persona_id` in the API request.
+- **`--no-query-expansion`**: Boolean flag (not `--skip-query-expansion`). Clearer than a double-negative `--skip-*` — the flag name says what happens ("no query expansion"), not what it skips.
+- **No `--quiet` flag**: `search` is synchronous — no streaming to buffer. The response arrives in one shot. `--quiet` on `ask` exists because `ask` streams tokens. For `search`, the output is already "quiet" (one response, no incremental tokens).
+- **No `--prompt` / stdin piping**: `search` takes a query string, not a conversation context. The query is always the positional argument. No stdin context concatenation — that's an `ask` pattern where you pipe a document and ask a question about it. For `search`, the query should be self-contained.
+
+**RunE implementation:**
+
+```go
+RunE: func(cmd *cobra.Command, args []string) error {
+    _, client, err := requireClient()
+    if err != nil {
+        return err
+    }
+
+    if len(args) == 0 {
+        return exitcodes.New(exitcodes.BadRequest,
+            "no query provided\n  Usage: onyx-cli search \"your query\"")
+    }
+
+    req := models.SearchRequest{
+        Query: args[0],
+    }
+
+    if cmd.Flags().Changed("source") {
+        req.Sources = strings.Split(searchSources, ",")
+    }
+    if cmd.Flags().Changed("days") {
+        req.TimeCutoffDays = &searchDays
+    }
+    if cmd.Flags().Changed("limit") {
+        req.NumResults = searchLimit
+    }
+    if cmd.Flags().Changed("agent-id") {
+        req.PersonaID = &searchAgentID
+    }
+    if searchNoQueryExpansion {
+        req.SkipQueryExpansion = true
+    }
+
+    ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+    defer stop()
+
+    // Progress indicator on stderr (TTY only)
+    isTTY := ios.IsStdoutTTY
+    if isTTY {
+        fmt.Fprintf(ios.ErrOut, "\033[2mSearching...\033[0m\n")
+    }
+
+    resp, err := client.Search(ctx, req)
+    if err != nil {
+        return apiErrorToExit(err, "search failed")
+    }
+
+    if searchRaw {
+        data, err := json.MarshalIndent(resp, "", "  ")
+        if err != nil {
+            return fmt.Errorf("failed to marshal response: %w", err)
+        }
+        fmt.Fprintln(ios.Out, string(data))
+        return nil
+    }
+
+    // Default: print llm_facing_text through overflow writer
+    truncateAt := 0
+    if cmd.Flags().Changed("max-output") {
+        truncateAt = maxOutput
+    } else if !isTTY {
+        truncateAt = defaultMaxOutputBytes
+    }
+
+    ow := &overflow.Writer{Limit: truncateAt, Out: ios.Out, ErrOut: ios.ErrOut}
+    ow.Write(resp.LLMFacingText)
+    ow.Finish()
+
+    return nil
+}
+```
+
+**4. Register in root** (`cmd/root.go`)
+
+Add `rootCmd.AddCommand(newSearchCmd(ios))` alongside the existing commands.
+
+### C. Documentation
+
+**5. Update SKILL.md** (`internal/embedded/SKILL.md`)
+
+Add the `search` command documentation. The updated SKILL.md should:
+
+- Add `search` as the primary command (listed before `ask`)
+- Document all flags: `--source`, `--days`, `--limit`, `--agent-id`, `--raw`, `--no-query-expansion`, `--max-output`
+- Explain the search/ask distinction: search returns cited document results (JSON), ask returns an LLM answer
+- Update "When to Use" to distinguish search vs ask use cases:
+  - Use `search` when: finding specific documents, gathering context for a task, the agent needs to reason over multiple sources
+  - Use `ask` when: the user wants a direct answer, summarization, or synthesis
+
+**6. Update help text** (`cmd/search.go`)
+
+```go
+Long: `Search the Onyx knowledge base and return ranked, cited documents.
+
+Results are retrieved using the full search pipeline: LLM query expansion,
+hybrid retrieval, document selection, and context expansion — the same
+search quality as the Onyx chat interface.
+
+By default, output is the LLM-facing JSON that SearchTool produces — a
+{"results": [...]} object with citation IDs, titles, content, and source
+types. Use --raw for the full API response including document IDs, scores,
+links, and citation mapping.
+
+When stdout is not a TTY, output is truncated to --max-output bytes and the
+full response is saved to a temp file.`
+
+Example: `  onyx-cli search "What is our deployment process?"
+  onyx-cli search --source slack "auth migration status"
+  onyx-cli search --days 30 --limit 5 "recent production incidents"
+  onyx-cli search --agent-id 5 "engineering roadmap"
+  onyx-cli search --raw "API documentation" | jq '.results[].title'
+  onyx-cli search --no-query-expansion "exact error message text"`
+```
+
+### D. Consistency audit
+
+**7. Flag consistency across agent commands**
+
+Review and align flag conventions across `search`, `ask`, and `agents`:
+
+| Flag | `search` | `ask` | `agents` | Notes |
+|------|----------|-------|----------|-------|
+| `--raw` | Yes | — | — | Full API response; `search`-only (default output is already JSON) |
+| `--json` | — | Yes | Yes | Structured output; not on `search` because default is already JSON |
+| `--max-output` | Yes | Yes | No | `agents` output is small, truncation not needed |
+| `--agent-id` | Yes | Yes | — | Consistent name; maps to `persona_id` in API |
+| `--quiet` | No | Yes | No | Not applicable to synchronous commands |
+| `--prompt` | No | Yes | — | Not applicable to search |
+
+---
+
+## File Changes
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `cli/cmd/search.go` | `search` command (Cobra command, flag registration, RunE handler) |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `cli/cmd/root.go` | Add `rootCmd.AddCommand(newSearchCmd(ios))` |
+| `cli/internal/api/client.go` | Add `Search()` method, `doJSONLong()` helper, update `ClientAPI` interface |
+| `cli/internal/models/models.go` | Add `SearchRequest`, `SearchResult`, `SearchResponse` structs |
+| `cli/internal/embedded/SKILL.md` | Add `search` command documentation, update "When to Use" guidance |
+
+---
+
+## PR Strategy
+
+One PR. The surface area is small: one new command, one new API method, three new model structs, and a SKILL.md update. No refactoring of existing code — `search` is additive.
+
+---
+
+## Tests
+
+### Unit tests (Go `_test.go` files)
+
+**File:** `cli/cmd/search_test.go`
+
+1. **No query → exit code 2.** `onyx-cli search` with no args returns `BadRequest`.
+2. **Source parsing.** `--source slack,google_drive` produces `Sources: ["slack", "google_drive"]` in the request.
+3. **Flags set correctly.** `--days 30 --limit 5 --agent-id 3 --no-query-expansion` maps to the right `SearchRequest` fields. Unset flags produce zero values / nil pointers (not sent in JSON).
+
+These tests mock the API client (no server needed). They verify flag→request mapping and error paths.
+
+**File:** `cli/internal/api/client_test.go` (extend existing)
+
+4. **`Search()` returns `SearchResponse`.** Mock HTTP server returns a canned JSON response. Assert fields map correctly.
+5. **`Search()` on 401 returns `OnyxAPIError` with `StatusCode: 401`.** Verify error propagation.
+
+### Integration tests
+
+**File:** `backend/tests/integration/tests/cli/test_cli_commands.py` (extend existing)
+
+These tests run the real CLI binary against a real Onyx backend via `subprocess.run()`, using the existing `run_cli()` helper, `cli_binary` fixture, and `pat_token` fixture. They require `ONYX_CLI_BINARY` to be set and are skipped otherwise.
+
+Tests need seeded documents so search has something to find. Use `CCPairManager.create_from_scratch()` + `DocumentManager.seed_doc_with_content()` with a unique phrase per test (same pattern as `backend/tests/integration/tests/search/test_search_api.py`).
+
+1. **`test_search_returns_results`** — Seed a doc with a unique phrase. Run `onyx-cli search "<phrase>"`. Assert exit code 0, stdout is non-empty and contains the phrase.
+
+2. **`test_search_raw`** — Same setup. Run `onyx-cli search --raw "<phrase>"`. Parse stdout as JSON. Assert `results` is a list with at least one entry, `llm_facing_text` is non-empty, `citation_mapping` is a dict. Assert the seeded doc's `document_id` appears in results.
+
+3. **`test_search_source_filter`** — Seed docs on two different CC pairs (different sources if possible). Run `onyx-cli search --raw --source <source_type> "<phrase>"`. Assert only matching source appears in results.
+
+4. **`test_search_agent_id`** — Create a document set + persona scoped to it (same pattern as `test_persona_scoped_search` in the search API integration tests). Run `onyx-cli search --agent-id <persona_id> "<phrase>"`. Assert scoped doc appears, out-of-scope doc does not.
+
+5. **`test_search_truncation`** — Run `onyx-cli search --max-output 50 "<phrase>"`. Assert "response truncated" and "Full response:" appear in stdout.
+
+6. **`test_search_no_query`** — Run `onyx-cli search` with no args. Assert exit code 2.
+
+7. **`test_search_bad_pat`** — Run `onyx-cli search "test"` with `pat="bad-token"`. Assert exit code 4.
+
+8. **`test_search_not_configured`** — Run `onyx-cli search "test"` with no PAT. Assert exit code 3.

--- a/docs/craft/features/search/4-craft-search.md
+++ b/docs/craft/features/search/4-craft-search.md
@@ -6,7 +6,7 @@
 
 Wire onyx-cli into the Craft sandbox as the primary search tool, replacing the legacy `files/` corpus sync. Mint session-scoped PATs, bundle the CLI binary, create a `company-search` skill with the user's available sources, and tear down the file-sync infrastructure.
 
-**Assumes Parts 1–3 are complete.** The CLI binary accepts `ONYX_SERVER_URL` + `ONYX_API_KEY` env vars, has `search` and `validate-config` commands, and produces agent-optimized output without a TTY. `POST /api/search` exists and returns ranked, permissioned results.
+**Part 1 is complete.** The CLI binary accepts `ONYX_SERVER_URL` + `ONYX_PAT` env vars, has `search` and `validate-config` commands, and produces agent-optimized output without a TTY. **Parts 2–3 are assumed complete.** `POST /api/search` exists and returns ranked, permissioned results.
 
 ---
 
@@ -20,7 +20,7 @@ After this work, the sandbox has one path to company knowledge: `onyx-cli search
 |----------|--------|-------|
 | Company knowledge | `find`/`grep` over JSON files in `files/` | `onyx-cli search "<query>"` |
 | Available sources | Scanned from `files/` directory at setup | Listed in `company-search` SKILL.md, queried from user's connectors |
-| Auth | None (files are pre-synced) | Session-scoped PAT via `ONYX_API_KEY` env var |
+| Auth | None (files are pre-synced) | Session-scoped PAT via `ONYX_PAT` env var |
 | AGENTS.md guidance | "Start at `files/`, use `find`/`grep`" | "Use the `company-search` skill" |
 
 ### What the sandbox contains
@@ -31,7 +31,7 @@ After this work, the sandbox has one path to company knowledge: `onyx-cli search
 | S3 sidecar container | Runs `s5cmd sync` at pod start | Gone |
 | `onyx-cli` binary | Not present | `/usr/local/bin/onyx-cli` |
 | `company-search` skill | Does not exist | `.opencode/skills/company-search/SKILL.md` with user's sources |
-| `ONYX_API_KEY` env var | Not set | Session-scoped PAT, 7-day expiry |
+| `ONYX_PAT` env var | Not set | Session-scoped PAT, 7-day expiry |
 | `ONYX_SERVER_URL` env var | Not set | Internal Kube service address |
 
 ### Session auth lifecycle
@@ -40,7 +40,7 @@ After this work, the sandbox has one path to company knowledge: `onyx-cli search
 Session created / resumed
   └─ delete old PAT if one exists (handles resume after sleep)
   └─ mint fresh PAT (name: craft-session-{session_id}, expires: 7 days)
-  └─ inject ONYX_API_KEY into sandbox environment
+  └─ inject ONYX_PAT into sandbox environment
   └─ validate: onyx-cli validate-config
   └─ agent runs, calls onyx-cli search as needed
 Session ended
@@ -124,7 +124,7 @@ Session PATs are infrastructure — users shouldn't have to see or manage them. 
 
 **4. Inject env vars into sandbox** (`sandbox/kubernetes/kubernetes_sandbox_manager.py`)
 
-In `setup_session_workspace()`, make `ONYX_API_KEY` and `ONYX_SERVER_URL` available to agent-launched processes. The mechanism depends on how OpenCode propagates environment to child processes — either via an env file sourced by the shell, exports in the session setup script, or a shell profile.
+In `setup_session_workspace()`, make `ONYX_PAT` and `ONYX_SERVER_URL` available to agent-launched processes. The mechanism depends on how OpenCode propagates environment to child processes — either via an env file sourced by the shell, exports in the session setup script, or a shell profile.
 
 `ONYX_SERVER_URL` comes from a new config value:
 
@@ -132,18 +132,18 @@ In `setup_session_workspace()`, make `ONYX_API_KEY` and `ONYX_SERVER_URL` availa
 # server/features/build/configs.py
 SANDBOX_ONYX_SERVER_URL = os.environ.get(
     "SANDBOX_ONYX_SERVER_URL",
-    "http://api-server.onyx.svc.cluster.local:8080",
+    "http://api-server.onyx.svc.cluster.local:8080/api",
 )
 ```
 
-For local dev (`SandboxBackend.LOCAL`): defaults to `http://localhost:8080`.
+For local dev (`SandboxBackend.LOCAL`): defaults to `http://localhost:8080/api`.
 
 **5. Validate at session start** (`sandbox/kubernetes/kubernetes_sandbox_manager.py`)
 
 After injecting env vars, before the agent starts:
 
 ```bash
-ONYX_API_KEY="..." ONYX_SERVER_URL="..." onyx-cli validate-config
+ONYX_PAT="..." ONYX_SERVER_URL="..." onyx-cli validate-config
 ```
 
 Non-zero exit → abort session setup with `OnyxError`. Better to fail immediately than let the agent discover mid-task that search is broken.
@@ -193,8 +193,10 @@ assume it exists.
 
 ## Output
 
-Stdout is markdown with numbered citations like `[1]`, `[2]`. Cite results by
-their citation number when referencing them in your response.
+Stdout is JSON with a top-level `results` array. Each result has a `document`
+field (the citation ID), plus `title`, `content`, `source_type`, and other
+metadata. Cite results by their `document` number when referencing them in your
+response.
 ```
 
 No `run.sh`. The agent calls `onyx-cli search` directly.
@@ -250,8 +252,9 @@ Delete the "Knowledge Sources" section, `{{KNOWLEDGE_SOURCES_SECTION}}` placehol
 ### Step 1: Information Retrieval
 
 1. **Search** company knowledge using the `company-search` skill. Run
-   `onyx-cli search "<query>"` and read the returned markdown; cite results by
-   their citation number when you reference them.
+   `onyx-cli search "<query>"` and read the returned JSON; each result has a
+   `document` field (the citation ID) — cite results by that number when you
+   reference them.
 2. Read the `company-search` SKILL.md for available sources and flags.
 3. **Iterate** — run additional searches to refine. Use `--source` to narrow by
    connector and `--days` for recent content.
@@ -296,7 +299,7 @@ Remove the `get_persistent_document_writer()` call and the code path that writes
 
 ### E. Local development
 
-Apply the same changes to the local sandbox manager (`sandbox/manager/directory_manager.py`): mint PAT, inject env vars, copy + render skills, remove `files/` symlink. `ONYX_SERVER_URL` defaults to `http://localhost:8080`. The CLI binary must be on the developer's `$PATH`.
+Apply the same changes to the local sandbox manager (`sandbox/manager/directory_manager.py`): mint PAT, inject env vars, copy + render skills, remove `files/` symlink. `ONYX_SERVER_URL` defaults to `http://localhost:8080/api`. The CLI binary must be on the developer's `$PATH`.
 
 ---
 

--- a/docs/craft/features/search/search-design.md
+++ b/docs/craft/features/search/search-design.md
@@ -80,6 +80,10 @@ The search API returns retrieved documents with citations — not an LLM-generat
 - **User-facing agents decide what to do with search results.** Fewer options if given a pre-digested answer.
 - The existing `ask` command already provides the "give me an LLM answer" path. `search` is the complementary primitive: retrieval without generation.
 
+### Note: LLM-Facing Output Format
+
+`search-requirements.md` describes the search output as "a single markdown blob to stdout." The actual `SearchTool` implementation (`convert_inference_sections_to_llm_string()`) produces a JSON string — `json.dumps({"results": [...]})` with fields like `document` (citation ID), `title`, `content`, `source_type`. This is what chat-flow LLM consumers already see. We use the same JSON format for consistency: the search API returns it as `llm_facing_text`, and the CLI prints it to stdout by default. The requirements doc is preserved as-is for historical reference.
+
 ### Consumer Note: Onyx MCP Server
 
 The new search API (Part 2) should also become the backend for the Onyx MCP server's search tool. The MCP server currently calls the EE `send_search_query` endpoint (Search Mode parity). Once the chat-mode search API exists, the MCP server should switch to it — giving MCP consumers the same search quality upgrade. This is out of scope for this project but is a direct beneficiary.
@@ -89,9 +93,9 @@ The new search API (Part 2) should also become the backend for the Onyx MCP serv
 ## Dependencies Between Parts
 
 ```
-Part 1 (CLI refactor)  ──────────────────────────────────────┐
+Part 1 (CLI refactor)  ✅ COMPLETE ──────────────────────────┐
                                                               │
-Part 2 (Search API)  ─────────────────────────────────────────┤
+Part 2 (Search API)  ✅ COMPLETE ─────────────────────────────┤
                                                               ▼
 Part 3 (CLI search command)  ──► depends on Part 1 + Part 2
                                                               │
@@ -103,7 +107,13 @@ Parts 1 and 2 are independent and can be developed in parallel. Part 3 requires 
 
 ---
 
-## Part 1: Agent-First CLI Refactor
+## Part 1: Agent-First CLI Refactor (COMPLETE)
+
+> **Status: Implemented.** Part 1 introduced several patterns that Parts 2-4 should be aware of:
+> - **IOStreams abstraction** — All command output flows through an `IOStreams` struct (Stdout/Stderr writers, IsInteractive flag, MaxOutput limit). New commands should accept `IOStreams` rather than writing to `os.Stdout` directly.
+> - **Relative URL paths** — API client methods use relative paths (e.g., `"/chat/send-message-simple-api"`), not absolute URLs. The base URL is joined at request time.
+> - **Shared command helpers** — Common patterns (output formatting, error handling, JSON marshaling, TTY gating) are factored into helper functions under `cli/cmd/`. New commands should reuse these rather than reimplementing.
+> - **Python integration tests** — CLI integration tests live in `cli/tests/` and are written in Python (pytest). They invoke the compiled binary as a subprocess and assert on stdout, stderr, and exit codes. Parts 2-4 should follow this pattern.
 
 ### Objective
 
@@ -137,7 +147,7 @@ Non-interactive mode output must be optimized for LLM consumption:
 Agents must not be able to configure the CLI — they cannot set the Onyx URL, API key, or any other persistent setting. Configuration is a human operation:
 
 - The `configure` command is gated behind interactive mode (requires TTY). Without a TTY, it fails with a clear error.
-- Inside Craft sandboxes, the CLI is configured entirely via environment variables (`ONYX_SERVER_URL`, `ONYX_API_KEY`). No config file is created, read, or needed.
+- Inside Craft sandboxes, the CLI is configured entirely via environment variables (`ONYX_SERVER_URL`, `ONYX_PAT`). No config file is created, read, or needed.
 - The `validate-config` command remains available in non-interactive mode (read-only, useful for health checks).
 - Outside of Craft (e.g., a developer using onyx-cli with Claude Code), the config file works as it does today.
 
@@ -154,7 +164,7 @@ Agents can see all CLI commands, but human-only commands are gated behind the TU
 
 Agents use both exit codes and error messages. Exit codes tell the agent (and scripts) that something failed; the stderr error message tells the agent *what* failed and *what to do about it*. Both matter:
 
-- The existing exit code set (`NotConfigured=1`, `BadRequest=2`, `AuthFailure=3`, `Unreachable=4`) must be extended to cover the full surface of failures an agent might encounter (rate limited, search-specific errors, etc.).
+- The exit code set is: `Success=0`, `General=1`, `BadRequest=2`, `NotConfigured=3`, `AuthFailure=4`, `Unreachable=5`, `RateLimited=6`, `Timeout=7`, `ServerError=8`, `NotAvailable=9`.
 - Every non-zero exit must print a clear, actionable error message to stderr — not just an error code or generic "request failed." The message should help an agent understand the problem and either fix it or ask the user for help (e.g., `"authentication failed: PAT expired, ask the user to generate a new one"`).
 
 #### R1.6: Version and capability discovery
@@ -177,7 +187,14 @@ The CLI's `install-skill` command installs a `SKILL.md` for agent harnesses (Cla
 
 ---
 
-## Part 2: Search API
+## Part 2: Search API (COMPLETE)
+
+> **Status: Implemented.** Key implementation details for Parts 3-4:
+> - **Endpoint** — `POST /api/search`, routed through `backend/onyx/server/features/search/api.py` with request/response models in `models.py`.
+> - **NullEmitter** — `SearchTool` requires an `Emitter`; a no-op `NullEmitter` in `backend/onyx/chat/emitter.py` satisfies this for non-chat callers.
+> - **Integration tests** — `backend/tests/integration/tests/search/test_search_api.py`.
+> - **`message_history` support** — Added beyond the original plan. Callers with conversation context can pass it in for better query expansion (resolves pronouns, follow-ups, etc.).
+> - **Field naming** — LLM override fields use `provider`/`model`, consistent with the rest of the API surface.
 
 ### Objective
 
@@ -261,7 +278,7 @@ The response includes both structured data (for programmatic consumers) and an L
       "updated_at": "2026-03-12T00:00:00Z"
     }
   ],
-  "llm_facing_text": "[1] Enterprise Sales Playbook (Google Drive, 2026-03-12)\n...",
+  "llm_facing_text": "{\"results\": [{\"document\": 1, \"title\": \"Enterprise Sales Playbook\", \"source_type\": \"google_drive\", \"content\": \"...\"}]}",
   "citation_mapping": { "1": "google_drive__abc123" },
   "query_expansion": {
     "semantic_queries": ["..."],
@@ -271,7 +288,7 @@ The response includes both structured data (for programmatic consumers) and an L
 ```
 
 - `results`: The full ranked result set with all metadata. Derived from `SearchDocsResponse.search_docs` / `displayed_docs`.
-- `llm_facing_text`: The same citation-rich markdown string that `SearchTool` produces as its `llm_facing_response`. Ready to paste into an LLM context window.
+- `llm_facing_text`: The same citation-rich JSON string that `SearchTool` produces as its `llm_facing_response` — a `{"results": [...]}` object where each result has fields like `document` (citation ID), `title`, `content`, `source_type`, etc. Ready to paste into an LLM context window.
 - `citation_mapping`: Maps citation numbers to document IDs, matching the chat tool's behavior.
 - `query_expansion`: What queries the LLM expanded the original into. Useful for debugging and transparency.
 
@@ -333,9 +350,9 @@ Whether search-results and LLM-generated-answers are exposed as two separate com
 
 The implementation plan for this part should make and justify this decision.
 
-#### R3.3: Default output is LLM-facing markdown
+#### R3.3: Default output is LLM-facing JSON
 
-When not in JSON mode, the command prints the `llm_facing_text` from the API response to stdout. This is citation-rich markdown that an agent can directly consume and cite from. Progress/status goes to stderr.
+When not in JSON mode, the command prints the `llm_facing_text` from the API response to stdout. This is a JSON string containing citation-tagged search results (with document IDs, titles, content, source types, etc.) that an agent can directly consume and cite from. Progress/status goes to stderr.
 
 In JSON mode, the command prints the full structured API response.
 
@@ -358,7 +375,7 @@ Agents need a way to list available personas with enough information to choose o
 
 - **Command structure**: The search/ask split is a UX decision that affects how agents discover and use the CLI. The implementation plan must justify the chosen structure.
 - **Flag design**: Flags must map cleanly to the API's parameters while being intuitive on the command line.
-- **Output format stability**: Agents will parse this output. The markdown format must be stable. The JSON format must be a documented, versioned contract.
+- **Output format stability**: Agents will parse this output. The LLM-facing JSON format must be stable. The full structured JSON response must be a documented, versioned contract.
 - **Consistency across commands**: All agent-usable commands should feel like they're from the same tool.
 
 ---
@@ -376,7 +393,7 @@ Wire onyx-cli into the Craft sandbox as the primary search tool, replacing the l
 Each Craft session gets a dedicated PAT that exists only for the session's lifetime. This follows the existing pattern of internal service authentication — the Discord bot service already hits the API server directly with a "service account" API key and tenant context is handled there. Craft PATs work the same way: provisioned per session, scoped to the session's user.
 
 - **Provisioning**: At session creation, mint a new PAT scoped to the session's user. The PAT name should identify it as session-bound (e.g., `craft-session-{session_id}`). The PAT's permissions are the same as the user's — no elevation, no restriction beyond what the user already has. (PAT scopes will be addressed later by the Permissions system, not this project.)
-- **Injection**: For this version, the PAT value (the raw token, not the hash) is injected directly into the sandbox environment as `ONYX_API_KEY`. The CLI reads this env var for authentication. The backend URL is injected as `ONYX_SERVER_URL`, pointing at the internal Kube service address (not the public nginx URL, which is irrelevant inside the cluster). Long-term, the raw PAT will not be exposed to the sandbox at all — the egress interception proxy (Craft V1 project #4) will inject credentials server-side on outbound requests, so the sandbox never sees secrets. This direct env var injection is the interim approach until that proxy layer is in place.
+- **Injection**: For this version, the PAT value (the raw token, not the hash) is injected directly into the sandbox environment as `ONYX_PAT`. The CLI reads this env var for authentication. The backend URL is injected as `ONYX_SERVER_URL`, pointing at the internal Kube service address (not the public nginx URL, which is irrelevant inside the cluster). Long-term, the raw PAT will not be exposed to the sandbox at all — the egress interception proxy (Craft V1 project #4) will inject credentials server-side on outbound requests, so the sandbox never sees secrets. This direct env var injection is the interim approach until that proxy layer is in place.
 - **Deprovisioning**: When the session ends (user closes it, idle timeout, explicit cleanup), the PAT is revoked. Revoked PATs immediately stop working — any in-flight search requests fail with an auth error.
 - **Expiration**: Session PATs should have a time-based expiration as a safety net (e.g., 24 hours), independent of session lifecycle. If the session cleanup path fails, the PAT still expires.
 - **Audit**: Session PATs are distinguishable from user-created PATs in the PAT list. Users should see them (transparency) but they should be clearly labeled as session-managed and not manually editable.
@@ -388,7 +405,7 @@ The onyx-cli binary must be available inside the sandbox:
 - The binary is included in the sandbox Docker image. This is a build-time dependency, not a runtime download.
 - The binary version is pinned to the Onyx release. There is no version mismatch between the CLI and the backend it talks to.
 - The binary is on `$PATH` inside the sandbox so the agent can invoke it as `onyx-cli` without a full path.
-- The binary works without a config file — it reads `ONYX_API_KEY` and `ONYX_SERVER_URL` from the environment (per Part 1's agent-first design). No `configure` step is needed or possible.
+- The binary works without a config file — it reads `ONYX_PAT` and `ONYX_SERVER_URL` from the environment (per Part 1's agent-first design). No `configure` step is needed or possible.
 
 #### R4.3: CLI skill creation
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Craft search docs to reflect the implemented CLI refactor and Search API, adds a complete Part 3 plan for the new `search` CLI command, and aligns Craft integration with `ONYX_PAT` and the LLM-facing JSON output.

- **New Features**
  - Added “Part 3: CLI Search Command & Agent Tool Surface” plan detailing the `search` command, flags (`--source`, `--days`, `--limit`, `--agent-id`, `--raw`, `--no-query-expansion`, `--max-output`), client changes (`doJSONLong`, request/response models), and tests.
  - Documented default behavior: print `llm_facing_text` (JSON) to stdout; `--raw` returns full `POST /api/search` response.

- **Refactors**
  - Marked Parts 1–2 as IMPLEMENTED with divergence notes (e.g., `provider`/`model` fields, `message_history`, `NullEmitter` in `emitter.py`, LLM cost limit check, integration-test focus).
  - Updated Craft integration docs to use `ONYX_PAT`, internal `ONYX_SERVER_URL` including `/api`, and JSON-based skill output; revised validation and examples.
  - Clarified design: LLM-facing output is JSON (not markdown), updated exit codes, dependency status, and agent-first patterns.

<sup>Written for commit 2e8c258bbbd8328f15baf5f9030be0064ec08979. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

