### PR TITLE
fix(mcp): per user multiple header (#10995) to release v3.3

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -48,6 +48,13 @@ env:
   MCP_API_KEY_SERVER_HOST: 0.0.0.0
   MCP_API_KEY_SERVER_PUBLIC_HOST: host.docker.internal
 
+  # for MCP per-user API key (multi-field template) tests
+  MCP_PER_USER_KEY_TEST_PORT: 8007
+  MCP_PER_USER_KEY_TEST_URL: http://host.docker.internal:8007/mcp
+  MCP_PER_USER_KEY_REQUIRED_HEADER: X-Username
+  MCP_PER_USER_KEY_SERVER_HOST: 0.0.0.0
+  MCP_PER_USER_KEY_SERVER_PUBLIC_HOST: host.docker.internal
+
   MOCK_LLM_RESPONSE: true
   MCP_TEST_SERVER_PORT: 8004
   MCP_TEST_SERVER_URL: http://host.docker.internal:8004/mcp
@@ -330,7 +337,7 @@ jobs:
       - name: Start Docker containers
         run: |
           cd deployment/docker_compose
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mcp-oauth-test.yml -f docker-compose.mcp-api-key-test.yml up -d
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mcp-oauth-test.yml -f docker-compose.mcp-api-key-test.yml -f docker-compose.mcp-per-user-key-test.yml up -d
         id: start_docker
 
       - name: Wait for service to be ready
@@ -407,6 +414,29 @@ jobs:
 
             if curl -sf "http://localhost:${MCP_API_KEY_TEST_PORT:-8005}/healthz" > /dev/null; then
               echo "MCP API Key mock server is ready!"
+              break
+            fi
+
+            sleep 3
+          done
+
+      - name: Wait for MCP per-user key mock server
+        run: |
+          echo "Waiting for MCP per-user key mock server on port ${MCP_PER_USER_KEY_TEST_PORT:-8007}..."
+          start_time=$(date +%s)
+          timeout=120
+
+          while true; do
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            if [ $elapsed_time -ge $timeout ]; then
+              echo "Timeout reached. MCP per-user key mock server did not become ready in ${timeout}s."
+              exit 1
+            fi
+
+            if curl -sf "http://localhost:${MCP_PER_USER_KEY_TEST_PORT:-8007}/healthz" > /dev/null; then
+              echo "MCP per-user key mock server is ready!"
               break
             fi
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -60,6 +60,7 @@ from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_tools_by_mcp_server_id
 from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.mcp.models import apply_auto_substitutions
 from onyx.server.features.mcp.models import MCPApiKeyResponse
 from onyx.server.features.mcp.models import MCPAuthTemplate
 from onyx.server.features.mcp.models import MCPConnectionData
@@ -419,11 +420,10 @@ def _build_headers_from_template(
     template_headers = template_data.headers
 
     for name, value_template in template_headers.items():
-        # Replace placeholders
         value = value_template
         for key, cred_value in credentials.items():
             value = value.replace(f"{{{key}}}", cred_value)
-        value = value.replace("{user_email}", user_email)
+        value = apply_auto_substitutions(value, user_email=user_email)
 
         if name:
             headers[name] = value
@@ -1082,9 +1082,15 @@ def _db_mcp_server_to_api_mcp_server(
                     template_config, apply_mask=False
                 )
                 headers = template_config_dict.get("headers", {})
+                # Prefer the explicitly persisted list; fall back to deriving
+                # from header placeholders for servers created before
+                # `required_fields` was persisted.
+                required_fields = template_config_dict.get(
+                    "required_fields"
+                ) or MCPAuthTemplate.derive_required_fields(headers)
                 auth_template = MCPAuthTemplate(
                     headers=headers,
-                    required_fields=[],  # would need to regex, not worth it
+                    required_fields=required_fields,
                 )
         except Exception as e:
             logger.warning(
@@ -1627,11 +1633,21 @@ def _upsert_mcp_server(
             # Per-user server: create template and save creator's per-user config
             template_data = request.auth_template
 
+            # Trust the explicit list when present, otherwise derive it from
+            # the header placeholders so the user-side modal always knows
+            # which fields to prompt for. Older servers created before this
+            # field was persisted are healed lazily on read.
+            persisted_required_fields = (
+                template_data.required_fields
+                or MCPAuthTemplate.derive_required_fields(template_data.headers)
+            )
+
             # Create template config: faithful representation of what's in the admin panel
             template_config = create_connection_config(
                 config_data=MCPConnectionData(
                     headers=template_data.headers,
                     header_substitutions=request.admin_credentials,
+                    required_fields=persisted_required_fields,
                 ),
                 mcp_server_id=mcp_server.id,
                 user_email="",

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 from enum import Enum
 from typing import Any
 from typing import List
@@ -16,6 +17,39 @@ from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 
+# Matches `{placeholder_name}` inside header value templates.
+_PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
+
+
+def _build_auto_substitution_map(*, user_email: str) -> dict[str, str]:
+    """Single source of truth for placeholders the backend fills in
+    automatically when rendering an ``MCPAuthTemplate`` into final headers.
+
+    Both the substitution call site (``apply_auto_substitutions``) and the
+    "which fields must the user supply" derivation
+    (``MCPAuthTemplate.derive_required_fields``) read from this map, so adding
+    a new auto-filled placeholder is a one-line change here.
+    """
+    return {"user_email": user_email}
+
+
+# Names of placeholders the backend auto-substitutes; never surfaced to the
+# user as fields they must fill in. Derived from the substitution map so the
+# two can never drift.
+AUTO_SUBSTITUTED_PLACEHOLDER_KEYS: frozenset[str] = frozenset(
+    _build_auto_substitution_map(user_email="").keys()
+)
+
+
+def apply_auto_substitutions(value: str, *, user_email: str) -> str:
+    """Substitute every backend-managed placeholder in ``value`` (e.g.
+    ``{user_email}``). User-provided substitutions are handled separately at
+    the call site that has access to the user's credential map."""
+    subst = _build_auto_substitution_map(user_email=user_email)
+    for key, replacement in subst.items():
+        value = value.replace(f"{{{key}}}", replacement)
+    return value
+
 
 # This should be updated along with MCPConnectionData
 class MCPOAuthKeys(str, Enum):
@@ -32,6 +66,11 @@ class MCPConnectionData(TypedDict):
 
     headers: dict[str, str]
     header_substitutions: NotRequired[dict[str, str]]
+    # Names of fields the user must supply for header substitution. Persisted
+    # only on the per-user template config (the admin's connection config that
+    # serves as the template); empty/absent on regular per-user configs and on
+    # admin-credential configs.
+    required_fields: NotRequired[list[str]]
 
     # For OAuth only
     # Note: Update MCPOAuthKeys if necessary when modifying these
@@ -60,6 +99,20 @@ class MCPAuthTemplate(BaseModel):
         default_factory=list,
         description="List of required field names that users must provide",
     )
+
+    @staticmethod
+    def derive_required_fields(headers: dict[str, str]) -> list[str]:
+        """Extract the set of `{placeholder}` field names referenced by
+        ``headers`` values, excluding placeholders the backend fills in
+        automatically (see ``AUTO_SUBSTITUTED_PLACEHOLDER_KEYS``).
+        """
+        seen: set[str] = set()
+        for value in headers.values():
+            for match in _PLACEHOLDER_RE.findall(value):
+                if match in AUTO_SUBSTITUTED_PLACEHOLDER_KEYS:
+                    continue
+                seen.add(match)
+        return list(seen)
 
 
 class MCPToolCreateRequest(BaseModel):

--- a/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
+++ b/backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py
@@ -1,17 +1,30 @@
+import argparse
 import sys
 from datetime import datetime
 from datetime import timezone
 from typing import Any
+from typing import Awaitable
+from typing import Callable
 from typing import Dict
 from typing import Optional
 
 import bcrypt
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
 from fastmcp import FastMCP
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
 from fastmcp.server.dependencies import get_access_token
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.responses import Response
 
-# pip install fastmcp bcrypt
+# pip install fastmcp bcrypt fastapi uvicorn
+
+DEFAULT_PORT = 8003
+MCP_PATH_PREFIX = "/mcp"
 
 
 # ---- pretend database --------------------------------------------------------
@@ -89,6 +102,41 @@ class ApiKeyVerifier(TokenVerifier):
         )
 
 
+# ---- middleware -------------------------------------------------------------
+
+
+class RequireHeadersMiddleware(BaseHTTPMiddleware):
+    """Reject requests under ``MCP_PATH_PREFIX`` that omit any required header.
+
+    Useful for testing the per-user MCP API-key flow in onyx where the admin
+    templates extra headers (e.g. ``X-Username: {username}``) so each user is
+    prompted for additional fields alongside their API key.
+
+    The bearer token is still validated by ``ApiKeyVerifier`` after this
+    middleware passes.
+    """
+
+    def __init__(self, app: Any, required_headers: list[str]) -> None:
+        super().__init__(app)
+        self.required_headers = required_headers
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if not request.url.path.startswith(MCP_PATH_PREFIX):
+            return await call_next(request)
+
+        for header in self.required_headers:
+            if not request.headers.get(header):
+                return JSONResponse(
+                    {"error": f"Missing required header '{header}'"},
+                    status_code=401,
+                )
+        return await call_next(request)
+
+
 # ---- server -----------------------------------------------------------------
 
 
@@ -103,11 +151,34 @@ def make_many_tools(mcp: FastMCP) -> None:
         make_tool(i)
 
 
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a local MCP server with per-user API key auth.",
+    )
+    parser.add_argument(
+        "port",
+        nargs="?",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"Port to listen on (default: {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "--require-header",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Header name (e.g. X-Username) that must be present and non-empty "
+            "on every /mcp request. Repeat the flag to require multiple "
+            "headers. When unset, only the bearer token is required."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        port = int(sys.argv[1])
-    else:
-        port = 8003
+    args = parse_args(sys.argv[1:])
+    required_headers: list[str] = args.require_header or []
 
     mcp = FastMCP("My HTTP MCP", auth=ApiKeyVerifier(API_KEY_RECORDS))
 
@@ -122,4 +193,26 @@ if __name__ == "__main__":
         }
 
     make_many_tools(mcp)
-    mcp.run(transport="http", host="127.0.0.1", port=port, path="/mcp")
+
+    mcp_app = mcp.http_app()
+    app = FastAPI(
+        title="MCP Per-User API Key Test Server",
+        lifespan=mcp_app.lifespan,
+    )
+
+    @app.get("/healthz")
+    def health() -> PlainTextResponse:
+        return PlainTextResponse("ok")
+
+    if required_headers:
+        app.add_middleware(
+            RequireHeadersMiddleware,
+            required_headers=required_headers,
+        )
+        print(f"Requiring headers on {MCP_PATH_PREFIX}: {required_headers}")
+
+    app.mount("/", mcp_app)
+    # Bind on 0.0.0.0 so the server is reachable both via 127.0.0.1 for local
+    # manual testing and from sibling containers via host.docker.internal in
+    # the playwright CI compose stack. Matches run_mcp_server_api_key.py.
+    uvicorn.run(app, host="0.0.0.0", port=args.port)

--- a/deployment/docker_compose/docker-compose.mcp-per-user-key-test.yml
+++ b/deployment/docker_compose/docker-compose.mcp-per-user-key-test.yml
@@ -1,0 +1,20 @@
+name: onyx
+
+services:
+  mcp_per_user_key_server:
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:latest}
+    restart: on-failure
+    working_dir: /workspace
+    environment:
+      - MCP_PER_USER_KEY_TEST_PORT=${MCP_PER_USER_KEY_TEST_PORT:-8007}
+      - MCP_PER_USER_KEY_REQUIRED_HEADER=${MCP_PER_USER_KEY_REQUIRED_HEADER:-X-Username}
+      - MCP_SERVER_HOST=${MCP_PER_USER_KEY_SERVER_HOST:-0.0.0.0}
+      - MCP_SERVER_PUBLIC_HOST=${MCP_PER_USER_KEY_SERVER_PUBLIC_HOST:-host.docker.internal}
+    command: >
+      /bin/sh -c "
+      python backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py ${MCP_PER_USER_KEY_TEST_PORT:-8007} --require-header ${MCP_PER_USER_KEY_REQUIRED_HEADER:-X-Username}
+      "
+    ports:
+      - "${MCP_PER_USER_KEY_TEST_PORT:-8007}:${MCP_PER_USER_KEY_TEST_PORT:-8007}"
+    volumes:
+      - ../..:/workspace:ro

--- a/web/tests/e2e/mcp/mcp_per_user_key.spec.ts
+++ b/web/tests/e2e/mcp/mcp_per_user_key.spec.ts
@@ -1,0 +1,471 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { loginAs, apiLogin } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import {
+  startMcpPerUserKeyServer,
+  McpServerProcess,
+} from "@tests/e2e/utils/mcpServer";
+
+// API keys baked into run_mcp_server_per_user_key.py. The script's middleware
+// also requires every /mcp/* request to carry a non-empty `X-Username` header
+// when launched with `--require-header X-Username`, which is exactly the
+// scenario this spec exercises end-to-end.
+const ADMIN_API_KEY =
+  process.env.MCP_PER_USER_KEY_ADMIN_KEY ||
+  "mcp_live-kid_alice_001-S3cr3tAlice";
+const BASIC_USER_API_KEY =
+  process.env.MCP_PER_USER_KEY_USER_KEY || "mcp_live-kid_bob_001-S3cr3tBob";
+const ADMIN_USERNAME = "admin-pw";
+const BASIC_USERNAME = "basic-pw";
+const REQUIRED_USERNAME_HEADER = "X-Username";
+const DEFAULT_PORT = Number(process.env.MCP_PER_USER_KEY_TEST_PORT || "8007");
+const MCP_PER_USER_KEY_TEST_URL = process.env.MCP_PER_USER_KEY_TEST_URL;
+
+async function ensureOnboardingComplete(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    try {
+      await fetch("/api/user/personalization", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ name: "Playwright User" }),
+      });
+    } catch {
+      // ignore personalization failures
+    }
+  });
+
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+}
+
+async function scrollToBottom(page: Page): Promise<void> {
+  try {
+    await page.evaluate(() => {
+      window.scrollTo(0, document.body.scrollHeight);
+    });
+    await page.waitForTimeout(200);
+  } catch {
+    // ignore scrolling failures
+  }
+}
+
+test.describe("MCP per-user API key auth (multi-field template)", () => {
+  test.describe.configure({ mode: "serial" });
+
+  let serverProcess: McpServerProcess | null = null;
+  let serverId: number | null = null;
+  let serverName: string;
+  let serverUrl: string;
+  let basicUserEmail: string;
+  let basicUserPassword: string;
+  let createdProviderId: number | null = null;
+
+  test.beforeAll(async ({ browser }) => {
+    if (MCP_PER_USER_KEY_TEST_URL) {
+      serverUrl = MCP_PER_USER_KEY_TEST_URL;
+      console.log(
+        `[test-setup] Using dockerized MCP per-user key server at ${serverUrl}`
+      );
+    } else {
+      serverProcess = await startMcpPerUserKeyServer({
+        port: DEFAULT_PORT,
+        requiredHeaders: [REQUIRED_USERNAME_HEADER],
+      });
+      serverUrl = `http://${serverProcess.address.host}:${serverProcess.address.port}/mcp`;
+      console.log(
+        `[test-setup] MCP per-user key server started locally at ${serverUrl}`
+      );
+    }
+
+    serverName = `PW Per-User Key Server ${Date.now()}`;
+
+    const adminContext = await browser.newContext({
+      storageState: "admin_auth.json",
+    });
+    const adminPage = await adminContext.newPage();
+    const adminClient = new OnyxApiClient(adminPage.request);
+
+    createdProviderId = await adminClient.ensurePublicProvider();
+
+    try {
+      const existingServers = await adminClient.listMcpServers();
+      for (const server of existingServers) {
+        if (server.server_url === serverUrl) {
+          await adminClient.deleteMcpServer(server.id);
+        }
+      }
+    } catch (error) {
+      console.warn("Failed to cleanup existing MCP servers", error);
+    }
+
+    basicUserEmail = `pw-per-user-key-${Date.now()}@example.com`;
+    basicUserPassword = "BasicUserPass123!";
+    await adminClient.registerUser(basicUserEmail, basicUserPassword);
+
+    await adminContext.close();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const adminContext = await browser.newContext({
+      storageState: "admin_auth.json",
+    });
+    const adminPage = await adminContext.newPage();
+    const adminClient = new OnyxApiClient(adminPage.request);
+
+    if (createdProviderId !== null) {
+      await adminClient.deleteProvider(createdProviderId);
+    }
+    if (serverId) {
+      await adminClient.deleteMcpServer(serverId);
+    }
+
+    await adminContext.close();
+
+    if (serverProcess) {
+      await serverProcess.stop();
+    }
+  });
+
+  test("Admin configures per-user MCP server with two required template fields", async ({
+    page,
+  }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+
+    await page.goto("/admin/actions/mcp");
+    await page.waitForURL("**/admin/actions/mcp**");
+
+    // Open the Add MCP Server modal and fill basic info
+    await page.getByRole("button", { name: /Add MCP Server/i }).click();
+    await page.waitForTimeout(500);
+
+    await page.locator("input#name").fill(serverName);
+    await page
+      .locator("textarea#description")
+      .fill("Test per-user multi-field API key MCP server");
+    await page.locator("input#server_url").fill(serverUrl);
+
+    const createServerResponsePromise = page.waitForResponse((resp) => {
+      try {
+        const url = new URL(resp.url());
+        return (
+          url.pathname === "/api/admin/mcp/server" &&
+          resp.request().method() === "POST" &&
+          resp.ok()
+        );
+      } catch {
+        return false;
+      }
+    });
+    await page.getByRole("button", { name: "Add Server" }).click();
+    const createServerResponse = await createServerResponsePromise;
+    const createdServer = (await createServerResponse.json()) as {
+      id?: number;
+    };
+    expect(createdServer.id).toBeTruthy();
+    serverId = Number(createdServer.id);
+    expect(serverId).toBeGreaterThan(0);
+
+    // Auth modal opens automatically after server creation.
+    await page.waitForTimeout(500);
+
+    // Switch auth method to API Key (default is OAuth).
+    const authMethodSelect = page.getByTestId("mcp-auth-method-select");
+    await authMethodSelect.click();
+    await page.getByRole("option", { name: "API Key" }).click();
+    await page.waitForTimeout(300);
+
+    // Per-user tab is the default for API Key, but click it explicitly so the
+    // test fails loudly if that default ever changes.
+    const perUserTab = page.getByRole("tab", {
+      name: /Individual Key.*Per User/i,
+    });
+    await expect(perUserTab).toBeVisible({ timeout: 5000 });
+    await perUserTab.click();
+    await page.waitForTimeout(200);
+
+    // The headers section is rendered by InputKeyValue, which exposes a
+    // role="group" wrapper named "<keyTitle> and <valueTitle> pairs" and gives
+    // each input an aria-label of "<keyPlaceholder|"Key"> <index+1>" /
+    // "<valuePlaceholder|"Value"> <index+1>". PerUserAuthConfig doesn't pass
+    // placeholders, so the row 1 inputs end up as "Key 1" / "Value 1" rather
+    // than the visible column titles. Scope to the group so other "Key N"
+    // labels elsewhere on the page can't collide.
+    const headerGroup = page.getByRole("group", {
+      name: /Header Name and Header Value pairs/i,
+    });
+
+    // Header row 1 is pre-populated with "Authorization" / "Bearer {api_key}"
+    // by PerUserAuthConfig's initialization effect; we just need to confirm
+    // and add row 2.
+    const firstHeaderName = headerGroup.getByLabel("Key 1");
+    const firstHeaderValue = headerGroup.getByLabel("Value 1");
+    await expect(firstHeaderName).toHaveValue("Authorization");
+    await expect(firstHeaderValue).toHaveValue("Bearer {api_key}");
+
+    // Add a second header row for the X-Username placeholder. The button's
+    // accessible name is "Add Header Name and Header Value pair" (built from
+    // the column titles), so the regex matches via the "Add Header" prefix.
+    const addHeaderButton = headerGroup.getByRole("button", {
+      name: /Add Header Name and Header Value pair/i,
+    });
+    await addHeaderButton.click();
+
+    const secondHeaderName = headerGroup.getByLabel("Key 2");
+    const secondHeaderValue = headerGroup.getByLabel("Value 2");
+    await expect(secondHeaderName).toBeVisible({ timeout: 5000 });
+    await secondHeaderName.fill(REQUIRED_USERNAME_HEADER);
+    await secondHeaderValue.fill("{username}");
+
+    // The "Only for your own account" section should reveal once placeholders
+    // are detected. Fill the admin's own credentials.
+    const adminApiKeyInput = page.locator(
+      'input[name="user_credentials.api_key"]'
+    );
+    const adminUsernameInput = page.locator(
+      'input[name="user_credentials.username"]'
+    );
+    await expect(adminApiKeyInput).toBeVisible({ timeout: 5000 });
+    await expect(adminUsernameInput).toBeVisible({ timeout: 5000 });
+    await adminApiKeyInput.fill(ADMIN_API_KEY);
+    await adminUsernameInput.fill(ADMIN_USERNAME);
+
+    // Save the server. The upsert call hits POST /api/admin/mcp/servers/create
+    // (not the singular /server endpoint that creates the bare record) and the
+    // backend validates admin's creds against the running mock server during
+    // this call, so a failure here means the substitution path or the mock
+    // middleware is broken. We watch for the response so the assertion below
+    // doesn't race the credential roundtrip.
+    const upsertResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().endsWith("/api/admin/mcp/servers/create") &&
+        resp.request().method() === "POST"
+    );
+
+    const connectButton = page.getByTestId("mcp-auth-connect-button");
+    await expect(connectButton).toBeVisible({ timeout: 5000 });
+    await expect(connectButton).toBeEnabled({ timeout: 5000 });
+    await connectButton.click();
+    const upsertResponse = await upsertResponsePromise;
+    expect(upsertResponse.ok()).toBeTruthy();
+
+    // Non-OAuth flow closes the modal in-place and triggers a tools fetch via
+    // onTriggerFetchTools (no hard navigation). Verify we land back on the
+    // MCP admin page with the server card visible and tools loadable.
+    await expect(
+      page.getByText(serverName, { exact: false }).first()
+    ).toBeVisible({ timeout: 20000 });
+
+    const refreshButton = page.getByRole("button", { name: "Refresh tools" });
+    await expect(refreshButton).toBeVisible({ timeout: 10000 });
+    await refreshButton.click();
+
+    await expect(page.getByText("No tools available")).not.toBeVisible({
+      timeout: 15000,
+    });
+  });
+
+  test("Admin attaches the MCP server to the default agent", async ({
+    page,
+  }) => {
+    test.skip(!serverId, "MCP server must be created first");
+
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+
+    await page.goto("/admin/configuration/chat-preferences");
+    await page.waitForURL("**/admin/configuration/chat-preferences**");
+
+    await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
+      timeout: 10000,
+    });
+
+    await scrollToBottom(page);
+
+    const serverCard = page
+      .locator(".opal-card-expandable")
+      .filter({ hasText: serverName })
+      .first();
+    await expect(serverCard).toBeVisible({ timeout: 10000 });
+    await serverCard.scrollIntoViewIfNeeded();
+
+    const serverSwitch = serverCard.getByRole("switch").first();
+    await expect(serverSwitch).toBeVisible({ timeout: 5000 });
+
+    const serverState = await serverSwitch.getAttribute("aria-checked");
+    if (serverState !== "true") {
+      await serverSwitch.click();
+      await expect(page.getByText("Tools updated").first()).toBeVisible({
+        timeout: 10000,
+      });
+    }
+  });
+
+  test("Basic user is prompted for every template field and can authenticate", async ({
+    page,
+  }) => {
+    test.skip(!serverId, "MCP server must be configured first");
+    test.skip(!basicUserEmail, "Basic user must be created first");
+
+    await page.context().clearCookies();
+    await apiLogin(page, basicUserEmail, basicUserPassword);
+
+    await page.goto("/app");
+    await page.waitForURL("**/app**");
+    await ensureOnboardingComplete(page);
+
+    const actionsButton = page.getByTestId("action-management-toggle");
+    await expect(actionsButton).toBeVisible({ timeout: 10000 });
+    await actionsButton.click();
+
+    const popover = page.locator('[data-testid="tool-options"]');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+
+    const serverLineItem = popover
+      .locator(".group\\/LineItem")
+      .filter({ hasText: serverName })
+      .first();
+    await expect(serverLineItem).toBeVisible({ timeout: 10000 });
+
+    // Clicking the line item before authenticating opens the auth modal
+    // (per-user, API_TOKEN, not yet authenticated).
+    await serverLineItem.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText(/Enter Credentials/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // === The actual regression check ===
+    // Both required fields must be rendered as inputs. Before the
+    // `required_fields` persistence fix, only `api_key` was shown and the
+    // user could submit without filling `username`, leaving the literal
+    // `{username}` in the X-Username header sent to the upstream server.
+    const apiKeyField = dialog.locator("input#api_key");
+    const usernameField = dialog.locator("input#username");
+    await expect(apiKeyField).toBeVisible({ timeout: 5000 });
+    await expect(usernameField).toBeVisible({ timeout: 5000 });
+
+    // The save button stays disabled until both fields are non-empty.
+    const saveButton = dialog.getByRole("button", {
+      name: /Save Credentials/i,
+    });
+    await expect(saveButton).toBeVisible({ timeout: 5000 });
+    await expect(saveButton).toBeDisabled();
+
+    await apiKeyField.fill(BASIC_USER_API_KEY);
+    await expect(saveButton).toBeDisabled();
+
+    await usernameField.fill(BASIC_USERNAME);
+    await expect(saveButton).toBeEnabled({ timeout: 5000 });
+
+    const credentialsResponsePromise = page.waitForResponse((resp) => {
+      try {
+        const url = new URL(resp.url());
+        return (
+          url.pathname === "/api/mcp/user-credentials" &&
+          resp.request().method() === "POST"
+        );
+      } catch {
+        return false;
+      }
+    });
+    await saveButton.click();
+    const credentialsResponse = await credentialsResponsePromise;
+    expect(credentialsResponse.ok()).toBeTruthy();
+
+    // The actions popover closes when the auth modal opens (Radix focus
+    // semantics), so after the modal closes there's no popover to re-acquire
+    // the line item from. Reopen it explicitly.
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    await actionsButton.click();
+    const reopenedPopover = page.locator('[data-testid="tool-options"]');
+    await expect(reopenedPopover).toBeVisible({ timeout: 5000 });
+
+    // Now that the user is authenticated, clicking the line item should drill
+    // into the tool list view (mcpView) rather than reopening the auth modal.
+    const refreshedServerLineItem = reopenedPopover
+      .locator(".group\\/LineItem")
+      .filter({ hasText: serverName })
+      .first();
+    await expect(refreshedServerLineItem).toBeVisible({ timeout: 10000 });
+    await refreshedServerLineItem.click();
+    await expect(
+      reopenedPopover.getByText(/(Enable|Disable) All/i).first()
+    ).toBeVisible({ timeout: 10000 });
+  });
+
+  test("Re-authenticate row exposes the multi-field modal with the same gating", async ({
+    page,
+  }) => {
+    test.skip(!serverId, "MCP server must be configured first");
+    test.skip(!basicUserEmail, "Basic user must be created first");
+
+    await page.context().clearCookies();
+    await apiLogin(page, basicUserEmail, basicUserPassword);
+
+    await page.goto("/app");
+    await page.waitForURL("**/app**");
+    await ensureOnboardingComplete(page);
+
+    const actionsButton = page.getByTestId("action-management-toggle");
+    await expect(actionsButton).toBeVisible({ timeout: 10000 });
+    await actionsButton.click();
+
+    const popover = page.locator('[data-testid="tool-options"]');
+    await expect(popover).toBeVisible({ timeout: 5000 });
+
+    const serverLineItem = popover
+      .locator(".group\\/LineItem")
+      .filter({ hasText: serverName })
+      .first();
+    await expect(serverLineItem).toBeVisible({ timeout: 10000 });
+
+    // Already authenticated from the previous test, so this drills into the
+    // tool list rather than opening the auth modal.
+    await serverLineItem.click();
+    await expect(
+      popover.getByText(/(Enable|Disable) All/i).first()
+    ).toBeVisible({ timeout: 10000 });
+
+    // The Re-Authenticate row is rendered as a footer line item inside the
+    // drilled-in tool list view (see `mcpFooter` in ActionsPopover/index.tsx).
+    const reauthRow = popover
+      .locator(".group\\/LineItem")
+      .filter({ hasText: /Re-Authenticate/i })
+      .first();
+    await expect(reauthRow).toBeVisible({ timeout: 5000 });
+    await reauthRow.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText(/Manage Credentials/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Both fields still rendered; gating still enforces "all-or-nothing".
+    const apiKeyField = dialog.locator("input#api_key");
+    const usernameField = dialog.locator("input#username");
+    await expect(apiKeyField).toBeVisible({ timeout: 5000 });
+    await expect(usernameField).toBeVisible({ timeout: 5000 });
+
+    const updateButton = dialog.getByRole("button", {
+      name: /Update Credentials/i,
+    });
+    await expect(updateButton).toBeVisible({ timeout: 5000 });
+
+    await apiKeyField.fill("");
+    await usernameField.fill("");
+    await expect(updateButton).toBeDisabled();
+
+    await apiKeyField.fill(BASIC_USER_API_KEY);
+    await expect(updateButton).toBeDisabled();
+
+    await usernameField.fill(BASIC_USERNAME);
+    await expect(updateButton).toBeEnabled({ timeout: 5000 });
+  });
+});

