### PR TITLE
ci: build craft-edge images on experimental-cc4a tags

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -32,6 +32,7 @@ jobs:
       is-beta: ${{ steps.check.outputs.is-beta }}
       is-beta-standalone: ${{ steps.check.outputs.is-beta-standalone }}
       is-latest: ${{ steps.check.outputs.is-latest }}
+      is-experimental-cc4a: ${{ steps.check.outputs.is-experimental-cc4a }}
       is-test-run: ${{ steps.check.outputs.is-test-run }}
       sanitized-tag: ${{ steps.check.outputs.sanitized-tag }}
       short-sha: ${{ steps.check.outputs.short-sha }}
@@ -69,6 +70,7 @@ jobs:
           IS_BETA_STANDALONE=false
           IS_LATEST=false
           IS_PROD_TAG=false
+          IS_EXPERIMENTAL_CC4A=false
           IS_TEST_RUN=false
           BUILD_DESKTOP=false
           BUILD_WEB=false
@@ -93,9 +95,16 @@ jobs:
           if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta(\.[0-9]+)?$ ]]; then
             IS_BETA=true
           fi
+          if [[ "$TAG" == experimental-cc4a.* ]]; then
+            IS_EXPERIMENTAL_CC4A=true
+          fi
 
           # Determine what to build based on tag type
-          if [[ "$IS_CLOUD" == "true" ]]; then
+          if [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
+            # experimental-cc4a tags: craft backend + web + model-server, no regular backend
+            BUILD_BACKEND=false
+            BUILD_WEB=true
+          elif [[ "$IS_CLOUD" == "true" ]]; then
             BUILD_WEB_CLOUD=true
           else
             BUILD_WEB=true
@@ -122,8 +131,9 @@ jobs:
             fi
           fi
 
-          # Build craft-latest backend alongside the regular latest.
-          if [[ "$IS_LATEST" == "true" ]]; then
+          # Build craft backend for stable releases (tagged craft-latest) and
+          # experimental cc4a tags (tagged craft-edge for dev clusters).
+          if [[ "$IS_LATEST" == "true" ]] || [[ "$IS_EXPERIMENTAL_CC4A" == "true" ]]; then
             BUILD_BACKEND_CRAFT=true
           fi
 
@@ -148,6 +158,7 @@ jobs:
             echo "is-beta=$IS_BETA"
             echo "is-beta-standalone=$IS_BETA_STANDALONE"
             echo "is-latest=$IS_LATEST"
+            echo "is-experimental-cc4a=$IS_EXPERIMENTAL_CC4A"
             echo "is-test-run=$IS_TEST_RUN"
             echo "sanitized-tag=$SANITIZED_TAG"
             echo "short-sha=$SHORT_SHA"
@@ -156,7 +167,7 @@ jobs:
   check-version-tag:
     runs-on: ubuntu-slim
     timeout-minutes: 10
-    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ !startsWith(github.ref_name, 'nightly-latest') && !startsWith(github.ref_name, 'experimental-') && github.ref_name != 'edge' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -616,6 +627,7 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
 
@@ -1269,7 +1281,8 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=craft-latest
+            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || 'craft-latest' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && github.ref_name || '' }}
 
       - name: Create and push manifest
         env:
@@ -1494,6 +1507,7 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('model-server-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
 

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -627,7 +627,7 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
 
@@ -1282,7 +1282,7 @@ jobs:
             latest=false
           tags: |
             type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || 'craft-latest' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && github.ref_name || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && github.ref_name || '' }}
 
       - name: Create and push manifest
         env:
