### PR TITLE
chore(ci): path-filter python and database test workflows

### DIFF
--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -17,7 +17,28 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      db: ${{ steps.filter.outputs.db || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          filters: |
+            db:
+              - 'backend/**'
+              - 'tools/ods/**'
+              - 'pyproject.toml'
+              - 'deployment/docker_compose/docker-compose.yml'
+              - 'deployment/docker_compose/docker-compose.dev.yml'
+              - '.github/workflows/pr-database-tests.yml'
+              - '.github/actions/setup-python-and-install-dependencies/**'
+
   database-tests:
+    needs: changes
+    if: needs.changes.outputs.db == 'true'
     runs-on:
       - runs-on
       - runner=2cpu-linux-arm64

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -23,6 +23,11 @@ jobs:
     outputs:
       db: ${{ steps.filter.outputs.db || 'true' }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       db: ${{ steps.filter.outputs.db || 'true' }}
     steps:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -23,6 +23,11 @@ jobs:
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -17,7 +17,25 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          filters: |
+            python:
+              - 'backend/**'
+              - 'pyproject.toml'
+              - '.github/workflows/pr-python-checks.yml'
+              - '.github/actions/setup-python-and-install-dependencies/**'
+
   mypy-check:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     # See https://runs-on.com/runners/linux/
     # NOTE: This job is named mypy-check for branch protection compatibility,
     # but it actually runs ty (astral-sh's Rust type checker).

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -17,7 +17,25 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python || 'true' }}
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          filters: |
+            python:
+              - 'backend/**'
+              - 'pyproject.toml'
+              - '.github/workflows/pr-python-tests.yml'
+              - '.github/actions/setup-python-and-install-dependencies/**'
+
   backend-check:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     # See https://runs-on.com/runners/linux/
     runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}-backend-check"]
     timeout-minutes: 45

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -23,6 +23,11 @@ jobs:
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'


### PR DESCRIPTION
## Summary
- Adds a small `changes` job to `pr-python-checks.yml`, `pr-python-tests.yml`, and `pr-database-tests.yml` that uses `dorny/paths-filter@v3` (same pin as `pr-python-connector-tests.yml`) to detect whether the workflow's relevant paths changed.
- The main job (`mypy-check`, `backend-check`, `database-tests`) gains `needs: changes` + `if: needs.changes.outputs.<name> == 'true'`. When no relevant files change in a `pull_request` or `merge_group` event, the job is skipped — which counts as a passing required status check, so the merge queue check names stay stable.
- The output uses a `|| 'true'` fallback so tag pushes (and any other event where the filter step is skipped) always run the work.

## Filter scopes
- **Python checks (ty)** and **Python tests**: `backend/**` (ty's configured src root + where the unit tests live, covering JSON/YAML fixtures), root `pyproject.toml` (ty + pytest + ruff config), the workflow file itself, and `.github/actions/setup-python-and-install-dependencies/**`.
- **Database tests**: broader to be safe — `backend/**`, `tools/ods/**` (workflow runs `ods openapi all`), root `pyproject.toml`, `deployment/docker_compose/docker-compose.yml` + `docker-compose.dev.yml`, the workflow file, and the shared setup action.
- `pr-quality-checks.yml` is intentionally untouched — prek's `--all-files` plus the actions check are broad enough that filtering would create more risk than savings.

## Test plan
- [ ] Open this PR with a no-op change touching only this file set → the three workflows should run on the PR (since the workflow file itself is in each filter).
- [ ] Verify in the merge queue that the three required checks report success (or "skipped → passing") rather than blocking.
- [ ] Follow up with a docs-only PR after merge to confirm the three jobs are skipped while `pr-quality-checks` still runs.
- [ ] Confirm branch-protection required checks reference the job names (`mypy-check`, `backend-check`, `database-tests`) — not workflow names — so skipped jobs satisfy them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Python checks, Python tests, and database tests when unrelated files change to speed up CI and keep required check names stable for the merge queue. Adds a checkout-backed path-filter gate so skipped jobs count as passing and don’t fail on `merge_group`.

- **Refactors**
  - Add `changes` job using `dorny/paths-filter@v3` with a 5-minute timeout; run only on `pull_request`/`merge_group` and default outputs to `'true'` for other events.
  - Precede the filter with `actions/checkout@v6` so `merge_group` has a working tree, preventing filter failures and preserving the skip-as-pass behavior.
  - Gate `mypy-check`, `backend-check`, and `database-tests` with `needs: changes` + `if:` on the filter output.
  - Watch paths: Python checks/tests watch `backend/**`, `pyproject.toml`, the workflow file, and `.github/actions/setup-python-and-install-dependencies/**`; database tests also watch `tools/ods/**` and Docker Compose files.

<sup>Written for commit 5a69f97a29d20971b9cfc42f1bd91abd79fc2f0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

