### PR TITLE
chore: bump sandbox cli version

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
@@ -6,7 +6,7 @@ matplotlib==3.9.1
 matplotlib-inline>=0.1.7
 matplotlib-venn>=1.1.2
 numpy==1.26.4
-onyx-cli==1.0.2
+onyx-cli==1.0.3
 opencv-python>=4.11.0.86
 openpyxl>=3.1.5
 pandas==2.2.2


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the sandbox Docker environment to use `onyx-cli` 1.0.3 instead of 1.0.2. Keeps the CLI in the build sandbox up to date.

<sup>Written for commit d508395278c39826fc68692a134aef7c599a5dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

