### PR TITLE
feat(connectors/slack): add Enterprise Grid support

### DIFF
--- a/backend/ee/onyx/external_permissions/slack/channel_access.py
+++ b/backend/ee/onyx/external_permissions/slack/channel_access.py
@@ -2,6 +2,7 @@ from slack_sdk import WebClient
 
 from onyx.access.models import ExternalAccess
 from onyx.connectors.models import BasicExpertInfo
+from onyx.connectors.slack.connector import channel_team_ids
 from onyx.connectors.slack.connector import ChannelType
 from onyx.connectors.slack.utils import expert_info_from_slack_id
 from onyx.connectors.slack.utils import make_paginated_slack_api_call
@@ -11,20 +12,25 @@ def get_channel_access(
     client: WebClient,
     channel: ChannelType,
     user_cache: dict[str, BasicExpertInfo | None],
+    team_id_to_user_emails: dict[str, set[str]] | None = None,
 ) -> ExternalAccess:
-    """
-    Get channel access permissions for a Slack channel.
+    """Get channel access permissions for a Slack channel.
 
-    Args:
-        client: Slack WebClient instance
-        channel: Slack channel object containing channel info
-        user_cache: Cache of user IDs to BasicExpertInfo objects. May be updated in place.
-
-    Returns:
-        ExternalAccess object for the channel.
+    On Enterprise Grid, public channels are scoped to the union of users in
+    the workspaces the channel is shared into (via ``team_id_to_user_emails``).
+    On non-Grid, public channels stay org-public (existing behavior).
     """
     channel_is_public = not channel["is_private"]
     if channel_is_public:
+        if team_id_to_user_emails:
+            emails: set[str] = set()
+            for tid in channel_team_ids(channel):
+                emails |= team_id_to_user_emails.get(tid, set())
+            return ExternalAccess(
+                external_user_emails=emails,
+                external_user_group_ids=set(),
+                is_public=False,
+            )
         return ExternalAccess(
             external_user_emails=set(),
             external_user_group_ids=set(),
@@ -33,7 +39,6 @@ def get_channel_access(
 
     channel_id = channel["id"]
 
-    # Get all member IDs for the channel
     member_ids = []
     for result in make_paginated_slack_api_call(
         client.conversations_members,
@@ -43,21 +48,16 @@ def get_channel_access(
 
     member_emails = set()
     for member_id in member_ids:
-        # Try to get user info from cache or fetch it
         user_info = expert_info_from_slack_id(
             user_id=member_id,
             client=client,
             user_cache=user_cache,
         )
-
-        # If we have user info and an email, add it to the set
         if user_info and user_info.email:
             member_emails.add(user_info.email)
 
     return ExternalAccess(
         external_user_emails=member_emails,
-        # NOTE: groups are not used, since adding a group to a channel just adds all
-        # users that are in the group.
         external_user_group_ids=set(),
         is_public=False,
     )

--- a/backend/ee/onyx/external_permissions/slack/channel_access.py
+++ b/backend/ee/onyx/external_permissions/slack/channel_access.py
@@ -26,14 +26,15 @@ def get_channel_access(
             emails: set[str] = set()
             for tid in channel_team_ids(channel):
                 emails |= team_id_to_user_emails.get(tid, set())
-            if len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
+            if 0 < len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
                 return ExternalAccess(
                     external_user_emails=emails,
                     external_user_group_ids=set(),
                     is_public=False,
                 )
-            # Union exceeds the perm-sync size guard; fall through to is_public
-            # so the doc stays accessible instead of being silently dropped.
+            # Empty union (channel's teams not in cache — e.g. workspace added
+            # post-init or Slack Connect share) or union past the perm-sync
+            # size guard. Fall back to is_public so the doc stays accessible.
         return ExternalAccess(
             external_user_emails=set(),
             external_user_group_ids=set(),

--- a/backend/ee/onyx/external_permissions/slack/channel_access.py
+++ b/backend/ee/onyx/external_permissions/slack/channel_access.py
@@ -26,11 +26,14 @@ def get_channel_access(
             emails: set[str] = set()
             for tid in channel_team_ids(channel):
                 emails |= team_id_to_user_emails.get(tid, set())
-            return ExternalAccess(
-                external_user_emails=emails,
-                external_user_group_ids=set(),
-                is_public=False,
-            )
+            if len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
+                return ExternalAccess(
+                    external_user_emails=emails,
+                    external_user_group_ids=set(),
+                    is_public=False,
+                )
+            # Union exceeds the perm-sync size guard; fall through to is_public
+            # so the doc stays accessible instead of being silently dropped.
         return ExternalAccess(
             external_user_emails=set(),
             external_user_group_ids=set(),

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -82,11 +82,16 @@ def _fetch_channel_permissions(
             emails: set[str] = set()
             for tid in channel_team_ids(channel):
                 emails |= team_id_to_user_emails.get(tid, set())
-            channel_permissions[channel_id] = ExternalAccess(
-                external_user_emails=emails,
-                external_user_group_ids=set(),
-                is_public=False,
-            )
+            if len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
+                channel_permissions[channel_id] = ExternalAccess(
+                    external_user_emails=emails,
+                    external_user_group_ids=set(),
+                    is_public=False,
+                )
+            else:
+                # Union exceeds perm-sync size guard; fall back to is_public so
+                # the doc stays accessible instead of being silently dropped.
+                channel_permissions[channel_id] = ExternalAccess.public()
         else:
             channel_permissions[channel_id] = workspace_permissions
 

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -82,15 +82,16 @@ def _fetch_channel_permissions(
             emails: set[str] = set()
             for tid in channel_team_ids(channel):
                 emails |= team_id_to_user_emails.get(tid, set())
-            if len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
+            if 0 < len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
                 channel_permissions[channel_id] = ExternalAccess(
                     external_user_emails=emails,
                     external_user_group_ids=set(),
                     is_public=False,
                 )
             else:
-                # Union exceeds perm-sync size guard; fall back to is_public so
-                # the doc stays accessible instead of being silently dropped.
+                # Empty union (unknown teams, e.g. workspace added post-init
+                # or Slack Connect share) or union past the perm-sync size
+                # guard. Fall back to is_public so the doc stays accessible.
                 channel_permissions[channel_id] = ExternalAccess.public()
         else:
             channel_permissions[channel_id] = workspace_permissions

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -134,7 +134,7 @@ def _fetch_channel_permissions(
 
 def _get_slack_document_access(
     slack_connector: SlackConnector,
-    channel_permissions: dict[str, ExternalAccess],  # noqa: ARG001
+    channel_permissions: dict[str, ExternalAccess],
     callback: IndexingHeartbeatInterface | None,
     indexing_start: SecondsSinceUnixEpoch | None = None,
 ) -> Generator[DocExternalAccess, None, None]:
@@ -148,15 +148,21 @@ def _get_slack_document_access(
             if isinstance(doc_metadata, HierarchyNode):
                 # TODO: handle hierarchynodes during sync
                 continue
-            if doc_metadata.external_access is None:
+            external_access = doc_metadata.external_access
+            if external_access is None:
                 raise ValueError(
                     f"No external access for document {doc_metadata.id}. "
                     "Please check to make sure that your Slack bot token has the "
                     "`channels:read` scope"
                 )
+            channel_id = getattr(doc_metadata, "parent_hierarchy_raw_node_id", None)
+            if channel_id is not None:
+                override_access = channel_permissions.get(channel_id)
+                if override_access is not None:
+                    external_access = override_access
 
             yield DocExternalAccess(
-                external_access=doc_metadata.external_access,
+                external_access=external_access,
                 doc_id=doc_metadata.id,
             )
 

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -43,7 +43,7 @@ def _fetch_workspace_permissions(
 
 def _fetch_channel_permissions(
     slack_client: WebClient,
-    workspace_permissions: ExternalAccess,
+    workspace_permissions: ExternalAccess,  # noqa: ARG001
     user_id_to_email_map: dict[str, str],
     team_ids: list[str] | None = None,
     team_id_to_user_emails: dict[str, set[str]] | None = None,
@@ -93,8 +93,9 @@ def _fetch_channel_permissions(
                 # or Slack Connect share) or union past the perm-sync size
                 # guard. Fall back to is_public so the doc stays accessible.
                 channel_permissions[channel_id] = ExternalAccess.public()
-        else:
-            channel_permissions[channel_id] = workspace_permissions
+        # Non-Grid public channels keep their ingest-time is_public=True; no
+        # override entry so `_get_slack_document_access` falls back to the slim
+        # doc's original access.
 
     private_channel_ids = [
         channel["id"] for channel in private_channels if "id" in channel
@@ -218,7 +219,13 @@ def slack_doc_sync(
 
     team_id_to_user_emails: dict[str, set[str]] | None = None
     if grid_team_ids:
-        team_id_to_user_emails = fetch_team_user_emails(slack_client, grid_team_ids)
+        try:
+            team_id_to_user_emails = fetch_team_user_emails(slack_client, grid_team_ids)
+        except Exception as e:
+            # Without per-team users, Grid public-channel scoping degrades to
+            # is_public via the empty-union fallback. Keep perm-sync running.
+            logger.warning("fetch_team_user_emails failed on Grid org: %s", e)
+            team_id_to_user_emails = None
         user_id_to_email_map = fetch_user_id_to_email_map(
             slack_client, team_ids=grid_team_ids
         )

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -4,12 +4,14 @@ from slack_sdk import WebClient
 
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsIdsFunction
+from ee.onyx.external_permissions.slack.utils import fetch_team_user_emails
 from ee.onyx.external_permissions.slack.utils import fetch_user_id_to_email_map
 from onyx.access.models import DocExternalAccess
 from onyx.access.models import ExternalAccess
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import HierarchyNode
+from onyx.connectors.slack.connector import channel_team_ids
 from onyx.connectors.slack.connector import get_channels
 from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
@@ -44,6 +46,7 @@ def _fetch_channel_permissions(
     workspace_permissions: ExternalAccess,
     user_id_to_email_map: dict[str, str],
     team_ids: list[str] | None = None,
+    team_id_to_user_emails: dict[str, set[str]] | None = None,
 ) -> dict[str, ExternalAccess]:
     channel_permissions = {}
     if team_ids:
@@ -70,11 +73,22 @@ def _fetch_channel_permissions(
             get_public=False,
             get_private=True,
         )
-    public_channel_ids = [
-        channel["id"] for channel in public_channels if "id" in channel
-    ]
-    for channel_id in public_channel_ids:
-        channel_permissions[channel_id] = workspace_permissions
+    for channel in public_channels:
+        channel_id = channel.get("id")
+        if not channel_id:
+            continue
+        if team_id_to_user_emails:
+            # Grid: union users across the workspaces this channel is shared into
+            emails: set[str] = set()
+            for tid in channel_team_ids(channel):
+                emails |= team_id_to_user_emails.get(tid, set())
+            channel_permissions[channel_id] = ExternalAccess(
+                external_user_emails=emails,
+                external_user_group_ids=set(),
+                is_public=False,
+            )
+        else:
+            channel_permissions[channel_id] = workspace_permissions
 
     private_channel_ids = [
         channel["id"] for channel in private_channels if "id" in channel
@@ -190,9 +204,14 @@ def slack_doc_sync(
     except Exception as e:
         logger.warning("Slack Grid detection during perm sync failed: %s", e)
 
-    user_id_to_email_map = fetch_user_id_to_email_map(
-        slack_client, team_ids=grid_team_ids
-    )
+    team_id_to_user_emails: dict[str, set[str]] | None = None
+    if grid_team_ids:
+        team_id_to_user_emails = fetch_team_user_emails(slack_client, grid_team_ids)
+        user_id_to_email_map = fetch_user_id_to_email_map(
+            slack_client, team_ids=grid_team_ids
+        )
+    else:
+        user_id_to_email_map = fetch_user_id_to_email_map(slack_client)
     if not user_id_to_email_map:
         raise ValueError(
             "No user id to email map found. Please check to make sure that your Slack bot token has the `users:read.email` scope"
@@ -206,6 +225,7 @@ def slack_doc_sync(
         workspace_permissions=workspace_permissions,
         user_id_to_email_map=user_id_to_email_map,
         team_ids=grid_team_ids,
+        team_id_to_user_emails=team_id_to_user_emails,
     )
 
     slack_connector = SlackConnector(**cc_pair.connector.connector_specific_config)

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -182,12 +182,6 @@ def slack_doc_sync(
         r,
     )
 
-    user_id_to_email_map = fetch_user_id_to_email_map(slack_client)
-    if not user_id_to_email_map:
-        raise ValueError(
-            "No user id to email map found. Please check to make sure that your Slack bot token has the `users:read.email` scope"
-        )
-
     grid_team_ids: list[str] | None = None
     try:
         auth_response = slack_client.auth_test()
@@ -195,6 +189,14 @@ def slack_doc_sync(
             grid_team_ids = list_grid_team_ids(slack_client)
     except Exception as e:
         logger.warning("Slack Grid detection during perm sync failed: %s", e)
+
+    user_id_to_email_map = fetch_user_id_to_email_map(
+        slack_client, team_ids=grid_team_ids
+    )
+    if not user_id_to_email_map:
+        raise ValueError(
+            "No user id to email map found. Please check to make sure that your Slack bot token has the `users:read.email` scope"
+        )
 
     workspace_permissions = _fetch_workspace_permissions(
         user_id_to_email_map=user_id_to_email_map,

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -47,8 +47,6 @@ def _fetch_channel_permissions(
 ) -> dict[str, ExternalAccess]:
     channel_permissions = {}
     if team_ids:
-        # Enterprise Grid: enumerate channels across every workspace in the org
-        # so org-shared and per-workspace channels are all covered.
         public_channels = get_channels_across_teams(
             client=slack_client,
             team_ids=team_ids,
@@ -190,8 +188,6 @@ def slack_doc_sync(
             "No user id to email map found. Please check to make sure that your Slack bot token has the `users:read.email` scope"
         )
 
-    # Detect Enterprise Grid via auth_test and enumerate teams once so channel
-    # listing covers every workspace in the org.
     grid_team_ids: list[str] | None = None
     try:
         auth_response = slack_client.auth_test()

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -4,6 +4,7 @@ from slack_sdk import WebClient
 
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsIdsFunction
+from ee.onyx.external_permissions.slack.channel_access import get_channel_access
 from ee.onyx.external_permissions.slack.utils import fetch_team_user_emails
 from ee.onyx.external_permissions.slack.utils import fetch_user_id_to_email_map
 from onyx.access.models import DocExternalAccess
@@ -11,7 +12,6 @@ from onyx.access.models import ExternalAccess
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import HierarchyNode
-from onyx.connectors.slack.connector import channel_team_ids
 from onyx.connectors.slack.connector import get_channels
 from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
@@ -78,21 +78,12 @@ def _fetch_channel_permissions(
         if not channel_id:
             continue
         if team_id_to_user_emails:
-            # Grid: union users across the workspaces this channel is shared into
-            emails: set[str] = set()
-            for tid in channel_team_ids(channel):
-                emails |= team_id_to_user_emails.get(tid, set())
-            if 0 < len(emails) <= ExternalAccess.MAX_NUM_ENTRIES:
-                channel_permissions[channel_id] = ExternalAccess(
-                    external_user_emails=emails,
-                    external_user_group_ids=set(),
-                    is_public=False,
-                )
-            else:
-                # Empty union (unknown teams, e.g. workspace added post-init
-                # or Slack Connect share) or union past the perm-sync size
-                # guard. Fall back to is_public so the doc stays accessible.
-                channel_permissions[channel_id] = ExternalAccess.public()
+            channel_permissions[channel_id] = get_channel_access(
+                client=slack_client,
+                channel=channel,
+                user_cache={},
+                team_id_to_user_emails=team_id_to_user_emails,
+            )
         # Non-Grid public channels keep their ingest-time is_public=True; no
         # override entry so `_get_slack_document_access` falls back to the slim
         # doc's original access.

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -11,6 +11,8 @@ from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.slack.connector import get_channels
+from onyx.connectors.slack.connector import get_channels_across_teams
+from onyx.connectors.slack.connector import list_grid_team_ids
 from onyx.connectors.slack.connector import make_paginated_slack_api_call
 from onyx.connectors.slack.connector import SlackConnector
 from onyx.db.models import ConnectorCredentialPair
@@ -41,24 +43,41 @@ def _fetch_channel_permissions(
     slack_client: WebClient,
     workspace_permissions: ExternalAccess,
     user_id_to_email_map: dict[str, str],
+    team_ids: list[str] | None = None,
 ) -> dict[str, ExternalAccess]:
     channel_permissions = {}
-    public_channels = get_channels(
-        client=slack_client,
-        get_public=True,
-        get_private=False,
-    )
+    if team_ids:
+        # Enterprise Grid: enumerate channels across every workspace in the org
+        # so org-shared and per-workspace channels are all covered.
+        public_channels = get_channels_across_teams(
+            client=slack_client,
+            team_ids=team_ids,
+            get_public=True,
+            get_private=False,
+        )
+        private_channels = get_channels_across_teams(
+            client=slack_client,
+            team_ids=team_ids,
+            get_public=False,
+            get_private=True,
+        )
+    else:
+        public_channels = get_channels(
+            client=slack_client,
+            get_public=True,
+            get_private=False,
+        )
+        private_channels = get_channels(
+            client=slack_client,
+            get_public=False,
+            get_private=True,
+        )
     public_channel_ids = [
         channel["id"] for channel in public_channels if "id" in channel
     ]
     for channel_id in public_channel_ids:
         channel_permissions[channel_id] = workspace_permissions
 
-    private_channels = get_channels(
-        client=slack_client,
-        get_public=False,
-        get_private=True,
-    )
     private_channel_ids = [
         channel["id"] for channel in private_channels if "id" in channel
     ]
@@ -171,6 +190,16 @@ def slack_doc_sync(
             "No user id to email map found. Please check to make sure that your Slack bot token has the `users:read.email` scope"
         )
 
+    # Detect Enterprise Grid via auth_test and enumerate teams once so channel
+    # listing covers every workspace in the org.
+    grid_team_ids: list[str] | None = None
+    try:
+        auth_response = slack_client.auth_test()
+        if auth_response.get("enterprise_id"):
+            grid_team_ids = list_grid_team_ids(slack_client)
+    except Exception as e:
+        logger.warning("Slack Grid detection during perm sync failed: %s", e)
+
     workspace_permissions = _fetch_workspace_permissions(
         user_id_to_email_map=user_id_to_email_map,
     )
@@ -178,6 +207,7 @@ def slack_doc_sync(
         slack_client=slack_client,
         workspace_permissions=workspace_permissions,
         user_id_to_email_map=user_id_to_email_map,
+        team_ids=grid_team_ids,
     )
 
     slack_connector = SlackConnector(**cc_pair.connector.connector_specific_config)

--- a/backend/ee/onyx/external_permissions/slack/utils.py
+++ b/backend/ee/onyx/external_permissions/slack/utils.py
@@ -1,5 +1,8 @@
 from slack_sdk import WebClient
 
+from onyx.connectors.slack.utils import (
+    fetch_team_user_emails as _fetch_team_user_emails,
+)
 from onyx.connectors.slack.utils import make_paginated_slack_api_call
 
 
@@ -29,17 +32,6 @@ def fetch_team_user_emails(
     slack_client: WebClient,
     team_ids: list[str],
 ) -> dict[str, set[str]]:
-    """Per-workspace user email sets, used to scope public-channel access
-    on Grid so W1 users don't get access to W2's public channels."""
-    result: dict[str, set[str]] = {}
-    for tid in team_ids:
-        emails: set[str] = set()
-        for user_info in make_paginated_slack_api_call(
-            slack_client.users_list, team_id=tid
-        ):
-            for user in user_info.get("members", []):
-                email = user.get("profile", {}).get("email")
-                if email:
-                    emails.add(email)
-        result[tid] = emails
-    return result
+    """Re-export of ``onyx.connectors.slack.utils.fetch_team_user_emails`` for
+    callers that already import it from this EE module."""
+    return _fetch_team_user_emails(slack_client, team_ids)

--- a/backend/ee/onyx/external_permissions/slack/utils.py
+++ b/backend/ee/onyx/external_permissions/slack/utils.py
@@ -5,14 +5,21 @@ from onyx.connectors.slack.utils import make_paginated_slack_api_call
 
 def fetch_user_id_to_email_map(
     slack_client: WebClient,
+    team_ids: list[str] | None = None,
 ) -> dict[str, str]:
-    user_id_to_email_map = {}
-    for user_info in make_paginated_slack_api_call(
-        slack_client.users_list,
-    ):
-        for user in user_info.get("members", []):
-            if user.get("profile", {}).get("email"):
-                user_id_to_email_map[user.get("id")] = user.get("profile", {}).get(
-                    "email"
-                )
+    """On Grid org installs, ``users.list`` requires a ``team_id``; iterate
+    every team and merge. Without ``team_ids`` (non-Grid), call once."""
+    user_id_to_email_map: dict[str, str] = {}
+    team_iter = team_ids if team_ids else [None]
+    for tid in team_iter:
+        kwargs: dict[str, str] = {}
+        if tid:
+            kwargs["team_id"] = tid
+        for user_info in make_paginated_slack_api_call(
+            slack_client.users_list, **kwargs
+        ):
+            for user in user_info.get("members", []):
+                email = user.get("profile", {}).get("email")
+                if email:
+                    user_id_to_email_map[user.get("id")] = email
     return user_id_to_email_map

--- a/backend/ee/onyx/external_permissions/slack/utils.py
+++ b/backend/ee/onyx/external_permissions/slack/utils.py
@@ -10,7 +10,7 @@ def fetch_user_id_to_email_map(
     """On Grid org installs, ``users.list`` requires a ``team_id``; iterate
     every team and merge. Without ``team_ids`` (non-Grid), call once."""
     user_id_to_email_map: dict[str, str] = {}
-    team_iter = team_ids if team_ids else [None]
+    team_iter: list[str | None] = list(team_ids) if team_ids else [None]
     for tid in team_iter:
         kwargs: dict[str, str] = {}
         if tid:
@@ -23,3 +23,23 @@ def fetch_user_id_to_email_map(
                 if email:
                     user_id_to_email_map[user.get("id")] = email
     return user_id_to_email_map
+
+
+def fetch_team_user_emails(
+    slack_client: WebClient,
+    team_ids: list[str],
+) -> dict[str, set[str]]:
+    """Per-workspace user email sets, used to scope public-channel access
+    on Grid so W1 users don't get access to W2's public channels."""
+    result: dict[str, set[str]] = {}
+    for tid in team_ids:
+        emails: set[str] = set()
+        for user_info in make_paginated_slack_api_call(
+            slack_client.users_list, team_id=tid
+        ):
+            for user in user_info.get("members", []):
+                email = user.get("profile", {}).get("email")
+                if email:
+                    emails.add(email)
+        result[tid] = emails
+    return result

--- a/backend/onyx/connectors/slack/access.py
+++ b/backend/onyx/connectors/slack/access.py
@@ -14,27 +14,25 @@ def get_channel_access(
     client: WebClient,
     channel: ChannelType,
     user_cache: dict[str, BasicExpertInfo | None],
+    team_id_to_user_emails: dict[str, set[str]] | None = None,
 ) -> ExternalAccess | None:
-    """
-    Get channel access permissions for a Slack channel.
-    This functionality requires Enterprise Edition.
+    """Get channel access permissions for a Slack channel. EE only.
 
-    Args:
-        client: Slack WebClient instance
-        channel: Slack channel object containing channel info
-        user_cache: Cache of user IDs to BasicExpertInfo objects. May be updated in place.
-
-    Returns:
-        ExternalAccess object for the channel. None if EE is not enabled.
+    ``team_id_to_user_emails`` (Grid only): when provided, public channels
+    are scoped to the union of the workspaces they're shared into instead of
+    being marked org-public.
     """
