### PR TITLE
fix: remove num_hits from public search api

### DIFF
--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -209,7 +209,6 @@ def search(
             starting_citation_num=1,
             original_query=request.query,
             skip_query_expansion=request.skip_query_expansion,
-            num_hits=request.num_results,
             message_history=request.message_history
             or [
                 ChatMinimalTextMessage(

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -15,8 +15,6 @@ class SearchAPIRequest(BaseModel):
     tags: list[Tag] | None = None
     time_cutoff_days: int | None = Field(None, ge=1)
 
-    num_results: int = Field(default=50, ge=1, le=100)
-
     persona_id: int | None = None
 
     provider: str | None = None


### PR DESCRIPTION
## Description


num_hits actually controls vespa/opensearch number of chunks to return. The chat sets this as a constant to 50 and we should replicate that (not allow callers to specify number of chunk results from the index).
## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `num_results` field from the public Search API and stopped passing it as `num_hits` internally. The server now applies its own default limit for consistent results.

- **Migration**
  - Stop sending `num_results` in Search API requests; the server selects the result limit automatically.

<sup>Written for commit 3c8b5eaaec56967943222363874975c20cc8ecc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

