### PR TITLE
fix(skills): simplify skill schema uniqueness

### DIFF
--- a/backend/alembic/versions/b6d184cfdaf3_skills.py
+++ b/backend/alembic/versions/b6d184cfdaf3_skills.py
@@ -34,7 +34,6 @@ def upgrade() -> None:
         sa.Column("author_user_id", postgresql.UUID(as_uuid=True), nullable=True),
         sa.Column("is_public", sa.Boolean(), nullable=False),
         sa.Column("enabled", sa.Boolean(), nullable=False),
-        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "created_at",
             sa.DateTime(timezone=True),
@@ -53,13 +52,7 @@ def upgrade() -> None:
             ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        "ux_skill_slug",
-        "skill",
-        ["slug"],
-        unique=True,
-        postgresql_where=sa.text("deleted_at IS NULL"),
+        sa.UniqueConstraint("slug", name="uq_skill_slug"),
     )
 
     op.create_table(
@@ -82,5 +75,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("skill__user_group")
-    op.drop_index("ux_skill_slug", table_name="skill")
     op.drop_table("skill")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4204,9 +4204,6 @@ class Skill(Base):
     )
     is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    deleted_at: Mapped[datetime.datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
 
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -4224,14 +4221,7 @@ class Skill(Base):
         viewonly=True,
     )
 
-    __table_args__ = (
-        Index(
-            "ux_skill_slug",
-            "slug",
-            unique=True,
-            postgresql_where=text("deleted_at IS NULL"),
-        ),
-    )
+    __table_args__ = (UniqueConstraint("slug", name="uq_skill_slug"),)
 
 
 """


### PR DESCRIPTION
## Description

Schema-only patch for Skills V1 before the next deploy.

Changes:
- Remove the unused `skill.deleted_at` column from the initial migration/model.
- Replace the partial unique slug index with a normal named unique constraint: `uq_skill_slug`.

This keeps the deployed schema aligned with the DB helper layer, which translates `uq_skill_slug` violations into `DUPLICATE_RESOURCE`.

## How Has This Been Tested?

- `uv run ruff check backend/alembic/versions/b6d184cfdaf3_skills.py backend/onyx/db/models.py`
- `uv run ruff format --check backend/alembic/versions/b6d184cfdaf3_skills.py backend/onyx/db/models.py`
- `uv run ty check backend/alembic/versions/b6d184cfdaf3_skills.py backend/onyx/db/models.py`
- `git diff --check`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the Skills V1 schema by removing the unused `skill.deleted_at` column and replacing the partial slug index with a named unique constraint `uq_skill_slug`. Aligns with the DB helpers so slug collisions return `DUPLICATE_RESOURCE` consistently.

<sup>Written for commit f45e894e499ea12e00921653681b396785dc1f82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