-    # Check if EE is enabled
     if not global_version.is_ee_version():
         return None
 
-    # Fetch the EE implementation
     ee_get_channel_access = cast(
         Callable[
-            [WebClient, ChannelType, dict[str, BasicExpertInfo | None]],
+            [
+                WebClient,
+                ChannelType,
+                dict[str, BasicExpertInfo | None],
+                dict[str, set[str]] | None,
+            ],
             ExternalAccess,
         ],
         fetch_versioned_implementation(
@@ -42,4 +40,4 @@ def get_channel_access(
         ),
     )
 
-    return ee_get_channel_access(client, channel, user_cache)
+    return ee_get_channel_access(client, channel, user_cache, team_id_to_user_emails)

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -61,6 +61,7 @@ from onyx.connectors.slack.models import ThreadType
 from onyx.connectors.slack.onyx_retry_handler import OnyxRedisSlackRetryHandler
 from onyx.connectors.slack.onyx_slack_web_client import OnyxSlackWebClient
 from onyx.connectors.slack.utils import expert_info_from_slack_id
+from onyx.connectors.slack.utils import fetch_team_user_emails
 from onyx.connectors.slack.utils import get_message_link
 from onyx.connectors.slack.utils import make_paginated_slack_api_call
 from onyx.connectors.slack.utils import SlackTextCleaner
@@ -606,6 +607,7 @@ def _get_all_doc_ids(
     end: SecondsSinceUnixEpoch | None = None,
     team_ids: list[str] | None = None,
     team_id_to_url: dict[str, str] | None = None,
+    team_id_to_user_emails: dict[str, set[str]] | None = None,
 ) -> GenerateSlimDocumentOutput:
     """
     Get all document ids in the workspace, channel by channel
@@ -630,6 +632,7 @@ def _get_all_doc_ids(
             client=client,
             channel=channel,
             user_cache=user_cache,
+            team_id_to_user_emails=team_id_to_user_emails,
         )
 
         # Yield the channel as a HierarchyNode first (before any documents)
@@ -803,6 +806,7 @@ class SlackConnector(
         self._is_grid: bool = False
         self._team_ids: list[str] = []
         self._team_id_to_url: dict[str, str] = {}
+        self._team_id_to_user_emails: dict[str, set[str]] = {}
         # self.delay_lock: str | None = None  # the redis key for the shared lock
         # self.delay_key: str | None = None  # the redis key for the shared delay
 
@@ -961,6 +965,7 @@ class SlackConnector(
         self._is_grid = is_grid
         self._team_ids = []
         self._team_id_to_url = {}
+        self._team_id_to_user_emails = {}
         if self._is_grid and self.client is not None:
             try:
                 self._team_ids = list_grid_team_ids(self.client)
@@ -991,10 +996,23 @@ class SlackConnector(
                             continue
                         if url:
                             self._team_id_to_url[tid] = url
+                try:
+                    self._team_id_to_user_emails = fetch_team_user_emails(
+                        grid_client, self._team_ids
+                    )
+                except SlackApiError as e:
+                    # Public-channel access on Grid stays org-wide instead of
+                    # per-workspace if this fails. Surfaced via missing_scope etc.
+                    logger.warning(
+                        "users.list per-team failed on Grid org: %s",
+                        e.response.get("error", ""),
+                    )
+                    self._team_id_to_user_emails = {}
             logger.info(
-                "Slack Enterprise Grid detected: teams=%s urls_resolved=%s",
+                "Slack Enterprise Grid detected: teams=%s urls_resolved=%s users_scoped=%s",
                 len(self._team_ids),
                 len(self._team_id_to_url),
+                sum(len(v) for v in self._team_id_to_user_emails.values()),
             )
 
     def retrieve_all_slim_docs_perm_sync(
@@ -1017,6 +1035,9 @@ class SlackConnector(
             end=end,
             team_ids=self._team_ids if self._is_grid else None,
             team_id_to_url=self._team_id_to_url if self._is_grid else None,
+            team_id_to_user_emails=(
+                self._team_id_to_user_emails if self._is_grid else None
+            ),
         )
 
     def _load_from_checkpoint(
@@ -1076,6 +1097,9 @@ class SlackConnector(
                     client=self.client,
                     channel=checkpoint.current_channel,
                     user_cache=self.user_cache,
+                    team_id_to_user_emails=(
+                        self._team_id_to_user_emails if self._is_grid else None
+                    ),
                 )
                 checkpoint.current_channel_access = channel_access
             checkpoint.has_more = True
@@ -1276,6 +1300,9 @@ class SlackConnector(
                             client=self.client,
                             channel=new_channel,
                             user_cache=self.user_cache,
+                            team_id_to_user_emails=(
+                                self._team_id_to_user_emails if self._is_grid else None
+                            ),
                         )
                         checkpoint.current_channel_access = channel_access
                 else:

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -254,6 +254,12 @@ def _build_doc_id(channel_id: str, thread_ts: str) -> str:
     return f"{channel_id}__{thread_ts}"
 
 
+def _channel_team_id(channel: ChannelType) -> str | None:
+    """Grid workspace id for a channel; ``conversations.info`` returns it as
+    ``context_team_id`` while ``conversations.list`` returns it as ``team``."""
+    return channel.get("team") or channel.get("context_team_id")
+
+
 def thread_to_doc(
     channel: ChannelType,
     thread: ThreadType,
@@ -264,7 +270,7 @@ def thread_to_doc(
     team_id_to_url: dict[str, str] | None = None,
 ) -> Document:
     channel_id = channel["id"]
-    channel_team = channel.get("team")
+    channel_team = _channel_team_id(channel)
 
     initial_sender_expert_info = expert_info_from_slack_id(
         user_id=thread[0].get("user"), client=client, user_cache=user_cache
@@ -432,7 +438,7 @@ def _channel_to_hierarchy_node(
 ) -> HierarchyNode:
     """Convert a Slack channel to a HierarchyNode."""
     resolved_url: str | None = None
-    channel_team = channel.get("team")
+    channel_team = _channel_team_id(channel)
     if channel_team and team_id_to_url is not None:
         resolved_url = team_id_to_url.get(channel_team)
     if not resolved_url:
@@ -724,7 +730,7 @@ def _process_message(
                         message,
                         client,
                         channel["id"],
-                        team_id=channel.get("team"),
+                        team_id=_channel_team_id(channel),
                         team_id_to_url=team_id_to_url,
                     ),
                 ),

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -810,6 +810,18 @@ class SlackConnector(
         # self.delay_lock: str | None = None  # the redis key for the shared lock
         # self.delay_key: str | None = None  # the redis key for the shared delay
 
+    @property
+    def grid_team_ids(self) -> list[str] | None:
+        return self._team_ids if self._is_grid else None
+
+    @property
+    def grid_team_id_to_url(self) -> dict[str, str] | None:
+        return self._team_id_to_url if self._is_grid else None
+
+    @property
+    def grid_team_id_to_user_emails(self) -> dict[str, set[str]] | None:
+        return self._team_id_to_user_emails if self._is_grid else None
+
     @classmethod
     @override
     def normalize_url(cls, url: str) -> NormalizationResult:
@@ -1033,11 +1045,9 @@ class SlackConnector(
             workspace_url=self._workspace_url,
             start=start,
             end=end,
-            team_ids=self._team_ids if self._is_grid else None,
-            team_id_to_url=self._team_id_to_url if self._is_grid else None,
-            team_id_to_user_emails=(
-                self._team_id_to_user_emails if self._is_grid else None
-            ),
+            team_ids=self.grid_team_ids,
+            team_id_to_url=self.grid_team_id_to_url,
+            team_id_to_user_emails=(self.grid_team_id_to_user_emails),
         )
 
     def _load_from_checkpoint(
@@ -1097,9 +1107,7 @@ class SlackConnector(
                     client=self.client,
                     channel=checkpoint.current_channel,
                     user_cache=self.user_cache,
-                    team_id_to_user_emails=(
-                        self._team_id_to_user_emails if self._is_grid else None
-                    ),
+                    team_id_to_user_emails=(self.grid_team_id_to_user_emails),
                 )
                 checkpoint.current_channel_access = channel_access
             checkpoint.has_more = True
@@ -1146,7 +1154,7 @@ class SlackConnector(
                     channel,
                     checkpoint.current_channel_access,
                     self._workspace_url,
-                    team_id_to_url=self._team_id_to_url if self._is_grid else None,
+                    team_id_to_url=self.grid_team_id_to_url,
                 )
 
             logger.debug(
@@ -1195,9 +1203,7 @@ class SlackConnector(
                             seen_thread_ts=seen_thread_ts,
                             channel_access=checkpoint.current_channel_access,
                             msg_filter_func=self.msg_filter_func,
-                            team_id_to_url=(
-                                self._team_id_to_url if self._is_grid else None
-                            ),
+                            team_id_to_url=(self.grid_team_id_to_url),
                         )
                     )
 
@@ -1300,9 +1306,7 @@ class SlackConnector(
                             client=self.client,
                             channel=new_channel,
                             user_cache=self.user_cache,
-                            team_id_to_user_emails=(
-                                self._team_id_to_user_emails if self._is_grid else None
-                            ),
+                            team_id_to_user_emails=(self.grid_team_id_to_user_emails),
                         )
                         checkpoint.current_channel_access = channel_access
                 else:

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -94,13 +94,19 @@ def _collect_paginated_channels(
     client: WebClient,
     exclude_archived: bool,
     channel_types: list[str],
+    team_id: str | None = None,
 ) -> list[ChannelType]:
     channels: list[ChannelType] = []
+    extra_kwargs: dict[str, Any] = {}
+    if team_id is not None:
+        # Enterprise Grid: scope channel listing to a specific workspace
+        extra_kwargs["team_id"] = team_id
     for result in make_paginated_slack_api_call(
         client.conversations_list,
         exclude_archived=exclude_archived,
         # also get private channels the bot is added to
         types=channel_types,
+        **extra_kwargs,
     ):
         channels.extend(result["channels"])
 
@@ -112,8 +118,13 @@ def get_channels(
     exclude_archived: bool = True,
     get_public: bool = True,
     get_private: bool = True,
+    team_id: str | None = None,
 ) -> list[ChannelType]:
-    """Get all channels in the workspace."""
+    """Get all channels in the workspace.
+
+    On Enterprise Grid, pass team_id to scope the listing to a specific
+    workspace within the org.
+    """
     channels: list[ChannelType] = []
     channel_types = []
     if get_public:
@@ -126,6 +137,7 @@ def get_channels(
             client=client,
             exclude_archived=exclude_archived,
             channel_types=channel_types,
+            team_id=team_id,
         )
     except SlackApiError as e:
         msg = f"Unable to fetch private channels due to: {e}."
@@ -139,8 +151,70 @@ def get_channels(
             client=client,
             exclude_archived=exclude_archived,
             channel_types=channel_types,
+            team_id=team_id,
         )
     return channels
+
+
+def list_grid_team_ids(client: WebClient) -> list[str]:
+    """List all team (workspace) IDs in an Enterprise Grid org.
+
+    Requires ``team:read`` (or ``auth.teams:read``) scope on the bot token of
+    an org-level install. Returns an empty list if the call surfaces no teams.
+    """
+    team_ids: list[str] = []
+    for result in make_paginated_slack_api_call(client.auth_teams_list):
+        for team in result.get("teams", []):
+            team_id = team.get("id")
+            if team_id:
+                team_ids.append(team_id)
+    return team_ids
+
+
+def fetch_team_url(client: WebClient, team_id: str) -> str | None:
+    """Fetch a workspace URL for a given Grid team id via ``team.info``."""
+    try:
+        response = client.team_info(team=team_id)
+    except SlackApiError as e:
+        logger.warning(
+            "team_info failed for team_id=%s: %s", team_id, e.response.get("error", "")
+        )
+        return None
+    team = cast(dict[str, Any], response.get("team", {}))
+    url = team.get("url")
+    return cast(str, url) if isinstance(url, str) else None
+
+
+def get_channels_across_teams(
+    client: WebClient,
+    team_ids: list[str],
+    exclude_archived: bool = True,
+    get_public: bool = True,
+    get_private: bool = True,
+) -> list[ChannelType]:
+    """Enumerate channels across every workspace in an Enterprise Grid org.
+
+    Slack returns org-shared channels under each workspace they're shared into,
+    so dedupe by channel id while keeping the first occurrence (which retains
+    the ``team`` field of the home workspace for that listing).
+    """
+    seen: set[str] = set()
+    merged: list[ChannelType] = []
+    for team_id in team_ids:
+        per_team = get_channels(
+            client=client,
+            exclude_archived=exclude_archived,
+            get_public=get_public,
+            get_private=get_private,
+            team_id=team_id,
+        )
+        for channel in per_team:
+            channel_id = channel.get("id")
+            if not channel_id or channel_id in seen:
+                continue
+            seen.add(channel_id)
+            merged.append(channel)
+    return merged
 
 
 def get_channel_messages(
@@ -199,8 +273,10 @@ def thread_to_doc(
     client: WebClient,
     user_cache: dict[str, BasicExpertInfo | None],
     channel_access: ExternalAccess | None,
+    team_id_to_url: dict[str, str] | None = None,
 ) -> Document:
     channel_id = channel["id"]
+    channel_team = channel.get("team")
 
     initial_sender_expert_info = expert_info_from_slack_id(
         user_id=thread[0].get("user"), client=client, user_cache=user_cache
@@ -240,7 +316,13 @@ def thread_to_doc(
         id=_build_doc_id(channel_id=channel_id, thread_ts=thread[0]["ts"]),
         sections=[
             TextSection(
-                link=get_message_link(event=m, client=client, channel_id=channel_id),
+                link=get_message_link(
+                    event=m,
+                    client=client,
+                    channel_id=channel_id,
+                    team_id=channel_team,
+                    team_id_to_url=team_id_to_url,
+                ),
                 text=slack_cleaner.index_clean(m["text"]),
             )
             for m in thread
@@ -358,19 +440,30 @@ def _channel_to_hierarchy_node(
     channel: ChannelType,
     channel_access: ExternalAccess | None,
     workspace_url: str | None = None,
+    team_id_to_url: dict[str, str] | None = None,
 ) -> HierarchyNode:
     """Convert a Slack channel to a HierarchyNode.
 
     Args:
         channel: The Slack channel object
         channel_access: External access permissions for the channel
-        workspace_url: The workspace URL (e.g., https://myworkspace.slack.com)
+        workspace_url: Fallback workspace URL for non-Grid installs
+        team_id_to_url: Per-team URL map for Enterprise Grid; when the channel
+            carries a ``team`` field, that workspace's URL is preferred.
 
     Returns:
         A HierarchyNode representing the channel
     """
+    # Prefer the per-team URL on Enterprise Grid so links route to the correct workspace.
+    resolved_url: str | None = None
+    channel_team = channel.get("team")
+    if channel_team and team_id_to_url is not None:
+        resolved_url = team_id_to_url.get(channel_team)
+    if not resolved_url:
+        resolved_url = workspace_url
+
     # Link format: https://{workspace}.slack.com/archives/{channel_id}
-    link = f"{workspace_url}/archives/{channel['id']}" if workspace_url else None
+    link = f"{resolved_url}/archives/{channel['id']}" if resolved_url else None
 
     return HierarchyNode(
         raw_node_id=channel["id"],
@@ -454,6 +547,7 @@ def _message_to_doc(
     msg_filter_func: Callable[
         [MessageType], SlackMessageFilterReason | None
     ] = default_msg_filter,
+    team_id_to_url: dict[str, str] | None = None,
 ) -> tuple[Document | None, SlackMessageFilterReason | None]:
     """Returns a doc or None.
     If None is returned, the second element of the tuple may be a filter reason
@@ -501,6 +595,7 @@ def _message_to_doc(
         client=client,
         user_cache=user_cache,
         channel_access=channel_access,
+        team_id_to_url=team_id_to_url,
     )
     return doc, None
 
@@ -516,14 +611,22 @@ def _get_all_doc_ids(
     workspace_url: str | None = None,
     start: SecondsSinceUnixEpoch | None = None,
     end: SecondsSinceUnixEpoch | None = None,
+    team_ids: list[str] | None = None,
+    team_id_to_url: dict[str, str] | None = None,
 ) -> GenerateSlimDocumentOutput:
     """
     Get all document ids in the workspace, channel by channel
     This is pretty identical to get_all_docs, but it returns a set of ids instead of documents
     This makes it an order of magnitude faster than get_all_docs
+
+    On Enterprise Grid, pass ``team_ids`` to enumerate channels across every
+    workspace in the org and ``team_id_to_url`` to build per-workspace links.
     """
 
-    all_channels = get_channels(client)
+    if team_ids:
+        all_channels = get_channels_across_teams(client=client, team_ids=team_ids)
+    else:
+        all_channels = get_channels(client)
     filtered_channels = filter_channels(
         all_channels, channels, channel_name_regex_enabled
     )
@@ -540,7 +643,14 @@ def _get_all_doc_ids(
         )
 
         # Yield the channel as a HierarchyNode first (before any documents)
-        yield [_channel_to_hierarchy_node(channel, external_access, workspace_url)]
+        yield [
+            _channel_to_hierarchy_node(
+                channel,
+                external_access,
+                workspace_url,
+                team_id_to_url=team_id_to_url,
+            )
+        ]
 
         channel_message_batches = get_channel_messages(
             client=client,
@@ -598,6 +708,7 @@ def _process_message(
     msg_filter_func: Callable[
         [MessageType], SlackMessageFilterReason | None
     ] = default_msg_filter,
+    team_id_to_url: dict[str, str] | None = None,
 ) -> ProcessedSlackMessage:
     thread_ts = message.get("thread_ts")
     thread_or_message_ts = thread_ts or message["ts"]
@@ -616,6 +727,7 @@ def _process_message(
             seen_thread_ts=seen_thread_ts,
             channel_access=channel_access,
             msg_filter_func=msg_filter_func,
+            team_id_to_url=team_id_to_url,
         )
         return ProcessedSlackMessage(
             doc=doc,
@@ -634,7 +746,13 @@ def _process_message(
                     document_id=_build_doc_id(
                         channel_id=channel["id"], thread_ts=thread_or_message_ts
                     ),
-                    document_link=get_message_link(message, client, channel["id"]),
+                    document_link=get_message_link(
+                        message,
+                        client,
+                        channel["id"],
+                        team_id=channel.get("team"),
+                        team_id_to_url=team_id_to_url,
+                    ),
                 ),
                 failure_message=str(e),
                 exception=e,
@@ -693,6 +811,10 @@ class SlackConnector(
         self.use_redis: bool = use_redis
         # Workspace URL for building channel links (e.g., https://myworkspace.slack.com)
         self._workspace_url: str | None = None
+        # Enterprise Grid org state. Empty / False when not on Grid.
+        self._is_grid: bool = False
+        self._team_ids: list[str] = []
+        self._team_id_to_url: dict[str, str] = {}
         # self.delay_lock: str | None = None  # the redis key for the shared lock
         # self.delay_key: str | None = None  # the redis key for the shared delay
 
@@ -839,13 +961,51 @@ class SlackConnector(
         self.text_cleaner = SlackTextCleaner(client=self.client)
         self.credentials_provider = credentials_provider
 
-        # Extract workspace URL from auth_test response for building channel links
+        # Extract workspace URL from auth_test response for building channel links.
+        # On Enterprise Grid, also enumerate teams in the org so downstream
+        # channel listing / link building can be team-scoped.
+        is_grid = False
         try:
             auth_response = self.client.auth_test()
             self._workspace_url = auth_response.get("url")
+            is_grid = bool(auth_response.get("enterprise_id"))
         except Exception as e:
             logger.warning("Failed to get workspace URL from auth_test: %s", e)
             self._workspace_url = None
+
+        self._is_grid = is_grid
+        self._team_ids = []
+        self._team_id_to_url = {}
+        if self._is_grid and self.client is not None:
+            try:
+                self._team_ids = list_grid_team_ids(self.client)
+            except SlackApiError as e:
+                logger.warning(
+                    "auth.teams.list failed on Grid org: %s",
+                    e.response.get("error", ""),
+                )
+                self._team_ids = []
+            # Fan out team.info calls in parallel so a 50+ workspace org doesn't
+            # serialize that many round-trips during connector init.
+            if self._team_ids:
+                grid_client = self.client
+                with ThreadPoolExecutor(
+                    max_workers=min(8, len(self._team_ids))
+                ) as executor:
+                    url_futures = {
+                        executor.submit(fetch_team_url, grid_client, tid): tid
+                        for tid in self._team_ids
+                    }
+                    for future in as_completed(url_futures):
+                        tid = url_futures[future]
+                        url = future.result()
+                        if url:
+                            self._team_id_to_url[tid] = url
+            logger.info(
+                "Slack Enterprise Grid detected: teams=%s urls_resolved=%s",
+                len(self._team_ids),
+                len(self._team_id_to_url),
+            )
 
     def retrieve_all_slim_docs_perm_sync(
         self,
@@ -865,6 +1025,8 @@ class SlackConnector(
             workspace_url=self._workspace_url,
             start=start,
             end=end,
+            team_ids=self._team_ids if self._is_grid else None,
+            team_id_to_url=self._team_id_to_url if self._is_grid else None,
         )
 
     def _load_from_checkpoint(
@@ -896,7 +1058,12 @@ class SlackConnector(
         # if this is the very first time we've called this, need to
         # get all relevant channels and save them into the checkpoint
         if checkpoint.channel_ids is None:
-            raw_channels = get_channels(self.client)
+            if self._is_grid and self._team_ids:
+                raw_channels = get_channels_across_teams(
+                    client=self.client, team_ids=self._team_ids
+                )
+            else:
+                raw_channels = get_channels(self.client)
             filtered_channels = filter_channels(
                 raw_channels, self.channels, self.channel_regex_enabled
             )
@@ -965,6 +1132,7 @@ class SlackConnector(
                     channel,
                     checkpoint.current_channel_access,
                     self._workspace_url,
+                    team_id_to_url=self._team_id_to_url if self._is_grid else None,
                 )
 
             logger.debug(
@@ -1013,6 +1181,9 @@ class SlackConnector(
                             seen_thread_ts=seen_thread_ts,
                             channel_access=checkpoint.current_channel_access,
                             msg_filter_func=self.msg_filter_func,
+                            team_id_to_url=(
+                                self._team_id_to_url if self._is_grid else None
+                            ),
                         )
                     )
 
@@ -1205,6 +1376,25 @@ class SlackConnector(
                     f"Slack API returned a failure: {error_msg}"
                 )
 
+            # 3) Enterprise Grid: also confirm we can enumerate workspaces in the
+            # org. Without team:read, channel listing across the Grid org is not
+            # possible.
+            if auth_response.get("enterprise_id"):
+                teams_resp = self.fast_client.auth_teams_list(limit=1)
+                if not teams_resp.get("ok", False):
+                    grid_error = teams_resp.get(
+                        "error", "Unknown error from auth.teams.list"
+                    )
+                    if grid_error == "missing_scope":
+                        raise InsufficientPermissionsError(
+                            "Slack Enterprise Grid org detected but the bot token "
+                            "lacks the `team:read` scope required to list workspaces "
+                            "(auth.teams.list)."
+                        )
+                    raise UnexpectedValidationError(
+                        f"Slack auth.teams.list returned a failure: {grid_error}"
+                    )
+
             # 3) If channels are specified and regex is not enabled, verify each is accessible
             # NOTE: removed this for now since it may be too slow for large workspaces which may
             # have some automations which create a lot of channels (100k+)
@@ -1241,6 +1431,13 @@ class SlackConnector(
                 # Continue validation without failing - the connector is likely valid but just rate limited
                 return
             elif slack_error == "missing_scope":
+                needed_scope = e.response.get("needed", "")
+                if needed_scope == "team:read" or needed_scope == "auth.teams:read":
+                    raise InsufficientPermissionsError(
+                        "Slack Enterprise Grid org detected but the bot token "
+                        "lacks the `team:read` scope required to list workspaces "
+                        "(auth.teams.list)."
+                    )
                 raise InsufficientPermissionsError(
                     "Slack bot token lacks the necessary scope to list/access channels. "
                     "Please ensure your Slack app has 'channels:read' (and/or 'groups:read' for private channels)."

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -197,6 +197,11 @@ def get_channels_across_teams(
     Slack returns org-shared channels under each workspace they're shared into,
     so dedupe by channel id while keeping the first occurrence (which retains
     the ``team`` field of the home workspace for that listing).
+
+    When ``conversations.list`` is called with an explicit ``team_id``, Slack
+    omits the ``team`` field on each returned channel (it's implicit from the
+    query). Stamp the queried ``team_id`` onto the channel so downstream
+    callers can resolve per-workspace URLs without an extra API round-trip.
     """
     seen: set[str] = set()
     merged: list[ChannelType] = []
@@ -213,6 +218,8 @@ def get_channels_across_teams(
             if not channel_id or channel_id in seen:
                 continue
             seen.add(channel_id)
+            if not channel.get("team"):
+                channel["team"] = team_id
             merged.append(channel)
     return merged
 
@@ -463,7 +470,9 @@ def _channel_to_hierarchy_node(
         resolved_url = workspace_url
 
     # Link format: https://{workspace}.slack.com/archives/{channel_id}
-    link = f"{resolved_url}/archives/{channel['id']}" if resolved_url else None
+    link = (
+        f"{resolved_url.rstrip('/')}/archives/{channel['id']}" if resolved_url else None
+    )
 
     return HierarchyNode(
         raw_node_id=channel["id"],

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -260,6 +260,16 @@ def _channel_team_id(channel: ChannelType) -> str | None:
     return channel.get("team") or channel.get("context_team_id")
 
 
+def channel_team_ids(channel: ChannelType) -> list[str]:
+    """All Grid workspaces this channel is shared into. Falls back to the
+    single home team id when ``shared_team_ids`` is absent."""
+    shared = channel.get("shared_team_ids") or []
+    if shared:
+        return list(shared)
+    single = _channel_team_id(channel)
+    return [single] if single else []
+
+
 def thread_to_doc(
     channel: ChannelType,
     thread: ThreadType,

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -99,7 +99,6 @@ def _collect_paginated_channels(
     channels: list[ChannelType] = []
     extra_kwargs: dict[str, Any] = {}
     if team_id is not None:
-        # Enterprise Grid: scope channel listing to a specific workspace
         extra_kwargs["team_id"] = team_id
     for result in make_paginated_slack_api_call(
         client.conversations_list,
@@ -120,11 +119,7 @@ def get_channels(
     get_private: bool = True,
     team_id: str | None = None,
 ) -> list[ChannelType]:
-    """Get all channels in the workspace.
-
-    On Enterprise Grid, pass team_id to scope the listing to a specific
-    workspace within the org.
-    """
+    """Get all channels in the workspace. Pass team_id to scope to one Grid workspace."""
     channels: list[ChannelType] = []
     channel_types = []
     if get_public:
@@ -157,11 +152,7 @@ def get_channels(
 
 
 def list_grid_team_ids(client: WebClient) -> list[str]:
-    """List all team (workspace) IDs in an Enterprise Grid org.
-
-    Requires ``team:read`` (or ``auth.teams:read``) scope on the bot token of
-    an org-level install. Returns an empty list if the call surfaces no teams.
-    """
+    """Return Grid org team IDs via ``auth.teams.list`` (needs ``team:read``)."""
     team_ids: list[str] = []
     for result in make_paginated_slack_api_call(client.auth_teams_list):
         for team in result.get("teams", []):
@@ -192,17 +183,7 @@ def get_channels_across_teams(
     get_public: bool = True,
     get_private: bool = True,
 ) -> list[ChannelType]:
-    """Enumerate channels across every workspace in an Enterprise Grid org.
-
-    Slack returns org-shared channels under each workspace they're shared into,
-    so dedupe by channel id while keeping the first occurrence (which retains
-    the ``team`` field of the home workspace for that listing).
-
-    When ``conversations.list`` is called with an explicit ``team_id``, Slack
-    omits the ``team`` field on each returned channel (it's implicit from the
-    query). Stamp the queried ``team_id`` onto the channel so downstream
-    callers can resolve per-workspace URLs without an extra API round-trip.
-    """
+    """Enumerate Grid org channels across teams; dedupe by id, stamp team_id."""
     seen: set[str] = set()
     merged: list[ChannelType] = []
     for team_id in team_ids:
@@ -449,19 +430,7 @@ def _channel_to_hierarchy_node(
     workspace_url: str | None = None,
     team_id_to_url: dict[str, str] | None = None,
 ) -> HierarchyNode:
-    """Convert a Slack channel to a HierarchyNode.
-
-    Args:
-        channel: The Slack channel object
-        channel_access: External access permissions for the channel
-        workspace_url: Fallback workspace URL for non-Grid installs
-        team_id_to_url: Per-team URL map for Enterprise Grid; when the channel
-            carries a ``team`` field, that workspace's URL is preferred.
-
-    Returns:
-        A HierarchyNode representing the channel
-    """
-    # Prefer the per-team URL on Enterprise Grid so links route to the correct workspace.
+    """Convert a Slack channel to a HierarchyNode."""
     resolved_url: str | None = None
     channel_team = channel.get("team")
     if channel_team and team_id_to_url is not None:
@@ -469,7 +438,6 @@ def _channel_to_hierarchy_node(
     if not resolved_url:
         resolved_url = workspace_url
 
-    # Link format: https://{workspace}.slack.com/archives/{channel_id}
     link = (
         f"{resolved_url.rstrip('/')}/archives/{channel['id']}" if resolved_url else None
     )
@@ -627,9 +595,6 @@ def _get_all_doc_ids(
     Get all document ids in the workspace, channel by channel
     This is pretty identical to get_all_docs, but it returns a set of ids instead of documents
     This makes it an order of magnitude faster than get_all_docs
-
-    On Enterprise Grid, pass ``team_ids`` to enumerate channels across every
-    workspace in the org and ``team_id_to_url`` to build per-workspace links.
     """
 
     if team_ids:
@@ -818,9 +783,7 @@ class SlackConnector(
         self.credentials_provider: CredentialsProviderInterface | None = None
         self.credential_prefix: str | None = None
         self.use_redis: bool = use_redis
-        # Workspace URL for building channel links (e.g., https://myworkspace.slack.com)
         self._workspace_url: str | None = None
-        # Enterprise Grid org state. Empty / False when not on Grid.
         self._is_grid: bool = False
         self._team_ids: list[str] = []
         self._team_id_to_url: dict[str, str] = {}
@@ -970,9 +933,6 @@ class SlackConnector(
         self.text_cleaner = SlackTextCleaner(client=self.client)
         self.credentials_provider = credentials_provider
 
-        # Extract workspace URL from auth_test response for building channel links.
-        # On Enterprise Grid, also enumerate teams in the org so downstream
-        # channel listing / link building can be team-scoped.
         is_grid = False
         try:
             auth_response = self.client.auth_test()
@@ -994,8 +954,6 @@ class SlackConnector(
                     e.response.get("error", ""),
                 )
                 self._team_ids = []
-            # Fan out team.info calls in parallel so a 50+ workspace org doesn't
-            # serialize that many round-trips during connector init.
             if self._team_ids:
                 grid_client = self.client
                 with ThreadPoolExecutor(
@@ -1010,10 +968,7 @@ class SlackConnector(
                         try:
                             url = future.result()
                         except Exception as e:
-                            # Non-SlackApiError (e.g. transient network failures
-                            # past the retry budget) would otherwise abort
-                            # connector init for the whole Grid org. Skip the
-                            # team; channel links fall back to _workspace_url.
+                            # swallow per-team failures so one bad team.info doesn't abort init
                             logger.warning(
                                 "team.info failed for team_id=%s: %s", tid, e
                             )
@@ -1395,10 +1350,7 @@ class SlackConnector(
                     f"Slack API returned a failure: {error_msg}"
                 )
 
-            # 3) Enterprise Grid: confirm we can enumerate workspaces in the
-            # org. Without team:read, channel listing across the Grid org is not
-            # possible. The Slack SDK raises SlackApiError on failure (caught
-            # below), so no inline ok-check is needed here.
+            # 3) Grid: verify team:read by calling auth.teams.list
             if auth_response.get("enterprise_id"):
                 self.fast_client.auth_teams_list(limit=1)
 

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -998,7 +998,17 @@ class SlackConnector(
                     }
                     for future in as_completed(url_futures):
                         tid = url_futures[future]
-                        url = future.result()
+                        try:
+                            url = future.result()
+                        except Exception as e:
+                            # Non-SlackApiError (e.g. transient network failures
+                            # past the retry budget) would otherwise abort
+                            # connector init for the whole Grid org. Skip the
+                            # team; channel links fall back to _workspace_url.
+                            logger.warning(
+                                "team.info failed for team_id=%s: %s", tid, e
+                            )
+                            continue
                         if url:
                             self._team_id_to_url[tid] = url
             logger.info(
@@ -1376,26 +1386,14 @@ class SlackConnector(
                     f"Slack API returned a failure: {error_msg}"
                 )
 
-            # 3) Enterprise Grid: also confirm we can enumerate workspaces in the
+            # 3) Enterprise Grid: confirm we can enumerate workspaces in the
             # org. Without team:read, channel listing across the Grid org is not
-            # possible.
+            # possible. The Slack SDK raises SlackApiError on failure (caught
+            # below), so no inline ok-check is needed here.
             if auth_response.get("enterprise_id"):
-                teams_resp = self.fast_client.auth_teams_list(limit=1)
-                if not teams_resp.get("ok", False):
-                    grid_error = teams_resp.get(
-                        "error", "Unknown error from auth.teams.list"
-                    )
-                    if grid_error == "missing_scope":
-                        raise InsufficientPermissionsError(
-                            "Slack Enterprise Grid org detected but the bot token "
-                            "lacks the `team:read` scope required to list workspaces "
-                            "(auth.teams.list)."
-                        )
-                    raise UnexpectedValidationError(
-                        f"Slack auth.teams.list returned a failure: {grid_error}"
-                    )
+                self.fast_client.auth_teams_list(limit=1)
 
-            # 3) If channels are specified and regex is not enabled, verify each is accessible
+            # 4) If channels are specified and regex is not enabled, verify each is accessible
             # NOTE: removed this for now since it may be too slow for large workspaces which may
             # have some automations which create a lot of channels (100k+)
 

--- a/backend/onyx/connectors/slack/models.py
+++ b/backend/onyx/connectors/slack/models.py
@@ -43,6 +43,7 @@ class ChannelType(TypedDict):
     previous_names: list[str]
     num_members: int
     team: NotRequired[str]
+    context_team_id: NotRequired[str]
 
 
 class AttachmentType(TypedDict):

--- a/backend/onyx/connectors/slack/models.py
+++ b/backend/onyx/connectors/slack/models.py
@@ -42,7 +42,6 @@ class ChannelType(TypedDict):
     purpose: ChannelTopicPurposeType
     previous_names: list[str]
     num_members: int
-    # Present on Enterprise Grid: id of the workspace (team) this channel belongs to.
     team: NotRequired[str]
 
 

--- a/backend/onyx/connectors/slack/models.py
+++ b/backend/onyx/connectors/slack/models.py
@@ -44,6 +44,7 @@ class ChannelType(TypedDict):
     num_members: int
     team: NotRequired[str]
     context_team_id: NotRequired[str]
+    shared_team_ids: NotRequired[list[str]]
 
 
 class AttachmentType(TypedDict):

--- a/backend/onyx/connectors/slack/models.py
+++ b/backend/onyx/connectors/slack/models.py
@@ -42,6 +42,8 @@ class ChannelType(TypedDict):
     purpose: ChannelTopicPurposeType
     previous_names: list[str]
     num_members: int
+    # Present on Enterprise Grid: id of the workspace (team) this channel belongs to.
+    team: NotRequired[str]
 
 
 class AttachmentType(TypedDict):

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -35,11 +35,25 @@ def get_base_url(token: str) -> str:
     return client.auth_test()["url"]
 
 
-def get_message_link(event: MessageType, client: WebClient, channel_id: str) -> str:
+def get_message_link(
+    event: MessageType,
+    client: WebClient,
+    channel_id: str,
+    team_id: str | None = None,
+    team_id_to_url: dict[str, str] | None = None,
+) -> str:
     message_ts = event["ts"]
     message_ts_without_dot = message_ts.replace(".", "")
     thread_ts = event.get("thread_ts")
-    base_url = get_base_url(client.token)
+
+    # On Enterprise Grid the channel lives under a specific workspace (team_id).
+    # Prefer that workspace URL so the link opens the correct workspace, falling
+    # back to auth.test on the token (org URL for org-level installs).
+    base_url: str | None = None
+    if team_id and team_id_to_url is not None:
+        base_url = team_id_to_url.get(team_id)
+    if not base_url:
+        base_url = get_base_url(client.token)
 
     link = f"{base_url.rstrip('/')}/archives/{channel_id}/p{message_ts_without_dot}" + (
         f"?thread_ts={thread_ts}" if thread_ts else ""

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -46,9 +46,6 @@ def get_message_link(
     message_ts_without_dot = message_ts.replace(".", "")
     thread_ts = event.get("thread_ts")
 
-    # On Enterprise Grid the channel lives under a specific workspace (team_id).
-    # Prefer that workspace URL so the link opens the correct workspace, falling
-    # back to auth.test on the token (org URL for org-level installs).
     base_url: str | None = None
     if team_id and team_id_to_url is not None:
         base_url = team_id_to_url.get(team_id)

--- a/backend/onyx/connectors/slack/utils.py
+++ b/backend/onyx/connectors/slack/utils.py
@@ -35,6 +35,27 @@ def get_base_url(token: str) -> str:
     return client.auth_test()["url"]
 
 
+def fetch_team_user_emails(
+    slack_client: WebClient,
+    team_ids: list[str],
+) -> dict[str, set[str]]:
+    """Per-workspace user email sets. Used to scope public-channel access on
+    Enterprise Grid so users from one workspace can't see another workspace's
+    public channels."""
+    result: dict[str, set[str]] = {}
+    for tid in team_ids:
+        emails: set[str] = set()
+        for user_info in make_paginated_slack_api_call(
+            slack_client.users_list, team_id=tid
+        ):
+            for user in user_info.get("members", []):
+                email = user.get("profile", {}).get("email")
+                if email:
+                    emails.add(email)
+        result[tid] = emails
+    return result
+
+
 def get_message_link(
     event: MessageType,
     client: WebClient,

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -1,0 +1,193 @@
+"""Unit tests for EE Slack perm sync on Enterprise Grid."""
+
+from typing import Any
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from ee.onyx.external_permissions.slack.doc_sync import _fetch_channel_permissions
+from ee.onyx.external_permissions.slack.doc_sync import _fetch_workspace_permissions
+from ee.onyx.external_permissions.slack.utils import fetch_team_user_emails
+from ee.onyx.external_permissions.slack.utils import fetch_user_id_to_email_map
+from onyx.connectors.slack.models import ChannelType
+
+
+def _channel(channel_id: str, **overrides: Any) -> ChannelType:
+    base: dict[str, Any] = {
+        "id": channel_id,
+        "name": f"chan-{channel_id.lower()}",
+        "is_channel": True,
+        "is_group": False,
+        "is_im": False,
+        "created": 0,
+        "creator": "U1",
+        "is_archived": False,
+        "is_general": False,
+        "unlinked": 0,
+        "name_normalized": f"chan-{channel_id.lower()}",
+        "is_shared": False,
+        "is_ext_shared": False,
+        "is_org_shared": False,
+        "pending_shared": [],
+        "is_pending_ext_shared": False,
+        "is_member": True,
+        "is_private": False,
+        "is_mpim": False,
+        "updated": 0,
+        "topic": {"value": "", "creator": "", "last_set": 0},
+        "purpose": {"value": "", "creator": "", "last_set": 0},
+        "previous_names": [],
+        "num_members": 0,
+    }
+    base.update(overrides)
+    return cast(ChannelType, base)
+
+
+class TestFetchUserIdToEmailMap:
+    def test_non_grid_calls_users_list_without_team_id(self) -> None:
+        client = MagicMock()
+        with patch(
+            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.return_value = iter(
+                [{"members": [{"id": "U1", "profile": {"email": "u1@x.com"}}]}]
+            )
+            result = fetch_user_id_to_email_map(client)
+            assert result == {"U1": "u1@x.com"}
+            assert mock_paginate.call_count == 1
+            assert "team_id" not in mock_paginate.call_args.kwargs
+
+    def test_grid_iterates_each_team_with_team_id(self) -> None:
+        client = MagicMock()
+        with patch(
+            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.side_effect = [
+                iter([{"members": [{"id": "U1", "profile": {"email": "u1@x.com"}}]}]),
+                iter([{"members": [{"id": "U2", "profile": {"email": "u2@x.com"}}]}]),
+            ]
+            result = fetch_user_id_to_email_map(client, team_ids=["T1", "T2"])
+            assert result == {"U1": "u1@x.com", "U2": "u2@x.com"}
+            assert mock_paginate.call_count == 2
+            assert mock_paginate.call_args_list[0].kwargs == {"team_id": "T1"}
+            assert mock_paginate.call_args_list[1].kwargs == {"team_id": "T2"}
+
+
+class TestFetchTeamUserEmails:
+    def test_returns_per_team_email_sets(self) -> None:
+        client = MagicMock()
+        with patch(
+            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.side_effect = [
+                iter([{"members": [{"id": "U1", "profile": {"email": "u1@x.com"}}]}]),
+                iter(
+                    [
+                        {
+                            "members": [
+                                {"id": "U2", "profile": {"email": "u2@x.com"}},
+                                {"id": "U3", "profile": {"email": "u3@x.com"}},
+                            ]
+                        }
+                    ]
+                ),
+            ]
+            result = fetch_team_user_emails(client, ["T1", "T2"])
+            assert result == {"T1": {"u1@x.com"}, "T2": {"u2@x.com", "u3@x.com"}}
+
+    def test_skips_users_without_email(self) -> None:
+        client = MagicMock()
+        with patch(
+            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.return_value = iter(
+                [
+                    {
+                        "members": [
+                            {"id": "U1", "profile": {"email": "u1@x.com"}},
+                            {"id": "U2", "profile": {}},
+                        ]
+                    }
+                ]
+            )
+            assert fetch_team_user_emails(client, ["T1"]) == {"T1": {"u1@x.com"}}
+
+
+class TestFetchChannelPermissionsGrid:
+    def test_public_channel_scoped_to_its_workspace_users(self) -> None:
+        client = MagicMock()
+        ws_emails = {
+            "T_W1": {"a@x.com", "b@x.com", "c@x.com"},
+            "T_W2": {"z@x.com"},
+        }
+        ch_w1 = _channel("C_W1", team="T_W1")
+        ch_w2 = _channel("C_W2", team="T_W2")
+        with patch(
+            "ee.onyx.external_permissions.slack.doc_sync.get_channels_across_teams"
+        ) as mock_get:
+            mock_get.side_effect = [[ch_w1, ch_w2], []]  # public, private
+            workspace_perm = _fetch_workspace_permissions({"U1": "a@x.com"})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={},
+                team_ids=["T_W1", "T_W2"],
+                team_id_to_user_emails=ws_emails,
+            )
+            assert result["C_W1"].external_user_emails == {
+                "a@x.com",
+                "b@x.com",
+                "c@x.com",
+            }
+            assert result["C_W2"].external_user_emails == {"z@x.com"}
+            assert result["C_W1"].is_public is False
+            assert result["C_W2"].is_public is False
+
+    def test_org_shared_public_channel_unions_users_across_workspaces(self) -> None:
+        client = MagicMock()
+        ws_emails = {
+            "T_W1": {"a@x.com", "b@x.com"},
+            "T_W2": {"z@x.com"},
+        }
+        shared = _channel(
+            "C_SHARED",
+            team="T_W1",
+            shared_team_ids=["T_W1", "T_W2"],
+            is_org_shared=True,
+        )
+        with patch(
+            "ee.onyx.external_permissions.slack.doc_sync.get_channels_across_teams"
+        ) as mock_get:
+            mock_get.side_effect = [[shared], []]
+            workspace_perm = _fetch_workspace_permissions({})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={},
+                team_ids=["T_W1", "T_W2"],
+                team_id_to_user_emails=ws_emails,
+            )
+            assert result["C_SHARED"].external_user_emails == {
+                "a@x.com",
+                "b@x.com",
+                "z@x.com",
+            }
+
+    def test_non_grid_falls_back_to_workspace_permissions(self) -> None:
+        client = MagicMock()
+        ch = _channel("C1")  # no team field, non-Grid
+        with patch(
+            "ee.onyx.external_permissions.slack.doc_sync.get_channels"
+        ) as mock_get:
+            mock_get.side_effect = [[ch], []]  # public, private
+            workspace_perm = _fetch_workspace_permissions(
+                {"U1": "a@x.com", "U2": "b@x.com"}
+            )
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={},
+                team_ids=None,
+                team_id_to_user_emails=None,
+            )
+            assert result["C1"].external_user_emails == {"a@x.com", "b@x.com"}

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -179,6 +179,27 @@ class TestFetchChannelPermissionsGrid:
                 "z@x.com",
             }
 
+    def test_public_channel_fallback_to_is_public_when_teams_unknown(
+        self,
+    ) -> None:
+        client = MagicMock()
+        ws_emails = {"T_W1": {"a@x.com"}}
+        ch = _channel("C_UNKNOWN", team="T_UNKNOWN")
+        with patch(
+            "ee.onyx.external_permissions.slack.doc_sync.get_channels_across_teams"
+        ) as mock_get:
+            mock_get.side_effect = [[ch], []]
+            workspace_perm = _fetch_workspace_permissions({})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={},
+                team_ids=["T_W1"],
+                team_id_to_user_emails=ws_emails,
+            )
+            assert result["C_UNKNOWN"].is_public is True
+            assert result["C_UNKNOWN"].external_user_emails == set()
+
     def test_public_channel_fallback_to_is_public_when_union_exceeds_cap(
         self,
     ) -> None:
@@ -255,6 +276,32 @@ class TestEEGetChannelAccessGrid:
         )
         assert access.is_public is False
         assert access.external_user_emails == {"a@x.com", "z@x.com"}
+
+    def test_public_channel_grid_falls_back_to_is_public_when_teams_unknown(
+        self,
+    ) -> None:
+        ch = _channel("C1", is_private=False, team="T_UNKNOWN")
+        access = ee_get_channel_access(
+            MagicMock(),
+            ch,
+            {},
+            team_id_to_user_emails={"T1": {"a@x.com"}},
+        )
+        assert access.is_public is True
+        assert access.external_user_emails == set()
+
+    def test_public_channel_grid_falls_back_to_is_public_when_channel_team_ids_empty(
+        self,
+    ) -> None:
+        ch = _channel("C1", is_private=False)  # no team / context_team_id
+        access = ee_get_channel_access(
+            MagicMock(),
+            ch,
+            {},
+            team_id_to_user_emails={"T1": {"a@x.com"}},
+        )
+        assert access.is_public is True
+        assert access.external_user_emails == set()
 
     def test_public_channel_grid_falls_back_to_is_public_when_union_exceeds_cap(
         self,

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -222,7 +222,13 @@ class TestFetchChannelPermissionsGrid:
             assert result["C_BIG"].is_public is True
             assert result["C_BIG"].external_user_emails == set()
 
-    def test_non_grid_falls_back_to_workspace_permissions(self) -> None:
+    def test_non_grid_public_channel_not_overridden(self) -> None:
+        """Non-Grid public channels stay with their ingest-time is_public=True.
+
+        The override path in ``_get_slack_document_access`` only fires when
+        the channel id is in ``channel_permissions``; non-Grid public
+        channels are intentionally absent so the ingest value wins.
+        """
         client = MagicMock()
         ch = _channel("C1")  # no team field, non-Grid
         with patch(
@@ -239,7 +245,7 @@ class TestFetchChannelPermissionsGrid:
                 team_ids=None,
                 team_id_to_user_emails=None,
             )
-            assert result["C1"].external_user_emails == {"a@x.com", "b@x.com"}
+            assert "C1" not in result
 
 
 class TestEEGetChannelAccessGrid:

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -5,6 +5,9 @@ from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from ee.onyx.external_permissions.slack.channel_access import (
+    get_channel_access as ee_get_channel_access,
+)
 from ee.onyx.external_permissions.slack.doc_sync import _fetch_channel_permissions
 from ee.onyx.external_permissions.slack.doc_sync import _fetch_workspace_permissions
 from ee.onyx.external_permissions.slack.doc_sync import _get_slack_document_access
@@ -80,7 +83,7 @@ class TestFetchTeamUserEmails:
     def test_returns_per_team_email_sets(self) -> None:
         client = MagicMock()
         with patch(
-            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+            "onyx.connectors.slack.utils.make_paginated_slack_api_call"
         ) as mock_paginate:
             mock_paginate.side_effect = [
                 iter([{"members": [{"id": "U1", "profile": {"email": "u1@x.com"}}]}]),
@@ -101,7 +104,7 @@ class TestFetchTeamUserEmails:
     def test_skips_users_without_email(self) -> None:
         client = MagicMock()
         with patch(
-            "ee.onyx.external_permissions.slack.utils.make_paginated_slack_api_call"
+            "onyx.connectors.slack.utils.make_paginated_slack_api_call"
         ) as mock_paginate:
             mock_paginate.return_value = iter(
                 [
@@ -194,6 +197,68 @@ class TestFetchChannelPermissionsGrid:
                 team_id_to_user_emails=None,
             )
             assert result["C1"].external_user_emails == {"a@x.com", "b@x.com"}
+
+
+class TestEEGetChannelAccessGrid:
+    def test_public_channel_non_grid_returns_is_public_true(self) -> None:
+        ch = _channel("C1", is_private=False)
+        access = ee_get_channel_access(MagicMock(), ch, {}, team_id_to_user_emails=None)
+        assert access.is_public is True
+        assert access.external_user_emails == set()
+
+    def test_public_channel_grid_scoped_to_workspace_users(self) -> None:
+        ch = _channel("C1", is_private=False, team="T1")
+        access = ee_get_channel_access(
+            MagicMock(),
+            ch,
+            {},
+            team_id_to_user_emails={"T1": {"a@x.com"}, "T2": {"z@x.com"}},
+        )
+        assert access.is_public is False
+        assert access.external_user_emails == {"a@x.com"}
+
+    def test_public_channel_grid_org_shared_unions_workspaces(self) -> None:
+        ch = _channel(
+            "C1",
+            is_private=False,
+            team="T1",
+            shared_team_ids=["T1", "T2"],
+            is_org_shared=True,
+        )
+        access = ee_get_channel_access(
+            MagicMock(),
+            ch,
+            {},
+            team_id_to_user_emails={"T1": {"a@x.com"}, "T2": {"z@x.com"}},
+        )
+        assert access.is_public is False
+        assert access.external_user_emails == {"a@x.com", "z@x.com"}
+
+    def test_private_channel_uses_members_path_regardless_of_grid(self) -> None:
+        client = MagicMock()
+        ch = _channel("C1", is_private=True, team="T1")
+        with (
+            patch(
+                "ee.onyx.external_permissions.slack.channel_access.make_paginated_slack_api_call"
+            ) as mock_paginate,
+            patch(
+                "ee.onyx.external_permissions.slack.channel_access.expert_info_from_slack_id"
+            ) as mock_expert,
+        ):
+            mock_paginate.return_value = iter([{"members": ["U1", "U2"]}])
+            mock_expert.side_effect = (
+                lambda user_id, client, user_cache: (  # noqa: ARG005
+                    MagicMock(email=f"{user_id.lower()}@x.com") if user_id else None
+                )
+            )
+            access = ee_get_channel_access(
+                client,
+                ch,
+                {},
+                team_id_to_user_emails={"T1": {"a@x.com"}, "T2": {"z@x.com"}},
+            )
+            assert access.is_public is False
+            assert access.external_user_emails == {"u1@x.com", "u2@x.com"}
 
 
 class TestGetSlackDocumentAccess:

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -337,10 +337,8 @@ class TestEEGetChannelAccessGrid:
             ) as mock_expert,
         ):
             mock_paginate.return_value = iter([{"members": ["U1", "U2"]}])
-            mock_expert.side_effect = (
-                lambda user_id, client, user_cache: (  # noqa: ARG005
-                    MagicMock(email=f"{user_id.lower()}@x.com") if user_id else None
-                )
+            mock_expert.side_effect = lambda user_id, client, user_cache: (  # noqa: ARG005
+                MagicMock(email=f"{user_id.lower()}@x.com") if user_id else None
             )
             access = ee_get_channel_access(
                 client,

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -7,8 +7,11 @@ from unittest.mock import patch
 
 from ee.onyx.external_permissions.slack.doc_sync import _fetch_channel_permissions
 from ee.onyx.external_permissions.slack.doc_sync import _fetch_workspace_permissions
+from ee.onyx.external_permissions.slack.doc_sync import _get_slack_document_access
 from ee.onyx.external_permissions.slack.utils import fetch_team_user_emails
 from ee.onyx.external_permissions.slack.utils import fetch_user_id_to_email_map
+from onyx.access.models import ExternalAccess
+from onyx.connectors.models import SlimDocument
 from onyx.connectors.slack.models import ChannelType
 
 
@@ -191,3 +194,62 @@ class TestFetchChannelPermissionsGrid:
                 team_id_to_user_emails=None,
             )
             assert result["C1"].external_user_emails == {"a@x.com", "b@x.com"}
+
+
+class TestGetSlackDocumentAccess:
+    def test_channel_permissions_override_external_access(self) -> None:
+        connector = MagicMock()
+        original_access = ExternalAccess(
+            external_user_emails=set(),
+            external_user_group_ids=set(),
+            is_public=True,
+        )
+        override_access = ExternalAccess(
+            external_user_emails={"allowed@x.com"},
+            external_user_group_ids=set(),
+            is_public=False,
+        )
+        slim_doc = SlimDocument(
+            id="C1__123",
+            external_access=original_access,
+            parent_hierarchy_raw_node_id="C1",
+        )
+        connector.retrieve_all_slim_docs_perm_sync.return_value = iter([[slim_doc]])
+
+        results = list(
+            _get_slack_document_access(
+                slack_connector=connector,
+                channel_permissions={"C1": override_access},
+                callback=None,
+                indexing_start=None,
+            )
+        )
+
+        assert len(results) == 1
+        assert results[0].external_access == override_access
+
+    def test_falls_back_when_channel_missing(self) -> None:
+        connector = MagicMock()
+        access = ExternalAccess(
+            external_user_emails={"stay@x.com"},
+            external_user_group_ids=set(),
+            is_public=False,
+        )
+        slim_doc = SlimDocument(
+            id="C2__999",
+            external_access=access,
+            parent_hierarchy_raw_node_id="C2",
+        )
+        connector.retrieve_all_slim_docs_perm_sync.return_value = iter([[slim_doc]])
+
+        results = list(
+            _get_slack_document_access(
+                slack_connector=connector,
+                channel_permissions={},
+                callback=None,
+                indexing_start=None,
+            )
+        )
+
+        assert len(results) == 1
+        assert results[0].external_access == access

--- a/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/slack/test_grid_perm_sync.py
@@ -179,6 +179,28 @@ class TestFetchChannelPermissionsGrid:
                 "z@x.com",
             }
 
+    def test_public_channel_fallback_to_is_public_when_union_exceeds_cap(
+        self,
+    ) -> None:
+        client = MagicMock()
+        big = {f"u{i}@x.com" for i in range(ExternalAccess.MAX_NUM_ENTRIES + 1)}
+        ws_emails = {"T_W1": big}
+        ch = _channel("C_BIG", team="T_W1")
+        with patch(
+            "ee.onyx.external_permissions.slack.doc_sync.get_channels_across_teams"
+        ) as mock_get:
+            mock_get.side_effect = [[ch], []]
+            workspace_perm = _fetch_workspace_permissions({})
+            result = _fetch_channel_permissions(
+                slack_client=client,
+                workspace_permissions=workspace_perm,
+                user_id_to_email_map={},
+                team_ids=["T_W1"],
+                team_id_to_user_emails=ws_emails,
+            )
+            assert result["C_BIG"].is_public is True
+            assert result["C_BIG"].external_user_emails == set()
+
     def test_non_grid_falls_back_to_workspace_permissions(self) -> None:
         client = MagicMock()
         ch = _channel("C1")  # no team field, non-Grid
@@ -233,6 +255,22 @@ class TestEEGetChannelAccessGrid:
         )
         assert access.is_public is False
         assert access.external_user_emails == {"a@x.com", "z@x.com"}
+
+    def test_public_channel_grid_falls_back_to_is_public_when_union_exceeds_cap(
+        self,
+    ) -> None:
+        from onyx.access.models import ExternalAccess as _EA
+
+        big = {f"u{i}@x.com" for i in range(_EA.MAX_NUM_ENTRIES + 1)}
+        ch = _channel("C1", is_private=False, team="T1")
+        access = ee_get_channel_access(
+            MagicMock(),
+            ch,
+            {},
+            team_id_to_user_emails={"T1": big},
+        )
+        assert access.is_public is True
+        assert access.external_user_emails == set()
 
     def test_private_channel_uses_members_path_regardless_of_grid(self) -> None:
         client = MagicMock()

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -145,6 +145,18 @@ class TestGetChannelsAcrossTeams:
             assert get_channels_across_teams(MagicMock(), []) == []
             mock_get_channels.assert_not_called()
 
+    def test_stamps_team_id_when_channel_team_missing(self) -> None:
+        # Slack omits the team field on conversations.list when called with
+        # an explicit team_id. Stamping the queried team_id onto each channel
+        # lets downstream URL resolution work without an extra API call.
+        ch_no_team = _channel("C1")
+        ch_with_team = _channel("C2", team="T_EXISTING")
+        with patch("onyx.connectors.slack.connector.get_channels") as mock_get_channels:
+            mock_get_channels.side_effect = [[ch_no_team, ch_with_team]]
+            result = get_channels_across_teams(MagicMock(), ["T_QUERIED"])
+            stamped = {c["id"]: c.get("team") for c in result}
+            assert stamped == {"C1": "T_QUERIED", "C2": "T_EXISTING"}
+
 
 class TestChannelToHierarchyNode:
     def test_grid_uses_per_team_url(self) -> None:

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 from slack_sdk.errors import SlackApiError
 
+from onyx.connectors.slack.connector import _channel_team_id
 from onyx.connectors.slack.connector import _channel_to_hierarchy_node
 from onyx.connectors.slack.connector import fetch_team_url
 from onyx.connectors.slack.connector import get_channels_across_teams
@@ -156,6 +157,19 @@ class TestGetChannelsAcrossTeams:
             result = get_channels_across_teams(MagicMock(), ["T_QUERIED"])
             stamped = {c["id"]: c.get("team") for c in result}
             assert stamped == {"C1": "T_QUERIED", "C2": "T_EXISTING"}
+
+
+class TestChannelTeamId:
+    def test_prefers_team_field(self) -> None:
+        ch = _channel("C1", team="T_LIST", context_team_id="T_INFO")
+        assert _channel_team_id(ch) == "T_LIST"
+
+    def test_falls_back_to_context_team_id(self) -> None:
+        ch = _channel("C1", context_team_id="T_INFO")
+        assert _channel_team_id(ch) == "T_INFO"
+
+    def test_none_when_neither_present(self) -> None:
+        assert _channel_team_id(_channel("C1")) is None
 
 
 class TestChannelToHierarchyNode:

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -14,6 +14,7 @@ from slack_sdk.errors import SlackApiError
 
 from onyx.connectors.slack.connector import _channel_team_id
 from onyx.connectors.slack.connector import _channel_to_hierarchy_node
+from onyx.connectors.slack.connector import channel_team_ids
 from onyx.connectors.slack.connector import fetch_team_url
 from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
@@ -170,6 +171,23 @@ class TestChannelTeamId:
 
     def test_none_when_neither_present(self) -> None:
         assert _channel_team_id(_channel("C1")) is None
+
+
+class TestChannelTeamIdsPlural:
+    def test_uses_shared_team_ids_when_present(self) -> None:
+        ch = _channel("C1", team="T1", shared_team_ids=["T1", "T2", "T3"])
+        assert channel_team_ids(ch) == ["T1", "T2", "T3"]
+
+    def test_falls_back_to_single_team_id(self) -> None:
+        ch = _channel("C1", team="T1")
+        assert channel_team_ids(ch) == ["T1"]
+
+    def test_falls_back_to_context_team_id(self) -> None:
+        ch = _channel("C1", context_team_id="T_INFO")
+        assert channel_team_ids(ch) == ["T_INFO"]
+
+    def test_empty_when_no_team_info(self) -> None:
+        assert channel_team_ids(_channel("C1")) == []
 
 
 class TestChannelToHierarchyNode:

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -1,0 +1,243 @@
+"""Unit tests for Slack Enterprise Grid helpers.
+
+These tests exercise the Grid-specific code paths added to the Slack connector
+using a mocked Slack ``WebClient``. They do not hit the real Slack API.
+"""
+
+from typing import Any
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from onyx.connectors.slack.connector import _channel_to_hierarchy_node
+from onyx.connectors.slack.connector import fetch_team_url
+from onyx.connectors.slack.connector import get_channels_across_teams
+from onyx.connectors.slack.connector import list_grid_team_ids
+from onyx.connectors.slack.models import ChannelType
+from onyx.connectors.slack.models import MessageType
+from onyx.connectors.slack.utils import get_message_link
+
+
+def _channel(channel_id: str, **overrides: Any) -> ChannelType:
+    base: dict[str, Any] = {
+        "id": channel_id,
+        "name": f"chan-{channel_id.lower()}",
+        "is_channel": True,
+        "is_group": False,
+        "is_im": False,
+        "created": 0,
+        "creator": "U1",
+        "is_archived": False,
+        "is_general": False,
+        "unlinked": 0,
+        "name_normalized": f"chan-{channel_id.lower()}",
+        "is_shared": False,
+        "is_ext_shared": False,
+        "is_org_shared": False,
+        "pending_shared": [],
+        "is_pending_ext_shared": False,
+        "is_member": True,
+        "is_private": False,
+        "is_mpim": False,
+        "updated": 0,
+        "topic": {"value": "", "creator": "", "last_set": 0},
+        "purpose": {"value": "", "creator": "", "last_set": 0},
+        "previous_names": [],
+        "num_members": 0,
+    }
+    base.update(overrides)
+    return cast(ChannelType, base)
+
+
+def _msg(ts: str, thread_ts: str | None = None) -> MessageType:
+    data: dict[str, Any] = {"type": "message", "user": "U1", "text": "hi", "ts": ts}
+    if thread_ts is not None:
+        data["thread_ts"] = thread_ts
+    return cast(MessageType, data)
+
+
+class TestListGridTeamIds:
+    def test_returns_team_ids_from_paginated_response(self) -> None:
+        with patch(
+            "onyx.connectors.slack.connector.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.return_value = iter(
+                [
+                    {"teams": [{"id": "T1"}, {"id": "T2"}]},
+                    {"teams": [{"id": "T3"}]},
+                ]
+            )
+            client = MagicMock()
+            assert list_grid_team_ids(client) == ["T1", "T2", "T3"]
+
+    def test_skips_teams_without_id(self) -> None:
+        with patch(
+            "onyx.connectors.slack.connector.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.return_value = iter(
+                [{"teams": [{"id": "T1"}, {"name": "no-id-team"}, {"id": ""}]}]
+            )
+            assert list_grid_team_ids(MagicMock()) == ["T1"]
+
+    def test_empty_response_returns_empty_list(self) -> None:
+        with patch(
+            "onyx.connectors.slack.connector.make_paginated_slack_api_call"
+        ) as mock_paginate:
+            mock_paginate.return_value = iter([{"teams": []}])
+            assert list_grid_team_ids(MagicMock()) == []
+
+
+class TestFetchTeamUrl:
+    def test_returns_url_from_team_info(self) -> None:
+        client = MagicMock()
+        client.team_info.return_value = MagicMock(
+            get=lambda key, default=None: (
+                {"id": "T1", "url": "https://acme.slack.com/"}
+                if key == "team"
+                else default
+            )
+        )
+        assert fetch_team_url(client, "T1") == "https://acme.slack.com/"
+        client.team_info.assert_called_once_with(team="T1")
+
+    def test_returns_none_when_slack_api_errors(self) -> None:
+        client = MagicMock()
+        err_response = MagicMock()
+        err_response.get.return_value = "team_not_found"
+        client.team_info.side_effect = SlackApiError("boom", err_response)
+        assert fetch_team_url(client, "T_BAD") is None
+
+    def test_returns_none_when_url_missing(self) -> None:
+        client = MagicMock()
+        client.team_info.return_value = MagicMock(
+            get=lambda key, default=None: ({} if key == "team" else default)
+        )
+        assert fetch_team_url(client, "T1") is None
+
+
+class TestGetChannelsAcrossTeams:
+    def test_iterates_each_team_and_concatenates(self) -> None:
+        team_one_channels = [_channel("C1"), _channel("C2")]
+        team_two_channels = [_channel("C3")]
+        with patch("onyx.connectors.slack.connector.get_channels") as mock_get_channels:
+            mock_get_channels.side_effect = [team_one_channels, team_two_channels]
+            result = get_channels_across_teams(MagicMock(), ["T1", "T2"])
+            assert [c["id"] for c in result] == ["C1", "C2", "C3"]
+            assert mock_get_channels.call_count == 2
+            assert mock_get_channels.call_args_list[0].kwargs["team_id"] == "T1"
+            assert mock_get_channels.call_args_list[1].kwargs["team_id"] == "T2"
+
+    def test_dedupes_org_shared_channels_by_id(self) -> None:
+        shared = _channel("CSHARED", is_org_shared=True)
+        with patch("onyx.connectors.slack.connector.get_channels") as mock_get_channels:
+            mock_get_channels.side_effect = [
+                [shared, _channel("C1")],
+                [shared, _channel("C2")],
+            ]
+            result = get_channels_across_teams(MagicMock(), ["T1", "T2"])
+            assert [c["id"] for c in result] == ["CSHARED", "C1", "C2"]
+
+    def test_empty_team_list_returns_empty(self) -> None:
+        with patch("onyx.connectors.slack.connector.get_channels") as mock_get_channels:
+            assert get_channels_across_teams(MagicMock(), []) == []
+            mock_get_channels.assert_not_called()
+
+
+class TestChannelToHierarchyNode:
+    def test_grid_uses_per_team_url(self) -> None:
+        channel = _channel("C1", team="T1")
+        team_id_to_url = {
+            "T1": "https://team-one.slack.com",
+            "T2": "https://team-two.slack.com",
+        }
+        node = _channel_to_hierarchy_node(
+            channel,
+            channel_access=None,
+            workspace_url="https://fallback.slack.com",
+            team_id_to_url=team_id_to_url,
+        )
+        assert node.link == "https://team-one.slack.com/archives/C1"
+
+    def test_grid_falls_back_to_workspace_url_when_team_absent(self) -> None:
+        channel = _channel("C1")  # no team field
+        node = _channel_to_hierarchy_node(
+            channel,
+            channel_access=None,
+            workspace_url="https://fallback.slack.com",
+            team_id_to_url={"T1": "https://team-one.slack.com"},
+        )
+        assert node.link == "https://fallback.slack.com/archives/C1"
+
+    def test_non_grid_path_uses_workspace_url_unchanged(self) -> None:
+        channel = _channel("C1")
+        node = _channel_to_hierarchy_node(
+            channel,
+            channel_access=None,
+            workspace_url="https://ws.slack.com",
+        )
+        assert node.link == "https://ws.slack.com/archives/C1"
+
+
+class TestGetMessageLinkTeamAware:
+    def test_uses_per_team_url_when_provided(self) -> None:
+        client = MagicMock()
+        client.token = "xoxb-test"
+        link = get_message_link(
+            event=_msg("1700000000.000100"),
+            client=client,
+            channel_id="C1",
+            team_id="T1",
+            team_id_to_url={"T1": "https://team-one.slack.com"},
+        )
+        assert link.startswith("https://team-one.slack.com/archives/C1/p")
+
+    def test_falls_back_to_get_base_url_when_team_id_to_url_missing(self) -> None:
+        client = MagicMock()
+        client.token = "xoxb-fallback"
+        with patch(
+            "onyx.connectors.slack.utils.get_base_url",
+            return_value="https://fallback.slack.com",
+        ):
+            link = get_message_link(
+                event=_msg("1700000000.000100"),
+                client=client,
+                channel_id="C1",
+                team_id="T1",
+                team_id_to_url=None,
+            )
+        assert link.startswith("https://fallback.slack.com/archives/C1/p")
+
+    def test_thread_ts_appended_when_present(self) -> None:
+        client = MagicMock()
+        client.token = "xoxb-thread"
+        link = get_message_link(
+            event=_msg("1700000001.000200", thread_ts="1700000000.000100"),
+            client=client,
+            channel_id="C1",
+            team_id="T1",
+            team_id_to_url={"T1": "https://team-one.slack.com"},
+        )
+        assert "?thread_ts=1700000000.000100" in link
+
+
+@pytest.mark.parametrize(
+    "channel_id_set,expected_order",
+    [
+        ([("T1", ["C1", "C2"]), ("T2", ["C2", "C3"])], ["C1", "C2", "C3"]),
+        ([("T1", []), ("T2", ["C9"])], ["C9"]),
+    ],
+)
+def test_dedupe_preserves_first_occurrence_order(
+    channel_id_set: list[tuple[str, list[str]]],
+    expected_order: list[str],
+) -> None:
+    with patch("onyx.connectors.slack.connector.get_channels") as mock_get_channels:
+        mock_get_channels.side_effect = [
+            [_channel(cid) for cid in cids] for _, cids in channel_id_set
+        ]
+        team_ids = [tid for tid, _ in channel_id_set]
+        result = get_channels_across_teams(MagicMock(), team_ids)
+        assert [c["id"] for c in result] == expected_order

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -18,6 +18,7 @@ from onyx.connectors.slack.connector import channel_team_ids
 from onyx.connectors.slack.connector import fetch_team_url
 from onyx.connectors.slack.connector import get_channels_across_teams
 from onyx.connectors.slack.connector import list_grid_team_ids
+from onyx.connectors.slack.connector import SlackConnector
 from onyx.connectors.slack.models import ChannelType
 from onyx.connectors.slack.models import MessageType
 from onyx.connectors.slack.utils import get_message_link
@@ -285,3 +286,41 @@ def test_dedupe_preserves_first_occurrence_order(
         team_ids = [tid for tid, _ in channel_id_set]
         result = get_channels_across_teams(MagicMock(), team_ids)
         assert [c["id"] for c in result] == expected_order
+
+
+class TestSlackConnectorGridProperties:
+    def _connector(
+        self,
+        is_grid: bool,
+        team_ids: list[str],
+        team_id_to_url: dict[str, str],
+        team_id_to_user_emails: dict[str, set[str]],
+    ) -> SlackConnector:
+        c = SlackConnector(channels=None, use_redis=False)
+        c._is_grid = is_grid
+        c._team_ids = team_ids
+        c._team_id_to_url = team_id_to_url
+        c._team_id_to_user_emails = team_id_to_user_emails
+        return c
+
+    def test_grid_properties_return_underlying_fields_on_grid(self) -> None:
+        c = self._connector(
+            is_grid=True,
+            team_ids=["T1"],
+            team_id_to_url={"T1": "https://x.slack.com"},
+            team_id_to_user_emails={"T1": {"a@x.com"}},
+        )
+        assert c.grid_team_ids == ["T1"]
+        assert c.grid_team_id_to_url == {"T1": "https://x.slack.com"}
+        assert c.grid_team_id_to_user_emails == {"T1": {"a@x.com"}}
+
+    def test_grid_properties_return_none_when_not_grid(self) -> None:
+        c = self._connector(
+            is_grid=False,
+            team_ids=["T1"],
+            team_id_to_url={"T1": "https://x.slack.com"},
+            team_id_to_user_emails={"T1": {"a@x.com"}},
+        )
+        assert c.grid_team_ids is None
+        assert c.grid_team_id_to_url is None
+        assert c.grid_team_id_to_user_emails is None


### PR DESCRIPTION
## Description

Linear: [CS-69](https://linear.app/onyx-app/issue/CS-69)

Slack connector now supports Enterprise Grid orgs in a single install. Existing single-workspace installs are unchanged — all new parameters default to None and Grid behaviour is gated on `auth.test().enterprise_id`.

**What's added**
- `list_grid_team_ids`, `fetch_team_url`, `get_channels_across_teams` helpers
- `_channel_to_hierarchy_node` / `get_message_link` resolve per-workspace URL from each channel's `team` field
- `validate_connector_settings` checks `auth.teams.list` access on Grid; missing `team:read` surfaces `InsufficientPermissionsError`
- EE `get_channel_access` is Grid-aware: public channels on Grid scope to the union of users in the workspaces the channel is shared into (via `shared_team_ids`); fall back to `is_public=True` when the union is empty (unknown teams) or exceeds `ExternalAccess.MAX_NUM_ENTRIES`
- EE `doc_sync` applies the per-workspace `channel_permissions` map (previously orphaned by `# noqa: ARG001`) so the Grid scoping reaches Vespa
- `fetch_team_user_emails` (new) builds per-workspace email sets for scoping; `fetch_user_id_to_email_map` updated to accept `team_ids` since `users.list` on a Grid org token requires it
- `team.info` calls fan out via `ThreadPoolExecutor` so large orgs don't serialize init

**What's not changed**
- Credential JSON schema (still `{"slack_bot_token": str}`)
- No DB migration, no new deps
- Non-Grid code path (verified by a regression test asserting non-Grid public channels stay absent from the override map)

## How Has This Been Tested?

**Unit tests (62 total in `backend/tests/unit/{ee/onyx/external_permissions,onyx/connectors}/slack/`):**
- Helpers: `list_grid_team_ids`, `fetch_team_url`, `get_channels_across_teams` (dedupe, team-id stamping, paginated `auth.teams.list`)
- Channel team-id resolution: `_channel_team_id` (`team` → `context_team_id` fallback), `channel_team_ids` (`shared_team_ids` → singular fallback)
- URL routing: `_channel_to_hierarchy_node` per-team URL + trailing-slash trim; `get_message_link` per-team override
- EE `get_channel_access` Grid path: per-workspace scoping, org-shared union, empty-union fallback, MAX_NUM_ENTRIES cap fallback, private-channel members path unchanged
- EE perm sync: `fetch_user_id_to_email_map` per-team iteration, `fetch_team_user_emails` per-team email sets, `_fetch_channel_permissions` Grid + non-Grid paths, `_get_slack_document_access` channel-permissions override + fallback
- Regression: `SlackConnector.grid_*` property getters return underlying fields on Grid and `None` otherwise (catches the recursive-property bug from the DRY refactor)

**Live test against a real Enterprise Grid sandbox (`onyx-test-sandbox.enterprise.slack.com`, 2 workspaces, 11 channels):**
- Grid detected via `auth.test().enterprise_id`
- 2 workspaces enumerated via `auth.teams.list`, per-team URLs resolved via parallel `team.info`
- Per-workspace user maps populated (W2: 1 user, W1: 8 users)
- All 11 public channels return `is_public=False` with workspace-scoped emails at ingest time (no `is_public=True` leakage)
- 73 documents ingested with links routed to the correct per-workspace URL
- Perm sync override map populated correctly for all 11 channels
- **0 cross-workspace ACL leaks** asserted by comparing each channel's permission set against the channel's home workspace's user set

**Review:**
- 6 iterations of codex-review (`codex exec --sandbox workspace-write` with gpt-5-codex) caught and fixed: ingest-time `get_channel_access` not Grid-aware, MAX_NUM_ENTRIES cap, empty-union fallback, non-Grid public regression, bare `fetch_team_user_emails` perm-sync crash. Two final consecutive clean passes (iters 5 + 6) closed the loop. Refactor commit reviewed separately by codex — clean.
- Pre-commit `ty`, `ruff`, `black` clean on every commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check