### PR TITLE
fix: onyx-cli version in sandbox

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
@@ -6,7 +6,7 @@ matplotlib==3.9.1
 matplotlib-inline>=0.1.7
 matplotlib-venn>=1.1.2
 numpy==1.26.4
-onyx-cli==1.0.1
+onyx-cli==1.0.2
 opencv-python>=4.11.0.86
 openpyxl>=3.1.5
 pandas==2.2.2


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `onyx-cli` from 1.0.1 to 1.0.2 in the sandbox Docker `initial-requirements.txt`. Aligns the sandbox with the current CLI release and avoids build/run issues seen with 1.0.1.

<sup>Written for commit cd4d4f32dd0fb5234a7271a0b01d51565bb282c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

