### PR TITLE
chore: always show indexing metrics

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/IndexAttemptsTable.tsx
@@ -21,8 +21,6 @@ import { SvgBarChartSmall, SvgClock, SvgInfo } from "@opal/icons";
 import ExceptionTraceModal from "@/sections/modals/PreviewModal/ExceptionTraceModal";
 import { Tooltip } from "@opal/components";
 import { Section } from "@/layouts/general-layouts";
-import useFeatureFlag from "@/hooks/useFeatureFlag";
-import { FEATURE_FLAGS } from "@/lib/featureFlags";
 import StageMetricsModal from "./StageMetricsModal";
 export interface IndexingAttemptsTableProps {
   ccPair: CCPairFullInfo;
@@ -42,9 +40,6 @@ export function IndexAttemptsTable({
     number | null
   >(null);
   const [metricsAttemptId, setMetricsAttemptId] = useState<number | null>(null);
-  const stageMetricsEnabled = useFeatureFlag(
-    FEATURE_FLAGS.INDEX_ATTEMPT_METRICS
-  );
 
   if (!indexAttempts?.length) {
     return (
@@ -72,7 +67,7 @@ export function IndexAttemptsTable({
         />
       )}
 
-      {stageMetricsEnabled && metricsAttemptId !== null && (
+      {metricsAttemptId !== null && (
         <StageMetricsModal
           indexAttemptId={metricsAttemptId}
           onClose={() => setMetricsAttemptId(null)}
@@ -151,15 +146,13 @@ export function IndexAttemptsTable({
                         <Text font="secondary-body" color="text-03">
                           {`${docsPerMinute} docs / min`}
                         </Text>
-                        {stageMetricsEnabled && (
-                          <Button
-                            icon={SvgBarChartSmall}
-                            prominence="tertiary"
-                            size="sm"
-                            tooltip="View stage metrics"
-                            onClick={() => setMetricsAttemptId(indexAttempt.id)}
-                          />
-                        )}
+                        <Button
+                          icon={SvgBarChartSmall}
+                          prominence="tertiary"
+                          size="sm"
+                          tooltip="View stage metrics"
+                          onClick={() => setMetricsAttemptId(indexAttempt.id)}
+                        />
                       </Section>
                     ) : (
                       indexAttempt.status === "success" && (

--- a/web/src/hooks/useFeatureFlag.ts
+++ b/web/src/hooks/useFeatureFlag.ts
@@ -24,10 +24,6 @@ import { IS_DEV } from "@/lib/constants";
  *   when PostHog is unavailable).
  *
  * @example
- * // On in dev, off in prod-without-PostHog, otherwise PostHog-driven.
- * const showMetrics = useFeatureFlag(FEATURE_FLAGS.INDEX_ATTEMPT_METRICS);
- *
- * @example
  * // Force `true` as the fallback regardless of environment.
  * const animationDisabled = useFeatureFlag(
  *   FEATURE_FLAGS.CRAFT_ANIMATION_DISABLED,

--- a/web/src/lib/featureFlags.ts
+++ b/web/src/lib/featureFlags.ts
@@ -15,8 +15,6 @@
 export const FEATURE_FLAGS = {
   /** Disables the Onyx Craft (Build Mode) sidebar intro animation. */
   CRAFT_ANIMATION_DISABLED: "craft-animation-disabled",
-  /** Enables the per-index-attempt stage metrics UI (admin connector page). */
-  INDEX_ATTEMPT_METRICS: "index-attempt-metrics",
 } as const;
 
 export type FeatureFlagKey = (typeof FEATURE_FLAGS)[keyof typeof FEATURE_FLAGS];


### PR DESCRIPTION
## Description

un-feature flagging

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show indexing stage metrics in the admin connector page. The Stage Metrics button and modal are now always available on index attempts.

- **Refactors**
  - Removed `useFeatureFlag` gating from `IndexAttemptsTable` so metrics render whenever `metricsAttemptId` is set.
  - Deleted `FEATURE_FLAGS.INDEX_ATTEMPT_METRICS` from `featureFlags.ts`.
  - Cleaned up example references in `useFeatureFlag` comments.

<sup>Written for commit 7f9bb2548b2f2390cac41d9f8e95ec7c508641cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