--- a/web/tests/e2e/utils/mcpServer.ts
+++ b/web/tests/e2e/utils/mcpServer.ts
@@ -212,6 +212,74 @@ export async function startMcpApiKeyServer(
 }
 
 /**
+ * Start the MCP per-user API key test server.
+ *
+ * Each request must carry an `Authorization: Bearer mcp_live-<key_id>-<secret>`
+ * header. When `requiredHeaders` is non-empty, every `/mcp/*` request must
+ * also carry those headers (non-empty values), exercising the multi-field
+ * per-user template flow in onyx.
+ *
+ * Pre-shared keys baked into the script:
+ *   - `mcp_live-kid_alice_001-S3cr3tAlice`
+ *   - `mcp_live-kid_bob_001-S3cr3tBob`
+ */
+export async function startMcpPerUserKeyServer(
+  options: StartServerOptions & { requiredHeaders?: string[] } = {}
+): Promise<McpServerProcess> {
+  const bindHost = options.bindHost || DEFAULT_BIND_HOST;
+  const publicHost = options.publicHost || DEFAULT_PUBLIC_HOST;
+  const port = options.port ?? 8007; // avoid clashing with other MCP test servers
+  const pythonBinary = options.pythonBinary || "python3";
+  const readyTimeout = options.readyTimeoutMs ?? READY_TIMEOUT_MS;
+  const requiredHeaders = options.requiredHeaders ?? [];
+
+  const scriptPath =
+    options.scriptPath ||
+    path.resolve(
+      __dirname,
+      "../../../..",
+      "backend/tests/integration/mock_services/mcp_test_server/run_mcp_server_per_user_key.py"
+    );
+  const scriptDir = path.dirname(scriptPath);
+
+  const requiredHeaderArgs = requiredHeaders.flatMap((header) => [
+    "--require-header",
+    header,
+  ]);
+  const proc = spawn(
+    pythonBinary,
+    [scriptPath, port.toString(), ...requiredHeaderArgs],
+    {
+      cwd: scriptDir,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        MCP_SERVER_PORT: port.toString(),
+        MCP_SERVER_HOST: bindHost,
+        MCP_SERVER_PUBLIC_HOST: publicHost,
+      },
+    }
+  );
+
+  proc.stdout.on("data", (chunk) => {
+    const message = chunk.toString();
+    console.log(`[mcp-per-user-key-server] ${message.trimEnd()}`);
+  });
+  proc.stderr.on("data", (chunk) => {
+    const message = chunk.toString();
+    console.error(`[mcp-per-user-key-server:stderr] ${message.trimEnd()}`);
+  });
+
+  proc.on("error", (err) => {
+    console.error("[mcp-per-user-key-server] failed to start", err);
+  });
+
+  await waitForPort(bindHost, port, proc, readyTimeout);
+
+  return new McpServerProcess(proc, bindHost, publicHost, port);
+}
+
+/**
  * Start the MCP Google OAuth Pass-Through test server.
  *
  * This server validates Google OAuth tokens that are passed through from Onyx.


### PR DESCRIPTION
Cherry-pick of commit 4f163ee17a12a44e8d3f4d1f0bbeeef74d086bba to release/v3.3 branch.

Original PR: #10995

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user MCP API key auth to support multiple header placeholders and require users to fill all required fields. Templates now persist `required_fields` and the backend auto-fills placeholders like `{user_email}`.

- **Bug Fixes**
  - Persist and derive `required_fields` from header templates; fall back for older servers on read.
  - Add `apply_auto_substitutions` and use it when building headers to auto-fill `{user_email}` and exclude it from prompts.
  - Update server upsert to store `required_fields` so the user modal correctly lists all fields; validate admin creds against multi-header templates.
  - Add a per-user MCP test server requiring an extra header, compose/CI wiring, and end-to-end tests that verify multi-field prompts and re-auth.

<sup>Written for commit 4c0ce44a9a071a07f2f1e49966518985079590b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

