### PR TITLE
feat(skills): Add builtin skill registry primitive

### DIFF
--- a/backend/alembic/versions/b6d184cfdaf3_skills.py
+++ b/backend/alembic/versions/b6d184cfdaf3_skills.py
@@ -26,11 +26,6 @@ def upgrade() -> None:
         sa.Column("description", sa.Text(), nullable=False),
         sa.Column("bundle_file_id", sa.String(), nullable=False),
         sa.Column("bundle_sha256", sa.String(length=64), nullable=False),
-        sa.Column(
-            "manifest_metadata",
-            postgresql.JSONB(astext_type=sa.Text()),
-            nullable=False,
-        ),
         sa.Column("author_user_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("is_public", sa.Boolean(), nullable=False),
         sa.Column("enabled", sa.Boolean(), nullable=False),

--- a/backend/alembic/versions/b6d184cfdaf3_skills.py
+++ b/backend/alembic/versions/b6d184cfdaf3_skills.py
@@ -34,7 +34,6 @@ def upgrade() -> None:
         sa.Column("author_user_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("is_public", sa.Boolean(), nullable=False),
         sa.Column("enabled", sa.Boolean(), nullable=False),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -53,13 +52,7 @@ def upgrade() -> None:
             ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        "ux_skill_slug",
-        "skill",
-        ["slug"],
-        unique=True,
-        postgresql_where=sa.text("deleted_at IS NULL"),
+        sa.UniqueConstraint("slug", name="uq_skill_slug"),
     )
 
     op.create_table(
@@ -82,5 +75,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("skill__user_group")
-    op.drop_index("ux_skill_slug", table_name="skill")
     op.drop_table("skill")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4190,7 +4190,6 @@ class Skill(Base):
     # Bundle bytes (single, replaced on re-upload).
     bundle_file_id: Mapped[str] = mapped_column(String, nullable=False)
     bundle_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
-    manifest_metadata: Mapped[dict[str, Any]] = mapped_column(PGJSONB, nullable=False)
 
     author_user_id: Mapped[UUID | None] = mapped_column(
         PGUUID(as_uuid=True),

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4199,9 +4199,6 @@ class Skill(Base):
     )
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    deleted_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -4219,14 +4216,7 @@ class Skill(Base):
         viewonly=True,
     )
 
-    __table_args__ = (
-        Index(
-            "ux_skill_slug",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
+    __table_args__ = (UniqueConstraint("slug", name="uq_skill_slug"),)
 
 
 """

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -1,1 +1,315 @@
+"""DB operations for custom (admin-uploaded) skills.
 
+Access model:
+- Admin reads: see every row. Disabled skills stay visible so admins can
+  re-enable them.
+- User reads: filter `enabled = True`, plus `is_public` OR the user is in a
+  group that has been granted access.
+
+Delete is a hard delete — `delete_skill` removes the row and returns its
+`bundle_file_id` so the caller can drop the blob from the file store
+immediately (skills sync via S3-backed bundles, so blob retention isn't
+needed).
+
+These helpers never commit — callers control the transaction boundary so a
+multi-step admin flow (e.g. create row + replace grants) can roll back atomically.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete
+from sqlalchemy import or_
+from sqlalchemy import Select
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.utils import is_unique_violation
+from onyx.db.utils import UNSET
+from onyx.db.utils import UnsetType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.registry import CustomSkill
+
+# Name of the unique constraint on `skill.slug` (declared on the model and
+# created by the Skills V1 migration). Used to translate the specific
+# collision into `DUPLICATE_RESOURCE`.
+SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
+
+
+def _custom_skill_from_model(skill: Skill) -> CustomSkill:
+    return CustomSkill(
+        id=skill.id,
+        slug=skill.slug,
+        name=skill.name,
+        description=skill.description,
+        bundle_file_id=skill.bundle_file_id,
+        bundle_sha256=skill.bundle_sha256,
+        manifest_metadata=skill.manifest_metadata,
+        is_public=skill.is_public,
+        enabled=skill.enabled,
+    )
+
+
+def _add_user_visibility_filter(
+    stmt: Select[tuple[Skill]], user: User
+) -> Select[tuple[Skill]]:
+    """Restrict a `select(Skill)` to rows the given user can see.
+
+    Mirrors `onyx.db.persona._add_user_filters` minus the direct user-grant
+    branch (no `Skill__User` table in V1). Admins bypass the filter; everyone
+    else — including `GLOBAL_CURATOR` and `CURATOR` — goes through the
+    is_public-or-group-grant path. The curator-specific elevated access in
+    persona exists to gate *editability* of curator-owned personas; skills
+    have no editability dimension at the user-read layer in V1 (only admins
+    mutate skills), so global-curators are intentionally treated the same as
+    regular users for visibility.
+    """
+    if user.role == UserRole.ADMIN:
+        return stmt
+
+    group_grant_exists = (
+        select(Skill__UserGroup.skill_id)
+        .join(
+            User__UserGroup,
+            User__UserGroup.user_group_id == Skill__UserGroup.user_group_id,
+        )
+        .where(Skill__UserGroup.skill_id == Skill.id)
+        .where(User__UserGroup.user_id == user.id)
+        .exists()
+    )
+
+    return stmt.where(or_(Skill.is_public.is_(True), group_grant_exists))
+
+
+def list_skills_for_user(user: User, db_session: Session) -> Sequence[CustomSkill]:
+    """Skills the user can use in a session.
+
+    Filtered to `enabled = True`: disabled skills never reach the materializer.
+    """
+    stmt = select(Skill).where(Skill.enabled.is_(True)).order_by(Skill.name)
+    stmt = _add_user_visibility_filter(stmt, user)
+    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
+
+
+def fetch_skill_for_user(
+    skill_id: UUID, user: User, db_session: Session
+) -> CustomSkill | None:
+    """Single-skill lookup with the same filter as `list_skills_for_user`.
+
+    Returns None when the skill does not exist, is disabled, or the user has
+    no grant — callers translate to 404 as needed.
+    """
+    stmt = select(Skill).where(Skill.id == skill_id).where(Skill.enabled.is_(True))
+    stmt = _add_user_visibility_filter(stmt, user)
+    skill = db_session.scalars(stmt).one_or_none()
+    return _custom_skill_from_model(skill) if skill is not None else None
+
+
+def _fetch_skill_model_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
+    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
+    stmt = select(Skill).where(Skill.id == skill_id)
+    return db_session.scalars(stmt).one_or_none()
+
+
+def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> CustomSkill | None:
+    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    return _custom_skill_from_model(skill) if skill is not None else None
+
+
+def list_skills_for_admin(db_session: Session) -> Sequence[CustomSkill]:
+    """All skills, for the admin UI.
+
+    Disabled skills are included so the admin can re-enable them.
+    """
+    stmt = select(Skill).order_by(Skill.name)
+    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
+
+
+def create_skill(
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    bundle_file_id: str,
+    bundle_sha256: str,
+    manifest_metadata: dict[str, Any],
+    is_public: bool,
+    author_user_id: UUID | None,
+    db_session: Session,
+) -> CustomSkill:
+    """Insert a new Skill row.
+
+    Slug collisions are caught two ways: a pre-check for the fast happy path,
+    and an IntegrityError handler on flush that translates the `uq_skill_slug`
+    constraint violation into `OnyxError(DUPLICATE_RESOURCE)` for the
+    concurrent-writer race. Both raise the same structured error so callers
+    never see a raw IntegrityError.
+    """
+    existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
+    if existing is not None:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"A skill with slug '{slug}' already exists.",
+        )
+
+    skill = Skill(
+        slug=slug,
+        name=name,
+        description=description,
+        bundle_file_id=bundle_file_id,
+        bundle_sha256=bundle_sha256,
+        manifest_metadata=manifest_metadata,
+        is_public=is_public,
+        author_user_id=author_user_id,
+        enabled=True,
+    )
+    db_session.add(skill)
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
+    return _custom_skill_from_model(skill)
+
+
+def replace_skill_bundle(
+    *,
+    skill_id: UUID,
+    new_bundle_file_id: str,
+    new_bundle_sha256: str,
+    new_manifest_metadata: dict[str, Any],
+    db_session: Session,
+) -> tuple[CustomSkill, str]:
+    """Swap a skill's bundle blob.
+
+    Returns `(skill, old_bundle_file_id)` so the caller can delete the old
+    blob from FileStore AFTER the transaction commits — never inline.
+    """
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
+
+    old_bundle_file_id = skill.bundle_file_id
+    skill.bundle_file_id = new_bundle_file_id
+    skill.bundle_sha256 = new_bundle_sha256
+    skill.manifest_metadata = new_manifest_metadata
+    db_session.flush()
+    return _custom_skill_from_model(skill), old_bundle_file_id
+
+
+def patch_skill(
+    *,
+    skill_id: UUID,
+    slug: str | UnsetType = UNSET,
+    name: str | UnsetType = UNSET,
+    description: str | UnsetType = UNSET,
+    is_public: bool | UnsetType = UNSET,
+    enabled: bool | UnsetType = UNSET,
+    db_session: Session,
+) -> CustomSkill:
+    """Partial update of admin-controlled metadata.
+
+    `UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
+    uniqueness is re-checked when the slug changes (the `uq_skill_slug`
+    constraint is the DB backstop; this raises `DUPLICATE_RESOURCE` first
+    for a clean structured error).
+    """
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
+
+    slug_changed = not isinstance(slug, UnsetType) and slug != skill.slug
+    if slug_changed:
+        assert not isinstance(slug, UnsetType)
+        clashing = db_session.scalars(
+            select(Skill.id).where(Skill.slug == slug).where(Skill.id != skill_id)
+        ).first()
+        if clashing is not None:
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            )
+        skill.slug = slug
+
+    if not isinstance(name, UnsetType):
+        skill.name = name
+    if not isinstance(description, UnsetType):
+        skill.description = description
+    if not isinstance(is_public, UnsetType):
+        skill.is_public = is_public
+    if not isinstance(enabled, UnsetType):
+        skill.enabled = enabled
+
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
+    return _custom_skill_from_model(skill)
+
+
+def replace_skill_grants(
+    skill_id: UUID, group_ids: Sequence[int], db_session: Session
+) -> None:
+    """Replace all group grants for a skill in a single transaction.
+
+    Dedups the input. Does not commit — the caller owns the transaction.
+    """
+    if _fetch_skill_model_for_admin(skill_id, db_session) is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"Skill {skill_id} not found.",
+        )
+    db_session.execute(
+        delete(Skill__UserGroup).where(Skill__UserGroup.skill_id == skill_id)
+    )
+    seen: set[int] = set()
+    for group_id in group_ids:
+        if group_id in seen:
+            continue
+        seen.add(group_id)
+        db_session.add(Skill__UserGroup(skill_id=skill_id, user_group_id=group_id))
+    db_session.flush()
+
+
+def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
+    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup.
+
+    Returns `None` if the skill did not exist (idempotent). The
+    `skill__user_group` rows cascade delete via the FK. The caller is
+    responsible for removing the bundle blob from the file store AFTER
+    the transaction commits; running sandbox pods keep their materialized
+    copy until the next bundle-sync cycle.
+    """
+    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    if skill is None:
+        return None
+    # TODO: delete the bundle blob from S3 (file store) once the API caller
+    # wires this up — currently returned for the caller to handle.
+    bundle_file_id = skill.bundle_file_id
+    db_session.delete(skill)
+    db_session.flush()
+    return bundle_file_id

--- a/backend/onyx/db/utils.py
+++ b/backend/onyx/db/utils.py
@@ -1,12 +1,44 @@
 from enum import Enum
 from typing import Any
+from typing import Final
 
 from psycopg2 import errorcodes
 from psycopg2 import OperationalError
+from psycopg2.errors import UniqueViolation
 from pydantic import BaseModel
 from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 
 from onyx.db.models import Base
+
+
+class UnsetType:
+    """Sentinel distinguishing 'not provided' from None/falsy in patch helpers.
+
+    Use as the default for optional parameters whose caller might legitimately
+    want to set the column to `None`. Typed as a dedicated class so unions
+    like `str | UnsetType` survive type checking — `str | Any` would collapse
+    to `Any` and silently disable enforcement at the call site.
+    """
+
+
+UNSET: Final[UnsetType] = UnsetType()
+
+
+def is_unique_violation(exc: IntegrityError, constraint: str) -> bool:
+    """True iff the IntegrityError came from the named unique constraint/index.
+
+    Postgres surfaces the violated constraint via `diag.constraint_name` on
+    the underlying psycopg2 error. Callers can use this to translate the
+    specific collision into a structured `OnyxError(DUPLICATE_RESOURCE)` while
+    letting unrelated integrity errors (FK violations, NOT NULL, etc.) bubble
+    up unchanged.
+    """
+    orig = exc.orig
+    return (
+        isinstance(orig, UniqueViolation)
+        and getattr(orig.diag, "constraint_name", None) == constraint
+    )
 
 
 def model_to_dict(model: Base) -> dict[str, Any]:

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -1,1 +1,267 @@
+"""Custom skill bundle validation and helpers.
 
