### PR TITLE
chore(devtools): commit Playwright MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp", "--headless", "--isolated"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp", "--headless", "--isolated"]
+      "args": ["@playwright/mcp@0.0.75", "--headless", "--isolated"]
     }
   }
 }


### PR DESCRIPTION
## Description



## How Has This Been Tested?

<img width="1900" height="391" alt="20260513_12h46m36s_grim" src="https://github.com/user-attachments/assets/aeacc29a-1ff6-42c0-a8c4-1f6610cdc3a9" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.mcp.json` to register the Playwright MCP server so devtools can launch `@playwright/mcp@0.0.75` in headless, isolated mode via `npx`. Pinning the version prevents silent behavior drift and lets MCP-compatible tools run Playwright commands without extra setup.

<sup>Written for commit c0eadc56a112697139a5e01a2412eee9b640d435. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

