### PR TITLE
feat(indexing): add Cohere embed-v4.0 with response-format compat

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -42,6 +42,11 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_embed_english_light_v3_0",
     ),
     _BaseEmbeddingModel(
+        name="cohere/embed-v4.0",
+        dim=1536,
+        index_name="danswer_chunk_cohere_embed_v4_0",
+    ),
+    _BaseEmbeddingModel(
         name="openai/text-embedding-3-large",
         dim=3072,
         index_name="danswer_chunk_openai_text_embedding_3_large",

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -250,6 +250,25 @@ def format_embedding_error(
     )
 
 
+def _extract_cohere_embeddings(response_embeddings: Any) -> list[Embedding]:
+    """Normalize Cohere's embed response across SDK versions.
+
+    v3 models return ``response.embeddings`` as a flat ``list[list[float]]``.
+    v4 models return an ``EmbedByTypeResponseEmbeddings`` object that carries
+    the embeddings under ``float_`` (and possibly other per-type buckets when
+    ``embedding_types`` is set). We always read the float bucket here since
+    we never request alternate types.
+    """
+    if isinstance(response_embeddings, list):
+        return cast(list[Embedding], response_embeddings)
+
+    float_embeddings = getattr(response_embeddings, "float_", None)
+    if isinstance(float_embeddings, list):
+        return cast(list[Embedding], float_embeddings)
+
+    raise RuntimeError("Unsupported Cohere embedding response format.")
+
+
 # Custom exception for authentication errors
 class AuthenticationError(Exception):
     """Raised when authentication fails with a provider."""
@@ -322,7 +341,7 @@ class CloudEmbedding:
                 input_type=embedding_type,
                 truncate="END",
             )
-            final_embeddings.extend(cast(list[Embedding], response.embeddings))
+            final_embeddings.extend(_extract_cohere_embeddings(response.embeddings))
         return final_embeddings
 
     async def _embed_voyage(

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -340,6 +340,10 @@ class CloudEmbedding:
                 model=model,
                 input_type=embedding_type,
                 truncate="END",
+                # Explicit float request — guarantees .float_ is populated
+                # on Cohere's typed v4 response and keeps the contract
+                # explicit on the older v3 endpoint too.
+                embedding_types=["float"],
             )
             final_embeddings.extend(_extract_cohere_embeddings(response.embeddings))
         return final_embeddings

