### PR TITLE
refactor(search api + cli): preprocess response from search pipeline to be coherent for consumers and update onyx cli for new api

### DIFF
--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -39,9 +39,9 @@ Follow this two-step pattern for most tasks:
 ### Step 1: Information Retrieval
 
 1. **Search** company knowledge using the `company-search` skill. Run
-   `onyx-cli search "<query>"` and read the returned JSON; each result has a
-   `document` field (the citation ID) — cite results by that number when you
-   reference them.
+   `onyx-cli search "<query>"` and read the returned JSON; each result has
+   `title`, `url`, and `content` fields — cite results by title and URL when
+   you reference them.
 2. Read the `company-search` SKILL.md for available sources and flags.
 3. **Iterate** — run additional searches to refine. Use `--source` to narrow by
    connector and `--days` for recent content.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/company-search/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/company-search/SKILL.md.template
@@ -23,11 +23,11 @@ assume it exists.
 |------|-------------|---------|
 | `--source` | Filter by source type (comma-separated) | `--source slack,google_drive` |
 | `--days` | Only return results from the last N days | `--days 30` |
-| `--limit` | Maximum number of results | `--limit 5` |
 
 ## Output
 
-Stdout is JSON with a top-level `results` array. Each result has a `document`
-field (the citation ID), plus `title`, `content`, `source_type`, and other
-metadata. Cite results by their `document` number when referencing them in your
-response.
+Stdout is JSON with a top-level `results` array. Each result has `title`,
+`url`, `source_type`, `content`, and `updated_at`. Results contain only
+documents the LLM judged relevant, ordered by relevance; `content` is the
+full chunk text of each. Cite results by title and URL when referencing
+them in your response.

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -209,7 +209,6 @@ def search(
             starting_citation_num=1,
             original_query=request.query,
             skip_query_expansion=request.skip_query_expansion,
-            num_hits=request.num_results,
             message_history=request.message_history
             or [
                 ChatMinimalTextMessage(

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -24,7 +24,6 @@ from onyx.chat.emitter import NullEmitter
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import PersonaSearchInfo
-from onyx.context.search.models import SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.llm import can_user_access_llm_provider
@@ -54,37 +53,6 @@ from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter(prefix="/search")
-
-
-def _build_results(
-    citation_mapping: dict[int, str],
-    llm_facing_text: str,
-) -> list[SearchResult]:
-    """Build SearchResults from the LLM-facing JSON, one per merged section."""
-    if not llm_facing_text:
-        return []
-    parsed = json.loads(llm_facing_text)
-
-    results: list[SearchResult] = []
-    for entry in parsed.get("results", []):
-        citation_id = entry.get("document")
-        if not isinstance(citation_id, int):
-            continue
-        document_id = citation_mapping.get(citation_id)
-        if document_id is None:
-            continue
-        results.append(
-            SearchResult(
-                citation_id=citation_id,
-                document_id=document_id,
-                title=entry["title"],
-                content=entry["content"],
-                link=entry.get("url"),
-                source_type=entry["source_type"],
-                updated_at=entry.get("updated_at"),
-            )
-        )
-    return results
 
 
 @router.post("", dependencies=[Depends(require_vector_db)])
@@ -220,12 +188,19 @@ def search(
         queries=[request.query],
     )
 
-    # 8. Map output
-    search_docs_response = cast(SearchDocsResponse, tool_response.rich_response)
-
+    # 8. Map LLM-facing JSON entries to SearchResults (one per merged section).
+    llm_facing_text = tool_response.llm_facing_response
+    entries = json.loads(llm_facing_text)["results"] if llm_facing_text else []
     return SearchResponse(
-        results=_build_results(
-            search_docs_response.citation_mapping,
-            tool_response.llm_facing_response,
-        ),
+        results=[
+            SearchResult(
+                citation_id=entry["document"],
+                title=entry["title"],
+                content=entry["content"],
+                link=entry.get("url"),
+                source_type=entry["source_type"],
+                updated_at=entry.get("updated_at"),
+            )
+            for entry in entries
+        ],
     )

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -1,18 +1,16 @@
 """Search API endpoint (POST /api/search).
 
 Runs the full SearchTool.run() pipeline — the same multi-stage search that
-powers chat mode.  Returns ranked results without generating
-an LLM answer.
+powers chat mode. Returns ranked results without generating an LLM answer.
 
 Intended for programmatic consumers (onyx-cli, Craft sandbox, integrations).
 
 Not the same as the Onyx Search UI backend at /api/search/send-search-message
 (ee/onyx/server/query_and_chat/search_backend.py), which calls search_pipeline()
-directly — a lighter-weight flow with optional query expansion and streaming.
+directly — a lighter-weight flow with optional query expansion.
 """
 
-from datetime import datetime
-from datetime import timedelta
+import json
 from datetime import timezone
 from typing import cast
 
@@ -42,9 +40,9 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.factory import get_default_llm
 from onyx.llm.factory import get_llm_for_persona
 from onyx.llm.factory import llm_from_provider
-from onyx.server.features.search.models import SearchAPIRequest
-from onyx.server.features.search.models import SearchAPIResponse
-from onyx.server.features.search.models import SearchAPIResult
+from onyx.server.features.search.models import SearchRequest
+from onyx.server.features.search.models import SearchResponse
+from onyx.server.features.search.models import SearchResult
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
@@ -58,29 +56,57 @@ from shared_configs.contextvars import get_current_tenant_id
 router = APIRouter(prefix="/search")
 
 
+def _extract_content_by_citation(llm_facing_text: str) -> dict[int, str]:
+    """Build a citation_id → full chunk content map from llm_facing_text.
+
+    ``llm_facing_text`` is the JSON-encoded payload ``SearchTool`` builds via
+    ``convert_inference_sections_to_llm_string`` — we parse it once at the API
+    boundary so consumers get full chunks on each ``SearchResult`` without
+    duplicating the join logic. No defensive try/except: the producer is
+    in-process and always emits valid JSON; if that ever breaks, an unhandled
+    exception is the right signal.
+    """
+    if not llm_facing_text:
+        return {}
+    parsed = json.loads(llm_facing_text)
+    content_by_citation: dict[int, str] = {}
+    for entry in parsed.get("results", []):
+        citation_id = entry.get("document")
+        content = entry.get("content")
+        if isinstance(citation_id, int) and isinstance(content, str) and content:
+            content_by_citation[citation_id] = content
+    return content_by_citation
+
+
 def _build_results(
     search_docs_response: SearchDocsResponse,
-) -> list[SearchAPIResult]:
-    docs = search_docs_response.displayed_docs or search_docs_response.search_docs
+    llm_facing_text: str,
+) -> list[SearchResult]:
+    # Only LLM-selected docs are returned. If the LLM judged nothing relevant
+    # we return an empty list rather than dumping the raw retrieval pool —
+    # callers get a clean "nothing matched" signal instead of blurb-only noise.
+    docs = search_docs_response.displayed_docs or []
     citation_mapping = search_docs_response.citation_mapping
 
     doc_id_to_citation: dict[str, int] = {
         doc_id: citation_id for citation_id, doc_id in citation_mapping.items()
     }
+    content_by_citation = _extract_content_by_citation(llm_facing_text)
 
-    results: list[SearchAPIResult] = []
+    results: list[SearchResult] = []
     for doc in docs:
         citation_id = doc_id_to_citation.get(doc.document_id)
+        full_content = (
+            content_by_citation.get(citation_id) if citation_id is not None else None
+        )
         results.append(
-            SearchAPIResult(
+            SearchResult(
                 citation_id=citation_id,
                 document_id=doc.document_id,
-                chunk_ind=doc.chunk_ind,
                 title=doc.semantic_identifier,
-                blurb=doc.blurb,
+                content=full_content or doc.blurb,
                 link=doc.link,
                 source_type=doc.source_type.value,
-                score=doc.score,
                 updated_at=doc.updated_at.isoformat() if doc.updated_at else None,
             )
         )
@@ -90,10 +116,10 @@ def _build_results(
 
 @router.post("", dependencies=[Depends(require_vector_db)])
 def search(
-    request: SearchAPIRequest,
+    request: SearchRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> SearchAPIResponse:
+) -> SearchResponse:
     # 1. Load persona
     persona = None
     if request.persona_id is not None:
@@ -156,12 +182,12 @@ def search(
         llm_provider_api_key=llm.config.api_key,
     )
 
-    # 3. Build filters
-    time_cutoff = None
-    if request.time_cutoff_days is not None:
-        time_cutoff = datetime.now(timezone.utc) - timedelta(
-            days=request.time_cutoff_days
-        )
+    # 3. Build filters. See SearchRequest.time_cutoff for the naive-→-UTC
+    # contract; we apply it here so downstream comparison against tz-aware
+    # document timestamps works.
+    time_cutoff = request.time_cutoff
+    if time_cutoff is not None and time_cutoff.tzinfo is None:
+        time_cutoff = time_cutoff.replace(tzinfo=timezone.utc)
 
     base_filters = BaseFilters(
         source_type=request.sources,
@@ -223,8 +249,6 @@ def search(
     # 8. Map output
     search_docs_response = cast(SearchDocsResponse, tool_response.rich_response)
 
-    return SearchAPIResponse(
-        results=_build_results(search_docs_response),
-        llm_facing_text=tool_response.llm_facing_response,
-        citation_mapping=search_docs_response.citation_mapping,
+    return SearchResponse(
+        results=_build_results(search_docs_response, tool_response.llm_facing_response),
     )

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -56,61 +56,34 @@ from shared_configs.contextvars import get_current_tenant_id
 router = APIRouter(prefix="/search")
 
 
-def _extract_content_by_citation(llm_facing_text: str) -> dict[int, str]:
-    """Build a citation_id → full chunk content map from llm_facing_text.
-
-    ``llm_facing_text`` is the JSON-encoded payload ``SearchTool`` builds via
-    ``convert_inference_sections_to_llm_string`` — we parse it once at the API
-    boundary so consumers get full chunks on each ``SearchResult`` without
-    duplicating the join logic. No defensive try/except: the producer is
-    in-process and always emits valid JSON; if that ever breaks, an unhandled
-    exception is the right signal.
-    """
-    if not llm_facing_text:
-        return {}
-    parsed = json.loads(llm_facing_text)
-    content_by_citation: dict[int, str] = {}
-    for entry in parsed.get("results", []):
-        citation_id = entry.get("document")
-        content = entry.get("content")
-        if isinstance(citation_id, int) and isinstance(content, str) and content:
-            content_by_citation[citation_id] = content
-    return content_by_citation
-
-
 def _build_results(
-    search_docs_response: SearchDocsResponse,
+    citation_mapping: dict[int, str],
     llm_facing_text: str,
 ) -> list[SearchResult]:
-    # Only LLM-selected docs are returned. If the LLM judged nothing relevant
-    # we return an empty list rather than dumping the raw retrieval pool —
-    # callers get a clean "nothing matched" signal instead of blurb-only noise.
-    docs = search_docs_response.displayed_docs or []
-    citation_mapping = search_docs_response.citation_mapping
-
-    doc_id_to_citation: dict[str, int] = {
-        doc_id: citation_id for citation_id, doc_id in citation_mapping.items()
-    }
-    content_by_citation = _extract_content_by_citation(llm_facing_text)
+    """Build SearchResults from the LLM-facing JSON, one per merged section."""
+    if not llm_facing_text:
+        return []
+    parsed = json.loads(llm_facing_text)
 
     results: list[SearchResult] = []
-    for doc in docs:
-        citation_id = doc_id_to_citation.get(doc.document_id)
-        full_content = (
-            content_by_citation.get(citation_id) if citation_id is not None else None
-        )
+    for entry in parsed.get("results", []):
+        citation_id = entry.get("document")
+        if not isinstance(citation_id, int):
+            continue
+        document_id = citation_mapping.get(citation_id)
+        if document_id is None:
+            continue
         results.append(
             SearchResult(
                 citation_id=citation_id,
-                document_id=doc.document_id,
-                title=doc.semantic_identifier,
-                content=full_content or doc.blurb,
-                link=doc.link,
-                source_type=doc.source_type.value,
-                updated_at=doc.updated_at.isoformat() if doc.updated_at else None,
+                document_id=document_id,
+                title=entry["title"],
+                content=entry["content"],
+                link=entry.get("url"),
+                source_type=entry["source_type"],
+                updated_at=entry.get("updated_at"),
             )
         )
-
     return results
 
 
@@ -235,6 +208,7 @@ def search(
             starting_citation_num=1,
             original_query=request.query,
             skip_query_expansion=request.skip_query_expansion,
+            include_link=True,
             message_history=request.message_history
             or [
                 ChatMinimalTextMessage(
@@ -250,5 +224,8 @@ def search(
     search_docs_response = cast(SearchDocsResponse, tool_response.rich_response)
 
     return SearchResponse(
-        results=_build_results(search_docs_response, tool_response.llm_facing_response),
+        results=_build_results(
+            search_docs_response.citation_mapping,
+            tool_response.llm_facing_response,
+        ),
     )

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -15,8 +15,6 @@ class SearchAPIRequest(BaseModel):
     tags: list[Tag] | None = None
     time_cutoff_days: int | None = Field(None, ge=1)
 
-    num_results: int = Field(default=50, ge=1, le=100)
-
     persona_id: int | None = None
 
     provider: str | None = None

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import model_validator
@@ -7,13 +9,15 @@ from onyx.context.search.models import Tag
 from onyx.tools.models import ChatMinimalTextMessage
 
 
-class SearchAPIRequest(BaseModel):
+class SearchRequest(BaseModel):
     query: str = Field(..., min_length=1, max_length=2048)
 
     sources: list[DocumentSource] | None = None
     document_sets: list[str] | None = None
     tags: list[Tag] | None = None
-    time_cutoff_days: int | None = Field(None, ge=1)
+    # ISO 8601 timestamp. Only documents updated on or after this moment are
+    # returned. Naive (timezone-less) values are treated as UTC server-side.
+    time_cutoff: datetime | None = None
 
     persona_id: int | None = None
 
@@ -25,7 +29,7 @@ class SearchAPIRequest(BaseModel):
     message_history: list[ChatMinimalTextMessage] | None = None
 
     @model_validator(mode="after")
-    def validate_provider_model_pair(self) -> "SearchAPIRequest":
+    def validate_provider_model_pair(self) -> "SearchRequest":
         if self.model and not self.provider:
             raise ValueError("provider is required when model is specified")
         if self.provider and not self.model:
@@ -33,19 +37,19 @@ class SearchAPIRequest(BaseModel):
         return self
 
 
-class SearchAPIResult(BaseModel):
+class SearchResult(BaseModel):
     citation_id: int | None
     document_id: str
-    chunk_ind: int
     title: str
-    blurb: str
+    # Full chunk text from the LLM-selected document. The API only returns
+    # docs the LLM judged relevant, so in practice this is the full chunk;
+    # a blurb fallback exists for defensive cases (e.g. a selected doc whose
+    # chunk failed to round-trip through the LLM-facing JSON producer).
+    content: str
     link: str | None
     source_type: str
-    score: float | None
     updated_at: str | None
 
 
-class SearchAPIResponse(BaseModel):
-    results: list[SearchAPIResult]
-    llm_facing_text: str
-    citation_mapping: dict[int, str]
+class SearchResponse(BaseModel):
+    results: list[SearchResult]

--- a/backend/onyx/server/features/search/models.py
+++ b/backend/onyx/server/features/search/models.py
@@ -39,12 +39,10 @@ class SearchRequest(BaseModel):
 
 class SearchResult(BaseModel):
     citation_id: int | None
-    document_id: str
     title: str
-    # Full chunk text from the LLM-selected document. The API only returns
-    # docs the LLM judged relevant, so in practice this is the full chunk;
-    # a blurb fallback exists for defensive cases (e.g. a selected doc whose
-    # chunk failed to round-trip through the LLM-facing JSON producer).
+    # Full chunk text the LLM saw for this section. Multiple results may
+    # share a citation_id when the LLM selected multiple non-overlapping
+    # sections of the same document.
     content: str
     link: str | None
     source_type: str

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -184,6 +184,7 @@ class SearchToolOverrideKwargs(BaseModel):
     num_hits: int | None = NUM_RETURNED_HITS
     # Number of chunks (token approx) to include in the string to the LLM
     max_llm_chunks: int | None = MAX_CHUNKS_FED_TO_CHAT
+    include_link: bool = False
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -976,6 +976,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             citation_start=override_kwargs.starting_citation_num,
             limit=override_kwargs.max_llm_chunks,
             include_document_id=False,
+            include_link=override_kwargs.include_link,
         )
 
         # End overall timing

--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -399,6 +399,7 @@ def test_search_returns_results(
 
 
 def test_search_raw(
+    reset: None,  # noqa: ARG001
     cli_binary: Path,
     pat_token: str,
     admin_user: DATestUser,

--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -32,7 +32,7 @@ Test Suite:
 16. test_version_flag - Prints client and server version
 17. test_experiments - Lists feature flags
 18. test_search_returns_results - Search returns seeded document content
-19. test_search_raw - --raw outputs full SearchAPIResponse as JSON
+19. test_search_raw - --raw outputs full SearchResponse as JSON
 20. test_search_truncation - --max-output truncates with temp file path
 21. test_search_no_query - No query returns exit code 2
 22. test_search_bad_pat - Invalid PAT returns exit code 4
@@ -405,10 +405,10 @@ def test_search_raw(
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
 ) -> None:
-    """--raw outputs the full SearchAPIResponse as JSON."""
+    """--raw outputs the full SearchResponse as JSON."""
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
     phrase = "cli-search-raw-unique-phrase"
-    doc = DocumentManager.seed_doc_with_content(cc_pair, phrase, api_key)
+    DocumentManager.seed_doc_with_content(cc_pair, phrase, api_key)
 
     result = run_cli(
         cli_binary, ["search", "--raw", phrase], pat=pat_token, timeout=120
@@ -416,15 +416,12 @@ def test_search_raw(
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
 
+    # Exactly one doc was seeded with this phrase; ``reset`` wiped the rest,
+    # so the API must return exactly one result that contains it.
     data = json.loads(result.stdout)
-    assert isinstance(data["results"], list)
-    assert len(data["results"]) > 0
-    assert isinstance(data["llm_facing_text"], str)
-    assert len(data["llm_facing_text"]) > 0
-    assert isinstance(data["citation_mapping"], dict)
-
-    result_doc_ids = {r["document_id"] for r in data["results"]}
-    assert doc.id in result_doc_ids
+    assert len(data["results"]) == 1
+    assert phrase in data["results"][0]["content"]
+    assert data["results"][0]["citation_id"] is not None
 
 
 def test_search_truncation(
@@ -521,16 +518,12 @@ def test_search_agent_id(
     cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     shared_phrase = "cli-search-agent-scope-unique"
-    doc_in = DocumentManager.seed_doc_with_content(
-        cc_pair_in,
-        f"{shared_phrase} in scope",
-        api_key,
-    )
-    doc_out = DocumentManager.seed_doc_with_content(
-        cc_pair_out,
-        f"{shared_phrase} out of scope",
-        api_key,
-    )
+    # Suffixes ("in scope" / "out of scope") must not be substrings of each
+    # other so the negative assertion below stays meaningful.
+    included_content = f"{shared_phrase} in scope"
+    excluded_content = f"{shared_phrase} out of scope"
+    DocumentManager.seed_doc_with_content(cc_pair_in, included_content, api_key)
+    DocumentManager.seed_doc_with_content(cc_pair_out, excluded_content, api_key)
 
     doc_set = DocumentSetManager.create(
         cc_pair_ids=[cc_pair_in.id],
@@ -555,6 +548,6 @@ def test_search_agent_id(
     )
     assert result.returncode == 0, f"stderr: {result.stderr}"
     data = json.loads(result.stdout)
-    result_doc_ids = {r["document_id"] for r in data["results"]}
-    assert doc_in.id in result_doc_ids
-    assert doc_out.id not in result_doc_ids
+    contents = [r["content"] for r in data["results"]]
+    assert any(included_content in c for c in contents)
+    assert not any(excluded_content in c for c in contents)

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -42,19 +42,19 @@ def test_basic_search_returns_results(
 ) -> None:
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
     doc_content = "search api integration test unique document"
-    doc = DocumentManager.seed_doc_with_content(cc_pair, doc_content, api_key)
+    DocumentManager.seed_doc_with_content(cc_pair, doc_content, api_key)
 
     resp = _search(doc_content, admin_user)
     assert resp.status_code == 200
 
+    # Exactly one doc was seeded with this phrase; ``reset`` wiped the rest,
+    # so the API must return exactly one result that contains it.
     data = resp.json()
-    assert len(data["results"]) > 0
-
+    assert len(data["results"]) == 1
     result = data["results"][0]
-    assert result["document_id"] == doc.id
+    assert doc_content in result["content"]
     assert result["citation_id"] is not None
-    assert result["source_type"] is not None
-    assert result["content"]
+    assert result["source_type"]
 
 
 def test_document_set_filtering(
@@ -67,16 +67,13 @@ def test_document_set_filtering(
     cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     shared_phrase = "docset-filter-unique-phrase"
-    doc_in = DocumentManager.seed_doc_with_content(
-        cc_pair_in,
-        f"{shared_phrase} included",
-        api_key,
-    )
-    doc_out = DocumentManager.seed_doc_with_content(
-        cc_pair_out,
-        f"{shared_phrase} excluded",
-        api_key,
-    )
+    # The two contents share ``shared_phrase`` but the unique suffixes
+    # ("included" / "excluded") must not be substrings of each other —
+    # otherwise the negative assertion below silently becomes vacuous.
+    included_content = f"{shared_phrase} included"
+    excluded_content = f"{shared_phrase} excluded"
+    DocumentManager.seed_doc_with_content(cc_pair_in, included_content, api_key)
+    DocumentManager.seed_doc_with_content(cc_pair_out, excluded_content, api_key)
 
     doc_set = DocumentSetManager.create(
         cc_pair_ids=[cc_pair_in.id],
@@ -90,9 +87,9 @@ def test_document_set_filtering(
     resp = _search(shared_phrase, admin_user, document_sets=[doc_set.name])
     assert resp.status_code == 200
 
-    result_doc_ids = {r["document_id"] for r in resp.json()["results"]}
-    assert doc_in.id in result_doc_ids
-    assert doc_out.id not in result_doc_ids
+    contents = [r["content"] for r in resp.json()["results"]]
+    assert any(included_content in c for c in contents)
+    assert not any(excluded_content in c for c in contents)
 
 
 @pytest.mark.skipif(
@@ -124,14 +121,12 @@ def test_acl_enforcement(
     )
 
     doc_content = "restricted acl search document"
-    doc = DocumentManager.seed_doc_with_content(
-        restricted_cc_pair, doc_content, api_key
-    )
+    DocumentManager.seed_doc_with_content(restricted_cc_pair, doc_content, api_key)
 
     allowed_resp = _search(doc_content, privileged_user)
     assert allowed_resp.status_code == 200
-    allowed_doc_ids = {r["document_id"] for r in allowed_resp.json()["results"]}
-    assert doc.id in allowed_doc_ids
+    allowed_contents = [r["content"] for r in allowed_resp.json()["results"]]
+    assert any(doc_content in c for c in allowed_contents)
 
     blocked_resp = _search(doc_content, blocked_user)
     assert blocked_resp.status_code == 200
@@ -148,16 +143,12 @@ def test_persona_scoped_search(
     cc_pair_out = CCPairManager.create_from_scratch(user_performing_action=admin_user)
 
     shared_phrase = "persona-scope-unique-phrase"
-    doc_in = DocumentManager.seed_doc_with_content(
-        cc_pair_in,
-        f"{shared_phrase} in scope",
-        api_key,
-    )
-    doc_out = DocumentManager.seed_doc_with_content(
-        cc_pair_out,
-        f"{shared_phrase} out of scope",
-        api_key,
-    )
+    # Suffixes ("in scope" / "out of scope") must not be substrings of each
+    # other so the negative assertion below stays meaningful.
+    included_content = f"{shared_phrase} in scope"
+    excluded_content = f"{shared_phrase} out of scope"
+    DocumentManager.seed_doc_with_content(cc_pair_in, included_content, api_key)
+    DocumentManager.seed_doc_with_content(cc_pair_out, excluded_content, api_key)
 
     doc_set = DocumentSetManager.create(
         cc_pair_ids=[cc_pair_in.id],
@@ -177,9 +168,9 @@ def test_persona_scoped_search(
     resp = _search(shared_phrase, admin_user, persona_id=persona.id)
     assert resp.status_code == 200
 
-    result_doc_ids = {r["document_id"] for r in resp.json()["results"]}
-    assert doc_in.id in result_doc_ids
-    assert doc_out.id not in result_doc_ids
+    contents = [r["content"] for r in resp.json()["results"]]
+    assert any(included_content in c for c in contents)
+    assert not any(excluded_content in c for c in contents)
 
 
 def test_invalid_persona_returns_404(

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -49,15 +49,12 @@ def test_basic_search_returns_results(
 
     data = resp.json()
     assert len(data["results"]) > 0
-    assert isinstance(data["llm_facing_text"], str)
-    assert len(data["llm_facing_text"]) > 0
-    assert isinstance(data["citation_mapping"], dict)
 
     result = data["results"][0]
     assert result["document_id"] == doc.id
     assert result["citation_id"] is not None
     assert result["source_type"] is not None
-    assert result["blurb"] is not None
+    assert result["content"]
 
 
 def test_document_set_filtering(

--- a/cli/README.md
+++ b/cli/README.md
@@ -126,7 +126,7 @@ When called without a TTY (e.g., by an AI agent or piped into another command), 
 - **No subcommand**: prints help and exits 0 (instead of launching the TUI)
 - **Results to stdout**, progress/errors to stderr
 - **No ANSI codes** or interactive prompts
-- **`ask` output truncated** to 4096 bytes by default; full response saved to a temp file. Use `--max-output 0` to disable.
+- **`ask` output truncated** to 50000 bytes by default; full response saved to a temp file. Use `--max-output 0` to disable.
 
 ### Configuration
 

--- a/cli/cmd/ask.go
+++ b/cli/cmd/ask.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultMaxOutputBytes = 4096
+const defaultMaxOutputBytes = 50000
 
 func newAskCmd(ios *iostreams.IOStreams) *cobra.Command {
 	var (

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
@@ -15,37 +16,77 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// buildSearchRequest maps CLI flags into a SearchRequest.
-// Boolean "set" parameters indicate whether the corresponding flag was explicitly provided.
-func buildSearchRequest(
-	query string,
-	sources []string,
-	days int, daysSet bool,
-	limit int, limitSet bool,
-	agentID int, agentIDSet bool,
-	defaultAgentID int,
-	noQueryExpansion bool,
-) models.SearchRequest {
-	req := models.SearchRequest{Query: query}
+// searchOutputResult is the per-document JSON shape `onyx-cli search` prints
+// (without --raw). One ``content`` field per result, no Onyx-internal jargon.
+type searchOutputResult struct {
+	Title      string  `json:"title"`
+	URL        *string `json:"url"`
+	SourceType string  `json:"source_type"`
+	Content    string  `json:"content"`
+	UpdatedAt  *string `json:"updated_at"`
+}
 
-	for _, s := range sources {
-		s = strings.TrimSpace(s)
-		if s != "" {
-			req.Sources = append(req.Sources, s)
+// searchOutput is the top-level wrapper for `onyx-cli search` default stdout.
+type searchOutput struct {
+	Results []searchOutputResult `json:"results"`
+}
+
+// maxSearchDays caps --days at ~100 years. The cap mostly exists to keep
+// `time.Duration(days) * 24h` from wrapping; nobody legitimately searches
+// further back than this.
+const maxSearchDays = 36500
+
+// toSearchOutput converts the API response into the default stdout shape.
+// `CitationID` is kept on `models.SearchResult` and only surfaced via --raw;
+// see `models.SearchResult` for the `Content` invariant.
+func toSearchOutput(resp models.SearchResponse) searchOutput {
+	out := searchOutput{Results: make([]searchOutputResult, 0, len(resp.Results))}
+	for _, r := range resp.Results {
+		out.Results = append(out.Results, searchOutputResult{
+			Title:      r.Title,
+			URL:        r.Link,
+			SourceType: r.SourceType,
+			Content:    r.Content,
+			UpdatedAt:  r.UpdatedAt,
+		})
+	}
+	return out
+}
+
+// searchFlags bundles the resolved CLI flag inputs for buildSearchRequest.
+// `daysSet` / `agentIDSet` track whether the corresponding flag was passed
+// explicitly (so unset flags don't end up in the JSON body).
+type searchFlags struct {
+	query            string
+	sources          []string
+	days             int
+	daysSet          bool
+	agentID          int
+	agentIDSet       bool
+	defaultAgentID   int
+	noQueryExpansion bool
+}
+
+// buildSearchRequest maps resolved CLI flags into the search API request body.
+func buildSearchRequest(flags searchFlags) models.SearchRequest {
+	req := models.SearchRequest{Query: flags.query}
+
+	for _, source := range flags.sources {
+		source = strings.TrimSpace(source)
+		if source != "" {
+			req.Sources = append(req.Sources, source)
 		}
 	}
-	if daysSet {
-		req.TimeCutoffDays = &days
+	if flags.daysSet {
+		cutoff := time.Now().UTC().Add(-time.Duration(flags.days) * 24 * time.Hour).Format(time.RFC3339)
+		req.TimeCutoff = &cutoff
 	}
-	if limitSet {
-		req.NumResults = limit
+	if flags.agentIDSet {
+		req.PersonaID = &flags.agentID
+	} else if flags.defaultAgentID != 0 {
+		req.PersonaID = &flags.defaultAgentID
 	}
-	if agentIDSet {
-		req.PersonaID = &agentID
-	} else if defaultAgentID != 0 {
-		req.PersonaID = &defaultAgentID
-	}
-	if noQueryExpansion {
+	if flags.noQueryExpansion {
 		req.SkipQueryExpansion = true
 	}
 	return req
@@ -55,7 +96,6 @@ func newSearchCmd(ios *iostreams.IOStreams) *cobra.Command {
 	var (
 		searchSources          string
 		searchDays             int
-		searchLimit            int
 		searchAgentID          int
 		searchRaw              bool
 		searchNoQueryExpansion bool
@@ -71,17 +111,18 @@ Results are retrieved using the full search pipeline: LLM query expansion,
 hybrid retrieval, document selection, and context expansion — the same
 search quality as the Onyx chat interface.
 
-By default, output is the LLM-facing JSON that SearchTool produces — a
-{"results": [...]} object with citation IDs, titles, content, and source
-types. Use --raw for the full API response including document IDs, scores,
-links, and citation mapping.
+By default, output is a lean JSON shape tuned for LLM consumers:
+{"results": [{title, url, source_type, content, updated_at}, ...]}.
+Results contain only documents the LLM judged relevant, ordered by relevance;
+content is the full chunk text of each. Use --raw for the full API response
+(adds per-result citation_id).
 
 When stdout is not a TTY, output is truncated to --max-output bytes and the
 full response is saved to a temp file.`,
 		Args: cobra.MaximumNArgs(1),
 		Example: `  onyx-cli search "What is our deployment process?"
   onyx-cli search --source slack "auth migration status"
-  onyx-cli search --days 30 --limit 5 "recent production incidents"
+  onyx-cli search --days 30 "recent production incidents"
   onyx-cli search --agent-id 5 "engineering roadmap"
   onyx-cli search --raw "API documentation" | jq '.results[].title'
   onyx-cli search --no-query-expansion "exact error message text"`,
@@ -96,19 +137,31 @@ full response is saved to a temp file.`,
 					"no query provided\n  Usage: onyx-cli search \"your query\"")
 			}
 
+			if cmd.Flags().Changed("days") {
+				if searchDays <= 0 {
+					return exitcodes.New(exitcodes.BadRequest,
+						"--days must be a positive integer")
+				}
+				if searchDays > maxSearchDays {
+					return exitcodes.New(exitcodes.BadRequest,
+						fmt.Sprintf("--days cannot exceed %d (~100 years)", maxSearchDays))
+				}
+			}
+
 			var sources []string
 			if cmd.Flags().Changed("source") {
 				sources = strings.Split(searchSources, ",")
 			}
-			req := buildSearchRequest(
-				args[0],
-				sources,
-				searchDays, cmd.Flags().Changed("days"),
-				searchLimit, cmd.Flags().Changed("limit"),
-				searchAgentID, cmd.Flags().Changed("agent-id"),
-				cfg.DefaultAgentID,
-				searchNoQueryExpansion,
-			)
+			req := buildSearchRequest(searchFlags{
+				query:            args[0],
+				sources:          sources,
+				days:             searchDays,
+				daysSet:          cmd.Flags().Changed("days"),
+				agentID:          searchAgentID,
+				agentIDSet:       cmd.Flags().Changed("agent-id"),
+				defaultAgentID:   cfg.DefaultAgentID,
+				noQueryExpansion: searchNoQueryExpansion,
+			})
 
 			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
@@ -139,8 +192,14 @@ full response is saved to a temp file.`,
 				truncateAt = defaultMaxOutputBytes
 			}
 
+			output := toSearchOutput(*resp)
+			data, err := json.MarshalIndent(output, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal response: %w", err)
+			}
+
 			ow := &overflow.Writer{Limit: truncateAt, Out: ios.Out, ErrOut: ios.ErrOut}
-			ow.Write(resp.LLMFacingText)
+			ow.Write(string(data))
 			ow.Finish()
 
 			return nil
@@ -149,9 +208,8 @@ full response is saved to a temp file.`,
 
 	cmd.Flags().StringVar(&searchSources, "source", "", "Filter by source type (comma-separated: slack,google_drive)")
 	cmd.Flags().IntVar(&searchDays, "days", 0, "Only return results from the last N days")
-	cmd.Flags().IntVar(&searchLimit, "limit", 0, "Maximum number of results (default: server decides)")
 	cmd.Flags().IntVar(&searchAgentID, "agent-id", 0, "Agent ID for scoped search")
-	cmd.Flags().BoolVar(&searchRaw, "raw", false, "Output full API response (results with scores, links, document IDs, citation mapping)")
+	cmd.Flags().BoolVar(&searchRaw, "raw", false, "Output full API response (adds per-result citation_id)")
 	cmd.Flags().BoolVar(&searchNoQueryExpansion, "no-query-expansion", false, "Skip LLM query expansion (faster, less comprehensive)")
 	cmd.Flags().IntVar(&maxOutput, "max-output", defaultMaxOutputBytes,
 		"Max bytes to print before truncating (0 to disable, auto-enabled for non-TTY, ignored with --raw)")

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/onyx-dot-app/onyx/cli/internal/models"
 	"github.com/spf13/cobra"
 )
 
@@ -54,16 +56,16 @@ func TestBuildSearchRequest(t *testing.T) {
 		sources          []string
 		days             int
 		daysSet          bool
-		limit            int
-		limitSet         bool
 		agentID          int
 		agentIDSet       bool
 		defaultAgentID   int
 		noQueryExpansion bool
 
-		wantSources            []string
-		wantTimeCutoffDays     *int
-		wantNumResults         int
+		wantSources []string
+		// wantDaysAgo is the expected "N days ago" cutoff; buildSearchRequest
+		// converts this to an ISO timestamp ~N*24h before now, asserted
+		// within a 10s tolerance below.
+		wantDaysAgo            *int
 		wantPersonaID          *int
 		wantSkipQueryExpansion bool
 	}{
@@ -85,24 +87,20 @@ func TestBuildSearchRequest(t *testing.T) {
 			wantSources: []string{"slack", "google_drive"},
 		},
 		{
-			name:               "days_limit_agentID_set",
+			name:               "days_agentID_set",
 			query:              "test query",
 			days:               30,
 			daysSet:            true,
-			limit:              5,
-			limitSet:           true,
 			agentID:            3,
 			agentIDSet:         true,
-			wantTimeCutoffDays: intPtr(30),
-			wantNumResults:     5,
+			wantDaysAgo: intPtr(30),
 			wantPersonaID:      intPtr(3),
 		},
 		{
 			name:               "unset_flags_produce_zero_values",
 			query:              "test query",
 			wantSources:        nil,
-			wantTimeCutoffDays: nil,
-			wantNumResults:     0,
+			wantDaysAgo: nil,
 			wantPersonaID:      nil,
 		},
 		{
@@ -142,15 +140,16 @@ func TestBuildSearchRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := buildSearchRequest(
-				tt.query,
-				tt.sources,
-				tt.days, tt.daysSet,
-				tt.limit, tt.limitSet,
-				tt.agentID, tt.agentIDSet,
-				tt.defaultAgentID,
-				tt.noQueryExpansion,
-			)
+			req := buildSearchRequest(searchFlags{
+				query:            tt.query,
+				sources:          tt.sources,
+				days:             tt.days,
+				daysSet:          tt.daysSet,
+				agentID:          tt.agentID,
+				agentIDSet:       tt.agentIDSet,
+				defaultAgentID:   tt.defaultAgentID,
+				noQueryExpansion: tt.noQueryExpansion,
+			})
 
 			if req.Query != tt.query {
 				t.Errorf("Query = %q, want %q", req.Query, tt.query)
@@ -172,23 +171,25 @@ func TestBuildSearchRequest(t *testing.T) {
 				}
 			}
 
-			// TimeCutoffDays
-			if tt.wantTimeCutoffDays == nil {
-				if req.TimeCutoffDays != nil {
-					t.Errorf("TimeCutoffDays = %v, want nil", *req.TimeCutoffDays)
+			// TimeCutoff: when days is set, expect an ISO timestamp roughly
+			// `days` days before now.
+			if tt.wantDaysAgo == nil {
+				if req.TimeCutoff != nil {
+					t.Errorf("TimeCutoff = %v, want nil", *req.TimeCutoff)
 				}
 			} else {
-				if req.TimeCutoffDays == nil {
-					t.Fatalf("TimeCutoffDays = nil, want %d", *tt.wantTimeCutoffDays)
+				if req.TimeCutoff == nil {
+					t.Fatalf("TimeCutoff = nil, want ~%d days ago", *tt.wantDaysAgo)
 				}
-				if *req.TimeCutoffDays != *tt.wantTimeCutoffDays {
-					t.Errorf("TimeCutoffDays = %d, want %d", *req.TimeCutoffDays, *tt.wantTimeCutoffDays)
+				parsed, err := time.Parse(time.RFC3339, *req.TimeCutoff)
+				if err != nil {
+					t.Fatalf("TimeCutoff %q is not RFC3339: %v", *req.TimeCutoff, err)
 				}
-			}
-
-			// NumResults
-			if req.NumResults != tt.wantNumResults {
-				t.Errorf("NumResults = %d, want %d", req.NumResults, tt.wantNumResults)
+				expected := time.Now().UTC().Add(-time.Duration(*tt.wantDaysAgo) * 24 * time.Hour)
+				delta := parsed.Sub(expected)
+				if delta < -10*time.Second || delta > 10*time.Second {
+					t.Errorf("TimeCutoff = %v (off by %v), want ~%v", parsed, delta, expected)
+				}
 			}
 
 			// PersonaID
@@ -210,5 +211,77 @@ func TestBuildSearchRequest(t *testing.T) {
 				t.Errorf("SkipQueryExpansion = %v, want %v", req.SkipQueryExpansion, tt.wantSkipQueryExpansion)
 			}
 		})
+	}
+}
+
+func TestToSearchOutput(t *testing.T) {
+	intPtr := func(v int) *int { return &v }
+	strPtr := func(v string) *string { return &v }
+
+	resp := models.SearchResponse{
+		Results: []models.SearchResult{
+			{
+				CitationID: intPtr(1),
+				Title:      "Onboarding guide",
+				Content:    "Full chunk text for doc A — multiple paragraphs.",
+				Link:       strPtr("https://docs.example.com/a"),
+				SourceType: "google_drive",
+				UpdatedAt:  strPtr("2026-01-15T09:00:00Z"),
+			},
+			{
+				// Defensive case: the API contract guarantees every result is
+				// LLM-selected, but we still verify the projection handles
+				// nullable fields (CitationID, Link, UpdatedAt) cleanly when
+				// they happen to be nil.
+				CitationID: nil,
+				Title:      "Stale draft",
+				Content:    "Blurb for doc B",
+				Link:       nil,
+				SourceType: "confluence",
+				UpdatedAt:  nil,
+			},
+		},
+	}
+
+	out := toSearchOutput(resp)
+
+	if len(out.Results) != 2 {
+		t.Fatalf("Results length = %d, want 2", len(out.Results))
+	}
+
+	// Fully-populated result: every field should round-trip.
+	selected := out.Results[0]
+	if selected.Title != "Onboarding guide" {
+		t.Errorf("Results[0].Title = %q, want %q", selected.Title, "Onboarding guide")
+	}
+	if selected.Content != "Full chunk text for doc A — multiple paragraphs." {
+		t.Errorf("Results[0].Content = %q, want full chunk", selected.Content)
+	}
+	if selected.URL == nil || *selected.URL != "https://docs.example.com/a" {
+		t.Errorf("Results[0].URL = %v, want https://docs.example.com/a", selected.URL)
+	}
+	if selected.SourceType != "google_drive" {
+		t.Errorf("Results[0].SourceType = %q, want google_drive", selected.SourceType)
+	}
+	if selected.UpdatedAt == nil || *selected.UpdatedAt != "2026-01-15T09:00:00Z" {
+		t.Errorf("Results[0].UpdatedAt = %v, want 2026-01-15T09:00:00Z", selected.UpdatedAt)
+	}
+
+	// Nullable fields should round-trip as nil without panic.
+	withNils := out.Results[1]
+	if withNils.Title != "Stale draft" {
+		t.Errorf("Results[1].Title = %q, want Stale draft", withNils.Title)
+	}
+	if withNils.Content != "Blurb for doc B" {
+		t.Errorf("Results[1].Content = %q, want %q", withNils.Content, "Blurb for doc B")
+	}
+	if withNils.URL != nil {
+		t.Errorf("Results[1].URL = %v, want nil", withNils.URL)
+	}
+	if withNils.SourceType != "confluence" {
+		t.Errorf("Results[1].SourceType = %q, want confluence", withNils.SourceType)
+	}
+	if withNils.UpdatedAt != nil {
+		t.Errorf("Results[1].UpdatedAt = %v, want nil", withNils.UpdatedAt)
 	}
 }

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -21,11 +21,17 @@ import (
 )
 
 // Client is the Onyx API client.
+//
+// Three http.Clients are kept so each call site can pick a timeout matched to
+// its expected work: 30s for quick JSON endpoints, 60s for /search (which
+// runs LLM query expansion + relevance selection), and 5min for streaming
+// chat responses and uploads.
 type Client struct {
-	baseURL        string
-	apiKey         string
-	httpClient     *http.Client // default 30s timeout for quick requests
-	longHTTPClient *http.Client // 5min timeout for streaming/uploads
+	baseURL             string
+	apiKey              string
+	httpClient          *http.Client // 30s
+	searchHTTPClient    *http.Client // 60s
+	streamingHTTPClient *http.Client // 5min
 }
 
 // NewClient creates a new API client from config.
@@ -45,7 +51,11 @@ func NewClient(cfg config.OnyxCliConfig) *Client {
 			Timeout:   30 * time.Second,
 			Transport: transport,
 		},
-		longHTTPClient: &http.Client{
+		searchHTTPClient: &http.Client{
+			Timeout:   60 * time.Second,
+			Transport: transport,
+		},
+		streamingHTTPClient: &http.Client{
 			Timeout:   5 * time.Minute,
 			Transport: transport,
 		},
@@ -133,14 +143,10 @@ func (c *Client) doJSON(ctx context.Context, method, path string, reqBody any, r
 	return c.doJSONWith(ctx, c.httpClient, method, path, reqBody, result)
 }
 
-func (c *Client) doJSONLong(ctx context.Context, method, path string, reqBody any, result any) error {
-	return c.doJSONWith(ctx, c.longHTTPClient, method, path, reqBody, result)
-}
-
 // Search calls POST /api/search and returns the response.
 func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.SearchResponse, error) {
 	var resp models.SearchResponse
-	if err := c.doJSONLong(ctx, "POST", "/search", req, &resp); err != nil {
+	if err := c.doJSONWith(ctx, c.searchHTTPClient, "POST", "/search", req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil
@@ -286,7 +292,7 @@ func (c *Client) UploadFile(ctx context.Context, filePath string) (*models.FileD
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
-	resp, err := c.longHTTPClient.Do(req)
+	resp, err := c.streamingHTTPClient.Do(req)
 	if err != nil {
 		return nil, wrapTimeoutError(err)
 	}

--- a/cli/internal/api/client_test.go
+++ b/cli/internal/api/client_test.go
@@ -34,9 +34,7 @@ func TestSearch_Success(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
-			"results": [{"citation_id": 1, "document_id": "doc-1", "chunk_ind": 0, "title": "Test", "blurb": "blurb", "link": null, "source_type": "web", "score": 0.95, "updated_at": null}],
-			"llm_facing_text": "{\"results\": []}",
-			"citation_mapping": {"1": "doc-1"}
+			"results": [{"citation_id": 1, "title": "Test", "content": "full chunk text", "link": null, "source_type": "web", "updated_at": null}]
 		}`))
 	}))
 	defer srv.Close()
@@ -49,11 +47,8 @@ func TestSearch_Success(t *testing.T) {
 	if len(resp.Results) != 1 {
 		t.Fatalf("expected 1 result, got %d", len(resp.Results))
 	}
-	if resp.Results[0].DocumentID != "doc-1" {
-		t.Errorf("document_id = %q, want %q", resp.Results[0].DocumentID, "doc-1")
-	}
-	if resp.LLMFacingText == "" {
-		t.Error("llm_facing_text is empty")
+	if resp.Results[0].Content != "full chunk text" {
+		t.Errorf("content = %q, want %q", resp.Results[0].Content, "full chunk text")
 	}
 }
 

--- a/cli/internal/api/stream.go
+++ b/cli/internal/api/stream.go
@@ -58,7 +58,7 @@ func (c *Client) SendMessageStream(
 		}
 		req.Header.Set("Content-Type", "application/json")
 
-		resp, err := c.longHTTPClient.Do(req)
+		resp, err := c.streamingHTTPClient.Do(req)
 		if err != nil {
 			if ctx.Err() != nil {
 				return // cancelled

--- a/cli/internal/embedded/SKILL.md
+++ b/cli/internal/embedded/SKILL.md
@@ -59,14 +59,14 @@ Exit code 0 on success. Non-zero with a descriptive error on failure (see exit c
 onyx-cli search "What is our deployment process?"
 ```
 
-Returns ranked, cited documents from the Onyx knowledge base as JSON. The default output is the LLM-facing format — `{"results": [...]}` with citation IDs, titles, content, and source types. Use `--raw` for the full API response including document IDs, scores, links, and citation mapping.
+Returns ranked, cited documents from the Onyx knowledge base as JSON. Default output is a lean shape: `{"results": [{title, url, source_type, content, updated_at}, ...]}`. Results contain only documents the LLM judged relevant, ordered by relevance; `content` is the full chunk text of each. Use `--raw` for the full API response (adds per-result `citation_id`).
 
 ```bash
 # Filter by source
 onyx-cli search --source slack,google_drive "auth migration status"
 
 # Recent results only
-onyx-cli search --days 30 --limit 5 "recent production incidents"
+onyx-cli search --days 30 "recent production incidents"
 
 # Use a specific agent for scoped search
 onyx-cli search --agent-id 5 "engineering roadmap"
@@ -82,11 +82,10 @@ onyx-cli search --no-query-expansion "exact error message text"
 | ----------------------- | ------ | ---------------------------------------------------------------- |
 | `--source`              | string | Filter by source type (comma-separated: slack,google_drive)      |
 | `--days`                | int    | Only return results from the last N days                         |
-| `--limit`               | int    | Maximum number of results (default: server decides)              |
 | `--agent-id`            | int    | Agent ID for scoped search (inherits filters, document sets)     |
-| `--raw`                 | bool   | Output full API response (results with scores, links, document IDs, citation mapping) |
+| `--raw`                 | bool   | Output full API response (adds per-result citation_id) |
 | `--no-query-expansion`  | bool   | Skip LLM query expansion (faster, less comprehensive)           |
-| `--max-output`          | int    | Max bytes to print before truncating (0 to disable, default 4096 for non-TTY, ignored with --raw) |
+| `--max-output`          | int    | Max bytes to print before truncating (0 to disable, default 50000 for non-TTY, ignored with --raw) |
 
 ### Ask a question
 
@@ -94,7 +93,7 @@ onyx-cli search --no-query-expansion "exact error message text"
 onyx-cli ask "What is our company's PTO policy?"
 ```
 
-Streams an LLM-generated answer as plain text to stdout. Use `search` instead when you need the source documents rather than a synthesized answer. When stdout is not a TTY, output is truncated to 4096 bytes and the full response is saved to a temp file (path printed at the end). Use `--max-output 0` to disable truncation.
+Streams an LLM-generated answer as plain text to stdout. Use `search` instead when you need the source documents rather than a synthesized answer. When stdout is not a TTY, output is truncated to 50000 bytes and the full response is saved to a temp file (path printed at the end). Use `--max-output 0` to disable truncation.
 
 ```bash
 # Use a specific agent
@@ -113,7 +112,7 @@ onyx-cli ask --json "List all active API integrations"
 | `--json`       | bool | Output NDJSON stream events instead of plain text (bypasses truncation) |
 | `--quiet`      | bool | Buffer output and print once at end (no streaming)           |
 | `--prompt`     | str  | Question text (use with piped stdin context)                 |
-| `--max-output` | int  | Max bytes to print before truncating (0 to disable, default 4096 for non-TTY) |
+| `--max-output` | int  | Max bytes to print before truncating (0 to disable, default 50000 for non-TTY) |
 
 ### List available agents
 
@@ -137,7 +136,7 @@ Checks config exists, PAT is present, server is reachable, and credentials are v
 - **stdout**: Results only (answer text, agent list, status)
 - **stderr**: Progress indicators, warnings, errors
 - **Non-TTY**: No ANSI escape codes, no interactive prompts
-- **Truncation**: When stdout is not a TTY, `search` and `ask` output is truncated to 4096 bytes. Full response is saved to a temp file whose path is printed. Read the temp file for more.
+- **Truncation**: When stdout is not a TTY, `search` and `ask` output is truncated to 50000 bytes. Full response is saved to a temp file whose path is printed. Read the temp file for more.
 
 ## Exit Codes
 

--- a/cli/internal/models/models.go
+++ b/cli/internal/models/models.go
@@ -103,31 +103,32 @@ type Placement struct {
 
 // SearchRequest is the request body for POST /api/search.
 type SearchRequest struct {
-	Query              string   `json:"query"`
-	Sources            []string `json:"sources,omitempty"`
-	DocumentSets       []string `json:"document_sets,omitempty"`
-	TimeCutoffDays     *int     `json:"time_cutoff_days,omitempty"`
-	NumResults         int      `json:"num_results,omitempty"`
-	PersonaID          *int     `json:"persona_id,omitempty"`
-	SkipQueryExpansion bool     `json:"skip_query_expansion,omitempty"`
+	Query        string   `json:"query"`
+	Sources      []string `json:"sources,omitempty"`
+	DocumentSets []string `json:"document_sets,omitempty"`
+	// TimeCutoff is an ISO 8601 timestamp. Only documents updated on or after
+	// this moment are returned; naive (timezone-less) values are treated as
+	// UTC server-side.
+	TimeCutoff         *string `json:"time_cutoff,omitempty"`
+	PersonaID          *int    `json:"persona_id,omitempty"`
+	SkipQueryExpansion bool    `json:"skip_query_expansion,omitempty"`
 }
 
 // SearchResult is a single document result from the search API.
+//
+// Content is the full chunk text the LLM saw for this section. Multiple
+// results may share a CitationID when the LLM selected multiple
+// non-overlapping sections of the same document.
 type SearchResult struct {
-	CitationID *int     `json:"citation_id"`
-	DocumentID string   `json:"document_id"`
-	ChunkInd   int      `json:"chunk_ind"`
-	Title      string   `json:"title"`
-	Blurb      string   `json:"blurb"`
-	Link       *string  `json:"link"`
-	SourceType string   `json:"source_type"`
-	Score      *float64 `json:"score"`
-	UpdatedAt  *string  `json:"updated_at"`
+	CitationID *int    `json:"citation_id"`
+	Title      string  `json:"title"`
+	Content    string  `json:"content"`
+	Link       *string `json:"link"`
+	SourceType string  `json:"source_type"`
+	UpdatedAt  *string `json:"updated_at"`
 }
 
 // SearchResponse is the response from POST /api/search.
 type SearchResponse struct {
-	Results         []SearchResult `json:"results"`
-	LLMFacingText   string         `json:"llm_facing_text"`
-	CitationMapping map[int]string `json:"citation_mapping"`
+	Results []SearchResult `json:"results"`
 }

--- a/docs/craft/features/search/1-onyx-cli-ax-refactor.md
+++ b/docs/craft/features/search/1-onyx-cli-ax-refactor.md
@@ -29,7 +29,7 @@ After this refactor, onyx-cli has two modes determined by TTY detection:
 
 Conventions for all agent-usable commands:
 - Results to stdout, progress/errors to stderr
-- Non-TTY output truncated to 4096 bytes with full response in temp file (agents can read more if needed)
+- Non-TTY output truncated to 50000 bytes with full response in temp file (agents can read more if needed)
 - No ANSI codes, no interactive prompts
 - Every failure has a distinct exit code and an actionable error message on stderr
 
@@ -73,7 +73,7 @@ The CLI is a Go project at `cli/` (Go 1.26.1, Cobra + Bubble Tea), distributed a
 - **Entry point**: `main.go` → `cmd.Execute()` → Cobra root command
 - **Default command**: previously fell through to `chatCmd.RunE` unconditionally — crashes without TTY
 - **TTY detection**: `golang.org/x/term.IsTerminal(fd)`, used inline in `ask.go` (stdout) and `configure.go` (stdin)
-- **`ask` output**: `overflow.Writer` truncates to 4096 bytes for non-TTY. `--json` emits NDJSON stream events.
+- **`ask` output**: `overflow.Writer` truncates to 50000 bytes for non-TTY. `--json` emits NDJSON stream events.
 - **`configure`**: Previously had both interactive wizard and non-interactive flag path (`--server-url`/`--api-key`)
 - **`validate-config`**: Human-readable text only, no `--json`, no capability detection
 - **Exit codes**: 0–5 previously defined in `internal/exitcodes/codes.go`. HTTP errors mostly fell through to `General = 1`.
@@ -92,7 +92,7 @@ The CLI is a Go project at `cli/` (Go 1.26.1, Cobra + Bubble Tea), distributed a
 
 **2. Keep non-TTY output truncation (no change)** (`cmd/ask.go`, `internal/overflow/writer.go`)
 
-The existing truncation behavior is correct for agents. Coding agents have tool call output limits — dumping a full LLM response into the agent's context window wastes tokens. The current design handles this well: full response goes to a temp file, first 4096 bytes go to stdout, and the agent gets the file path to read more if needed. No changes required.
+The existing truncation behavior is correct for agents. Coding agents have tool call output limits — dumping a full LLM response into the agent's context window wastes tokens. The current design handles this well: full response goes to a temp file, first 50000 bytes go to stdout, and the agent gets the file path to read more if needed. No changes required.
 
 **3. Remove `configure` non-interactive path** (`cmd/configure.go`)
 

--- a/docs/craft/features/search/2-new-search-api.md
+++ b/docs/craft/features/search/2-new-search-api.md
@@ -3,6 +3,13 @@
 > **Status: IMPLEMENTED** — shipped and merged via PR #10966.
 > Annotations marked *[Diverged]* or *[New]* note where the final implementation
 > differs from or adds to the original plan.
+>
+> ⚠️ **The request/response shapes below are the original design and are now
+> stale.** The final shipped contract — collapsed `num_results`,
+> `time_cutoff_days`, `chunk_ind`, `blurb`, `llm_facing_text`,
+> `citation_mapping`, and `score` away — lives in
+> [`backend/onyx/server/features/search/models.py`](../../../../backend/onyx/server/features/search/models.py).
+> This doc is preserved for historical context.
 
 > Parent design doc: [search-design.md](search-design.md)
 

--- a/docs/craft/features/search/3-cli-search-command.md
+++ b/docs/craft/features/search/3-cli-search-command.md
@@ -1,6 +1,15 @@
 # Part 3: CLI Search Command & Agent Tool Surface — Implementation Plan
 
 > Parent design: [search-design.md](search-design.md) (Part 3)
+>
+> ⚠️ **The flags and shapes below describe the original design and are now
+> stale.** `--limit`/`--num-results` were removed, `--days` converts to ISO
+> client-side, default output is a lean `{title, url, source_type, content,
+> updated_at}` projection, and there is no `llm_facing_text` /
+> `citation_mapping` / `score` on the wire. See
+> [`cli/cmd/search.go`](../../../../cli/cmd/search.go) and
+> [`backend/onyx/server/features/search/models.py`](../../../../backend/onyx/server/features/search/models.py)
+> for the shipped surfaces.
 
 ## Objective
 
@@ -19,7 +28,7 @@ After this work, the CLI has two primary agent-usable commands:
 
 Both commands share:
 - `--agent-id` for persona scoping
-- Non-TTY truncation via `overflow.Writer` (4096 bytes default)
+- Non-TTY truncation via `overflow.Writer` (50000 bytes default)
 - Clean exit codes, stderr for progress, stdout for results
 - No interactive prompts
 
@@ -58,7 +67,7 @@ A single command with a mode flag (e.g., `search --answer`) would hide this dist
 - **`cmd/root.go:96-104`**: Command registration via `rootCmd.AddCommand(...)`. The `search` command is added here.
 - **`cmd/common.go`**: `requireClient()` returns `(config, client, error)`. `apiErrorToExit()` maps API/auth errors to exit codes. Both used by `search`.
 - **`internal/api/client.go`**: `Client` struct with `doJSON()` for synchronous JSON requests (30s timeout). `search` needs a new `Search()` method using this pattern, but with `longHTTPClient` (5min timeout) because SearchTool runs LLM calls internally.
-- **`internal/overflow/writer.go`**: Truncation writer. `search` uses this identically to `ask` — non-TTY output truncated at 4096 bytes, full response in temp file.
+- **`internal/overflow/writer.go`**: Truncation writer. `search` uses this identically to `ask` — non-TTY output truncated at 50000 bytes, full response in temp file.
 - **`internal/exitcodes/codes.go`**: Exit codes 0-9. No new codes needed — the existing set covers all search failure modes.
 - **`internal/models/models.go`**: Go structs for API types. Needs new structs for `SearchAPIRequest`/`SearchAPIResponse`.
 - **`internal/embedded/SKILL.md`**: Agent-facing documentation. Must be updated with the `search` command.

--- a/docs/craft/features/search/4-craft-search.md
+++ b/docs/craft/features/search/4-craft-search.md
@@ -6,14 +6,14 @@
 
 Wire onyx-cli into the Craft sandbox as the primary search tool, replacing the legacy `files/` corpus sync. Provision per-user PATs with encrypted-at-rest storage, bundle the CLI binary, create a `company-search` skill with the user's available sources, and tear down the file-sync infrastructure.
 
-**Parts 1–3 are complete.** Part 1 repositioned onyx-cli as an agent-first tool with `ONYX_SERVER_URL`/`ONYX_PAT` env var support, clean exit codes, and `validate-config`. Part 2 shipped `POST /api/search` backed by the full `SearchTool.run()` pipeline (query expansion, hybrid retrieval, LLM document selection, context expansion). Part 3 added the `search` CLI command wrapping that endpoint with `--source`, `--days`, `--limit`, `--agent-id`, `--raw`, and `--no-query-expansion` flags.
+**Parts 1–3 are complete.** Part 1 repositioned onyx-cli as an agent-first tool with `ONYX_SERVER_URL`/`ONYX_PAT` env var support, clean exit codes, and `validate-config`. Part 2 shipped `POST /api/search` backed by the full `SearchTool.run()` pipeline (query expansion, hybrid retrieval, LLM document selection, context expansion). Part 3 added the `search` CLI command wrapping that endpoint with `--source`, `--days`, `--agent-id`, `--raw`, and `--no-query-expansion` flags.
 
 > Key implementation details from Parts 1–3 that affect this plan:
 > - **IOStreams pattern** (Part 1): CLI commands use an `IOStreams` struct for testable I/O. Agent-facing output goes to stdout, progress to stderr.
 > - **`NullEmitter`** (Part 2): Located in `backend/onyx/chat/emitter.py`. Allows `SearchTool` to run without a streaming consumer.
 > - **`message_history`** (Part 2): The search API accepts optional conversation context for better query expansion — not needed for Part 4's skill-based usage, but available.
-> - **`doJSONLong()`** (Part 3): CLI uses a 5-minute HTTP timeout for the search endpoint since `SearchTool.run()` includes multiple LLM calls.
-> - **Default output** (Part 3): `onyx-cli search` prints `llm_facing_text` (a JSON string with `{"results": [...]}`) to stdout by default. `--raw` prints the full `SearchAPIResponse`.
+> - **HTTP timeout** (Part 3): CLI uses the standard `doJSON()` timeout for the search endpoint. The path runs LLM query expansion + relevance selection but does NOT generate a full answer, so the standard 30s ceiling applies (no separate long-timeout client).
+> - **Default output** (Part 3): `onyx-cli search` prints a lean JSON shape — `{"results": [{title, url, source_type, content, updated_at}, ...]}` — to stdout by default. Results contain only documents the LLM judged relevant, ordered by relevance; `content` is the full chunk text of each. `--raw` prints the full `SearchResponse` (adds per-result `citation_id` and `document_id`).
 
 ---
 
@@ -261,14 +261,14 @@ assume it exists.
 |------|-------------|---------|
 | `--source` | Filter by source type (comma-separated) | `--source slack,google_drive` |
 | `--days` | Only return results from the last N days | `--days 30` |
-| `--limit` | Maximum number of results | `--limit 5` |
 
 ## Output
 
-Stdout is JSON with a top-level `results` array. Each result has a `document`
-field (the citation ID), plus `title`, `content`, `source_type`, and other
-metadata. Cite results by their `document` number when referencing them in your
-response.
+Stdout is JSON with a top-level `results` array. Each result has `title`,
+`url`, `source_type`, `content`, and `updated_at`. Results contain only
+documents the LLM judged relevant, ordered by relevance; `content` is the
+full chunk text of each. Cite results by title and URL when referencing
+them in your response.
 ```
 
 **7. Add `build_available_sources_section` and `render_company_search_skill`**

--- a/docs/craft/features/search/search-design.md
+++ b/docs/craft/features/search/search-design.md
@@ -140,7 +140,7 @@ Non-interactive mode output must be optimized for LLM consumption:
 - `--json` flag switches to structured JSON (for programmatic consumers)
 - `--quiet` flag suppresses progress/status output (already exists on `ask`)
 - Progress and status information goes to stderr; results go to stdout (clean pipe separation)
-- Non-TTY output is truncated to 4096 bytes with the full response saved to a temp file. This is intentional — coding agents have tool call output limits, and the temp file path lets the agent read more if needed. The `--max-output` flag provides an override.
+- Non-TTY output is truncated to 50000 bytes with the full response saved to a temp file. This is intentional — coding agents have tool call output limits, and the temp file path lets the agent read more if needed. The `--max-output` flag provides an override.
 
 #### R1.3: Configuration isolation
 
@@ -195,6 +195,8 @@ The CLI's `install-skill` command installs a `SKILL.md` for agent harnesses (Cla
 > - **Integration tests** — `backend/tests/integration/tests/search/test_search_api.py`.
 > - **`message_history` support** — Added beyond the original plan. Callers with conversation context can pass it in for better query expansion (resolves pronouns, follow-ups, etc.).
 > - **Field naming** — LLM override fields use `provider`/`model`, consistent with the rest of the API surface.
+>
+> ⚠️ **The request/response examples in the Part 2 subsections below describe the original design and are stale.** The shipped contract dropped `num_results`, `time_cutoff_days`, `chunk_ind`, `blurb`, `score`, `llm_facing_text`, and `citation_mapping`; `content` (full chunk for LLM-selected docs, blurb fallback) is the single content field; only LLM-selected docs are returned. See `backend/onyx/server/features/search/models.py` for the authoritative shapes.
 
 ### Objective
 
@@ -326,9 +328,9 @@ The search endpoint lives under `/api/search` (not `/api/build/...` or `/api/cha
 
 > **Status: Implemented.** Key implementation details for Part 4:
 > - **Two commands** — Resolved as separate `search` and `ask` commands. `search` returns retrieved documents with citations; `ask` returns LLM-generated answers. Different backends, different output shapes and cost profiles.
-> - **Flags** — `--source` (comma-separated source filter), `--days` (recency cutoff), `--limit` (max results), `--agent-id` (persona/agent scoping), `--no-query-expansion` (skip LLM expansion), `--raw` (full API response instead of `llm_facing_text`).
-> - **Default output** — `onyx-cli search` prints `llm_facing_text` (the citation-rich JSON string from `SearchTool`) to stdout. Non-TTY output is truncated to 4096 bytes with a temp file for overflow.
-> - **5-minute timeout** — `doJSONLong()` helper uses a 5-minute HTTP timeout since `SearchTool.run()` includes multiple LLM calls.
+> - **Flags** — `--source` (comma-separated source filter), `--days` (recency cutoff, converted to an ISO timestamp client-side and sent as `time_cutoff`), `--agent-id` (persona/agent scoping), `--no-query-expansion` (skip LLM expansion), `--raw` (full API response instead of the lean projection). No per-call result-count knob; `/api/search` runs the chat-flow-equivalent pool (50 hits → ≤25 chunks).
+> - **Default output** — `onyx-cli search` prints a lean projection — `{"results": [{title, url, source_type, content, updated_at}, ...]}` — to stdout. Results contain only documents the LLM judged relevant, ordered by relevance; `content` is the full chunk text of each (the server populates `content` directly on each `SearchResult`, so consumers never fall back). Non-TTY output is truncated to 50000 bytes with a temp file for overflow.
+> - **60s timeout** — `Client.Search` uses a dedicated `searchHTTPClient` with a 60s timeout. The search path runs LLM query expansion + relevance selection but does not generate a full answer, so it doesn't need the 5-minute long-timeout client; 60s is the right middle ground for two short LLM calls.
 
 ### Objective
 


### PR DESCRIPTION
## Description

The previous Search API just returned what the SearchTool/pipeline spat out. This was extremely unideal as there is more result processing in the core chat flow to coerce final docs with the final citations map. 

This refactored API does similar post-processing work to create a final, coherent results list for agent/human consumption. It removes unnecessary fields and merges the final selected docs with citations.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Search API to return only LLM-selected sections with full content and updates `onyx-cli search` to emit a lean `{title, url, source_type, content, updated_at}` JSON by default. Replaces the day-based cutoff with an ISO timestamp, simplifies models, and tightens CLI ergonomics and timeouts.

- **Refactors**
  - Build results from LLM-facing JSON; set `citation_id` from each entry’s `document`; include `link`; drop top-level `llm_facing_text` and `citation_mapping`.
  - Simplified models: `SearchAPI*` → `Search*`; remove `document_id`, `chunk_ind`, `blurb`, `score`; `results[].content` is the full chunk text; return an empty list when nothing is selected.
  - Replace `time_cutoff_days` with `time_cutoff` (ISO 8601; naive treated as UTC); remove `num_results` and stop passing `num_hits`.
  - CLI: `onyx-cli search` prints a lean JSON projection; `--raw` returns the full API response (adds per-result `citation_id`); remove `--limit`; `--days` converts to `time_cutoff` client‑side with validation; use a 60s search HTTP timeout; increase non‑TTY truncation default to 50000 bytes. Docs and SKILL templates updated to cite by title and URL.

- **Migration**
  - Requests: drop `num_results`; use `time_cutoff` instead of `time_cutoff_days`.
  - Responses: consume `results[].content`; do not expect `llm_facing_text`, `citation_mapping`, or `document_id`; `link` may be present.
  - CLI: `onyx-cli search` outputs `{title,url,source_type,content,updated_at}`; use `--raw` for the full response; `--limit` is removed; `--days` must be a positive integer (≤ 36500).

<sup>Written for commit 09c891852066cbef1224c79e5fcfdc39b753f13f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---

## Before / After

### Request body

```diff
 {
   "query": "...",
-  "time_cutoff_days": 30,
-  "num_results": 50,
+  "time_cutoff": "2026-01-15T00:00:00Z",
   "persona_id": 1,
   "skip_query_expansion": false
 }
```

- Removed `num_results` — the API now always uses the chat-flow-equivalent retrieval pool.
- `time_cutoff_days: int` → `time_cutoff: datetime` (ISO 8601; naive values treated as UTC server-side).

### Response body

```diff
 {
   "results": [
     {
       "citation_id": 1,
       "document_id": "doc-abc",
-      "chunk_ind": 4,
       "title": "Onboarding guide",
-      "blurb": "Short snippet...",
+      "content": "...full chunk text the LLM saw...",
       "link": "https://...",
       "source_type": "google_drive",
-      "score": 0.87,
       "updated_at": "2026-01-15T09:00:00"
     }
-  ],
-  "llm_facing_text": "{...JSON dump of LLM-facing entries...}",
-  "citation_mapping": {"1": "doc-abc"}
+  ]
 }
```

- Removed per-result: `chunk_ind`, `blurb`, `score`.
- Removed top-level: `llm_facing_text`, `citation_mapping` — both derivable from `results`.
- Added per-result: `content` (full chunk text — the LLM-selected section's content; consumers no longer need to parse `llm_facing_text` to recover this).

### Result-list semantics

- **Before:** `results` was sourced from `SearchDocsResponse.displayed_docs or search_docs` — falling back to the raw retrieval pool when the LLM selected nothing. Consumers had to choose between `blurb` (short snippet) and parsing `llm_facing_text` (full content).
- **After:** `results` is built directly from the LLM-facing JSON — one entry per LLM-selected merged section, each carrying its own full chunk content. If the LLM judged nothing relevant, the list is empty (no fallback to unselected docs).
- **Multi-section-per-doc:** when the LLM selects multiple non-overlapping sections of one long document, the API now returns one result per section (same `document_id`, distinct `content`). The previous code had a join bug that clobbered the earlier section's content when this happened.
