### PR TITLE
fix(onyx-cli): show clean error when server returns HTML instead of JSON

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -81,8 +81,8 @@ func isHTMLResponse(contentType string, body []byte) bool {
 	if strings.Contains(contentType, "text/html") {
 		return true
 	}
-	trimmed := strings.TrimSpace(string(body))
-	return strings.HasPrefix(trimmed, "<!DOCTYPE") || strings.HasPrefix(trimmed, "<html")
+	lower := strings.ToLower(strings.TrimSpace(string(body)))
+	return strings.HasPrefix(lower, "<!doctype") || strings.HasPrefix(lower, "<html")
 }
 
 func wrapTimeoutError(err error) error {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -68,7 +68,21 @@ func checkResponse(resp *http.Response) error {
 		return nil
 	}
 	body, _ := io.ReadAll(resp.Body)
+	if isHTMLResponse(resp.Header.Get("Content-Type"), body) {
+		return &OnyxAPIError{
+			StatusCode: resp.StatusCode,
+			Detail:     "server returned HTML instead of JSON — your server URL may be pointing at the web UI instead of the API (try appending /api)",
+		}
+	}
 	return &OnyxAPIError{StatusCode: resp.StatusCode, Detail: string(body)}
+}
+
+func isHTMLResponse(contentType string, body []byte) bool {
+	if strings.Contains(contentType, "text/html") {
+		return true
+	}
+	trimmed := strings.TrimSpace(string(body))
+	return strings.HasPrefix(trimmed, "<!DOCTYPE") || strings.HasPrefix(trimmed, "<html")
 }
 
 func wrapTimeoutError(err error) error {


### PR DESCRIPTION
## Description

When the CLI is configured with a server URL pointing at the web UI instead of the API server (e.g. missing `/api` suffix), error responses return full HTML pages that get dumped to the terminal. This detects HTML responses and shows a concise error message suggesting the user check their server URL.

## How Has This Been Tested?

- Built the CLI (`go build ./...`) and verified it compiles cleanly.
- Manually tested with a server URL missing the `/api` suffix to confirm the HTML error is caught and a clean message is shown.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and handle HTML responses in the CLI when the server URL points to the web UI (missing `/api`). We check the Content-Type and HTML markers and show a clean error that suggests appending `/api` instead of dumping the page.

<sup>Written for commit c7025f7f5a14a429b30d2e5a48de32afa9cbfc53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

