### PR TITLE
fix(confluence): use the REST API with non-scoped tokens for downloading attachments

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -635,6 +635,7 @@ class ConfluenceConnector(
                         attachment=attachment,
                         page_id=_get_page_id(page),
                         allow_images=self.allow_images,
+                        is_cloud=self.is_cloud,
                     )
                     if response is None:
                         continue

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -82,8 +82,8 @@ class AttachmentProcessingResult(BaseModel):
 def _make_attachment_link(
     confluence_client: "OnyxConfluence",
     attachment: dict[str, Any],
-    parent_content_id: str | None = None,
-    is_cloud: bool = True,
+    parent_content_id: str | None,
+    is_cloud: bool,
 ) -> str | None:
     download_link = ""
 
@@ -110,7 +110,7 @@ def process_attachment(
     attachment: dict[str, Any],
     parent_content_id: str | None,
     allow_images: bool,
-    is_cloud: bool = True,
+    is_cloud: bool,
 ) -> AttachmentProcessingResult:
     """
     Processes a Confluence attachment. If it's a document, extracts text,
@@ -249,7 +249,7 @@ def convert_attachment_to_content(
     attachment: dict[str, Any],
     page_id: str,
     allow_images: bool,
-    is_cloud: bool = True,
+    is_cloud: bool,
 ) -> tuple[str | None, str | None] | None:
     """
     Facade function which:

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -83,10 +83,11 @@ def _make_attachment_link(
     confluence_client: "OnyxConfluence",
     attachment: dict[str, Any],
     parent_content_id: str | None = None,
+    is_cloud: bool = True,
 ) -> str | None:
     download_link = ""
 
-    if "api.atlassian.com" in confluence_client.url:
+    if is_cloud:
         # https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-content---attachments/#api-wiki-rest-api-content-id-child-attachment-attachmentid-download-get
         if not parent_content_id:
             logger.warning(
@@ -109,6 +110,7 @@ def process_attachment(
     attachment: dict[str, Any],
     parent_content_id: str | None,
     allow_images: bool,
+    is_cloud: bool = True,
 ) -> AttachmentProcessingResult:
     """
     Processes a Confluence attachment. If it's a document, extracts text,
@@ -126,7 +128,7 @@ def process_attachment(
             )
 
         attachment_link = _make_attachment_link(
-            confluence_client, attachment, parent_content_id
+            confluence_client, attachment, parent_content_id, is_cloud
         )
         if not attachment_link:
             return AttachmentProcessingResult(
@@ -247,6 +249,7 @@ def convert_attachment_to_content(
     attachment: dict[str, Any],
     page_id: str,
     allow_images: bool,
+    is_cloud: bool = True,
 ) -> tuple[str | None, str | None] | None:
     """
     Facade function which:
@@ -264,7 +267,9 @@ def convert_attachment_to_content(
         )
         return None
 
-    result = process_attachment(confluence_client, attachment, page_id, allow_images)
+    result = process_attachment(
+        confluence_client, attachment, page_id, allow_images, is_cloud
+    )
     if result.error is not None:
         logger.warning(
             "Attachment %s encountered error: %s", attachment["title"], result.error


### PR DESCRIPTION
## Description

https://developer.atlassian.com/changelog/#CHANGE-2735

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the Confluence REST API for attachment downloads on Cloud so non-scoped tokens work. Make Cloud detection explicit with a required `is_cloud` flag wired from the connector.

- **Bug Fixes**
  - Build attachment download URLs via the Cloud REST route when `is_cloud` is true; remove URL sniffing logic.
  - Thread a required `is_cloud` param through `convert_attachment_to_content`, `process_attachment`, and `_make_attachment_link`, and pass `self.is_cloud` from the connector.

<sup>Written for commit 07d21a9e532ad989fb898cd0a2959ff17004a20a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



