### PR TITLE
feat(open_url): add OPEN_URL_VALIDATE_SSRF opt-out for trusted networks

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -656,6 +656,15 @@ OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED = (
     os.environ.get("OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED", "true").lower() == "true"
 )
 
+# Whether the open_url tool enforces SSRF protection (rejecting URLs that
+# resolve to private/internal IPs). Default true to keep multi-tenant SaaS
+# safe. Self-hosted operators on trusted networks (e.g. internal docs that
+# resolve to RFC1918 addresses via split-horizon DNS) can set to false to
+# allow fetching from private ranges.
+OPEN_URL_VALIDATE_SSRF = (
+    os.environ.get("OPEN_URL_VALIDATE_SSRF", "true").lower() == "true"
+)
+
 HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY = os.environ.get(
     "HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY",
     HtmlBasedConnectorTransformLinksStrategy.STRIP,

--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 import requests
 
 from onyx.configs.app_configs import OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED
+from onyx.configs.app_configs import OPEN_URL_VALIDATE_SSRF
 from onyx.file_processing.html_utils import ParsedHTML
 from onyx.file_processing.html_utils import web_html_cleanup
 from onyx.tools.tool_implementations.open_url.models import WebContent
@@ -170,12 +171,14 @@ class OnyxWebCrawler(WebContentProvider):
         max_pdf_size_bytes: int | None = None,
         max_html_size_bytes: int | None = None,
         playwright_fallback_enabled: bool = OPEN_URL_PLAYWRIGHT_FALLBACK_ENABLED,
+        validate_ssrf: bool = OPEN_URL_VALIDATE_SSRF,
     ) -> None:
         self._read_timeout_seconds = timeout_seconds
         self._connect_timeout_seconds = connect_timeout_seconds
         self._max_pdf_size_bytes = max_pdf_size_bytes
         self._max_html_size_bytes = max_html_size_bytes
         self._playwright_fallback_enabled = playwright_fallback_enabled