+See docs/craft/features/skills/skills_plan.md §5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import shutil
+import stat
+import zipfile
+from pathlib import Path
+from typing import Final
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.registry import BuiltinSkillRegistry
+
+DEFAULT_PER_FILE_MAX_BYTES: Final[int] = 25 * 1024 * 1024
+DEFAULT_TOTAL_MAX_BYTES: Final[int] = 100 * 1024 * 1024
+
+SKILL_MD_NAME: Final[str] = "SKILL.md"
+TEMPLATE_SUFFIX: Final[str] = ".template"
+
+SLUG_REGEX: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+_ZIP_UNIX_CREATE_SYSTEM: Final[int] = 3
+
+
+def _check_slug(slug: str) -> None:
+    if not SLUG_REGEX.match(slug):
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"invalid slug '{slug}'")
+
+
+def _is_symlink(info: zipfile.ZipInfo) -> bool:
+    """True if the zip entry was archived as a Unix symlink.
+
+    We inspect the zip-entry metadata (``external_attr`` mode bits) rather
+    than ``Path.is_symlink()`` because at validation time nothing has been
+    extracted to disk yet — and the whole point of the check is to refuse
+    to extract.
+    """
+    if info.create_system != _ZIP_UNIX_CREATE_SYSTEM:
+        return False
+    unix_mode = (info.external_attr >> 16) & 0xFFFF
+    return stat.S_ISLNK(unix_mode)
+
+
+def _check_zip_entry_path(name: str) -> str:
+    """Reject path-traversal entries; return a clean relative posix path.
+
+    A zip-bomb-style entry like ``../../etc/passwd`` or ``/etc/passwd`` must
+    never reach disk. We refuse to even look at the file contents in that case.
+    """
+    trimmed = name.rstrip("/")
+    if not trimmed:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"bundle entry has empty path: '{name}'",
+        )
+    if trimmed.startswith("/") or "\\" in trimmed:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"bundle entry escapes root: '{name}'",
+        )
+    parts = trimmed.split("/")
+    if any(p in ("", ".", "..") for p in parts):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"bundle entry escapes root: '{name}'",
+        )
+    return trimmed
+
+
+def validate_custom_bundle(
+    zip_bytes: bytes,
+    slug: str,
+    *,
+    per_file_max_bytes: int = DEFAULT_PER_FILE_MAX_BYTES,
+    total_max_bytes: int = DEFAULT_TOTAL_MAX_BYTES,
+) -> None:
+    """Validate a custom skill bundle. Returns on success, raises on failure.
+
+    Args:
+        zip_bytes: Raw zip bytes uploaded by an admin.
+        slug: Caller-supplied slug for this skill.
+        per_file_max_bytes: Per-entry uncompressed cap.
+        total_max_bytes: Total uncompressed cap.
+
+    Raises:
+        OnyxError(INVALID_INPUT): structural violations (bad slug, missing
+            SKILL.md, traversal, symlink, template, unreadable entry).
+        OnyxError(PAYLOAD_TOO_LARGE): per-file or total size cap exceeded.
+    """
+    _check_slug(slug)
+    if slug in BuiltinSkillRegistry.instance().reserved_slugs():
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"slug '{slug}' is reserved")
+
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+
+    with zf:
+        total = 0
+        saw_skill_md = False
+
+        for info in zf.infolist():
+            if info.is_dir():
+                _check_zip_entry_path(info.filename)
+                continue
+
+            normalized = _check_zip_entry_path(info.filename)
+            if _is_symlink(info):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"bundle contains a symlink: '{normalized}'",
+                )
+            if normalized.endswith(TEMPLATE_SUFFIX):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "custom skills cannot ship templates",
+                )
+
+            size = 0
+            try:
+                with zf.open(info, mode="r") as fh:
+                    while True:
+                        chunk = fh.read(64 * 1024)
+                        if not chunk:
+                            break
+                        size += len(chunk)
+                        if size > per_file_max_bytes:
+                            raise OnyxError(
+                                OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                                f"file '{normalized}' exceeds "
+                                f"{per_file_max_bytes // (1024 * 1024)} MiB",
+                            )
+                        total += len(chunk)
+                        if total > total_max_bytes:
+                            raise OnyxError(
+                                OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                                f"bundle exceeds "
+                                f"{total_max_bytes // (1024 * 1024)} MiB uncompressed",
+                            )
+            except OnyxError:
+                raise
+            except Exception as exc:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"cannot read '{normalized}': {exc}",
+                ) from exc
+
+            if normalized == SKILL_MD_NAME:
+                saw_skill_md = True
+
+        if not saw_skill_md:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILL.md missing at bundle root",
+            )
+
+
+def _safe_unzip(
+    zip_bytes: bytes,
+    dest: Path,
+    *,
+    per_file_max_bytes: int = DEFAULT_PER_FILE_MAX_BYTES,
+    total_max_bytes: int = DEFAULT_TOTAL_MAX_BYTES,
+) -> None:
+    """Defensive unzip into ``dest`` for use at materialization time.
+
+    The validator should have already rejected traversal/symlink/oversized
+    bundles at upload, but a validator bug or a tampered blob shouldn't equal
+    a sandbox escape or a disk-exhaustion incident. We re-check everything
+    here — traversal, symlinks, and the same per-file + total size caps.
+
+    On any failure mid-extraction (size cap hit, OS error, unsupported
+    compression, etc.) the entire ``dest`` directory is removed before the
+    error propagates, so the caller never sees a half-populated skill tree.
+    """
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+    except zipfile.BadZipFile:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "bundle is not a valid zip")
+
+    _mkdir_or_raise(dest)
+    dest_resolved = dest.resolve()
+
+    try:
+        with zf:
+            total = 0
+            for info in zf.infolist():
+                if _is_symlink(info):
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"bundle contains a symlink: '{info.filename}'",
+                    )
+                normalized = _check_zip_entry_path(info.filename)
+                target = (dest / normalized).resolve()
+                try:
+                    target.relative_to(dest_resolved)
+                except ValueError:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"bundle entry escapes root: '{info.filename}'",
+                    )
+                if info.is_dir():
+                    _mkdir_or_raise(target)
+                    continue
+                _mkdir_or_raise(target.parent)
+                size = 0
+                try:
+                    with zf.open(info, mode="r") as src, open(target, "wb") as out:
+                        while True:
+                            chunk = src.read(64 * 1024)
+                            if not chunk:
+                                break
+                            size += len(chunk)
+                            if size > per_file_max_bytes:
+                                raise OnyxError(
+                                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                                    f"file '{normalized}' exceeds "
+                                    f"{per_file_max_bytes // (1024 * 1024)} MiB",
+                                )
+                            total += len(chunk)
+                            if total > total_max_bytes:
+                                raise OnyxError(
+                                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                                    f"bundle exceeds "
+                                    f"{total_max_bytes // (1024 * 1024)} MiB uncompressed",
+                                )
+                            out.write(chunk)
+                except OnyxError:
+                    raise
+                except Exception as exc:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"cannot extract '{normalized}': {exc}",
+                    ) from exc
+    except BaseException:
+        shutil.rmtree(dest, ignore_errors=True)
+        raise
+
+
+def _mkdir_or_raise(path: Path) -> None:
+    """``path.mkdir(parents=True, exist_ok=True)`` with OS errors translated
+    to ``OnyxError`` so failed bundle extraction never surfaces as a 500."""
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"cannot create '{path}': {exc}",
+        ) from exc
+
+
+def compute_bundle_sha256(zip_bytes: bytes) -> str:
+    """SHA-256 of the raw upload bytes.
+
+    Hashed over the zip-as-uploaded — two zips with identical contents but
+    different timestamps still hash differently. We're detecting "this is the
+    exact same upload," not "the contents match."
+    """
+    return hashlib.sha256(zip_bytes).hexdigest()

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -9,10 +9,7 @@ from pydantic import ConfigDict
 from sqlalchemy.orm import Session
 
 _SLUG_REGEX = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
-
-
-def _always_available(_: Session) -> bool:
-    return True
+_DEFAULT_IS_AVAILABLE: Callable[[Session], bool] = lambda _: True  # noqa: E731
 
 
 class BuiltinSkill(BaseModel):
@@ -25,7 +22,7 @@ class BuiltinSkill(BaseModel):
     name: str
     description: str
     has_template: bool
-    is_available: Callable[[Session], bool] = _always_available
+    is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
     unavailable_reason: str | None = None
     configure_url: str | None = None
 
@@ -109,7 +106,7 @@ class BuiltinSkillRegistry:
         self,
         slug: str,
         source_dir: Path,
-        is_available: Callable[[Session], bool] = _always_available,
+        is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE,
         unavailable_reason: str | None = None,
         configure_url: str | None = None,
     ) -> None:

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -139,7 +139,7 @@ class BuiltinSkillRegistry:
     def list_all(self) -> list[BuiltinSkill]:
         return list(self._skills.values())
 
-    def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
+    def list_available(self, db: Session) -> list[BuiltinSkill]:
         return [skill for skill in self.list_all() if skill.is_available(db)]
 
     def get(self, slug: str) -> BuiltinSkill | None:

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -1,40 +1,55 @@
 import re
 from collections.abc import Callable
 from pathlib import Path
+from threading import Lock
 from typing import ClassVar
 
 import yaml
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import field_validator
 from sqlalchemy.orm import Session
 
 _SLUG_REGEX = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_FRONTMATTER_REGEX = re.compile(
+    r"\A---[ \t]*\r?\n(?P<frontmatter>.*?)(?:\r?\n)---[ \t]*(?:\r?\n|\Z)",
+    re.DOTALL,
+)
 _DEFAULT_IS_AVAILABLE: Callable[[Session], bool] = lambda _: True  # noqa: E731
+_SLUG_ERROR = (
+    "Skill slug must start with a lowercase letter, contain only lowercase "
+    "letters, numbers, and hyphens, and be at most 64 characters."
+)
 
 
-class BuiltinSkill(BaseModel):
-    """In-memory entry for an on-disk built-in skill."""
+class Skill(BaseModel):
+    """Common skill metadata shared by built-in and custom skill views."""
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     slug: str
-    source_dir: Path
     name: str
     description: str
+
+    @field_validator("slug")
+    @classmethod
+    def validate_slug(cls, slug: str) -> str:
+        if not _SLUG_REGEX.fullmatch(slug):
+            raise ValueError(_SLUG_ERROR)
+        return slug
+
+
+class BuiltinSkill(Skill):
+    """In-memory entry for an on-disk built-in skill."""
+
+    source_dir: Path
     has_template: bool
     is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
     unavailable_reason: str | None = None
     configure_url: str | None = None
 
 
-def _validate_slug(slug: str) -> None:
-    if not _SLUG_REGEX.fullmatch(slug):
-        raise ValueError(
-            f"Skill slug must match ^[a-z][a-z0-9-]{{0,63}}$; got {slug!r}"
-        )
-
-
-def _skill_metadata_path(source_dir: Path) -> tuple[Path, bool]:
+def _select_skill_definition_path(source_dir: Path) -> tuple[Path, bool]:
     skill_md_path = source_dir / "SKILL.md"
     template_path = source_dir / "SKILL.md.template"
 
@@ -46,31 +61,26 @@ def _skill_metadata_path(source_dir: Path) -> tuple[Path, bool]:
 
     raise ValueError(
         f"Built-in skill source directory {source_dir} must contain "
-        "SKILL.md or SKILL.md.template"
+        "either SKILL.md or SKILL.md.template"
     )
 
 
 def _read_frontmatter(path: Path) -> dict[str, object]:
     content = path.read_text(encoding="utf-8")
-    lines = content.splitlines()
+    match = _FRONTMATTER_REGEX.match(content)
+    if match is None:
+        raise ValueError(
+            f"{path} must start with YAML frontmatter delimited by two --- lines"
+        )
 
-    if not lines or lines[0].strip() != "---":
-        raise ValueError(f"{path} must start with YAML frontmatter")
-
-    frontmatter_lines: list[str] = []
-    for line in lines[1:]:
-        if line.strip() == "---":
-            parsed = yaml.safe_load("\n".join(frontmatter_lines)) or {}
-            if not isinstance(parsed, dict):
-                raise ValueError(f"{path} frontmatter must be a mapping")
-            return parsed
-        frontmatter_lines.append(line)
-
-    raise ValueError(f"{path} frontmatter is missing closing --- delimiter")
+    parsed = yaml.safe_load(match.group("frontmatter")) or {}
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{path} frontmatter must be a mapping")
+    return parsed
 
 
 def _read_metadata(source_dir: Path) -> tuple[str, str, bool]:
-    metadata_path, has_template = _skill_metadata_path(source_dir)
+    metadata_path, has_template = _select_skill_definition_path(source_dir)
     frontmatter = _read_frontmatter(metadata_path)
 
     name = frontmatter.get("name")
@@ -88,6 +98,7 @@ class BuiltinSkillRegistry:
     """Process-wide registry populated with on-disk built-in skills at boot."""
 
     _instance: ClassVar["BuiltinSkillRegistry | None"] = None
+    _instance_lock: ClassVar[Lock] = Lock()
 
     def __init__(self) -> None:
         self._skills: dict[str, BuiltinSkill] = {}
@@ -95,12 +106,15 @@ class BuiltinSkillRegistry:
     @classmethod
     def instance(cls) -> "BuiltinSkillRegistry":
         if cls._instance is None:
-            cls._instance = cls()
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
         return cls._instance
 
     @classmethod
     def _reset_for_testing(cls) -> None:
-        cls._instance = None
+        with cls._instance_lock:
+            cls._instance = None
 
     def register(
         self,
@@ -110,8 +124,6 @@ class BuiltinSkillRegistry:
         unavailable_reason: str | None = None,
         configure_url: str | None = None,
     ) -> None:
-        _validate_slug(slug)
-
         if slug in self._skills:
             raise ValueError(f"Built-in skill {slug!r} is already registered")
 

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -1,1 +1,193 @@
+import re
+from collections.abc import Callable
+from collections.abc import Sequence
+from pathlib import Path
+from typing import ClassVar
 
