### PR TITLE
feat(indexing): add Gemini embedding-2-preview with instruction prompts

### DIFF
--- a/backend/onyx/configs/embedding_configs.py
+++ b/backend/onyx/configs/embedding_configs.py
@@ -72,6 +72,11 @@ _BASE_EMBEDDING_MODELS = [
         index_name="danswer_chunk_text_embedding_005",
     ),
     _BaseEmbeddingModel(
+        name="google/gemini-embedding-2-preview",
+        dim=3072,
+        index_name="danswer_chunk_gemini_embedding_2_preview",
+    ),
+    _BaseEmbeddingModel(
         name="voyage/voyage-large-2-instruct",
         dim=1024,
         index_name="danswer_chunk_voyage_large_2_instruct",

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -228,6 +228,40 @@ def is_authentication_error(error: Exception) -> bool:
     )
 
 
+_GEMINI_EMBEDDING_2_MODEL_PREFIX = "gemini-embedding-2"
+
+# Gemini embedding-2 ignores task_type entirely; instead the documented way
+# to differentiate query vs. document is to wrap the input in Google's task
+# instruction format. The exact templates come from
+# https://ai.google.dev/gemini-api/docs/embeddings (Gemini Embedding 2 section).
+_GEMINI_EMBEDDING_2_PROMPT_TEMPLATES = {
+    "RETRIEVAL_QUERY": "task: search result | query: {text}",
+    "RETRIEVAL_DOCUMENT": "title: none | text: {text}",
+}
+
+
+def _is_gemini_embedding_2_model(model: str) -> bool:
+    return (
+        model.split("/")[-1]
+        .strip()
+        .lower()
+        .startswith(_GEMINI_EMBEDDING_2_MODEL_PREFIX)
+    )
+
+
+def _format_vertex_embedding_text(text: str, model: str, embedding_type: str) -> str:
+    if not _is_gemini_embedding_2_model(model):
+        return text
+
+    template = _GEMINI_EMBEDDING_2_PROMPT_TEMPLATES.get(embedding_type)
+    if template is None:
+        raise RuntimeError(
+            f"Unsupported Gemini embedding-2 task type: {embedding_type}"
+        )
+
+    return template.format(text=text)
+
+
 def format_embedding_error(
     error: Exception,
     service_name: str,
@@ -369,8 +403,7 @@ class CloudEmbedding:
         from google import genai
         from google.genai import types as genai_types
 
-        if not model:
-            model = DEFAULT_VERTEX_MODEL
+        resolved_model = model or DEFAULT_VERTEX_MODEL
 
         service_account_info = json.loads(self.api_key)
         credentials = service_account.Credentials.from_service_account_info(
@@ -391,19 +424,38 @@ class CloudEmbedding:
             credentials=credentials,
         )
 
-        embed_config = genai_types.EmbedContentConfig(
-            task_type=embedding_type,
-            output_dimensionality=reduced_dimension,
-            auto_truncate=True,
-        )
+        # gemini-embedding-2 rejects task_type; embedding intent is conveyed
+        # via the instruction-formatted text instead. Older models continue
+        # to use task_type.
+        if _is_gemini_embedding_2_model(resolved_model):
+            embed_config = genai_types.EmbedContentConfig(
+                output_dimensionality=reduced_dimension,
+                auto_truncate=True,
+            )
+        else:
+            embed_config = genai_types.EmbedContentConfig(
+                task_type=embedding_type,
+                output_dimensionality=reduced_dimension,
+                auto_truncate=True,
+            )
 
         async def _embed_batch(batch_texts: list[str]) -> list[Embedding]:
             content_requests: list[Any] = [
-                genai_types.Content(parts=[genai_types.Part(text=text)])
+                genai_types.Content(
+                    parts=[
+                        genai_types.Part(
+                            text=_format_vertex_embedding_text(
+                                text=text,
+                                model=resolved_model,
+                                embedding_type=embedding_type,
+                            )
+                        )
+                    ]
+                )
                 for text in batch_texts
             ]
             response = await client.aio.models.embed_content(
-                model=model,
+                model=resolved_model,
                 contents=content_requests,
                 config=embed_config,
             )

--- a/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
+++ b/backend/tests/unit/onyx/configs/test_google_embedding_configs.py
@@ -1,0 +1,13 @@
+from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
+
+
+def test_supported_embedding_models_include_gemini_embedding_2_preview() -> None:
+    gemini_embedding_2_models = [
+        model
+        for model in SUPPORTED_EMBEDDING_MODELS
+        if model.name == "google/gemini-embedding-2-preview"
+    ]
+
+    # One FLOAT-precision entry and one BFLOAT16-precision entry per registered model.
+    assert len(gemini_embedding_2_models) == 2
+    assert {model.dim for model in gemini_embedding_2_models} == {3072}

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -72,6 +72,111 @@ async def test_openai_embedding(
         mock_client.embeddings.create.assert_called_once()
 
 
+def _build_google_embed_response(
+    embeddings: list[list[float]],
+) -> MagicMock:
+    response = MagicMock()
+    response.embeddings = [MagicMock(values=embedding) for embedding in embeddings]
+    return response
+
+
+@pytest.mark.asyncio
+async def test_vertex_embed_keeps_task_type_for_existing_models(
+    sample_embeddings: list[list[float]],
+) -> None:
+    """Existing Vertex models continue to receive task_type and unmodified text."""
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info"
+    ) as mock_credentials:
+        mock_credentials.return_value = MagicMock()
+
+        with patch("google.genai.Client") as mock_genai_client:
+            mock_client = MagicMock()
+            mock_client.aio.models.embed_content = AsyncMock(
+                return_value=_build_google_embed_response(sample_embeddings[:1])
+            )
+            mock_client.aio.aclose = AsyncMock()
+            mock_genai_client.return_value = mock_client
+
+            embedding = CloudEmbedding(
+                '{"project_id":"test-project"}',
+                EmbeddingProvider.GOOGLE,
+            )
+            try:
+                result = await embedding._embed_vertex(
+                    ["query text"],
+                    "text-embedding-005",
+                    "RETRIEVAL_QUERY",
+                    128,
+                )
+            finally:
+                await embedding.aclose()
+
+            assert result == sample_embeddings[:1]
+
+            embed_call = mock_client.aio.models.embed_content.await_args
+            assert embed_call is not None
+            config = embed_call.kwargs["config"]
+            contents = embed_call.kwargs["contents"]
+
+            assert config.task_type == "RETRIEVAL_QUERY"
+            assert config.output_dimensionality == 128
+            assert config.auto_truncate is True
+            assert contents[0].parts[0].text == "query text"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("embedding_type", "expected_text"),
+    [
+        ("RETRIEVAL_QUERY", "task: search result | query: hello world"),
+        ("RETRIEVAL_DOCUMENT", "title: none | text: hello world"),
+    ],
+)
+async def test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2(
+    embedding_type: str,
+    expected_text: str,
+    sample_embeddings: list[list[float]],
+) -> None:
+    """gemini-embedding-2 omits task_type and prefixes the text per Google's docs."""
+    with patch(
+        "google.oauth2.service_account.Credentials.from_service_account_info"
+    ) as mock_credentials:
+        mock_credentials.return_value = MagicMock()
+
+        with patch("google.genai.Client") as mock_genai_client:
+            mock_client = MagicMock()
+            mock_client.aio.models.embed_content = AsyncMock(
+                return_value=_build_google_embed_response(sample_embeddings[:1])
+            )
+            mock_client.aio.aclose = AsyncMock()
+            mock_genai_client.return_value = mock_client
+
+            embedding = CloudEmbedding(
+                '{"project_id":"test-project"}',
+                EmbeddingProvider.GOOGLE,
+            )
+            try:
+                result = await embedding._embed_vertex(
+                    ["hello world"],
+                    "gemini-embedding-2-preview",
+                    embedding_type,
+                    None,
+                )
+            finally:
+                await embedding.aclose()
+
+            assert result == sample_embeddings[:1]
+
+            embed_call = mock_client.aio.models.embed_content.await_args
+            assert embed_call is not None
+            config = embed_call.kwargs["config"]
+            contents = embed_call.kwargs["contents"]
+
+            assert config.task_type is None
+            assert contents[0].parts[0].text == expected_text
+
+
 @pytest.mark.asyncio
 async def test_rate_limit_handling() -> None:
     with patch(

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -101,6 +101,15 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
         passagePrefix: "",
         description: "Smaller, lighter-weight embedding model from Google.",
       },
