### PR TITLE
feat(skills): DB ops for custom skills (P1.060-P1.068)

### DIFF
--- a/backend/alembic/versions/b6d184cfdaf3_skills.py
+++ b/backend/alembic/versions/b6d184cfdaf3_skills.py
@@ -34,7 +34,6 @@ def upgrade() -> None:
         sa.Column("author_user_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("is_public", sa.Boolean(), nullable=False),
         sa.Column("enabled", sa.Boolean(), nullable=False),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -53,13 +52,7 @@ def upgrade() -> None:
             ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        "ux_skill_slug",
-        "skill",
-        ["slug"],
-        unique=True,
-        postgresql_where=sa.text("deleted_at IS NULL"),
+        sa.UniqueConstraint("slug", name="uq_skill_slug"),
     )
 
     op.create_table(
@@ -82,5 +75,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("skill__user_group")
-    op.drop_index("ux_skill_slug", table_name="skill")
     op.drop_table("skill")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4199,9 +4199,6 @@ class Skill(Base):
     )
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    deleted_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -4219,14 +4216,7 @@ class Skill(Base):
         viewonly=True,
     )
 
-    __table_args__ = (
-        Index(
-            "ux_skill_slug",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
+    __table_args__ = (UniqueConstraint("slug", name="uq_skill_slug"),)
 
 
 """

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -1,1 +1,268 @@
+"""DB operations for custom (admin-uploaded) skills.
 
+Access model:
+- Admin reads: filter `deleted_at IS NULL` only. Disabled skills stay visible
+  so admins can re-enable them.
+- User reads: filter `enabled = True AND deleted_at IS NULL`, plus `is_public`
+  OR the user is in a group that has been granted access.
+
+These helpers never commit — callers control the transaction boundary so a
+multi-step admin flow (e.g. create row + replace grants) can roll back atomically.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+from typing import Final
+from uuid import UUID
+
+from sqlalchemy import delete
+from sqlalchemy import func
+from sqlalchemy import or_
+from sqlalchemy import Select
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+_UNSET: Final[Any] = object()
+
+
+def _add_user_visibility_filter(
+    stmt: Select[tuple[Skill]], user: User
+) -> Select[tuple[Skill]]:
+    """Restrict a `select(Skill)` to rows the given user can see.
+
+    Mirrors `onyx.db.persona._add_user_filters` minus the direct user-grant
+    branch (no `Skill__User` table in V1). Admins bypass the filter; everyone
+    else sees `is_public=True` OR membership in a group that holds a grant.
+    """
+    if user.role == UserRole.ADMIN:
+        return stmt
+
+    group_grant_exists = (
+        select(Skill__UserGroup.skill_id)
+        .join(
+            User__UserGroup,
+            User__UserGroup.user_group_id == Skill__UserGroup.user_group_id,
+        )
+        .where(Skill__UserGroup.skill_id == Skill.id)
+        .where(User__UserGroup.user_id == user.id)
+        .exists()
+    )
+
+    return stmt.where(or_(Skill.is_public.is_(True), group_grant_exists))
+
+
+def list_skills_for_user(user: User, db_session: Session) -> Sequence[Skill]:
+    """Skills the user can use in a session.
+
+    Filtered to `enabled = True AND deleted_at IS NULL`: disabled or soft-deleted
+    skills never reach the materializer.
+    """
+    stmt = (
+        select(Skill)
+        .where(Skill.enabled.is_(True))
+        .where(Skill.deleted_at.is_(None))
+        .order_by(Skill.name)
+    )
+    stmt = _add_user_visibility_filter(stmt, user)
+    return db_session.scalars(stmt).all()
+
+
+def fetch_skill_for_user(
+    skill_id: UUID, user: User, db_session: Session
+) -> Skill | None:
+    """Single-skill lookup with the same filter as `list_skills_for_user`.
+
+    Returns None when the skill does not exist, is disabled, soft-deleted, or
+    the user has no grant — callers translate to 404 as needed.
+    """
+    stmt = (
+        select(Skill)
+        .where(Skill.id == skill_id)
+        .where(Skill.enabled.is_(True))
+        .where(Skill.deleted_at.is_(None))
+    )
+    stmt = _add_user_visibility_filter(stmt, user)
+    return db_session.scalars(stmt).one_or_none()
+
+
+def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
+    """Admin lookup: `deleted_at IS NULL` only (no `enabled` filter)."""
+    stmt = select(Skill).where(Skill.id == skill_id).where(Skill.deleted_at.is_(None))
+    return db_session.scalars(stmt).one_or_none()
+
+
+def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
+    """All non-soft-deleted skills, for the admin UI.
+
+    Disabled skills are included so the admin can re-enable them; soft-deleted
+    rows are hidden by default (engineer-only undelete bypasses this helper).
+    """
+    stmt = select(Skill).where(Skill.deleted_at.is_(None)).order_by(Skill.name)
+    return db_session.scalars(stmt).all()
+
+
+def create_skill(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    bundle_file_id: str,
+    bundle_sha256: str,
+    manifest_metadata: dict[str, Any],
+    is_public: bool,
+    author_user_id: UUID | None,
+    db_session: Session,
+) -> Skill:
+    """Insert a new Skill row.
+
+    Raises `OnyxError(DUPLICATE_RESOURCE)` if a non-deleted skill with the
+    same slug already exists. The partial unique index on `slug WHERE
+    deleted_at IS NULL` enforces this at the DB layer as a backstop; this
+    helper checks first so the caller gets a clean structured error rather
+    than an IntegrityError.
+    """
+    existing = db_session.scalars(
+        select(Skill.id).where(Skill.slug == slug).where(Skill.deleted_at.is_(None))
+    ).first()
+    if existing is not None:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"A skill with slug '{slug}' already exists.",
+        )
+
+    skill = Skill(
+        slug=slug,
+        name=name,
+        description=description,
+        bundle_file_id=bundle_file_id,
+        bundle_sha256=bundle_sha256,
+        manifest_metadata=manifest_metadata,
+        is_public=is_public,
+        author_user_id=author_user_id,
+        enabled=True,
+    )
+    db_session.add(skill)
+    db_session.flush()
+    return skill
+
+
+def replace_skill_bundle(
+    *,
+    skill_id: UUID,
+    new_bundle_file_id: str,
+    new_bundle_sha256: str,
+    new_manifest_metadata: dict[str, Any],
+    db_session: Session,
+) -> tuple[Skill, str]:
+    """Swap a skill's bundle blob.
+
+    Returns `(skill, old_bundle_file_id)` so the caller can delete the old
+    blob from FileStore AFTER the transaction commits — never inline.
+    """
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
+
+    old_bundle_file_id = skill.bundle_file_id
+    skill.bundle_file_id = new_bundle_file_id
+    skill.bundle_sha256 = new_bundle_sha256
+    skill.manifest_metadata = new_manifest_metadata
+    db_session.flush()
+    return skill, old_bundle_file_id
+
+
+def patch_skill(
+    *,
+    skill_id: UUID,
+    slug: str | Any = _UNSET,
+    name: str | Any = _UNSET,
+    description: str | Any = _UNSET,
+    is_public: bool | Any = _UNSET,
+    enabled: bool | Any = _UNSET,
+    db_session: Session,
+) -> Skill:
+    """Partial update of admin-controlled metadata.
+
+    `_UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
+    uniqueness is re-checked when the slug changes (the partial unique index
+    is the DB backstop; this raises `DUPLICATE_RESOURCE` first for a clean
+    structured error).
+    """
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
+
+    if slug is not _UNSET and slug != skill.slug:
+        clashing = db_session.scalars(
+            select(Skill.id)
+            .where(Skill.slug == slug)
+            .where(Skill.deleted_at.is_(None))
+            .where(Skill.id != skill_id)
+        ).first()
+        if clashing is not None:
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            )
+        skill.slug = slug
+
+    if name is not _UNSET:
+        skill.name = name
+    if description is not _UNSET:
+        skill.description = description
+    if is_public is not _UNSET:
+        skill.is_public = is_public
+    if enabled is not _UNSET:
+        skill.enabled = enabled
+
+    db_session.flush()
+    return skill
+
+
+def replace_skill_grants(
+    skill_id: UUID, group_ids: Sequence[int], db_session: Session
+) -> None:
+    """Replace all group grants for a skill in a single transaction.
+
+    Dedups the input. Does not commit — the caller owns the transaction.
+    """
+    db_session.execute(
+        delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
+    )
+    seen: set[int] = set()
+    for group_id in group_ids:
+        if group_id in seen:
+            continue
+        seen.add(group_id)
+        db_session.add(Skill__UserGroup(skill_id=skill_id, user_group_id=group_id))
+    db_session.flush()
+
+
+def delete_skill(skill_id: UUID, db_session: Session) -> None:
+    """Soft-delete by stamping `deleted_at = now()`.
+
+    The bundle blob is NOT removed inline; the weekly sweep (§16) deletes it
+    after the soft-delete ages past the retention window, then hard-deletes
+    the row. Running sessions continue to use the on-pod copy.
+
+    Idempotent: re-deleting an already-deleted skill is a no-op.
+    """
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        return
+    skill.deleted_at = func.now()
+    db_session.flush()

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -36,11 +36,26 @@ from onyx.db.utils import UNSET
 from onyx.db.utils import UnsetType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.registry import CustomSkill
 
 # Name of the unique constraint on `skill.slug` (declared on the model and
 # created by the Skills V1 migration). Used to translate the specific
 # collision into `DUPLICATE_RESOURCE`.
 SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
