### PR TITLE
test(ingestion): assert ingestion-API docs are searchable (ENG-3387)

### DIFF
--- a/backend/tests/integration/tests/ingestion/test_ingestion_api.py
+++ b/backend/tests/integration/tests/ingestion/test_ingestion_api.py
@@ -5,6 +5,9 @@ from onyx.db.models import Document
 from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import IngestionManager
+from tests.integration.common_utils.managers.document_search import (
+    DocumentSearchManager,
+)
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.vespa import vespa_fixture
@@ -59,3 +62,62 @@ def test_ingestion_api_crud(
 
     vespa_docs = vespa_client.get_documents_by_id([doc.id])["documents"]
     assert len(vespa_docs) == 0
+
+
+def test_ingestion_api_doc_is_searchable(
+    reset: None,  # noqa: ARG001
+    vespa_client: vespa_fixture,
+) -> None:
+    """Regression test for ENG-3387: documents created via the ingestion API
+    must appear in search results, not just exist in Vespa.
+
+    The existing CRUD test only verifies that the doc lands in Postgres and
+    Vespa. The original bug was that ingested docs were stored correctly but
+    were never returned by user-facing search — typically because the cc_pair
+    lacked the PUBLIC access type or the doc's ACL was misconfigured.
+    """
+    admin_user: DATestUser = UserManager.create(email="admin@onyx.app")
+    cc_pair = CCPairManager.create_from_scratch(
+        name="Ingestion-Search-Test",
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "file_locations": [],
+            "file_names": [],
+            "zip_metadata_file_id": None,
+        },
+        user_performing_action=admin_user,
+    )
+    api_key = APIKeyManager.create(user_performing_action=admin_user)
+    api_key.headers.update(admin_user.headers)
+
+    # Distinctive content the search query can latch onto; a UUID-like
+    # token keeps the assertion deterministic against any seed corpus that
+    # might exist in the test environment.
+    distinctive_phrase = "platypus chartreuse 7f3a91-ingestion-eng3387"
+    doc = IngestionManager.seed_doc_with_content(
+        cc_pair=cc_pair,
+        content=f"This document mentions {distinctive_phrase} once.",
+        document_id="eng3387-searchable-doc",
+        api_key=api_key,
+    )
+
+    # Sanity check that the indexing pipeline did write to Vespa — if this
+    # fails the bug is somewhere upstream of search.
+    vespa_docs = vespa_client.get_documents_by_id([doc.id])["documents"]
+    assert len(vespa_docs) == 1, (
+        "ingested doc never reached Vespa — bug is in the indexing pipeline, "
+        "not the search-time ACL filter"
+    )
+
+    # The actual ENG-3387 assertion: a user who has access to the cc_pair
+    # should see this doc returned by /search/send-search-message.
+    matching_blurbs = DocumentSearchManager.search_documents(
+        query=distinctive_phrase,
+        user_performing_action=admin_user,
+    )
+    assert any(distinctive_phrase in blurb for blurb in matching_blurbs), (
+        f"Ingested document was indexed in Vespa but did not surface in search "
+        f"results for the same admin user. ACL or doc-set filtering is dropping "
+        f"it at query time. Got blurbs: {matching_blurbs!r}"
+    )


### PR DESCRIPTION
## Description

[ENG-3387](https://linear.app/onyx-app/issue/ENG-3387) is a customer report from January 2026: docs pushed through the ingestion API show up in storage but not in search results. The ticket says "Requires investigation" and points to a Discord thread.

**Code-audit finding:** The default cc_pair has been marked \`access_type=AccessType.PUBLIC\` since [hagen-danswer's 2024-09 commit](https://github.com/onyx-dot-app/onyx/commit/2274cab5549), and the ingestion endpoint correctly routes docs through the full indexing pipeline (\`DocumentIndexingBatchAdapter\` → \`get_access_for_documents\` → PUBLIC ACL → Vespa write). On paper the bug should be fixed.

**Why this PR is just a test:** the existing \`test_ingestion_api_crud\` covers the create/list/delete path but only verifies that documents reach Postgres and Vespa. It never issues a search query. That's exactly the gap the customer hit: a doc can be indexed perfectly and still get dropped at query time by ACL filtering or a misconfigured cc_pair.

The new \`test_ingestion_api_doc_is_searchable\` closes that gap:

1. Creates a PUBLIC cc_pair and an API key.
2. POSTs a doc containing a deterministic UUID-style phrase through \`/onyx-api/ingestion\`.
3. Sanity-checks Vespa actually received the doc.
4. Queries that same phrase through \`/search/send-search-message\` as the admin and asserts the doc surfaces in results.

If the bug is gone, this test passes and ENG-3387 can be closed as fixed-and-now-covered-by-regression. If it fails, the assertion message points at whether the breakage is in indexing (Vespa empty) or in search-time ACL/filter logic (Vespa has it, but search dropped it).

Could not run the integration suite locally (the generated OpenAPI client used by \`CCPairManager\` is built by openapi-generator-cli during the integration Docker image build; my dev env doesn't have it). The spec passes \`ty\` / \`ruff\` / \`black\` / lazy-import checks and CI will exercise it.

## How Has This Been Tested?

- Pre-commit (\`ty\`, \`ruff\`, \`black\`, lazy-import check) passes.
- CI's integration-tests (\`tests/ingestion\`) job will run the spec end-to-end against Vespa, Postgres, Redis, and the model server.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a regression test to ensure docs ingested via the API show up in search (ENG-3387). It seeds a doc with a unique phrase on a PUBLIC cc_pair, confirms Vespa wrote it, then queries the phrase and asserts the doc appears—catching ACL/cc_pair misconfigurations at query time.

<sup>Written for commit 4655aaf3aae4e03b895869b3f6f0a394bab81f57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