@@ -1507,7 +1507,7 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('model-server-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'craft-latest' || '' }}
-            type=raw,value=${{ needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
 
@@ -1529,12 +1529,14 @@ jobs:
       - merge-web
       - merge-web-cloud
       - merge-backend
+      - merge-backend-craft
       - merge-model-server
     if: >-
       always() && !cancelled() &&
       (needs.merge-web.result == 'success' ||
        needs.merge-web-cloud.result == 'success' ||
        needs.merge-backend.result == 'success' ||
+       needs.merge-backend-craft.result == 'success' ||
        needs.merge-model-server.result == 'success')
     runs-on:
       - runs-on
@@ -1564,7 +1566,13 @@ jobs:
           case "$COMPONENT" in
             web) RESULT="$MERGE_WEB" ;;
             web-cloud) RESULT="$MERGE_WEB_CLOUD" ;;
-            backend) RESULT="$MERGE_BACKEND" ;;
+            backend)
+              if [ "$MERGE_BACKEND" == "success" ] || [ "$MERGE_BACKEND_CRAFT" == "success" ]; then
+                RESULT="success"
+              else
+                RESULT="skipped"
+              fi
+              ;;
             model-server) RESULT="$MERGE_MODEL_SERVER" ;;
           esac
           if [ "$RESULT" == "success" ]; then
@@ -1577,6 +1585,7 @@ jobs:
           MERGE_WEB: ${{ needs.merge-web.result }}
           MERGE_WEB_CLOUD: ${{ needs.merge-web-cloud.result }}
           MERGE_BACKEND: ${{ needs.merge-backend.result }}
+          MERGE_BACKEND_CRAFT: ${{ needs.merge-backend-craft.result }}
           MERGE_MODEL_SERVER: ${{ needs.merge-model-server.result }}
 
       - uses: runs-on/action@742bf56072eb4845a0f94b3394673e4903c90ff0


### PR DESCRIPTION
## Description

Add `craft-edge` Docker Hub tagging for `experimental-cc4a.*` tags so dev clusters can pull a consistent set of craft-enabled images without waiting for a stable release.

**On `experimental-cc4a.*` tags:**
- Build craft backend (`ENABLE_CRAFT=true`), web, and model-server
- Tag all three as `craft-edge` + raw tag name (e.g., `experimental-cc4a.90`)
- Skip regular (non-craft) backend build
- Skip desktop build
- Skip version tag check (prevents spurious Slack failure notifications)

**On stable semver tags (unchanged):**
- Build `craft-latest` alongside regular `latest` (existing behavior)

**Dev cluster usage:**
Set all image tags in the configmap to `craft-edge` for a rolling dev deployment that tracks experimental builds.

| Image | `experimental-cc4a.*` tag | Stable `vX.Y.Z` (highest) |
|-------|--------------------------|---------------------------|
| `onyx-backend` (craft) | `craft-edge` + raw tag | `craft-latest` |
| `onyx-web-server` | `craft-edge` + raw tag | `craft-latest` + `latest` |
| `onyx-model-server` | `craft-edge` + raw tag | `craft-latest` + `latest` |
| `sandbox` (separate workflow) | auto-versioned + `latest` | — |

## How Has This Been Tested?

- Reviewed workflow logic for all tag type combinations (experimental, stable highest, stable non-highest, cloud, nightly, beta)
- Verified no regression for existing stable/cloud/nightly tag flows

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build and tag craft-enabled images as `craft-edge` for `experimental-cc4a.*` tags so dev clusters can pull consistent craft builds. Also scan the craft backend with Trivy on experimental tags; stable semver flows remain unchanged.

- **New Features**
  - Detect `experimental-cc4a.*` tags and build craft backend (`ENABLE_CRAFT=true`), web, and model-server; skip regular backend and desktop.
  - Tag all three images with `craft-edge` and the raw tag (e.g., `experimental-cc4a.90`) on non-test runs; stable releases continue to publish `latest` and `craft-latest`.
  - Skip the version tag check for `experimental-*` to avoid noisy Slack failures.

- **Bug Fixes**
  - Trivy scans the craft backend image when the regular backend build is skipped.
  - Update merge gate and tag logic to handle craft-only builds and guard `craft-edge` tags on test runs.

<sup>Written for commit a461d34f343d6d5ad10a266a7f21db2b3dc0e1b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

