### PR TITLE
feat(llm): use Bifrost normalized_name for display names

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1638,7 +1638,10 @@ def get_bifrost_available_models(
     for model in models:
         try:
             model_id = model.get("id", "")
-            model_name = model.get("name", model_id)
+            # Prefer Bifrost's `normalized_name` (e.g. "Claude Sonnet 4.5"),
+            # which is only populated for models in its pricing catalog;
+            # fall back to the OpenAI-compatible `name`, then the raw id.
+            model_name = model.get("normalized_name") or model.get("name") or model_id
 
             if not model_id:
                 continue

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -994,6 +994,42 @@ class TestGetBifrostAvailableModels:
             called_url = mock_get.call_args[0][0]
             assert called_url == "https://bifrost.example.com/v1/models"
 
+    def test_prefers_normalized_name_for_display_name(self) -> None:
+        """Bifrost's `normalized_name` (pricing-catalog-derived) wins over `name`."""
+        from onyx.server.manage.llm.api import get_bifrost_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "id": "anthropic/claude-sonnet-4-5",
+                    "name": "claude-sonnet-4-5",
+                    "normalized_name": "Claude Sonnet 4.5",
+                },
+                {
+                    "id": "openai/gpt-4o",
+                    "name": "GPT-4o",
+                },
+                {
+                    "id": "some/custom-model",
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = BifrostModelsRequest(api_base="https://bifrost.example.com")
+            results = get_bifrost_available_models(request, MagicMock(), mock_session)
+
+            by_name = {r.name: r.display_name for r in results}
+            assert by_name["anthropic/claude-sonnet-4-5"] == "Claude Sonnet 4.5"
+            assert by_name["openai/gpt-4o"] == "GPT-4o"
+            assert by_name["some/custom-model"] == "some/custom-model"
+
     def test_request_failure_is_logged_and_wrapped(self) -> None:
         """Test that request-layer failures are logged before raising OnyxError."""
         from onyx.server.manage.llm.api import get_bifrost_available_models


### PR DESCRIPTION
## Description

[Bifrost recently added](https://github.com/maximhq/bifrost/pull/3372) a `normalized_name` field to its `GET /v1/models` response — it turns raw model slugs like `claude-sonnet-4-5` into human-readable names like `Claude Sonnet 4.5`. The field is only populated for models in Bifrost's pricing catalog (`omitempty` otherwise).

Prefer `normalized_name` when present, falling back to the OpenAI-compatible `name` field, then the raw `id`. The fallback chain keeps older Bifrost versions and models outside the pricing catalog working with the same display names they had before.

Existing rows in the DB are preserved by `sync_model_configurations` (only inserts new models), so users won't see previously-saved models silently rename themselves after a Bifrost upgrade — only newly-added models pick up the pretty name.

## How Has This Been Tested?

Added `test_prefers_normalized_name_for_display_name` to `TestGetBifrostAvailableModels` covering the full fallback chain (normalized_name present → name → id). Ran the full Bifrost test class — 5/5 pass:

```
pytest backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py::TestGetBifrostAvailableModels
```

The existing `test_returns_model_list` fixture has no `normalized_name` anywhere and still passes, which serves as the regression check for old Bifrost responses.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show human-readable model names from Bifrost when available. Keeps compatibility with older Bifrost versions and avoids renaming existing saved models.

- **New Features**
  - Use normalized_name > name > id from /v1/models when building display names.
  - Added unit test covering the fallback chain; existing fixtures without normalized_name still pass.

<sup>Written for commit 6067feddbdabb9fb79c1094ab57857ea15223e24. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

