### PR TITLE
fix: helm add sandbox backend

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -85,7 +85,7 @@ SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 # Container image for sandbox pods
 # Should include Next.js template, opencode CLI, and agent skills
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.5"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.41"
 )
 
 # S3 bucket for sandbox file storage (snapshots, knowledge files, uploads)

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.4.49
+version: 0.4.50
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -39,3 +39,4 @@ data:
   {{- if .Values.codeInterpreter.enabled }}
   CODE_INTERPRETER_BASE_URL: "http://{{ .Release.Name }}-code-interpreter:{{ .Values.codeInterpreter.service.port }}"
   {{- end }}
+  SANDBOX_BACKEND: "kubernetes"

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -39,4 +39,6 @@ data:
   {{- if .Values.codeInterpreter.enabled }}
   CODE_INTERPRETER_BASE_URL: "http://{{ .Release.Name }}-code-interpreter:{{ .Values.codeInterpreter.service.port }}"
   {{- end }}
-  SANDBOX_BACKEND: "kubernetes"
+  {{- if and (toString (index .Values.configMap "ENABLE_CRAFT" | default "") | eq "true") (not (index .Values.configMap "SANDBOX_API_SERVER_URL")) }}
+  {{- fail "configMap.SANDBOX_API_SERVER_URL must be set when configMap.ENABLE_CRAFT is enabled" }}
+  {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1371,6 +1371,8 @@ configMap:
   HARD_DELETE_CHATS: ""
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
+  # Sandbox config — always "kubernetes" for Helm deployments
+  SANDBOX_BACKEND: "kubernetes"
 
 # -- Additional arbitrary manifests to render as part of the release. Each entry
 # may be either a YAML mapping (a single Kubernetes object) or a multi-line


### PR DESCRIPTION
- **fix(helm): add SANDBOX_BACKEND to template configmap**
- **verison**

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default sandbox backend to Kubernetes in Helm (`SANDBOX_BACKEND`) and fail if `ENABLE_CRAFT` is true without `SANDBOX_API_SERVER_URL`. Bump `SANDBOX_CONTAINER_IMAGE` to v0.1.41 and chart to 0.4.50.

<sup>Written for commit 22c7d1e9ee07ee64bc18bd2c1b6f941d4b496270. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

