### PR TITLE
feat(skills): deliver built-ins via S3 Files in K8s sandboxes

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -374,9 +374,22 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     from onyx.server.features.build.skills.builtins_registration import (
         register_craft_builtins,
     )
+    from onyx.skills.backends import bootstrap_builtins_to_backend
+    from onyx.skills.backends import get_skills_backend
     from onyx.skills.registry import BuiltinSkillRegistry
 
     register_craft_builtins(BuiltinSkillRegistry.instance())
+    # Mirror built-ins to the active skills backend (S3 Files in K8s
+    # deployments, no-op when SKILLS_S3_BUCKET is unset). Boot is
+    # best-effort — a failure here shouldn't keep api_server down; sandbox
+    # sessions degrade to "no /skills/ mount available" until next restart.
+    try:
+        bootstrap_builtins_to_backend(
+            registry=BuiltinSkillRegistry.instance(),
+            backend=get_skills_backend(),
+        )
+    except Exception as e:
+        logger.error("Failed to bootstrap skills backend: %s", e, exc_info=True)
 
     if not MULTI_TENANT:
         # don't emit a metric for every pod rollover/restart

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -104,6 +104,31 @@ ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 SANDBOX_API_SERVER_URL = os.environ.get("SANDBOX_API_SERVER_URL", "")
 
 # ============================================================================
+# Skills delivery — S3 Files backend (Kubernetes only)
+#
+# When SKILLS_S3_BUCKET is set, api_server mirrors built-in skills to the
+# bucket at startup and sandbox pods mount the bucket as NFSv4 via the
+# aws-efs-csi-driver. Leave the bucket empty for local/dev or docker-compose
+# — the materializer reads from SKILLS_TEMPLATE_PATH directly in those modes.
+#
+# See docs/craft/features/skills/skills_plan.md §"Three-backend architecture".
+# ============================================================================
+
+# Bucket holding skill files. Versioning must be enabled (S3 Files requirement).
+# Naming convention: onyx-skills-{cluster}.
+SKILLS_S3_BUCKET = os.environ.get("SKILLS_S3_BUCKET", "")
+
+# Optional key prefix inside the bucket. Used by shared dev buckets to
+# isolate per-developer scratch space, e.g. "dev/alice/". Production
+# leaves this empty so writes land under tenants/<id>/ at the bucket root.
+SKILLS_S3_PREFIX = os.environ.get("SKILLS_S3_PREFIX", "")
+
+# File system ID (fs-XXXX) used by sandbox pods to mount /skills via
+# efs.csi.aws.com. Empty disables CSI injection — api_server still mirrors
+# bytes to S3, but pods won't get a /skills/ mount.
+SKILLS_S3_FILES_FILE_SYSTEM_ID = os.environ.get("SKILLS_S3_FILES_FILE_SYSTEM_ID", "")
+
+# ============================================================================
 # SSE Streaming Configuration
 # ============================================================================
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -66,6 +66,7 @@ from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
 from onyx.server.features.build.configs import SANDBOX_S3_BUCKET
 from onyx.server.features.build.configs import SANDBOX_SERVICE_ACCOUNT_NAME
+from onyx.server.features.build.configs import SKILLS_S3_FILES_FILE_SYSTEM_ID
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client import (
     ACPEvent,
@@ -96,6 +97,8 @@ from onyx.server.features.build.sandbox.util.persona_mapping import (
 )
 from onyx.skills import SkillManifestEntry
 from onyx.skills import SkillsManifest
+from onyx.skills.backends import get_skills_backend
+from onyx.skills.backends import S3FilesSkillsBackend
 from onyx.skills.registry import BuiltinSkillRegistry
 from onyx.utils.logger import setup_logger
 
@@ -270,6 +273,59 @@ class KubernetesSandboxManager(SandboxManager):
             include_org_info=include_org_info,
         )
 
