### PR TITLE
fix: truncate tool-call results exceeding MAX_TOOL_RESULT_TOKENS

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -25,6 +25,7 @@ from onyx.chat.prompt_utils import build_system_prompt
 from onyx.chat.prompt_utils import get_default_base_system_prompt
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.chat_configs import MAX_LLM_CYCLES
+from onyx.configs.chat_configs import MAX_TOOL_RESULT_TOKENS
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
@@ -623,6 +624,29 @@ def _create_context_files_message(
     )
 
 
+def _truncate_tool_result(
+    result: str,
+    token_counter: Callable[[str], int],
+    max_tokens: int,
+) -> str:
+    token_count = token_counter(result)
+    if token_count <= max_tokens:
+        return result
+    # Binary-search for the longest prefix that fits within max_tokens.
+    lo, hi = 0, len(result)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if token_counter(result[:mid]) <= max_tokens:
+            lo = mid
+        else:
+            hi = mid - 1
+    truncated = result[:lo]
+    return (
+        truncated
+        + f"\n\n[TRUNCATED: response was {token_count} tokens, showing first {max_tokens}]"
+    )
+
+
 def run_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,
@@ -1139,7 +1163,11 @@ def run_llm_loop(
                     tc = tool_response.tool_call
                     assert tc is not None  # Already filtered above
 
-                    tool_response_message = tool_response.llm_facing_response
+                    tool_response_message = _truncate_tool_result(
+                        tool_response.llm_facing_response,
+                        token_counter,
+                        MAX_TOOL_RESULT_TOKENS,
+                    )
                     tool_response_token_count = token_counter(tool_response_message)
 
                     tool_response_msg = ChatMessageSimple(

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -70,3 +70,8 @@ COMPRESSION_TRIGGER_RATIO = float(os.environ.get("COMPRESSION_TRIGGER_RATIO", "0
 SKIP_DEEP_RESEARCH_CLARIFICATION = (
     os.environ.get("SKIP_DEEP_RESEARCH_CLARIFICATION", "false").lower() == "true"
 )
+
+# Maximum tokens allowed per tool-call result before it is truncated.
+# Prevents oversized MCP / custom-tool responses from blowing the context window.
+# Mirrors MAX_MCP_OUTPUT_TOKENS used by Claude Code. Override via env var.
+MAX_TOOL_RESULT_TOKENS: int = int(os.environ.get("MAX_TOOL_RESULT_TOKENS") or 20_000)


### PR DESCRIPTION
**Problem:**

**Closes 11007**

Large MCP/custom-tool responses are appended verbatim into the LLM message history with no token size guard. On verbose MCP servers (Figma, web-scrape, etc.) this blows the model's context window and causes a provider error.

 **Root cause**

`run_llm_loop` in `backend/onyx/chat/llm_loop.py` appends `tool_response.llm_facing_response` directly to `simple_chat_history` with no budget check.

 **Fix**

- Added `_truncate_tool_result()` in `llm_loop.py` that binary-searches for the longest character prefix whose token count stays within `MAX_TOOL_RESULT_TOKENS`. A `[TRUNCATED: ...]` suffix is appended so the model knows data was cut.
- Added `MAX_TOOL_RESULT_TOKENS` (default 20 000, env-overridable via `MAX_TOOL_RESULT_TOKENS` env var) to `backend/onyx/configs/chat_configs.py`.

 **Precedent**

This mirrors `MAX_MCP_OUTPUT_TOKENS` used by Claude Code and is the approach recommended in the Figma MCP server docs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncates oversized MCP/custom-tool responses before adding them to the LLM conversation to prevent context overflows and provider errors. Fixes Linear 11007 by enforcing a per-result token budget and marking truncated outputs.

- **Bug Fixes**
  - Add _truncate_tool_result and apply it in run_llm_loop to cap tool-call results and append a [TRUNCATED: ...] marker.
  - Introduce MAX_TOOL_RESULT_TOKENS (default 20,000; env overridable) to limit per-result tokens, mirroring the MAX_MCP_OUTPUT_TOKENS precedent.

<sup>Written for commit 04189bb9ddf65faabbbebcfe03a64cb1b8451ec4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

