### PR TITLE
feat(gitlab-connector): index all branches and deduplicate files

### DIFF
--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -164,7 +164,7 @@ class GitlabConnector(LoadConnector, PollConnector):
 
         # Fetch code files
         if self.include_code_files:
-            processed_blob_shas: set[str] = set()
+            processed_path_blobs: set[tuple[str, str]] = set()
             all_branches = list(project.branches.list(iterator=True))
             default_branch = project.default_branch
             # Sort branches: default branch first, then alphabetically
@@ -186,10 +186,10 @@ class GitlabConnector(LoadConnector, PollConnector):
                                 continue
 
                             if file["type"] == "blob":
-                                blob_sha = file["id"]
-                                if blob_sha in processed_blob_shas:
+                                path_blob = (file["path"], file["id"])
+                                if path_blob in processed_path_blobs:
                                     continue
-                                processed_blob_shas.add(blob_sha)
+                                processed_path_blobs.add(path_blob)
 
                                 code_doc_batch.append(
                                     _convert_code_to_document(

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -94,35 +94,30 @@ def _convert_issue_to_document(issue: Any) -> Document:
 
 
 def _convert_code_to_document(
-    project: Project, file: Any, url: str, projectName: str, projectOwner: str
+    project: Project, file: Any, url: str, projectName: str, projectOwner: str, branch: str
 ) -> Document:
-    # Dynamically get the default branch from the project object
-    default_branch = project.default_branch
-
     # Fetch the file content using the correct branch
     file_content_obj = project.files.get(
         file_path=file["path"],
-        ref=default_branch,  # Use the default branch
+        ref=branch,
     )
     try:
         file_content = file_content_obj.decode().decode("utf-8")
     except UnicodeDecodeError:
         file_content = file_content_obj.decode().decode("latin-1")
 
-    # Construct the file URL dynamically using the default branch
-    file_url = (
-        f"{url}/{projectOwner}/{projectName}/-/blob/{default_branch}/{file['path']}"
-    )
+    # Construct the file URL dynamically using the provided branch
+    file_url = f"{url}/{projectOwner}/{projectName}/-/blob/{branch}/{file['path']}"
 
     # Create and return a Document object
     doc = Document(
-        id=file["id"],
+        id=file_url,
         sections=[TextSection(link=file_url, text=file_content)],
         source=DocumentSource.GITLAB,
         semantic_identifier=file["name"],
         doc_updated_at=datetime.now().replace(tzinfo=timezone.utc),
         primary_owners=[],  # Add owners if needed
-        metadata={"type": "CodeFile"},
+        metadata={"type": "CodeFile", "branch": branch},
     )
     return doc
 
@@ -169,32 +164,48 @@ class GitlabConnector(LoadConnector, PollConnector):
 
         # Fetch code files
         if self.include_code_files:
-            # Fetching using BFS as project.report_tree with recursion causing slow load
-            queue = deque([""])  # Start with the root directory
-            while queue:
-                current_path = queue.popleft()
-                files = project.repository_tree(path=current_path, all=True)
-                for file_batch in _batch_gitlab_objects(files, self.batch_size):
-                    code_doc_batch: list[Document | HierarchyNode] = []
-                    for file in file_batch:
-                        if _should_exclude(file["path"]):
-                            continue
+            processed_blob_shas: set[str] = set()
+            all_branches = list(project.branches.list(iterator=True))
+            default_branch = project.default_branch
+            # Sort branches: default branch first, then alphabetically
+            all_branches.sort(key=lambda b: (b.name != default_branch, b.name))
 
-                        if file["type"] == "blob":
-                            code_doc_batch.append(
-                                _convert_code_to_document(
-                                    project,
-                                    file,
-                                    self.gitlab_client.url,
-                                    self.project_name,
-                                    self.project_owner,
+            for branch in all_branches:
+                branch_name = branch.name
+                # Fetching using BFS as project.report_tree with recursion causing slow load
+                queue = deque([""])  # Start with the root directory
+                while queue:
+                    current_path = queue.popleft()
+                    files = project.repository_tree(
+                        path=current_path, ref=branch_name, all=True
+                    )
+                    for file_batch in _batch_gitlab_objects(files, self.batch_size):
+                        code_doc_batch: list[Document | HierarchyNode] = []
+                        for file in file_batch:
+                            if _should_exclude(file["path"]):
+                                continue
+
+                            if file["type"] == "blob":
+                                blob_sha = file["id"]
+                                if blob_sha in processed_blob_shas:
+                                    continue
+                                processed_blob_shas.add(blob_sha)
+
+                                code_doc_batch.append(
+                                    _convert_code_to_document(
+                                        project,
+                                        file,
+                                        self.gitlab_client.url,
+                                        self.project_name,
+                                        self.project_owner,
+                                        branch_name,
+                                    )
                                 )
-                            )
-                        elif file["type"] == "tree":
-                            queue.append(file["path"])
+                            elif file["type"] == "tree":
+                                queue.append(file["path"])
 
-                    if code_doc_batch:
-                        yield code_doc_batch
+                        if code_doc_batch:
+                            yield code_doc_batch
 
         if self.include_mrs:
             merge_requests = project.mergerequests.list(

--- a/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
+++ b/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
@@ -39,7 +39,7 @@ def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
     doc_batches = gitlab_connector.load_from_state()
     docs = list(itertools.chain(*doc_batches))
     # Assert right number of docs - Adjust if necessary based on test repo state
-    assert len(docs) == 79
+    assert len(docs) >= 79
 
     # Find one of each type to validate
     validated_mr = False
@@ -104,8 +104,8 @@ def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
             doc.semantic_identifier == target_code_file_semantic_id
             and doc_type == "CodeFile"
         ):
-            # ID is a git hash (e.g., 'd177...'), Link is the blob URL
-            assert doc.id != section.link
+            # ID is now the blob URL
+            assert doc.id == section.link
             assert section.link.endswith("/README.md")
             assert "# onyx" in section.text  # Check for a known part of the content
             # Code files might not have primary owners assigned this way
@@ -122,7 +122,7 @@ def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
             assert gitlab_base_url in doc.id  # Issue ID should be a URL
             assert doc.id == section.link  # Link and ID are the same URL
         elif doc_type == "CodeFile" and not validated_code_file:
-            assert doc.id != section.link  # ID is GID/hash, link is blob URL
+            assert doc.id == section.link  # Link and ID are the same URL
 
         # Early exit optimization (optional)
         # if validated_mr and validated_issue and validated_code_file:

--- a/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
+++ b/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
@@ -39,7 +39,9 @@ def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
     doc_batches = gitlab_connector.load_from_state()
     docs = list(itertools.chain(*doc_batches))
     # Assert right number of docs - Adjust if necessary based on test repo state
-    assert len(docs) >= 79
+    # Deduplication ensures that even with multiple branches, identical files
+    # are only indexed once, so the count should remain stable.
+    assert len(docs) == 79
 
     # Find one of each type to validate
     validated_mr = False

--- a/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_connector.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_connector.py
@@ -1,0 +1,121 @@
+from unittest.mock import MagicMock
+
+from onyx.connectors.gitlab.connector import GitlabConnector
+from onyx.connectors.models import Document
+
+
+def test_gitlab_fetch_deduplicate_blobs():
+    # Mocking GitLab project and its branches
+    mock_gitlab_client = MagicMock()
+    mock_gitlab_client.url = "https://gitlab.com"
+    mock_project = MagicMock()
+    mock_gitlab_client.projects.get.return_value = mock_project
+    mock_project.default_branch = "main"
+
+    # We want to test that 'main' and 'dev' have the same file content
+    mock_branch_main = MagicMock()
+    mock_branch_main.name = "main"
+    mock_branch_dev = MagicMock()
+    mock_branch_dev.name = "dev"
+
+    # Return branches in an order that would normally cause duplicates if not sorted/deduped
+    mock_project.branches.list.return_value = [mock_branch_dev, mock_branch_main]
+
+    # Mocking repository tree: same file content (blob_id_shared) on both branches
+    def mock_repository_tree(*_args, **kwargs):
+        _path = kwargs.get("path")
+        _ref = kwargs.get("ref")
+        _all = kwargs.get("all")
+        return [{"path": "README.md", "type": "blob", "name": "README.md", "id": "blob_id_shared"}]
+
+    mock_project.repository_tree.side_effect = mock_repository_tree
+
+    # Mocking project.files.get
+    mock_file_obj = MagicMock()
+    mock_file_obj.decode.return_value.decode.return_value = "content"
+    mock_project.files.get.return_value = mock_file_obj
+
+    connector = GitlabConnector(
+        project_owner="owner",
+        project_name="repo",
+        include_code_files=True,
+        include_mrs=False,
+        include_issues=False
+    )
+    connector.gitlab_client = mock_gitlab_client
+
+    # Run fetch
+    doc_batches = list(connector._fetch_from_gitlab())
+
+    # Check results
+    all_docs = []
+    for batch in doc_batches:
+        for item in batch:
+            if isinstance(item, Document):
+                all_docs.append(item)
+
+    # Should only have 1 document because they were identical
+    assert len(all_docs) == 1
+
+    # The document should be from the 'main' branch because it's the default and prioritized
+    doc = all_docs[0]
+    assert doc.metadata["branch"] == "main"
+    assert doc.id == "https://gitlab.com/owner/repo/-/blob/main/README.md"
+
+def test_gitlab_fetch_different_blobs():
+    # Mocking GitLab project and its branches
+    mock_gitlab_client = MagicMock()
+    mock_gitlab_client.url = "https://gitlab.com"
+    mock_project = MagicMock()
+    mock_gitlab_client.projects.get.return_value = mock_project
+    mock_project.default_branch = "main"
+
+    mock_branch_main = MagicMock()
+    mock_branch_main.name = "main"
+    mock_branch_dev = MagicMock()
+    mock_branch_dev.name = "dev"
+
+    mock_project.branches.list.return_value = [mock_branch_main, mock_branch_dev]
+
+    # Mocking repository tree: different file content on main vs dev
+    def mock_repository_tree(*_args, **kwargs):
+        _path = kwargs.get("path")
+        _ref = kwargs.get("ref")
+        _all = kwargs.get("all")
+        if _ref == "main":
+            return [{"path": "README.md", "type": "blob", "name": "README.md", "id": "blob_id_main"}]
+        else:
+            return [{"path": "README.md", "type": "blob", "name": "README.md", "id": "blob_id_dev"}]
+
+    mock_project.repository_tree.side_effect = mock_repository_tree
+
+    # Mocking project.files.get
+    mock_file_obj = MagicMock()
+    mock_file_obj.decode.return_value.decode.return_value = "content"
+    mock_project.files.get.return_value = mock_file_obj
+
+    connector = GitlabConnector(
+        project_owner="owner",
+        project_name="repo",
+        include_code_files=True,
+        include_mrs=False,
+        include_issues=False
+    )
+    connector.gitlab_client = mock_gitlab_client
+
+    # Run fetch
+    doc_batches = list(connector._fetch_from_gitlab())
+
+    # Check results
+    all_docs = []
+    for batch in doc_batches:
+        for item in batch:
+            if isinstance(item, Document):
+                all_docs.append(item)
+
+    # Should have 2 documents because they were different
+    assert len(all_docs) == 2
+
+    # Verify both exist
+    assert any(d.metadata["branch"] == "main" for d in all_docs)
+    assert any(d.metadata["branch"] == "dev" for d in all_docs)

--- a/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_connector.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_connector.py
@@ -119,3 +119,70 @@ def test_gitlab_fetch_different_blobs():
     # Verify both exist
     assert any(d.metadata["branch"] == "main" for d in all_docs)
     assert any(d.metadata["branch"] == "dev" for d in all_docs)
+
+
+def test_gitlab_fetch_identical_content_different_paths():
+    # Mocking GitLab project
+    mock_gitlab_client = MagicMock()
+    mock_gitlab_client.url = "https://gitlab.com"
+    mock_project = MagicMock()
+    mock_gitlab_client.projects.get.return_value = mock_project
+    mock_project.default_branch = "main"
+
+    mock_branch_main = MagicMock()
+    mock_branch_main.name = "main"
+    mock_project.branches.list.return_value = [mock_branch_main]
+
+    # Two different files with identical content (same blob SHA)
+    def mock_repository_tree(*_args, **kwargs):
+        return [
+            {
+                "path": "pkg1/__init__.py",
+                "type": "blob",
+                "name": "__init__.py",
+                "id": "blob_shared_sha",
+            },
+            {
+                "path": "pkg2/__init__.py",
+                "type": "blob",
+                "name": "__init__.py",
+                "id": "blob_shared_sha",
+            },
+        ]
+
+    mock_project.repository_tree.side_effect = mock_repository_tree
+
+    # Mocking project.files.get
+    mock_file_obj = MagicMock()
+    mock_file_obj.decode.return_value.decode.return_value = "content"
+    mock_project.files.get.return_value = mock_file_obj
+
+    connector = GitlabConnector(
+        project_owner="owner",
+        project_name="repo",
+        include_code_files=True,
+        include_mrs=False,
+        include_issues=False,
+    )
+    connector.gitlab_client = mock_gitlab_client
+
+    # Run fetch
+    doc_batches = list(connector._fetch_from_gitlab())
+
+    # Check results
+    all_docs = []
+    for batch in doc_batches:
+        for item in batch:
+            if isinstance(item, Document):
+                all_docs.append(item)
+
+    # Should have 2 documents even though content is identical, because paths are different
+    assert len(all_docs) == 2
+    assert any(
+        d.id == "https://gitlab.com/owner/repo/-/blob/main/pkg1/__init__.py"
+        for d in all_docs
+    )
+    assert any(
+        d.id == "https://gitlab.com/owner/repo/-/blob/main/pkg2/__init__.py"
+        for d in all_docs
+    )


### PR DESCRIPTION
This PR updates the GitLab connector to index all branches instead of just the default one.

Key changes:
- Iterates through all project branches.
- Changes document IDs for code files to the file URL for stability across updates.
- Implements blob SHA deduplication to avoid redundant indexing of identical files across branches.
- Prioritizes the default branch during indexing.
- Adds comprehensive unit tests and updates existing integration tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Index all GitLab branches and deduplicate unchanged files across branches using (path, blob SHA) to avoid redundant code documents. Switch code file document IDs to stable file URLs, add branch metadata, and prioritize the default branch.

- New Features
  - Indexes all branches (default branch first) and traverses the tree with the branch ref.
  - Deduplicates code files across branches by (path, blob SHA); keeps the default-branch copy.
  - Sets the file URL as the document ID for code files; stores branch in `metadata`.
  - Adds unit tests for multi-branch and dedupe; tightens integration test to an exact doc count.

- Migration
  - Code file IDs changed to file URLs. Run a full reindex and update any consumers using the old hash-based IDs.

<sup>Written for commit 4af10e67ee5faa34e850a1cbc598cb648293913e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

