### PR TITLE
perf(playwright): bump admin CI workers 2→4

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   // When debugging, comment out the first `workers` line and uncomment the second one.
   // The second one runs the tests in serial, which helps when using the playwright-debugger to step through each test-step.
   // - @raunakab
-  workers: process.env.CI ? 2 : undefined, // Limit to 2 parallel workers in CI to reduce flakiness
+  workers: process.env.CI ? 4 : undefined,
   // workers: 1,
 
   reporter: [["list"]],


### PR DESCRIPTION
## Description

Admin Playwright job runs ~18m on an `8cpu-linux-arm64` runner with `workers: 2` (6 cores idle). Bumping to 4 to halve the test step.

Measured across 9 recent successful admin runs (runs `25874920353`, `25874524049`, `25874508333`, `25874482769`, `25874426057`, `25873257205`, `25866685084`, `25861550165`, `25842097477`):
- total: ~18m
- setup: ~3m37s (20%)
- `Run Playwright tests` step: ~13m54s (77%)
- teardown: ~30s

Target after bump: ~11m total (~7m tests + 3m37s setup).

The previous `2` was chosen to reduce flakiness. Will re-run CI a few times before merge to check flake rate.

## How Has This Been Tested?

5 admin re-runs on same SHA via `gh run rerun --job`:

| Attempt | Duration | Result |
| -- | -- | -- |
| 1 | 14m55s | ✅ |
| 2 | 13m34s | ✅ |
| 3 | 14m08s | ✅ |
| 4 | 14m40s | ✅ |
| 5 | 13m10s | ✅ |

Mean **14m05s** (min 13m10s, max 14m55s) vs ~18m baseline. 0/5 flake.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check