+        self._validate_ssrf = validate_ssrf
         self._headers = {
             "User-Agent": user_agent,
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -207,6 +210,7 @@ class OnyxWebCrawler(WebContentProvider):
                 url,
                 headers=self._headers,
                 timeout=(self._connect_timeout_seconds, self._read_timeout_seconds),
+                allow_private_network=not self._validate_ssrf,
             )
         except SSRFException as exc:
             logger.error(
@@ -330,7 +334,9 @@ class OnyxWebCrawler(WebContentProvider):
               or rendered HTML didn't parse to anything). Caller should fall
               back to its own status-based failure reason.
         """
-        rendered: RenderedPage | None = fetch_rendered_html(url)
+        rendered: RenderedPage | None = fetch_rendered_html(
+            url, allow_private_network=not self._validate_ssrf
+        )
         if rendered is None:
             return None
 

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -237,6 +237,7 @@ def fetch_rendered_html(
     *,
     navigation_timeout_ms: int = DEFAULT_NAVIGATION_TIMEOUT_MS,
     bot_challenge_grace_ms: int = DEFAULT_BOT_CHALLENGE_GRACE_MS,
+    allow_private_network: bool = False,
 ) -> RenderedPage | None:
     """Render a single URL via headless Chromium and return the final HTML.
 
@@ -245,6 +246,10 @@ def fetch_rendered_html(
     one-shot fetches where bot-detection mitigation is needed; not the
     right tool for high-volume crawling (use a long-lived `BrowserContext`
     via `start_playwright()` instead).
+
+    When ``allow_private_network`` is True, the private-IP guard is skipped
+    so operators on trusted networks can render URLs that resolve to RFC1918
+    addresses. Scheme/credential/blocked-hostname checks still apply.
 
     Returns:
         RenderedPage on success, or None if navigation failed entirely
@@ -258,7 +263,7 @@ def fetch_rendered_html(
     # small TOCTOU window between validation and the actual navigation, the
     # same window that ssrf_safe_get accepts for HTTPS URLs.
     try:
-        validate_outbound_http_url(url)
+        validate_outbound_http_url(url, allow_private_network=allow_private_network)
     except (SSRFException, ValueError) as exc:
         logger.warning(
             "Refusing Playwright fallback for %s (%s)", url, exc.__class__.__name__

--- a/backend/onyx/utils/playwright_fetch.py
+++ b/backend/onyx/utils/playwright_fetch.py
@@ -263,7 +263,11 @@ def fetch_rendered_html(
     # small TOCTOU window between validation and the actual navigation, the
     # same window that ssrf_safe_get accepts for HTTPS URLs.
     try:
-        validate_outbound_http_url(url, allow_private_network=allow_private_network)
+        validate_outbound_http_url(
+            url,
+            allow_private_network=allow_private_network,
+            block_loopback_and_link_local=True,
+        )
     except (SSRFException, ValueError) as exc:
         logger.warning(
             "Refusing Playwright fallback for %s (%s)", url, exc.__class__.__name__

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -193,6 +193,7 @@ def validate_outbound_http_url(
     *,
     allow_private_network: bool = False,
     https_only: bool = False,
+    block_loopback_and_link_local: bool = False,
 ) -> str:
     """
     Validate a URL that will be used by backend outbound HTTP calls.
@@ -201,6 +202,18 @@ def validate_outbound_http_url(
         url: The URL to validate.
         allow_private_network: If True, skip private/reserved IP checks.
         https_only: If True, reject http:// URLs (only https:// is allowed).
+        block_loopback_and_link_local: When ``allow_private_network=True``,
+            additionally reject URLs whose host (or DNS resolution) is in the
+            always-dangerous IP classes — loopback (127.0.0.0/8, ::1),
+            unspecified (0.0.0.0, ::), and link-local (169.254.0.0/16,
+            fe80::/10, which contains cloud-metadata endpoints). Default
+            False to preserve behavior for admin-configured callers (voice
+            API, sharepoint, hooks) where the operator typed the URL
+            themselves and reaching a local container at 127.0.0.1 is a
+            feature. Pass True for LLM-controlled paths like ``open_url``
+            where prompt-supplied URLs need a stricter floor regardless of
+            the network opt-out. No-op when ``allow_private_network=False``,
+            since the standard private-IP guard already covers these.
 
     Returns:
         A normalized URL string with surrounding whitespace removed.
@@ -235,21 +248,14 @@ def validate_outbound_http_url(
     if hostname in BLOCKED_HOSTNAMES:
         raise SSRFException(f"Access to hostname '{parsed.hostname}' is not allowed.")
 
-    # Loopback (127.0.0.0/8, ::1), unspecified (0.0.0.0, ::), and link-local
-    # (169.254.0.0/16, fe80::/10) addresses are *always* blocked, even when
-    # allow_private_network=True. Opting into private networks means RFC1918
-    # services in the operator's VPC — never the application host's own
-    # loopback (admin APIs, sidecars) or the cloud-metadata endpoints
-    # (IAM credential exfiltration on AWS/GCP/Azure GovCloud, etc.).
-    try:
-        ip_obj = ipaddress.ip_address(hostname)
-    except ValueError:
-        # Hostname is a DNS name. On the opt-out path, _validate_and_resolve_url
-        # would otherwise be skipped — but the always-blocked floor still
-        # needs to apply, or names like `loopback.attacker.com` → 127.0.0.1
-        # or `imds.attacker.com` → 169.254.169.254 would slip through. RFC1918
-        # results stay allowed since opting in is the whole point of the flag.
-        if allow_private_network:
+    if allow_private_network and block_loopback_and_link_local:
+        # Loopback / unspecified / link-local addresses are always rejected
+        # on this path even when private networks are otherwise allowed.
+        # Applies to both IP literals and DNS names — closes the cloud-
+        # metadata SSRF surface and the "DNS rebinding to loopback" surface.
+        try:
+            ip_obj = ipaddress.ip_address(hostname)
+        except ValueError:
             blocked_ip = _hostname_resolves_to_always_blocked_ip(hostname)
             if blocked_ip is not None:
                 raise SSRFException(
@@ -257,12 +263,12 @@ def validate_outbound_http_url(
                     f"unspecified/link-local IP '{blocked_ip}'. Access is "
                     f"not allowed."
                 )
-    else:
-        if _is_always_blocked_ip(ip_obj):
-            raise SSRFException(
-                f"Access to loopback/unspecified/link-local IP "
-                f"'{parsed.hostname}' is not allowed."
-            )
+        else:
+            if _is_always_blocked_ip(ip_obj):
+                raise SSRFException(
+                    f"Access to loopback/unspecified/link-local IP "
+                    f"'{parsed.hostname}' is not allowed."
+                )
 
     if not allow_private_network:
         _validate_and_resolve_url(normalized_url)
@@ -288,10 +294,17 @@ def _make_ssrf_safe_request(
     When ``allow_private_network`` is True, the private-IP guard is skipped
     so operators on trusted networks can fetch URLs that resolve to RFC1918
     addresses (e.g. internal docs sites behind split-horizon DNS). Scheme,
-    credential, and blocked-hostname checks still apply.
+    credential, and blocked-hostname checks still apply, and the always-
+    dangerous IP classes (loopback / unspecified / link-local, which contains
+    cloud-metadata endpoints) remain blocked on this path since callers are
+    LLM-controlled and need a stricter floor than admin-configured paths.
     """
     if allow_private_network:
-        validate_outbound_http_url(url, allow_private_network=True)
+        validate_outbound_http_url(
+            url,
+            allow_private_network=True,
+            block_loopback_and_link_local=True,
+        )
         return requests.get(
             url,
             headers=headers,

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -200,13 +200,29 @@ def _make_ssrf_safe_request(
     url: str,
     headers: dict[str, str] | None = None,
     timeout: float | tuple[float, float] = 15,
+    allow_private_network: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
     Make a single GET request with SSRF protection (no redirect following).
 
     Returns the response which may be a redirect (3xx status).
+
+    When ``allow_private_network`` is True, the private-IP guard is skipped
+    so operators on trusted networks can fetch URLs that resolve to RFC1918
+    addresses (e.g. internal docs sites behind split-horizon DNS). Scheme,
+    credential, and blocked-hostname checks still apply.
     """
+    if allow_private_network:
+        validate_outbound_http_url(url, allow_private_network=True)
+        return requests.get(
+            url,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=False,
+            **kwargs,
+        )
+
     # Validate and resolve the URL to get a safe IP
     validated_ip, original_hostname, port = _validate_and_resolve_url(url)
 
@@ -259,6 +275,7 @@ def ssrf_safe_get(
     headers: dict[str, str] | None = None,
     timeout: float | tuple[float, float] = 15,
     follow_redirects: bool = True,
+    allow_private_network: bool = False,
     **kwargs: Any,
 ) -> requests.Response:
     """
@@ -273,6 +290,10 @@ def ssrf_safe_get(
         headers: Optional headers to include in the request
         timeout: Request timeout in seconds
         follow_redirects: Whether to follow redirects (each redirect URL is validated)
+        allow_private_network: If True, allow URLs that resolve to private/internal
+            IPs. Use only when the operator has explicitly opted in (e.g. trusted
+            self-hosted deployment fetching internal docs). Scheme, credential, and
+            blocked-hostname checks still apply on each hop.
         **kwargs: Additional arguments passed to requests.get()
 
     Returns:
@@ -283,7 +304,13 @@ def ssrf_safe_get(
         ValueError: If the URL is malformed
         requests.RequestException: If the request fails
     """
-    response = _make_ssrf_safe_request(url, headers, timeout, **kwargs)
+    response = _make_ssrf_safe_request(
+        url,
+        headers,
+        timeout,
+        allow_private_network=allow_private_network,
+        **kwargs,
+    )
 
     if not follow_redirects:
         return response
@@ -314,7 +341,13 @@ def ssrf_safe_get(
 
         # Validate and follow the redirect (this will raise SSRFException if invalid)
         current_url = redirect_url
-        response = _make_ssrf_safe_request(redirect_url, headers, timeout, **kwargs)
+        response = _make_ssrf_safe_request(
+            redirect_url,
+            headers,
+            timeout,
+            allow_private_network=allow_private_network,
+            **kwargs,
+        )
 
     if response.is_redirect and redirect_count >= MAX_REDIRECTS:
         raise SSRFException(f"Too many redirects (max {MAX_REDIRECTS})")

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -57,14 +57,31 @@ def _is_ip_private_or_reserved(ip_str: str) -> bool:
         return True
 
 
-def _hostname_resolves_to_always_blocked_ip(hostname: str) -> str | None:
-    """Resolve ``hostname`` via DNS and return the first address that is
-    loopback or unspecified, or None if none of them are.
+def _is_always_blocked_ip(
+    ip_obj: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """True if ``ip_obj`` falls into a class that must be blocked even when
+    private networks are otherwise allowed.
 
-    Used on the ``allow_private_network=True`` path to maintain the loopback
-    floor for DNS names — a hostname like ``loopback.attacker.com`` that
-    resolves to ``127.0.0.1`` must not be reachable just because private
-    networks are otherwise allowed. RFC1918 / link-local results are
+    - Loopback (127.0.0.0/8, ::1): the application host's own loopback.
+      Reaching it exposes admin APIs, sidecars, etc.
+    - Unspecified (0.0.0.0, ::): commonly aliased to loopback by the kernel.
+    - Link-local (169.254.0.0/16, fe80::/10): cloud-metadata endpoints
+      (169.254.169.254 on AWS/GCP/Azure) live here. Opting into RFC1918
+      should NEVER open up IMDS — that's a credential exfiltration path.
+    """
+    return ip_obj.is_loopback or ip_obj.is_unspecified or ip_obj.is_link_local
+
+
+def _hostname_resolves_to_always_blocked_ip(hostname: str) -> str | None:
+    """Resolve ``hostname`` via DNS and return the first address in an
+    always-blocked class (loopback / unspecified / link-local), or None.
+
+    Used on the ``allow_private_network=True`` path to maintain the
+    always-blocked floor for DNS names — e.g. an attacker-controlled
+    record like ``loopback.attacker.com`` → 127.0.0.1, or
+    ``imds.attacker.com`` → 169.254.169.254, must not be reachable just
+    because private networks are otherwise allowed. RFC1918 results are
     *not* flagged here; opting into those is the whole point of the flag.
 
     Returns None on DNS failure — the actual request will fail naturally
@@ -83,7 +100,7 @@ def _hostname_resolves_to_always_blocked_ip(hostname: str) -> str | None:
             ip_obj = ipaddress.ip_address(ip_str)
         except ValueError:
             continue
-        if ip_obj.is_loopback or ip_obj.is_unspecified:
+        if _is_always_blocked_ip(ip_obj):
             return ip_str
     return None
 
@@ -218,31 +235,33 @@ def validate_outbound_http_url(
     if hostname in BLOCKED_HOSTNAMES:
         raise SSRFException(f"Access to hostname '{parsed.hostname}' is not allowed.")
 
-    # Loopback (127.0.0.0/8, ::1) and unspecified (0.0.0.0, ::) addresses
-    # are *always* blocked, even when allow_private_network=True. Opting into
-    # private networks means RFC1918 / link-local services in the operator's
-    # VPC — never the application host's own loopback, which would expose
-    # admin APIs, sidecars, etc. running on the same machine.
+    # Loopback (127.0.0.0/8, ::1), unspecified (0.0.0.0, ::), and link-local
+    # (169.254.0.0/16, fe80::/10) addresses are *always* blocked, even when
+    # allow_private_network=True. Opting into private networks means RFC1918
+    # services in the operator's VPC — never the application host's own
+    # loopback (admin APIs, sidecars) or the cloud-metadata endpoints
+    # (IAM credential exfiltration on AWS/GCP/Azure GovCloud, etc.).
     try:
         ip_obj = ipaddress.ip_address(hostname)
     except ValueError:
         # Hostname is a DNS name. On the opt-out path, _validate_and_resolve_url
-        # would otherwise be skipped — but the always-blocked floor still needs
-        # to apply, or a name like `loopback.attacker.com` resolving to
-        # 127.0.0.1 would slip through. RFC1918/link-local results stay
-        # allowed since opting in is the whole point of the flag.
+        # would otherwise be skipped — but the always-blocked floor still
+        # needs to apply, or names like `loopback.attacker.com` → 127.0.0.1
+        # or `imds.attacker.com` → 169.254.169.254 would slip through. RFC1918
+        # results stay allowed since opting in is the whole point of the flag.
         if allow_private_network:
             blocked_ip = _hostname_resolves_to_always_blocked_ip(hostname)
             if blocked_ip is not None:
                 raise SSRFException(
                     f"Hostname '{parsed.hostname}' resolves to loopback/"
-                    f"unspecified IP '{blocked_ip}'. Access is not allowed."
+                    f"unspecified/link-local IP '{blocked_ip}'. Access is "
+                    f"not allowed."
                 )
     else:
-        if ip_obj.is_loopback or ip_obj.is_unspecified:
+        if _is_always_blocked_ip(ip_obj):
             raise SSRFException(
-                f"Access to loopback/unspecified IP '{parsed.hostname}' "
-                f"is not allowed."
+                f"Access to loopback/unspecified/link-local IP "
+                f"'{parsed.hostname}' is not allowed."
             )
 
     if not allow_private_network:

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -187,6 +187,23 @@ def validate_outbound_http_url(
     if hostname in BLOCKED_HOSTNAMES:
         raise SSRFException(f"Access to hostname '{parsed.hostname}' is not allowed.")
 
+    # Loopback (127.0.0.0/8, ::1) and unspecified (0.0.0.0, ::) IP literals
+    # are *always* blocked, even when allow_private_network=True. Opting into
+    # private networks means RFC1918 / link-local services in the operator's
+    # VPC — never the application host's own loopback, which would expose
+    # admin APIs, sidecars, etc. running on the same machine.
+    try:
+        ip_obj = ipaddress.ip_address(hostname)
+        if ip_obj.is_loopback or ip_obj.is_unspecified:
+            raise SSRFException(
+                f"Access to loopback/unspecified IP '{parsed.hostname}' "
+                f"is not allowed."
+            )
+    except ValueError:
+        # Not an IP literal — DNS resolution handles loopback/private cases
+        # when allow_private_network=False.
+        pass
+
     if not allow_private_network:
         _validate_and_resolve_url(normalized_url)
 

--- a/backend/onyx/utils/url.py
+++ b/backend/onyx/utils/url.py
@@ -57,6 +57,37 @@ def _is_ip_private_or_reserved(ip_str: str) -> bool:
         return True
 
 
+def _hostname_resolves_to_always_blocked_ip(hostname: str) -> str | None:
+    """Resolve ``hostname`` via DNS and return the first address that is
+    loopback or unspecified, or None if none of them are.
+
+    Used on the ``allow_private_network=True`` path to maintain the loopback
+    floor for DNS names — a hostname like ``loopback.attacker.com`` that
+    resolves to ``127.0.0.1`` must not be reachable just because private
+    networks are otherwise allowed. RFC1918 / link-local results are
+    *not* flagged here; opting into those is the whole point of the flag.
+
+    Returns None on DNS failure — the actual request will fail naturally
+    if the name is unresolvable, and an internal-only name that's
+    legitimately reachable from the runtime but not from the validation
+    context shouldn't get spuriously rejected here.
+    """
+    try:
+        addr_info = socket.getaddrinfo(hostname, None)
+    except socket.gaierror:
+        return None
+
+    for info in addr_info:
+        ip_str = str(info[4][0])
+        try:
+            ip_obj = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if ip_obj.is_loopback or ip_obj.is_unspecified:
+            return ip_str
+    return None
+
+
 def _validate_and_resolve_url(url: str) -> tuple[str, str, int]:
     """
     Validate a URL for SSRF and resolve it to a safe IP address.
@@ -187,22 +218,32 @@ def validate_outbound_http_url(
     if hostname in BLOCKED_HOSTNAMES:
         raise SSRFException(f"Access to hostname '{parsed.hostname}' is not allowed.")
 
-    # Loopback (127.0.0.0/8, ::1) and unspecified (0.0.0.0, ::) IP literals
+    # Loopback (127.0.0.0/8, ::1) and unspecified (0.0.0.0, ::) addresses
     # are *always* blocked, even when allow_private_network=True. Opting into
     # private networks means RFC1918 / link-local services in the operator's
     # VPC — never the application host's own loopback, which would expose
     # admin APIs, sidecars, etc. running on the same machine.
     try:
         ip_obj = ipaddress.ip_address(hostname)
+    except ValueError:
+        # Hostname is a DNS name. On the opt-out path, _validate_and_resolve_url
+        # would otherwise be skipped — but the always-blocked floor still needs
+        # to apply, or a name like `loopback.attacker.com` resolving to
+        # 127.0.0.1 would slip through. RFC1918/link-local results stay
+        # allowed since opting in is the whole point of the flag.
+        if allow_private_network:
+            blocked_ip = _hostname_resolves_to_always_blocked_ip(hostname)
+            if blocked_ip is not None:
+                raise SSRFException(
+                    f"Hostname '{parsed.hostname}' resolves to loopback/"
+                    f"unspecified IP '{blocked_ip}'. Access is not allowed."
+                )
+    else:
         if ip_obj.is_loopback or ip_obj.is_unspecified:
             raise SSRFException(
                 f"Access to loopback/unspecified IP '{parsed.hostname}' "
                 f"is not allowed."
             )
-    except ValueError:
-        # Not an IP literal — DNS resolution handles loopback/private cases
-        # when allow_private_network=False.
-        pass
 
     if not allow_private_network:
         _validate_and_resolve_url(normalized_url)

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_onyx_web_crawler_playwright_fallback.py
@@ -71,7 +71,9 @@ def test_403_triggers_playwright_fallback(
 
     result = OnyxWebCrawler()._fetch_url("https://example.com/")
 
-    mock_render.assert_called_once_with("https://example.com/")
+    mock_render.assert_called_once_with(
+        "https://example.com/", allow_private_network=False
+    )
     assert result.scrape_successful
     assert "Hello world" in result.full_content
     assert result.title == "Real Page"

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -308,6 +308,66 @@ class TestSsrfSafeGet:
                 assert call_args[1]["timeout"] == (5, 15)
 
 
+class TestSsrfSafeGetAllowPrivateNetwork:
+    """Tests for the allow_private_network opt-out on ssrf_safe_get."""
+
+    def test_allows_private_ip_when_enabled(self) -> None:
+        mock_response = MagicMock()
+        mock_response.is_redirect = False
+
+        with patch("onyx.utils.url.requests.get") as mock_get:
+            mock_get.return_value = mock_response
+
+            response = ssrf_safe_get("http://192.168.1.1/", allow_private_network=True)
+
+            # Request goes out to the original URL, not pinned to an IP
+            mock_get.assert_called_once()
+            assert mock_get.call_args[0][0] == "http://192.168.1.1/"
+            assert response == mock_response
+
+    def test_allows_hostname_resolving_to_private_ip_when_enabled(self) -> None:
+        """Split-horizon DNS (e.g. js.jpl.nasa.gov inside JPL's VPC) should
+        succeed when the operator has opted out of the private-IP guard."""
+        mock_response = MagicMock()
+        mock_response.is_redirect = False
+
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            # validate_outbound_http_url with allow_private_network=True
+            # short-circuits before resolving, so DNS shouldn't be hit, but
+            # set up a private-IP answer to confirm the bypass still works
+            # even when resolution would otherwise flag the URL.
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.1", 443))]
+
+            with patch("onyx.utils.url.requests.get") as mock_get:
+                mock_get.return_value = mock_response
+
+                ssrf_safe_get(
+                    "https://js.jpl.nasa.gov/docs",
+                    allow_private_network=True,
+                )
+
+                mock_get.assert_called_once()
+                assert mock_get.call_args[0][0] == "https://js.jpl.nasa.gov/docs"
+
+    def test_still_blocks_metadata_hostname_when_enabled(self) -> None:
+        """The blocked-hostname list (e.g. metadata.google.internal) must
+        keep working even when the private-IP guard is off — opting into
+        private networks shouldn't open up cloud metadata access."""
+        with pytest.raises(SSRFException, match="not allowed"):
+            ssrf_safe_get(
+                "http://metadata.google.internal/latest",
+                allow_private_network=True,
+            )
+
+    def test_still_blocks_credentials_when_enabled(self) -> None:
+        with pytest.raises(SSRFException, match="embedded credentials"):
+            ssrf_safe_get("http://user:pass@10.0.0.1/", allow_private_network=True)
+
+    def test_still_blocks_invalid_scheme_when_enabled(self) -> None:
+        with pytest.raises(SSRFException, match="Invalid URL scheme"):
+            ssrf_safe_get("file:///etc/passwd", allow_private_network=True)
+
+
 class TestValidateOutboundHttpUrl:
     def test_rejects_private_ip_by_default(self) -> None:
         with pytest.raises(SSRFException, match="internal/private IP"):

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -367,17 +367,73 @@ class TestSsrfSafeGetAllowPrivateNetwork:
         with pytest.raises(SSRFException, match="Invalid URL scheme"):
             ssrf_safe_get("file:///etc/passwd", allow_private_network=True)
 
+    def test_still_blocks_loopback_ip_when_enabled(self) -> None:
+        """Even with the private-network opt-out, the LLM tool must not be
+        able to reach the application host's own loopback (admin APIs,
+        sidecars)."""
+        with pytest.raises(SSRFException, match="loopback/unspecified"):
+            ssrf_safe_get("http://127.0.0.1:8080/", allow_private_network=True)
+
+    def test_follows_redirect_to_private_ip_when_enabled(self) -> None:
+        """A 302 to another private-network URL should be followed when
+        opted in — validation re-runs on each hop and accepts private IPs."""
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "http://10.0.0.2/final"}
+
+        final_response = MagicMock()
+        final_response.is_redirect = False
+
+        with patch("onyx.utils.url.requests.get") as mock_get:
+            mock_get.side_effect = [redirect_response, final_response]
+
+            response = ssrf_safe_get(
+                "http://10.0.0.1/start", allow_private_network=True
+            )
+
+            assert response == final_response
+            assert mock_get.call_count == 2
+            assert mock_get.call_args_list[1][0][0] == "http://10.0.0.2/final"
+
+    def test_redirect_to_blocked_hostname_is_rejected_when_enabled(self) -> None:
+        """A redirect to a blocked hostname (e.g. cloud metadata) must still
+        raise, even if the initial hop succeeded under the opt-out."""
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {
+            "Location": "http://metadata.google.internal/latest"
+        }
+
+        with patch("onyx.utils.url.requests.get") as mock_get:
+            mock_get.return_value = redirect_response
+
+            with pytest.raises(SSRFException, match="not allowed"):
+                ssrf_safe_get("http://10.0.0.1/start", allow_private_network=True)
+
+    def test_redirect_to_loopback_is_rejected_when_enabled(self) -> None:
+        """A redirect to a loopback IP literal must also be rejected — same
+        reasoning as the direct-hit case."""
+        redirect_response = MagicMock()
+        redirect_response.is_redirect = True
+        redirect_response.headers = {"Location": "http://127.0.0.1:8080/admin"}
+
+        with patch("onyx.utils.url.requests.get") as mock_get:
+            mock_get.return_value = redirect_response
+
+            with pytest.raises(SSRFException, match="loopback/unspecified"):
+                ssrf_safe_get("http://10.0.0.1/start", allow_private_network=True)
+
 
 class TestValidateOutboundHttpUrl:
     def test_rejects_private_ip_by_default(self) -> None:
         with pytest.raises(SSRFException, match="internal/private IP"):
-            validate_outbound_http_url("http://127.0.0.1:8000")
+            validate_outbound_http_url("http://10.0.0.1:8000")
 
-    def test_allows_private_ip_when_explicitly_enabled(self) -> None:
+    def test_allows_rfc1918_ip_when_explicitly_enabled(self) -> None:
         validated_url = validate_outbound_http_url(
-            "http://127.0.0.1:8000", allow_private_network=True
+            "http://10.0.0.1:8000", allow_private_network=True
         )
-        assert validated_url == "http://127.0.0.1:8000"
+        assert validated_url == "http://10.0.0.1:8000"
 
     def test_blocks_metadata_hostname_when_private_is_enabled(self) -> None:
         with pytest.raises(SSRFException, match="not allowed"):
@@ -385,3 +441,24 @@ class TestValidateOutboundHttpUrl:
                 "http://metadata.google.internal/latest",
                 allow_private_network=True,
             )
+
+    def test_blocks_loopback_ipv4_when_private_is_enabled(self) -> None:
+        """Loopback is always blocked, even when private-network is allowed —
+        opting into RFC1918 shouldn't expose the application host's loopback."""
+        with pytest.raises(SSRFException, match="loopback/unspecified"):
+            validate_outbound_http_url(
+                "http://127.0.0.1:8080/", allow_private_network=True
+            )
+
+    def test_blocks_loopback_range_when_private_is_enabled(self) -> None:
+        """Any address in 127.0.0.0/8 must be blocked, not just 127.0.0.1."""
+        with pytest.raises(SSRFException, match="loopback/unspecified"):
+            validate_outbound_http_url("http://127.1.2.3/", allow_private_network=True)
+
+    def test_blocks_loopback_ipv6_when_private_is_enabled(self) -> None:
+        with pytest.raises(SSRFException, match="loopback/unspecified"):
+            validate_outbound_http_url("http://[::1]:8080/", allow_private_network=True)
+
+    def test_blocks_unspecified_ipv4_when_private_is_enabled(self) -> None:
+        with pytest.raises(SSRFException, match="loopback/unspecified"):
+            validate_outbound_http_url("http://0.0.0.0/", allow_private_network=True)

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -462,3 +462,69 @@ class TestValidateOutboundHttpUrl:
     def test_blocks_unspecified_ipv4_when_private_is_enabled(self) -> None:
         with pytest.raises(SSRFException, match="loopback/unspecified"):
             validate_outbound_http_url("http://0.0.0.0/", allow_private_network=True)
+
+    def test_blocks_dns_name_resolving_to_loopback_when_private_is_enabled(
+        self,
+    ) -> None:
+        """A DNS name that resolves to 127.0.0.1 must be blocked even on the
+        opt-out path — e.g. an attacker-controlled `loopback.attacker.com`
+        record could otherwise reach the app host's loopback."""
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 80))]
+            with pytest.raises(SSRFException, match="resolves to loopback"):
+                validate_outbound_http_url(
+                    "http://loopback.attacker.com/",
+                    allow_private_network=True,
+                )
+
+    def test_blocks_dns_name_resolving_to_ipv6_loopback_when_private_is_enabled(
+        self,
+    ) -> None:
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(30, 1, 6, "", ("::1", 80, 0, 0))]
+            with pytest.raises(SSRFException, match="resolves to loopback"):
+                validate_outbound_http_url(
+                    "http://loopback6.attacker.com/",
+                    allow_private_network=True,
+                )
+
+    def test_blocks_dns_name_resolving_to_unspecified_when_private_is_enabled(
+        self,
+    ) -> None:
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("0.0.0.0", 80))]
+            with pytest.raises(SSRFException, match="resolves to loopback"):
+                validate_outbound_http_url(
+                    "http://unspecified.attacker.com/",
+                    allow_private_network=True,
+                )
+
+    def test_allows_dns_name_resolving_to_rfc1918_when_private_is_enabled(
+        self,
+    ) -> None:
+        """The whole point of the opt-out: a DNS name resolving to RFC1918
+        should still succeed."""
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.5", 443))]
+            validated = validate_outbound_http_url(
+                "https://js.jpl.nasa.gov/", allow_private_network=True
+            )
+            assert validated == "https://js.jpl.nasa.gov/"
+
+    def test_dns_failure_does_not_raise_when_private_is_enabled(self) -> None:
+        """If DNS resolution fails during the loopback pre-check, don't
+        reject — internal-only names that aren't resolvable from the
+        validation context should still be allowed (the actual request will
+        fail on its own if the name is truly broken). The loopback guard is
+        defense-in-depth, not the primary gatekeeper on this path."""
+        import socket as socket_module
+
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.side_effect = socket_module.gaierror(
+                "Name resolution failed"
+            )
+            validated = validate_outbound_http_url(
+                "https://internal-only.company.com/",
+                allow_private_network=True,
+            )
+            assert validated == "https://internal-only.company.com/"

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -443,81 +443,108 @@ class TestValidateOutboundHttpUrl:
                 allow_private_network=True,
             )
 
-    def test_blocks_loopback_ipv4_when_private_is_enabled(self) -> None:
-        """Loopback is always blocked, even when private-network is allowed —
-        opting into RFC1918 shouldn't expose the application host's loopback."""
+    def test_allows_loopback_when_private_enabled_without_floor(self) -> None:
+        """Admin-configured callers (voice API for local Azure speech
+        containers, etc.) explicitly want to reach 127.0.0.1. The
+        block_loopback_and_link_local flag stays False by default so
+        validate_outbound_http_url(allow_private_network=True) preserves
+        that behavior — the stricter floor is opt-in for LLM-controlled
+        paths like open_url."""
+        validated = validate_outbound_http_url(
+            "http://127.0.0.1:5000", allow_private_network=True
+        )
+        assert validated == "http://127.0.0.1:5000"
+
+    def test_blocks_loopback_ipv4_with_floor(self) -> None:
+        """When block_loopback_and_link_local=True (open_url path), loopback
+        is rejected even though private networks are otherwise allowed."""
         with pytest.raises(SSRFException, match="loopback/unspecified"):
             validate_outbound_http_url(
-                "http://127.0.0.1:8080/", allow_private_network=True
+                "http://127.0.0.1:8080/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
             )
 
-    def test_blocks_loopback_range_when_private_is_enabled(self) -> None:
+    def test_blocks_loopback_range_with_floor(self) -> None:
         """Any address in 127.0.0.0/8 must be blocked, not just 127.0.0.1."""
         with pytest.raises(SSRFException, match="loopback/unspecified"):
-            validate_outbound_http_url("http://127.1.2.3/", allow_private_network=True)
+            validate_outbound_http_url(
+                "http://127.1.2.3/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
+            )
 
-    def test_blocks_loopback_ipv6_when_private_is_enabled(self) -> None:
+    def test_blocks_loopback_ipv6_with_floor(self) -> None:
         with pytest.raises(SSRFException, match="loopback/unspecified"):
-            validate_outbound_http_url("http://[::1]:8080/", allow_private_network=True)
+            validate_outbound_http_url(
+                "http://[::1]:8080/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
+            )
 
-    def test_blocks_unspecified_ipv4_when_private_is_enabled(self) -> None:
+    def test_blocks_unspecified_ipv4_with_floor(self) -> None:
         with pytest.raises(SSRFException, match="loopback/unspecified"):
-            validate_outbound_http_url("http://0.0.0.0/", allow_private_network=True)
+            validate_outbound_http_url(
+                "http://0.0.0.0/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
+            )
 
-    def test_blocks_link_local_ipv4_literal_when_private_is_enabled(self) -> None:
-        """Link-local IPv4 (169.254.0.0/16) is always blocked — covers the
-        cloud-metadata range. 169.254.169.254 itself is also in
+    def test_blocks_link_local_ipv4_literal_with_floor(self) -> None:
+        """Link-local IPv4 (169.254.0.0/16) is in the always-blocked tier —
+        covers the cloud-metadata range. 169.254.169.254 itself is also in
         BLOCKED_HOSTNAMES, but other link-local literals (e.g. 169.254.0.1)
         are not, so the IP-class check is what stops them."""
         with pytest.raises(SSRFException, match="loopback/unspecified/link-local"):
             validate_outbound_http_url(
-                "http://169.254.0.1/", allow_private_network=True
+                "http://169.254.0.1/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
             )
 
-    def test_blocks_link_local_ipv6_literal_when_private_is_enabled(self) -> None:
-        """Link-local IPv6 (fe80::/10) is always blocked."""
+    def test_blocks_link_local_ipv6_literal_with_floor(self) -> None:
+        """Link-local IPv6 (fe80::/10) is in the always-blocked tier."""
         with pytest.raises(SSRFException, match="loopback/unspecified/link-local"):
-            validate_outbound_http_url("http://[fe80::1]/", allow_private_network=True)
+            validate_outbound_http_url(
+                "http://[fe80::1]/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
+            )
 
-    def test_blocks_dns_name_resolving_to_loopback_when_private_is_enabled(
-        self,
-    ) -> None:
-        """A DNS name that resolves to 127.0.0.1 must be blocked even on the
-        opt-out path — e.g. an attacker-controlled `loopback.attacker.com`
-        record could otherwise reach the app host's loopback."""
+    def test_blocks_dns_name_resolving_to_loopback_with_floor(self) -> None:
+        """A DNS name that resolves to 127.0.0.1 must be blocked on the
+        floor path — e.g. an attacker-controlled `loopback.attacker.com`
+        record could otherwise reach the app host's loopback via open_url."""
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("127.0.0.1", 80))]
             with pytest.raises(SSRFException, match="resolves to loopback"):
                 validate_outbound_http_url(
                     "http://loopback.attacker.com/",
                     allow_private_network=True,
+                    block_loopback_and_link_local=True,
                 )
 
-    def test_blocks_dns_name_resolving_to_ipv6_loopback_when_private_is_enabled(
-        self,
-    ) -> None:
+    def test_blocks_dns_name_resolving_to_ipv6_loopback_with_floor(self) -> None:
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(30, 1, 6, "", ("::1", 80, 0, 0))]
             with pytest.raises(SSRFException, match="resolves to loopback"):
                 validate_outbound_http_url(
                     "http://loopback6.attacker.com/",
                     allow_private_network=True,
+                    block_loopback_and_link_local=True,
                 )
 
-    def test_blocks_dns_name_resolving_to_unspecified_when_private_is_enabled(
-        self,
-    ) -> None:
+    def test_blocks_dns_name_resolving_to_unspecified_with_floor(self) -> None:
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("0.0.0.0", 80))]
             with pytest.raises(SSRFException, match="resolves to loopback"):
                 validate_outbound_http_url(
                     "http://unspecified.attacker.com/",
                     allow_private_network=True,
+                    block_loopback_and_link_local=True,
                 )
 