+
+
+def _custom_skill_from_model(skill: Skill) -> CustomSkill:
+    return CustomSkill(
+        id=skill.id,
+        slug=skill.slug,
+        name=skill.name,
+        description=skill.description,
+        bundle_file_id=skill.bundle_file_id,
+        bundle_sha256=skill.bundle_sha256,
+        manifest_metadata=skill.manifest_metadata,
+        is_public=skill.is_public,
+        enabled=skill.enabled,
+    )
 
 
 def _add_user_visibility_filter(
@@ -74,19 +89,19 @@ def _add_user_visibility_filter(
     return stmt.where(or_(Skill.is_public.is_(True), group_grant_exists))
 
 
-def list_skills_for_user(user: User, db_session: Session) -> Sequence[Skill]:
+def list_skills_for_user(user: User, db_session: Session) -> Sequence[CustomSkill]:
     """Skills the user can use in a session.
 
     Filtered to `enabled = True`: disabled skills never reach the materializer.
     """
     stmt = select(Skill).where(Skill.enabled.is_(True)).order_by(Skill.name)
     stmt = _add_user_visibility_filter(stmt, user)
-    return db_session.scalars(stmt).all()
+    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
 
 
 def fetch_skill_for_user(
     skill_id: UUID, user: User, db_session: Session
-) -> Skill | None:
+) -> CustomSkill | None:
     """Single-skill lookup with the same filter as `list_skills_for_user`.
 
     Returns None when the skill does not exist, is disabled, or the user has
@@ -94,22 +109,29 @@ def fetch_skill_for_user(
     """
     stmt = select(Skill).where(Skill.id == skill_id).where(Skill.enabled.is_(True))
     stmt = _add_user_visibility_filter(stmt, user)
-    return db_session.scalars(stmt).one_or_none()
+    skill = db_session.scalars(stmt).one_or_none()
+    return _custom_skill_from_model(skill) if skill is not None else None
 
 
-def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
+def _fetch_skill_model_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
     """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
     stmt = select(Skill).where(Skill.id == skill_id)
     return db_session.scalars(stmt).one_or_none()
 
 
-def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
+def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> CustomSkill | None:
+    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    return _custom_skill_from_model(skill) if skill is not None else None
+
+
+def list_skills_for_admin(db_session: Session) -> Sequence[CustomSkill]:
     """All skills, for the admin UI.
 
     Disabled skills are included so the admin can re-enable them.
     """
     stmt = select(Skill).order_by(Skill.name)
-    return db_session.scalars(stmt).all()
+    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
 
 
 def create_skill(
@@ -123,7 +145,7 @@ def create_skill(
     is_public: bool,
     author_user_id: UUID | None,
     db_session: Session,
-) -> Skill:
+) -> CustomSkill:
     """Insert a new Skill row.
 
     Slug collisions are caught two ways: a pre-check for the fast happy path,
@@ -160,7 +182,7 @@ def create_skill(
                 f"A skill with slug '{slug}' already exists.",
             ) from e
         raise
-    return skill
+    return _custom_skill_from_model(skill)
 
 
 def replace_skill_bundle(
@@ -170,13 +192,13 @@ def replace_skill_bundle(
     new_bundle_sha256: str,
     new_manifest_metadata: dict[str, Any],
     db_session: Session,
-) -> tuple[Skill, str]:
+) -> tuple[CustomSkill, str]:
     """Swap a skill's bundle blob.
 
     Returns `(skill, old_bundle_file_id)` so the caller can delete the old
     blob from FileStore AFTER the transaction commits — never inline.
     """
-    skill = fetch_skill_for_admin(skill_id, db_session)
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
     if skill is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
@@ -188,7 +210,7 @@ def replace_skill_bundle(
     skill.bundle_sha256 = new_bundle_sha256
     skill.manifest_metadata = new_manifest_metadata
     db_session.flush()
-    return skill, old_bundle_file_id
+    return _custom_skill_from_model(skill), old_bundle_file_id
 
 
 def patch_skill(
@@ -200,7 +222,7 @@ def patch_skill(
     is_public: bool | UnsetType = UNSET,
     enabled: bool | UnsetType = UNSET,
     db_session: Session,
-) -> Skill:
+) -> CustomSkill:
     """Partial update of admin-controlled metadata.
 
     `UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
@@ -208,7 +230,7 @@ def patch_skill(
     constraint is the DB backstop; this raises `DUPLICATE_RESOURCE` first
     for a clean structured error).
     """
-    skill = fetch_skill_for_admin(skill_id, db_session)
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
     if skill is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
@@ -246,7 +268,7 @@ def patch_skill(
                 f"A skill with slug '{slug}' already exists.",
             ) from e
         raise
-    return skill
+    return _custom_skill_from_model(skill)
 
 
 def replace_skill_grants(
@@ -256,7 +278,7 @@ def replace_skill_grants(
 
     Dedups the input. Does not commit — the caller owns the transaction.
     """
-    if fetch_skill_for_admin(skill_id, db_session) is None:
+    if _fetch_skill_model_for_admin(skill_id, db_session) is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
             f"Skill {skill_id} not found.",
@@ -282,7 +304,7 @@ def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
     the transaction commits; running sandbox pods keep their materialized
     copy until the next bundle-sync cycle.
     """
-    skill = fetch_skill_for_admin(skill_id, db_session)
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
     if skill is None:
         return None
     # TODO: delete the bundle blob from S3 (file store) once the API caller

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -127,10 +127,10 @@ def create_skill(
     """Insert a new Skill row.
 
     Slug collisions are caught two ways: a pre-check for the fast happy path,
-    and a SAVEPOINT-wrapped flush that translates the partial unique index's
-    IntegrityError into `OnyxError(DUPLICATE_RESOURCE)` for the concurrent-
-    writer race. Both raise the same structured error so callers never see
-    a raw IntegrityError.
+    and an IntegrityError handler on flush that translates the partial unique
+    index's violation into `OnyxError(DUPLICATE_RESOURCE)` for the concurrent-
+    writer race. Both raise the same structured error so callers never see a
+    raw IntegrityError.
     """
     existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
     if existing is not None:
@@ -150,10 +150,9 @@ def create_skill(
         author_user_id=author_user_id,
         enabled=True,
     )
+    db_session.add(skill)
     try:
-        with db_session.begin_nested():
-            db_session.add(skill)
-            db_session.flush()
+        db_session.flush()
     except IntegrityError as e:
         if is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
             raise OnyxError(
@@ -239,8 +238,7 @@ def patch_skill(
         skill.enabled = enabled
 
     try:
-        with db_session.begin_nested():
-            db_session.flush()
+        db_session.flush()
     except IntegrityError as e:
         if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
             raise OnyxError(

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -50,7 +50,12 @@ def _add_user_visibility_filter(
 
     Mirrors `onyx.db.persona._add_user_filters` minus the direct user-grant
     branch (no `Skill__User` table in V1). Admins bypass the filter; everyone
-    else sees `is_public=True` OR membership in a group that holds a grant.
+    else — including `GLOBAL_CURATOR` and `CURATOR` — goes through the
+    is_public-or-group-grant path. The curator-specific elevated access in
+    persona exists to gate *editability* of curator-owned personas; skills
+    have no editability dimension at the user-read layer in V1 (only admins
+    mutate skills), so global-curators are intentionally treated the same as
+    regular users for visibility.
     """
     if user.role == UserRole.ADMIN:
         return stmt

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -9,8 +9,7 @@ Access model:
 Delete is a hard delete — `delete_skill` removes the row and returns its
 `bundle_file_id` so the caller can drop the blob from the file store
 immediately (skills sync via S3-backed bundles, so blob retention isn't
-needed). The legacy `deleted_at` column from the V1 migration is left
-unset; callers don't filter on it.
+needed).
 
 These helpers never commit — callers control the transaction boundary so a
 multi-step admin flow (e.g. create row + replace grants) can roll back atomically.
@@ -38,9 +37,10 @@ from onyx.db.utils import UnsetType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
-# Name of the partial unique index on `skill.slug` (created in the Skills V1
-# migration). Used to translate the specific collision into `DUPLICATE_RESOURCE`.
-SKILL_SLUG_UNIQUE_INDEX = "ux_skill_slug"
+# Name of the unique constraint on `skill.slug` (declared on the model and
+# created by the Skills V1 migration). Used to translate the specific
+# collision into `DUPLICATE_RESOURCE`.
+SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
 
 
 def _add_user_visibility_filter(
@@ -127,10 +127,10 @@ def create_skill(
     """Insert a new Skill row.
 
     Slug collisions are caught two ways: a pre-check for the fast happy path,
-    and an IntegrityError handler on flush that translates the partial unique
-    index's violation into `OnyxError(DUPLICATE_RESOURCE)` for the concurrent-
-    writer race. Both raise the same structured error so callers never see a
-    raw IntegrityError.
+    and an IntegrityError handler on flush that translates the `uq_skill_slug`
+    constraint violation into `OnyxError(DUPLICATE_RESOURCE)` for the
+    concurrent-writer race. Both raise the same structured error so callers
+    never see a raw IntegrityError.
     """
     existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
     if existing is not None:
@@ -154,7 +154,7 @@ def create_skill(
     try:
         db_session.flush()
     except IntegrityError as e:
-        if is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",
@@ -204,9 +204,9 @@ def patch_skill(
     """Partial update of admin-controlled metadata.
 
     `UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
-    uniqueness is re-checked when the slug changes (the partial unique index
-    is the DB backstop; this raises `DUPLICATE_RESOURCE` first for a clean
-    structured error).
+    uniqueness is re-checked when the slug changes (the `uq_skill_slug`
+    constraint is the DB backstop; this raises `DUPLICATE_RESOURCE` first
+    for a clean structured error).
     """
     skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
@@ -240,7 +240,7 @@ def patch_skill(
     try:
         db_session.flush()
     except IntegrityError as e:
-        if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
+        if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -30,7 +30,17 @@ from onyx.db.models import User__UserGroup
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
-_UNSET: Final[Any] = object()
+
+class _UnsetType:
+    """Sentinel distinguishing 'not provided' from None/falsy in patch helpers.
+
+    Typed as a dedicated class (instead of `Final[Any]`) so unions like
+    `str | _UnsetType` retain their real type at the call site — `str | Any`
+    collapses to `Any` and silently disables type checking on the parameter.
+    """
+
+
+_UNSET: Final[_UnsetType] = _UnsetType()
 
 
 def _add_user_visibility_filter(
@@ -185,11 +195,11 @@ def replace_skill_bundle(
 def patch_skill(
     *,
     skill_id: UUID,
-    slug: str | Any = _UNSET,
-    name: str | Any = _UNSET,
-    description: str | Any = _UNSET,
-    is_public: bool | Any = _UNSET,
-    enabled: bool | Any = _UNSET,
+    slug: str | _UnsetType = _UNSET,
+    name: str | _UnsetType = _UNSET,
+    description: str | _UnsetType = _UNSET,
+    is_public: bool | _UnsetType = _UNSET,
+    enabled: bool | _UnsetType = _UNSET,
     db_session: Session,
 ) -> Skill:
     """Partial update of admin-controlled metadata.
@@ -206,7 +216,7 @@ def patch_skill(
             f"Skill {skill_id} not found.",
         )
 
-    if slug is not _UNSET and slug != skill.slug:
+    if not isinstance(slug, _UnsetType) and slug != skill.slug:
         clashing = db_session.scalars(
             select(Skill.id)
             .where(Skill.slug == slug)
@@ -220,13 +230,13 @@ def patch_skill(
             )
         skill.slug = slug
 
-    if name is not _UNSET:
+    if not isinstance(name, _UnsetType):
         skill.name = name
-    if description is not _UNSET:
+    if not isinstance(description, _UnsetType):
         skill.description = description
-    if is_public is not _UNSET:
+    if not isinstance(is_public, _UnsetType):
         skill.is_public = is_public
-    if enabled is not _UNSET:
+    if not isinstance(enabled, _UnsetType):
         skill.enabled = enabled
 
     db_session.flush()

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -240,6 +240,11 @@ def replace_skill_grants(
 
     Dedups the input. Does not commit — the caller owns the transaction.
     """
+    if fetch_skill_for_admin(skill_id, db_session) is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
     db_session.execute(
         delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
     )

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -20,6 +20,7 @@ from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import Select
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
@@ -138,11 +139,11 @@ def create_skill(
 ) -> Skill:
     """Insert a new Skill row.
 
-    Raises `OnyxError(DUPLICATE_RESOURCE)` if a non-deleted skill with the
-    same slug already exists. The partial unique index on `slug WHERE
-    deleted_at IS NULL` enforces this at the DB layer as a backstop; this
-    helper checks first so the caller gets a clean structured error rather
-    than an IntegrityError.
+    Slug collisions are caught two ways: a pre-check for the fast happy path,
+    and a SAVEPOINT-wrapped flush that translates the partial unique index's
+    IntegrityError into `OnyxError(DUPLICATE_RESOURCE)` for the concurrent-
+    writer race. Both raise the same structured error so callers never see
+    a raw IntegrityError.
     """
     existing = db_session.scalars(
         select(Skill.id).where(Skill.slug == slug).where(Skill.deleted_at.is_(None))
@@ -164,8 +165,15 @@ def create_skill(
         author_user_id=author_user_id,
         enabled=True,
     )
-    db_session.add(skill)
-    db_session.flush()
+    try:
+        with db_session.begin_nested():
+            db_session.add(skill)
+            db_session.flush()
+    except IntegrityError as e:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"A skill with slug '{slug}' already exists.",
+        ) from e
     return skill
 
 
@@ -221,7 +229,9 @@ def patch_skill(
             f"Skill {skill_id} not found.",
         )
 
-    if not isinstance(slug, _UnsetType) and slug != skill.slug:
+    slug_changed = not isinstance(slug, _UnsetType) and slug != skill.slug
+    if slug_changed:
+        assert not isinstance(slug, _UnsetType)
         clashing = db_session.scalars(
             select(Skill.id)
             .where(Skill.slug == slug)
@@ -244,7 +254,16 @@ def patch_skill(
     if not isinstance(enabled, _UnsetType):
         skill.enabled = enabled
 
-    db_session.flush()
+    try:
+        with db_session.begin_nested():
+            db_session.flush()
+    except IntegrityError as e:
+        if slug_changed:
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
     return skill
 
 

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -12,7 +12,6 @@ multi-step admin flow (e.g. create row + replace grants) can roll back atomicall
 
 from collections.abc import Sequence
 from typing import Any
-from typing import Final
 from uuid import UUID
 
 from sqlalchemy import delete
@@ -28,39 +27,15 @@ from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.db.utils import is_unique_violation
+from onyx.db.utils import UNSET
+from onyx.db.utils import UnsetType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
-
-class _UnsetType:
-    """Sentinel distinguishing 'not provided' from None/falsy in patch helpers.
-
-    Typed as a dedicated class (instead of `Final[Any]`) so unions like
-    `str | _UnsetType` retain their real type at the call site — `str | Any`
-    collapses to `Any` and silently disables type checking on the parameter.
-    """
-
-
-_UNSET: Final[_UnsetType] = _UnsetType()
-
 # Name of the partial unique index on `skill.slug` (created in the Skills V1
-# migration). We match on this when translating `IntegrityError` so we only
-# remap the actual slug-collision violation, not FK or other constraint
-# failures.
-_SKILL_SLUG_UNIQUE_INDEX = "ux_skill_slug"
-
-
-def _is_slug_unique_violation(exc: IntegrityError) -> bool:
-    """True iff the IntegrityError came from the slug partial unique index.
-
-    Postgres surfaces the violated constraint via `diag.constraint_name`
-    on the underlying psycopg2 error. Anything else (FK violations on
-    `author_user_id`, NOT NULL, etc.) is left to bubble up.
-    """
-    orig = getattr(exc, "orig", None)
-    diag = getattr(orig, "diag", None)
-    constraint = getattr(diag, "constraint_name", None)
-    return constraint == _SKILL_SLUG_UNIQUE_INDEX
+# migration). Used to translate the specific collision into `DUPLICATE_RESOURCE`.
+SKILL_SLUG_UNIQUE_INDEX = "ux_skill_slug"
 
 
 def _add_user_visibility_filter(
@@ -189,7 +164,7 @@ def create_skill(
             db_session.add(skill)
             db_session.flush()
     except IntegrityError as e:
-        if _is_slug_unique_violation(e):
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",
@@ -229,16 +204,16 @@ def replace_skill_bundle(
 def patch_skill(
     *,
     skill_id: UUID,
-    slug: str | _UnsetType = _UNSET,
-    name: str | _UnsetType = _UNSET,
-    description: str | _UnsetType = _UNSET,
-    is_public: bool | _UnsetType = _UNSET,
-    enabled: bool | _UnsetType = _UNSET,
+    slug: str | UnsetType = UNSET,
+    name: str | UnsetType = UNSET,
+    description: str | UnsetType = UNSET,
+    is_public: bool | UnsetType = UNSET,
+    enabled: bool | UnsetType = UNSET,
     db_session: Session,
 ) -> Skill:
     """Partial update of admin-controlled metadata.
 
-    `_UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
+    `UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
     uniqueness is re-checked when the slug changes (the partial unique index
     is the DB backstop; this raises `DUPLICATE_RESOURCE` first for a clean
     structured error).
@@ -250,9 +225,9 @@ def patch_skill(
             f"Skill {skill_id} not found.",
         )
 
-    slug_changed = not isinstance(slug, _UnsetType) and slug != skill.slug
+    slug_changed = not isinstance(slug, UnsetType) and slug != skill.slug
     if slug_changed:
-        assert not isinstance(slug, _UnsetType)
+        assert not isinstance(slug, UnsetType)
         clashing = db_session.scalars(
             select(Skill.id)
             .where(Skill.slug == slug)
@@ -266,20 +241,20 @@ def patch_skill(
             )
         skill.slug = slug
 
-    if not isinstance(name, _UnsetType):
+    if not isinstance(name, UnsetType):
         skill.name = name
-    if not isinstance(description, _UnsetType):
+    if not isinstance(description, UnsetType):
         skill.description = description
-    if not isinstance(is_public, _UnsetType):
+    if not isinstance(is_public, UnsetType):
         skill.is_public = is_public
-    if not isinstance(enabled, _UnsetType):
+    if not isinstance(enabled, UnsetType):
         skill.enabled = enabled
 
     try:
         with db_session.begin_nested():
             db_session.flush()
     except IntegrityError as e:
-        if slug_changed and _is_slug_unique_violation(e):
+        if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_INDEX):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -1,10 +1,16 @@
 """DB operations for custom (admin-uploaded) skills.
 
 Access model:
-- Admin reads: filter `deleted_at IS NULL` only. Disabled skills stay visible
-  so admins can re-enable them.
-- User reads: filter `enabled = True AND deleted_at IS NULL`, plus `is_public`
-  OR the user is in a group that has been granted access.
+- Admin reads: see every row. Disabled skills stay visible so admins can
+  re-enable them.
+- User reads: filter `enabled = True`, plus `is_public` OR the user is in a
+  group that has been granted access.
+
+Delete is a hard delete — `delete_skill` removes the row and returns its
+`bundle_file_id` so the caller can drop the blob from the file store
+immediately (skills sync via S3-backed bundles, so blob retention isn't
+needed). The legacy `deleted_at` column from the V1 migration is left
+unset; callers don't filter on it.
 
 These helpers never commit — callers control the transaction boundary so a
 multi-step admin flow (e.g. create row + replace grants) can roll back atomically.
@@ -15,7 +21,6 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import delete
-from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import Select
 from sqlalchemy import select
@@ -72,15 +77,9 @@ def _add_user_visibility_filter(
 def list_skills_for_user(user: User, db_session: Session) -> Sequence[Skill]:
     """Skills the user can use in a session.
 
-    Filtered to `enabled = True AND deleted_at IS NULL`: disabled or soft-deleted
-    skills never reach the materializer.
+    Filtered to `enabled = True`: disabled skills never reach the materializer.
     """
-    stmt = (
-        select(Skill)
-        .where(Skill.enabled.is_(True))
-        .where(Skill.deleted_at.is_(None))
-        .order_by(Skill.name)
-    )
+    stmt = select(Skill).where(Skill.enabled.is_(True)).order_by(Skill.name)
     stmt = _add_user_visibility_filter(stmt, user)
     return db_session.scalars(stmt).all()
 
@@ -90,32 +89,26 @@ def fetch_skill_for_user(
 ) -> Skill | None:
     """Single-skill lookup with the same filter as `list_skills_for_user`.
 
-    Returns None when the skill does not exist, is disabled, soft-deleted, or
-    the user has no grant — callers translate to 404 as needed.
+    Returns None when the skill does not exist, is disabled, or the user has
+    no grant — callers translate to 404 as needed.
     """
-    stmt = (
-        select(Skill)
-        .where(Skill.id == skill_id)
-        .where(Skill.enabled.is_(True))
-        .where(Skill.deleted_at.is_(None))
-    )
+    stmt = select(Skill).where(Skill.id == skill_id).where(Skill.enabled.is_(True))
     stmt = _add_user_visibility_filter(stmt, user)
     return db_session.scalars(stmt).one_or_none()
 
 
 def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
-    """Admin lookup: `deleted_at IS NULL` only (no `enabled` filter)."""
-    stmt = select(Skill).where(Skill.id == skill_id).where(Skill.deleted_at.is_(None))
+    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
+    stmt = select(Skill).where(Skill.id == skill_id)
     return db_session.scalars(stmt).one_or_none()
 
 
 def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
-    """All non-soft-deleted skills, for the admin UI.
+    """All skills, for the admin UI.
 
-    Disabled skills are included so the admin can re-enable them; soft-deleted
-    rows are hidden by default (engineer-only undelete bypasses this helper).
+    Disabled skills are included so the admin can re-enable them.
     """
-    stmt = select(Skill).where(Skill.deleted_at.is_(None)).order_by(Skill.name)
+    stmt = select(Skill).order_by(Skill.name)
     return db_session.scalars(stmt).all()
 
 
@@ -139,9 +132,7 @@ def create_skill(
     writer race. Both raise the same structured error so callers never see
     a raw IntegrityError.
     """
-    existing = db_session.scalars(
-        select(Skill.id).where(Skill.slug == slug).where(Skill.deleted_at.is_(None))
-    ).first()
+    existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
     if existing is not None:
         raise OnyxError(
             OnyxErrorCode.DUPLICATE_RESOURCE,
@@ -229,10 +220,7 @@ def patch_skill(
     if slug_changed:
         assert not isinstance(slug, UnsetType)
         clashing = db_session.scalars(
-            select(Skill.id)
-            .where(Skill.slug == slug)
-            .where(Skill.deleted_at.is_(None))
-            .where(Skill.id != skill_id)
+            select(Skill.id).where(Skill.slug == slug).where(Skill.id != skill_id)
         ).first()
         if clashing is not None:
             raise OnyxError(
@@ -287,17 +275,19 @@ def replace_skill_grants(
     db_session.flush()
 
 
-def delete_skill(skill_id: UUID, db_session: Session) -> None:
-    """Soft-delete by stamping `deleted_at = now()`.
+def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
+    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup.
 
-    The bundle blob is NOT removed inline; the weekly sweep (§16) deletes it
-    after the soft-delete ages past the retention window, then hard-deletes
-    the row. Running sessions continue to use the on-pod copy.
-
-    Idempotent: re-deleting an already-deleted skill is a no-op.
+    Returns `None` if the skill did not exist (idempotent). The
+    `skill__user_group` rows cascade delete via the FK. The caller is
+    responsible for removing the bundle blob from the file store AFTER
+    the transaction commits; running sandbox pods keep their materialized
+    copy until the next bundle-sync cycle.
     """
     skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
-        return
-    skill.deleted_at = func.now()
+        return None
+    bundle_file_id = skill.bundle_file_id
+    db_session.delete(skill)
     db_session.flush()
+    return bundle_file_id

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -43,6 +43,25 @@ class _UnsetType:
 
 _UNSET: Final[_UnsetType] = _UnsetType()
 
+# Name of the partial unique index on `skill.slug` (created in the Skills V1
+# migration). We match on this when translating `IntegrityError` so we only
+# remap the actual slug-collision violation, not FK or other constraint
+# failures.
+_SKILL_SLUG_UNIQUE_INDEX = "ux_skill_slug"
+
+
+def _is_slug_unique_violation(exc: IntegrityError) -> bool:
+    """True iff the IntegrityError came from the slug partial unique index.
+
+    Postgres surfaces the violated constraint via `diag.constraint_name`
+    on the underlying psycopg2 error. Anything else (FK violations on
+    `author_user_id`, NOT NULL, etc.) is left to bubble up.
+    """
+    orig = getattr(exc, "orig", None)
+    diag = getattr(orig, "diag", None)
+    constraint = getattr(diag, "constraint_name", None)
+    return constraint == _SKILL_SLUG_UNIQUE_INDEX
+
 
 def _add_user_visibility_filter(
     stmt: Select[tuple[Skill]], user: User
@@ -170,10 +189,12 @@ def create_skill(
             db_session.add(skill)
             db_session.flush()
     except IntegrityError as e:
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"A skill with slug '{slug}' already exists.",
-        ) from e
+        if _is_slug_unique_violation(e):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
     return skill
 
 
@@ -258,7 +279,7 @@ def patch_skill(
         with db_session.begin_nested():
             db_session.flush()
     except IntegrityError as e:
-        if slug_changed:
+        if slug_changed and _is_slug_unique_violation(e):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -285,6 +285,8 @@ def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
     skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
         return None
+    # TODO: delete the bundle blob from S3 (file store) once the API caller
+    # wires this up — currently returned for the caller to handle.
     bundle_file_id = skill.bundle_file_id
     db_session.delete(skill)
     db_session.flush()

--- a/backend/onyx/db/utils.py
+++ b/backend/onyx/db/utils.py
@@ -1,12 +1,44 @@
 from enum import Enum
 from typing import Any
+from typing import Final
 
 from psycopg2 import errorcodes
 from psycopg2 import OperationalError
+from psycopg2.errors import UniqueViolation
 from pydantic import BaseModel
 from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 
 from onyx.db.models import Base
+
+
+class UnsetType:
+    """Sentinel distinguishing 'not provided' from None/falsy in patch helpers.
+
+    Use as the default for optional parameters whose caller might legitimately
+    want to set the column to `None`. Typed as a dedicated class so unions
+    like `str | UnsetType` survive type checking — `str | Any` would collapse
+    to `Any` and silently disable enforcement at the call site.
+    """
+
+
+UNSET: Final[UnsetType] = UnsetType()
+
+
+def is_unique_violation(exc: IntegrityError, constraint: str) -> bool:
+    """True iff the IntegrityError came from the named unique constraint/index.
+
+    Postgres surfaces the violated constraint via `diag.constraint_name` on
+    the underlying psycopg2 error. Callers can use this to translate the
+    specific collision into a structured `OnyxError(DUPLICATE_RESOURCE)` while
+    letting unrelated integrity errors (FK violations, NOT NULL, etc.) bubble
+    up unchanged.
+    """
+    orig = exc.orig
+    return (
+        isinstance(orig, UniqueViolation)
+        and getattr(orig.diag, "constraint_name", None) == constraint
+    )
 
 
 def model_to_dict(model: Base) -> dict[str, Any]:

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -43,7 +43,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.010-P1.015` Module skeletons
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.020-P1.027` BuiltinSkillRegistry core
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
-- `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 - `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
 
@@ -109,15 +109,15 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.6 DB ops  (spec §3)
 
-- `[WIP @claude-coupled-lattice]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
-- `[WIP @claude-coupled-lattice]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
 
 ---
 


### PR DESCRIPTION
## Description

Implements the Phase 1.6 DB ops layer for the Skills V1 universal primitive in `backend/onyx/db/skill.py`. This is the persistence-helper slice claimed on the shared task board ([`docs/craft/features/skills/TODOS.md`](../blob/skills-2/docs/craft/features/skills/TODOS.md)) as `P1.060-P1.068`.

Helpers added:

- `list_skills_for_user` / `fetch_skill_for_user` — `enabled = True AND deleted_at IS NULL`, plus `is_public` OR group-grant visibility via `_add_user_visibility_filter` (mirrors `onyx.db.persona._add_user_filters` minus the V1.5 direct-user-grant branch).
- `list_skills_for_admin` / `fetch_skill_for_admin` — `deleted_at IS NULL` only, so admins can still surface and re-enable disabled skills.
- `create_skill` and `patch_skill` — pre-check slug collisions against non-deleted rows and raise `OnyxError(DUPLICATE_RESOURCE)` so callers get a structured error instead of an IntegrityError from the partial unique index.
- `replace_skill_bundle` — returns `(skill, old_bundle_file_id)` so the API layer can delete the old blob AFTER commit.
- `replace_skill_grants` — dedups and re-issues join rows in a single transaction.
- `delete_skill` — soft-delete via `deleted_at = func.now()`. The sweep (`P5.031-P5.033`) handles blob cleanup + hard delete after the retention window.

None of the helpers commit — callers own the transaction so multi-step admin flows (create row + replace grants) can roll back atomically.

Stacked on `skills-base` (#11058).

## How Has This Been Tested?

- Smoke import (`uv run python -c "from onyx.db.skill import …"`) — passes against the venv.
- Pre-commit (`ruff`, `black`, `ty`, `lazy-imports`) — all pass on the new file.
- Functional coverage deferred to the Phase 2 API external-dependency tests (`P2.032-P2.036`), which exercise these helpers end-to-end through the admin and user routers. Phase 1.6 itself does not list test tasks on the board.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [skills-base #11058](https://github.com/onyx-dot-app/onyx/pull/11058)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Phase 1.6 DB helpers for custom skills with user/admin visibility, user reads filtered to enabled only, and hard-delete. Removes `deleted_at`, replaces the partial slug index with `UniqueConstraint` (`uq_skill_slug`), and marks P1.060–P1.068 as REVIEW in docs.

- **New Features**
  - Read helpers: users see enabled + public or group-granted; admins see all.
  - `create_skill` / `patch_skill`: pre-check slug collisions; `patch_skill` uses `UnsetType` from `onyx.db.utils`.
  - `replace_skill_bundle`: swaps bundle and returns old `bundle_file_id` for post-commit cleanup.
  - `replace_skill_grants`: dedups and replaces group grants; raises `NOT_FOUND` when the skill is missing.
  - Return `CustomSkill` views; helpers never commit—callers own the transaction.

- **Bug Fixes**
  - Translate only slug-unique `IntegrityError` (`uq_skill_slug`) into `DUPLICATE_RESOURCE` via `is_unique_violation`; others bubble up.
  - Dropped SAVEPOINT usage in create/patch paths.

<sup>Written for commit cfdc5c932bd52be3578afdd6cadc714d842eee91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