+import yaml
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from sqlalchemy.orm import Session
+
+_SLUG_REGEX = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+
+class SkillRequirement(BaseModel):
+    """Org-level dependency a built-in skill needs to be usable."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    key: str
+    name: str
+    description: str
+    configure_url: str
+    check: Callable[[Session], bool]
+
+
+class BuiltinSkill(BaseModel):
+    """In-memory entry for an on-disk built-in skill."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    slug: str
+    source_dir: Path
+    name: str
+    description: str
+    has_template: bool
+    requirements: tuple[SkillRequirement, ...] = ()
+
+
+class SkillRequirementStatus(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    name: str
+    description: str
+    configure_url: str
+    satisfied: bool
+
+
+class BuiltinSkillStatus(BaseModel):
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    skill: BuiltinSkill
+    available: bool
+    requirements: tuple[SkillRequirementStatus, ...]
+
+
+def _validate_slug(slug: str) -> None:
+    if not _SLUG_REGEX.fullmatch(slug):
+        raise ValueError(
+            f"Skill slug must match ^[a-z][a-z0-9-]{{0,63}}$; got {slug!r}"
+        )
+
+
+def _skill_metadata_path(source_dir: Path) -> tuple[Path, bool]:
+    skill_md_path = source_dir / "SKILL.md"
+    template_path = source_dir / "SKILL.md.template"
+
+    if template_path.exists():
+        return template_path, True
+
+    if skill_md_path.exists():
+        return skill_md_path, False
+
+    raise ValueError(
+        f"Built-in skill source directory {source_dir} must contain "
+        "SKILL.md or SKILL.md.template"
+    )
+
+
+def _read_frontmatter(path: Path) -> dict[str, object]:
+    content = path.read_text()
+    lines = content.splitlines()
+
+    if not lines or lines[0].strip() != "---":
+        raise ValueError(f"{path} must start with YAML frontmatter")
+
+    frontmatter_lines: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            parsed = yaml.safe_load("\n".join(frontmatter_lines)) or {}
+            if not isinstance(parsed, dict):
+                raise ValueError(f"{path} frontmatter must be a mapping")
+            return parsed
+        frontmatter_lines.append(line)
+
+    raise ValueError(f"{path} frontmatter is missing closing --- delimiter")
+
+
+def _read_metadata(source_dir: Path) -> tuple[str, str, bool]:
+    metadata_path, has_template = _skill_metadata_path(source_dir)
+    frontmatter = _read_frontmatter(metadata_path)
+
+    name = frontmatter.get("name")
+    description = frontmatter.get("description")
+
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError(f"{metadata_path} frontmatter must include name")
+    if not isinstance(description, str) or not description.strip():
+        raise ValueError(f"{metadata_path} frontmatter must include description")
+
+    return name, description, has_template
+
+
+class BuiltinSkillRegistry:
+    """Process-wide registry populated with on-disk built-in skills at boot."""
+
+    _instance: ClassVar["BuiltinSkillRegistry | None"] = None
+
+    def __init__(self) -> None:
+        self._skills: dict[str, BuiltinSkill] = {}
+
+    @classmethod
+    def instance(cls) -> "BuiltinSkillRegistry":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    def register(
+        self,
+        slug: str,
+        source_dir: Path,
+        requirements: Sequence[SkillRequirement] = (),
+    ) -> None:
+        _validate_slug(slug)
+
+        if slug in self._skills:
+            raise ValueError(f"Built-in skill {slug!r} is already registered")
+
+        resolved_source_dir = source_dir.resolve()
+        if not resolved_source_dir.is_dir():
+            raise ValueError(
+                f"Built-in skill source directory {resolved_source_dir} does not exist"
+            )
+
+        name, description, has_template = _read_metadata(resolved_source_dir)
+        self._skills[slug] = BuiltinSkill(
+            slug=slug,
+            source_dir=resolved_source_dir,
+            name=name,
+            description=description,
+            has_template=has_template,
+            requirements=tuple(requirements),
+        )
+
+    def list_all(self) -> list[BuiltinSkill]:
+        return list(self._skills.values())
+
+    def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
+        return [
+            skill
+            for skill in self.list_all()
+            if all(requirement.check(db) for requirement in skill.requirements)
+        ]
+
+    def evaluate_for_admin(self, db: Session) -> list[BuiltinSkillStatus]:
+        statuses: list[BuiltinSkillStatus] = []
+        for skill in self.list_all():
+            requirement_statuses = tuple(
+                SkillRequirementStatus(
+                    key=requirement.key,
+                    name=requirement.name,
+                    description=requirement.description,
+                    configure_url=requirement.configure_url,
+                    satisfied=requirement.check(db),
+                )
+                for requirement in skill.requirements
+            )
+            statuses.append(
+                BuiltinSkillStatus(
+                    skill=skill,
+                    available=all(status.satisfied for status in requirement_statuses),
+                    requirements=requirement_statuses,
+                )
+            )
+
+        return statuses
+
+    def get(self, slug: str) -> BuiltinSkill | None:
+        return self._skills.get(slug)
+
+    def reserved_slugs(self) -> set[str]:
+        return set(self._skills)

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -2,7 +2,10 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 from threading import Lock
+from typing import Any
 from typing import ClassVar
+from typing import Literal
+from uuid import UUID
 
 import yaml
 from pydantic import BaseModel
@@ -42,11 +45,24 @@ class BuiltinSkill(Skill):
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
+    source: Literal["builtin"] = "builtin"
     source_dir: Path
     has_template: bool
     is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
     unavailable_reason: str | None = None
     configure_url: str | None = None
+
+
+class CustomSkill(Skill):
+    """DB-backed skill metadata needed by skill consumers."""
+
+    source: Literal["custom"] = "custom"
+    id: UUID
+    bundle_file_id: str
+    bundle_sha256: str
+    manifest_metadata: dict[str, Any]
+    is_public: bool
+    enabled: bool
 
 
 def _select_skill_definition_path(source_dir: Path) -> tuple[Path, bool]:

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -25,8 +25,6 @@ _SLUG_ERROR = (
 class Skill(BaseModel):
     """Common skill metadata shared by built-in and custom skill views."""
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
     slug: str
     name: str
     description: str
@@ -41,6 +39,8 @@ class Skill(BaseModel):
 
 class BuiltinSkill(Skill):
     """In-memory entry for an on-disk built-in skill."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     source_dir: Path
     has_template: bool

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -126,6 +126,10 @@ class BuiltinSkillRegistry:
             cls._instance = cls()
         return cls._instance
 
+    @classmethod
+    def _reset_for_testing(cls) -> None:
+        cls._instance = None
+
     def register(
         self,
         slug: str,

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -79,7 +79,7 @@ def _skill_metadata_path(source_dir: Path) -> tuple[Path, bool]:
 
 
 def _read_frontmatter(path: Path) -> dict[str, object]:
-    content = path.read_text()
+    content = path.read_text(encoding="utf-8")
     lines = content.splitlines()
 
     if not lines or lines[0].strip() != "---":

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -1,6 +1,5 @@
 import re
 from collections.abc import Callable
-from collections.abc import Sequence
 from pathlib import Path
 from typing import ClassVar
 
@@ -12,16 +11,8 @@ from sqlalchemy.orm import Session
 _SLUG_REGEX = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 
 
-class SkillRequirement(BaseModel):
-    """Org-level dependency a built-in skill needs to be usable."""
-
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
-    key: str
-    name: str
-    description: str
-    configure_url: str
-    check: Callable[[Session], bool]
+def _always_available(_: Session) -> bool:
+    return True
 
 
 class BuiltinSkill(BaseModel):
@@ -34,25 +25,9 @@ class BuiltinSkill(BaseModel):
     name: str
     description: str
     has_template: bool
-    requirements: tuple[SkillRequirement, ...] = ()
-
-
-class SkillRequirementStatus(BaseModel):
-    model_config = ConfigDict(frozen=True)
-
-    key: str
-    name: str
-    description: str
-    configure_url: str
-    satisfied: bool
-
-
-class BuiltinSkillStatus(BaseModel):
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
-    skill: BuiltinSkill
-    available: bool
-    requirements: tuple[SkillRequirementStatus, ...]
+    is_available: Callable[[Session], bool] = _always_available
+    unavailable_reason: str | None = None
+    configure_url: str | None = None
 
 
 def _validate_slug(slug: str) -> None:
@@ -134,7 +109,9 @@ class BuiltinSkillRegistry:
         self,
         slug: str,
         source_dir: Path,
-        requirements: Sequence[SkillRequirement] = (),
+        is_available: Callable[[Session], bool] = _always_available,
+        unavailable_reason: str | None = None,
+        configure_url: str | None = None,
     ) -> None:
         _validate_slug(slug)
 
@@ -154,41 +131,16 @@ class BuiltinSkillRegistry:
             name=name,
             description=description,
             has_template=has_template,
-            requirements=tuple(requirements),
+            is_available=is_available,
+            unavailable_reason=unavailable_reason,
+            configure_url=configure_url,
         )
 
     def list_all(self) -> list[BuiltinSkill]:
         return list(self._skills.values())
 
     def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
-        return [
-            skill
-            for skill in self.list_all()
-            if all(requirement.check(db) for requirement in skill.requirements)
-        ]
-
-    def evaluate_for_admin(self, db: Session) -> list[BuiltinSkillStatus]:
-        statuses: list[BuiltinSkillStatus] = []
-        for skill in self.list_all():
-            requirement_statuses = tuple(
-                SkillRequirementStatus(
-                    key=requirement.key,
-                    name=requirement.name,
-                    description=requirement.description,
-                    configure_url=requirement.configure_url,
-                    satisfied=requirement.check(db),
-                )
-                for requirement in skill.requirements
-            )
-            statuses.append(
-                BuiltinSkillStatus(
-                    skill=skill,
-                    available=all(status.satisfied for status in requirement_statuses),
-                    requirements=requirement_statuses,
-                )
-            )
-
-        return statuses
+        return [skill for skill in self.list_all() if skill.is_available(db)]
 
     def get(self, slug: str) -> BuiltinSkill | None:
         return self._skills.get(slug)

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -50,7 +50,6 @@ class BuiltinSkill(Skill):
     has_template: bool
     is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
     unavailable_reason: str | None = None
-    configure_url: str | None = None
 
 
 class CustomSkill(Skill):
@@ -138,7 +137,6 @@ class BuiltinSkillRegistry:
         source_dir: Path,
         is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE,
         unavailable_reason: str | None = None,
-        configure_url: str | None = None,
     ) -> None:
         if slug in self._skills:
             raise ValueError(f"Built-in skill {slug!r} is already registered")
@@ -158,7 +156,6 @@ class BuiltinSkillRegistry:
             has_template=has_template,
             is_available=is_available,
             unavailable_reason=unavailable_reason,
-            configure_url=configure_url,
         )
 
     def list_all(self) -> list[BuiltinSkill]:

--- a/backend/tests/unit/onyx/skills/test_bundle.py
+++ b/backend/tests/unit/onyx/skills/test_bundle.py
@@ -1,0 +1,384 @@
+"""Unit tests for the custom skill bundle validator (spec §5)."""
+
+from __future__ import annotations
+
+import io
+import stat
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.bundle import _safe_unzip
+from onyx.skills.bundle import _ZIP_UNIX_CREATE_SYSTEM
+from onyx.skills.bundle import compute_bundle_sha256
+from onyx.skills.bundle import validate_custom_bundle
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _build_zip(
+    entries: list[tuple[str, bytes]],
+    *,
+    symlinks: list[tuple[str, bytes]] | None = None,
+    fixed_date: tuple[int, int, int, int, int, int] = (2026, 1, 1, 0, 0, 0),
+) -> bytes:
+    """Build a zip in-memory. ``symlinks`` is a list of (path, target) pairs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path, data in entries:
+            info = zipfile.ZipInfo(filename=path, date_time=fixed_date)
+            zf.writestr(info, data)
+        for path, target in symlinks or []:
+            info = zipfile.ZipInfo(filename=path, date_time=fixed_date)
+            info.create_system = _ZIP_UNIX_CREATE_SYSTEM
+            info.external_attr = (stat.S_IFLNK | 0o755) << 16
+            zf.writestr(info, target)
+    return buf.getvalue()
+
+
+VALID_SKILL_MD = b"# Hello\n\nBody content.\n"
+
+
+def _valid_bundle() -> bytes:
+    return _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("scripts/run.sh", b"#!/bin/sh\necho hi\n"),
+            ("docs/notes.md", b"# Notes\n"),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_valid_bundle_accepted() -> None:
+    # No raise = pass; validator returns None.
+    assert validate_custom_bundle(_valid_bundle(), slug="hello") is None
+
+
+# ---------------------------------------------------------------------------
+# Failure modes — one test per rule from spec §5
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_zip() -> None:
+    with pytest.raises(OnyxError, match="not a valid zip"):
+        validate_custom_bundle(b"not a zip", slug="hello")
+
+
+def test_rejects_missing_skill_md() -> None:
+    zip_bytes = _build_zip([("scripts/run.sh", b"#!/bin/sh\n")])
+    with pytest.raises(OnyxError, match="SKILL.md missing at bundle root"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+def test_rejects_skill_md_not_at_root() -> None:
+    zip_bytes = _build_zip([("subdir/SKILL.md", VALID_SKILL_MD)])
+    with pytest.raises(OnyxError, match="SKILL.md missing at bundle root"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+def test_rejects_template_file() -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("SKILL.md.template", b"# templated\n"),
+        ]
+    )
+    with pytest.raises(OnyxError, match="cannot ship templates"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../escape.txt",
+        "foo/../../escape.txt",
+        "/etc/passwd",
+        "./shouldnotbehere",
+    ],
+)
+def test_rejects_path_traversal(bad_path: str) -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            (bad_path, b"oops"),
+        ]
+    )
+    with pytest.raises(OnyxError, match="escapes root"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+def test_rejects_symlink() -> None:
+    zip_bytes = _build_zip(
+        [("SKILL.md", VALID_SKILL_MD)],
+        symlinks=[("link", b"/etc/passwd")],
+    )
+    with pytest.raises(OnyxError, match="symlink"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+def test_rejects_oversized_single_file() -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("big.bin", b"\x00" * 64),
+        ]
+    )
+    with pytest.raises(OnyxError, match="exceeds"):
+        validate_custom_bundle(zip_bytes, slug="hello", per_file_max_bytes=32)
+
+
+def test_rejects_oversized_total() -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", b"x" * 64),
+            ("a.bin", b"y" * 64),
+            ("b.bin", b"z" * 64),
+        ]
+    )
+    with pytest.raises(OnyxError, match="uncompressed"):
+        validate_custom_bundle(
+            zip_bytes,
+            slug="hello",
+            per_file_max_bytes=1024,
+            total_max_bytes=128,
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_slug",
+    [
+        "",
+        "Hello",
+        "1starts-with-digit",
+        "has_underscore",
+        "a" * 65,
+        "..",
+    ],
+)
+def test_rejects_invalid_slug(bad_slug: str) -> None:
+    with pytest.raises(OnyxError, match="invalid slug"):
+        validate_custom_bundle(_valid_bundle(), slug=bad_slug)
+
+
+def test_rejects_reserved_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    from onyx.skills.registry import BuiltinSkillRegistry
+
+    monkeypatch.setattr(
+        BuiltinSkillRegistry.instance(),
+        "reserved_slugs",
+        lambda: {"pptx", "image-generation"},
+    )
+    with pytest.raises(OnyxError, match="reserved"):
+        validate_custom_bundle(_valid_bundle(), slug="pptx")
+
+
+# ---------------------------------------------------------------------------
+# compute_bundle_sha256
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_is_deterministic_for_same_bytes() -> None:
+    bundle = _valid_bundle()
+    assert compute_bundle_sha256(bundle) == compute_bundle_sha256(bundle)
+
+
+def test_sha256_differs_when_bytes_differ() -> None:
+    a = _valid_bundle()
+    b = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("scripts/run.sh", b"#!/bin/sh\necho different\n"),
+        ]
+    )
+    assert compute_bundle_sha256(a) != compute_bundle_sha256(b)
+
+
+def test_sha256_differs_for_same_content_different_timestamps() -> None:
+    """compute_bundle_sha256 is a raw-bytes hash — same contents repacked with
+    different timestamps deliberately hash differently.
+
+    Spec §5: ``deterministic over raw bytes`` — we want to detect "this is the
+    exact same upload," not "the contents match."
+    """
+    entries = [
+        ("SKILL.md", VALID_SKILL_MD),
+        ("scripts/run.sh", b"#!/bin/sh\n"),
+    ]
+    a = _build_zip(entries, fixed_date=(2026, 1, 1, 0, 0, 0))
+    b = _build_zip(entries, fixed_date=(2026, 6, 15, 12, 30, 0))
+    assert a != b
+    assert compute_bundle_sha256(a) != compute_bundle_sha256(b)
+
+
+# ---------------------------------------------------------------------------
+# _safe_unzip
+# ---------------------------------------------------------------------------
+
+
+def test_safe_unzip_extracts_valid_bundle(tmp_path: Path) -> None:
+    _safe_unzip(_valid_bundle(), tmp_path / "out")
+    assert (tmp_path / "out" / "SKILL.md").read_bytes() == VALID_SKILL_MD
+    assert (tmp_path / "out" / "scripts" / "run.sh").exists()
+
+
+def test_safe_unzip_rejects_traversal(tmp_path: Path) -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("../escape.txt", b"x"),
+        ]
+    )
+    with pytest.raises(OnyxError, match="escapes root"):
+        _safe_unzip(zip_bytes, tmp_path / "out")
+
+
+def test_safe_unzip_rejects_symlink(tmp_path: Path) -> None:
+    zip_bytes = _build_zip(
+        [("SKILL.md", VALID_SKILL_MD)],
+        symlinks=[("link", b"/etc/passwd")],
+    )
+    with pytest.raises(OnyxError, match="symlink"):
+        _safe_unzip(zip_bytes, tmp_path / "out")
+
+
+def test_safe_unzip_enforces_per_file_cap(tmp_path: Path) -> None:
+    """Defense-in-depth: even if upload validation is bypassed or the stored
+    blob is tampered, extraction must not write unbounded data to disk."""
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("big.bin", b"\x00" * 64),
+        ]
+    )
+    with pytest.raises(OnyxError, match="exceeds"):
+        _safe_unzip(zip_bytes, tmp_path / "out", per_file_max_bytes=32)
+
+
+def test_safe_unzip_cleans_dest_on_size_cap_failure(tmp_path: Path) -> None:
+    """Half-extracted skill trees on disk break atomicity — a failed
+    _safe_unzip must leave nothing behind."""
+    out = tmp_path / "out"
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("a/first.bin", b"\x00" * 16),
+            ("a/second.bin", b"\x00" * 64),  # tips us past per_file cap
+        ]
+    )
+    with pytest.raises(OnyxError, match="exceeds"):
+        _safe_unzip(zip_bytes, out, per_file_max_bytes=32)
+    assert not out.exists()
+
+
+def test_safe_unzip_cleans_dest_on_unreadable_entry(tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    zip_bytes = _zip_with_patched_compression_method(VALID_SKILL_MD, method=99)
+    with pytest.raises(OnyxError, match="cannot extract"):
+        _safe_unzip(zip_bytes, out)
+    assert not out.exists()
+
+
+def test_safe_unzip_wraps_mkdir_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A permissions / OS failure during mkdir must surface as OnyxError,
+    not bubble as a raw OSError → HTTP 500."""
+
+    def boom(self: Path, *_args: object, **_kwargs: object) -> None:  # noqa: ARG001
+        raise PermissionError("simulated permission denied")
+
+    monkeypatch.setattr(Path, "mkdir", boom)
+    with pytest.raises(OnyxError, match="cannot create"):
+        _safe_unzip(_valid_bundle(), tmp_path / "out")
+
+
+def test_safe_unzip_enforces_total_cap(tmp_path: Path) -> None:
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", b"x" * 64),
+            ("a.bin", b"y" * 64),
+            ("b.bin", b"z" * 64),
+        ]
+    )
+    with pytest.raises(OnyxError, match="uncompressed"):
+        _safe_unzip(
+            zip_bytes,
+            tmp_path / "out",
+            per_file_max_bytes=1024,
+            total_max_bytes=128,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error translation — corrupt / exotic compression
+# ---------------------------------------------------------------------------
+
+
+def _zip_with_patched_compression_method(payload: bytes, method: int) -> bytes:
+    """Build a valid ZIP_STORED zip, then patch the compression-method field
+    in both the local header and the central directory to ``method``.
+
+    `zipfile.ZipFile(...).writestr()` refuses to write an unknown method, but
+    `zipfile.ZipFile(...).open()` happily reads what it can and raises
+    `NotImplementedError` when it can't — which is exactly the failure mode we
+    want to exercise.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("SKILL.md", payload)
+    raw = bytearray(buf.getvalue())
+    # Patch every occurrence of the compression-method field. In each header
+    # the method is a little-endian uint16 at a fixed offset from the magic.
+    for magic, offset in ((b"PK\x03\x04", 8), (b"PK\x01\x02", 10)):
+        pos = raw.find(magic)
+        if pos != -1:
+            raw[pos + offset : pos + offset + 2] = method.to_bytes(2, "little")
+    return bytes(raw)
+
+
+def test_rejects_unsupported_compression() -> None:
+    """A ZIP using a stdlib-unknown compression method raises NotImplementedError
+    from zf.open() — we must translate that to OnyxError, not a 500."""
+    zip_bytes = _zip_with_patched_compression_method(VALID_SKILL_MD, method=99)
+    with pytest.raises(OnyxError, match="cannot read"):
+        validate_custom_bundle(zip_bytes, slug="hello")
+
+
+def test_safe_unzip_rejects_unsupported_compression(tmp_path: Path) -> None:
+    zip_bytes = _zip_with_patched_compression_method(VALID_SKILL_MD, method=99)
+    with pytest.raises(OnyxError, match="cannot extract"):
+        _safe_unzip(zip_bytes, tmp_path / "out")
+
+
+# ---------------------------------------------------------------------------
+# Error code mapping
+# ---------------------------------------------------------------------------
+
+
+def test_size_violation_returns_413() -> None:
+    """Spec §5 size-cap violations should return HTTP 413, not 400."""
+    zip_bytes = _build_zip(
+        [
+            ("SKILL.md", VALID_SKILL_MD),
+            ("big.bin", b"\x00" * 64),
+        ]
+    )
+    with pytest.raises(OnyxError) as exc_info:
+        validate_custom_bundle(zip_bytes, slug="hello", per_file_max_bytes=32)
+    assert exc_info.value.status_code == 413
+
+
+def test_validation_violation_returns_400() -> None:
+    """Non-size violations still return 400."""
+    with pytest.raises(OnyxError) as exc_info:
+        validate_custom_bundle(b"not a zip", slug="hello")
+    assert exc_info.value.status_code == 400

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -76,7 +76,7 @@ def test_reset_for_testing_clears_singleton(tmp_path: Path) -> None:
     assert fresh_registry.get("singleton-skill") is None
 
 
-def test_list_satisfied_excludes_unavailable_skill(
+def test_list_available_excludes_unavailable_skill(
     tmp_path: Path,
 ) -> None:
     registry = BuiltinSkillRegistry()
@@ -93,7 +93,7 @@ def test_list_satisfied_excludes_unavailable_skill(
         configure_url="/admin/configuration/provider",
     )
 
-    assert [skill.slug for skill in registry.list_satisfied(db)] == ["available"]
+    assert [skill.slug for skill in registry.list_available(db)] == ["available"]
 
     unavailable = registry.get("unavailable")
     assert unavailable is not None

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -151,7 +151,6 @@ def test_list_available_excludes_unavailable_skill(
         unavailable_dir,
         is_available=lambda _: False,
         unavailable_reason="Configure the provider first.",
-        configure_url="/admin/configuration/provider",
     )
 
     assert [skill.slug for skill in registry.list_available(db)] == ["available"]
@@ -160,4 +159,3 @@ def test_list_available_excludes_unavailable_skill(
     assert unavailable is not None
     assert unavailable.is_available(db) is False
     assert unavailable.unavailable_reason == "Configure the provider first."
-    assert unavailable.configure_url == "/admin/configuration/provider"

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -28,7 +28,8 @@ def _write_skill(
                 f"# {slug}",
                 "",
             ]
-        )
+        ),
+        encoding="utf-8",
     )
     return skill_dir
 
