### PR TITLE
chore: update onyx-cli default url

### DIFF
--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -119,6 +119,7 @@ def run_cli(
         "PATH": os.environ.get("PATH", ""),
         "HOME": os.environ.get("HOME", ""),
         "ONYX_SERVER_URL": server_url,
+        "ONYX_API_PREFIX": "",
         "XDG_CONFIG_HOME": tempfile.mkdtemp(),
     }
     if pat is not None:

--- a/cli/README.md
+++ b/cli/README.md
@@ -31,7 +31,7 @@ Environment variables override config file values:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `ONYX_SERVER_URL` | No | API base URL (default: `https://cloud.onyx.app/api`) |
+| `ONYX_SERVER_URL` | No | Server URL (default: `https://cloud.onyx.app`) |
 | `ONYX_PAT` | No | Personal access token for authentication (required if no config file) |
 | `ONYX_PERSONA_ID` | No | Default agent/persona ID |
 | `ONYX_STREAM_MARKDOWN` | No | Enable/disable progressive markdown rendering (true/false) |
@@ -133,7 +133,7 @@ When called without a TTY (e.g., by an AI agent or piped into another command), 
 If a human has already run `onyx-cli chat` (which includes first-time setup), the CLI works out of the box — no additional setup needed. Environment variables can override the config file or serve as an alternative when no config file exists:
 
 ```shell
-export ONYX_SERVER_URL="https://your-onyx-server.com/api"
+export ONYX_SERVER_URL="https://your-onyx-server.com"
 export ONYX_PAT="your-pat"
 ```
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -40,7 +40,7 @@ func printVersion(ios *iostreams.IOStreams, cmd *cobra.Command) {
 	ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 	defer cancel()
 
-	log.Debug("fetching backend version from /api/version")
+	log.Debug("fetching backend version")
 	backendVersion, err := client.GetBackendVersion(ctx)
 	if err != nil {
 		log.WithError(err).Debug("could not fetch backend version")

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -29,6 +29,8 @@ type Client struct {
 }
 
 // NewClient creates a new API client from config.
+// ServerURL is the server origin (e.g. "https://cloud.onyx.app").
+// APIURL appends the /api prefix to form the API base URL.
 func NewClient(cfg config.OnyxCliConfig) *Client {
 	var transport *http.Transport
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
@@ -37,7 +39,7 @@ func NewClient(cfg config.OnyxCliConfig) *Client {
 		transport = &http.Transport{}
 	}
 	return &Client{
-		baseURL: strings.TrimRight(cfg.ServerURL, "/"),
+		baseURL: config.APIURL(cfg.ServerURL),
 		apiKey:  cfg.APIKey,
 		httpClient: &http.Client{
 			Timeout:   30 * time.Second,
@@ -71,7 +73,7 @@ func checkResponse(resp *http.Response) error {
 	if isHTMLResponse(resp.Header.Get("Content-Type"), body) {
 		return &OnyxAPIError{
 			StatusCode: resp.StatusCode,
-			Detail:     "server returned HTML instead of JSON — your server URL may be pointing at the web UI instead of the API (try appending /api)",
+			Detail:     "server returned HTML instead of JSON — check that your server URL is correct",
 		}
 	}
 	return &OnyxAPIError{StatusCode: resp.StatusCode, Detail: string(body)}
@@ -311,7 +313,7 @@ func (c *Client) UploadFile(ctx context.Context, filePath string) (*models.FileD
 	}, nil
 }
 
-// GetBackendVersion fetches the backend version string from /api/version.
+// GetBackendVersion fetches the backend version string.
 func (c *Client) GetBackendVersion(ctx context.Context) (string, error) {
 	var resp struct {
 		BackendVersion string `json:"backend_version"`

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -41,7 +41,7 @@ func TestSearch_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := testutil.NewClient(srv.URL + "/api")
+	client := testutil.NewClient(srv.URL)
 	resp, err := client.Search(t.Context(), models.SearchRequest{Query: "test"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -36,7 +36,7 @@ type OnyxCliConfig struct {
 // DefaultConfig returns a config with default values.
 func DefaultConfig() OnyxCliConfig {
 	return OnyxCliConfig{
-		ServerURL:      "https://cloud.onyx.app/api",
+		ServerURL:      "https://cloud.onyx.app",
 		APIKey:         "",
 		DefaultAgentID: 0,
 	}
@@ -56,16 +56,18 @@ func (c OnyxCliConfig) IsConfigured() bool {
 	return c.APIKey != ""
 }
 
-// WebOrigin strips any API path suffix from a server URL, returning the web
-// app origin suitable for browser URLs (e.g., /admin/indexing/status).
-func WebOrigin(serverURL string) string {
-	u := strings.TrimRight(serverURL, "/")
-	for _, suffix := range []string{"/api/v1", "/api"} {
-		if strings.HasSuffix(u, suffix) {
-			return u[:len(u)-len(suffix)]
-		}
+// APIURL appends the API prefix (default "/api") to the server origin.
+// Set ONYX_API_PREFIX="" for direct backend access without the proxy prefix.
+func APIURL(serverURL string) string {
+	prefix := "/api"
+	if v, ok := os.LookupEnv("ONYX_API_PREFIX"); ok {
+		prefix = v
 	}
-	return u
+	u := strings.TrimRight(serverURL, "/")
+	if prefix == "" {
+		return u
+	}
+	return u + "/" + strings.Trim(prefix, "/")
 }
 
 // ConfigDir returns ~/.config/onyx-cli

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -27,7 +27,7 @@ func writeConfig(t *testing.T, dir string, data []byte) {
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := DefaultConfig()
-	if cfg.ServerURL != "https://cloud.onyx.app/api" {
+	if cfg.ServerURL != "https://cloud.onyx.app" {
 		t.Errorf("expected default server URL, got %s", cfg.ServerURL)
 	}
 	if cfg.APIKey != "" {
@@ -55,7 +55,7 @@ func TestLoadDefaults(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
 	cfg := Load()
-	if cfg.ServerURL != "https://cloud.onyx.app/api" {
+	if cfg.ServerURL != "https://cloud.onyx.app" {
 		t.Errorf("expected default URL, got %s", cfg.ServerURL)
 	}
 	if cfg.APIKey != "" {
@@ -95,7 +95,7 @@ func TestLoadCorruptFile(t *testing.T) {
 	writeConfig(t, dir, []byte("not valid json {{{"))
 
 	cfg := Load()
-	if cfg.ServerURL != "https://cloud.onyx.app/api" {
+	if cfg.ServerURL != "https://cloud.onyx.app" {
 		t.Errorf("expected default URL on corrupt file, got %s", cfg.ServerURL)
 	}
 }
@@ -250,5 +250,41 @@ func TestSaveCreatesParentDirs(t *testing.T) {
 
 	if !ConfigExists() {
 		t.Error("config file should exist after save")
+	}
+}
+
+func TestAPIURL(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"https://cloud.onyx.app", "https://cloud.onyx.app/api"},
+		{"https://cloud.onyx.app/", "https://cloud.onyx.app/api"},
+		{"http://localhost:8080", "http://localhost:8080/api"},
+		{"http://localhost:3000", "http://localhost:3000/api"},
+	}
+	for _, tc := range cases {
+		got := APIURL(tc.input)
+		if got != tc.want {
+			t.Errorf("APIURL(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestAPIURLEmptyPrefix(t *testing.T) {
+	t.Setenv("ONYX_API_PREFIX", "")
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"http://localhost:8080", "http://localhost:8080"},
+		{"http://localhost:8080/", "http://localhost:8080"},
+		{"https://cloud.onyx.app", "https://cloud.onyx.app"},
+	}
+	for _, tc := range cases {
+		got := APIURL(tc.input)
+		if got != tc.want {
+			t.Errorf("APIURL(%q) = %q, want %q", tc.input, got, tc.want)
+		}
 	}
 }

--- a/cli/internal/embedded/SKILL.md
+++ b/cli/internal/embedded/SKILL.md
@@ -28,13 +28,13 @@ If a human has already run `onyx-cli chat` (which includes first-time setup), th
 Environment variables override the config file and can be used as an alternative when no config file exists:
 
 ```bash
-export ONYX_SERVER_URL="https://your-onyx-server.com/api"  # default: https://cloud.onyx.app/api
+export ONYX_SERVER_URL="https://your-onyx-server.com"  # default: https://cloud.onyx.app
 export ONYX_PAT="your-pat"
 ```
 
 | Variable          | Required | Description                                              |
 | ----------------- | -------- | -------------------------------------------------------- |
-| `ONYX_SERVER_URL` | No       | Onyx server base URL (default: `https://cloud.onyx.app/api`) |
+| `ONYX_SERVER_URL` | No       | Onyx server URL (default: `https://cloud.onyx.app`) |
 | `ONYX_PAT`    | Yes      | Personal access token for authentication (unless config file exists) |
 | `ONYX_PERSONA_ID` | No       | Default agent/persona ID                                 |
 | `ONYX_STREAM_MARKDOWN` | No | Enable/disable progressive markdown rendering (true/false) |

--- a/cli/internal/testutil/testutil.go
+++ b/cli/internal/testutil/testutil.go
@@ -26,6 +26,7 @@ func StatusServer(status int) *httptest.Server {
 }
 
 // OnyxServer returns an httptest.Server that simulates the Onyx backend.
+// Routes are mounted under /api to match the production URL layout.
 func OnyxServer(meStatus int) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/me", func(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +38,7 @@ func OnyxServer(meStatus int) *httptest.Server {
 	mux.HandleFunc("/api/version", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"backend_version": "0.1.0"})
 	})
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
 	return httptest.NewServer(mux)

--- a/cli/internal/tui/commands.go
+++ b/cli/internal/tui/commands.go
@@ -49,7 +49,7 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		return cmdNew(m)
 
 	case "/connectors":
-		url := config.WebOrigin(m.config.ServerURL) + "/admin/indexing/status"
+		url := strings.TrimRight(m.config.ServerURL, "/") + "/admin/indexing/status"
 		if browser.OpenBrowser(url) {
 			m.viewport.addInfo("Opened " + url + " in browser")
 		} else {
@@ -58,7 +58,7 @@ func handleSlashCommand(m Model, text string) (Model, tea.Cmd) {
 		return m, nil
 
 	case "/settings":
-		url := config.WebOrigin(m.config.ServerURL) + "/app/settings/general"
+		url := strings.TrimRight(m.config.ServerURL, "/") + "/app/settings/general"
 		if browser.OpenBrowser(url) {
 			m.viewport.addInfo("Opened " + url + " in browser")
 		} else {

--- a/cli/internal/tui/sshauth.go
+++ b/cli/internal/tui/sshauth.go
@@ -126,7 +126,7 @@ func (m AuthModel) Update(msg tea.Msg) (AuthModel, tea.Cmd) {
 
 // View renders the auth prompt.
 func (m AuthModel) View() string {
-	settingsURL := config.WebOrigin(m.serverURL) + "/app/settings/accounts-access"
+	settingsURL := strings.TrimRight(m.serverURL, "/") + "/app/settings/accounts-access"
 
 	var b strings.Builder
 	b.WriteString("\n")


### PR DESCRIPTION
## Description

Since we plan to block inter-pod traffic, cli should universally expect the webserver URL instead of API server



## How Has This Been Tested?

Local build
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the CLI default `ONYX_SERVER_URL` to the server origin (e.g., https://cloud.onyx.app) and automatically add the API prefix when calling the backend. Introduces `ONYX_API_PREFIX` to customize or disable the prefix, and updates docs, tests, and UI links.

- **New Features**
  - The client builds the API base using `serverOrigin + "/api"` by default.
  - `ONYX_API_PREFIX` lets you change the prefix or set it to "" for direct backend access.
  - Clearer error when the server returns HTML instead of JSON.

- **Migration**
  - If your `ONYX_SERVER_URL` includes `/api`, remove it (e.g., use https://your-host).
  - For servers without a proxy prefix, set `ONYX_API_PREFIX=""`.

<sup>Written for commit f3597deaaa30ac9b7382a710b5e2366db127d487. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

