### PR TITLE
refactor: better copy PAT button in creation modal

### DIFF
--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import {
   SvgArrowExchange,
+  SvgCopy,
   SvgKey,
   SvgLock,
   SvgMinusCircle,
@@ -48,6 +49,7 @@ import { ValidSources } from "@/lib/types";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
 import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
+import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import Code from "@/refresh-components/Code";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import { InputPrompt } from "@/app/app/interfaces";
@@ -105,6 +107,39 @@ function PATModal({
   onCreate,
   createdToken,
 }: PATModalProps) {
+  if (createdToken?.token) {
+    return (
+      <Modal open onOpenChange={(open) => !open && onClose()}>
+        <Modal.Content width="sm" height="sm">
+          <Modal.Header
+            title="Access Token"
+            icon={SvgKey}
+            onClose={onClose}
+            description="Save this token before continuing. It won't be shown again."
+          />
+          <Modal.Body>
+            <Code showCopyButton={false}>{createdToken.token}</Code>
+          </Modal.Body>
+          <Modal.Footer>
+            <BasicModalFooter
+              submit={
+                <Button
+                  icon={SvgCopy}
+                  onClick={() => {
+                    navigator.clipboard.writeText(createdToken.token);
+                    toast.success("Token copied to clipboard.");
+                  }}
+                >
+                  Copy Token
+                </Button>
+              }
+            />
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+    );
+  }
+
   return (
     <ConfirmationModalLayout
       icon={SvgKey}
@@ -112,73 +147,57 @@ function PATModal({
       description="All API requests using this token will inherit your access permissions and be attributed to you as an individual."
       onClose={onClose}
       submit={
-        !!createdToken?.token ? (
-          <Button onClick={onClose}>Done</Button>
-        ) : (
-          <Button
-            disabled={isCreating || !newTokenName.trim()}
-            onClick={onCreate}
-          >
-            {isCreating ? "Creating Token..." : "Create Token"}
-          </Button>
-        )
+        <Button
+          disabled={isCreating || !newTokenName.trim()}
+          onClick={onCreate}
+        >
+          {isCreating ? "Creating Token..." : "Create Token"}
+        </Button>
       }
-      hideCancel={!!createdToken}
     >
       <Section gap={1}>
-        {/* Token Creation*/}
-        {!!createdToken?.token ? (
-          <InputVertical title="Token Value" withLabel>
-            <Code>{createdToken.token}</Code>
-          </InputVertical>
-        ) : (
-          <>
-            <InputVertical title="Token Name" withLabel>
-              <InputTypeIn
-                placeholder="Name your token"
-                value={newTokenName}
-                onChange={(e) => setNewTokenName(e.target.value)}
-                variant={isCreating ? "disabled" : undefined}
-                autoComplete="new-password"
-              />
-            </InputVertical>
-            <InputVertical
-              title="Expires in"
-              subDescription={
-                expirationDays === "null"
-                  ? undefined
-                  : (() => {
-                      const expiryDate = new Date();
-                      expiryDate.setUTCDate(
-                        expiryDate.getUTCDate() + parseInt(expirationDays)
-                      );
-                      expiryDate.setUTCHours(23, 59, 59, 999);
-                      return `This token will expire at: ${expiryDate
-                        .toISOString()
-                        .replace("T", " ")
-                        .replace(".999Z", " UTC")}`;
-                    })()
-              }
-              withLabel
-            >
-              <InputSelect
-                value={expirationDays}
-                onValueChange={setExpirationDays}
-                disabled={isCreating}
-              >
-                <InputSelect.Trigger placeholder="Select expiration" />
-                <InputSelect.Content>
-                  <InputSelect.Item value="7">7 days</InputSelect.Item>
-                  <InputSelect.Item value="30">30 days</InputSelect.Item>
-                  <InputSelect.Item value="365">365 days</InputSelect.Item>
-                  <InputSelect.Item value="null">
-                    No expiration
-                  </InputSelect.Item>
-                </InputSelect.Content>
-              </InputSelect>
-            </InputVertical>
-          </>
-        )}
+        <InputVertical title="Token Name" withLabel>
+          <InputTypeIn
+            placeholder="Name your token"
+            value={newTokenName}
+            onChange={(e) => setNewTokenName(e.target.value)}
+            variant={isCreating ? "disabled" : undefined}
+            autoComplete="new-password"
+          />
+        </InputVertical>
+        <InputVertical
+          title="Expires in"
+          subDescription={
+            expirationDays === "null"
+              ? undefined
+              : (() => {
+                  const expiryDate = new Date();
+                  expiryDate.setUTCDate(
+                    expiryDate.getUTCDate() + parseInt(expirationDays)
+                  );
+                  expiryDate.setUTCHours(23, 59, 59, 999);
+                  return `This token will expire at: ${expiryDate
+                    .toISOString()
+                    .replace("T", " ")
+                    .replace(".999Z", " UTC")}`;
+                })()
+          }
+          withLabel
+        >
+          <InputSelect
+            value={expirationDays}
+            onValueChange={setExpirationDays}
+            disabled={isCreating}
+          >
+            <InputSelect.Trigger placeholder="Select expiration" />
+            <InputSelect.Content>
+              <InputSelect.Item value="7">7 days</InputSelect.Item>
+              <InputSelect.Item value="30">30 days</InputSelect.Item>
+              <InputSelect.Item value="365">365 days</InputSelect.Item>
+              <InputSelect.Item value="null">No expiration</InputSelect.Item>
+            </InputSelect.Content>
+          </InputSelect>
+        </InputVertical>
       </Section>
     </ConfirmationModalLayout>
   );

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -14,7 +14,6 @@ import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import {
   SvgArrowExchange,
-  SvgCopy,
   SvgKey,
   SvgLock,
   SvgMinusCircle,
@@ -51,6 +50,7 @@ import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import Code from "@/refresh-components/Code";
+import CopyIconButton from "@/refresh-components/buttons/CopyIconButton";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import { InputPrompt } from "@/app/app/interfaces";
 import usePromptShortcuts from "@/hooks/usePromptShortcuts";
@@ -123,15 +123,12 @@ function PATModal({
           <Modal.Footer>
             <BasicModalFooter
               submit={
-                <Button
-                  icon={SvgCopy}
-                  onClick={() => {
-                    navigator.clipboard.writeText(createdToken.token);
-                    toast.success("Token copied to clipboard.");
-                  }}
+                <CopyIconButton
+                  getCopyText={() => createdToken.token}
+                  prominence="primary"
                 >
                   Copy Token
-                </Button>
+                </CopyIconButton>
               }
             />
           </Modal.Footer>

--- a/web/tests/e2e/auth/pat_management.spec.ts
+++ b/web/tests/e2e/auth/pat_management.spec.ts
@@ -69,7 +69,7 @@ test("PAT Complete Workflow", async ({ page }, testInfo) => {
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 
   // Copy the newly created token via the footer "Copy Token" button
-  await page.locator('button:has-text("Copy Token")').first().click();
+  await page.getByRole("button", { name: "Copy Token" }).click();
 
   // Wait a moment for clipboard to be written and verify
   await page.waitForTimeout(500);

--- a/web/tests/e2e/auth/pat_management.spec.ts
+++ b/web/tests/e2e/auth/pat_management.spec.ts
@@ -68,8 +68,8 @@ test("PAT Complete Workflow", async ({ page }, testInfo) => {
   // Grant clipboard permissions before copying
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
 
-  // Copy the newly created token (button is inside .code-copy-button)
-  await page.locator(".code-copy-button button").click();
+  // Copy the newly created token via the footer "Copy Token" button
+  await page.locator('button:has-text("Copy Token")').first().click();
 
   // Wait a moment for clipboard to be written and verify
   await page.waitForTimeout(500);
@@ -78,7 +78,8 @@ test("PAT Complete Workflow", async ({ page }, testInfo) => {
   );
   expect(clipboardText).toBe(tokenValue);
 
-  await page.locator('button:has-text("Done")').first().click();
+  // Close the modal
+  await page.keyboard.press("Escape");
   await expect(page.getByText(tokenName).first()).toBeVisible({
     timeout: 5000,
   });
@@ -198,8 +199,8 @@ test("PAT Multiple Tokens Management", async ({ page }, testInfo) => {
       .first()
       .waitFor({ state: "visible", timeout: 5000 });
 
-    // Close the modal by clicking "Done"
-    await page.locator('button:has-text("Done")').first().click();
+    // Close the modal
+    await page.keyboard.press("Escape");
 
     // Wait for token to appear in the list
     await expect(page.getByText(token.name).first()).toBeVisible({


### PR DESCRIPTION
## Description
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved the PAT creation flow by moving the generated token into a focused modal with a clear “Copy Token” action. This makes copying explicit and clarifies the token won’t be shown again.

- **New Features**
  - Show the token in a dedicated `Modal` with a warning that it won’t be shown again; hide the inline code block copy control.
  - Add a footer “Copy Token” button using `CopyIconButton` with clipboard write and toast feedback.

- **Refactors**
  - Simplified the creation modal to only include name/expiry and a “Create Token” button; removed “Done”. Close via Escape or the header close icon.
  - Updated e2e tests to click “Copy Token” and close the modal with Escape.

<sup>Written for commit 6cac56ab1bc525303b411e308c8904a34e5fda4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