@@ -42,6 +43,14 @@ def test_register_rejects_duplicate_slug(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="already registered"):
         registry.register("shared-slug", second_dir)
+
+
+def test_register_rejects_invalid_slug(tmp_path: Path) -> None:
+    registry = BuiltinSkillRegistry()
+    skill_dir = _write_skill(tmp_path, "invalid-source")
+
+    with pytest.raises(ValueError, match="start with a lowercase letter"):
+        registry.register("Invalid_Slug", skill_dir)
 
 
 def test_register_rejects_missing_skill_md(tmp_path: Path) -> None:

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -66,6 +66,17 @@ def test_register_detects_template_metadata_source(tmp_path: Path) -> None:
     assert skill.name == "templated"
 
 
+def test_reset_for_testing_clears_singleton(tmp_path: Path) -> None:
+    BuiltinSkillRegistry._reset_for_testing()
+    registry = BuiltinSkillRegistry.instance()
+    registry.register("singleton-skill", _write_skill(tmp_path, "singleton-skill"))
+
+    BuiltinSkillRegistry._reset_for_testing()
+    fresh_registry = BuiltinSkillRegistry.instance()
+
+    assert fresh_registry.get("singleton-skill") is None
+
+
 def test_list_satisfied_and_admin_status_expose_unmet_requirement(
     tmp_path: Path,
 ) -> None:

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -1,11 +1,13 @@
 from pathlib import Path
 from typing import cast
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
 from onyx.skills.registry import BuiltinSkill
 from onyx.skills.registry import BuiltinSkillRegistry
+from onyx.skills.registry import CustomSkill
 from onyx.skills.registry import Skill
 
 
@@ -65,6 +67,29 @@ def test_shared_skill_shape_is_mutable() -> None:
     assert skill.description == "After"
 
 
