### PR TITLE
fix(billing): update help URL to correct documentation path

### DIFF
--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -12,7 +12,7 @@ import { uploadLicense } from "@/lib/billing/svc";
 import { LicenseStatus } from "@/lib/billing/interfaces";
 import { formatDateShort } from "@/lib/dateUtils";
 
-const BILLING_HELP_URL = "https://docs.onyx.app/more/billing";
+const BILLING_HELP_URL = "https://docs.onyx.app/admins/billing/overview";
 
 interface LicenseActivationCardProps {
   isOpen: boolean;


### PR DESCRIPTION
## Description

Update the billing help URL from the old path (`/more/billing`) to the correct documentation path (`/admins/billing/overview`).

## How Has This Been Tested?

Verified the new URL points to the correct documentation page.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the billing help link in `LicenseActivationCard` by updating the URL from `/more/billing` to `/admins/billing/overview` so users land on the correct documentation.

<sup>Written for commit 5175a6f5524d49fffd4bfd6f79ddd6a562c466a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

