### PR TITLE
refactor(web): migrate ActionsPopover to LineItemButton

### DIFF
--- a/web/lib/opal/src/components/buttons/line-item-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/line-item-button/components.tsx
@@ -26,6 +26,7 @@ type LineItemButtonOwnProps = Pick<
   | "group"
   | "ref"
   | "type"
+  | "disabled"
 > & {
   /** Interactive select variant. @default "select-light" */
   selectVariant?: "select-light" | "select-heavy";
@@ -59,7 +60,8 @@ function LineItemButton({
   target,
   group,
   ref,
-  type = "button",
+  type,
+  disabled = false,
 
   // Sizing
   rounding = "md",
@@ -80,6 +82,7 @@ function LineItemButton({
       target={target}
       group={group}
       ref={ref}
+      disabled={disabled}
     >
       <Interactive.Container
         type={type}

--- a/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/ActionLineItem.tsx
@@ -5,19 +5,16 @@ import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
 import { ToolSnapshot } from "@/lib/tools/interfaces";
 import { getIconForAction } from "@/app/app/services/actionUtils";
 import { ToolAuthStatus } from "@/lib/hooks/useToolOAuthStatus";
-import LineItem from "@/refresh-components/buttons/LineItem";
-import { Tooltip } from "@opal/components";
-import IconButton from "@/refresh-components/buttons/IconButton";
-import { Button } from "@opal/components";
+import { Button, LineItemButton } from "@opal/components";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
+import { markdown } from "@opal/utils";
 import type { IconProps } from "@opal/types";
 import { SvgChevronRight, SvgKey, SvgSettings, SvgSlash } from "@opal/icons";
 import { useProjectsContext } from "@/providers/ProjectsContext";
-import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import EnabledCount from "@/refresh-components/EnabledCount";
 import { Section } from "@/layouts/general-layouts";
+import { Hoverable } from "@opal/core";
 
 export interface ActionItemProps {
   tool?: ToolSnapshot;
@@ -37,7 +34,6 @@ export interface ActionItemProps {
   toolAuthStatus?: ToolAuthStatus;
   onOAuthAuthenticate?: () => void;
   onClose?: () => void;
-  // Source counts for internal search tool
   sourceCounts?: { enabled: number; total: number };
 }
 
@@ -61,7 +57,6 @@ export default function ActionLineItem({
   onClose,
   sourceCounts,
 }: ActionItemProps) {
-  const router = useRouter();
   const { currentProjectId } = useProjectsContext();
 
   const Icon = tool ? getIconForAction(tool) : ProvidedIcon!;
@@ -80,7 +75,6 @@ export default function ActionLineItem({
   const isSearchToolAndNotInProject =
     tool?.in_code_tool_id === SEARCH_TOOL_ID && !currentProjectId;
 
-  // Show source count when: internal search is pinned, has some (but not all) sources enabled
   const shouldShowSourceCount =
     isSearchToolAndNotInProject &&
     !isSearchToolWithNoConnectors &&
@@ -92,9 +86,12 @@ export default function ActionLineItem({
   const tooltipText = tooltip || tool?.description;
 
   return (
-    <Tooltip tooltip={tooltipText}>
-      <LineItem
-        data-testid={`tool-option-${toolName}`}
+    <Hoverable.Root group="action-row" data-testid={`tool-option-${toolName}`}>
+      <LineItemButton
+        sizePreset="main-ui"
+        variant="section"
+        rounding="sm"
+        center
         onClick={() => {
           if (isUnavailable) {
             onForceToggle();
@@ -106,11 +103,15 @@ export default function ActionLineItem({
             onSourceManagementOpen?.();
           else onClose?.();
         }}
-        selected={isForced}
+        state={isForced ? "selected" : "empty"}
         disabled={isSearchToolWithNoConnectors || (isUnavailable && !isForced)}
-        muted={isUnavailable && isForced}
-        strikethrough={disabled}
+        color={
+          disabled || (isUnavailable && isForced) ? "muted" : "interactive"
+        }
+        title={disabled ? markdown(`~~${label}~~`) : label}
         icon={Icon}
+        tooltip={tooltipText}
+        tooltipSide="right"
         rightChildren={
           <Section gap={0.25} flexDirection="row">
             {!isUnavailable && tool?.oauth_config_id && toolAuthStatus && (
@@ -129,55 +130,61 @@ export default function ActionLineItem({
               />
             )}
 
-            {!isSearchToolWithNoConnectors && !isUnavailable && (
-              // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
-              <IconButton
-                icon={SvgSlash}
-                onClick={noProp(onToggle)}
-                internal
-                aria-label={disabled ? "Enable" : "Disable"}
-                className={cn(
-                  !disabled && "invisible group-hover/LineItem:visible",
-                  // Hide when showing source count (it has its own hover behavior)
-                  shouldShowSourceCount && "!hidden"
-                )}
-                tooltip={disabled ? "Enable" : "Disable"}
-              />
-            )}
+            {!isSearchToolWithNoConnectors &&
+              !isUnavailable &&
+              !shouldShowSourceCount &&
+              (disabled ? (
+                <Button
+                  icon={SvgSlash}
+                  onClick={noProp(onToggle)}
+                  prominence="internal"
+                  size="sm"
+                  aria-label="Enable"
+                  tooltip="Enable"
+                />
+              ) : (
+                <Hoverable.Item group="action-row" variant="appear-on-hover">
+                  <Button
+                    icon={SvgSlash}
+                    onClick={noProp(onToggle)}
+                    prominence="internal"
+                    size="sm"
+                    aria-label="Disable"
+                    tooltip="Disable"
+                  />
+                </Hoverable.Item>
+              ))}
 
             {isUnavailable && showAdminConfigure && adminConfigureHref && (
               <Button
                 icon={SvgSettings}
-                onClick={noProp(() => {
-                  router.push(adminConfigureHref as Route);
-                  onClose?.();
-                })}
+                href={adminConfigureHref as Route}
                 prominence="tertiary"
                 size="sm"
                 tooltip={adminConfigureTooltip}
               />
             )}
 
-            {/* Source count for internal search - show when some but not all sources selected AND tool is pinned */}
             {shouldShowSourceCount && (
-              <span className="relative flex items-center whitespace-nowrap">
-                {/* Show count normally, disable icon on hover - both in same space */}
-                <span className="group-hover/LineItem:invisible">
+              <div className="relative flex items-center whitespace-nowrap">
+                <Hoverable.Item group="action-row" variant="appear-on-rest">
                   <EnabledCount
                     enabledCount={sourceCounts.enabled}
                     totalCount={sourceCounts.total}
                   />
-                </span>
-                <span className="absolute inset-0 flex items-center justify-center invisible group-hover/LineItem:visible">
-                  <Button
-                    icon={SvgSlash}
-                    onClick={noProp(onToggle)}
-                    prominence="tertiary"
-                    size="sm"
-                    tooltip={disabled ? "Enable" : "Disable"}
-                  />
-                </span>
-              </span>
+                </Hoverable.Item>
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <Hoverable.Item group="action-row" variant="appear-on-hover">
+                    <Button
+                      icon={SvgSlash}
+                      onClick={noProp(onToggle)}
+                      prominence="tertiary"
+                      size="sm"
+                      tooltip="Disable"
+                    />
+                  </Hoverable.Item>
+                </div>
+              </div>
             )}
 
             {isSearchToolAndNotInProject && (
@@ -190,11 +197,16 @@ export default function ActionLineItem({
                 icon={
                   isSearchToolWithNoConnectors ? SvgSettings : SvgChevronRight
                 }
-                onClick={noProp(() => {
-                  if (isSearchToolWithNoConnectors)
-                    router.push("/admin/add-connector");
-                  else onSourceManagementOpen?.();
-                })}
+                href={
+                  isSearchToolWithNoConnectors
+                    ? ("/admin/add-connector" as Route)
+                    : undefined
+                }
+                onClick={
+                  isSearchToolWithNoConnectors
+                    ? undefined
+                    : noProp(onSourceManagementOpen)
+                }
                 prominence="tertiary"
                 size="sm"
                 tooltip={
@@ -206,9 +218,7 @@ export default function ActionLineItem({
             )}
           </Section>
         }
-      >
-        {label}
-      </LineItem>
-    </Tooltip>
+      />
+    </Hoverable.Root>
   );
 }

--- a/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/MCPLineItem.tsx
@@ -6,10 +6,9 @@ import {
   MCPAuthenticationPerformer,
   ToolSnapshot,
 } from "@/lib/tools/interfaces";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import { noProp } from "@/lib/utils";
-import { cn } from "@opal/utils";
+import { cn, markdown } from "@opal/utils";
 import type { IconProps } from "@opal/types";
 import {
   SvgCheck,
@@ -19,7 +18,7 @@ import {
   SvgServer,
 } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
-import { Button } from "@opal/components";
+import { Button, LineItemButton } from "@opal/components";
 import EnabledCount from "@/refresh-components/EnabledCount";
 
 export interface MCPServer {
@@ -95,44 +94,48 @@ export default function MCPLineItem({
   const allToolsDisabled = enabledTools.length === 0 && tools.length > 0;
 
   return (
-    <LineItem
-      data-mcp-server-id={server.id}
-      data-mcp-server-name={server.name}
-      icon={getServerIcon()}
-      onClick={handleClick}
-      strikethrough={allToolsDisabled}
-      selected={isActive}
-      rightChildren={
-        <Section gap={0.25} flexDirection="row">
-          {isAuthenticated &&
-            tools.length > 0 &&
-            enabledTools.length > 0 &&
-            tools.length !== enabledTools.length && (
-              <EnabledCount
-                enabledCount={enabledTools.length}
-                totalCount={tools.length}
+    <div data-mcp-server-id={server.id} data-mcp-server-name={server.name}>
+      <LineItemButton
+        sizePreset="main-ui"
+        variant="section"
+        rounding="sm"
+        center
+        icon={getServerIcon()}
+        onClick={handleClick}
+        state={isActive ? "selected" : "empty"}
+        color={allToolsDisabled ? "muted" : "interactive"}
+        tooltipSide="right"
+        title={allToolsDisabled ? markdown(`~~${server.name}~~`) : server.name}
+        rightChildren={
+          <Section gap={0.25} flexDirection="row">
+            {isAuthenticated &&
+              tools.length > 0 &&
+              enabledTools.length > 0 &&
+              tools.length !== enabledTools.length && (
+                <EnabledCount
+                  enabledCount={enabledTools.length}
+                  totalCount={tools.length}
+                />
+              )}
+            {canClickIntoServer && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                size="sm"
+                onClick={onSelect}
               />
             )}
-          {canClickIntoServer && (
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              size="sm"
-              onClick={onSelect}
-            />
-          )}
-          {showReauthButton && (
-            <Button
-              icon={SvgKey}
-              prominence="tertiary"
-              size="sm"
-              onClick={onAuthenticate}
-            />
-          )}
-        </Section>
-      }
-    >
-      {server.name}
-    </LineItem>
+            {showReauthButton && (
+              <Button
+                icon={SvgKey}
+                prominence="tertiary"
+                size="sm"
+                onClick={onAuthenticate}
+              />
+            )}
+          </Section>
+        }
+      />
+    </div>
   );
 }

--- a/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/SwitchList.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { Button } from "@opal/components";
+import { Button, LineItemButton } from "@opal/components";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { PopoverMenu } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import type { IconProps } from "@opal/types";
-import { Tooltip } from "@opal/components";
 import Switch from "@/refresh-components/inputs/Switch";
 import { SvgChevronLeft, SvgPlug, SvgUnplug } from "@opal/icons";
 
@@ -78,40 +76,45 @@ export default function SwitchList({
           />
         </div>,
 
-        <LineItem
+        <LineItemButton
           key="enable-disable-all"
+          sizePreset="main-ui"
+          variant="section"
+          rounding="sm"
+          center
           icon={allDisabled ? SvgPlug : SvgUnplug}
           onClick={allDisabled ? onEnableAll : onDisableAll}
-        >
-          {allDisabled ? "Enable All" : "Disable All"}
-        </LineItem>,
+          title={allDisabled ? "Enable All" : "Disable All"}
+        />,
 
         ...filteredItems.map((item) => {
           const tooltip = item.disabled
             ? item.disabledTooltip
             : item.description;
           return (
-            <Tooltip key={item.id} tooltip={tooltip}>
-              <LineItem
-                icon={
-                  item.leading
-                    ? ((() =>
-                        item.leading) as React.FunctionComponent<IconProps>)
-                    : undefined
-                }
-                strokeIcon={false}
-                rightChildren={
-                  <Switch
-                    checked={item.isEnabled}
-                    onCheckedChange={item.onToggle}
-                    aria-label={`Toggle ${item.label}`}
-                    disabled={item.disabled}
-                  />
-                }
-              >
-                {item.label}
-              </LineItem>
-            </Tooltip>
+            <LineItemButton
+              key={item.id}
+              sizePreset="main-ui"
+              variant="section"
+              rounding="sm"
+              center
+              tooltip={tooltip}
+              tooltipSide="right"
+              icon={
+                item.leading
+                  ? ((() => item.leading) as React.FunctionComponent<IconProps>)
+                  : undefined
+              }
+              title={item.label}
+              rightChildren={
+                <Switch
+                  checked={item.isEnabled}
+                  onCheckedChange={item.onToggle}
+                  aria-label={`Toggle ${item.label}`}
+                  disabled={item.disabled}
+                />
+              }
+            />
           );
         }),
       ]}

--- a/web/src/refresh-components/popovers/ActionsPopover/index.tsx
+++ b/web/src/refresh-components/popovers/ActionsPopover/index.tsx
@@ -9,7 +9,7 @@ import {
   WEB_SEARCH_TOOL_ID,
 } from "@/app/app/components/tools/constants";
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
-import { Popover, PopoverMenu } from "@opal/components";
+import { Button, LineItemButton, Popover, PopoverMenu } from "@opal/components";
 import SwitchList, {
   SwitchListItem,
 } from "@/refresh-components/popovers/ActionsPopover/SwitchList";
@@ -34,7 +34,6 @@ import { useLLMProviders } from "@/hooks/useLanguageModels";
 import { useVectorDbEnabled } from "@/providers/SettingsProvider";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { useToolOAuthStatus } from "@/lib/hooks/useToolOAuthStatus";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import ActionLineItem from "@/refresh-components/popovers/ActionsPopover/ActionLineItem";
 import MCPLineItem, {
@@ -42,7 +41,6 @@ import MCPLineItem, {
 } from "@/refresh-components/popovers/ActionsPopover/MCPLineItem";
 import { useProjectsContext } from "@/providers/ProjectsContext";
 import { SvgActions, SvgChevronRight, SvgKey, SvgSliders } from "@opal/icons";
-import { Button } from "@opal/components";
 
 function buildTooltipMessage(
   actionDescription: string,
@@ -714,15 +712,19 @@ export default function ActionsPopover({
   };
 
   const mcpFooter = showActiveReauthRow ? (
-    <LineItem
+    <LineItemButton
+      sizePreset="main-ui"
+      variant="section"
+      rounding="sm"
+      center
+      tooltipSide="right"
       onClick={handleFooterReauthClick}
       icon={selectedMcpServerData?.isLoading ? SimpleLoader : SvgKey}
+      title="Re-Authenticate"
       rightChildren={
         <Button icon={SvgChevronRight} prominence="tertiary" size="sm" />
       }
-    >
-      Re-Authenticate
-    </LineItem>
+    />
   ) : undefined;
 
   const configuredSources = getConfiguredSources(effectiveAvailableSources);
@@ -923,9 +925,17 @@ export default function ActionsPopover({
         null,
 
         (isAdmin || isCurator) && (
-          <LineItem href="/admin/actions" icon={SvgActions} key="more-actions">
-            More Actions
-          </LineItem>
+          <LineItemButton
+            key="more-actions"
+            sizePreset="main-ui"
+            variant="section"
+            rounding="sm"
+            center
+            tooltipSide="right"
+            href="/admin/actions"
+            icon={SvgActions}
+            title="More Actions"
+          />
         ),
       ]}
     </PopoverMenu>


### PR DESCRIPTION
## Description

Migrates all `LineItem` usages in `ActionsPopover/` to `LineItemButton` from `@opal/components`, and cleans up several related issues along the way:

- Replaces `LineItem` with `LineItemButton` across `ActionLineItem`, `MCPLineItem`, `SwitchList`, and `index.tsx`
- Adds `disabled` prop to `LineItemButton` and removes the `type="button"` default on `Interactive.Container` — fixing a nested-button HTML validity bug where inner `Button` elements were being ejected by the browser
- Migrates `IconButton` usages to Opal `Button`
- Replaces Tailwind `group-hover` span logic with `Hoverable.Root` / `Hoverable.Item` from `@opal/core` for CSS-driven hover-reveal
- Converts `router.push()` navigation buttons to `href` props (renders as `<a>` tags)
- Adds `rounding="sm"`, `center`, and `tooltipSide="right"` for consistent styling

## How Has This Been Tested?

Manually tested in the browser via the Actions popover — verified tool toggle, hover-reveal disable button, source count display, MCP server rows, SwitchList, and admin configure navigation.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates Actions popover rows to `LineItemButton` for consistent UI and cleaner interactions. Also fixes invalid nested-button markup so inner controls render correctly.

- **Refactors**
  - Replaced `LineItem` with `LineItemButton` in `ActionLineItem`, `MCPLineItem`, `SwitchList`, and `index` under ActionsPopover.
  - Exposed `disabled` on `LineItemButton` and removed the default `type="button"` to avoid nested button issues.
  - Swapped `IconButton` for `Button` from `@opal/components`.
  - Moved hover-reveal to `Hoverable.Root` / `Hoverable.Item` from `@opal/core`; removed Tailwind `group-hover` logic.
  - Converted `router.push` actions to `href` links where appropriate.
  - Unified styling: `sizePreset="main-ui"`, `variant="section"`, `rounding="sm"`, `center`, `tooltipSide="right"`.

- **Bug Fixes**
  - Resolved nested-button HTML validity so inner buttons (e.g., disable toggles) are no longer stripped by the browser.

<sup>Written for commit 46f14a3a0eef925a7b3aae2b79a0b27c98feaf77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