--- a/backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py
+++ b/backend/tests/unit/onyx/configs/test_cohere_embedding_configs.py
@@ -1,0 +1,13 @@
+from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
+
+
+def test_supported_embedding_models_include_cohere_embed_v4() -> None:
+    cohere_embed_v4_models = [
+        model
+        for model in SUPPORTED_EMBEDDING_MODELS
+        if model.name == "cohere/embed-v4.0"
+    ]
+
+    # One FLOAT-precision entry and one BFLOAT16-precision entry per registered model.
+    assert len(cohere_embed_v4_models) == 2
+    assert {model.dim for model in cohere_embed_v4_models} == {1536}

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -73,6 +73,66 @@ async def test_openai_embedding(
 
 
 @pytest.mark.asyncio
+async def test_cohere_embed_supports_v3_response_format(
+    sample_embeddings: list[list[float]],
+) -> None:
+    """v3 models hand back ``response.embeddings`` as a flat ``list[list[float]]``."""
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.embeddings = sample_embeddings
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-english-v3.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings
+
+
+@pytest.mark.asyncio
+async def test_cohere_embed_supports_v4_response_format(
+    sample_embeddings: list[list[float]],
+) -> None:
+    """v4 models hand back ``response.embeddings`` as an EmbedByTypeResponseEmbeddings
+    object with the float bucket on ``.float_``."""
+    with patch(
+        "onyx.natural_language_processing.search_nlp_models.CohereAsyncClient"
+    ) as mock_cohere:
+        mock_client = AsyncMock()
+        mock_cohere.return_value = mock_client
+
+        embeddings_by_type = MagicMock()
+        embeddings_by_type.float_ = sample_embeddings
+
+        mock_response = MagicMock()
+        mock_response.embeddings = embeddings_by_type
+        mock_client.embed = AsyncMock(return_value=mock_response)
+
+        embedding = CloudEmbedding("fake-key", EmbeddingProvider.COHERE)
+        try:
+            result = await embedding._embed_cohere(
+                ["test1", "test2"],
+                "embed-v4.0",
+                "search_document",
+            )
+        finally:
+            await embedding.aclose()
+
+        assert result == sample_embeddings
+
+
+@pytest.mark.asyncio
 async def test_rate_limit_handling() -> None:
     with patch(
         "onyx.natural_language_processing.search_nlp_models.CloudEmbedding.embed"

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -47,6 +47,15 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         description:
           "Cohere's lightweight English embedding model. Faster and more efficient for simpler tasks.",
       },
+      {
+        modelName: "embed-v4.0",
+        modelDim: 1536,
+        normalize: false,
+        queryPrefix: "",
+        passagePrefix: "",
+        description:
+          "Cohere's latest multilingual embedding model with the default 1536-dim output for stronger retrieval quality.",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Description

Adds Cohere's [embed-v4.0](https://docs.cohere.com/docs/cohere-embed) (1536-dim) as a first-class embedding model for [ENG-4039](https://linear.app/onyx-app/issue/ENG-4039).

**Backend:**
- Register \`cohere/embed-v4.0\` in \`SUPPORTED_EMBEDDING_MODELS\` (index name \`danswer_chunk_cohere_embed_v4_0\`, dim 1536) so the Vespa setup creates the index.
- Add \`_extract_cohere_embeddings\` helper in \`search_nlp_models.py\` and route \`_embed_cohere\` through it. Cohere v3 returns \`response.embeddings\` as a flat \`list[list[float]]\`; v4 returns an \`EmbedByTypeResponseEmbeddings\` object that carries the embeddings under \`.float_\`. The helper handles both shapes so existing v3 users aren't broken while new v4 users work correctly.

**Frontend:**
- Add a \`embed-v4.0\` entry under the Cohere provider in \`web/src/lib/indexing/index.ts:CLOUD_BASED_PROVIDERS\` so the admin can select it from the embedding picker.

Note: deliberately added only one \`_BaseEmbeddingModel\` entry for v4 (no legacy \`danswer_chunk_embed_v4_0\` alias) — that two-entry pattern only exists for older models that went through a Vespa naming migration. Newer additions like \`gemini-embedding-001\` and \`text-embedding-005\` also use a single entry.

Re-opens the change-set from the now-stale #10523.

## How Has This Been Tested?

- Three new unit tests pass locally:
  - \`test_supported_embedding_models_include_cohere_embed_v4\` — config registers correctly.
  - \`test_cohere_embed_supports_v3_response_format\` — v3 flat-list response unchanged.
  - \`test_cohere_embed_supports_v4_response_format\` — v4 \`.float_\` response decoded correctly.
- Pre-commit (ty, ruff, black, prettier, tsgo) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cohere `cohere/embed-v4.0` as a supported embedding model and makes response handling compatible with both v3 and v4. This registers a Vespa index and exposes the model in the admin UI, addressing ENG-4039.

- **New Features**
  - Add `cohere/embed-v4.0` (1536-dim) to `SUPPORTED_EMBEDDING_MODELS` with index `danswer_chunk_cohere_embed_v4_0`.
  - Expose the model in the embedding picker under the Cohere provider (`web/src/lib/indexing/index.ts`).

- **Bug Fixes**
  - Normalize Cohere embed responses across SDK versions via `_extract_cohere_embeddings` and explicitly request `embedding_types=['float']` in `_embed_cohere` to guarantee v4 `.float_` data (ENG-4039).
  - Add unit tests for v3/v4 response formats and model registration.

<sup>Written for commit cd46a314742e7a72e832dec5a11cdb2b0d4c83f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

