### PR TITLE
fix: opencode config for anthropic

### DIFF
--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -40,6 +40,7 @@ def build_opencode_config(
         "$schema": "https://opencode.ai/config.json",
         "model": opencode_model,
         "provider": {},
+        "enabled_providers": [provider],
     }
 
     # Build provider configuration
@@ -56,21 +57,26 @@ def build_opencode_config(
     # Build model configuration with thinking/reasoning options
     options: dict[str, Any] = {}
 
+    # Models that support adaptive thinking (4.6+). Older models (4.5 and
+    # earlier) require thinking.type: "enabled" with budget_tokens.
+    _ADAPTIVE_THINKING_MODELS = {
+        "claude-opus-4-6",
+        "claude-opus-4-7",
+        "claude-sonnet-4-6",
+    }
+
     if provider == "openai":
         options["reasoningEffort"] = "high"
-    elif provider == "anthropic":
-        options["thinking"] = {
-            "type": "enabled",
-            "budgetTokens": 16000,
-        }
+    elif provider in ("anthropic", "bedrock"):
+        if model_name in _ADAPTIVE_THINKING_MODELS or model_name.startswith(
+            tuple(f"{m}-" for m in _ADAPTIVE_THINKING_MODELS)
+        ):
+            options["thinking"] = {"type": "adaptive"}
+        else:
+            options["thinking"] = {"type": "enabled", "budgetTokens": 16000}
     elif provider == "google":
         options["thinking_budget"] = 16000
         options["thinking_level"] = "high"
-    elif provider == "bedrock":
-        options["thinking"] = {
-            "type": "enabled",
-            "budgetTokens": 16000,
-        }
     elif provider == "azure":
         options["reasoningEffort"] = "high"
 


### PR DESCRIPTION
## Description

Updates the opencode config builder to support adaptive thinking for newer Anthropic models (4.6+) and adds `enabled_providers` to the config.

- Add `enabled_providers` field to opencode config so only the relevant provider is active
- Use `thinking.type: "adaptive"` for Claude 4.6+ models (opus-4-6, opus-4-7, sonnet-4-6) instead of fixed `budget_tokens`
- Keep `thinking.type: "enabled"` with `budgetTokens: 16000` for older models (4.5 and earlier)
- Merge bedrock and anthropic thinking config (same logic)

## How Has This Been Tested?

Manually verified config output for anthropic and bedrock providers with both old and new model names.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check