### PR TITLE
docs(db): broaden statement_cache_size=0 comment beyond pgbouncer

### DIFF
--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -49,13 +49,10 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
 
         connect_args["ssl"] = create_ssl_context_if_iam()
 
-        # Use unnamed prepared statements (auto-destroyed at end of statement)
-        # instead of asyncpg's default client-side cache of named statements.
-        # Required for pgbouncer transaction pool mode (server connections
-        # rotate with `DISCARD ALL` between txns, wiping cached statements),
-        # and avoids greenlet-bridge races on the first asyncpg connect that
-        # surface as `MissingGreenlet` / `greenlet_spawn has not been called`
-        # on cold async sessions.
+        # Disable asyncpg's named prepared-statement cache. Cache-vs-server
+        # desync produces intermittent `MissingGreenlet` /
+        # `prepared statement does not exist` errors under poolers and on
+        # cold async connects.
         connect_args["statement_cache_size"] = 0
 
         engine_kwargs = {

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -49,11 +49,13 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
 
         connect_args["ssl"] = create_ssl_context_if_iam()
 
-        # Disable asyncpg's prepared-statement cache. Required when running
-        # against pgbouncer in transaction pool mode: the server connection
-        # rotates between transactions (with `DISCARD ALL`), so cached named
-        # prepared statements get wiped, leading to intermittent
-        # `prepared statement does not exist` / `MissingGreenlet` errors.
+        # Use unnamed prepared statements (auto-destroyed at end of statement)
+        # instead of asyncpg's default client-side cache of named statements.
+        # Required for pgbouncer transaction pool mode (server connections
+        # rotate with `DISCARD ALL` between txns, wiping cached statements),
+        # and avoids greenlet-bridge races on the first asyncpg connect that
+        # surface as `MissingGreenlet` / `greenlet_spawn has not been called`
+        # on cold async sessions.
         connect_args["statement_cache_size"] = 0
 
         engine_kwargs = {


### PR DESCRIPTION
## Description

Follow-up to #10871. Original code comment framed `statement_cache_size=0` as a pgbouncer-only workaround. The same setting also prevents `MissingGreenlet` / `greenlet_spawn has not been called` errors on cold async connects in self-hosted deployments without any pooler (matches the first-login intermittent error reported by self-hosted users). Broaden the comment to document both motivations so future readers don't assume the setting is safe to drop on non-pgbouncer stacks.

Comment-only. No runtime change.

## How Has This Been Tested?

N/A — comment-only diff.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check