### PR TITLE
fix(hook_UI): hook management button right side aligned

### DIFF
--- a/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
+++ b/web/src/ee/refresh-pages/admin/HooksPage/index.tsx
@@ -387,7 +387,7 @@ function ConnectedHookCard({
               </div>
 
               <Disabled disabled={isBusy}>
-                <div className="flex items-center pb-1 px-1 gap-1">
+                <div className="flex items-center justify-end pb-1 px-1 gap-1">
                   {hook.is_active ? (
                     <>
                       <Hoverable.Item


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->
Root cause: Disabled applies self-stretch via .opal-disabled, which overrides the parent's items-end and expands the wrapper to full width. The inner button row then sat left-aligned inside it.

Fix: Add justify-end to the button row so buttons are pushed to the right edge regardless of the wrapper's width.

The misalignment was most visible on active hooks because the "Connected" status label is wider than the icon buttons, making the gap obvious. Inactive hooks had the same underlying issue but the Reconnect button and icon buttons happen to be similar widths.

https://linear.app/onyx-app/issue/ENG-4118/agent-wiki
## How Has This Been Tested?
test locally
Before the fix
<img width="1494" height="431" alt="Screenshot 2026-05-13 at 3 45 16 PM" src="https://github.com/user-attachments/assets/e0f42289-0f98-4a24-9d3b-ae3431d73655" />


After the fix 
<img width="668" height="529" alt="Screenshot 2026-05-13 at 3 43 48 PM" src="https://github.com/user-attachments/assets/f05920e4-5647-4e14-b918-7e7f016ae0a9" />


<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Right-aligns hook action buttons on the Hooks page by adding `justify-end` to the action row, fixing the left shift when the wrapper is disabled. Addresses Linear ENG-4118 and removes the visible offset on active hooks.

<sup>Written for commit 22b6a52facbd5becab49c1558038af5ea764f529. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

