### PR TITLE
[Fix] Add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -216,6 +216,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -389,6 +389,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source_type: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -489,7 +490,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source_type,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -528,6 +529,7 @@ class JiraConnector(
         # Custom JQL query to filter Jira issues
         jql_query: str | None = None,
         scoped_token: bool = False,
+        source_type: DocumentSource = DocumentSource.JIRA,
     ) -> None:
         self.batch_size = batch_size
 
@@ -541,6 +543,7 @@ class JiraConnector(
         self.labels_to_skip = set(labels_to_skip)
         self.jql_query = jql_query
         self.scoped_token = scoped_token
+        self.source_type = source_type
         self._jira_client: JIRA | None = None
         # Cache project permissions to avoid fetching them repeatedly across runs
         self._project_permissions_cache: dict[str, Any] = {}
@@ -838,6 +841,7 @@ class JiraConnector(
                     comment_email_blacklist=self.comment_email_blacklist,
                     labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+                    source_type=self.source_type,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:
@@ -1069,6 +1073,23 @@ class JiraConnector(
     def build_dummy_checkpoint(self) -> JiraConnectorCheckpoint:
         return JiraConnectorCheckpoint(
             has_more=True,
+        )
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    """Connector for Jira Service Management tickets.
+
+    Jira Service Management tickets are Jira issues under service management
+    projects, so the existing Jira issue ingestion, checkpointing, permissions,
+    and JQL filtering logic can be reused directly. Exposing a dedicated source
+    lets admins configure JSM separately from general Jira Software indexing.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(
+            *args,
+            source_type=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+            **kwargs,
         )
 
 

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py
@@ -1,0 +1,29 @@
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.connector import JiraConnector
+from onyx.connectors.jira.connector import JiraServiceManagementConnector
+from onyx.connectors.registry import CONNECTOR_CLASS_MAP
+
+
+def test_jira_service_management_connector_uses_dedicated_source() -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url="https://example.atlassian.net",
+        project_key="HELP",
+    )
+
+    assert connector.source_type == DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+
+def test_jira_connector_keeps_original_source() -> None:
+    connector = JiraConnector(
+        jira_base_url="https://example.atlassian.net",
+        project_key="ENG",
+    )
+
+    assert connector.source_type == DocumentSource.JIRA
+
+
+def test_jira_service_management_registry_mapping() -> None:
+    mapping = CONNECTOR_CLASS_MAP[DocumentSource.JIRA_SERVICE_MANAGEMENT]
+
+    assert mapping.module_path == "onyx.connectors.jira.connector"
+    assert mapping.class_name == "JiraServiceManagementConnector"

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -745,6 +745,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management tickets to index from a Jira Service Management project.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira Service Management base URL:",
+        label: "Jira Service Management Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira Service Management instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your Jira Service Management Tickets?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "Everything",
+            fields: [
+              {
+                type: "string_tab",
+                label: "Everything",
+                name: "everything",
+                description:
+                  "This connector will index all issues the provided credentials have access to!",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The key of a specific project to index (e.g., 'PROJ').",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "JQL Query",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to filter Jira issues." +
+                  "\n\nIMPORTANT: Do not include any time-based filters in the JQL query as that will conflict with the connector's logic. Additionally, do not include ORDER BY clauses." +
+                  "\n\nSee Atlassian's [JQL documentation](https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/) for more details on syntax.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -239,6 +239,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",
@@ -614,6 +615,7 @@ export const federatedSourceToRegularSource = (
 export const validAutoSyncSources = [
   ValidSources.Confluence,
   ValidSources.Jira,
+  ValidSources.JiraServiceManagement,
   ValidSources.GoogleDrive,
   ValidSources.Gmail,
   ValidSources.Slack,


### PR DESCRIPTION
## Summary
- add Jira Service Management as a dedicated document source and connector registry entry
- reuse Jira ingestion/checkpointing logic through `JiraServiceManagementConnector` while preserving the JSM `source_type`
- expose Jira Service Management in frontend source metadata and connector configuration
- add unit coverage for source selection and registry mapping

## Testing
- `python3 -m compileall -q backend/onyx/connectors/jira/connector.py backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py`
- `ruff check backend/onyx/connectors/jira/connector.py backend/tests/unit/onyx/connectors/jira/test_jira_service_management.py`

Note: targeted pytest collection was attempted locally, but the ad-hoc test environment is missing the repository's full backend dependency chain (`fastapi_users`, `redis`, `puremagic`, then `mypy_boto3_s3`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Jira Service Management as a dedicated connector and source, reusing Jira ingestion while tagging documents as JSM. Exposes JSM in the UI for separate setup and auto-sync.

- **New Features**
  - Added `DocumentSource.JIRA_SERVICE_MANAGEMENT` and mapped it to `JiraServiceManagementConnector` in `CONNECTOR_CLASS_MAP`.
  - Introduced `JiraServiceManagementConnector` (subclass of `JiraConnector`) that sets `source_type` to JSM; `source_type` is threaded through `process_jira_issue` and checkpoints.
  - Frontend: added `jira_service_management` config with indexing scope tabs (Everything, Project, JQL), plus `scoped_token` and `comment_email_blacklist`; updated `SOURCE_METADATA_MAP`, `ValidSources`, and `validAutoSyncSources`.
  - Unit tests cover connector source selection and registry mapping.

<sup>Written for commit abeb0427fcddcb732e3f340ff8f468ad97cd7fd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