+      {
+        modelName: "gemini-embedding-2-preview",
+        modelDim: 3072,
+        normalize: false,
+        queryPrefix: "",
+        passagePrefix: "",
+        description:
+          "Google's multimodal embedding model. Higher-quality retrieval with a 3072-dim output.",
+      },
     ],
   },
   {


### PR DESCRIPTION
## Description

Adds Google's [gemini-embedding-2-preview](https://ai.google.dev/gemini-api/docs/models/gemini-embedding-2-preview) (3072-dim) as a first-class embedding model on the Vertex provider, for [ENG-4040](https://linear.app/onyx-app/issue/ENG-4040).

**Backend:**

- Register \`google/gemini-embedding-2-preview\` in \`SUPPORTED_EMBEDDING_MODELS\` (index name \`danswer_chunk_gemini_embedding_2_preview\`, dim 3072) so Vespa setup creates the index.
- Add \`_is_gemini_embedding_2_model\` + \`_format_vertex_embedding_text\` helpers in \`search_nlp_models.py\`.
- In \`_embed_vertex\`:
  - When the resolved model is gemini-embedding-2, build the \`EmbedContentConfig\` **without** \`task_type\` (the API rejects/ignores it for v2 — confirmed in [Google's docs](https://ai.google.dev/gemini-api/docs/embeddings) and a [Gemini API forum thread](https://discuss.ai.google.dev/t/gemini-embedding-2-preview-appears-to-ignore-task-type-for-text-and-image-embeddings/134720)).
  - Per-text content gets wrapped in Google's documented instruction format:
    - Query: \`task: search result | query: {content}\`
    - Document: \`title: none | text: {content}\`
  - All other Vertex models keep their existing \`task_type\` + unmodified-text path.

**Frontend:**

- Add a \`gemini-embedding-2-preview\` entry under the Google provider in \`web/src/lib/indexing/index.ts:CLOUD_BASED_PROVIDERS\` so the admin can select it from the embedding picker.

Note: deliberately used Google's official prompt templates from their docs rather than generic \"Represent this query…\"-style strings — Google explicitly documents \`task: search result | query: ...\` and \`title: none | text: ...\` for asymmetric retrieval against gemini-embedding-2.

Re-opens the change-set from the now-stale #10522 (with corrected prompt templates).

## How Has This Been Tested?

- Four new unit tests pass locally:
  - \`test_supported_embedding_models_include_gemini_embedding_2_preview\` — config registers.
  - \`test_vertex_embed_keeps_task_type_for_existing_models\` — pre-existing Vertex models unaffected.
  - \`test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2[RETRIEVAL_QUERY]\` — query path.
  - \`test_vertex_embed_uses_instruction_prefix_for_gemini_embedding_2[RETRIEVAL_DOCUMENT]\` — document path.
- Pre-commit (ty, ruff, black, prettier, tsgo) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google’s `google/gemini-embedding-2-preview` (3072‑dim) as a Vertex embedding and switches this model to instruction prompts instead of `task_type`. Implements ENG-4040 and exposes the model in the indexing UI.

- **New Features**
  - Register `google/gemini-embedding-2-preview` (3072‑dim); Vespa index is created.
  - For this model, omit `task_type` and wrap text using Google’s query/document instruction templates; other Vertex models are unchanged.
  - Add the model to the Google provider in the admin embedding picker.
  - Unit tests cover registration and both embedding paths.

<sup>Written for commit 527c3eb48d1892ec28f2a3c36788679c5dae20c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

