### PR TITLE
feat(craft): Add tables for external apps

### DIFF
--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -36,7 +36,7 @@ def upgrade() -> None:
             server_default=sa.text("'{}'::jsonb"),
         ),
         sa.Column(
-            "organisation_credentials",
+            "organization_credentials",
             postgresql.JSONB(),
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -50,6 +50,18 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
         sa.ForeignKeyConstraint(["skill_id"], ["skill.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("skill_id", name="uq_external_app_skill_id"),

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -1,0 +1,91 @@
+"""External app tables
+
+Revision ID: db87b27e93ef
+Revises: 2c7f9d3a84a0
+Create Date: 2026-05-12 14:07:05.057008
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "db87b27e93ef"
+down_revision = "2c7f9d3a84a0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "external_app",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column(
+            "upstream_urls",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column(
+            "auth_template",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "organisation_credentials",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "external_app_user_credentials",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("external_app_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "user_credentials",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["external_app_id"], ["external_app.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "external_app_id",
+            "user_id",
+            name="uq_external_app_user_credentials_app_user",
+        ),
+    )
+    op.create_index(
+        "ix_external_app_user_credentials_external_app_id",
+        "external_app_user_credentials",
+        ["external_app_id"],
+    )
+    op.create_index(
+        "ix_external_app_user_credentials_user_id",
+        "external_app_user_credentials",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_external_app_user_credentials_user_id",
+        table_name="external_app_user_credentials",
+    )
+    op.drop_index(
+        "ix_external_app_user_credentials_external_app_id",
+        table_name="external_app_user_credentials",
+    )
+    op.drop_table("external_app_user_credentials")
+    op.drop_table("external_app")

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -30,7 +30,7 @@ def upgrade() -> None:
             server_default="CUSTOM",
         ),
         sa.Column(
-            "upstream_urls",
+            "upstream_url_patterns",
             postgresql.ARRAY(sa.String()),
             nullable=False,
             server_default="{}",

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -21,8 +21,11 @@ def upgrade() -> None:
     op.create_table(
         "external_app",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("name", sa.String(), nullable=False),
-        sa.Column("description", sa.String(), nullable=False),
+        sa.Column(
+            "skill_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
         sa.Column(
             "app_type",
             sa.String(),
@@ -47,25 +50,9 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),
-        sa.Column(
-            "enabled",
-            sa.Boolean(),
-            nullable=False,
-            server_default=sa.true(),
-        ),
-        sa.Column(
-            "created_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.DateTime(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
+        sa.ForeignKeyConstraint(["skill_id"], ["skill.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("skill_id", name="uq_external_app_skill_id"),
     )
 
     op.create_table(

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -41,6 +41,12 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
         ),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -45,7 +45,7 @@ def upgrade() -> None:
     )
 
     op.create_table(
-        "external_app_user_credentials",
+        "external_app_user_credential",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("external_app_id", sa.Integer(), nullable=False),
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
@@ -63,29 +63,29 @@ def upgrade() -> None:
         sa.UniqueConstraint(
             "external_app_id",
             "user_id",
-            name="uq_external_app_user_credentials_app_user",
+            name="uq_external_app_user_credential_app_user",
         ),
     )
     op.create_index(
-        "ix_external_app_user_credentials_external_app_id",
-        "external_app_user_credentials",
+        "ix_external_app_user_credential_external_app_id",
+        "external_app_user_credential",
         ["external_app_id"],
     )
     op.create_index(
-        "ix_external_app_user_credentials_user_id",
-        "external_app_user_credentials",
+        "ix_external_app_user_credential_user_id",
+        "external_app_user_credential",
         ["user_id"],
     )
 
 
 def downgrade() -> None:
     op.drop_index(
-        "ix_external_app_user_credentials_user_id",
-        table_name="external_app_user_credentials",
+        "ix_external_app_user_credential_user_id",
+        table_name="external_app_user_credential",
     )
     op.drop_index(
-        "ix_external_app_user_credentials_external_app_id",
-        table_name="external_app_user_credentials",
+        "ix_external_app_user_credential_external_app_id",
+        table_name="external_app_user_credential",
     )
-    op.drop_table("external_app_user_credentials")
+    op.drop_table("external_app_user_credential")
     op.drop_table("external_app")

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -73,11 +73,6 @@ def upgrade() -> None:
         ),
     )
     op.create_index(
-        "ix_external_app_user_credential_external_app_id",
-        "external_app_user_credential",
-        ["external_app_id"],
-    )
-    op.create_index(
         "ix_external_app_user_credential_user_id",
         "external_app_user_credential",
         ["user_id"],
@@ -87,10 +82,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index(
         "ix_external_app_user_credential_user_id",
-        table_name="external_app_user_credential",
-    )
-    op.drop_index(
-        "ix_external_app_user_credential_external_app_id",
         table_name="external_app_user_credential",
     )
     op.drop_table("external_app_user_credential")

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "db87b27e93ef"
-down_revision = "2c7f9d3a84a0"
+down_revision = "ea418a384b9d"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/db87b27e93ef_external_app_tables.py
+++ b/backend/alembic/versions/db87b27e93ef_external_app_tables.py
@@ -24,6 +24,12 @@ def upgrade() -> None:
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("description", sa.String(), nullable=False),
         sa.Column(
+            "app_type",
+            sa.String(),
+            nullable=False,
+            server_default="CUSTOM",
+        ),
+        sa.Column(
             "upstream_urls",
             postgresql.ARRAY(sa.String()),
             nullable=False,
@@ -47,6 +53,18 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.true(),
         ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
         sa.PrimaryKeyConstraint("id"),
     )
 
@@ -60,6 +78,18 @@ def upgrade() -> None:
             postgresql.JSONB(),
             nullable=False,
             server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
         ),
         sa.ForeignKeyConstraint(
             ["external_app_id"], ["external_app.id"], ondelete="CASCADE"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -334,6 +334,22 @@ class SandboxStatus(str, PyEnum):
         return self == SandboxStatus.SLEEPING
 
 
+class ExternalAppType(str, PyEnum):
+    """Discriminator for the External Apps OAuth dispatch layer.
+
+    Each built-in value names a provider with its own configured
+    authorize URL, token URL, scope, and response parser in
+    `external_apps.providers`. `CUSTOM` is for admin-defined apps
+    that don't go through any built-in OAuth flow (static-token
+    integrations, internal services, etc.).
+    """
+
+    GOOGLE_CALENDAR = "GOOGLE_CALENDAR"
+    SLACK = "SLACK"
+    LINEAR = "LINEAR"
+    CUSTOM = "CUSTOM"
+
+
 class PatType(str, PyEnum):
     USER = "USER"
     CRAFT = "CRAFT"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5881,7 +5881,7 @@ class ExternalAppUserCredential(Base):
         nullable=False,
         index=True,
     )
-    user_credentials: Mapped[dict[str, str]] = mapped_column(
+    user_credentials: Mapped[dict[str, Any]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5866,7 +5866,6 @@ class ExternalAppUserCredential(Base):
         Integer,
         ForeignKey("external_app.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
     user_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5860,7 +5860,7 @@ class ExternalApp(Base):
         default=ExternalAppType.CUSTOM,
         server_default=ExternalAppType.CUSTOM.value,
     )
-    upstream_urls: Mapped[list[str]] = mapped_column(
+    upstream_url_patterns: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )
     auth_template: Mapped[dict[str, Any]] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5846,7 +5846,7 @@ class ExternalApp(Base):
     auth_template: Mapped[dict[str, str]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
-    organisation_credentials: Mapped[dict[str, str]] = mapped_column(
+    organization_credentials: Mapped[dict[str, str]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5839,11 +5839,18 @@ class ExternalApp(Base):
     __tablename__ = "external_app"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    name: Mapped[str] = mapped_column(String, nullable=False)
-    description: Mapped[str] = mapped_column(String, nullable=False)
-    # Discriminator for the OAuth-provider dispatch layer.
-    # Decoupled from `name` (a human-editable display string) so
-    # renaming an app doesn't silently break OAuth.
+    # Display name, description, and lifecycle (including enabled state
+    # via skill presence) live on the linked Skill row. ON DELETE
+    # CASCADE: removing the skill removes the external_app gateway.
+    skill_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("skill.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    # Discriminator for the OAuth-provider dispatch layer. Decoupled
+    # from the linked skill's name so renaming the skill doesn't
+    # silently break OAuth.
     #
     # `CUSTOM` covers admin-defined apps that don't go through any
     # built-in OAuth flow. Built-in values match entries in
@@ -5874,20 +5881,6 @@ class ExternalApp(Base):
         nullable=False,
         default=dict,
         server_default=text("'{}'::jsonb"),
-    )
-    enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=text("true")
-    )
-    created_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        nullable=False,
-    )
-    updated_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime(timezone=True),
-        server_default=func.now(),
-        onupdate=func.now(),
-        nullable=False,
     )
 
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -64,6 +64,7 @@ from onyx.db.enums import ChatSessionSharedStatus
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import DefaultAppMode
 from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import ExternalAppType
 from onyx.db.enums import GrantSource
 from onyx.db.enums import HierarchyNodeType
 from onyx.db.enums import HookFailStrategy
@@ -5840,6 +5841,25 @@ class ExternalApp(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False)
+    # Discriminator for the OAuth-provider dispatch layer.
+    # Decoupled from `name` (a human-editable display string) so
+    # renaming an app doesn't silently break OAuth.
+    #
+    # `CUSTOM` covers admin-defined apps that don't go through any
+    # built-in OAuth flow. Built-in values match entries in
+    # `external_apps.providers.PROVIDERS`.
+    #
+    # NOT unique — providers like self-hosted GitLab/Jira can have
+    # multiple distinct instances within one Onyx (each with its own
+    # client_id + base URL) and would all share the same app_type.
+    # Duplicate detection for the typical "one Slack" case happens
+    # at the UI layer.
+    app_type: Mapped[ExternalAppType] = mapped_column(
+        Enum(ExternalAppType, native_enum=False),
+        nullable=False,
+        default=ExternalAppType.CUSTOM,
+        server_default=ExternalAppType.CUSTOM.value,
+    )
     upstream_urls: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )
@@ -5857,6 +5877,17 @@ class ExternalApp(Base):
     )
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )
 
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
@@ -5883,6 +5914,17 @@ class ExternalAppUserCredential(Base):
     )
     user_credentials: Mapped[dict[str, Any]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
     )
 
     external_app: Mapped["ExternalApp"] = relationship(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5843,10 +5843,10 @@ class ExternalApp(Base):
     upstream_urls: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list
     )
-    auth_template: Mapped[dict[str, str]] = mapped_column(
+    auth_template: Mapped[dict[str, Any]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
-    organization_credentials: Mapped[dict[str, str]] = mapped_column(
+    organization_credentials: Mapped[dict[str, Any]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5850,15 +5850,15 @@ class ExternalApp(Base):
         postgresql.JSONB(), nullable=False, default=dict
     )
 
-    user_credentials: Mapped[list["ExternalAppUserCredentials"]] = relationship(
-        "ExternalAppUserCredentials",
+    user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
+        "ExternalAppUserCredential",
         back_populates="external_app",
         cascade="all, delete-orphan",
     )
 
 
-class ExternalAppUserCredentials(Base):
-    __tablename__ = "external_app_user_credentials"
+class ExternalAppUserCredential(Base):
+    __tablename__ = "external_app_user_credential"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     external_app_id: Mapped[int] = mapped_column(
@@ -5885,6 +5885,6 @@ class ExternalAppUserCredentials(Base):
         UniqueConstraint(
             "external_app_id",
             "user_id",
-            name="uq_external_app_user_credentials_app_user",
+            name="uq_external_app_user_credential_app_user",
         ),
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5882,6 +5882,17 @@ class ExternalApp(Base):
         default=dict,
         server_default=text("'{}'::jsonb"),
     )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
 
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
         "ExternalAppUserCredential",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5894,6 +5894,7 @@ class ExternalApp(Base):
         nullable=False,
     )
 
+    skill: Mapped["Skill"] = relationship("Skill")
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
         "ExternalAppUserCredential",
         back_populates="external_app",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5841,15 +5841,23 @@ class ExternalApp(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=False)
     upstream_urls: Mapped[list[str]] = mapped_column(
-        postgresql.ARRAY(String), nullable=False, default=list
+        postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )
     auth_template: Mapped[dict[str, Any]] = mapped_column(
-        postgresql.JSONB(), nullable=False, default=dict
+        postgresql.JSONB(),
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
     )
     organization_credentials: Mapped[dict[str, Any]] = mapped_column(
-        postgresql.JSONB(), nullable=False, default=dict
+        postgresql.JSONB(),
+        nullable=False,
+        default=dict,
+        server_default=text("'{}'::jsonb"),
     )
-    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
 
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
         "ExternalAppUserCredential",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5849,6 +5849,7 @@ class ExternalApp(Base):
     organization_credentials: Mapped[dict[str, str]] = mapped_column(
         postgresql.JSONB(), nullable=False, default=dict
     )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
     user_credentials: Mapped[list["ExternalAppUserCredential"]] = relationship(
         "ExternalAppUserCredential",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5832,3 +5832,59 @@ class HookExecutionLog(Base):
     )
 
     hook: Mapped["Hook"] = relationship("Hook", back_populates="execution_logs")
+
+
+class ExternalApp(Base):
+    __tablename__ = "external_app"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    description: Mapped[str] = mapped_column(String, nullable=False)
+    upstream_urls: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(String), nullable=False, default=list
+    )
+    auth_template: Mapped[dict[str, str]] = mapped_column(
+        postgresql.JSONB(), nullable=False, default=dict
+    )
+    organisation_credentials: Mapped[dict[str, str]] = mapped_column(
+        postgresql.JSONB(), nullable=False, default=dict
+    )
+
+    user_credentials: Mapped[list["ExternalAppUserCredentials"]] = relationship(
+        "ExternalAppUserCredentials",
+        back_populates="external_app",
+        cascade="all, delete-orphan",
+    )
+
+
+class ExternalAppUserCredentials(Base):
+    __tablename__ = "external_app_user_credentials"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    external_app_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("external_app.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_credentials: Mapped[dict[str, str]] = mapped_column(
+        postgresql.JSONB(), nullable=False, default=dict
+    )
+
+    external_app: Mapped["ExternalApp"] = relationship(
+        "ExternalApp", back_populates="user_credentials"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "external_app_id",
+            "user_id",
+            name="uq_external_app_user_credentials_app_user",
+        ),
+    )


### PR DESCRIPTION
## Description
This PR introduces the following tables for external apps. `external_app` and `external_app_user_credentials`

## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds database tables and SQLAlchemy models for external app integrations linked to a `Skill`. Enables provider routing via `ExternalAppType`, org-wide settings, per-user credentials, URL pattern matching, and timestamps on both tables.

- **New Features**
  - `external_app` table: `skill_id` (UUID, unique, FK to `skill.id`, CASCADE), `app_type` (`ExternalAppType`: `GOOGLE_CALENDAR`, `SLACK`, `LINEAR`, `CUSTOM`, default `CUSTOM`), `upstream_url_patterns` (ARRAY), `auth_template` (JSONB), `organization_credentials` (JSONB), `created_at`, `updated_at`.
  - `external_app_user_credential` table: links to app and user (UUID); `user_credentials` (JSONB); unique on `(external_app_id, user_id)`; index on `user_id`; CASCADE on deletes; `created_at`, `updated_at`.
  - SQLAlchemy models with relationships, delete-orphan cascade, and `updated_at` auto-update.

- **Migration**
  - Run `alembic upgrade head`.

<sup>Written for commit 6b6d1d2c5a67828040ffa26a679e2ae4100a01a7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11033?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

