### PR TITLE
docs(craft): claim skills task board tasks

### DIFF
--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -40,7 +40,9 @@ If you're an agent picking up work:
 
 _(Update this section as you claim things. Keep it short — just the active `WIP` and `REVIEW` items so anyone glancing at the file can see what's hot.)_
 
-- _(nothing yet)_
+- `[WIP @codex-charged-perovskite]` `P1.010-P1.015` Module skeletons
+- `[WIP @codex-charged-perovskite]` `P1.020-P1.027` BuiltinSkillRegistry core
+- `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 
 ---
 
@@ -59,25 +61,25 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.2 Module skeletons  (spec §2)
 
-- `[TODO]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
-- `[TODO]` `P1.011` Create empty `backend/onyx/skills/registry.py`
-- `[TODO]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
-- `[TODO]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
-- `[TODO]` `P1.014` Create empty `backend/onyx/skills/render.py`
-- `[TODO]` `P1.015` Create empty `backend/onyx/db/skill.py`
+- `[WIP @codex-charged-perovskite]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
+- `[WIP @codex-charged-perovskite]` `P1.011` Create empty `backend/onyx/skills/registry.py`
+- `[WIP @codex-charged-perovskite]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
+- `[WIP @codex-charged-perovskite]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
+- `[WIP @codex-charged-perovskite]` `P1.014` Create empty `backend/onyx/skills/render.py`
+- `[WIP @codex-charged-perovskite]` `P1.015` Create empty `backend/onyx/db/skill.py`
 
 ### 1.3 BuiltinSkillRegistry  (spec §4)
 
-- `[TODO]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
-- `[TODO]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
-- `[TODO]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
-- `[TODO]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
-- `[TODO]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
-- `[TODO]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
-- `[TODO]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
-- `[TODO]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
-- `[TODO]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
-- `[TODO]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
+- `[WIP @codex-charged-perovskite]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
+- `[WIP @codex-charged-perovskite]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
+- `[WIP @codex-charged-perovskite]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
+- `[WIP @codex-charged-perovskite]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
+- `[WIP @codex-charged-perovskite]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
+- `[WIP @codex-charged-perovskite]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
+- `[WIP @codex-charged-perovskite]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
+- `[WIP @codex-charged-perovskite]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
+- `[WIP @codex-charged-perovskite]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
+- `[WIP @codex-charged-perovskite]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
 
 ### 1.4 Bundle validator  (spec §5)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -51,11 +51,11 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.1 Database + migration  (spec §3)
 
-- `[TODO]` `P1.001` Add `Skill` model to `backend/onyx/db/models.py` with all columns + indexes per §3
-- `[TODO]` `P1.002` Add `Skill__UserGroup` join table to `backend/onyx/db/models.py`
-- `[TODO]` `P1.003` Add `FileOrigin.SKILL_BUNDLE` to `backend/onyx/configs/constants.py:373`
-- `[TODO]` `P1.005` Create Alembic revision under `backend/alembic/versions/<hash>_skills.py` — `CREATE TABLE skill`, then `CREATE UNIQUE INDEX ux_skill_slug ON skill (slug) WHERE deleted_at IS NULL` (partial unique so slugs can be reused after soft-delete); `CREATE TABLE skill__user_group`; `ALTER TYPE fileorigin ADD VALUE 'skill_bundle'`. No extra perf index in V1.  (deps: P1.001, P1.002, P1.003)
-- `[TODO]` `P1.006` Run `alembic -n schema_private upgrade head` on a fresh EE tenant; confirm clean apply + idempotent re-run  (deps: P1.005)
+- `[DONE @rohoswagger #10996]` `P1.001` Add `Skill` model to `backend/onyx/db/models.py` with all columns + indexes per §3
+- `[DONE @rohoswagger #10996]` `P1.002` Add `Skill__UserGroup` join table to `backend/onyx/db/models.py`
+- `[DONE @rohoswagger #10996]` `P1.003` Add `FileOrigin.SKILL_BUNDLE` to `backend/onyx/configs/constants.py:373`
+- `[DONE @rohoswagger #10996]` `P1.005` Create Alembic revision under `backend/alembic/versions/<hash>_skills.py` — `CREATE TABLE skill`, then `CREATE UNIQUE INDEX ux_skill_slug ON skill (slug) WHERE deleted_at IS NULL` (partial unique so slugs can be reused after soft-delete); `CREATE TABLE skill__user_group`; `ALTER TYPE fileorigin ADD VALUE 'skill_bundle'`. No extra perf index in V1.  (deps: P1.001, P1.002, P1.003)
+- `[DONE @rohoswagger #10996]` `P1.006` Run `alembic -n schema_private upgrade head` on a fresh EE tenant; confirm clean apply + idempotent re-run  (deps: P1.005)
 
 ### 1.2 Module skeletons  (spec §2)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -44,6 +44,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[WIP @codex-charged-perovskite]` `P1.020-P1.027` BuiltinSkillRegistry core
 - `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
+- `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 
 ---
 
@@ -84,17 +85,17 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.4 Bundle validator  (spec §5)
 
-- `[TODO]` `P1.030` Define `InvalidBundleError(OnyxError)` with `INVALID_REQUEST` code  (deps: P1.012)
-- `[TODO]` `P1.031` Implement `validate_custom_bundle(zip_bytes, slug) -> ManifestMetadata` — zip parse, SKILL.md root check, frontmatter parse, no `*.template`  (deps: P1.030)
-- `[TODO]` `P1.032` Add path-traversal + symlink rejection to `validate_custom_bundle`  (deps: P1.031)
-- `[TODO]` `P1.033` Add per-file + total-size streaming check (defaults 25 MiB / 100 MiB)  (deps: P1.031)
+- `[WIP @claude-coupled-josephson]` `P1.030` Define `InvalidBundleError(OnyxError)` with `INVALID_REQUEST` code  (deps: P1.012)
+- `[WIP @claude-coupled-josephson]` `P1.031` Implement `validate_custom_bundle(zip_bytes, slug) -> ManifestMetadata` — zip parse, SKILL.md root check, frontmatter parse, no `*.template`  (deps: P1.030)
+- `[WIP @claude-coupled-josephson]` `P1.032` Add path-traversal + symlink rejection to `validate_custom_bundle`  (deps: P1.031)
+- `[WIP @claude-coupled-josephson]` `P1.033` Add per-file + total-size streaming check (defaults 25 MiB / 100 MiB)  (deps: P1.031)
 - `[TODO]` `P1.035` Add slug regex + reserved-slug check (uses `BuiltinSkillRegistry.reserved_slugs()`)  (deps: P1.031, P1.027)
-- `[TODO]` `P1.036` Implement `_safe_unzip(zip_bytes, dest)` for defensive re-check at materialization
-- `[TODO]` `P1.037` Implement `compute_bundle_sha256(zip_bytes)` — deterministic over raw bytes
-- `[TODO]` `P1.038` Unit test fixture: valid bundle zip (`SKILL.md` + frontmatter + scripts dir)
-- `[TODO]` `P1.039` Unit test fixture: invalid bundles, one per failure mode (no SKILL.md, traversal entry, symlink, oversized, contains `*.template`)
-- `[TODO]` `P1.040` Unit test: each invalid fixture rejected with the correct error reason  (deps: P1.039, P1.031-P1.033, P1.035)
-- `[TODO]` `P1.041` Unit test: `compute_bundle_sha256` deterministic across two zips of same content with different timestamps  (deps: P1.037)
+- `[WIP @claude-coupled-josephson]` `P1.036` Implement `_safe_unzip(zip_bytes, dest)` for defensive re-check at materialization
+- `[WIP @claude-coupled-josephson]` `P1.037` Implement `compute_bundle_sha256(zip_bytes)` — deterministic over raw bytes
+- `[WIP @claude-coupled-josephson]` `P1.038` Unit test fixture: valid bundle zip (`SKILL.md` + frontmatter + scripts dir)
+- `[WIP @claude-coupled-josephson]` `P1.039` Unit test fixture: invalid bundles, one per failure mode (no SKILL.md, traversal entry, symlink, oversized, contains `*.template`)
+- `[WIP @claude-coupled-josephson]` `P1.040` Unit test: each invalid fixture rejected with the correct error reason  (deps: P1.039, P1.031-P1.033, P1.035)
+- `[WIP @claude-coupled-josephson]` `P1.041` Unit test: `compute_bundle_sha256` deterministic across two zips of same content with different timestamps  (deps: P1.037)
 
 ### 1.5 Materializer  (spec §6)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -43,6 +43,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[WIP @codex-charged-perovskite]` `P1.010-P1.015` Module skeletons
 - `[WIP @codex-charged-perovskite]` `P1.020-P1.027` BuiltinSkillRegistry core
 - `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
+- `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 
 ---
 
@@ -106,15 +107,15 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.6 DB ops  (spec §3)
 
-- `[TODO]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
-- `[TODO]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
-- `[TODO]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
-- `[TODO]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
-- `[TODO]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
-- `[TODO]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
-- `[TODO]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
-- `[TODO]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
-- `[TODO]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
+- `[WIP @claude-coupled-lattice]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
+- `[WIP @claude-coupled-lattice]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
 
 ---
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -45,6 +45,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
+- `[WIP @claude-collapsing-meson]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
 
 ---
 
@@ -355,15 +356,15 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 
 ### 5.4 Sweep: orphan blobs + aged soft-deletes  (spec §16)
 
-- `[TODO]` `P5.030` Create `backend/onyx/background/celery/tasks/skills/__init__.py`
-- `[TODO]` `P5.031` Create `backend/onyx/background/celery/tasks/skills/tasks.py` with `@shared_task(name="cleanup_orphaned_skill_blobs")` (must include `expires=3600` per `CLAUDE.md`)
-- `[TODO]` `P5.032` Implement `_orphan_skill_blob_ids(db, older_than)` — FileStore records with `origin = SKILL_BUNDLE`, `created_at < now() - older_than`, whose IDs are NOT referenced by any `skill.bundle_file_id` (crash-recovery path)
-- `[TODO]` `P5.033` Implement `_aged_soft_deleted_skills(db, older_than)` — `Skill` rows with `deleted_at IS NOT NULL AND deleted_at < now() - older_than` (lifecycle-cleanup path)
-- `[TODO]` `P5.034` Task body: for each orphan blob, delete from FileStore; for each aged soft-deleted skill, delete its `bundle_file_id` blob THEN hard-delete the row
-- `[TODO]` `P5.035` Add weekly beat schedule entry
-- `[TODO]` `P5.036` Unit test: orphan blob older than 14 days → deleted by task
-- `[TODO]` `P5.037` Unit test: skill with `deleted_at` older than 14 days → blob deleted AND row hard-deleted
-- `[TODO]` `P5.038` Integration test: soft-delete a skill, run sweep immediately → blob NOT deleted, row still present with `deleted_at` set; advance time by 15 days → run sweep → blob deleted, row gone
+- `[WIP @claude-collapsing-meson]` `P5.030` Create `backend/onyx/background/celery/tasks/skills/__init__.py`
+- `[WIP @claude-collapsing-meson]` `P5.031` Create `backend/onyx/background/celery/tasks/skills/tasks.py` with `@shared_task(name="cleanup_orphaned_skill_blobs")` (must include `expires=3600` per `CLAUDE.md`)
+- `[WIP @claude-collapsing-meson]` `P5.032` Implement `_orphan_skill_blob_ids(db, older_than)` — FileStore records with `origin = SKILL_BUNDLE`, `created_at < now() - older_than`, whose IDs are NOT referenced by any `skill.bundle_file_id` (crash-recovery path)
+- `[WIP @claude-collapsing-meson]` `P5.033` Implement `_aged_soft_deleted_skills(db, older_than)` — `Skill` rows with `deleted_at IS NOT NULL AND deleted_at < now() - older_than` (lifecycle-cleanup path)
+- `[WIP @claude-collapsing-meson]` `P5.034` Task body: for each orphan blob, delete from FileStore; for each aged soft-deleted skill, delete its `bundle_file_id` blob THEN hard-delete the row
+- `[WIP @claude-collapsing-meson]` `P5.035` Add weekly beat schedule entry
+- `[WIP @claude-collapsing-meson]` `P5.036` Unit test: orphan blob older than 14 days → deleted by task
+- `[WIP @claude-collapsing-meson]` `P5.037` Unit test: skill with `deleted_at` older than 14 days → blob deleted AND row hard-deleted
+- `[WIP @claude-collapsing-meson]` `P5.038` Integration test: soft-delete a skill, run sweep immediately → blob NOT deleted, row still present with `deleted_at` set; advance time by 15 days → run sweep → blob deleted, row gone
 
 ### 5.5 Per-session skills UI  (spec §11)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -45,7 +45,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
-- `[WIP @claude-collapsing-meson]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
 
 ---
 
@@ -356,15 +356,15 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 
 ### 5.4 Sweep: orphan blobs + aged soft-deletes  (spec §16)
 
-- `[WIP @claude-collapsing-meson]` `P5.030` Create `backend/onyx/background/celery/tasks/skills/__init__.py`
-- `[WIP @claude-collapsing-meson]` `P5.031` Create `backend/onyx/background/celery/tasks/skills/tasks.py` with `@shared_task(name="cleanup_orphaned_skill_blobs")` (must include `expires=3600` per `CLAUDE.md`)
-- `[WIP @claude-collapsing-meson]` `P5.032` Implement `_orphan_skill_blob_ids(db, older_than)` — FileStore records with `origin = SKILL_BUNDLE`, `created_at < now() - older_than`, whose IDs are NOT referenced by any `skill.bundle_file_id` (crash-recovery path)
-- `[WIP @claude-collapsing-meson]` `P5.033` Implement `_aged_soft_deleted_skills(db, older_than)` — `Skill` rows with `deleted_at IS NOT NULL AND deleted_at < now() - older_than` (lifecycle-cleanup path)
-- `[WIP @claude-collapsing-meson]` `P5.034` Task body: for each orphan blob, delete from FileStore; for each aged soft-deleted skill, delete its `bundle_file_id` blob THEN hard-delete the row
-- `[WIP @claude-collapsing-meson]` `P5.035` Add weekly beat schedule entry
-- `[WIP @claude-collapsing-meson]` `P5.036` Unit test: orphan blob older than 14 days → deleted by task
-- `[WIP @claude-collapsing-meson]` `P5.037` Unit test: skill with `deleted_at` older than 14 days → blob deleted AND row hard-deleted
-- `[WIP @claude-collapsing-meson]` `P5.038` Integration test: soft-delete a skill, run sweep immediately → blob NOT deleted, row still present with `deleted_at` set; advance time by 15 days → run sweep → blob deleted, row gone
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.030` Create `backend/onyx/background/celery/tasks/skills/__init__.py`
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.031` Create `backend/onyx/background/celery/tasks/skills/tasks.py` with `@shared_task(name="cleanup_orphaned_skill_blobs")` (must include `expires=3600` per `CLAUDE.md`)
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.032` Implement `_orphan_skill_blob_ids(db, older_than)` — FileStore records with `origin = SKILL_BUNDLE`, `created_at < now() - older_than`, whose IDs are NOT referenced by any `skill.bundle_file_id` (crash-recovery path)
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.033` Implement `_aged_soft_deleted_skills(db, older_than)` — `Skill` rows with `deleted_at IS NOT NULL AND deleted_at < now() - older_than` (lifecycle-cleanup path)
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.034` Task body: for each orphan blob, delete from FileStore; for each aged soft-deleted skill, delete its `bundle_file_id` blob THEN hard-delete the row
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.035` Add weekly beat schedule entry
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.036` Unit test: orphan blob older than 14 days → deleted by task
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.037` Unit test: skill with `deleted_at` older than 14 days → blob deleted AND row hard-deleted
+- `[REVIEW @claude-collapsing-meson #11064]` `P5.038` Integration test: soft-delete a skill, run sweep immediately → blob NOT deleted, row still present with `deleted_at` set; advance time by 15 days → run sweep → blob deleted, row gone
 
 ### 5.5 Per-session skills UI  (spec §11)
 


### PR DESCRIPTION
Part of a stack managed by `ez`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Skills task board to reflect ownership: 1.1 database DONE (#10996); 1.2 module skeletons, 1.3 BuiltinSkillRegistry + tests, 1.4 bundle validator, and 1.6 DB ops marked WIP; 5.4 sweep now in REVIEW (#11064).

<sup>Written for commit 976fc508729e1871d4eea79fed05abe213a93766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Additional Options

- [x] Override Linear Check