-    def test_blocks_dns_name_resolving_to_aws_metadata_when_private_is_enabled(
-        self,
-    ) -> None:
+    def test_blocks_dns_name_resolving_to_aws_metadata_with_floor(self) -> None:
         """The canonical SSRF attack: an attacker-controlled DNS record
         pointing at 169.254.169.254 must not let the LLM tool exfiltrate
         IAM credentials from a cloud-hosted Onyx deployment, even when the
@@ -528,11 +555,10 @@ class TestValidateOutboundHttpUrl:
                 validate_outbound_http_url(
                     "http://imds.attacker.com/latest/meta-data/iam/",
                     allow_private_network=True,
+                    block_loopback_and_link_local=True,
                 )
 
-    def test_blocks_dns_name_resolving_to_link_local_when_private_is_enabled(
-        self,
-    ) -> None:
+    def test_blocks_dns_name_resolving_to_link_local_with_floor(self) -> None:
         """Any link-local IPv4 (169.254.0.0/16), not just the metadata IP."""
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("169.254.42.42", 80))]
@@ -540,25 +566,26 @@ class TestValidateOutboundHttpUrl:
                 validate_outbound_http_url(
                     "http://link-local.attacker.com/",
                     allow_private_network=True,
+                    block_loopback_and_link_local=True,
                 )
 
-    def test_allows_dns_name_resolving_to_rfc1918_when_private_is_enabled(
-        self,
-    ) -> None:
+    def test_allows_dns_name_resolving_to_rfc1918_with_floor(self) -> None:
         """The whole point of the opt-out: a DNS name resolving to RFC1918