+    def _build_skills_csi_volume(
+        self, tenant_id: str
+    ) -> tuple[client.V1VolumeMount | None, client.V1Volume | None]:
+        """Return (mount, volume) for the per-tenant S3 Files CSI volume.
+
+        Returns ``(None, None)`` when the active skills backend isn't S3
+        Files or the file system ID isn't configured. The materializer
+        running in the pod will emit symlinks pointing at
+        ``/skills/_builtins/<slug>`` regardless — they'll just dangle on
+        deployments without the CSI mount, which is fine: the integration
+        is opt-in per cluster.
+
+        The access point ID is resolved via ``ensure_access_point``,
+        which does a tag-based DescribeAccessPoints (creating the AP on
+        first call). AWS is the authority for that mapping — caching it
+        in Postgres would just be one more place to keep in sync.
+        """
+        if not SKILLS_S3_FILES_FILE_SYSTEM_ID:
+            return None, None
+
+        backend = get_skills_backend()
+        if not isinstance(backend, S3FilesSkillsBackend):
+            return None, None
+
+        try:
+            access_point_id = backend.ensure_access_point(tenant_id)
+        except Exception:
+            logger.exception(
+                "Failed to resolve skills access point for tenant %s; "
+                "skipping CSI mount for this pod create",
+                tenant_id,
+            )
+            return None, None
+
+        mount = client.V1VolumeMount(
+            name="skills",
+            mount_path="/skills",
+            read_only=True,
+        )
+        volume = client.V1Volume(
+            name="skills",
+            csi=client.V1CSIVolumeSource(
+                driver="efs.csi.aws.com",
+                read_only=True,
+                volume_attributes={
+                    "fileSystemId": SKILLS_S3_FILES_FILE_SYSTEM_ID,
+                    "accessPointId": access_point_id,
+                    "path": "/",
+                },
+            ),
+        )
+        return mount, volume
+
     def _create_sandbox_pod(
         self,
         sandbox_id: str,
@@ -306,17 +362,21 @@ class KubernetesSandboxManager(SandboxManager):
             client.V1EnvVar(name="ONYX_SERVER_URL", value=SANDBOX_API_SERVER_URL),
         ]
 
+        skills_mount, skills_volume = self._build_skills_csi_volume(tenant_id)
+
+        sandbox_volume_mounts = [
+            client.V1VolumeMount(name="workspace", mount_path="/workspace/sessions"),
+        ]
+        if skills_mount is not None:
+            sandbox_volume_mounts.append(skills_mount)
+
         sandbox_container = client.V1Container(
             name="sandbox",
             image=self._image,
             image_pull_policy="IfNotPresent",
             ports=container_ports,
             env=sandbox_env_vars,
-            volume_mounts=[
-                client.V1VolumeMount(
-                    name="workspace", mount_path="/workspace/sessions"
-                ),
-            ],
+            volume_mounts=sandbox_volume_mounts,
             resources=client.V1ResourceRequirements(
                 requests={"cpu": "1000m", "memory": "2Gi"},
                 limits={"cpu": "2000m", "memory": "10Gi"},
@@ -346,6 +406,8 @@ class KubernetesSandboxManager(SandboxManager):
                 empty_dir=client.V1EmptyDirVolumeSource(size_limit="50Gi"),
             ),
         ]
