### PR TITLE
fix(asana): stop dropping teamless projects from explicit allowlist (#11016) to release v3.3

### DIFF
--- a/backend/onyx/connectors/asana/asana_api.py
+++ b/backend/onyx/connectors/asana/asana_api.py
@@ -87,7 +87,11 @@ class AsanaAPI:
         seen_task_gids: set[str] = set()
         for project_gid in projects_list:
             for task in self._get_tasks_for_project(
-                project_gid, start_date, start_seconds, seen_task_gids
+                project_gid,
+                start_date,
+                start_seconds,
+                seen_task_gids,
+                project_gids,
             ):
                 yield task
         logger.info(f"Completed fetching {self.task_count} tasks from Asana")
@@ -102,6 +106,7 @@ class AsanaAPI:
         start_date: str,
         start_seconds: int,
         seen_task_gids: set[str],
+        project_gids: list[str] | None,
     ) -> Iterator[AsanaTask]:
         project = self.project_api.get_project(project_gid, opts={})
         project_name = project.get("name", project_gid)
@@ -111,20 +116,20 @@ class AsanaAPI:
         if project.get("archived"):
             logger.info(f"Skipping archived project: {project_name} ({project_gid})")
             return
-        if not team_gid:
+        # The team filter narrows the workspace-wide sync. When the user has
+        # picked specific projects via `project_gids`, respect that choice
+        # regardless of team membership — those projects were explicitly
+        # opted in upstream by the project_gid filter in get_tasks.
+        if (
+            project.get("privacy_setting") == "private"
+            and self.team_gid
+            and team_gid != self.team_gid
+            and project_gids is None
+        ):
             logger.info(
-                f"Skipping project without a team: {project_name} ({project_gid})"
+                f"Skipping private project not in configured team: {project_name} ({project_gid})"
             )
             return