-        should still succeed."""
+        should succeed even with the floor on."""
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.5", 443))]
             validated = validate_outbound_http_url(
-                "https://js.jpl.nasa.gov/", allow_private_network=True
+                "https://js.jpl.nasa.gov/",
+                allow_private_network=True,
+                block_loopback_and_link_local=True,
             )
             assert validated == "https://js.jpl.nasa.gov/"
 
-    def test_dns_failure_does_not_raise_when_private_is_enabled(self) -> None:
-        """If DNS resolution fails during the loopback pre-check, don't
+    def test_dns_failure_does_not_raise_with_floor(self) -> None:
+        """If DNS resolution fails during the floor pre-check, don't
         reject — internal-only names that aren't resolvable from the
         validation context should still be allowed (the actual request will
-        fail on its own if the name is truly broken). The loopback guard is
+        fail on its own if the name is truly broken). The floor is
         defense-in-depth, not the primary gatekeeper on this path."""
         import socket as socket_module
 
@@ -569,5 +596,6 @@ class TestValidateOutboundHttpUrl:
             validated = validate_outbound_http_url(
                 "https://internal-only.company.com/",
                 allow_private_network=True,
+                block_loopback_and_link_local=True,
             )
             assert validated == "https://internal-only.company.com/"

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -327,15 +327,16 @@ class TestSsrfSafeGetAllowPrivateNetwork:
 
     def test_allows_hostname_resolving_to_private_ip_when_enabled(self) -> None:
         """Split-horizon DNS (e.g. js.jpl.nasa.gov inside JPL's VPC) should
-        succeed when the operator has opted out of the private-IP guard."""
+        succeed when the operator has opted out of the private-IP guard.
+
+        DNS is still resolved on the opt-out path — _hostname_resolves_to_
+        always_blocked_ip checks for the loopback/unspecified/link-local
+        floor — but RFC1918 results pass through cleanly.
+        """
         mock_response = MagicMock()
         mock_response.is_redirect = False
 
         with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
-            # validate_outbound_http_url with allow_private_network=True
-            # short-circuits before resolving, so DNS shouldn't be hit, but
-            # set up a private-IP answer to confirm the bypass still works
-            # even when resolution would otherwise flag the URL.
             mock_getaddrinfo.return_value = [(2, 1, 6, "", ("10.0.0.1", 443))]
 
             with patch("onyx.utils.url.requests.get") as mock_get:
@@ -463,6 +464,21 @@ class TestValidateOutboundHttpUrl:
         with pytest.raises(SSRFException, match="loopback/unspecified"):
             validate_outbound_http_url("http://0.0.0.0/", allow_private_network=True)
 
+    def test_blocks_link_local_ipv4_literal_when_private_is_enabled(self) -> None:
+        """Link-local IPv4 (169.254.0.0/16) is always blocked — covers the
+        cloud-metadata range. 169.254.169.254 itself is also in
+        BLOCKED_HOSTNAMES, but other link-local literals (e.g. 169.254.0.1)
+        are not, so the IP-class check is what stops them."""
+        with pytest.raises(SSRFException, match="loopback/unspecified/link-local"):
+            validate_outbound_http_url(
+                "http://169.254.0.1/", allow_private_network=True
+            )
+
+    def test_blocks_link_local_ipv6_literal_when_private_is_enabled(self) -> None:
+        """Link-local IPv6 (fe80::/10) is always blocked."""
+        with pytest.raises(SSRFException, match="loopback/unspecified/link-local"):
+            validate_outbound_http_url("http://[fe80::1]/", allow_private_network=True)
+
     def test_blocks_dns_name_resolving_to_loopback_when_private_is_enabled(
         self,
     ) -> None:
@@ -496,6 +512,33 @@ class TestValidateOutboundHttpUrl:
             with pytest.raises(SSRFException, match="resolves to loopback"):
                 validate_outbound_http_url(
                     "http://unspecified.attacker.com/",
+                    allow_private_network=True,
+                )
+
+    def test_blocks_dns_name_resolving_to_aws_metadata_when_private_is_enabled(
+        self,
+    ) -> None:
+        """The canonical SSRF attack: an attacker-controlled DNS record
+        pointing at 169.254.169.254 must not let the LLM tool exfiltrate
+        IAM credentials from a cloud-hosted Onyx deployment, even when the
+        operator has opted into private networks for their internal docs."""
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("169.254.169.254", 80))]
+            with pytest.raises(SSRFException, match="link-local"):
+                validate_outbound_http_url(
+                    "http://imds.attacker.com/latest/meta-data/iam/",
+                    allow_private_network=True,
+                )
+
+    def test_blocks_dns_name_resolving_to_link_local_when_private_is_enabled(
+        self,
+    ) -> None:
+        """Any link-local IPv4 (169.254.0.0/16), not just the metadata IP."""
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_getaddrinfo:
+            mock_getaddrinfo.return_value = [(2, 1, 6, "", ("169.254.42.42", 80))]
+            with pytest.raises(SSRFException, match="link-local"):
+                validate_outbound_http_url(
+                    "http://link-local.attacker.com/",
                     allow_private_network=True,
                 )
 


