### PR TITLE
fix(scim): return null instead of 404 when no token configured

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -229,11 +229,11 @@ def _get_scim_dal(db_session: Session = Depends(get_session)) -> ScimDAL:
 def get_active_scim_token(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     dal: ScimDAL = Depends(_get_scim_dal),
-) -> ScimTokenResponse:
-    """Return the currently active SCIM token's metadata, or 404 if none."""
+) -> ScimTokenResponse | None:
+    """Return the currently active SCIM token's metadata, or null if none."""
     token = dal.get_active_token()
     if not token:
-        raise HTTPException(status_code=404, detail="No active SCIM token")
+        return None
 
     # Derive the IdP domain from the first synced user as a heuristic.
     idp_domain: str | None = None

--- a/backend/tests/integration/common_utils/managers/scim_token.py
+++ b/backend/tests/integration/common_utils/managers/scim_token.py
@@ -38,10 +38,10 @@ class ScimTokenManager:
             headers=user_performing_action.headers,
             timeout=60,
         )
-        if response.status_code == 404:
-            return None
         response.raise_for_status()
         data = response.json()
+        if data is None:
+            return None
         return DATestScimToken(
             id=data["id"],
             name=data["name"],

--- a/backend/tests/integration/tests/scim/test_scim_tokens.py
+++ b/backend/tests/integration/tests/scim/test_scim_tokens.py
@@ -117,8 +117,8 @@ def test_non_admin_cannot_get_token(
     assert response.status_code == 403
 
 
-def test_no_active_token_returns_404(new_admin_user: DATestUser) -> None:
-    """GET active token returns 404 when no token exists."""
+def test_no_active_token_returns_null(new_admin_user: DATestUser) -> None:
+    """GET active token returns 200 with null body when no token exists."""
     # new_admin_user depends on the reset fixture, ensuring a clean DB
     # with no active SCIM tokens.
     active = ScimTokenManager.get_active(user_performing_action=new_admin_user)
@@ -129,7 +129,8 @@ def test_no_active_token_returns_404(new_admin_user: DATestUser) -> None:
         headers=new_admin_user.headers,
         timeout=60,
     )
-    assert response.status_code == 404
+    assert response.status_code == 200
+    assert response.json() is None
 
 
 def test_service_discovery_no_auth_required(

--- a/backend/tests/unit/onyx/server/scim/test_admin.py
+++ b/backend/tests/unit/onyx/server/scim/test_admin.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.scim import ScimDAL
@@ -56,19 +55,19 @@ class TestGetActiveToken:
 
         result = get_active_scim_token(_=admin_user, dal=scim_dal)
 
+        assert result is not None
         assert result.id == 1
         assert result.name == "prod-token"
         assert result.is_active is True
 
-    def test_raises_404_when_no_active_token(
+    def test_returns_none_when_no_active_token(
         self, scim_dal: ScimDAL, admin_user: User
     ) -> None:
         scim_dal._session.scalar.return_value = None  # ty: ignore[unresolved-attribute]
 
-        with pytest.raises(HTTPException) as exc_info:
-            get_active_scim_token(_=admin_user, dal=scim_dal)
+        result = get_active_scim_token(_=admin_user, dal=scim_dal)
 
-        assert exc_info.value.status_code == 404
+        assert result is None
 
 
 class TestCreateToken:

--- a/web/src/app/admin/scim/page.tsx
+++ b/web/src/app/admin/scim/page.tsx
@@ -30,18 +30,11 @@ function ScimContent() {
   const hasToken = !!token;
   const isConnected = hasToken && token.last_used_at !== null;
 
-  // 404 means no active token — not an error
-  const is404 =
-    tokenError &&
-    typeof tokenError === "object" &&
-    "status" in tokenError &&
-    (tokenError as { status: number }).status === 404;
-
   if (isLoading) {
     return <ThreeDotsLoader />;
   }
 
-  if (tokenError && !is404) {
+  if (tokenError) {
     return (
       <Text as="p" text03>
         Failed to load SCIM token status.

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -71,7 +71,7 @@ export function AnnouncementBanner() {
                   Your index is out of date - we strongly recommend updating
                   your search settings.{" "}
                   <Link
-                    href="/admin/configuration/index-settings"
+                    href={"/admin/configuration/index-settings" as Route}
                     className="ml-2 underline cursor-pointer"
                   >
                     Update here

--- a/web/src/hooks/useScimToken.ts
+++ b/web/src/hooks/useScimToken.ts
@@ -5,7 +5,7 @@ import type { ScimTokenResponse } from "@/app/admin/scim/interfaces";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 export function useScimToken() {
-  const { data, error, isLoading, mutate } = useSWR<ScimTokenResponse>(
+  const { data, error, isLoading, mutate } = useSWR<ScimTokenResponse | null>(
     SWR_KEYS.scimToken,
     errorHandlingFetcher,
     { shouldRetryOnError: false }

--- a/web/tests/e2e/admin/scim/fixtures.ts
+++ b/web/tests/e2e/admin/scim/fixtures.ts
@@ -4,7 +4,7 @@
  * Provides:
  * - Authenticated admin page
  * - Stateful mock for the SCIM token endpoint
- *   (GET starts as 404; POST creates a token and flips GET to 200)
+ *   (GET starts as 200+null; POST creates a token and GET returns it)
  */
 
 import { test as base, expect, Page } from "@playwright/test";
@@ -75,11 +75,7 @@ export const test = base.extend<{
         const method = route.request().method();
 
         if (method === "GET") {
-          if (currentToken) {
-            await route.fulfill(jsonResponse(currentToken));
-          } else {
-            await route.fulfill(jsonResponse({ detail: "Not found" }, 404));
-          }
+          await route.fulfill(jsonResponse(currentToken));
         } else if (method === "POST") {
           const { token, rawToken } = makeToken();
           currentToken = token;


### PR DESCRIPTION
## Description

**Bug:** Admin Users page fires `GET /admin/enterprise-settings/scim/token` on every mount to decide whether to render the SCIM banner. Tenants without SCIM provisioned get a 404 per page load → constant noise in multi-tenant logs, easy to misattribute to unrelated issues (customer reported "email invite broken" alongside this 404).

**Cause:** Endpoint raised `HTTPException(404, "No active SCIM token")` for the empty state.

**Fix:** Return `200` with `null` body when no active token exists. 401/403 unchanged. Updated integration test, test manager, and SCIM admin page to match.

Bundled a one-line `as Route` cast on `AnnouncementBanner.tsx:74` to match the existing pattern on line 85 of the same file — pre-commit TS hook was failing on it.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check