### PR TITLE
fix(db): cascade hierarchy_node join on cc_pair credential swap

### DIFF
--- a/backend/alembic/versions/e4ed20ddae7c_swap_credentials_hierarchy_fk_on_update_.py
+++ b/backend/alembic/versions/e4ed20ddae7c_swap_credentials_hierarchy_fk_on_update_.py
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "e4ed20ddae7c"
-down_revision = "b6d184cfdaf3"
+down_revision = "28429dd43807"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/e4ed20ddae7c_swap_credentials_hierarchy_fk_on_update_.py
+++ b/backend/alembic/versions/e4ed20ddae7c_swap_credentials_hierarchy_fk_on_update_.py
@@ -1,0 +1,44 @@
+"""swap_credentials_hierarchy_fk_on_update_cascade
+
+Revision ID: e4ed20ddae7c
+Revises: b6d184cfdaf3
+Create Date: 2026-05-13 11:24:28.753104
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e4ed20ddae7c"
+down_revision = "b6d184cfdaf3"
+branch_labels = None
+depends_on = None
+
+
+FK_NAME = "hierarchy_node_by_connector_cre_connector_id_credential_id_fkey"
+TABLE_NAME = "hierarchy_node_by_connector_credential_pair"
+
+
+def upgrade() -> None:
+    op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        TABLE_NAME,
+        "connector_credential_pair",
+        ["connector_id", "credential_id"],
+        ["connector_id", "credential_id"],
+        ondelete="CASCADE",
+        onupdate="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(FK_NAME, TABLE_NAME, type_="foreignkey")
+    op.create_foreign_key(
+        FK_NAME,
+        TABLE_NAME,
+        "connector_credential_pair",
+        ["connector_id", "credential_id"],
+        ["connector_id", "credential_id"],
+        ondelete="CASCADE",
+    )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2699,6 +2699,7 @@ class HierarchyNodeByConnectorCredentialPair(Base):
                 "connector_credential_pair.credential_id",
             ],
             ondelete="CASCADE",
+            onupdate="CASCADE",
         ),
         Index(
             "ix_hierarchy_node_cc_pair_connector_credential",

--- a/backend/tests/external_dependency_unit/db/test_swap_credentials_hierarchy.py
+++ b/backend/tests/external_dependency_unit/db/test_swap_credentials_hierarchy.py
@@ -1,0 +1,101 @@
+"""Test that swapping a cc_pair's credential_id cascades to the
+hierarchy_node_by_connector_credential_pair join table.
+
+Regression for ForeignKeyViolation on
+`hierarchy_node_by_connector_cre_connector_id_credential_id_fkey` when a
+connector with hierarchy nodes has its credential swapped (e.g. Confluence).
+"""
+
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import HierarchyNodeType
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import HierarchyNode
+from onyx.db.models import HierarchyNodeByConnectorCredentialPair
+
+
+def test_cc_pair_credential_swap_cascades_to_hierarchy_join(
+    db_session: Session,
+) -> None:
+    unique = uuid4().hex[:8]
+    connector = Connector(
+        name="test-connector-%s" % unique,
+        source=DocumentSource.CONFLUENCE,
+        input_type=InputType.POLL,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    old_credential = Credential(
+        source=DocumentSource.CONFLUENCE,
+        credential_json={"token": "old"},
+        admin_public=True,
+    )
+    new_credential = Credential(
+        source=DocumentSource.CONFLUENCE,
+        credential_json={"token": "new"},
+        admin_public=True,
+    )
+    db_session.add_all([old_credential, new_credential])
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=old_credential.id,
+        name="test-cc-pair",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+        auto_sync_options=None,
+    )
+    db_session.add(cc_pair)
+    db_session.flush()
+
+    hierarchy_node = HierarchyNode(
+        raw_node_id="test-space-%s" % unique,
+        display_name="Test Space",
+        source=DocumentSource.CONFLUENCE,
+        node_type=HierarchyNodeType.SPACE,
+    )
+    db_session.add(hierarchy_node)
+    db_session.flush()
+
+    join_row = HierarchyNodeByConnectorCredentialPair(
+        hierarchy_node_id=hierarchy_node.id,
+        connector_id=connector.id,
+        credential_id=old_credential.id,
+    )
+    db_session.add(join_row)
+    db_session.commit()
+
+    # Mirror swap_credentials_connector's UPDATE
+    cc_pair.credential_id = new_credential.id
+    db_session.commit()
+
+    reloaded = db_session.execute(
+        select(HierarchyNodeByConnectorCredentialPair).where(
+            HierarchyNodeByConnectorCredentialPair.hierarchy_node_id
+            == hierarchy_node.id,
+            HierarchyNodeByConnectorCredentialPair.connector_id == connector.id,
+        )
+    ).scalar_one()
+    assert reloaded.credential_id == new_credential.id
+
+    db_session.delete(hierarchy_node)
+    db_session.delete(cc_pair)
+    db_session.delete(old_credential)
+    db_session.delete(new_credential)
+    db_session.delete(connector)
+    db_session.commit()

--- a/backend/tests/external_dependency_unit/db/test_swap_credentials_hierarchy.py
+++ b/backend/tests/external_dependency_unit/db/test_swap_credentials_hierarchy.py
@@ -8,6 +8,7 @@ connector with hierarchy nodes has its credential swapped (e.g. Confluence).
 
 from uuid import uuid4
 
+from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -27,75 +28,94 @@ def test_cc_pair_credential_swap_cascades_to_hierarchy_join(
     db_session: Session,
 ) -> None:
     unique = uuid4().hex[:8]
-    connector = Connector(
-        name="test-connector-%s" % unique,
-        source=DocumentSource.CONFLUENCE,
-        input_type=InputType.POLL,
-        connector_specific_config={},
-        refresh_freq=None,
-        prune_freq=None,
-        indexing_start=None,
-    )
-    db_session.add(connector)
-    db_session.flush()
-
-    old_credential = Credential(
-        source=DocumentSource.CONFLUENCE,
-        credential_json={"token": "old"},
-        admin_public=True,
-    )
-    new_credential = Credential(
-        source=DocumentSource.CONFLUENCE,
-        credential_json={"token": "new"},
-        admin_public=True,
-    )
-    db_session.add_all([old_credential, new_credential])
-    db_session.flush()
-
-    cc_pair = ConnectorCredentialPair(
-        connector_id=connector.id,
-        credential_id=old_credential.id,
-        name="test-cc-pair",
-        status=ConnectorCredentialPairStatus.ACTIVE,
-        access_type=AccessType.PUBLIC,
-        auto_sync_options=None,
-    )
-    db_session.add(cc_pair)
-    db_session.flush()
-
-    hierarchy_node = HierarchyNode(
-        raw_node_id="test-space-%s" % unique,
-        display_name="Test Space",
-        source=DocumentSource.CONFLUENCE,
-        node_type=HierarchyNodeType.SPACE,
-    )
-    db_session.add(hierarchy_node)
-    db_session.flush()
-
-    join_row = HierarchyNodeByConnectorCredentialPair(
-        hierarchy_node_id=hierarchy_node.id,
-        connector_id=connector.id,
-        credential_id=old_credential.id,
-    )
-    db_session.add(join_row)
-    db_session.commit()
-
-    # Mirror swap_credentials_connector's UPDATE
-    cc_pair.credential_id = new_credential.id
-    db_session.commit()
-
-    reloaded = db_session.execute(
-        select(HierarchyNodeByConnectorCredentialPair).where(
-            HierarchyNodeByConnectorCredentialPair.hierarchy_node_id
-            == hierarchy_node.id,
-            HierarchyNodeByConnectorCredentialPair.connector_id == connector.id,
+    connector_id: int | None = None
+    old_credential_id: int | None = None
+    new_credential_id: int | None = None
+    hierarchy_node_id: int | None = None
+    try:
+        connector = Connector(
+            name="test-connector-%s" % unique,
+            source=DocumentSource.CONFLUENCE,
+            input_type=InputType.POLL,
+            connector_specific_config={},
+            refresh_freq=None,
+            prune_freq=None,
+            indexing_start=None,
         )
-    ).scalar_one()
-    assert reloaded.credential_id == new_credential.id
+        db_session.add(connector)
+        db_session.flush()
+        connector_id = connector.id
 
-    db_session.delete(hierarchy_node)
-    db_session.delete(cc_pair)
-    db_session.delete(old_credential)
-    db_session.delete(new_credential)
-    db_session.delete(connector)
-    db_session.commit()
+        old_credential = Credential(
+            source=DocumentSource.CONFLUENCE,
+            credential_json={"token": "old"},
+            admin_public=True,
+        )
+        new_credential = Credential(
+            source=DocumentSource.CONFLUENCE,
+            credential_json={"token": "new"},
+            admin_public=True,
+        )
+        db_session.add_all([old_credential, new_credential])
+        db_session.flush()
+        old_credential_id = old_credential.id
+        new_credential_id = new_credential.id
+
+        cc_pair = ConnectorCredentialPair(
+            connector_id=connector.id,
+            credential_id=old_credential.id,
+            name="test-cc-pair",
+            status=ConnectorCredentialPairStatus.ACTIVE,
+            access_type=AccessType.PUBLIC,
+            auto_sync_options=None,
+        )
+        db_session.add(cc_pair)
+        db_session.flush()
+
+        hierarchy_node = HierarchyNode(
+            raw_node_id="test-space-%s" % unique,
+            display_name="Test Space",
+            source=DocumentSource.CONFLUENCE,
+            node_type=HierarchyNodeType.SPACE,
+        )
+        db_session.add(hierarchy_node)
+        db_session.flush()
+        hierarchy_node_id = hierarchy_node.id
+
+        join_row = HierarchyNodeByConnectorCredentialPair(
+            hierarchy_node_id=hierarchy_node.id,
+            connector_id=connector.id,
+            credential_id=old_credential.id,
+        )
+        db_session.add(join_row)
+        db_session.commit()
+
+        cc_pair.credential_id = new_credential.id
+        db_session.commit()
+
+        reloaded = db_session.execute(
+            select(HierarchyNodeByConnectorCredentialPair).where(
+                HierarchyNodeByConnectorCredentialPair.hierarchy_node_id
+                == hierarchy_node.id,
+                HierarchyNodeByConnectorCredentialPair.connector_id == connector.id,
+            )
+        ).scalar_one()
+        assert reloaded.credential_id == new_credential.id
+    finally:
+        db_session.rollback()
+        if hierarchy_node_id is not None:
+            db_session.execute(
+                delete(HierarchyNode).where(HierarchyNode.id == hierarchy_node_id)
+            )
+        if connector_id is not None:
+            db_session.execute(
+                delete(ConnectorCredentialPair).where(
+                    ConnectorCredentialPair.connector_id == connector_id
+                )
+            )
+        for cred_id in (old_credential_id, new_credential_id):
+            if cred_id is not None:
+                db_session.execute(delete(Credential).where(Credential.id == cred_id))
+        if connector_id is not None:
+            db_session.execute(delete(Connector).where(Connector.id == connector_id))
+        db_session.commit()


### PR DESCRIPTION
## Description

Swapping a credential on a connector that has hierarchy nodes (Confluence, Google Drive, etc.) raised:

```
psycopg2.errors.ForeignKeyViolation: update or delete on table "connector_credential_pair" violates foreign key constraint "hierarchy_node_by_connector_cre_connector_id_credential_id_fkey" on table "hierarchy_node_by_connector_credential_pair"
```

The composite FK on `hierarchy_node_by_connector_credential_pair (connector_id, credential_id)` → `connector_credential_pair (connector_id, credential_id)` was `ON DELETE CASCADE` but lacked `ON UPDATE CASCADE`. `swap_credentials_connector` updates `cc_pair.credential_id` in place, which orphaned every join-table row pointing at the old tuple.

Migration drops and recreates the FK with `ON DELETE CASCADE ON UPDATE CASCADE`; the SQLAlchemy model is updated to match.

## How Has This Been Tested?

- New `tests/external_dependency_unit/db/test_swap_credentials_hierarchy.py` seeds a cc_pair + hierarchy_node + join row, updates `cc_pair.credential_id`, asserts the join row's `credential_id` cascades. Pre-migration: test reproduces the FK violation. Post-migration: passes.
- `alembic upgrade head` / `alembic downgrade -1` round-trip locally.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check