### PR TITLE
chore(fmt): fix `oxfmt` at HEAD

### DIFF
--- a/backend/onyx/server/features/build/api/templates/webapp_hmr_fixer.js
+++ b/backend/onyx/server/features/build/api/templates/webapp_hmr_fixer.js
@@ -85,7 +85,7 @@
 
   MockHmrWebSocket.prototype.removeEventListener = function (
     eventType,
-    callback,
+    callback
   ) {
     var listeners = this._l[eventType] || [];
     this._l[eventType] = listeners.filter(function (listener) {

--- a/backend/onyx/server/features/build/api/templates/webapp_offline.html
+++ b/backend/onyx/server/features/build/api/templates/webapp_offline.html
@@ -15,8 +15,8 @@
       }
 
       body {
-        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-          monospace;
+        font-family:
+          ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
         background: linear-gradient(to bottom right, #030712, #111827, #030712);
         min-height: 100vh;
         display: flex;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/example.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/example.tsx
@@ -7,7 +7,7 @@ function ExampleWrapper({ className, ...props }: React.ComponentProps<"div">) {
         data-slot="example-wrapper"
         className={cn(
           "mx-auto grid min-h-screen w-full max-w-5xl min-w-0 content-center items-start gap-8 p-4 pt-2 sm:gap-12 sm:p-6 md:grid-cols-2 md:gap-8 lg:p-12 2xl:max-w-6xl",
-          className,
+          className
         )}
         {...props}
       />
@@ -30,7 +30,7 @@ function Example({
       data-slot="example"
       className={cn(
         "mx-auto flex w-full max-w-lg min-w-0 flex-col gap-1 self-stretch lg:max-w-none",
-        containerClassName,
+        containerClassName
       )}
       {...props}
     >
@@ -43,7 +43,7 @@ function Example({
         data-slot="example-content"
         className={cn(
           "bg-background text-foreground flex min-w-0 flex-1 flex-col items-start gap-6 border border-dashed p-4 sm:p-6 *:[div:not([class*='w-'])]:w-full",
-          className,
+          className
         )}
       >
         {children}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/accordion.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/accordion.tsx
@@ -43,7 +43,7 @@ function AccordionTrigger({
         data-slot="accordion-trigger"
         className={cn(
           "focus-visible:ring-ring/50 focus-visible:border-ring focus-visible:after:border-ring **:data-[slot=accordion-trigger-icon]:text-muted-foreground rounded-lg py-2.5 text-left text-sm font-medium hover:underline focus-visible:ring-[3px] **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 group/accordion-trigger relative flex flex-1 items-start justify-between border border-transparent transition-all outline-none disabled:pointer-events-none disabled:opacity-50",
-          className,
+          className
         )}
         {...props}
       >
@@ -75,7 +75,7 @@ function AccordionContent({
       <div
         className={cn(
           "pt-0 pb-2.5 [&_a]:hover:text-foreground h-(--radix-accordion-content-height) [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
-          className,
+          className
         )}
       >
         {children}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/alert-dialog.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/alert-dialog.tsx
@@ -37,7 +37,7 @@ function AlertDialogOverlay({
       data-slot="alert-dialog-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50",
-        className,
+        className
       )}
       {...props}
     />
@@ -59,7 +59,7 @@ function AlertDialogContent({
         data-size={size}
         className={cn(
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
-          className,
+          className
         )}
         {...props}
       />
@@ -76,7 +76,7 @@ function AlertDialogHeader({
       data-slot="alert-dialog-header"
       className={cn(
         "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
-        className,
+        className
       )}
       {...props}
     />
@@ -92,7 +92,7 @@ function AlertDialogFooter({
       data-slot="alert-dialog-footer"
       className={cn(
         "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
-        className,
+        className
       )}
       {...props}
     />
@@ -108,7 +108,7 @@ function AlertDialogMedia({
       data-slot="alert-dialog-media"
       className={cn(
         "bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
-        className,
+        className
       )}
       {...props}
     />
@@ -124,7 +124,7 @@ function AlertDialogTitle({
       data-slot="alert-dialog-title"
       className={cn(
         "text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
-        className,
+        className
       )}
       {...props}
     />
@@ -140,7 +140,7 @@ function AlertDialogDescription({
       data-slot="alert-dialog-description"
       className={cn(
         "text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/alert.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/alert.tsx
@@ -16,7 +16,7 @@ const alertVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 function Alert({
@@ -40,7 +40,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="alert-title"
       className={cn(
         "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
-        className,
+        className
       )}
       {...props}
     />
@@ -56,7 +56,7 @@ function AlertDescription({
       data-slot="alert-description"
       className={cn(
         "text-muted-foreground text-sm text-balance md:text-pretty [&_p:not(:last-child)]:mb-4 [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/avatar.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/avatar.tsx
@@ -18,7 +18,7 @@ function Avatar({
       data-size={size}
       className={cn(
         "size-8 rounded-full after:rounded-full data-[size=lg]:size-10 data-[size=sm]:size-6 after:border-border group/avatar relative flex shrink-0 select-none after:absolute after:inset-0 after:border after:mix-blend-darken dark:after:mix-blend-lighten",
-        className,
+        className
       )}
       {...props}
     />
@@ -34,7 +34,7 @@ function AvatarImage({
       data-slot="avatar-image"
       className={cn(
         "rounded-full aspect-square size-full object-cover",
-        className,
+        className
       )}
       {...props}
     />
@@ -50,7 +50,7 @@ function AvatarFallback({
       data-slot="avatar-fallback"
       className={cn(
         "bg-muted text-muted-foreground rounded-full flex size-full items-center justify-center text-sm group-data-[size=sm]/avatar:text-xs",
-        className,
+        className
       )}
       {...props}
     />
@@ -66,7 +66,7 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
         "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
         "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
         "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
-        className,
+        className
       )}
       {...props}
     />
@@ -79,7 +79,7 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="avatar-group"
       className={cn(
         "*:data-[slot=avatar]:ring-background group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2",
-        className,
+        className
       )}
       {...props}
     />
@@ -95,7 +95,7 @@ function AvatarGroupCount({
       data-slot="avatar-group-count"
       className={cn(
         "bg-muted text-muted-foreground size-8 rounded-full text-sm group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3 ring-background relative flex shrink-0 items-center justify-center ring-2",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/badge.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/badge.tsx
@@ -24,7 +24,7 @@ const badgeVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 function Badge({

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/breadcrumb.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/breadcrumb.tsx
@@ -21,7 +21,7 @@ function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
       data-slot="breadcrumb-list"
       className={cn(
         "text-muted-foreground gap-1.5 text-sm flex flex-wrap items-center break-words",
-        className,
+        className
       )}
       {...props}
     />
@@ -98,7 +98,7 @@ function BreadcrumbEllipsis({
       aria-hidden="true"
       className={cn(
         "size-5 [&>svg]:size-4 flex items-center justify-center",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/button-group.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/button-group.tsx
@@ -18,7 +18,7 @@ const buttonGroupVariants = cva(
     defaultVariants: {
       orientation: "horizontal",
     },
-  },
+  }
 );
 
 function ButtonGroup({
@@ -50,7 +50,7 @@ function ButtonGroupText({
     <Comp
       className={cn(
         "bg-muted gap-2 rounded-lg border px-2.5 text-sm font-medium [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
-        className,
+        className
       )}
       {...props}
     />
@@ -68,7 +68,7 @@ function ButtonGroupSeparator({
       orientation={orientation}
       className={cn(
         "bg-input relative self-stretch data-[orientation=horizontal]:mx-px data-[orientation=horizontal]:w-auto data-[orientation=vertical]:my-px data-[orientation=vertical]:h-auto",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/button.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/button.tsx
@@ -38,7 +38,7 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
+  }
 );
 
 function Button({

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/calendar.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/calendar.tsx
@@ -36,7 +36,7 @@ function Calendar({
         "p-2 [--cell-radius:var(--radius-md)] [--cell-size:--spacing(7)] bg-background group/calendar [[data-slot=card-content]_&]:bg-transparent [[data-slot=popover-content]_&]:bg-transparent",
         String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
         String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
-        className,
+        className
       )}
       captionLayout={captionLayout}
       formatters={{
@@ -48,88 +48,88 @@ function Calendar({
         root: cn("w-fit", defaultClassNames.root),
         months: cn(
           "flex gap-4 flex-col md:flex-row relative",
-          defaultClassNames.months,
+          defaultClassNames.months
         ),
         month: cn("flex flex-col w-full gap-4", defaultClassNames.month),
         nav: cn(
           "flex items-center gap-1 w-full absolute top-0 inset-x-0 justify-between",
-          defaultClassNames.nav,
+          defaultClassNames.nav
         ),
         button_previous: cn(
           buttonVariants({ variant: buttonVariant }),
           "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_previous,
+          defaultClassNames.button_previous
         ),
         button_next: cn(
           buttonVariants({ variant: buttonVariant }),
           "size-(--cell-size) aria-disabled:opacity-50 p-0 select-none",
-          defaultClassNames.button_next,
+          defaultClassNames.button_next
         ),
         month_caption: cn(
           "flex items-center justify-center h-(--cell-size) w-full px-(--cell-size)",
-          defaultClassNames.month_caption,
+          defaultClassNames.month_caption
         ),
         dropdowns: cn(
           "w-full flex items-center text-sm font-medium justify-center h-(--cell-size) gap-1.5",
-          defaultClassNames.dropdowns,
+          defaultClassNames.dropdowns
         ),
         dropdown_root: cn(
           "relative cn-calendar-dropdown-root rounded-(--cell-radius)",
-          defaultClassNames.dropdown_root,
+          defaultClassNames.dropdown_root
         ),
         dropdown: cn(
           "absolute bg-popover inset-0 opacity-0",
-          defaultClassNames.dropdown,
+          defaultClassNames.dropdown
         ),
         caption_label: cn(
           "select-none font-medium",
           captionLayout === "label"
             ? "text-sm"
             : "cn-calendar-caption-label rounded-(--cell-radius) flex items-center gap-1 text-sm  [&>svg]:text-muted-foreground [&>svg]:size-3.5",
-          defaultClassNames.caption_label,
+          defaultClassNames.caption_label
         ),
         table: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "text-muted-foreground rounded-(--cell-radius) flex-1 font-normal text-[0.8rem] select-none",
-          defaultClassNames.weekday,
+          defaultClassNames.weekday
         ),
         week: cn("flex w-full mt-2", defaultClassNames.week),
         week_number_header: cn(
           "select-none w-(--cell-size)",
-          defaultClassNames.week_number_header,
+          defaultClassNames.week_number_header
         ),
         week_number: cn(
           "text-[0.8rem] select-none text-muted-foreground",
-          defaultClassNames.week_number,
+          defaultClassNames.week_number
         ),
         day: cn(
           "relative w-full rounded-(--cell-radius) h-full p-0 text-center [&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius) group/day aspect-square select-none",
           props.showWeekNumber
             ? "[&:nth-child(2)[data-selected=true]_button]:rounded-l-(--cell-radius)"
             : "[&:first-child[data-selected=true]_button]:rounded-l-(--cell-radius)",
-          defaultClassNames.day,
+          defaultClassNames.day
         ),
         range_start: cn(
           "rounded-l-(--cell-radius) bg-muted relative after:bg-muted after:absolute after:inset-y-0 after:w-4 after:right-0 -z-0 isolate",
-          defaultClassNames.range_start,
+          defaultClassNames.range_start
         ),
         range_middle: cn("rounded-none", defaultClassNames.range_middle),
         range_end: cn(
           "rounded-r-(--cell-radius) bg-muted relative after:bg-muted-200 after:absolute after:inset-y-0 after:w-4 after:left-0 -z-0 isolate",
-          defaultClassNames.range_end,
+          defaultClassNames.range_end
         ),
         today: cn(
           "bg-muted text-foreground rounded-(--cell-radius) data-[selected=true]:rounded-none",
-          defaultClassNames.today,
+          defaultClassNames.today
         ),
         outside: cn(
           "text-muted-foreground aria-selected:text-muted-foreground",
-          defaultClassNames.outside,
+          defaultClassNames.outside
         ),
         disabled: cn(
           "text-muted-foreground opacity-50",
-          defaultClassNames.disabled,
+          defaultClassNames.disabled
         ),
         hidden: cn("invisible", defaultClassNames.hidden),
         ...classNames,
@@ -213,7 +213,7 @@ function CalendarDayButton({
       className={cn(
         "data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[range-middle=true]:bg-muted data-[range-middle=true]:text-foreground data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-ring/50 dark:hover:text-foreground relative isolate z-10 flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 border-0 leading-none font-normal group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:ring-[3px] data-[range-end=true]:rounded-(--cell-radius) data-[range-end=true]:rounded-r-(--cell-radius) data-[range-middle=true]:rounded-none data-[range-start=true]:rounded-(--cell-radius) data-[range-start=true]:rounded-l-(--cell-radius) [&>span]:text-xs [&>span]:opacity-70",
         defaultClassNames.day,
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/card.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/card.tsx
@@ -13,7 +13,7 @@ function Card({
       data-size={size}
       className={cn(
         "ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -26,7 +26,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
-        className,
+        className
       )}
       {...props}
     />
@@ -39,7 +39,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className,
+        className
       )}
       {...props}
     />
@@ -62,7 +62,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-action"
       className={cn(
         "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className,
+        className
       )}
       {...props}
     />
@@ -85,7 +85,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/carousel.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/carousel.tsx
@@ -56,7 +56,7 @@ function Carousel({
       ...opts,
       axis: orientation === "horizontal" ? "x" : "y",
     },
-    plugins,
+    plugins
   );
   const [canScrollPrev, setCanScrollPrev] = React.useState(false);
   const [canScrollNext, setCanScrollNext] = React.useState(false);
@@ -85,7 +85,7 @@ function Carousel({
         scrollNext();
       }
     },
-    [scrollPrev, scrollNext],
+    [scrollPrev, scrollNext]
   );
 
   React.useEffect(() => {
@@ -145,7 +145,7 @@ function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
         className={cn(
           "flex",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
-          className,
+          className
         )}
         {...props}
       />
@@ -164,7 +164,7 @@ function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
       className={cn(
         "min-w-0 shrink-0 grow-0 basis-full",
         orientation === "horizontal" ? "pl-4" : "pt-4",
-        className,
+        className
       )}
       {...props}
     />
@@ -189,7 +189,7 @@ function CarouselPrevious({
         orientation === "horizontal"
           ? "top-1/2 -left-12 -translate-y-1/2"
           : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
-        className,
+        className
       )}
       disabled={!canScrollPrev}
       onClick={scrollPrev}
@@ -219,7 +219,7 @@ function CarouselNext({
         orientation === "horizontal"
           ? "top-1/2 -right-12 -translate-y-1/2"
           : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
-        className,
+        className
       )}
       disabled={!canScrollNext}
       onClick={scrollNext}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/chart.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/chart.tsx
@@ -56,7 +56,7 @@ function ChartContainer({
         data-chart={chartId}
         className={cn(
           "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
-          className,
+          className
         )}
         {...props}
       >
@@ -71,7 +71,7 @@ function ChartContainer({
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
-    ([, config]) => config.theme || config.color,
+    ([, config]) => config.theme || config.color
   );
 
   if (!colorConfig.length) {
@@ -94,7 +94,7 @@ ${colorConfig
   })
   .join("\n")}
 }
-`,
+`
           )
           .join("\n"),
       }}
@@ -174,7 +174,7 @@ function ChartTooltipContent({
     <div
       className={cn(
         "border-border/50 bg-background gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl grid min-w-[8rem] items-start",
-        className,
+        className
       )}
     >
       {!nestLabel ? tooltipLabel : null}
@@ -191,7 +191,7 @@ function ChartTooltipContent({
                 key={item.dataKey}
                 className={cn(
                   "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
-                  indicator === "dot" && "items-center",
+                  indicator === "dot" && "items-center"
                 )}
               >
                 {formatter && item?.value !== undefined && item.name ? (
@@ -211,7 +211,7 @@ function ChartTooltipContent({
                               "w-0 border-[1.5px] border-dashed bg-transparent":
                                 indicator === "dashed",
                               "my-0.5": nestLabel && indicator === "dashed",
-                            },
+                            }
                           )}
                           style={
                             {
@@ -225,7 +225,7 @@ function ChartTooltipContent({
                     <div
                       className={cn(
                         "flex flex-1 justify-between leading-none",
-                        nestLabel ? "items-end" : "items-center",
+                        nestLabel ? "items-end" : "items-center"
                       )}
                     >
                       <div className="grid gap-1.5">
@@ -274,7 +274,7 @@ function ChartLegendContent({
       className={cn(
         "flex items-center justify-center gap-4",
         verticalAlign === "top" ? "pb-3" : "pt-3",
-        className,
+        className
       )}
     >
       {payload
@@ -287,7 +287,7 @@ function ChartLegendContent({
             <div
               key={item.value}
               className={cn(
-                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3",
+                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
               )}
             >
               {itemConfig?.icon && !hideIcon ? (
@@ -311,7 +311,7 @@ function ChartLegendContent({
 function getPayloadConfigFromPayload(
   config: ChartConfig,
   payload: unknown,
-  key: string,
+  key: string
 ) {
   if (typeof payload !== "object" || payload === null) {
     return undefined;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/checkbox.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/checkbox.tsx
@@ -15,7 +15,7 @@ function Checkbox({
       data-slot="checkbox"
       className={cn(
         "border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border transition-colors group-has-disabled/field:opacity-50 focus-visible:ring-[3px] aria-invalid:ring-[3px] peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/combobox.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/combobox.tsx
@@ -114,7 +114,7 @@ function ComboboxContent({
           data-chips={!!anchor}
           className={cn(
             "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 max-h-72 min-w-36 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)",
-            className,
+            className
           )}
           {...props}
         />
@@ -129,7 +129,7 @@ function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
       data-slot="combobox-list"
       className={cn(
         "no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0 overflow-y-auto overscroll-contain",
-        className,
+        className
       )}
       {...props}
     />
@@ -146,7 +146,7 @@ function ComboboxItem({
       data-slot="combobox-item"
       className={cn(
         "data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -197,7 +197,7 @@ function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
       data-slot="combobox-empty"
       className={cn(
         "text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex",
-        className,
+        className
       )}
       {...props}
     />
@@ -227,7 +227,7 @@ function ComboboxChips({
       data-slot="combobox-chips"
       className={cn(
         "dark:bg-input/30 border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive dark:has-aria-invalid:border-destructive/50 flex min-h-8 flex-wrap items-center gap-1 rounded-lg border bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:ring-[3px] has-aria-invalid:ring-[3px] has-data-[slot=combobox-chip]:px-1",
-        className,
+        className
       )}
       {...props}
     />
@@ -247,7 +247,7 @@ function ComboboxChip({
       data-slot="combobox-chip"
       className={cn(
         "bg-muted text-foreground flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-data-[slot=combobox-chip-remove]:pr-0 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/command.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/command.tsx
@@ -23,7 +23,7 @@ function Command({
       data-slot="command"
       className={cn(
         "bg-popover text-popover-foreground rounded-xl! p-1 flex size-full flex-col overflow-hidden",
-        className,
+        className
       )}
       {...props}
     />
@@ -52,7 +52,7 @@ function CommandDialog({
       <DialogContent
         className={cn(
           "rounded-xl! top-1/3 translate-y-0 overflow-hidden p-0",
-          className,
+          className
         )}
         showCloseButton={showCloseButton}
       >
@@ -73,7 +73,7 @@ function CommandInput({
           data-slot="command-input"
           className={cn(
             "w-full text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-            className,
+            className
           )}
           {...props}
         />
@@ -94,7 +94,7 @@ function CommandList({
       data-slot="command-list"
       className={cn(
         "no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
-        className,
+        className
       )}
       {...props}
     />
@@ -123,7 +123,7 @@ function CommandGroup({
       data-slot="command-group"
       className={cn(
         "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
-        className,
+        className
       )}
       {...props}
     />
@@ -153,7 +153,7 @@ function CommandItem({
       data-slot="command-item"
       className={cn(
         "data-selected:bg-muted data-selected:text-foreground data-selected:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg:not([class*='size-'])]:size-4 [[data-slot=dialog-content]_&]:rounded-lg! group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -172,7 +172,7 @@ function CommandShortcut({
       data-slot="command-shortcut"
       className={cn(
         "text-muted-foreground group-data-selected/command-item:text-foreground ml-auto text-xs tracking-widest",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/context-menu.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/context-menu.tsx
@@ -70,7 +70,7 @@ function ContextMenuContent({
         data-slot="context-menu-content"
         className={cn(
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-36 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-context-menu-content-available-height) origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto",
-          className,
+          className
         )}
         {...props}
       />
@@ -94,7 +94,7 @@ function ContextMenuItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive focus:*:[svg]:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4 group/context-menu-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -115,7 +115,7 @@ function ContextMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -134,7 +134,7 @@ function ContextMenuSubContent({
       data-slot="context-menu-sub-content"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 bg-popover text-popover-foreground min-w-32 rounded-lg border p-1 shadow-lg duration-100 z-50 origin-(--radix-context-menu-content-transform-origin) overflow-hidden",
-        className,
+        className
       )}
       {...props}
     />
@@ -152,7 +152,7 @@ function ContextMenuCheckboxItem({
       data-slot="context-menu-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       checked={checked}
       {...props}
@@ -177,7 +177,7 @@ function ContextMenuRadioItem({
       data-slot="context-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -204,7 +204,7 @@ function ContextMenuLabel({
       data-inset={inset}
       className={cn(
         "text-muted-foreground px-1.5 py-1 text-xs font-medium data-[inset]:pl-8",
-        className,
+        className
       )}
       {...props}
     />
@@ -233,7 +233,7 @@ function ContextMenuShortcut({
       data-slot="context-menu-shortcut"
       className={cn(
         "text-muted-foreground group-focus/context-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/dialog.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/dialog.tsx
@@ -40,7 +40,7 @@ function DialogOverlay({
       data-slot="dialog-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
-        className,
+        className
       )}
       {...props}
     />
@@ -62,7 +62,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2",
-          className,
+          className
         )}
         {...props}
       >
@@ -107,7 +107,7 @@ function DialogFooter({
       data-slot="dialog-footer"
       className={cn(
         "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className,
+        className
       )}
       {...props}
     >
@@ -143,7 +143,7 @@ function DialogDescription({
       data-slot="dialog-description"
       className={cn(
         "text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/drawer.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/drawer.tsx
@@ -38,7 +38,7 @@ function DrawerOverlay({
       data-slot="drawer-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50",
-        className,
+        className
       )}
       {...props}
     />
@@ -57,7 +57,7 @@ function DrawerContent({
         data-slot="drawer-content"
         className={cn(
           "bg-background flex h-auto flex-col text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:rounded-t-xl data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:rounded-r-xl data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:rounded-l-xl data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:rounded-b-xl data-[vaul-drawer-direction=top]:border-b data-[vaul-drawer-direction=left]:sm:max-w-sm data-[vaul-drawer-direction=right]:sm:max-w-sm group/drawer-content fixed z-50",
-          className,
+          className
         )}
         {...props}
       >
@@ -74,7 +74,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="drawer-header"
       className={cn(
         "gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left flex flex-col",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/dropdown-menu.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ function DropdownMenuContent({
         align={align}
         className={cn(
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto data-[state=closed]:overflow-hidden",
-          className,
+          className
         )}
         {...props}
       />
@@ -77,7 +77,7 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -95,7 +95,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       checked={checked}
       {...props}
@@ -134,7 +134,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -164,7 +164,7 @@ function DropdownMenuLabel({
       data-inset={inset}
       className={cn(
         "text-muted-foreground px-1.5 py-1 text-xs font-medium data-[inset]:pl-8",
-        className,
+        className
       )}
       {...props}
     />
@@ -193,7 +193,7 @@ function DropdownMenuShortcut({
       data-slot="dropdown-menu-shortcut"
       className={cn(
         "text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
-        className,
+        className
       )}
       {...props}
     />
@@ -220,7 +220,7 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -239,7 +239,7 @@ function DropdownMenuSubContent({
       data-slot="dropdown-menu-sub-content"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-md p-1 shadow-lg ring-1 duration-100 z-50 origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/empty.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/empty.tsx
@@ -8,7 +8,7 @@ function Empty({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="empty"
       className={cn(
         "gap-4 rounded-lg border-dashed p-6 flex w-full min-w-0 flex-1 flex-col items-center justify-center text-center text-balance",
-        className,
+        className
       )}
       {...props}
     />
@@ -37,7 +37,7 @@ const emptyMediaVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 function EmptyMedia({
@@ -71,7 +71,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
       data-slot="empty-description"
       className={cn(
         "text-sm/relaxed text-muted-foreground [&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-        className,
+        className
       )}
       {...props}
     />
@@ -84,7 +84,7 @@ function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="empty-content"
       className={cn(
         "gap-2.5 text-sm flex w-full max-w-sm min-w-0 flex-col items-center text-balance",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/field.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/field.tsx
@@ -13,7 +13,7 @@ function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
       data-slot="field-set"
       className={cn(
         "gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3 flex flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -31,7 +31,7 @@ function FieldLegend({
       data-variant={variant}
       className={cn(
         "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
-        className,
+        className
       )}
       {...props}
     />
@@ -44,7 +44,7 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="field-group"
       className={cn(
         "gap-5 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4 group/field-group @container/field-group flex w-full flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -66,7 +66,7 @@ const fieldVariants = cva(
     defaultVariants: {
       orientation: "vertical",
     },
-  },
+  }
 );
 
 function Field({
@@ -91,7 +91,7 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="field-content"
       className={cn(
         "gap-0.5 group/field-content flex flex-1 flex-col leading-snug",
-        className,
+        className
       )}
       {...props}
     />
@@ -108,7 +108,7 @@ function FieldLabel({
       className={cn(
         "has-data-checked:bg-primary/5 has-data-checked:border-primary dark:has-data-checked:bg-primary/10 gap-2 group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-2.5 group/field-label peer/field-label flex w-fit leading-snug",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -121,7 +121,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="field-label"
       className={cn(
         "gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50 flex w-fit items-center leading-snug",
-        className,
+        className
       )}
       {...props}
     />
@@ -136,7 +136,7 @@ function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
         "text-muted-foreground text-left text-sm [[data-variant=legend]+&]:-mt-1.5 leading-normal font-normal group-has-[[data-orientation=horizontal]]/field:text-balance",
         "last:mt-0 nth-last-2:-mt-1",
         "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
-        className,
+        className
       )}
       {...props}
     />
@@ -156,7 +156,7 @@ function FieldSeparator({
       data-content={!!children}
       className={cn(
         "-my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2 relative",
-        className,
+        className
       )}
       {...props}
     >
@@ -202,7 +202,7 @@ function FieldError({
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
           (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>,
+            error?.message && <li key={index}>{error.message}</li>
         )}
       </ul>
     );

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/hover-card.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/hover-card.tsx
@@ -33,7 +33,7 @@ function HoverCardContent({
         sideOffset={sideOffset}
         className={cn(
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground w-64 rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100 z-50 origin-(--radix-hover-card-content-transform-origin) outline-hidden",
-          className,
+          className
         )}
         {...props}
       />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/input-group.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/input-group.tsx
@@ -15,7 +15,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       role="group"
       className={cn(
         "border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-disabled:bg-input/50 dark:has-disabled:bg-input/80 h-8 rounded-lg border transition-colors has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 [[data-slot=combobox-content]_&]:focus-within:border-inherit [[data-slot=combobox-content]_&]:focus-within:ring-0 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
-        className,
+        className
       )}
       {...props}
     />
@@ -40,7 +40,7 @@ const inputGroupAddonVariants = cva(
     defaultVariants: {
       align: "inline-start",
     },
-  },
+  }
 );
 
 function InputGroupAddon({
@@ -80,7 +80,7 @@ const inputGroupButtonVariants = cva(
     defaultVariants: {
       size: "xs",
     },
-  },
+  }
 );
 
 function InputGroupButton({
@@ -107,7 +107,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
     <span
       className={cn(
         "text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
-        className,
+        className
       )}
       {...props}
     />
@@ -123,7 +123,7 @@ function InputGroupInput({
       data-slot="input-group-control"
       className={cn(
         "rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1",
-        className,
+        className
       )}
       {...props}
     />
@@ -139,7 +139,7 @@ function InputGroupTextarea({
       data-slot="input-group-control"
       className={cn(
         "rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent flex-1 resize-none",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/input.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/item.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/item.tsx
@@ -12,7 +12,7 @@ function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="item-group"
       className={cn(
         "gap-4 has-[[data-size=sm]]:gap-2.5 has-[[data-size=xs]]:gap-2 group/item-group flex w-full flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -52,7 +52,7 @@ const itemVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
+  }
 );
 
 function Item({
@@ -89,7 +89,7 @@ const itemMediaVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 function ItemMedia({
@@ -113,7 +113,7 @@ function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="item-content"
       className={cn(
         "gap-1 group-data-[size=xs]/item:gap-0 flex flex-1 flex-col [&+[data-slot=item-content]]:flex-none",
-        className,
+        className
       )}
       {...props}
     />
@@ -126,7 +126,7 @@ function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="item-title"
       className={cn(
         "gap-2 text-sm leading-snug font-medium underline-offset-4 line-clamp-1 flex w-fit items-center",
-        className,
+        className
       )}
       {...props}
     />
@@ -139,7 +139,7 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
       data-slot="item-description"
       className={cn(
         "text-muted-foreground text-left text-sm leading-normal group-data-[size=xs]/item:text-xs [&>a:hover]:text-primary line-clamp-2 font-normal [&>a]:underline [&>a]:underline-offset-4",
-        className,
+        className
       )}
       {...props}
     />
@@ -162,7 +162,7 @@ function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="item-header"
       className={cn(
         "gap-2 flex basis-full items-center justify-between",
-        className,
+        className
       )}
       {...props}
     />
@@ -175,7 +175,7 @@ function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="item-footer"
       className={cn(
         "gap-2 flex basis-full items-center justify-between",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/kbd.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/kbd.tsx
@@ -6,7 +6,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
       data-slot="kbd"
       className={cn(
         "bg-muted text-muted-foreground [[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-sm px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/label.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/label.tsx
@@ -14,7 +14,7 @@ function Label({
       data-slot="label"
       className={cn(
         "gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/menubar.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/menubar.tsx
@@ -15,7 +15,7 @@ function Menubar({
       data-slot="menubar"
       className={cn(
         "bg-background h-8 gap-0.5 rounded-lg border p-1 flex items-center",
-        className,
+        className
       )}
       {...props}
     />
@@ -57,7 +57,7 @@ function MenubarTrigger({
       data-slot="menubar-trigger"
       className={cn(
         "hover:bg-muted aria-expanded:bg-muted rounded-sm px-1.5 py-px text-sm font-medium flex items-center outline-hidden select-none",
-        className,
+        className
       )}
       {...props}
     />
@@ -80,7 +80,7 @@ function MenubarContent({
         sideOffset={sideOffset}
         className={cn(
           "bg-popover text-popover-foreground data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg p-1 shadow-md ring-1 duration-100 z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
-          className,
+          className
         )}
         {...props}
       />
@@ -104,7 +104,7 @@ function MenubarItem({
       data-variant={variant}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg:not([class*='size-'])]:size-4 group/menubar-item relative flex cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -122,7 +122,7 @@ function MenubarCheckboxItem({
       data-slot="menubar-checkbox-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-1.5 pl-7 text-sm data-disabled:opacity-50 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       checked={checked}
       {...props}
@@ -147,7 +147,7 @@ function MenubarRadioItem({
       data-slot="menubar-radio-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-1.5 pl-7 text-sm data-disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -174,7 +174,7 @@ function MenubarLabel({
       data-inset={inset}
       className={cn(
         "px-1.5 py-1 text-sm font-medium data-[inset]:pl-8",
-        className,
+        className
       )}
       {...props}
     />
@@ -203,7 +203,7 @@ function MenubarShortcut({
       data-slot="menubar-shortcut"
       className={cn(
         "text-muted-foreground group-focus/menubar-item:text-accent-foreground text-xs tracking-widest ml-auto",
-        className,
+        className
       )}
       {...props}
     />
@@ -230,7 +230,7 @@ function MenubarSubTrigger({
       data-inset={inset}
       className={cn(
         "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-[inset]:pl-8 [&_svg:not([class*='size-'])]:size-4 flex cursor-default items-center outline-none select-none",
-        className,
+        className
       )}
       {...props}
     >
@@ -249,7 +249,7 @@ function MenubarSubContent({
       data-slot="menubar-sub-content"
       className={cn(
         "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-32 rounded-lg p-1 shadow-lg ring-1 duration-100 z-50 origin-(--radix-menubar-content-transform-origin) overflow-hidden",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/native-select.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/native-select.tsx
@@ -16,7 +16,7 @@ function NativeSelect({
     <div
       className={cn(
         "group/native-select relative w-fit has-[select:disabled]:opacity-50",
-        className,
+        className
       )}
       data-slot="native-select-wrapper"
       data-size={size}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/navigation-menu.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/navigation-menu.tsx
@@ -19,7 +19,7 @@ function NavigationMenu({
       data-viewport={viewport}
       className={cn(
         "max-w-max group/navigation-menu relative flex max-w-max flex-1 items-center justify-center",
-        className,
+        className
       )}
       {...props}
     >
@@ -38,7 +38,7 @@ function NavigationMenuList({
       data-slot="navigation-menu-list"
       className={cn(
         "gap-0 group flex flex-1 list-none items-center justify-center",
-        className,
+        className
       )}
       {...props}
     />
@@ -59,7 +59,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "bg-background hover:bg-muted focus:bg-muted data-open:hover:bg-muted data-open:focus:bg-muted data-open:bg-muted/50 focus-visible:ring-ring/50 data-popup-open:bg-muted/50 data-popup-open:hover:bg-muted rounded-lg px-2.5 py-1.5 text-sm font-medium transition-all focus-visible:ring-[3px] focus-visible:outline-1 disabled:opacity-50 group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center disabled:pointer-events-none outline-none",
+  "bg-background hover:bg-muted focus:bg-muted data-open:hover:bg-muted data-open:focus:bg-muted data-open:bg-muted/50 focus-visible:ring-ring/50 data-popup-open:bg-muted/50 data-popup-open:hover:bg-muted rounded-lg px-2.5 py-1.5 text-sm font-medium transition-all focus-visible:ring-[3px] focus-visible:outline-1 disabled:opacity-50 group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center disabled:pointer-events-none outline-none"
 );
 
 function NavigationMenuTrigger({
@@ -91,7 +91,7 @@ function NavigationMenuContent({
       data-slot="navigation-menu-content"
       className={cn(
         "data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-open:animate-in group-data-[viewport=false]/navigation-menu:data-closed:animate-out group-data-[viewport=false]/navigation-menu:data-closed:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-open:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-open:fade-in-0 group-data-[viewport=false]/navigation-menu:data-closed:fade-out-0 group-data-[viewport=false]/navigation-menu:ring-foreground/10 p-1 ease-[cubic-bezier(0.22,1,0.36,1)] group-data-[viewport=false]/navigation-menu:rounded-lg group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:ring-1 group-data-[viewport=false]/navigation-menu:duration-300 top-0 left-0 w-full group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none md:absolute md:w-auto",
-        className,
+        className
       )}
       {...props}
     />
@@ -105,14 +105,14 @@ function NavigationMenuViewport({
   return (
     <div
       className={cn(
-        "absolute top-full left-0 isolate z-50 flex justify-center",
+        "absolute top-full left-0 isolate z-50 flex justify-center"
       )}
     >
       <NavigationMenuPrimitive.Viewport
         data-slot="navigation-menu-viewport"
         className={cn(
           "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:zoom-out-95 data-open:zoom-in-90 ring-foreground/10 rounded-lg shadow ring-1 duration-100 origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden md:w-[var(--radix-navigation-menu-viewport-width)]",
-          className,
+          className
         )}
         {...props}
       />
@@ -129,7 +129,7 @@ function NavigationMenuLink({
       data-slot="navigation-menu-link"
       className={cn(
         "data-active:focus:bg-muted data-active:hover:bg-muted data-active:bg-muted/50 focus-visible:ring-ring/50 hover:bg-muted focus:bg-muted flex items-center gap-2 rounded-lg p-2 text-sm transition-all outline-none focus-visible:ring-[3px] focus-visible:outline-1 [&_svg:not([class*='size-'])]:size-4 [[data-slot=navigation-menu-content]_&]:rounded-md",
-        className,
+        className
       )}
       {...props}
     />
@@ -145,7 +145,7 @@ function NavigationMenuIndicator({
       data-slot="navigation-menu-indicator"
       className={cn(
         "data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/pagination.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/pagination.tsx
@@ -109,7 +109,7 @@ function PaginationEllipsis({
       data-slot="pagination-ellipsis"
       className={cn(
         "size-8 items-center justify-center [&_svg:not([class*='size-'])]:size-4 flex items-center justify-center",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/popover.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/popover.tsx
@@ -31,7 +31,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         className={cn(
           "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
-          className,
+          className
         )}
         {...props}
       />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/progress.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/progress.tsx
@@ -15,7 +15,7 @@ function Progress({
       data-slot="progress"
       className={cn(
         "bg-muted h-1 rounded-full relative flex w-full items-center overflow-x-hidden",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/radio-group.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/radio-group.tsx
@@ -28,7 +28,7 @@ function RadioGroupItem({
       data-slot="radio-group-item"
       className={cn(
         "border-input text-primary dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-[3px] aria-invalid:ring-[3px] group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/resizable.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/resizable.tsx
@@ -14,7 +14,7 @@ function ResizablePanelGroup({
       data-slot="resizable-panel-group"
       className={cn(
         "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -39,7 +39,7 @@ function ResizableHandle({
       data-slot="resizable-handle"
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/scroll-area.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/scroll-area.tsx
@@ -40,7 +40,7 @@ function ScrollBar({
       orientation={orientation}
       className={cn(
         "data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent flex touch-none p-px transition-colors select-none",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/select.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/select.tsx
@@ -45,7 +45,7 @@ function SelectTrigger({
       data-size={size}
       className={cn(
         "border-input data-[placeholder]:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -72,7 +72,7 @@ function SelectContent({
           "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className,
+          className
         )}
         position={position}
         align={align}
@@ -83,7 +83,7 @@ function SelectContent({
           data-position={position}
           className={cn(
             "data-[position=popper]:h-[var(--radix-select-trigger-height)] data-[position=popper]:w-full data-[position=popper]:min-w-[var(--radix-select-trigger-width)]",
-            position === "popper" && "",
+            position === "popper" && ""
           )}
         >
           {children}
@@ -117,7 +117,7 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     >
@@ -153,7 +153,7 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       className={cn(
         "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
-        className,
+        className
       )}
       {...props}
     >
@@ -171,7 +171,7 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       className={cn(
         "bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/separator.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/separator.tsx
@@ -18,7 +18,7 @@ function Separator({
       orientation={orientation}
       className={cn(
         "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/sheet.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/sheet.tsx
@@ -38,7 +38,7 @@ function SheetOverlay({
       data-slot="sheet-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50",
-        className,
+        className
       )}
       {...props}
     />
@@ -63,7 +63,7 @@ function SheetContent({
         data-side={side}
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
-          className,
+          className
         )}
         {...props}
       >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/sidebar.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/sidebar.tsx
@@ -84,7 +84,7 @@ function SidebarProvider({
       // This sets the cookie to keep the sidebar state.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
-    [setOpenProp, open],
+    [setOpenProp, open]
   );
 
   // Helper to toggle the sidebar.
@@ -122,7 +122,7 @@ function SidebarProvider({
       setOpenMobile,
       toggleSidebar,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
   );
 
   return (
@@ -138,7 +138,7 @@ function SidebarProvider({
         }
         className={cn(
           "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
-          className,
+          className
         )}
         {...props}
       >
@@ -168,7 +168,7 @@ function Sidebar({
         data-slot="sidebar"
         className={cn(
           "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
-          className,
+          className
         )}
         {...props}
       >
@@ -220,7 +220,7 @@ function Sidebar({
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
             ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
-            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
         )}
       />
       <div
@@ -234,7 +234,7 @@ function Sidebar({
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
             : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
-          className,
+          className
         )}
         {...props}
       >
@@ -294,7 +294,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
         "hover:group-data-[collapsible=offExamples]:bg-sidebar group-data-[collapsible=offExamples]:translate-x-0 group-data-[collapsible=offExamples]:after:left-full",
         "[[data-side=left][data-collapsible=offExamples]_&]:-right-2",
         "[[data-side=right][data-collapsible=offExamples]_&]:-left-2",
-        className,
+        className
       )}
       {...props}
     />
@@ -307,7 +307,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
       data-slot="sidebar-inset"
       className={cn(
         "bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -371,7 +371,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-sidebar="content"
       className={cn(
         "no-scrollbar gap-0 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-        className,
+        className
       )}
       {...props}
     />
@@ -402,7 +402,7 @@ function SidebarGroupLabel({
       data-sidebar="group-label"
       className={cn(
         "text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -422,7 +422,7 @@ function SidebarGroupAction({
       data-sidebar="group-action"
       className={cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -484,7 +484,7 @@ const sidebarMenuButtonVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
+  }
 );
 
 function SidebarMenuButton({
@@ -556,7 +556,7 @@ function SidebarMenuAction({
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
         showOnHover &&
           "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -573,7 +573,7 @@ function SidebarMenuBadge({
       data-sidebar="menu-badge"
       className={cn(
         "text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-active/menu-button:text-sidebar-accent-foreground pointer-events-none absolute right-1 flex h-5 min-w-5 rounded-md px-1 text-xs font-medium peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden",
-        className,
+        className
       )}
       {...props}
     />
@@ -625,7 +625,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-sidebar="menu-sub"
       className={cn(
         "border-sidebar-border mx-3.5 translate-x-px gap-1 border-l px-2.5 py-0.5 group-data-[collapsible=icon]:hidden flex min-w-0 flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -667,7 +667,7 @@ function SidebarMenuSubButton({
       data-active={isActive}
       className={cn(
         "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 focus-visible:ring-2 data-[size=md]:text-sm data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/slider.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/slider.tsx
@@ -20,7 +20,7 @@ function Slider({
         : Array.isArray(defaultValue)
           ? defaultValue
           : [min, max],
-    [value, defaultValue, min, max],
+    [value, defaultValue, min, max]
   );
 
   return (
@@ -32,7 +32,7 @@ function Slider({
       max={max}
       className={cn(
         "data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/switch.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/switch.tsx
@@ -18,7 +18,7 @@ function Switch({
       data-size={size}
       className={cn(
         "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/table.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/table.tsx
@@ -45,7 +45,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
       data-slot="table-footer"
       className={cn(
         "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -58,7 +58,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
       data-slot="table-row"
       className={cn(
         "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className,
+        className
       )}
       {...props}
     />
@@ -71,7 +71,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       data-slot="table-head"
       className={cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
-        className,
+        className
       )}
       {...props}
     />
@@ -84,7 +84,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
       data-slot="table-cell"
       className={cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/tabs.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/tabs.tsx
@@ -17,7 +17,7 @@ function Tabs({
       data-orientation={orientation}
       className={cn(
         "gap-2 group/tabs flex data-[orientation=horizontal]:flex-col",
-        className,
+        className
       )}
       {...props}
     />
@@ -36,7 +36,7 @@ const tabsListVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  },
+  }
 );
 
 function TabsList({
@@ -67,7 +67,7 @@ function TabsTrigger({
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/textarea.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       data-slot="textarea"
       className={cn(
         "border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 rounded-lg border bg-transparent px-2.5 py-2 text-base transition-colors focus-visible:ring-[3px] aria-invalid:ring-[3px] md:text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+        className
       )}
       {...props}
     />

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/toggle-group.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/toggle-group.tsx
@@ -42,7 +42,7 @@ function ToggleGroup({
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
         "rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch",
-        className,
+        className
       )}
       {...props}
     >
@@ -77,7 +77,7 @@ function ToggleGroupItem({
           variant: context.variant || variant,
           size: context.size || size,
         }),
-        className,
+        className
       )}
       {...props}
     >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/toggle.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/toggle.tsx
@@ -24,7 +24,7 @@ const toggleVariants = cva(
       variant: "default",
       size: "default",
     },
-  },
+  }
 );
 
 function Toggle({

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/tooltip.tsx
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/components/ui/tooltip.tsx
@@ -47,7 +47,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs bg-foreground text-background z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)",
-          className,
+          className
         )}
         {...props}
       >

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/hooks/use-mobile.ts
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/hooks/use-mobile.ts
@@ -4,7 +4,7 @@ const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
+    undefined
   );
 
   React.useEffect(() => {

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -18,8 +18,9 @@
         --white-15: rgba(0, 0, 0, 0.15);
         --white-20: rgba(0, 0, 0, 0.2);
         --white-30: rgba(0, 0, 0, 0.3);
-        --font-hanken-grotesk: "Hanken Grotesk", -apple-system,
-          BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        --font-hanken-grotesk:
+          "Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, sans-serif;
       }
 
       .dark {
@@ -467,7 +468,7 @@
           } catch (reachErr) {
             showSettings();
             showError(
-              `Could not connect to ${currentServerUrl}. Check the URL and your network connection.`,
+              `Could not connect to ${currentServerUrl}. Check the URL and your network connection.`
             );
             return;
           }

--- a/desktop/src/titlebar.js
+++ b/desktop/src/titlebar.js
@@ -228,7 +228,7 @@
     if (viewportHeight) {
       document.documentElement.style.setProperty(
         VIEWPORT_VAR,
-        `${viewportHeight}px`,
+        `${viewportHeight}px`
       );
     }
   }

--- a/docs/craft/features/skills/skills_plan.html
+++ b/docs/craft/features/skills/skills_plan.html
@@ -35,8 +35,8 @@
         box-sizing: border-box;
       }
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI",
-          sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
         background: var(--bg);
         color: var(--fg);
         line-height: 1.55;

--- a/examples/widget/src/app/widget/Widget.tsx
+++ b/examples/widget/src/app/widget/Widget.tsx
@@ -10,7 +10,7 @@ type NonEmptyObject = { [k: string]: any };
 
 const processSingleChunk = <T extends NonEmptyObject>(
   chunk: string,
-  currPartialChunk: string | null,
+  currPartialChunk: string | null
 ): [T | null, string | null] => {
   const completeChunk = (currPartialChunk || "") + chunk;
   try {
@@ -25,7 +25,7 @@ const processSingleChunk = <T extends NonEmptyObject>(
 
 const processRawChunkString = <T extends NonEmptyObject>(
   rawChunkString: string,
-  previousPartialChunk: string | null,
+  previousPartialChunk: string | null
 ): [T[], string | null] => {
   /* This is required because, in practice, we see that nginx does not send over
   each chunk one at a time even with buffering turned off. Instead,
@@ -41,7 +41,7 @@ const processRawChunkString = <T extends NonEmptyObject>(
   chunkSections.forEach((chunk) => {
     const [processedChunk, partialChunk] = processSingleChunk<T>(
       chunk,
-      currPartialChunk,
+      currPartialChunk
     );
     if (processedChunk) {
       parsedChunkSections.push(processedChunk);
@@ -55,7 +55,7 @@ const processRawChunkString = <T extends NonEmptyObject>(
 };
 
 async function* handleStream<T extends NonEmptyObject>(
-  streamingResponse: Response,
+  streamingResponse: Response
 ): AsyncGenerator<T[], void, unknown> {
   const reader = streamingResponse.body?.getReader();
   const decoder = new TextDecoder("utf-8");
@@ -73,7 +73,7 @@ async function* handleStream<T extends NonEmptyObject>(
 
     const [completedChunks, partialChunk] = processRawChunkString<T>(
       decoder.decode(value, { stream: true }),
-      previousPartialChunk,
+      previousPartialChunk
     );
     if (!completedChunks.length && !partialChunk) {
       break;
@@ -107,7 +107,7 @@ async function* sendMessage({
           // or specify an assistant you have defined
           persona_id: 0,
         }),
-      },
+      }
     );
 
     if (!createSessionResponse.ok) {
@@ -153,7 +153,7 @@ async function* sendMessage({
 
 export const ChatWidget = () => {
   const [messages, setMessages] = useState<{ text: string; isUser: boolean }[]>(
-    [],
+    []
   );
   const [inputText, setInputText] = useState("");
   const [isLoading, setIsLoading] = useState(false);

--- a/extensions/chrome/service_worker.js
+++ b/extensions/chrome/service_worker.js
@@ -17,7 +17,7 @@ chrome.runtime.onInstalled.addListener((details) => {
         if (!result[CHROME_SPECIFIC_STORAGE_KEYS.ONBOARDING_COMPLETE]) {
           chrome.tabs.create({ url: "src/pages/welcome.html" });
         }
-      },
+      }
     );
   }
 });
@@ -73,7 +73,7 @@ async function sendToOnyx(info, tab) {
 async function toggleNewTabOverride() {
   try {
     const result = await chrome.storage.local.get(
-      CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB,
+      CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB
     );
     const newValue =
       !result[CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB];
@@ -183,7 +183,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           [CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN]:
             result[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN],
         });
-      },
+      }
     );
     return true;
   }
@@ -196,7 +196,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           url: `${result[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN]}/auth/login`,
           active: true,
         });
-      },
+      }
     );
     return true;
   }
@@ -233,10 +233,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             .catch((error) => {
               console.error(
                 "[Onyx SW] Error opening side panel with text:",
-                error,
+                error
               );
             });
-        },
+        }
       );
     } else {
       console.error("[Onyx SW] Missing tabId or windowId");

--- a/extensions/chrome/src/pages/onyx_home.js
+++ b/extensions/chrome/src/pages/onyx_home.js
@@ -116,7 +116,7 @@ import { getOnyxDomain } from "../utils/storage.js";
         if (useOnyxAsDefaultNewTab === undefined) {
           useOnyxAsDefaultNewTab = !!(
             localStorage.getItem(
-              CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB,
+              CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB
             ) === "1"
           );
           chrome.storage.local.set({
@@ -133,7 +133,7 @@ import { getOnyxDomain } from "../utils/storage.js";
         }
 
         setIframeSrc(items[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN] + "/nrf");
-      },
+      }
     );
   }
 
@@ -163,7 +163,7 @@ import { getOnyxDomain } from "../utils/storage.js";
 
         setTheme(theme, backgroundImage);
         checkOnyxPreference();
-      },
+      }
     );
   }
 
@@ -171,7 +171,7 @@ import { getOnyxDomain } from "../utils/storage.js";
     if (preloadedIframe && preloadedIframe.contentWindow) {
       preloadedIframe.contentWindow.postMessage(
         { type: WEB_MESSAGE.PAGE_CHANGE, href: newSrc },
-        "*",
+        "*"
       );
     } else {
       console.error("Preloaded iframe not available");
@@ -223,7 +223,7 @@ import { getOnyxDomain } from "../utils/storage.js";
           [CHROME_SPECIFIC_STORAGE_KEYS.THEME]: theme,
           [CHROME_SPECIFIC_STORAGE_KEYS.BACKGROUND_IMAGE]: backgroundUrl,
         },
-        () => {},
+        () => {}
       );
     } else if (event.data.type === CHROME_MESSAGE.LOAD_NEW_PAGE) {
       loadNewPage(event.data.href);

--- a/extensions/chrome/src/pages/options.js
+++ b/extensions/chrome/src/pages/options.js
@@ -47,7 +47,7 @@ document.addEventListener("DOMContentLoaded", function () {
         updateThemeIcon(currentTheme);
 
         document.body.className = currentTheme === "light" ? "light-theme" : "";
-      },
+      }
     );
   }
 
@@ -68,9 +68,9 @@ document.addEventListener("DOMContentLoaded", function () {
         showStatusMessage(
           useOnyxAsDefault
             ? "Settings updated. Open a new tab to test it out. Click on the extension icon to bring up Onyx from any page."
-            : "Settings updated.",
+            : "Settings updated."
         );
-      },
+      }
     );
   }
 

--- a/extensions/chrome/src/pages/panel.js
+++ b/extensions/chrome/src/pages/panel.js
@@ -66,7 +66,7 @@ import {
           type: WEB_MESSAGE.PAGE_CHANGE,
           url: pageUrl,
         },
-        getIframeOrigin(),
+        getIframeOrigin()
       );
       currentUrl = pageUrl;
     }
@@ -104,7 +104,7 @@ import {
       if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
           { type: "PANEL_READY" },
-          getIframeOrigin(),
+          getIframeOrigin()
         );
       }
     } else if (event.data.type === CHROME_MESSAGE.AUTH_REQUIRED) {
@@ -131,7 +131,7 @@ import {
     if (response && response[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN]) {
       setIframeSrc(
         response[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN] + SIDE_PANEL_PATH,
-        "",
+        ""
       );
     } else {
       console.warn("Onyx domain not found, using default");
@@ -149,7 +149,7 @@ import {
       if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
           { type: CHROME_MESSAGE.TAB_URL_UPDATED, url: request.url },
-          getIframeOrigin(),
+          getIframeOrigin()
         );
       }
     }

--- a/extensions/chrome/src/pages/welcome.js
+++ b/extensions/chrome/src/pages/welcome.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", function () {
             : "dark";
         }
         applyTheme();
-      },
+      }
     );
   }
 
@@ -141,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function () {
         } else {
           window.close();
         }
-      },
+      }
     );
   }
 
@@ -158,7 +158,7 @@ document.addEventListener("DOMContentLoaded", function () {
         }
         useOnyxAsDefaultToggle.checked =
           result[CHROME_SPECIFIC_STORAGE_KEYS.USE_ONYX_AS_DEFAULT_NEW_TAB];
-      },
+      }
     );
   }
 

--- a/extensions/chrome/src/utils/content.js
+++ b/extensions/chrome/src/utils/content.js
@@ -26,7 +26,7 @@ function createSidePanel() {
     { action: ACTIONS.GET_CURRENT_ONYX_DOMAIN },
     function (response) {
       iframe.src = response[CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN];
-    },
+    }
   );
 
   sidePanel.appendChild(iframe);

--- a/extensions/chrome/src/utils/error-modal.js
+++ b/extensions/chrome/src/utils/error-modal.js
@@ -335,7 +335,7 @@ export function initAuthModal() {
               if (chrome.runtime.lastError) {
                 console.error(
                   "Error closing side panel:",
-                  chrome.runtime.lastError,
+                  chrome.runtime.lastError
                 );
               }
               chrome.tabs.create(
@@ -347,14 +347,14 @@ export function initAuthModal() {
                   if (chrome.runtime.lastError) {
                     console.error(
                       "Error opening auth tab:",
-                      chrome.runtime.lastError,
+                      chrome.runtime.lastError
                     );
                   }
-                },
+                }
               );
-            },
+            }
           );
-        },
+        }
       );
     });
   }

--- a/extensions/chrome/src/utils/selection-icon.js
+++ b/extensions/chrome/src/utils/selection-icon.js
@@ -48,11 +48,11 @@
 
     posX = Math.max(
       offset,
-      Math.min(posX, window.innerWidth - iconSize - offset),
+      Math.min(posX, window.innerWidth - iconSize - offset)
     );
     posY = Math.max(
       offset,
-      Math.min(posY, window.innerHeight - iconSize - offset),
+      Math.min(posY, window.innerHeight - iconSize - offset)
     );
 
     selectionIcon.style.left = `${posX}px`;
@@ -84,11 +84,11 @@
           if (chrome.runtime.lastError) {
             console.error(
               "[Onyx] Error sending message:",
-              chrome.runtime.lastError.message,
+              chrome.runtime.lastError.message
             );
           } else {
           }
-        },
+        }
       );
     }
 
@@ -133,7 +133,7 @@
     () => {
       hideIcon();
     },
-    true,
+    true
   );
 
   document.addEventListener("selectionchange", () => {

--- a/extensions/chrome/src/utils/storage.js
+++ b/extensions/chrome/src/utils/storage.js
@@ -13,7 +13,7 @@ export async function getOnyxDomain() {
 export function setOnyxDomain(domain, callback) {
   chrome.storage.local.set(
     { [CHROME_SPECIFIC_STORAGE_KEYS.ONYX_DOMAIN]: domain },
-    callback,
+    callback
   );
 }
 

--- a/web/lib/opal/src/components/buttons/filter-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/filter-button/components.tsx
@@ -13,8 +13,10 @@ import { ChevronIcon } from "@opal/components/buttons/chevron";
 // Types
 // ---------------------------------------------------------------------------
 
-interface FilterButtonProps
-  extends Omit<InteractiveStatefulProps, "variant" | "state" | "children"> {
+interface FilterButtonProps extends Omit<
+  InteractiveStatefulProps,
+  "variant" | "state" | "children"
+> {
   /** Left icon — always visible. */
   icon: IconFunctionComponent;
 

--- a/web/lib/opal/src/components/cards/card/styles.css
+++ b/web/lib/opal/src/components/cards/card/styles.css
@@ -88,8 +88,8 @@
    regardless of any status borderColor applied to the card. */
 
 .opal-card-expandable-header:has(
-    + .opal-card-expandable-wrapper[data-expanded="true"]
-  ) {
+  + .opal-card-expandable-wrapper[data-expanded="true"]
+) {
   @apply border-b-border-01;
 }
 

--- a/web/lib/opal/src/components/checkbox/components.tsx
+++ b/web/lib/opal/src/components/checkbox/components.tsx
@@ -11,8 +11,10 @@ import { SvgCheck, SvgMinus } from "@opal/icons";
 
 type CheckboxState = "unchecked" | "checked" | "indeterminate";
 
-interface CheckboxProps
-  extends Omit<React.ComponentPropsWithoutRef<"input">, "type" | "size"> {
+interface CheckboxProps extends Omit<
+  React.ComponentPropsWithoutRef<"input">,
+  "type" | "size"
+> {
   checked?: boolean;
   defaultChecked?: boolean;
   onCheckedChange?: (checked: boolean) => void;

--- a/web/lib/opal/src/components/pagination/components.tsx
+++ b/web/lib/opal/src/components/pagination/components.tsx
@@ -26,8 +26,10 @@ type PaginationSize = "lg" | "md" | "sm";
 /**
  * Compact `currentPage / totalPages` display with prev/next arrows.
  */
-interface SimplePaginationProps
-  extends Omit<WithoutStyles<HTMLAttributes<HTMLDivElement>>, "onChange"> {
+interface SimplePaginationProps extends Omit<
+  WithoutStyles<HTMLAttributes<HTMLDivElement>>,
+  "onChange"
+> {
   variant: "simple";
   /** The 1-based current page number. */
   currentPage: number;
@@ -47,8 +49,10 @@ interface SimplePaginationProps
  * Item-count display (`X~Y of Z`) with prev/next arrows.
  * Designed for table footers.
  */
-interface CountPaginationProps
-  extends Omit<WithoutStyles<HTMLAttributes<HTMLDivElement>>, "onChange"> {
+interface CountPaginationProps extends Omit<
+  WithoutStyles<HTMLAttributes<HTMLDivElement>>,
+  "onChange"
+> {
   variant: "count";
   /** The 1-based current page number. */
   currentPage: number;
@@ -72,8 +76,10 @@ interface CountPaginationProps
  * Numbered page buttons with ellipsis truncation for large page counts.
  * This is the default variant.
  */
-interface ListPaginationProps
-  extends Omit<WithoutStyles<HTMLAttributes<HTMLDivElement>>, "onChange"> {
+interface ListPaginationProps extends Omit<
+  WithoutStyles<HTMLAttributes<HTMLDivElement>>,
+  "onChange"
+> {
   variant?: "list";
   /** The 1-based current page number. */
   currentPage: number;

--- a/web/lib/opal/src/components/popover/components.tsx
+++ b/web/lib/opal/src/components/popover/components.tsx
@@ -117,10 +117,9 @@ const widthClasses: Record<PopoverWidths, string> = {
   "2xl": "w-100",
   trigger: "w-(--radix-popover-trigger-width)",
 };
-interface PopoverContentProps
-  extends WithoutStyles<
-    React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
-  > {
+interface PopoverContentProps extends WithoutStyles<
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+> {
   width?: PopoverWidths;
   /** Portal container. Set to a DOM element to render inside it (e.g. inside a modal). */
   container?: HTMLElement | null;

--- a/web/lib/opal/src/components/separator/components.tsx
+++ b/web/lib/opal/src/components/separator/components.tsx
@@ -4,8 +4,9 @@ import React from "react";
 import * as SeparatorPrimitive from "@radix-ui/react-separator";
 import { cn } from "@opal/utils";
 
-interface SeparatorProps
-  extends React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {
+interface SeparatorProps extends React.ComponentPropsWithoutRef<
+  typeof SeparatorPrimitive.Root
+> {
   noPadding?: boolean;
   /** Custom horizontal padding in rem. Overrides the default padding. */
   paddingXRem?: number;

--- a/web/lib/opal/src/components/table/TableBody.tsx
+++ b/web/lib/opal/src/components/table/TableBody.tsx
@@ -35,8 +35,9 @@ interface DraggableProps {
   isEnabled: boolean;
 }
 
-interface TableBodyProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLTableSectionElement>> {
+interface TableBodyProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLTableSectionElement>
+> {
   ref?: React.Ref<HTMLTableSectionElement>;
   /** DnD context props from useDraggableRows — enables drag-and-drop reordering */
   dndSortable?: DraggableProps;

--- a/web/lib/opal/src/components/table/TableCell.tsx
+++ b/web/lib/opal/src/components/table/TableCell.tsx
@@ -2,8 +2,9 @@ import { cn } from "@opal/utils";
 import { useTableSize } from "@opal/components/table/TableSizeContext";
 import type { WithoutStyles } from "@opal/types";
 
-interface TableCellProps
-  extends WithoutStyles<React.TdHTMLAttributes<HTMLTableCellElement>> {
+interface TableCellProps extends WithoutStyles<
+  React.TdHTMLAttributes<HTMLTableCellElement>
+> {
   children: React.ReactNode;
   /** Explicit pixel width for the cell. */
   width?: number;

--- a/web/lib/opal/src/components/table/TableElement.tsx
+++ b/web/lib/opal/src/components/table/TableElement.tsx
@@ -14,8 +14,9 @@ type TableSize = Extract<SizeVariants, "md" | "lg">;
 type TableVariant = "rows" | "cards";
 type SelectionBehavior = "no-select" | "single-select" | "multi-select";
 
-interface TableProps
-  extends WithoutStyles<React.TableHTMLAttributes<HTMLTableElement>> {
+interface TableProps extends WithoutStyles<
+  React.TableHTMLAttributes<HTMLTableElement>
+> {
   ref?: React.Ref<HTMLTableElement>;
   /** Visual row variant. @default "cards" */
   variant?: TableVariant;

--- a/web/lib/opal/src/components/table/TableHeader.tsx
+++ b/web/lib/opal/src/components/table/TableHeader.tsx
@@ -1,7 +1,8 @@
 import type { WithoutStyles } from "@opal/types";
 
-interface TableHeaderProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLTableSectionElement>> {
+interface TableHeaderProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLTableSectionElement>
+> {
   ref?: React.Ref<HTMLTableSectionElement>;
 }
 

--- a/web/lib/opal/src/components/table/TableRow.tsx
+++ b/web/lib/opal/src/components/table/TableRow.tsx
@@ -11,8 +11,9 @@ import { SvgHandle } from "@opal/icons";
 // Types
 // ---------------------------------------------------------------------------
 
-export interface TableRowProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLTableRowElement>> {
+export interface TableRowProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLTableRowElement>
+> {
   ref?: React.Ref<HTMLTableRowElement>;
   selected?: boolean;
   /** Disables interaction and applies disabled styling */

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -45,10 +45,9 @@ type TextColor =
   | "text-dark-03"
   | "text-dark-05";
 
-interface TextProps
-  extends WithoutStyles<
-    Omit<HTMLAttributes<HTMLElement>, "color" | "children">
-  > {
+interface TextProps extends WithoutStyles<
+  Omit<HTMLAttributes<HTMLElement>, "color" | "children">
+> {
   /** Font preset. Default: `"main-ui-body"`. */
   font?: TextFont;
 

--- a/web/lib/opal/src/core/animations/components.tsx
+++ b/web/lib/opal/src/core/animations/components.tsx
@@ -12,8 +12,9 @@ import { widthVariants } from "@opal/shared";
 
 type HoverableInteraction = "rest" | "hover";
 
-interface HoverableRootProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
+interface HoverableRootProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+> {
   children: React.ReactNode;
   group: string;
   /** Width preset. @default "auto" */
@@ -38,8 +39,9 @@ type HoverableItemVariant =
   | "appear-on-rest"
   | "replace-on-hover";
 
-interface HoverableItemProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
+interface HoverableItemProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+> {
   children: React.ReactNode;
   group?: string;
   variant?: HoverableItemVariant;

--- a/web/lib/opal/src/core/disabled/components.tsx
+++ b/web/lib/opal/src/core/disabled/components.tsx
@@ -7,8 +7,9 @@ import type { RichStr, WithoutStyles } from "@opal/types";
 // Types
 // ---------------------------------------------------------------------------
 
-interface DisabledProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
+interface DisabledProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+> {
   ref?: React.Ref<HTMLDivElement>;
 
   /**

--- a/web/lib/opal/src/core/interactive/container/components.tsx
+++ b/web/lib/opal/src/core/interactive/container/components.tsx
@@ -33,8 +33,9 @@ const interactiveContainerRoundingVariants: Record<
  *
  * Extends standard `<div>` attributes (minus `className` and `style`).
  */
-interface InteractiveContainerProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
+interface InteractiveContainerProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+> {
   /**
    * Ref forwarded to the underlying element.
    */

--- a/web/lib/opal/src/core/interactive/foldable/components.tsx
+++ b/web/lib/opal/src/core/interactive/foldable/components.tsx
@@ -6,8 +6,9 @@ import type { WithoutStyles } from "@opal/types";
 // Types
 // ---------------------------------------------------------------------------
 
-interface FoldableProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLDivElement>> {
+interface FoldableProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLDivElement>
+> {
   children: React.ReactNode;
 }
 

--- a/web/lib/opal/src/core/interactive/simple/components.tsx
+++ b/web/lib/opal/src/core/interactive/simple/components.tsx
@@ -7,11 +7,10 @@ import { guardPortalClick } from "@opal/core/interactive/utils";
 // Types
 // ---------------------------------------------------------------------------
 
-interface InteractiveSimpleProps
-  extends Omit<
-    React.HTMLAttributes<HTMLElement>,
-    "className" | "style" | "color"
-  > {
+interface InteractiveSimpleProps extends Omit<
+  React.HTMLAttributes<HTMLElement>,
+  "className" | "style" | "color"
+> {
   ref?: React.Ref<HTMLElement>;
 
   /**

--- a/web/lib/opal/src/core/interactive/stateful/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateful/components.tsx
@@ -25,8 +25,9 @@ type InteractiveStatefulInteraction = "rest" | "hover" | "active";
 /**
  * Props for {@link InteractiveStateful}.
  */
-interface InteractiveStatefulProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLElement>> {
+interface InteractiveStatefulProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLElement>
+> {
   ref?: React.Ref<HTMLElement>;
 
   /**

--- a/web/lib/opal/src/core/interactive/stateless/components.tsx
+++ b/web/lib/opal/src/core/interactive/stateless/components.tsx
@@ -21,8 +21,9 @@ type InteractiveStatelessInteraction = "rest" | "hover" | "active";
 /**
  * Props for {@link InteractiveStateless}.
  */
-interface InteractiveStatelessProps
-  extends WithoutStyles<React.HTMLAttributes<HTMLElement>> {
+interface InteractiveStatelessProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLElement>
+> {
   ref?: React.Ref<HTMLElement>;
 
   /**

--- a/web/lib/opal/src/layouts/general/components.tsx
+++ b/web/lib/opal/src/layouts/general/components.tsx
@@ -36,8 +36,9 @@ const heightClassmap: Record<Exclude<Length, number>, string> = {
   full: "h-full min-h-0",
 };
 
-interface SectionProps
-  extends WithoutStyles<React.HtmlHTMLAttributes<HTMLDivElement>> {
+interface SectionProps extends WithoutStyles<
+  React.HtmlHTMLAttributes<HTMLDivElement>
+> {
   className?: string;
   flexDirection?: FlexDirection;
   justifyContent?: JustifyContent;

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -18,10 +18,9 @@ import { Content, ContentAction } from "@opal/layouts";
 // Label
 // ---------------------------------------------------------------------------
 
-interface LabelProps
-  extends WithoutStyles<
-    Omit<React.LabelHTMLAttributes<HTMLLabelElement>, "htmlFor">
-  > {
+interface LabelProps extends WithoutStyles<
+  Omit<React.LabelHTMLAttributes<HTMLLabelElement>, "htmlFor">
+> {
   /** Sets `htmlFor` on the `<label>` to associate it with a form element by id. */
   label?: string;
   /** Switches cursor from `pointer` to `not-allowed`. */

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -208,12 +208,15 @@
 
   /* Font Family Variables */
   :root {
-    --font-hanken-grotesk: "Hanken Grotesk", -apple-system, BlinkMacSystemFont,
-      "Segoe UI", Roboto, sans-serif;
-    --font-dm-mono: "DM Mono", "SF Mono", Monaco, "Cascadia Code", "Roboto Mono",
-      Consolas, "Courier New", monospace;
-    --font-kh-teka: "KH Teka", -apple-system, BlinkMacSystemFont, "Segoe UI",
-      Roboto, sans-serif;
+    --font-hanken-grotesk:
+      "Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      sans-serif;
+    --font-dm-mono:
+      "DM Mono", "SF Mono", Monaco, "Cascadia Code", "Roboto Mono", Consolas,
+      "Courier New", monospace;
+    --font-kh-teka:
+      "KH Teka", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      sans-serif;
   }
 
   /* HEADING STYLES */

--- a/web/src/refresh-pages/admin/WebSearchPage/WebProviderSetupModal.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/WebProviderSetupModal.tsx
@@ -107,7 +107,7 @@ export function WebProviderSetupModal({ state }: WebProviderSetupModalProps) {
   const providerLabel =
     category === "search"
       ? getSearchProviderDisplayLabel(providerType, provider?.name)
-      : CONTENT_PROVIDER_DETAILS[providerType]?.label ?? providerType;
+      : (CONTENT_PROVIDER_DETAILS[providerType]?.label ?? providerType);
 
   const icon =
     category === "search"
@@ -124,7 +124,7 @@ export function WebProviderSetupModal({ state }: WebProviderSetupModalProps) {
       : undefined;
 
   const initialApiKey =
-    provider && provider.id > 0 ? provider.masked_api_key ?? "" : "";
+    provider && provider.id > 0 ? (provider.masked_api_key ?? "") : "";
 
   const initialConfig = configField
     ? (category === "search"

--- a/web/src/refresh-pages/admin/WebSearchPage/index.tsx
+++ b/web/src/refresh-pages/admin/WebSearchPage/index.tsx
@@ -80,7 +80,7 @@ export default function WebSearchPage() {
     const isExa = providerType === "exa";
     const sharedExaMaskedKey =
       isExa && !hasStoredKey
-        ? exaContentProvider?.masked_api_key ?? null
+        ? (exaContentProvider?.masked_api_key ?? null)
         : null;
 
     const effectiveProvider: WebSearchProviderView | null =

--- a/widget/index.html
+++ b/widget/index.html
@@ -10,8 +10,9 @@
       }
 
       body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-          "Helvetica", "Arial", sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica",
+          "Arial", sans-serif;
         margin: 0;
         padding: 0;
         background: #f5f5f5;

--- a/widget/src/config/config.ts
+++ b/widget/src/config/config.ts
@@ -21,7 +21,7 @@ export function resolveConfig(attributes: Partial<WidgetConfig>): WidgetConfig {
 
   if (!config.backendUrl || !config.apiKey) {
     throw new Error(
-      "backendUrl and apiKey are required for the widget to function",
+      "backendUrl and apiKey are required for the widget to function"
     );
   }
 

--- a/widget/src/services/api-service.ts
+++ b/widget/src/services/api-service.ts
@@ -15,7 +15,7 @@ export class ApiService {
 
   constructor(
     private backendUrl: string,
-    private apiKey: string,
+    private apiKey: string
   ) {}
 
   /**
@@ -33,7 +33,7 @@ export class ApiService {
         method: "POST",
         headers: this.getHeaders(),
         body: JSON.stringify(request),
-      },
+      }
     );
 
     if (!response.ok) {
@@ -79,7 +79,7 @@ export class ApiService {
         headers: this.getHeaders(),
         body: JSON.stringify(request),
         signal: params.signal,
-      },
+      }
     );
 
     if (!response.ok) {
@@ -104,7 +104,7 @@ export class ApiService {
    * Backend returns newline-delimited JSON packets
    */
   private async *parseSSEStream(
-    response: Response,
+    response: Response
   ): AsyncGenerator<Packet, void, unknown> {
     const reader = response.body?.getReader();
     if (!reader) {
@@ -145,7 +145,7 @@ export class ApiService {
             } catch (e) {
               // Fail fast on malformed packets - don't hide backend issues
               throw new Error(
-                `Failed to parse SSE packet: ${line}. Error: ${e}`,
+                `Failed to parse SSE packet: ${line}. Error: ${e}`
               );
             }
           }
@@ -172,7 +172,7 @@ export class ApiService {
         } catch (e) {
           // Fail fast on malformed final buffer packets
           throw new Error(
-            `Failed to parse final packet: ${buffer}. Error: ${e}`,
+            `Failed to parse final packet: ${buffer}. Error: ${e}`
           );
         }
       }
@@ -187,7 +187,7 @@ export class ApiService {
   private async fetchWithRetry(
     url: string,
     options: RequestInit,
-    retries = 0,
+    retries = 0
   ): Promise<Response> {
     try {
       const response = await fetch(url, options);

--- a/widget/src/services/stream-parser.ts
+++ b/widget/src/services/stream-parser.ts
@@ -21,7 +21,7 @@ export interface MessageIDs {
  */
 export function processPacket(
   packet: Packet,
-  currentMessage: ChatMessage | null,
+  currentMessage: ChatMessage | null
 ): {
   message: ChatMessage | null;
   citation?: { citation_number: number; document_id: string };

--- a/widget/src/styles/theme.ts
+++ b/widget/src/styles/theme.ts
@@ -10,8 +10,9 @@ export const theme = css`
 
   :host {
     /* Typography - Hanken Grotesk */
-    --onyx-font-family: "Hanken Grotesk", -apple-system, BlinkMacSystemFont,
-      "Segoe UI", sans-serif;
+    --onyx-font-family:
+      "Hanken Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI",
+      sans-serif;
     --onyx-font-family-mono: "DM Mono", "Monaco", "Menlo", monospace;
 
     /* Font Sizes */

--- a/widget/src/widget.ts
+++ b/widget/src/widget.ts
@@ -106,7 +106,7 @@ export class OnyxChatWidget extends LitElement {
     // Initialize API service
     this.apiService = new ApiService(
       this.config.backendUrl,
-      this.config.apiKey,
+      this.config.apiKey
     );
 
     // Load persisted session
@@ -128,7 +128,7 @@ export class OnyxChatWidget extends LitElement {
       this.style.setProperty("--theme-primary-05", this.config.primaryColor);
       this.style.setProperty(
         "--theme-primary-06",
-        this.adjustBrightness(this.config.primaryColor, -10),
+        this.adjustBrightness(this.config.primaryColor, -10)
       );
     }
 
@@ -136,11 +136,11 @@ export class OnyxChatWidget extends LitElement {
     if (this.config.backgroundColor) {
       this.style.setProperty(
         "--background-neutral-00",
-        this.config.backgroundColor,
+        this.config.backgroundColor
       );
       this.style.setProperty(
         "--background-neutral-03",
-        this.adjustBrightness(this.config.backgroundColor, -10),
+        this.adjustBrightness(this.config.backgroundColor, -10)
       );
     }
 
@@ -212,7 +212,7 @@ export class OnyxChatWidget extends LitElement {
             (_match, num) => {
               const displayNum = displayMap.get(Number(num));
               return displayNum ? `<sup>[${displayNum}]</sup>` : "";
-            },
+            }
           );
         } else {
           // Still streaming or no citations resolved yet — strip raw links
@@ -237,7 +237,7 @@ export class OnyxChatWidget extends LitElement {
    */
   private renderCitationBadge(
     c: ResolvedCitation,
-    displayNum: number,
+    displayNum: number
   ): TemplateResult {
     const title = c.semantic_identifier || "Source";
     const safeHref =
@@ -273,7 +273,7 @@ export class OnyxChatWidget extends LitElement {
    * Shows first 3 inline, collapses the rest behind a "+N more" toggle.
    */
   private renderCitations(
-    citations?: ResolvedCitation[],
+    citations?: ResolvedCitation[]
   ): string | TemplateResult {
     if (!citations?.length) return "";
     const limit = OnyxChatWidget.CITATIONS_COLLAPSED_COUNT;
@@ -290,7 +290,7 @@ export class OnyxChatWidget extends LitElement {
               </button>
               <div class="citation-overflow">
                 ${overflow.map((c, i) =>
-                  this.renderCitationBadge(c, limit + i + 1),
+                  this.renderCitationBadge(c, limit + i + 1)
                 )}
               </div>
             `
@@ -344,7 +344,7 @@ export class OnyxChatWidget extends LitElement {
       if (!this.chatSessionId) {
         this.isLoading = true;
         this.chatSessionId = await this.apiService.createChatSession(
-          this.config.agentId,
+          this.config.agentId
         );
         this.isLoading = false;
       }
@@ -377,7 +377,7 @@ export class OnyxChatWidget extends LitElement {
           // Update user message ID if we got one
           if (result.messageIds.userMessageId !== null) {
             const userMsgIndex = this.messages.findIndex(
-              (m) => m.id === userMessage.id,
+              (m) => m.id === userMessage.id
             );
             if (userMsgIndex >= 0) {
               // Create new array to trigger reactivity
@@ -412,7 +412,7 @@ export class OnyxChatWidget extends LitElement {
         if (result.citation) {
           this.citationMap.set(
             result.citation.citation_number,
-            result.citation.document_id,
+            result.citation.document_id
           );
         }
 
@@ -454,7 +454,7 @@ export class OnyxChatWidget extends LitElement {
 
           // Update or add message
           const existingIndex = this.messages.findIndex(
-            (m) => m.id === currentMessage?.id,
+            (m) => m.id === currentMessage?.id
           );
           if (existingIndex >= 0) {
             this.messages = [
@@ -590,7 +590,7 @@ export class OnyxChatWidget extends LitElement {
   private renderMessages() {
     // Check if there's a streaming message with content
     const hasStreamingContent = this.messages.some(
-      (m) => m.role === "assistant" && m.isStreaming && m.content.length > 0,
+      (m) => m.role === "assistant" && m.isStreaming && m.content.length > 0
     );
     // Show ellipsis only when: streaming AND (has status text OR no content yet)
     const showEllipsis =
@@ -609,12 +609,12 @@ export class OnyxChatWidget extends LitElement {
                 ${msg.role === "assistant"
                   ? html`${this.renderMarkdown(
                       msg.content,
-                      msg.citations,
+                      msg.citations
                     )}${this.renderCitations(msg.citations)}`
                   : msg.content}
               </div>
             </div>
-          `,
+          `
         )}
         ${showEllipsis
           ? html`

--- a/widget/vite.config.ts
+++ b/widget/vite.config.ts
@@ -36,10 +36,10 @@ export default defineConfig(({ mode }) => {
     define: isSelfHosted
       ? {
           "import.meta.env.VITE_WIDGET_BACKEND_URL": JSON.stringify(
-            env.VITE_WIDGET_BACKEND_URL,
+            env.VITE_WIDGET_BACKEND_URL
           ),
           "import.meta.env.VITE_WIDGET_API_KEY": JSON.stringify(
-            env.VITE_WIDGET_API_KEY,
+            env.VITE_WIDGET_API_KEY
           ),
         }
       : {},


### PR DESCRIPTION
## Description

It seems like `prettier` pre-commit hook was only formatting the `web/` directory and the new `oxfmt` is formatting everything which seems fine so just apply fixes.

## How Has This Been Tested?

`prek run --all-files`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopted `oxfmt` across the repo and reformatted files so the pre-commit hook applies consistent style beyond `web/`. No runtime changes; this is formatting only.

- **Refactors**
  - Applied `oxfmt` formatting repo-wide (previously `prettier` affected only `web/`).
  - Style-only updates: commas, line breaks, and type/prop signatures across backend templates, `web/lib/opal`, desktop, Chrome extension, widget, and docs.

<sup>Written for commit 5bfbf5b3719064c749b7e1e92151b0c89b470215. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