+        if skills_volume is not None:
+            volumes.append(skills_volume)
 
         # Pod spec
         pod_spec = client.V1PodSpec(
@@ -1094,9 +1156,12 @@ fi
 
         # Build skills materialization fragment for the in-pod setup script.
         # We mirror what onyx.skills.materialize.materialize_skills does:
-        # symlink each available built-in slug to /workspace/skills/<slug> and
-        # write a .skills_manifest.json describing the materialized set.
-        # Templated built-ins are skipped in this PR (render pipeline TBD).
+        # symlink each available built-in slug to /skills/_builtins/<slug>
+        # and write a .skills_manifest.json describing the materialized set.
+        # /skills/ is the S3 Files CSI mount (read-only NFSv4) injected by
+        # _build_skills_csi_volume; deployments without the mount get
+        # dangling links, which is acceptable while Phase A infra rolls
+        # out cluster-by-cluster. Templated built-ins are skipped (P1.052).
         with get_session_with_current_tenant() as db_session:
             available_skills = BuiltinSkillRegistry.instance().list_available(
                 db_session
@@ -1118,12 +1183,11 @@ fi
             indent=2
         ).replace("'", "'\\''")
         skill_link_cmds = "\n".join(
-            f"ln -sfn /workspace/skills/{s.slug} "
-            f"{session_path}/.agents/skills/{s.slug}"
+            f"ln -sfn /skills/_builtins/{s.slug} {session_path}/.agents/skills/{s.slug}"
             for s in non_template_builtins
         )
         skills_setup = f"""
-# Materialize skills (symlinks to baked-in /workspace/skills/<slug> + manifest)
+# Materialize skills (symlinks to /skills/_builtins/<slug> via S3 Files CSI mount + manifest)
 mkdir -p {session_path}/.agents/skills
 {skill_link_cmds}
 printf '%s' '{skills_manifest_json_escaped}' > {session_path}/.agents/skills/.skills_manifest.json

--- a/backend/onyx/skills/backends/__init__.py
+++ b/backend/onyx/skills/backends/__init__.py
@@ -1,0 +1,143 @@
+"""Skills delivery backends.
+
+Today only the S3 Files backend is wired up — local/dev and
+docker-compose deployments keep using ``SKILLS_TEMPLATE_PATH`` for the
+host-symlink path that upstream's materializer already targets. Adding
+a FilesystemSkillsBackend later for those modes is a clean addition
+because the protocol is independent of the backing store.
+
+Public API:
+    SkillsBackend, SkillFile, SkillsManifestEntry — types
+    S3FilesSkillsBackend                          — the K8s backend
+    get_skills_backend                            — singleton (or None)
+    bootstrap_builtins_to_backend                 — startup hook
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from threading import Lock
+
+from onyx.server.features.build.configs import SKILLS_S3_BUCKET
+from onyx.server.features.build.configs import SKILLS_S3_FILES_FILE_SYSTEM_ID
+from onyx.server.features.build.configs import SKILLS_S3_PREFIX
+from onyx.skills.backends.base import SkillFile
+from onyx.skills.backends.base import SkillsBackend
+from onyx.skills.backends.base import SkillsManifestEntry
+from onyx.skills.backends.s3_files import S3FilesSkillsBackend
+from onyx.skills.registry import BuiltinSkill
+from onyx.skills.registry import BuiltinSkillRegistry
+from onyx.utils.logger import setup_logger
+
+__all__ = [
+    "SkillFile",
+    "SkillsBackend",
+    "SkillsManifestEntry",
+    "S3FilesSkillsBackend",
+    "get_skills_backend",
+    "reset_skills_backend",
+    "bootstrap_builtins_to_backend",
+    "read_skill_tree_from_disk",
+]
+
+logger = setup_logger()
+
+_backend: SkillsBackend | None = None
+_backend_resolved: bool = False
+_backend_lock = Lock()
+
+
+def get_skills_backend() -> SkillsBackend | None:
+    """Return the active backend, or ``None`` when not configured.
+
+    Local/dev and docker-compose deployments leave ``SKILLS_S3_BUCKET``
+    empty and get ``None`` here. Callers (api_server startup, K8s pod
+    create) treat ``None`` as "no backend to bootstrap / no CSI mount to
+    inject" and silently fall back to upstream's host-symlink path.
+    """
+    global _backend, _backend_resolved
+    if not _backend_resolved:
+        with _backend_lock:
+            if not _backend_resolved:
+                _backend = _build_backend()
+                _backend_resolved = True
+    return _backend
+
+
+def reset_skills_backend() -> None:
+    """For tests."""
+    global _backend, _backend_resolved
+    with _backend_lock:
+        _backend = None
+        _backend_resolved = False
+
+
+def _build_backend() -> SkillsBackend | None:
+    if not SKILLS_S3_BUCKET:
+        return None
+    return S3FilesSkillsBackend(
+        bucket=SKILLS_S3_BUCKET,
+        key_prefix=SKILLS_S3_PREFIX,
+        file_system_id=SKILLS_S3_FILES_FILE_SYSTEM_ID or None,
+    )
+
+
+def read_skill_tree_from_disk(source_dir: Path) -> list[SkillFile]:
+    """Walk a source skill dir and return all files as ``SkillFile`` entries.
+
+    Used by ``bootstrap_builtins_to_backend`` to upload built-ins from
+    the codebase to the backend. Skips dotfiles and ``__pycache__``
+    anywhere in the tree but keeps everything else byte-for-byte.
+    """
+    out: list[SkillFile] = []
+    for child in sorted(source_dir.rglob("*")):
+        if not child.is_file():
+            continue
+        rel = child.relative_to(source_dir)
+        if any(part.startswith(".") or part == "__pycache__" for part in rel.parts):
+            continue
+        out.append(SkillFile(relative_path=rel.as_posix(), content=child.read_bytes()))
+    return out
+
+
+def bootstrap_builtins_to_backend(
+    registry: BuiltinSkillRegistry,
+    backend: SkillsBackend | None,
+) -> None:
+    """Write every registered built-in to the active backend.
+
+    No-op when ``backend`` is ``None`` (no S3 configured) — local/dev
+    deployments don't need this because the materializer there reads
+    from the host filesystem directly.
+
+    Idempotent: ``write_builtin`` re-PUTs the same bytes on every restart,
+    which is a no-op semantically. We deliberately don't filter on
+    ``is_available(db)`` here — admins need to *see* an image-generation
+    skill exists even on tenants without a provider configured;
+    availability filtering happens at materialization time.
+    """
+    if backend is None:
+        return
+
+    builtins: list[BuiltinSkill] = registry.list_all()
+    for skill in builtins:
+        try:
+            files = read_skill_tree_from_disk(skill.source_dir)
+            if not files:
+                logger.warning(
+                    "Built-in skill %s has no files on disk at %s — skipping",
+                    skill.slug,
+                    skill.source_dir,
+                )
+                continue
+            backend.write_builtin(skill.slug, files)
+            logger.info(
+                "Mirrored built-in skill %s (%d files) to skills backend",
+                skill.slug,
+                len(files),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to mirror built-in skill %s to skills backend", skill.slug
+            )
+            raise

--- a/backend/onyx/skills/backends/base.py
+++ b/backend/onyx/skills/backends/base.py
@@ -1,0 +1,99 @@
+"""Common types and the ``SkillsBackend`` protocol.
+
+A skills backend is the bridge between *where api_server writes* and
+*what the sandbox reads*. Today only the S3 Files backend is implemented
+(Kubernetes-only deployments); the protocol lives in its own module so
+adding Docker-volume or local-symlink backends later doesn't churn
+imports.
+
+The protocol is intentionally minimal: writes are idempotent (re-writing
+the same bytes is a no-op semantically), and reads are not modeled — the
+sandbox-side read path is the filesystem the deployment mode exposes at
+``/skills/`` (e.g. CSI mount), so the read path lives in the materializer,
+not here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol
+
+from pydantic import BaseModel
+
+
+class SkillFile(BaseModel):
+    """A single file in a skill tree.
+
+    ``relative_path`` is forward-slash-separated, relative to the skill
+    root (e.g. ``"SKILL.md"`` or ``"scripts/render.py"``). Symlinks,
+    dotted traversal, and absolute paths are rejected by
+    ``validate_skill_files`` so a buggy caller can't escape the skill
+    root via a backend write.
+    """
+
+    relative_path: str
+    content: bytes
+
+
+class SkillsManifestEntry(BaseModel):
+    """One row in the per-tenant ``_manifest.json``.
+
+    Built-ins are not listed in the per-tenant manifest (they're
+    discovered by ls on ``_builtins/``); customs are.
+    """
+
+    slug: str
+    name: str
+    description: str
+    bundle_sha256: str
+
+
+def _validate_relative_path(relative_path: str) -> None:
+    if not relative_path:
+        raise ValueError("skill file relative_path is empty")
+    if relative_path.startswith("/") or "\\" in relative_path:
+        raise ValueError(f"skill file relative_path is not relative: {relative_path!r}")
+    if any(part in ("", ".", "..") for part in relative_path.split("/")):
+        raise ValueError(f"skill file relative_path is traversal: {relative_path!r}")
+
+
+def validate_skill_files(files: Iterable[SkillFile]) -> list[SkillFile]:
+    """Materialize the iterable once and validate every path. Returns a
+    fresh list so callers can iterate twice (size check + write)."""
+    materialized = list(files)
+    for f in materialized:
+        _validate_relative_path(f.relative_path)
+    return materialized
+
+
+class SkillsBackend(Protocol):
+    """How api_server delivers skill files to sandboxes.
+
+    All write methods are idempotent: calling them twice with the same
+    inputs is a no-op (or a content-equivalent overwrite). Implementations
+    are responsible for atomicity within a single skill — partially-written
+    skill trees must never be visible to readers.
+    """
+
+    def write_builtin(self, slug: str, files: Iterable[SkillFile]) -> None:
+        """Write a built-in skill tree under ``_builtins/<slug>/``."""
+        ...
+
+    def write_custom(
+        self, tenant_id: str, slug: str, files: Iterable[SkillFile]
+    ) -> None:
+        """Write a custom skill tree under ``tenants/<tenant_id>/_custom/<slug>/``."""
+        ...
+
+    def delete_custom(self, tenant_id: str, slug: str) -> None:
+        """Remove a custom skill tree. No-op if missing."""
+        ...
+
+    def write_manifest(
+        self,
+        tenant_id: str,
+        builtin: Iterable[SkillsManifestEntry],
+        custom: Iterable[SkillsManifestEntry],
+    ) -> None:
+        """Replace the per-tenant manifest atomically."""
+        ...

--- a/backend/onyx/skills/backends/s3_files.py
+++ b/backend/onyx/skills/backends/s3_files.py
@@ -1,0 +1,251 @@
+"""S3 Files backend (Amazon S3 + S3 Files NFSv4 mount).
+
+api_server writes skill bytes into the bucket via the S3 API. Sandbox
+pods mount the same bucket as NFSv4 via the ``aws-efs-csi-driver`` and
+read from ``/skills/`` directly. Per-tenant isolation is enforced by
+S3 Files **access points** scoped to ``tenants/<tenant_id>/`` — each
+sandbox pod's CSI volume references that tenant's access point ID, so
+cross-tenant reads are blocked at the NFS layer.
+
+Two boto3 clients are involved:
+- ``s3``: ``put_object`` / ``delete_object`` writes.
+- ``elasticfilesystem``: access point lifecycle. The S3 Files service
+  reuses the EFS API namespace.
+
+Naming convention enforced here:
+- bucket layout:   ``s3://onyx-skills-{cluster}/[<prefix>/]tenants/<tenant_id>/...``
+- access point:    one per tenant, root ``/tenants/<tenant_id>``
+- access point identification: tagged ``onyx-tenant-id=<uuid>`` so
+  ``ensure_access_point`` is a paginated Describe + tag filter (no DB
+  cache needed — AWS is authoritative).
+
+See docs/craft/features/skills/skills_plan.md §"How the actual cloud
+deployment is wired" for the deployment topology.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.backends.base import SkillFile
+from onyx.skills.backends.base import SkillsManifestEntry
+from onyx.skills.backends.base import validate_skill_files
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_ACCESS_POINT_TENANT_TAG = "onyx-tenant-id"
+_BUILTINS_PREFIX = "_builtins"
+
+
+class S3FilesSkillsBackend:
+    """SkillsBackend backed by an S3 Files-linked bucket.
+
+    Args:
+        bucket: S3 bucket name (e.g. ``onyx-skills-craft-dev``). Must
+            have versioning enabled (S3 Files requirement).
+        key_prefix: Optional prefix within the bucket (e.g.
+            ``dev/alice/`` for shared dev buckets). Empty in production.
+        file_system_id: Optional ``fs-XXXX`` for the S3 Files file system.
+            Required to call ``ensure_access_point``; unset when the
+            api_server is in S3-write-only mode (no CSI mount).
+        region_name: Region for the S3 + EFS clients.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        key_prefix: str = "",
+        file_system_id: str | None = None,
+        region_name: str | None = None,
+    ) -> None:
+        if not bucket:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILLS_S3_BUCKET must be set for the s3_files skills backend",
+            )
+        self._bucket = bucket
+        self._key_prefix = key_prefix.rstrip("/")
+        self._file_system_id = file_system_id
+        self._region_name = region_name
+        self._s3: Any = boto3.client("s3", region_name=region_name)
+        self._efs: Any | None = None  # lazy — only when access points used
+
+    @property
+    def bucket(self) -> str:
+        return self._bucket
+
+    @property
+    def file_system_id(self) -> str | None:
+        return self._file_system_id
+
+    # ----- key layout ---------------------------------------------------
+
+    def _key(self, *parts: str) -> str:
+        base = (self._key_prefix + "/") if self._key_prefix else ""
+        return base + "/".join(parts)
+
+    def _builtin_key(self, slug: str, relative_path: str) -> str:
+        return self._key(_BUILTINS_PREFIX, slug, relative_path)
+
+    def _custom_key(self, tenant_id: str, slug: str, relative_path: str) -> str:
+        return self._key("tenants", tenant_id, "_custom", slug, relative_path)
+
+    def _manifest_key(self, tenant_id: str) -> str:
+        return self._key("tenants", tenant_id, "_manifest.json")
+
+    # ----- writes -------------------------------------------------------
+
+    def write_builtin(self, slug: str, files: Iterable[SkillFile]) -> None:
+        validated = validate_skill_files(files)
+        for f in validated:
+            self._put_object(self._builtin_key(slug, f.relative_path), f.content)
+
+    def write_custom(
+        self, tenant_id: str, slug: str, files: Iterable[SkillFile]
+    ) -> None:
+        validated = validate_skill_files(files)
+        for f in validated:
+            self._put_object(
+                self._custom_key(tenant_id, slug, f.relative_path), f.content
+            )
+
+    def delete_custom(self, tenant_id: str, slug: str) -> None:
+        prefix = self._key("tenants", tenant_id, "_custom", slug) + "/"
+        self._delete_prefix(prefix)
+
+    def write_manifest(
+        self,
+        tenant_id: str,
+        builtin: Iterable[SkillsManifestEntry],
+        custom: Iterable[SkillsManifestEntry],
+    ) -> None:
+        payload = json.dumps(
+            {
+                "builtin": [entry.model_dump(mode="json") for entry in builtin],
+                "custom": [entry.model_dump(mode="json") for entry in custom],
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        self._put_object(self._manifest_key(tenant_id), payload)
+
+    # ----- access points ------------------------------------------------
+
+    def ensure_access_point(self, tenant_id: str) -> str:
+        """Return the access point ID for ``tenant_id``, creating it on
+        first call.
+
+        Tag-keyed lookup so this is idempotent across api_server restarts
+        without any local state. AWS is the authority — if we ever cached
+        the mapping in Postgres we'd just be adding a place to keep in
+        sync. For latency, callers can wrap this in an LRU if pod create
+        ever becomes hot path (it currently isn't).
+        """
+        if not self._file_system_id:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "SKILLS_S3_FILES_FILE_SYSTEM_ID is required to manage access points",
+            )
+
+        existing = self._find_access_point(tenant_id)
+        if existing is not None:
+            return existing
+
+        efs = self._get_efs_client()
+        try:
+            resp = efs.create_access_point(
+                FileSystemId=self._file_system_id,
+                ClientToken=f"onyx-skills-{tenant_id}",
+                RootDirectory={
+                    "Path": f"/tenants/{tenant_id}",
+                    "CreationInfo": {
+                        "OwnerUid": 1000,
+                        "OwnerGid": 1000,
+                        "Permissions": "0755",
+                    },
+                },
+                PosixUser={"Uid": 1000, "Gid": 1000},
+                Tags=[
+                    {"Key": _ACCESS_POINT_TENANT_TAG, "Value": tenant_id},
+                    {"Key": "managed-by", "Value": "onyx-skills"},
+                ],
+            )
+        except ClientError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"failed to create access point for tenant {tenant_id}: {e}",
+            ) from e
+
+        return str(resp["AccessPointId"])
+
+    def delete_access_point(self, access_point_id: str) -> None:
+        """Best-effort delete. Non-existent APs are treated as success so
+        the caller can blindly clean up on tenant teardown."""
+        efs = self._get_efs_client()
+        try:
+            efs.delete_access_point(AccessPointId=access_point_id)
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "")
+            if code in ("AccessPointNotFound", "FileSystemNotFound"):
+                return
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"failed to delete access point {access_point_id}: {e}",
+            ) from e
+
+    def _find_access_point(self, tenant_id: str) -> str | None:
+        efs = self._get_efs_client()
+        try:
+            paginator = efs.get_paginator("describe_access_points")
+            for page in paginator.paginate(FileSystemId=self._file_system_id):
+                for ap in page.get("AccessPoints", []) or []:
+                    tags = {t["Key"]: t["Value"] for t in ap.get("Tags", []) or []}
+                    if tags.get(_ACCESS_POINT_TENANT_TAG) == tenant_id:
+                        return str(ap["AccessPointId"])
+        except ClientError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"failed to look up access point for tenant {tenant_id}: {e}",
+            ) from e
+        return None
+
+    def _get_efs_client(self) -> Any:
+        if self._efs is None:
+            self._efs = boto3.client("efs", region_name=self._region_name)
+        return self._efs
+
+    # ----- s3 helpers ---------------------------------------------------
+
+    def _put_object(self, key: str, body: bytes) -> None:
+        try:
+            self._s3.put_object(Bucket=self._bucket, Key=key, Body=body)
+        except ClientError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"failed to write s3://{self._bucket}/{key}: {e}",
+            ) from e
+
+    def _delete_prefix(self, prefix: str) -> None:
+        paginator = self._s3.get_paginator("list_objects_v2")
+        try:
+            for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+                contents = page.get("Contents") or []
+                if not contents:
+                    continue
+                self._s3.delete_objects(
+                    Bucket=self._bucket,
+                    Delete={"Objects": [{"Key": e["Key"]} for e in contents]},
+                )
+        except ClientError as e:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"failed to delete s3://{self._bucket}/{prefix}*: {e}",
+            ) from e

--- a/backend/tests/unit/onyx/skills/test_s3_files_backend.py
+++ b/backend/tests/unit/onyx/skills/test_s3_files_backend.py
@@ -1,0 +1,142 @@
+"""Unit tests for the S3 Files backend.
+
+We mock boto3 rather than pull in ``moto`` as a test dep — the surface
+we need to validate is the key layout and the access-point lookup
+semantics, both of which are pure call-shape assertions.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.skills.backends.base import SkillFile
+from onyx.skills.backends.s3_files import S3FilesSkillsBackend
+
+
+@pytest.fixture
+def fake_s3() -> MagicMock:
+    client = MagicMock()
+    client.get_paginator.return_value.paginate.return_value = []
+    return client
+
+
+@pytest.fixture
+def fake_efs() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def backend(fake_s3: MagicMock, fake_efs: MagicMock) -> Iterator[S3FilesSkillsBackend]:
+    with patch("onyx.skills.backends.s3_files.boto3") as boto3_mock:
+        boto3_mock.client.side_effect = lambda name, **_: (
+            fake_s3 if name == "s3" else fake_efs
+        )
+        yield S3FilesSkillsBackend(
+            bucket="skills-bucket",
+            file_system_id="fs-1234",
+            region_name="us-west-2",
+        )
+
+
+def test_write_builtin_uses_builtins_prefix(
+    backend: S3FilesSkillsBackend, fake_s3: MagicMock
+) -> None:
+    backend.write_builtin(
+        "pptx", [SkillFile(relative_path="SKILL.md", content=b"# pptx")]
+    )
+    fake_s3.put_object.assert_called_once_with(
+        Bucket="skills-bucket",
+        Key="_builtins/pptx/SKILL.md",
+        Body=b"# pptx",
+    )
+
+
+def test_write_custom_uses_tenant_scoped_key(
+    backend: S3FilesSkillsBackend, fake_s3: MagicMock
+) -> None:
+    backend.write_custom(
+        "tenant-a",
+        "my-skill",
+        [SkillFile(relative_path="scripts/run.sh", content=b"#!/bin/sh")],
+    )
+    fake_s3.put_object.assert_called_once_with(
+        Bucket="skills-bucket",
+        Key="tenants/tenant-a/_custom/my-skill/scripts/run.sh",
+        Body=b"#!/bin/sh",
+    )
+
+
+def test_key_prefix_applied_to_all_writes(
+    fake_s3: MagicMock, fake_efs: MagicMock
+) -> None:
+    with patch("onyx.skills.backends.s3_files.boto3") as boto3_mock:
+        boto3_mock.client.side_effect = lambda name, **_: (
+            fake_s3 if name == "s3" else fake_efs
+        )
+        b = S3FilesSkillsBackend(
+            bucket="dev-bucket",
+            key_prefix="dev/alice",
+            file_system_id="fs-1234",
+        )
+        b.write_builtin("pptx", [SkillFile(relative_path="SKILL.md", content=b"x")])
+    fake_s3.put_object.assert_called_once_with(
+        Bucket="dev-bucket",
+        Key="dev/alice/_builtins/pptx/SKILL.md",
+        Body=b"x",
+    )
+
+
+def test_ensure_access_point_returns_existing_match(
+    backend: S3FilesSkillsBackend, fake_efs: MagicMock
+) -> None:
+    fake_efs.get_paginator.return_value.paginate.return_value = [
+        {
+            "AccessPoints": [
+                {
+                    "AccessPointId": "fsap-existing",
+                    "Tags": [
+                        {"Key": "onyx-tenant-id", "Value": "tenant-a"},
+                    ],
+                }
+            ]
+        }
+    ]
+
+    ap_id = backend.ensure_access_point("tenant-a")
+    assert ap_id == "fsap-existing"
+    fake_efs.create_access_point.assert_not_called()
+
+
+def test_ensure_access_point_creates_when_missing(
+    backend: S3FilesSkillsBackend, fake_efs: MagicMock
+) -> None:
+    fake_efs.get_paginator.return_value.paginate.return_value = [{"AccessPoints": []}]
+    fake_efs.create_access_point.return_value = {"AccessPointId": "fsap-new"}
+
+    ap_id = backend.ensure_access_point("tenant-a")
+    assert ap_id == "fsap-new"
+    call: dict[str, Any] = fake_efs.create_access_point.call_args.kwargs
+    assert call["FileSystemId"] == "fs-1234"
+    assert call["RootDirectory"]["Path"] == "/tenants/tenant-a"
+    # Tag-based lookup must round-trip.
+    assert any(
+        t == {"Key": "onyx-tenant-id", "Value": "tenant-a"} for t in call["Tags"]
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "/abs/SKILL.md",
+        "../escape",
+        "scripts/../../boom",
+        "",
+        "scripts\\nope",
+    ],
+)
+def test_rejects_traversal_paths(backend: S3FilesSkillsBackend, bad_path: str) -> None:
+    with pytest.raises(ValueError):
+        backend.write_builtin("x", [SkillFile(relative_path=bad_path, content=b"")])


### PR DESCRIPTION
## Description

Phase B-D of the skills delivery design, K8s scope only. Wires a `SkillsBackend` abstraction (one implementation, `S3FilesSkillsBackend`) between api_server and sandbox pods so K8s deployments stop relying on the Dockerfile bake-in that upstream removed.

**New (`backend/onyx/skills/backends/`):**
- `base.py` — `SkillsBackend` Protocol, `SkillFile`, `SkillsManifestEntry`, traversal-rejecting path validation
- `s3_files.py` — `S3FilesSkillsBackend`: boto3 writes under `s3://onyx-skills-{cluster}/[<prefix>/](_builtins|tenants/<id>/_custom)/<slug>/`, plus `ensure_access_point(tenant_id)` that does a tag-based `DescribeAccessPoints` (creates the AP on first call, idempotent across restarts — AWS is the authority, no DB cache)
- `__init__.py` — `get_skills_backend()` returns `None` when `SKILLS_S3_BUCKET` is unset so local/dev and docker-compose keep working unchanged; `bootstrap_builtins_to_backend()` is a no-op in that case

**Modified:**
- `configs.py` — `SKILLS_S3_BUCKET`, `SKILLS_S3_PREFIX`, `SKILLS_S3_FILES_FILE_SYSTEM_ID` env vars
- `main.py` — startup bootstrap hook after `register_craft_builtins`. Best-effort: a failure logs but does not block api_server boot
- `kubernetes_sandbox_manager.py`:
  - `_build_skills_csi_volume(tenant_id)` injects an `efs.csi.aws.com` volume mounted read-only at `/skills/` using the tenant's access point ID
  - In-pod setup script symlinks `.agents/skills/<slug>` → `/skills/_builtins/<slug>` (was `/workspace/skills/<slug>`, which upstream stopped baking in)

**Out of scope:** `FilesystemSkillsBackend` / docker-volume backend (deferred), custom skill uploads, template rendering (P1.052).

## How Has This Been Tested?

- 53 unit tests pass (`uv run pytest tests/unit/onyx/skills/`), covering S3 key layout (with and without prefix), access-point lookup/create call shapes, and path-traversal rejection
- Import + factory wiring sanity-checked end-to-end via `python -c "import onyx.main"` with `SKILLS_S3_BUCKET` unset — backend resolves to `None`, no AWS calls fire
- Manual cluster validation is intentionally deferred to the Phase A spike in `cloud-deployment-yamls` (S3 Files file system + mount targets + CSI driver), per the plan

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delivers built-in skills to Kubernetes sandboxes via S3 Files. Adds `S3FilesSkillsBackend` that mirrors built-ins to S3 and mounts a read-only /skills in pods, replacing the removed Dockerfile bake-in; opt-in via env vars, local/dev unchanged.

- **New Features**
  - New `onyx.skills.backends` protocol with path-traversal validation; resolves to `None` when `SKILLS_S3_BUCKET` is unset.
  - `S3FilesSkillsBackend`: S3 writes under `_builtins/` and `tenants/<id>/_custom/`; per-tenant access points are created/looked up idempotently.
  - api_server startup mirrors built-ins to the backend (best effort, non-blocking).
  - K8s pods get an `efs.csi.aws.com` volume at `/skills` using the tenant’s access point; symlinks now point `.agents/skills/<slug>` → `/skills/_builtins/<slug>`. New envs: `SKILLS_S3_BUCKET`, `SKILLS_S3_PREFIX`, `SKILLS_S3_FILES_FILE_SYSTEM_ID`.

- **Migration**
  - Kubernetes only: enable S3 Files, install `aws-efs-csi-driver`, use a versioned S3 bucket, and set the envs above (leave unset to keep current behavior). Ensure IAM allows `efs:DescribeAccessPoints/CreateAccessPoint/DeleteAccessPoint` and `s3:PutObject/DeleteObject`.

<sup>Written for commit 630a3518812f97f93286d5d50820e9af0353cf90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