+def test_custom_skill_shape_matches_editable_db_metadata() -> None:
+    skill = CustomSkill(
+        id=uuid4(),
+        slug="custom",
+        name="Before",
+        description="Before",
+        bundle_file_id="file-id",
+        bundle_sha256="a" * 64,
+        manifest_metadata={"version": "1"},
+        is_public=False,
+        enabled=True,
+    )
+
+    skill.name = "After"
+    skill.description = "After"
+    skill.enabled = False
+
+    assert skill.source == "custom"
+    assert skill.name == "After"
+    assert skill.description == "After"
+    assert skill.enabled is False
+
+
 def test_builtin_skill_is_frozen(tmp_path: Path) -> None:
     skill = BuiltinSkill(
         slug="builtin",
@@ -76,6 +101,8 @@ def test_builtin_skill_is_frozen(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="frozen"):
         skill.name = "Changed"
+
+    assert skill.source == "builtin"
 
 
 def test_register_rejects_missing_skill_md(tmp_path: Path) -> None:

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.skills.registry import BuiltinSkillRegistry
+from onyx.skills.registry import SkillRequirement
+
+
+def _write_skill(
+    root: Path,
+    slug: str,
+    *,
+    description: str = "Test skill",
+    template: bool = False,
+) -> Path:
+    skill_dir = root / slug
+    skill_dir.mkdir()
+    skill_file = skill_dir / ("SKILL.md.template" if template else "SKILL.md")
+    skill_file.write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {slug}",
+                f"description: {description}",
+                "---",
+                "",
+                f"# {slug}",
+                "",
+            ]
+        )
+    )
+    return skill_dir
+
+
+def test_register_rejects_duplicate_slug(tmp_path: Path) -> None:
+    registry = BuiltinSkillRegistry()
+    first_dir = _write_skill(tmp_path, "first")
+    second_dir = _write_skill(tmp_path, "second")
+
+    registry.register("shared-slug", first_dir)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("shared-slug", second_dir)
+
+
+def test_register_rejects_missing_skill_md(tmp_path: Path) -> None:
+    registry = BuiltinSkillRegistry()
+    skill_dir = tmp_path / "missing-skill-md"
+    skill_dir.mkdir()
+
+    with pytest.raises(ValueError, match="SKILL.md"):
+        registry.register("missing-skill-md", skill_dir)
+
+
+def test_register_detects_template_metadata_source(tmp_path: Path) -> None:
+    registry = BuiltinSkillRegistry()
+    skill_dir = _write_skill(tmp_path, "templated", template=True)
+
+    registry.register("templated", skill_dir)
+
+    skill = registry.get("templated")
+    assert skill is not None
+    assert skill.has_template is True
+    assert skill.name == "templated"
+
+
+def test_list_satisfied_and_admin_status_expose_unmet_requirement(
+    tmp_path: Path,
+) -> None:
+    registry = BuiltinSkillRegistry()
+    available_dir = _write_skill(tmp_path, "available")
+    unavailable_dir = _write_skill(tmp_path, "unavailable")
+    db = cast(Session, object())
+
+    registry.register("available", available_dir)
+    registry.register(
+        "unavailable",
+        unavailable_dir,
+        requirements=[
+            SkillRequirement(
+                key="provider",
+                name="Provider",
+                description="Configure the provider first.",
+                configure_url="/admin/configuration/provider",
+                check=lambda _: False,
+            )
+        ],
+    )
+
+    assert [skill.slug for skill in registry.list_satisfied(db)] == ["available"]
+
+    statuses = {status.skill.slug: status for status in registry.evaluate_for_admin(db)}
+    assert statuses["available"].available is True
+    assert statuses["available"].requirements == ()
+    assert statuses["unavailable"].available is False
+    assert statuses["unavailable"].requirements[0].satisfied is False
+    assert (
+        statuses["unavailable"].requirements[0].description
+        == "Configure the provider first."
+    )

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -5,7 +5,6 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.skills.registry import BuiltinSkillRegistry
-from onyx.skills.registry import SkillRequirement
 
 
 def _write_skill(
@@ -77,7 +76,7 @@ def test_reset_for_testing_clears_singleton(tmp_path: Path) -> None:
     assert fresh_registry.get("singleton-skill") is None
 
 
-def test_list_satisfied_and_admin_status_expose_unmet_requirement(
+def test_list_satisfied_excludes_unavailable_skill(
     tmp_path: Path,
 ) -> None:
     registry = BuiltinSkillRegistry()
@@ -89,25 +88,15 @@ def test_list_satisfied_and_admin_status_expose_unmet_requirement(
     registry.register(
         "unavailable",
         unavailable_dir,
-        requirements=[
-            SkillRequirement(
-                key="provider",
-                name="Provider",
-                description="Configure the provider first.",
-                configure_url="/admin/configuration/provider",
-                check=lambda _: False,
-            )
-        ],
+        is_available=lambda _: False,
+        unavailable_reason="Configure the provider first.",
+        configure_url="/admin/configuration/provider",
     )
 
     assert [skill.slug for skill in registry.list_satisfied(db)] == ["available"]
 
-    statuses = {status.skill.slug: status for status in registry.evaluate_for_admin(db)}
-    assert statuses["available"].available is True
-    assert statuses["available"].requirements == ()
-    assert statuses["unavailable"].available is False
-    assert statuses["unavailable"].requirements[0].satisfied is False
-    assert (
-        statuses["unavailable"].requirements[0].description
-        == "Configure the provider first."
-    )
+    unavailable = registry.get("unavailable")
+    assert unavailable is not None
+    assert unavailable.is_available(db) is False
+    assert unavailable.unavailable_reason == "Configure the provider first."
+    assert unavailable.configure_url == "/admin/configuration/provider"

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -4,7 +4,9 @@ from typing import cast
 import pytest
 from sqlalchemy.orm import Session
 
+from onyx.skills.registry import BuiltinSkill
 from onyx.skills.registry import BuiltinSkillRegistry
+from onyx.skills.registry import Skill
 
 
 def _write_skill(
@@ -51,6 +53,29 @@ def test_register_rejects_invalid_slug(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="start with a lowercase letter"):
         registry.register("Invalid_Slug", skill_dir)
+
+
+def test_shared_skill_shape_is_mutable() -> None:
+    skill = Skill(slug="editable", name="Before", description="Before")
+
+    skill.name = "After"
+    skill.description = "After"
+
+    assert skill.name == "After"
+    assert skill.description == "After"
+
+
+def test_builtin_skill_is_frozen(tmp_path: Path) -> None:
+    skill = BuiltinSkill(
+        slug="builtin",
+        name="Builtin",
+        description="Builtin",
+        source_dir=tmp_path,
+        has_template=False,
+    )
+
+    with pytest.raises(ValueError, match="frozen"):
+        skill.name = "Changed"
 
 
 def test_register_rejects_missing_skill_md(tmp_path: Path) -> None:

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -44,7 +44,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.020-P1.027` BuiltinSkillRegistry core
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[REVIEW @claude-coupled-lattice #11060]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
-- `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 - `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
 
 ---
@@ -86,17 +86,17 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.4 Bundle validator  (spec §5)
 
-- `[WIP @claude-coupled-josephson]` `P1.030` Define `InvalidBundleError(OnyxError)` with `INVALID_REQUEST` code  (deps: P1.012)
-- `[WIP @claude-coupled-josephson]` `P1.031` Implement `validate_custom_bundle(zip_bytes, slug) -> ManifestMetadata` — zip parse, SKILL.md root check, frontmatter parse, no `*.template`  (deps: P1.030)
-- `[WIP @claude-coupled-josephson]` `P1.032` Add path-traversal + symlink rejection to `validate_custom_bundle`  (deps: P1.031)
-- `[WIP @claude-coupled-josephson]` `P1.033` Add per-file + total-size streaming check (defaults 25 MiB / 100 MiB)  (deps: P1.031)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.030` Define `InvalidBundleError(OnyxError)` with `INVALID_REQUEST` code  (deps: P1.012)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.031` Implement `validate_custom_bundle(zip_bytes, slug) -> ManifestMetadata` — zip parse, SKILL.md root check, frontmatter parse, no `*.template`  (deps: P1.030)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.032` Add path-traversal + symlink rejection to `validate_custom_bundle`  (deps: P1.031)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.033` Add per-file + total-size streaming check (defaults 25 MiB / 100 MiB)  (deps: P1.031)
 - `[TODO]` `P1.035` Add slug regex + reserved-slug check (uses `BuiltinSkillRegistry.reserved_slugs()`)  (deps: P1.031, P1.027)
-- `[WIP @claude-coupled-josephson]` `P1.036` Implement `_safe_unzip(zip_bytes, dest)` for defensive re-check at materialization
-- `[WIP @claude-coupled-josephson]` `P1.037` Implement `compute_bundle_sha256(zip_bytes)` — deterministic over raw bytes
-- `[WIP @claude-coupled-josephson]` `P1.038` Unit test fixture: valid bundle zip (`SKILL.md` + frontmatter + scripts dir)
-- `[WIP @claude-coupled-josephson]` `P1.039` Unit test fixture: invalid bundles, one per failure mode (no SKILL.md, traversal entry, symlink, oversized, contains `*.template`)
-- `[WIP @claude-coupled-josephson]` `P1.040` Unit test: each invalid fixture rejected with the correct error reason  (deps: P1.039, P1.031-P1.033, P1.035)
-- `[WIP @claude-coupled-josephson]` `P1.041` Unit test: `compute_bundle_sha256` deterministic across two zips of same content with different timestamps  (deps: P1.037)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.036` Implement `_safe_unzip(zip_bytes, dest)` for defensive re-check at materialization
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.037` Implement `compute_bundle_sha256(zip_bytes)` — deterministic over raw bytes
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.038` Unit test fixture: valid bundle zip (`SKILL.md` + frontmatter + scripts dir)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.039` Unit test fixture: invalid bundles, one per failure mode (no SKILL.md, traversal entry, symlink, oversized, contains `*.template`)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.040` Unit test: each invalid fixture rejected with the correct error reason  (deps: P1.039, P1.031-P1.033, P1.035)
+- `[REVIEW @claude-coupled-josephson #11059]` `P1.041` Unit test: `compute_bundle_sha256` deterministic across two zips of same content with different timestamps  (deps: P1.037)
 
 ### 1.5 Materializer  (spec §6)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -78,11 +78,11 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by `skill.is_available(db) == True`  (deps: P1.020, P1.024)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_available(db) -> list[BuiltinSkill]` — filter by `skill.is_available(db) == True`  (deps: P1.020, P1.024)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Admin callers can derive availability from `BuiltinSkill.is_available`, `unavailable_reason`, and `configure_url`; no separate `BuiltinSkillStatus` DTO in the registry layer  (deps: P1.025)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `is_available` returns False and preserves admin-facing unavailable metadata  (deps: P1.025, P1.026)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_available` excludes a skill whose `is_available` returns False and preserves admin-facing unavailable metadata  (deps: P1.025, P1.026)
 
 ### 1.4 Bundle validator  (spec §5)
 
@@ -140,7 +140,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 2.2 User router  (spec §7)
 
-- `[TODO]` `P2.020` Implement `GET /api/skills` — built-ins (filtered by `list_satisfied`) + customs visible to user  (deps: P2.003, P1.025, P1.060)
+- `[TODO]` `P2.020` Implement `GET /api/skills` — built-ins (filtered by `list_available`) + customs visible to user  (deps: P2.003, P1.025, P1.060)
 
 ### 2.3 Wire-up + tests
 
@@ -166,7 +166,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[TODO]` `P3.003` Register `pptx` built-in (no requirements)  (deps: P3.002)
 - `[TODO]` `P3.004` Register `image-generation` built-in with `is_available=lambda db: get_default_image_generation_config(db) is not None`, `unavailable_reason`, and `configure_url=/admin/configuration/image-generation`  (deps: P3.002, P1.020)
 - `[TODO]` `P3.005` Call `register_craft_builtins(BuiltinSkillRegistry.instance())` from `backend/onyx/main.py` startup (after DB init, before `app.include_router`)  (deps: P3.003, P3.004)
-- `[TODO]` `P3.006` Startup integration test: `assert registry.get("pptx") is not None`; `list_satisfied` excludes `image-generation` when no provider is configured  (deps: P3.005)
+- `[TODO]` `P3.006` Startup integration test: `assert registry.get("pptx") is not None`; `list_available` excludes `image-generation` when no provider is configured  (deps: P3.005)
 
 ### 3.2 Render-context helper
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -43,7 +43,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.010-P1.015` Module skeletons
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.020-P1.027` BuiltinSkillRegistry core
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
-- `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 - `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
 
@@ -109,15 +109,15 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.6 DB ops  (spec §3)
 
-- `[WIP @claude-coupled-lattice]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
-- `[WIP @claude-coupled-lattice]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
-- `[WIP @claude-coupled-lattice]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.060` Implement `list_skills_for_user(user, db)` — public OR group-grant query, filtered to **`enabled = True AND deleted_at IS NULL`**. Mirror `fetch_persona_by_id_for_user` at `backend/onyx/db/persona.py:81` (drop the user-direct-grant branch).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.061` Implement `fetch_skill_for_user(skill_id, user, db)` — same `enabled = True AND deleted_at IS NULL` filter as `list_skills_for_user`.  (deps: P1.060)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.062` Implement `fetch_skill_for_admin(skill_id, db)` — `deleted_at IS NULL` only (admins need disabled skills to re-enable them).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.063` Implement `list_skills_for_admin(db)` — `deleted_at IS NULL` only (admin UI shows disabled skills; soft-deleted hidden by default).  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.064` Implement `create_skill(slug, name, description, bundle_file_id, bundle_sha256, manifest_metadata, is_public, author_user_id, db) -> Skill`  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.065` Implement `replace_skill_bundle(skill_id, new_bundle_file_id, new_sha256, new_manifest_metadata, db) -> Skill` — returns `old_bundle_file_id` for caller blob cleanup  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.066` Implement `patch_skill(...)` — partial update; re-validate slug uniqueness if changing  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.067` Implement `replace_skill_grants(skill_id, group_ids, db)` — atomic delete + insert in one transaction  (deps: P1.015)
+- `[REVIEW @claude-coupled-lattice #11060]` `P1.068` Implement `delete_skill(skill_id, db) -> None` — soft-delete by setting `deleted_at = func.now()`. Blob NOT removed inline; sweep (P5.031–P5.033) handles it after 14 days.  (deps: P1.015)
 
 ---
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -40,9 +40,9 @@ If you're an agent picking up work:
 
 _(Update this section as you claim things. Keep it short — just the active `WIP` and `REVIEW` items so anyone glancing at the file can see what's hot.)_
 
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.010-P1.015` Module skeletons
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.020-P1.027` BuiltinSkillRegistry core
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.010-P1.015` Module skeletons
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.020-P1.027` BuiltinSkillRegistry core
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 - `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
@@ -64,25 +64,25 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.2 Module skeletons  (spec §2)
 
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.011` Create empty `backend/onyx/skills/registry.py`
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.014` Create empty `backend/onyx/skills/render.py`
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.015` Create empty `backend/onyx/db/skill.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.011` Create empty `backend/onyx/skills/registry.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.014` Create empty `backend/onyx/skills/render.py`
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.015` Create empty `backend/onyx/db/skill.py`
 
 ### 1.3 BuiltinSkillRegistry  (spec §4)
 
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
-- `[REVIEW @codex-charged-perovskite #pending]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
 
 ### 1.4 Bundle validator  (spec §5)
 

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -73,16 +73,16 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.3 BuiltinSkillRegistry  (spec §4)
 
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.020` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with frozen + arbitrary-types config, including optional `is_available`, `unavailable_reason`, and `configure_url` fields  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.021` Keep built-in availability as a single optional callable on `BuiltinSkill`; do not introduce a separate `SkillRequirement` abstraction in V1  (deps: P1.020)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by `skill.is_available(db) == True`  (deps: P1.020, P1.024)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Admin callers can derive availability from `BuiltinSkill.is_available`, `unavailable_reason`, and `configure_url`; no separate `BuiltinSkillStatus` DTO in the registry layer  (deps: P1.025)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `is_available` returns False and preserves admin-facing unavailable metadata  (deps: P1.025, P1.026)
 
 ### 1.4 Bundle validator  (spec §5)
 
@@ -130,8 +130,8 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 - `[TODO]` `P2.001` Create `backend/onyx/server/features/skills/__init__.py`
 - `[TODO]` `P2.002` Create `backend/onyx/server/features/skills/api.py` with router scaffolding
-- `[TODO]` `P2.003` Define Pydantic response models: `SkillsAdminList`, `BuiltinSkillAdmin`, `RequirementStatus`, `CustomSkillAdmin`, `SkillsForUser`, `SkillSummary`  (deps: P2.002)
-- `[TODO]` `P2.004` Implement `GET /api/admin/skills` — combine `registry.evaluate_for_admin(db)` + `list_skills_for_admin(db)`  (deps: P2.003, P1.026, P1.063)
+- `[TODO]` `P2.003` Define Pydantic response models: `SkillsAdminList`, `BuiltinSkillAdmin`, `CustomSkillAdmin`, `SkillsForUser`, `SkillSummary`  (deps: P2.002)
+- `[TODO]` `P2.004` Implement `GET /api/admin/skills` — combine `registry.list_all()` (evaluating each built-in's `is_available(db)`) + `list_skills_for_admin(db)`  (deps: P2.003, P1.026, P1.063)
 - `[TODO]` `P2.005` Implement `POST /api/admin/skills/custom` — full create flow per §7 (validate → save blobs → row → grants); inline blob cleanup on failure  (deps: P2.003, P1.031, P1.064, P1.067)
 - `[TODO]` `P2.006` Implement `PATCH /api/admin/skills/custom/{id}` — slug/name/description/is_public/enabled; re-validate slug uniqueness on slug change  (deps: P2.003, P1.066)
 - `[TODO]` `P2.007` Implement `PUT /api/admin/skills/custom/{id}/bundle` — replace flow; delete old blobs AFTER commit  (deps: P2.003, P1.031, P1.065)
@@ -164,7 +164,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[TODO]` `P3.001` Create `backend/onyx/server/features/build/skills/__init__.py`
 - `[TODO]` `P3.002` Create `backend/onyx/server/features/build/skills/builtins_registration.py` with `register_craft_builtins(registry)`  (deps: P3.001, P1.022)
 - `[TODO]` `P3.003` Register `pptx` built-in (no requirements)  (deps: P3.002)
-- `[TODO]` `P3.004` Register `image-generation` built-in with `SkillRequirement` checking `get_default_image_generation_config(db) is not None`, `configure_url=/admin/configuration/image-generation`  (deps: P3.002, P1.020)
+- `[TODO]` `P3.004` Register `image-generation` built-in with `is_available=lambda db: get_default_image_generation_config(db) is not None`, `unavailable_reason`, and `configure_url=/admin/configuration/image-generation`  (deps: P3.002, P1.020)
 - `[TODO]` `P3.005` Call `register_craft_builtins(BuiltinSkillRegistry.instance())` from `backend/onyx/main.py` startup (after DB init, before `app.include_router`)  (deps: P3.003, P3.004)
 - `[TODO]` `P3.006` Startup integration test: `assert registry.get("pptx") is not None`; `list_satisfied` excludes `image-generation` when no provider is configured  (deps: P3.005)
 
@@ -280,7 +280,7 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 - `[TODO]` `P4.010` `web/src/app/admin/skills/SkillsList.tsx` — table renderer using `@opal/components` Table
 - `[TODO]` `P4.011` `web/src/app/admin/skills/SkillRow.tsx` — icon + name + slug + description + source badge + access + action menu
 - `[TODO]` `P4.012` `web/src/app/admin/skills/SourceBadge.tsx` — Platform / Custom pill
-- `[TODO]` `P4.013` Access column rendering: `Available` for satisfied built-ins, `Needs setup · Configure →` (deep-link to `requirements[0].configure_url`) for unmet  (deps: P4.011)
+- `[TODO]` `P4.013` Access column rendering: `Available` for satisfied built-ins, `Needs setup · Configure →` (deep-link to `configure_url` when present) for unmet  (deps: P4.011)
 - `[TODO]` `P4.014` Search + filters: by name/slug, source (All/Platform/Custom), availability
 - `[TODO]` `P4.015` Loading / error / empty states
 
@@ -307,8 +307,8 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 ### 4.5 Built-in detail drawer
 
 - `[TODO]` `P4.040` `BuiltinDetailDrawer.tsx` — read-only metadata (name, slug, description, source path, files, frontmatter)
-- `[TODO]` `P4.041` Requirements section: list each `RequirementStatus` with ✓ if satisfied or ! + Configure button if missing  (deps: P4.040)
-- `[TODO]` `P4.042` Section omitted entirely if skill has no requirements
+- `[TODO]` `P4.041` Availability section: show `Available` or the built-in's `unavailable_reason` with a Configure button when `configure_url` is present  (deps: P4.040)
+- `[TODO]` `P4.042` Section omitted entirely if the built-in is available and has no setup copy/link
 
 ### 4.6 Edit / Replace / Grants / Delete modals
 
@@ -434,7 +434,7 @@ Listed so agents don't accidentally pick these up. Lift to a real task only if p
 - `[SKIP]` `V15.008` Per-skill permission declarations (network/fs/integrations)
 - `[SKIP]` `V15.009` Skill provenance / signing
 - `[SKIP]` `V15.010` Content scanning at upload (intentionally — false-confidence risk)
-- `[SKIP]` `V15.011` Shared/bundled `SkillRequirement` modules
+- `[SKIP]` `V15.011` Shared/bundled availability-check modules
 - `[SKIP]` `V15.012` In-browser skill editor
 - `[SKIP]` `V15.013` Slug rename history table
 - `[SKIP]` `V15.014` **Skill author tooling** — CLI scaffolder (`onyx-cli skill new`), local validator (`onyx-cli skill validate`), `--dry-run` upload mode, format-spec docs page. V1 assumes a developer hand-crafts the zip; the example-skill download (P4.025–P4.027) is the V1 cold-start aid. Pairs with V15.015 (user-authored skills) but useful for admin-authored too.

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -73,13 +73,13 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.3 BuiltinSkillRegistry  (spec §4)
 
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.020` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with frozen + arbitrary-types config, including optional `is_available`, `unavailable_reason`, and `configure_url` fields  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.020` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with frozen + arbitrary-types config, including optional `is_available` and `unavailable_reason` fields  (deps: P1.011)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.021` Keep built-in availability as a single optional callable on `BuiltinSkill`; do not introduce a separate `SkillRequirement` abstraction in V1  (deps: P1.020)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.023` Implement `register(slug, source_dir, is_available=..., unavailable_reason=None)` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.025` Implement `list_available(db) -> list[BuiltinSkill]` — filter by `skill.is_available(db) == True`  (deps: P1.020, P1.024)
-- `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Admin callers can derive availability from `BuiltinSkill.is_available`, `unavailable_reason`, and `configure_url`; no separate `BuiltinSkillStatus` DTO in the registry layer  (deps: P1.025)
+- `[REVIEW @codex-charged-perovskite #11061]` `P1.026` Admin callers can derive availability from `BuiltinSkill.is_available` and `unavailable_reason`; no separate `BuiltinSkillStatus` DTO in the registry layer  (deps: P1.025)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
 - `[REVIEW @codex-charged-perovskite #11061]` `P1.029` Unit test: `list_available` excludes a skill whose `is_available` returns False and preserves admin-facing unavailable metadata  (deps: P1.025, P1.026)
@@ -164,7 +164,7 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 - `[TODO]` `P3.001` Create `backend/onyx/server/features/build/skills/__init__.py`
 - `[TODO]` `P3.002` Create `backend/onyx/server/features/build/skills/builtins_registration.py` with `register_craft_builtins(registry)`  (deps: P3.001, P1.022)
 - `[TODO]` `P3.003` Register `pptx` built-in (no requirements)  (deps: P3.002)
-- `[TODO]` `P3.004` Register `image-generation` built-in with `is_available=lambda db: get_default_image_generation_config(db) is not None`, `unavailable_reason`, and `configure_url=/admin/configuration/image-generation`  (deps: P3.002, P1.020)
+- `[TODO]` `P3.004` Register `image-generation` built-in with `is_available=lambda db: get_default_image_generation_config(db) is not None` and `unavailable_reason`  (deps: P3.002, P1.020)
 - `[TODO]` `P3.005` Call `register_craft_builtins(BuiltinSkillRegistry.instance())` from `backend/onyx/main.py` startup (after DB init, before `app.include_router`)  (deps: P3.003, P3.004)
 - `[TODO]` `P3.006` Startup integration test: `assert registry.get("pptx") is not None`; `list_available` excludes `image-generation` when no provider is configured  (deps: P3.005)
 
@@ -280,7 +280,7 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 - `[TODO]` `P4.010` `web/src/app/admin/skills/SkillsList.tsx` — table renderer using `@opal/components` Table
 - `[TODO]` `P4.011` `web/src/app/admin/skills/SkillRow.tsx` — icon + name + slug + description + source badge + access + action menu
 - `[TODO]` `P4.012` `web/src/app/admin/skills/SourceBadge.tsx` — Platform / Custom pill
-- `[TODO]` `P4.013` Access column rendering: `Available` for satisfied built-ins, `Needs setup · Configure →` (deep-link to `configure_url` when present) for unmet  (deps: P4.011)
+- `[TODO]` `P4.013` Access column rendering: `Available` for satisfied built-ins, `Needs setup · Configure →` for unmet; frontend derives configure routes from built-in slugs  (deps: P4.011)
 - `[TODO]` `P4.014` Search + filters: by name/slug, source (All/Platform/Custom), availability
 - `[TODO]` `P4.015` Loading / error / empty states
 
@@ -307,7 +307,7 @@ OpenCode's native `skill` tool handles inventory; AGENTS.md inlining is duplicat
 ### 4.5 Built-in detail drawer
 
 - `[TODO]` `P4.040` `BuiltinDetailDrawer.tsx` — read-only metadata (name, slug, description, source path, files, frontmatter)
-- `[TODO]` `P4.041` Availability section: show `Available` or the built-in's `unavailable_reason` with a Configure button when `configure_url` is present  (deps: P4.040)
+- `[TODO]` `P4.041` Availability section: show `Available` or the built-in's `unavailable_reason`; frontend derives any Configure button route from the built-in slug  (deps: P4.040)
 - `[TODO]` `P4.042` Section omitted entirely if the built-in is available and has no setup copy/link
 
 ### 4.6 Edit / Replace / Grants / Delete modals

--- a/docs/craft/features/skills/TODOS.md
+++ b/docs/craft/features/skills/TODOS.md
@@ -40,9 +40,9 @@ If you're an agent picking up work:
 
 _(Update this section as you claim things. Keep it short — just the active `WIP` and `REVIEW` items so anyone glancing at the file can see what's hot.)_
 
-- `[WIP @codex-charged-perovskite]` `P1.010-P1.015` Module skeletons
-- `[WIP @codex-charged-perovskite]` `P1.020-P1.027` BuiltinSkillRegistry core
-- `[WIP @codex-charged-perovskite]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.010-P1.015` Module skeletons
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.020-P1.027` BuiltinSkillRegistry core
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.028-P1.029` BuiltinSkillRegistry unit tests
 - `[WIP @claude-coupled-lattice]` `P1.060-P1.068` Phase 1.6 DB ops (`backend/onyx/db/skill.py`)
 - `[WIP @claude-coupled-josephson]` `P1.030-P1.041` Bundle validator (excl. P1.035 reserved-slug check — depends on registry WIP)
 - `[REVIEW @claude-collapsing-meson #11064]` `P5.030-P5.038` Phase 5.4 orphan-blob + aged-soft-delete sweep
@@ -64,25 +64,25 @@ _(Update this section as you claim things. Keep it short — just the active `WI
 
 ### 1.2 Module skeletons  (spec §2)
 
-- `[WIP @codex-charged-perovskite]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
-- `[WIP @codex-charged-perovskite]` `P1.011` Create empty `backend/onyx/skills/registry.py`
-- `[WIP @codex-charged-perovskite]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
-- `[WIP @codex-charged-perovskite]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
-- `[WIP @codex-charged-perovskite]` `P1.014` Create empty `backend/onyx/skills/render.py`
-- `[WIP @codex-charged-perovskite]` `P1.015` Create empty `backend/onyx/db/skill.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.010` Create empty `backend/onyx/skills/__init__.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.011` Create empty `backend/onyx/skills/registry.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.012` Create empty `backend/onyx/skills/bundle.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.013` Create empty `backend/onyx/skills/materialize.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.014` Create empty `backend/onyx/skills/render.py`
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.015` Create empty `backend/onyx/db/skill.py`
 
 ### 1.3 BuiltinSkillRegistry  (spec §4)
 
-- `[WIP @codex-charged-perovskite]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
-- `[WIP @codex-charged-perovskite]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
-- `[WIP @codex-charged-perovskite]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
-- `[WIP @codex-charged-perovskite]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
-- `[WIP @codex-charged-perovskite]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
-- `[WIP @codex-charged-perovskite]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
-- `[WIP @codex-charged-perovskite]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
-- `[WIP @codex-charged-perovskite]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
-- `[WIP @codex-charged-perovskite]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
-- `[WIP @codex-charged-perovskite]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.020` Define `SkillRequirement` in `registry.py` as a Pydantic `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` (matches codebase convention; `arbitrary_types_allowed` is required for `Callable` + `Session`)  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.021` Define `BuiltinSkill` in `registry.py` as a Pydantic `BaseModel` with the same frozen + arbitrary-types config  (deps: P1.011)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.022` Implement `BuiltinSkillRegistry` singleton accessor (`.instance()`)  (deps: P1.021)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.023` Implement `register(slug, source_dir, requirements=[])` — read frontmatter, detect `SKILL.md.template` presence, slug regex validation, raise on duplicate or missing SKILL.md  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.024` Implement `list_all() -> list[BuiltinSkill]`  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.025` Implement `list_satisfied(db) -> list[BuiltinSkill]` — filter by all `requirement.check(db) == True`  (deps: P1.020, P1.024)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.026` Implement `evaluate_for_admin(db) -> list[BuiltinSkillStatus]` for admin UI  (deps: P1.025)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.027` Implement `get(slug)` and `reserved_slugs()`  (deps: P1.022)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.028` Unit test: register two slugs with collision → raise; register with missing SKILL.md → raise  (deps: P1.023)
+- `[REVIEW @codex-charged-perovskite #pending]` `P1.029` Unit test: `list_satisfied` excludes a skill whose `check` returns False; `evaluate_for_admin` returns the unmet requirement with description  (deps: P1.025, P1.026)
 
 ### 1.4 Bundle validator  (spec §5)
 

--- a/docs/craft/features/skills/skills.md
+++ b/docs/craft/features/skills/skills.md
@@ -94,7 +94,7 @@ Backend calls a hosted "Onyx Skills" service for bundles at session setup.
 ## Key Design Decisions
 
 1. **Universal layer is consumer-blind.** `backend/onyx/skills/` knows nothing about `BuildSession`, sandboxes, or `.opencode/skills`. Its public API is "given a destination path and a user, resolve and write all the skills they have access to." Consumers choose the destination path and pass the user.
-2. **Built-ins are a registry of `(slug, source_dir, is_available)` triples.** Registered at app boot. The registry exposes `list_available_for(db_session) -> list[BuiltinSkill]` which evaluates each `is_available` lazily. The build feature owns its own registration module (`backend/onyx/server/features/build/skills/builtins_registration.py`) that wires up Craft's built-ins. Other features add their own registration modules.
+2. **Built-ins are a registry of `(slug, source_dir, is_available)` entries.** Registered at app boot. The registry exposes `list_satisfied(db_session) -> list[BuiltinSkill]` which evaluates each `is_available` lazily. The build feature owns its own registration module (`backend/onyx/server/features/build/skills/builtins_registration.py`) that wires up Craft's built-ins. Other features add their own registration modules.
 3. **No DB rows for built-in state.** Admins do not configure built-ins per-org. Whether a built-in is available is determined entirely by code — its `is_available` callable inspects whatever it needs (env vars, configured providers, feature flags, sub-feature DB rows). This trades configurability for simplicity: there's no per-tenant "we don't want pptx" toggle, but also no admin surface to reason about, no state-row-vs-registry-mismatch failure mode, and no migration when we add or remove built-ins.
 4. **Built-ins ship `SKILL.md.template` to opt into rendering.** The materializer checks for `SKILL.md.template` in the source directory; if present, renders against `SkillRenderContext` and writes `SKILL.md`. Otherwise copies the existing `SKILL.md` verbatim. Other files always copy verbatim.
 5. **Custom skills cannot ship templates.** Validation rejects bundles containing any `*.template` file.
@@ -117,7 +117,7 @@ Backend calls a hosted "Onyx Skills" service for bundles at session setup.
                                 ┌──────────────────────────────────────────┐
                                 │  BuiltinSkillRegistry (in-memory)        │
                                 │  ├─ register(slug, dir, is_available)    │
-                                │  └─ list_available_for(db_session)       │
+                                │  └─ list_satisfied(db_session)           │
                                 │                                          │
                                 │  DB (backend/onyx/db/skill.py)           │
                                 │  ├─ skill (one bundle per row)           │
@@ -163,7 +163,7 @@ Materialization sequence (per Craft session start):
 SessionManager.setup_session
   └─ skills.materialize_skills(staging_dir, user, db_session, render_context)
         ├─ resolve:
-        │     ├─ available_builtins = registry.list_available_for(db_session)
+        │     ├─ available_builtins = registry.list_satisfied(db_session)
         │     └─ accessible_customs = list_skills_for_user(user, db_session)
         ├─ for each available built-in:
         │     ├─ copy source_dir → staging_dir/<slug>/
@@ -195,7 +195,7 @@ The Kubernetes path (`KubernetesSandboxManager._setup_session_workspace`, around
 **New files (universal layer):**
 
 - `backend/onyx/skills/__init__.py` — public API: `materialize_skills`, `resolve_skills`, `validate_custom_bundle`, `BuiltinSkillRegistry`, `SkillRenderContext`, `ResolvedSkill`, `BuiltinSkillRef`.
-- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None)`, `list_available_for(db_session) -> list[BuiltinSkill]`, `evaluate_for_admin(db_session) -> list[BuiltinSkillAvailability]` (returns each registered slug + bool + reason, used by the admin GET endpoint), `read_metadata(slug) -> BuiltinMetadata | None`. In-memory; rebuilt at boot.
+- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None, configure_url: str | None = None)`, `list_all() -> list[BuiltinSkill]`, `list_satisfied(db_session) -> list[BuiltinSkill]`, `get(slug)`, and `reserved_slugs()`. In-memory; rebuilt at boot.
 - `backend/onyx/skills/bundle.py` — zip helpers: `validate_custom_bundle(zip_bytes) -> ManifestMetadata | InvalidBundleError`, `compute_bundle_sha256(zip_bytes)`. Deterministic checks.
 - `backend/onyx/skills/materialize.py` — `materialize_skills(...)`, `SkillRenderContext` (Pydantic), the manifest writer. The render step delegates to a small `_render_template_placeholders` helper migrated from `agent_instructions.py` so it can be reused outside the build feature.
 - `backend/onyx/db/skill.py` — DB ops: `list_skills_for_user`, `fetch_skill_for_user`, `create_skill`, `replace_skill_bundle`, `delete_skill`. Mirrors `backend/onyx/db/persona.py` patterns.
@@ -350,7 +350,7 @@ def materialize_skills(
     Resolve and write every skill the user has access to into dest_path/<slug>/.
     Returns the manifest (also written as dest_path/.skills_manifest.json).
 
-    Available built-ins (from BuiltinSkillRegistry.list_available_for) get
+    Available built-ins (from BuiltinSkillRegistry.list_satisfied) get
     their SKILL.md.template rendered if present; custom skills the user has
     access to (via list_skills_for_user) are unzipped verbatim.
     """

--- a/docs/craft/features/skills/skills.md
+++ b/docs/craft/features/skills/skills.md
@@ -94,7 +94,7 @@ Backend calls a hosted "Onyx Skills" service for bundles at session setup.
 ## Key Design Decisions
 
 1. **Universal layer is consumer-blind.** `backend/onyx/skills/` knows nothing about `BuildSession`, sandboxes, or `.opencode/skills`. Its public API is "given a destination path and a user, resolve and write all the skills they have access to." Consumers choose the destination path and pass the user.
-2. **Built-ins are a registry of `(slug, source_dir, is_available)` entries.** Registered at app boot. The registry exposes `list_satisfied(db_session) -> list[BuiltinSkill]` which evaluates each `is_available` lazily. The build feature owns its own registration module (`backend/onyx/server/features/build/skills/builtins_registration.py`) that wires up Craft's built-ins. Other features add their own registration modules.
+2. **Built-ins are a registry of `(slug, source_dir, is_available)` entries.** Registered at app boot. The registry exposes `list_available(db_session) -> list[BuiltinSkill]` which evaluates each `is_available` lazily. The build feature owns its own registration module (`backend/onyx/server/features/build/skills/builtins_registration.py`) that wires up Craft's built-ins. Other features add their own registration modules.
 3. **No DB rows for built-in state.** Admins do not configure built-ins per-org. Whether a built-in is available is determined entirely by code — its `is_available` callable inspects whatever it needs (env vars, configured providers, feature flags, sub-feature DB rows). This trades configurability for simplicity: there's no per-tenant "we don't want pptx" toggle, but also no admin surface to reason about, no state-row-vs-registry-mismatch failure mode, and no migration when we add or remove built-ins.
 4. **Built-ins ship `SKILL.md.template` to opt into rendering.** The materializer checks for `SKILL.md.template` in the source directory; if present, renders against `SkillRenderContext` and writes `SKILL.md`. Otherwise copies the existing `SKILL.md` verbatim. Other files always copy verbatim.
 5. **Custom skills cannot ship templates.** Validation rejects bundles containing any `*.template` file.
@@ -117,7 +117,7 @@ Backend calls a hosted "Onyx Skills" service for bundles at session setup.
                                 ┌──────────────────────────────────────────┐
                                 │  BuiltinSkillRegistry (in-memory)        │
                                 │  ├─ register(slug, dir, is_available)    │
-                                │  └─ list_satisfied(db_session)           │
+                                │  └─ list_available(db_session)           │
                                 │                                          │
                                 │  DB (backend/onyx/db/skill.py)           │
                                 │  ├─ skill (one bundle per row)           │
@@ -163,7 +163,7 @@ Materialization sequence (per Craft session start):
 SessionManager.setup_session
   └─ skills.materialize_skills(staging_dir, user, db_session, render_context)
         ├─ resolve:
-        │     ├─ available_builtins = registry.list_satisfied(db_session)
+        │     ├─ available_builtins = registry.list_available(db_session)
         │     └─ accessible_customs = list_skills_for_user(user, db_session)
         ├─ for each available built-in:
         │     ├─ copy source_dir → staging_dir/<slug>/
@@ -195,7 +195,7 @@ The Kubernetes path (`KubernetesSandboxManager._setup_session_workspace`, around
 **New files (universal layer):**
 
 - `backend/onyx/skills/__init__.py` — public API: `materialize_skills`, `resolve_skills`, `validate_custom_bundle`, `BuiltinSkillRegistry`, `SkillRenderContext`, `ResolvedSkill`, `BuiltinSkillRef`.
-- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None, configure_url: str | None = None)`, `list_all() -> list[BuiltinSkill]`, `list_satisfied(db_session) -> list[BuiltinSkill]`, `get(slug)`, and `reserved_slugs()`. In-memory; rebuilt at boot.
+- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None, configure_url: str | None = None)`, `list_all() -> list[BuiltinSkill]`, `list_available(db_session) -> list[BuiltinSkill]`, `get(slug)`, and `reserved_slugs()`. In-memory; rebuilt at boot.
 - `backend/onyx/skills/bundle.py` — zip helpers: `validate_custom_bundle(zip_bytes) -> ManifestMetadata | InvalidBundleError`, `compute_bundle_sha256(zip_bytes)`. Deterministic checks.
 - `backend/onyx/skills/materialize.py` — `materialize_skills(...)`, `SkillRenderContext` (Pydantic), the manifest writer. The render step delegates to a small `_render_template_placeholders` helper migrated from `agent_instructions.py` so it can be reused outside the build feature.
 - `backend/onyx/db/skill.py` — DB ops: `list_skills_for_user`, `fetch_skill_for_user`, `create_skill`, `replace_skill_bundle`, `delete_skill`. Mirrors `backend/onyx/db/persona.py` patterns.
@@ -350,7 +350,7 @@ def materialize_skills(
     Resolve and write every skill the user has access to into dest_path/<slug>/.
     Returns the manifest (also written as dest_path/.skills_manifest.json).
 
-    Available built-ins (from BuiltinSkillRegistry.list_satisfied) get
+    Available built-ins (from BuiltinSkillRegistry.list_available) get
     their SKILL.md.template rendered if present; custom skills the user has
     access to (via list_skills_for_user) are unzipped verbatim.
     """

--- a/docs/craft/features/skills/skills.md
+++ b/docs/craft/features/skills/skills.md
@@ -195,7 +195,7 @@ The Kubernetes path (`KubernetesSandboxManager._setup_session_workspace`, around
 **New files (universal layer):**
 
 - `backend/onyx/skills/__init__.py` — public API: `materialize_skills`, `resolve_skills`, `validate_custom_bundle`, `BuiltinSkillRegistry`, `SkillRenderContext`, `ResolvedSkill`, `BuiltinSkillRef`.
-- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None, configure_url: str | None = None)`, `list_all() -> list[BuiltinSkill]`, `list_available(db_session) -> list[BuiltinSkill]`, `get(slug)`, and `reserved_slugs()`. In-memory; rebuilt at boot.
+- `backend/onyx/skills/registry.py` — `BuiltinSkillRegistry` singleton; `register(slug: str, source_dir: Path, is_available: Callable[[Session], bool], unavailable_reason: str | None = None)`, `list_all() -> list[BuiltinSkill]`, `list_available(db_session) -> list[BuiltinSkill]`, `get(slug)`, and `reserved_slugs()`. In-memory; rebuilt at boot.
 - `backend/onyx/skills/bundle.py` — zip helpers: `validate_custom_bundle(zip_bytes) -> ManifestMetadata | InvalidBundleError`, `compute_bundle_sha256(zip_bytes)`. Deterministic checks.
 - `backend/onyx/skills/materialize.py` — `materialize_skills(...)`, `SkillRenderContext` (Pydantic), the manifest writer. The render step delegates to a small `_render_template_placeholders` helper migrated from `agent_instructions.py` so it can be reused outside the build feature.
 - `backend/onyx/db/skill.py` — DB ops: `list_skills_for_user`, `fetch_skill_for_user`, `create_skill`, `replace_skill_bundle`, `delete_skill`. Mirrors `backend/onyx/db/persona.py` patterns.

--- a/docs/craft/features/skills/skills_plan.html
+++ b/docs/craft/features/skills/skills_plan.html
@@ -1827,7 +1827,7 @@ class BuiltinSkillRegistry:
         requirements: Sequence[SkillRequirement] = (),
     ) -> None: ...
     def list_all(self) -> list[BuiltinSkill]: ...
-    def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
+    def list_available(self, db: Session) -> list[BuiltinSkill]:
         """Built-ins whose requirements all check True. Used by the materializer."""
     def evaluate_for_admin(self, db: Session) -> list[BuiltinSkillStatus]:
         """Per-built-in: each requirement + satisfied bool. Used by /api/admin/skills."""
@@ -1960,7 +1960,7 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
       <li>
         Implement <code>BuiltinSkillRegistry</code>: singleton accessor,
         <code>register(slug, source_dir, requirements=[])</code>,
-        <code>list_all()</code>, <code>list_satisfied(db)</code>,
+        <code>list_all()</code>, <code>list_available(db)</code>,
         <code>evaluate_for_admin(db)</code>, <code>get(slug)</code>,
         <code>reserved_slugs()</code>.
       </li>
@@ -1986,7 +1986,7 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
             <code>assert registry.get("pptx") is not None</code> after boot.
           </li>
           <li>
-            <code>list_satisfied(db)</code> excludes
+            <code>list_available(db)</code> excludes
             <code>image-generation</code> when no provider is configured;
             includes it after one is added.
           </li>
@@ -2210,7 +2210,7 @@ def materialize_skills(
       <li>
         <code
           >builtins =
-          BuiltinSkillRegistry.instance().list_satisfied(db_session)</code
+          BuiltinSkillRegistry.instance().list_available(db_session)</code
         >
         — only built-ins whose declared requirements all check True. Unsatisfied
         built-ins are skipped silently; admins see them as "Needs setup" in the

--- a/docs/craft/features/skills/skills_plan.md
+++ b/docs/craft/features/skills/skills_plan.md
@@ -323,7 +323,7 @@ class BuiltinSkillRegistry:
         """Reads SKILL.md(.template) frontmatter, validates slug, stores entry."""
 
     def list_all(self) -> list[BuiltinSkill]: ...
-    def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
+    def list_available(self, db: Session) -> list[BuiltinSkill]:
         """Built-ins whose availability check returns True. Used by the materializer."""
     def get(self, slug: str) -> BuiltinSkill | None: ...
     def reserved_slugs(self) -> set[str]: ...
@@ -370,14 +370,14 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
 - [ ] Implement `BuiltinSkillRegistry`:
   - [ ] Singleton accessor (`BuiltinSkillRegistry.instance()`).
   - [ ] `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, validate slug, raise on duplicate or missing SKILL.md.
-  - [ ] `list_all()`, `list_satisfied(db)`, `get(slug)`, `reserved_slugs()`.
+  - [ ] `list_all()`, `list_available(db)`, `get(slug)`, `reserved_slugs()`.
 - [ ] Implement `register_craft_builtins(registry)` in `backend/onyx/server/features/build/skills/builtins_registration.py`:
   - [ ] `pptx` — no requirements.
   - [ ] `image-generation` — requires `get_default_image_generation_config(db) is not None`, deep-link to `/admin/configuration/image-generation`.
 - [ ] Wire the call into `backend/onyx/main.py` startup.
 - [ ] Startup integration tests:
   - [ ] `assert registry.get("pptx") is not None` after app boot.
-  - [ ] `registry.list_satisfied(db)` excludes `image-generation` when no provider is configured; includes it after one is added.
+  - [ ] `registry.list_available(db)` excludes `image-generation` when no provider is configured; includes it after one is added.
 
 ---
 
@@ -494,7 +494,7 @@ def materialize_skills(
 Algorithm:
 
 1. Ensure `dest_path` exists and is empty.
-2. `builtins = BuiltinSkillRegistry.instance().list_satisfied(db_session)` — only built-ins whose availability check returns true. Unsatisfied built-ins are skipped silently; admins see them as "Needs setup" in the admin UI.
+2. `builtins = BuiltinSkillRegistry.instance().list_available(db_session)` — only built-ins whose availability check returns true. Unsatisfied built-ins are skipped silently; admins see them as "Needs setup" in the admin UI.
 3. `customs = list_skills_for_user(user, db_session)` — single SQL query, public-OR-group-grant, filtered to `enabled = True AND deleted_at IS NULL`. Disabled or soft-deleted skills never reach the materialized set.
 4. For each built-in:
    - `shutil.copytree(source_dir, dest_path/slug)`.

--- a/docs/craft/features/skills/skills_plan.md
+++ b/docs/craft/features/skills/skills_plan.md
@@ -290,7 +290,7 @@ Built-in skills are on-disk directories. We need a way for each feature that shi
 
 ### Proposed Solution
 
-A process-wide singleton populated at app boot. Each registration captures a `(slug, source_dir, name, description, is_available, unavailable_reason, configure_url)` tuple — name/description are read from the source dir's `SKILL.md` frontmatter at registration time and cached. `is_available` is a single optional org-level dependency check for the skill (e.g. a configured Gemini provider for `image-generation`).
+A process-wide singleton populated at app boot. Each registration captures a `(slug, source_dir, name, description, is_available, unavailable_reason)` tuple — name/description are read from the source dir's `SKILL.md` frontmatter at registration time and cached. `is_available` is a single optional org-level dependency check for the skill (e.g. a configured Gemini provider for `image-generation`).
 
 ```python
 # backend/onyx/skills/registry.py
@@ -307,7 +307,6 @@ class BuiltinSkill(BaseModel):
     has_template: bool
     is_available: Callable[[Session], bool] = always_available
     unavailable_reason: str | None = None
-    configure_url: str | None = None
 
 class BuiltinSkillRegistry:
     """Process-wide. Populated at boot; treated as immutable after."""
@@ -318,7 +317,6 @@ class BuiltinSkillRegistry:
         source_dir: Path,
         is_available: Callable[[Session], bool] = always_available,
         unavailable_reason: str | None = None,
-        configure_url: str | None = None,
     ) -> None:
         """Reads SKILL.md(.template) frontmatter, validates slug, stores entry."""
 
@@ -346,7 +344,6 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
         source_dir=_SKILLS_DIR / "image-generation",
         is_available=lambda db: get_default_image_generation_config(db) is not None,
         unavailable_reason="Configure an image-generation provider before this skill can run.",
-        configure_url="/admin/configuration/image-generation",
     )
 
     # bio-builder, company-search registered when their on-disk dirs land.
@@ -369,7 +366,7 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
 ### Todos
 - [ ] Implement `BuiltinSkillRegistry`:
   - [ ] Singleton accessor (`BuiltinSkillRegistry.instance()`).
-  - [ ] `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, validate slug, raise on duplicate or missing SKILL.md.
+  - [ ] `register(slug, source_dir, is_available=..., unavailable_reason=None)` — read frontmatter, validate slug, raise on duplicate or missing SKILL.md.
   - [ ] `list_all()`, `list_available(db)`, `get(slug)`, `reserved_slugs()`.
 - [ ] Implement `register_craft_builtins(registry)` in `backend/onyx/server/features/build/skills/builtins_registration.py`:
   - [ ] `pptx` — no requirements.
@@ -573,7 +570,6 @@ class BuiltinSkillAdmin(BaseModel):
     has_template: bool
     available: bool
     unavailable_reason: str | None
-    configure_url: str | None
 
 class CustomSkillAdmin(BaseModel):
     id: UUID
@@ -1077,7 +1073,7 @@ Columns: letter-monogram avatar, name (and slug as subtext), description (trunca
 
 - **Built-in rows**: no action menu. Click row → drawer with read-only details (frontmatter, files list, on-disk path, availability status).
 - **Custom rows**: action menu → Edit, Replace bundle, Manage grants, Enable/Disable, Delete.
-- **Built-in availability**: Access column shows `Available` (green dot) when `available` is true, or `Needs setup` (warning) with an inline `Configure →` button when `configure_url` is present (e.g. `/admin/configuration/image-generation`).
+- **Built-in availability**: Access column shows `Available` (green dot) when `available` is true, or `Needs setup` (warning) with an inline `Configure →` button using a frontend route derived from the built-in slug.
 - **Search**: name + slug.
 - **Filter**: source (All / Platform / Custom), enabled state, availability (All / Available / Needs setup).
 - **Sort**: default by name; can sort by updated_at.

--- a/docs/craft/features/skills/skills_plan.md
+++ b/docs/craft/features/skills/skills_plan.md
@@ -141,7 +141,7 @@ A natural-looking simplification is to unify built-ins and custom skills under o
 
 Unifying them forces one of those lifecycles to bend:
 
-- If built-ins inherit the user-data lifecycle, every deploy needs a reconciliation step: compare the on-disk bundle's sha256 against the DB row, decide whether to clobber an admin's edits, tombstone removed built-ins, backfill new tenants, serialize `SkillRequirement.check` callables into rule expressions. None of these are unsolvable; all of them are real code, real tests, real ops complexity.
+- If built-ins inherit the user-data lifecycle, every deploy needs a reconciliation step: compare the on-disk bundle's sha256 against the DB row, decide whether to clobber an admin's edits, tombstone removed built-ins, backfill new tenants, serialize `is_available` callables into rule expressions. None of these are unsolvable; all of them are real code, real tests, real ops complexity.
 - If customs inherit the deploy-artifact lifecycle, they have to live in the repo — not viable, by definition.
 
 The current split costs ~30 lines (a route-handler merge in `api.py`) plus ~10 lines (a second loop in `materialize_skills`). The unified path would cost an upgrade-detection seeder, multi-tenant backfill, reconciliation logic on every deploy, and per-tenant FileStore growth for redundant bundle copies. Lopsided.
@@ -290,22 +290,10 @@ Built-in skills are on-disk directories. We need a way for each feature that shi
 
 ### Proposed Solution
 
-A process-wide singleton populated at app boot. Each registration captures a `(slug, source_dir, name, description, requirements)` tuple — name/description are read from the source dir's `SKILL.md` frontmatter at registration time and cached. `requirements` declare the org-level dependencies the skill needs to run (e.g. a configured Gemini provider for `image-generation`).
+A process-wide singleton populated at app boot. Each registration captures a `(slug, source_dir, name, description, is_available, unavailable_reason, configure_url)` tuple — name/description are read from the source dir's `SKILL.md` frontmatter at registration time and cached. `is_available` is a single optional org-level dependency check for the skill (e.g. a configured Gemini provider for `image-generation`).
 
 ```python
 # backend/onyx/skills/registry.py
-
-class SkillRequirement(BaseModel):
-    """Org-level dependency a built-in skill needs to be usable.
-    Frozen — registered at app boot, never mutated."""
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
-    key: str                                 # stable id, e.g. "image_generation_provider"
-    name: str                                # human label, e.g. "Image generation provider"
-    description: str                         # what's missing + where to set it up
-    configure_url: str                       # e.g. "/admin/configuration/image-generation"
-    check: Callable[[Session], bool]         # cheap; returns True if satisfied
-                                              # (arbitrary_types_allowed=True covers Callable + Session)
 
 class BuiltinSkill(BaseModel):
     """In-memory entry in the BuiltinSkillRegistry. Populated at boot from
@@ -317,7 +305,9 @@ class BuiltinSkill(BaseModel):
     name: str                                # from SKILL.md frontmatter
     description: str                         # from SKILL.md frontmatter
     has_template: bool
-    requirements: tuple[SkillRequirement, ...] = ()   # all must be satisfied
+    is_available: Callable[[Session], bool] = always_available
+    unavailable_reason: str | None = None
+    configure_url: str | None = None
 
 class BuiltinSkillRegistry:
     """Process-wide. Populated at boot; treated as immutable after."""
@@ -326,26 +316,25 @@ class BuiltinSkillRegistry:
         self,
         slug: str,
         source_dir: Path,
-        requirements: Sequence[SkillRequirement] = (),
+        is_available: Callable[[Session], bool] = always_available,
+        unavailable_reason: str | None = None,
+        configure_url: str | None = None,
     ) -> None:
         """Reads SKILL.md(.template) frontmatter, validates slug, stores entry."""
 
     def list_all(self) -> list[BuiltinSkill]: ...
     def list_satisfied(self, db: Session) -> list[BuiltinSkill]:
-        """Built-ins whose requirements all check True. Used by the materializer."""
-    def evaluate_for_admin(self, db: Session) -> list[BuiltinSkillStatus]:
-        """Per-built-in: each requirement + satisfied bool. Used by /api/admin/skills."""
+        """Built-ins whose availability check returns True. Used by the materializer."""
     def get(self, slug: str) -> BuiltinSkill | None: ...
     def reserved_slugs(self) -> set[str]: ...
 ```
 
-Registration happens at app boot. Each feature owns its own registration module and imports requirement checks from the modules that own the dependencies:
+Registration happens at app boot. Each feature owns its own registration module and imports availability checks from the modules that own the dependencies:
 
 ```python
 # backend/onyx/server/features/build/skills/builtins_registration.py
 
 from onyx.db.image_generation import get_default_image_generation_config
-from onyx.skills.registry import SkillRequirement
 
 _SKILLS_DIR = Path(__file__).parent.parent / "sandbox/kubernetes/docker/skills"
 
@@ -355,15 +344,9 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
     registry.register(
         slug="image-generation",
         source_dir=_SKILLS_DIR / "image-generation",
-        requirements=[
-            SkillRequirement(
-                key="image_generation_provider",
-                name="Image generation provider",
-                description="Configure an image-generation provider (e.g. Gemini, OpenAI) before this skill can run.",
-                configure_url="/admin/configuration/image-generation",
-                check=lambda db: get_default_image_generation_config(db) is not None,
-            ),
-        ],
+        is_available=lambda db: get_default_image_generation_config(db) is not None,
+        unavailable_reason="Configure an image-generation provider before this skill can run.",
+        configure_url="/admin/configuration/image-generation",
     )
 
     # bio-builder, company-search registered when their on-disk dirs land.
@@ -375,20 +358,19 @@ def register_craft_builtins(registry: BuiltinSkillRegistry) -> None:
 - **Why register at boot rather than on-demand.** Boot-time catches slug collisions and missing source dirs at process start, not mid-request.
 - **Why frontmatter parsing at registration, not materialization.** Lets the admin UI show built-in name/description without reading from disk on every request.
 - **Slug collision = fail loud at boot.** Deploy-time bug; operator must fix.
-- **`requirements` is structured, not a bare callable.** Letting the admin UI render *what's missing* and *where to fix it* requires more than a bool. A `SkillRequirement` carries enough metadata for the badge, the drawer detail, and the deep-link CTA. A future `is_disabled_by_admin(db)` flavor can be added the same way without changing call sites.
-- **Pydantic, not `@dataclass`.** Both `SkillRequirement` and `BuiltinSkill` use `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` to match the codebase convention (Pydantic models dominate ~96% of backend type definitions). `arbitrary_types_allowed` is required because `Callable` and `Session` aren't Pydantic-native. Frozen gives immutability + hashability for set membership without needing `__hash__` boilerplate.
+- **Single availability check, not a requirement object graph.** V1 only needs one setup condition per built-in. `BuiltinSkill` carries the callable plus the admin-facing reason and configure URL directly, which avoids duplicating the same name/description/configure fields across requirement/status DTOs. If a future skill needs multiple independently rendered setup requirements, add that abstraction when the need is real.
+- **Pydantic, not `@dataclass`.** `BuiltinSkill` uses `BaseModel` with `model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)` to match the codebase convention (Pydantic models dominate ~96% of backend type definitions). `arbitrary_types_allowed` is required because `Callable` and `Session` aren't Pydantic-native. Frozen gives immutability + hashability for set membership without needing `__hash__` boilerplate.
 - **Checks must be cheap and side-effect-free.** They run on every session-start materialization and every `GET /api/admin/skills`. Confirmed: all V1 checks are single-row DB lookups (`get_default_image_generation_config(db)`, `fetch_existing_llm_providers(db, ...)`) — sub-millisecond.
 - **Checks come from the feature module that owns the dependency.** `get_default_image_generation_config` lives in `backend/onyx/db/image_generation.py`; the registration module just composes them. Keeps coupling sane and tests independent.
-- **OR composition for "either of these works".** If a skill needs *one of N* providers, the requirement's `check` is `lambda db: provider_a(db) or provider_b(db)`. Single requirement, composed boolean — keeps the admin UI clean (one "Needs setup" entry, not N).
-- **No shared/bundled requirements between skills in V1.** If two skills need the same dep, each declares it independently. The admin will see two near-identical "Needs setup" CTAs but they both deep-link to the same configure page — acceptable noise for V1. If we ship five+ skills sharing one dep, factor out a `SHARED_REQUIREMENTS` module then.
+- **OR composition for "either of these works".** If a skill needs *one of N* providers, `is_available` is `lambda db: provider_a(db) or provider_b(db)`. Single check, composed boolean — keeps the admin UI clean (one "Needs setup" entry, not N).
+- **No shared/bundled availability checks between skills in V1.** If two skills need the same dep, each declares it independently. The admin will see two near-identical "Needs setup" CTAs but they both deep-link to the same configure page — acceptable noise for V1. If we ship five+ skills sharing one dep, factor out a shared helper then.
 - **Users never see unavailable built-ins.** Materializer skips them entirely → not in `.agents/skills/`, not in `AGENTS.md`. The agent doesn't know they could exist. No ghosted-but-disabled UI for users.
 
 ### Todos
-- [ ] Implement `SkillRequirement` dataclass in `backend/onyx/skills/registry.py`.
 - [ ] Implement `BuiltinSkillRegistry`:
   - [ ] Singleton accessor (`BuiltinSkillRegistry.instance()`).
-  - [ ] `register(slug, source_dir, requirements=[])` — read frontmatter, validate slug, raise on duplicate or missing SKILL.md.
-  - [ ] `list_all()`, `list_satisfied(db)`, `evaluate_for_admin(db)`, `get(slug)`, `reserved_slugs()`.
+  - [ ] `register(slug, source_dir, is_available=..., unavailable_reason=None, configure_url=None)` — read frontmatter, validate slug, raise on duplicate or missing SKILL.md.
+  - [ ] `list_all()`, `list_satisfied(db)`, `get(slug)`, `reserved_slugs()`.
 - [ ] Implement `register_craft_builtins(registry)` in `backend/onyx/server/features/build/skills/builtins_registration.py`:
   - [ ] `pptx` — no requirements.
   - [ ] `image-generation` — requires `get_default_image_generation_config(db) is not None`, deep-link to `/admin/configuration/image-generation`.
@@ -512,7 +494,7 @@ def materialize_skills(
 Algorithm:
 
 1. Ensure `dest_path` exists and is empty.
-2. `builtins = BuiltinSkillRegistry.instance().list_satisfied(db_session)` — only built-ins whose requirements all check True. Unsatisfied built-ins are skipped silently; admins see them as "Needs setup" in the admin UI.
+2. `builtins = BuiltinSkillRegistry.instance().list_satisfied(db_session)` — only built-ins whose availability check returns true. Unsatisfied built-ins are skipped silently; admins see them as "Needs setup" in the admin UI.
 3. `customs = list_skills_for_user(user, db_session)` — single SQL query, public-OR-group-grant, filtered to `enabled = True AND deleted_at IS NULL`. Disabled or soft-deleted skills never reach the materialized set.
 4. For each built-in:
    - `shutil.copytree(source_dir, dest_path/slug)`.
@@ -589,15 +571,9 @@ class BuiltinSkillAdmin(BaseModel):
     name: str
     description: str
     has_template: bool
-    available: bool                              # True iff every requirement satisfied
-    requirements: list[RequirementStatus]        # empty if skill has no requirements
-
-class RequirementStatus(BaseModel):
-    key: str
-    name: str
-    description: str
-    configure_url: str
-    satisfied: bool
+    available: bool
+    unavailable_reason: str | None
+    configure_url: str | None
 
 class CustomSkillAdmin(BaseModel):
     id: UUID
@@ -1099,9 +1075,9 @@ Single page at `/admin/skills`. **One unified list** of built-ins + customs toge
 #### 13.1 List view
 Columns: letter-monogram avatar, name (and slug as subtext), description (truncated), source badge (`Platform` / `Custom`), grants summary (customs only — "Org-wide" / "3 groups" / "5 users" / "Private"), updated_at, actions.
 
-- **Built-in rows**: no action menu. Click row → drawer with read-only details (frontmatter, files list, on-disk path, requirements + status).
+- **Built-in rows**: no action menu. Click row → drawer with read-only details (frontmatter, files list, on-disk path, availability status).
 - **Custom rows**: action menu → Edit, Replace bundle, Manage grants, Enable/Disable, Delete.
-- **Built-in availability**: Access column shows `Available` (green dot) when all requirements are satisfied, or `Needs setup · N missing` (warning) with an inline `Configure →` button that deep-links to the first unsatisfied requirement's `configure_url` (e.g. `/admin/configuration/image-generation`).
+- **Built-in availability**: Access column shows `Available` (green dot) when `available` is true, or `Needs setup` (warning) with an inline `Configure →` button when `configure_url` is present (e.g. `/admin/configuration/image-generation`).
 - **Search**: name + slug.
 - **Filter**: source (All / Platform / Custom), enabled state, availability (All / Available / Needs setup).
 - **Sort**: default by name; can sort by updated_at.
@@ -1533,7 +1509,7 @@ Items knowingly punted; each is reversible without breaking V1.
 
 | Deferred | When | How to add later |
 |---|---|---|
-| Shared/bundled `SkillRequirement` modules | When 5+ skills depend on the same configuration surface | Today each skill declares its requirements independently — fine when most skills need different things, but if e.g. five skills all need a configured Gemini provider, factor a shared `requirements.py` module that exports `IMAGE_GEN_PROVIDER`, `LLM_PROVIDER`, etc. The data model stays the same; only the registration code dedupes. |
+| Shared/bundled availability-check helpers | When 5+ skills depend on the same configuration surface | Today each skill declares its availability independently — fine when most skills need different things, but if e.g. five skills all need a configured Gemini provider, factor a shared helper module that exports `image_provider_available`, `llm_provider_available`, etc. The data model stays the same; only the registration code dedupes. |
 | Per-user skill grants (`Skill__User` table) | When customers report friction with "share with one teammate" via a single-member group workaround, or when user-authored skills (below) land. | Add a `skill__user (skill_id, user_id)` join table, an `Individual users` picker in the grants editor, an OR branch in `list_skills_for_user`'s access query, and `user_ids` to the POST/PUT bodies + `granted_user_ids` to `CustomSkillAdmin`. Migration is additive; no V1 schema disruption. |
 | **User-authored skills (third tier)** | V1.5 — when product wants users to author + share their own skills without admin involvement. | Big lift. Adds: (1) user-side `POST /api/skills` upload endpoint with per-user quota + rate limit, (2) `Skill__User` brought back from the cut above for user→user sharing, (3) `source = "user"` value on the manifest discriminator (already designed in V1), (4) skill promotion workflow — new `skill_promotion_request` table, request/approve endpoints, admin pending-promotions UI tab, (5) slug-namespace decision: stay tenant-global (simplest; user-authored shares a namespace with admin customs), or move to per-author namespace (more flexible, more complex), (6) **threat-model rewrite** — user-authored shifts the security model from "bounded by admin RBAC" to "any tenant user can introduce code that runs in other users' sessions." Lateral attacker model becomes first-class; §18 needs a real expansion. Interception layer still bounds external exfil but not within-tenant abuse. (7) User-facing "My skills" page + authorship indicator on the skills panel. ~+4-6 weeks of work after V1 ships. |
 | **Skill author tooling** | V1.5 — paired with user-authored skills, but useful for admin-authored skills too. | V1 assumes a developer hand-crafts the zip. V1.5 ships authoring affordances so non-engineers can produce a valid skill: (1) a CLI scaffolder (`onyx-cli skill new <slug>`) that generates SKILL.md template, frontmatter, an example script, and the zip layout, (2) a local validator (`onyx-cli skill validate <path>`) that runs the same Pydantic / slug / file-size / SKILL.md-required checks the server does — same error messages, no upload required, (3) a `--dry-run` upload mode that posts to the server, runs validation, and returns the would-be `OnyxError` without persisting, (4) docs page with the format spec, allowed tools, sandboxing constraints, and a worked example. None of this changes the server schema; it's purely a UX layer for skill authors. ~1-2 weeks once we know what shape user-authored skills take. |
@@ -1616,7 +1592,7 @@ In rough order of "cuttable first":
 
 1. **Invocation audit log** (Phase 5 stretch) — high value but defer to V1.5.
 2. **Built-in detail drawer** (Phase 4) — engineers can read source dirs directly.
-3. **`SkillRequirement` system** (Phase 1, §4) — ship `image-generation` always-available with a runtime-error caveat. Lose the clean "Needs setup" UX but cut a chunk of work. **Only acceptable** if the interception layer is the safety net.
+3. **Built-in availability checks** (Phase 1, §4) — ship `image-generation` always-available with a runtime-error caveat. Lose the clean "Needs setup" UX but cut a chunk of work. **Only acceptable** if the interception layer is the safety net.
 4. **Per-skill content endpoint** (`/api/build/sessions/{id}/skills/{slug}/content`, Phase 3) — SKILL.md preview drawer in panel; defer to V1.5.
 5. **Local sandbox backend skills materialization** — if Kubernetes is the only deploy target for V1, defer the local-backend changes.
 


### PR DESCRIPTION
## Summary
- add the universal BuiltinSkillRegistry models and singleton
- load built-in skill metadata from SKILL.md or SKILL.md.template frontmatter
- add unit coverage for duplicate registration, missing SKILL.md, template detection, and requirement filtering/admin status
- update the skills task board entries for this branch to REVIEW

## Tests
- uv run pytest -q backend/tests/unit/onyx/skills/test_registry.py
- uv run ruff check backend/onyx/skills/registry.py backend/tests/unit/onyx/skills/test_registry.py
- uv run ruff format --check backend/onyx/skills/registry.py backend/tests/unit/onyx/skills/test_registry.py
- uv run ty check backend/onyx/skills/registry.py backend/tests/unit/onyx/skills/test_registry.py


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a process-wide `BuiltinSkillRegistry`, DB ops for custom skills, and a custom bundle validator with safe unzip and SHA-256 hashing. Built-ins are filtered by availability; admins get CRUD + grants for uploaded skills with strict slug uniqueness.

- **New Features**
  - Registry loads `SKILL.md` or `.template`, validates slugs, tracks template presence, and filters via `list_available(db)`. APIs: `register`, `list_all`, `get`, `reserved_slugs`; test-only `_reset_for_testing()`. `BuiltinSkill` is frozen with optional `unavailable_reason`.
  - Custom skills: `CustomSkill` view; DB ops for visibility and CRUD — `list_skills_for_user/admin`, `fetch_skill_for_user/admin`, `create_skill` (pre-check + unique-constraint translation on `uq_skill_slug`), `replace_skill_bundle` (returns old `bundle_file_id`), `patch_skill` (uses `UNSET`; rechecks slug), `replace_skill_grants`, `delete_skill` (hard delete; returns `bundle_file_id`).
  - Bundle handling: `validate_custom_bundle` (slug + reserved-slug check, no `*.template`, path traversal and symlink rejection, streaming per-file/total size caps with 413s); `_safe_unzip` (defensive re-checks, cleans dest on failure); `compute_bundle_sha256`.

- **Refactors**
  - Renamed `list_satisfied` to `list_available`; default availability uses a lambda.
  - Slug validation moved to a Pydantic field validator; frontmatter parsing uses a single delimiter regex; registry singleton init/reset is lock-protected.
  - Schema: dropped `skill.deleted_at` and `skill.manifest_metadata`; replaced partial unique index with `uq_skill_slug`; models updated accordingly.
  - Removed built-in `configure_url`; frontend derives setup routes from known built-in slugs.

<sup>Written for commit df99b93e73c1ba79afd949d4fc7da9020b2851b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---