-        if project.get("privacy_setting") == "private":
-            if self.team_gid and team_gid != self.team_gid:
-                logger.info(
-                    f"Skipping private project not in configured team: {project_name} ({project_gid})"
-                )
-                return
-            logger.info(
-                f"Processing private project in configured team: {project_name} ({project_gid})"
-            )
 
         simple_start_date = start_date.split(".")[0].split("+")[0]
         logger.info(

--- a/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
+++ b/backend/tests/unit/onyx/connectors/asana/test_asana_connector.py
@@ -1,5 +1,6 @@
 """Tests for Asana connector configuration parsing."""
 
+from collections.abc import Iterator
 from typing import Any
 from typing import NamedTuple
 from unittest.mock import MagicMock
@@ -78,16 +79,23 @@ def _make_task_data(gid: str, name: str | None = None) -> dict[str, Any]:
 
 def _build_api_with_mocks(
     project_to_tasks: dict[str, list[dict[str, Any]]],
+    *,
+    team_gid: str | None = None,
+    project_metadata: dict[str, dict[str, Any]] | None = None,
 ) -> _AsanaTestSetup:
     """Construct an AsanaAPI with all SDK clients replaced by mocks.
 
-    `project_to_tasks` defines, in iteration order, the tasks each project
-    listing returns from `tasks_api.get_tasks_for_project`. Returns the api
-    plus the stories-api mock so tests can introspect call counts without
-    fighting `ty` type inference on the original SDK attributes.
+    `project_to_tasks` maps each project gid to the tasks `get_tasks_for_project`
+    will return when asked for that project. `project_metadata` lets a test
+    override per-project metadata returned by `get_project` (the default is a
+    public, team-bound, unarchived project). `team_gid` configures the API's
+    team filter.
+
+    Returns the api plus the stories-api mock so tests can introspect call
+    counts without fighting `ty` type inference on the original SDK attributes.
     """
     with patch("onyx.connectors.asana.asana_api.asana"):
-        api = AsanaAPI(api_token="token", workspace_gid="ws", team_gid=None)
+        api = AsanaAPI(api_token="token", workspace_gid="ws", team_gid=team_gid)
 
     project_api = MagicMock()
     tasks_api = MagicMock()
@@ -99,18 +107,29 @@ def _build_api_with_mocks(
     api.stories_api = stories_api
     api.users_api = users_api
 
-    project_api.get_projects.return_value = iter(
-        [{"gid": gid} for gid in project_to_tasks]
-    )
-    project_api.get_project.return_value = {
+    default_metadata: dict[str, Any] = {
         "name": "p",
         "team": {"gid": "T1"},
         "archived": False,
         "privacy_setting": "public",
     }
-    tasks_api.get_tasks_for_project.side_effect = [
-        iter(tasks) for tasks in project_to_tasks.values()
-    ]
+    metadata_overrides = project_metadata or {}
+
+    project_api.get_projects.return_value = iter(
+        [{"gid": gid} for gid in project_to_tasks]
+    )
+
+    def _get_project(gid: str, **_kwargs: Any) -> dict[str, Any]:
+        return {**default_metadata, **metadata_overrides.get(gid, {})}
+
+    project_api.get_project.side_effect = _get_project
+
+    def _get_tasks_for_project(
+        gid: str, *_args: Any, **_kwargs: Any
+    ) -> Iterator[dict[str, Any]]:
+        return iter(project_to_tasks.get(gid, []))
+
+    tasks_api.get_tasks_for_project.side_effect = _get_tasks_for_project
     stories_api.get_stories_for_task.return_value = iter([])
 
     return _AsanaTestSetup(api=api, stories_api=stories_api)
@@ -158,3 +177,156 @@ def test_get_tasks_no_duplicates_unchanged() -> None:
     assert [t.id for t in yielded] == ["A", "B", "C"]
     assert setup.api.task_count == 3
     assert setup.stories_api.get_stories_for_task.call_count == 3
+
+
+def test_get_tasks_processes_teamless_project_when_no_team_filter() -> None:
+    """A workspace-level project (team=None) must still be indexed when no
+    team filter is configured. The earlier `if not team_gid: return` skip
+    silently dropped these and produced 0/0 syncs in production."""
+    setup = _build_api_with_mocks(
+        {"P1": [_make_task_data("A")]},
+        team_gid=None,
+        project_metadata={"P1": {"team": None}},
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert [t.id for t in yielded] == ["A"]
+
+
+def test_get_tasks_processes_teamless_projects_when_explicitly_allowlisted() -> None:
+    """Customer's exact scenario from the Slack thread: three projects are
+    explicitly listed in `asana_project_ids`, every one of them returns
+    team=None from Asana, and the connector also has a `team_gid` configured.
+    Before the fix, every project was dropped at the `no team` skip and the
+    sync reported success with 0 documents."""
+    setup = _build_api_with_mocks(
+        {
+            "P1": [_make_task_data("A")],
+            "P2": [_make_task_data("B")],
+            "P3": [_make_task_data("C")],
+        },
+        team_gid="T_CONFIGURED",
+        project_metadata={
+            "P1": {"team": None},
+            "P2": {"team": None},
+            "P3": {"team": None},
+        },
+    )
+
+    yielded = list(
+        setup.api.get_tasks(
+            project_gids=["P1", "P2", "P3"],
+            start_date="2026-01-01T00:00:00+00:00",
+        )
+    )
+
+    assert [t.id for t in yielded] == ["A", "B", "C"]
+
+
+def test_get_tasks_skips_private_project_in_wrong_team() -> None:
+    """When a team filter is configured and the user did not allowlist a
+    private project that belongs to a different team, the connector must
+    still skip it — the team filter is the user's scope-narrowing tool."""
+    setup = _build_api_with_mocks(
+        {
+            "P_IN": [_make_task_data("A")],
+            "P_OUT": [_make_task_data("B")],
+        },
+        team_gid="T_CONFIGURED",
+        project_metadata={
+            "P_IN": {"team": {"gid": "T_CONFIGURED"}, "privacy_setting": "private"},
+            "P_OUT": {"team": {"gid": "T_OTHER"}, "privacy_setting": "private"},
+        },
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert [t.id for t in yielded] == ["A"]
+
+
+def test_get_tasks_processes_private_wrong_team_project_when_allowlisted() -> None:
+    """An explicit allowlist overrides the team filter even for private
+    projects — the user knows what they want."""
+    setup = _build_api_with_mocks(
+        {"P_OUT": [_make_task_data("B")]},
+        team_gid="T_CONFIGURED",
+        project_metadata={
+            "P_OUT": {"team": {"gid": "T_OTHER"}, "privacy_setting": "private"},
+        },
+    )
+
+    yielded = list(
+        setup.api.get_tasks(
+            project_gids=["P_OUT"], start_date="2026-01-01T00:00:00+00:00"
+        )
+    )
+
+    assert [t.id for t in yielded] == ["B"]
+
+
+def test_get_tasks_skips_private_teamless_project_with_team_filter_and_no_allowlist() -> (
+    None
+):
+    """A private, teamless project cannot satisfy the configured team filter
+    (None is never equal to a real team gid), so it must be skipped when the
+    user did not explicitly allowlist it. Pins the corner that emerges from
+    the new compound skip condition so future refactors of that branch don't
+    silently flip its behavior."""
+    setup = _build_api_with_mocks(
+        {"P_NULL": [_make_task_data("A")]},
+        team_gid="T_CONFIGURED",
+        project_metadata={
+            "P_NULL": {"team": None, "privacy_setting": "private"},
+        },
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert yielded == []
+
+
+def test_get_tasks_processes_public_teamless_project_with_team_filter_and_no_allowlist() -> (
+    None
+):
+    """Public projects are not subject to the team filter — only the
+    `private` branch applies it. A teamless public project must therefore
+    still index when no allowlist is supplied, even with a team filter
+    configured. Pins the symmetric counterpart of the private skip above."""
+    setup = _build_api_with_mocks(
+        {"P_NULL": [_make_task_data("A")]},
+        team_gid="T_CONFIGURED",
+        project_metadata={
+            "P_NULL": {"team": None, "privacy_setting": "public"},
+        },
+    )
+
+    yielded = list(
+        setup.api.get_tasks(project_gids=None, start_date="2026-01-01T00:00:00+00:00")
+    )
+
+    assert [t.id for t in yielded] == ["A"]
+
+
+def test_get_tasks_skips_archived_project_even_when_allowlisted() -> None:
+    """The archived filter is unconditional — even an explicit allowlist
+    shouldn't pull tasks from an archived project (they are read-only and
+    typically already indexed)."""
+    setup = _build_api_with_mocks(
+        {"P_ARCHIVED": [_make_task_data("X")]},
+        project_metadata={"P_ARCHIVED": {"archived": True}},
+    )
+
+    yielded = list(
+        setup.api.get_tasks(
+            project_gids=["P_ARCHIVED"], start_date="2026-01-01T00:00:00+00:00"
+        )
+    )
+
+    assert yielded == []


### PR DESCRIPTION
Cherry-pick of commit 1927ac24dba275273c596852da930b81428081a0 to release/v3.3 branch.

Original PR: #11016

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Asana sync to include teamless projects when explicitly allowlisted, preventing 0-document syncs. The team filter now only skips private projects outside the configured team unless the project is explicitly allowlisted.

- **Bug Fixes**
  - Respect `project_gids` allowlist: process listed projects even if `team` is None or not the configured `team_gid`.
  - Apply `team_gid` filter only to private projects during workspace-wide syncs; public projects still index and archived projects remain skipped.
  - Pass `project_gids` into per-project fetch logic and add unit tests covering teamless, private/public, and archived scenarios.

<sup>Written for commit 044253dea65ff5c7fbacc06e29df731668e53998. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

