### PR TITLE
[Fix] Add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -253,6 +253,7 @@ class DocumentSource(str, Enum):
     AIRTABLE = "airtable"
     HIGHSPOT = "highspot"
     DRUPAL_WIKI = "drupal_wiki"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
 
     IMAP = "imap"
     BITBUCKET = "bitbucket"

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,5 @@
+"""Jira Service Management Connector for Onyx."""
+
+from onyx.connectors.jira_service_management.connector import JiraServiceManagementConnector
+
+__all__ = ["JiraServiceManagementConnector"]

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,102 @@
+"""Jira Service Management connector.
+
+Jira Service Management projects are backed by Jira issues. Reuse the existing
+Jira connector implementation so JSM indexing keeps parity with Jira support
+(incremental sync, comments, hierarchy, permissions, checkpointing, and
+credential handling) while exposing a separate source type in Onyx.
+"""
+
+from typing import Any
+from typing import TypeVar
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.jira.connector import JiraConnector
+from onyx.connectors.jira.connector import JiraConnectorCheckpoint
+from onyx.connectors.models import Document
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
+
+_T = TypeVar("_T", Document, SlimDocument)
+
+
+def _as_jsm_source(document: _T) -> _T:
+    """Return a copy of a Jira document tagged as Jira Service Management."""
+
+    return document.model_copy(
+        update={"source": DocumentSource.JIRA_SERVICE_MANAGEMENT}
+    )
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    """Connector for Jira Service Management projects.
+
+    The configuration mirrors the Jira connector, except the frontend labels the
+    base URL as ``jsm_base_url``. Internally, JSM requests are Jira issues, so the
+    Jira connector APIs are the canonical and most complete way to index them.
+    """
+
+    def __init__(
+        self,
+        jsm_base_url: str | None = None,
+        jira_base_url: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        base_url = jsm_base_url or jira_base_url
+        if base_url is None:
+            raise ValueError("jsm_base_url is required")
+        super().__init__(jira_base_url=base_url, **kwargs)
+
+    def load_from_checkpoint(
+        self,
+        start: float,
+        end: float,
+        checkpoint: JiraConnectorCheckpoint,
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        yield from self._with_jsm_source(
+            super().load_from_checkpoint(start, end, checkpoint)
+        )
+
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: float,
+        end: float,
+        checkpoint: JiraConnectorCheckpoint,
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        yield from self._with_jsm_source(
+            super().load_from_checkpoint_with_perm_sync(start, end, checkpoint)
+        )
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: float | None = None,
+        end: float | None = None,
+        callback: Any = None,
+    ) -> GenerateSlimDocumentOutput:
+        for batch in super().retrieve_all_slim_docs_perm_sync(start, end, callback):
+            yield [
+                _as_jsm_source(item) if isinstance(item, SlimDocument) else item
+                for item in batch
+            ]
+
+    @staticmethod
+    def _with_jsm_source(
+        output: CheckpointOutput[JiraConnectorCheckpoint],
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        checkpoint: JiraConnectorCheckpoint | None = None
+
+        try:
+            while True:
+                item = next(output)
+                if isinstance(item, Document | SlimDocument):
+                    yield _as_jsm_source(item)
+                else:
+                    yield item
+        except StopIteration as stop:
+            checkpoint = stop.value
+
+        if checkpoint is None:
+            raise RuntimeError("Jira Service Management connector returned no checkpoint")
+
+        return checkpoint

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -745,6 +745,57 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which JSM tickets to index. You can index everything or specify a particular project.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the JSM base URL:",
+        label: "JSM Base URL",
+        name: "jsm_base_url",
+        optional: false,
+        description:
+          "The base URL of your JSM instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your JSM?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "Everything",
+            fields: [
+              {
+                type: "string_tab",
+                label: "Everything",
+                name: "everything",
+                description:
+                  "This connector will index all customer requests the provided credentials have access to!",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The key of a specific project to index (e.g., 'JSM').",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -309,6 +309,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -239,6 +239,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira-service-management`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -591,6 +591,7 @@ export enum ValidSources {
   Gitbook = "gitbook",
   Highspot = "highspot",
   DrupalWiki = "drupal_wiki",
+  JiraServiceManagement = "jira_service_management",
   Imap = "imap",
   Bitbucket = "bitbucket",
   TestRail = "testrail",


### PR DESCRIPTION
## Summary
- Add Jira Service Management as a configurable document source
- Reuse Jira ingestion behavior with JSM-specific connector configuration
- Add frontend source metadata, connector form, and credential template support

Fixes #2281

## Validation
- npm --prefix web run types:check
- PYTHONPATH=backend python -m py_compile backend/onyx/connectors/jira_service_management/connector.py backend/onyx/connectors/jira_service_management/__init__.py backend/onyx/connectors/registry.py backend/onyx/configs/constants.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Service Management connector that reuses the Jira ingestion pipeline to index JSM customer requests and comments with full parity. Resolves #2281.

- **New Features**
  - New `JiraServiceManagementConnector` (wraps `JiraConnector`) and tags docs as `jira_service_management` via `DocumentSource.JIRA_SERVICE_MANAGEMENT`.
  - Registered the source in the connector registry; accepts `jsm_base_url` in config.
  - Inherits Jira behavior: incremental sync, comments, hierarchy, permissions, and checkpointing.
  - UI: added source metadata, docs link, and a connector form (base URL; scope: everything or specific `project_key`).
  - Credentials: added template using `jira_user_email` and `jira_api_token`.

<sup>Written for commit 1fde0c5d0101a8ce5bafafcb950c7e3701778df2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

