### PR TITLE
chore(pre-commit): prefer `pre-commit-terraform`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
         files: ^(pyproject\.toml|uv\.lock|backend/requirements/.*\.txt)$
       - id: uv-run
         name: Check lazy imports
-        args: ["--active", "--with=onyx-devtools", "ods", "check-lazy-imports"]
+        args: ["--with=onyx-devtools", "ods", "check-lazy-imports"]
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$
       - id: uv-run
@@ -112,7 +112,6 @@ repos:
         language_version: "1.26.1"
         entry: bash -c "find . -name go.mod -not -path './.venv/*' -print0 | xargs -0 -I{} bash -c 'cd \"$(dirname {})\" && golangci-lint run ./...'"
 
-
   - repo: https://github.com/sirwart/ripsecrets
     rev: 7d94620933e79b8acaa0cd9e60e9864b07673d86 # frozen: v0.1.11
     hooks:
@@ -122,15 +121,14 @@ repos:
           - --additional-pattern
           - ^sk-[A-Za-z0-9_\-]{20,}$
 
-  - repo: local
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d
     hooks:
-      - id: terraform-fmt
-        name: terraform fmt
-        entry: terraform fmt -recursive
-        language: system
-        pass_filenames: false
+      - id: terraform_fmt
         files: \.tf$
 
+  - repo: local
+    hooks:
       - id: npm-install
         name: npm install
         description: "Automatically run 'npm install' after a checkout, pull or rebase"


### PR DESCRIPTION
## Description

The devcontainer doesn't have `terraform-fmt` installed and this `pre-commit-terraform` handles installation in pre-commit.

Also fixes the `Check lazy imports` hook for me. With the active venv, I get,

> hint: You're using CPython 3.14 (`cp314`), but `onnxruntime` (v1.20.1) only has wheels with the following Python ABI tags: `cp311`, `cp312`, `cp313`, `cp313t`

for some reason. We switched pre-commit from using the active venv a while ago and this was missed.

## How Has This Been Tested?

`prek run --all-files`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Terraform pre-commit hooks to `pre-commit-terraform` so formatting works without installing `terraform-fmt` in the devcontainer. Also fixes the "Check lazy imports" hook to not use the active venv, avoiding `onnxruntime` ABI errors on CPython 3.14.

- **Dependencies**
  - Add `antonbabenko/pre-commit-terraform`
  - Replace local `terraform fmt` with `terraform_fmt`

- **Bug Fixes**
  - Drop `--active` from the `uv-run` "Check lazy imports" hook to prevent `onnxruntime` wheel mismatch errors (`cp314`)

<sup>Written for commit cb1cc0d27bd84c758fbb091b4fe3f8ccee52c52c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