### PR DESCRIPTION
## Description

The `open_url` tool currently runs `ssrf_safe_get`, which unconditionally rejects URLs that resolve to private/internal IPs. That's the right default for multi-tenant SaaS, but breaks self-hosted operators whose internal docs sites resolve to RFC1918 addresses from inside their VPC (e.g. via split-horizon DNS — same hostname, public IP outside the network, private inside).

A customer hit this fetching their own internal documentation through `open_url` while the web connector (which has a parallel `WEB_CONNECTOR_VALIDATE_URLS` opt-out) worked fine on the same URL.

This adds an `OPEN_URL_VALIDATE_SSRF` env var (default `true`, matching today's behavior):

- When `true`: no change — `open_url` rejects private/internal IPs.
- When `false`: `ssrf_safe_get` and `fetch_rendered_html` are called with `allow_private_network=True`. Scheme checks, credential-in-URL checks, and the blocked-hostname list (`localhost`, cloud-metadata IPs, `kubernetes.default*`, etc.) still apply — only the private-IP guard is relaxed.

Mirrors the existing `WEB_CONNECTOR_VALIDATE_URLS` escape hatch on the web connector.

## How Has This Been Tested?

- Added 5 new unit tests in `test_url_ssrf.py::TestSsrfSafeGetAllowPrivateNetwork` covering: private-IP success, hostname-resolving-to-private-IP success, blocked-hostname still blocked, embedded-credentials still blocked, invalid-scheme still blocked.
- Updated the existing `test_403_triggers_playwright_fallback` assertion to expect the new `allow_private_network` kwarg.
- Full suite: `pytest backend/tests/unit/onyx/utils/test_url_ssrf.py backend/tests/unit/onyx/tools/tool_implementations/open_url/` → 182 passed.
- `ty check` clean on all touched files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-out for SSRF private-network blocking in `open_url` so self-hosted users can fetch internal docs. Default is unchanged; when disabled, RFC1918 targets are allowed while loopback, link-local, and unspecified IPs (and DNS names resolving to them) stay blocked in the `open_url` path.

- New Features
  - `OPEN_URL_VALIDATE_SSRF` env var (default `true`). Set to `false` to allow RFC1918 targets in `open_url`; Playwright fallback and redirects honor it.
  - In `open_url`, loopback/unspecified/link-local IPs (and DNS resolving to them, e.g., IMDS `169.254.169.254`) are always blocked; other admin-configured callers keep existing behavior and may use loopback when they explicitly allow private networks.
  - Still blocks bad schemes, embedded credentials, and blocked hostnames (e.g., `localhost`, cloud metadata, `kubernetes.default*`).

- Migration
  - Self-hosted on trusted networks: set `OPEN_URL_VALIDATE_SSRF=false` to fetch internal sites (e.g., split-horizon DNS).
  - Multi-tenant/SaaS: no action needed.

<sup>Written for commit bea5cd08299b2093d8a05f4b5ee49a5e83f4872c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

