### PR TITLE
chore(web): drop custom Cache-Control for /_next/static/*

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -35,7 +35,6 @@ const nextConfig = {
     unoptimized: true, // Disable image optimization to avoid requiring Sharp
   },
   async headers() {
-    const isDev = process.env.NODE_ENV === "development";
     return [
       {
         source: "/(.*)",
@@ -60,18 +59,6 @@ const nextConfig = {
             key: "Permissions-Policy",
             value:
               "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(self), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()",
-          },
-        ],
-      },
-      {
-        // Cache static assets (images, icons, fonts, etc.) to prevent refetching and re-renders
-        source: "/_next/static/:path*",
-        headers: [
-          {
-            key: "Cache-Control",
-            value: isDev
-              ? "no-cache, must-revalidate" // Dev: always check if fresh
-              : "public, max-age=2592000, immutable", // Prod: cache for 30 days
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Removes the custom `Cache-Control` header rule for `/_next/static/:path*` in `web/next.config.js`.
- Next.js already serves fingerprinted assets under `/_next/static/*` with `public, max-age=31536000, immutable` in production, and handles caching appropriately in dev. The override was redundant and caused the following warning at devserver startup:

  ```
  Warning: Custom Cache-Control headers detected for the following routes:
    - /_next/static/:path*
  ```

## Test plan
- [ ] `npm run dev` in `web/` no longer prints the "Custom Cache-Control headers detected" warning.
- [ ] Verify a production build still serves `/_next/static/*` assets with a long-lived, immutable `Cache-Control` value (Next.js default).
- [ ] Confirm the remaining security headers on `/(.*)` (CSP, HSTS, Referrer-Policy, X-Content-Type-Options, Permissions-Policy) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the custom `Cache-Control` header for `/_next/static/*` in `web/next.config.js` to stop the dev warning and rely on Next.js default caching for fingerprinted assets in production. Security headers on `/(.*)` are unchanged.

<sup>Written for commit 5d07244af3811898e69207b4eb87a11dc56b12b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

