### PR TITLE
feat(admin): admin-configurable site-wide banner

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -297,6 +297,7 @@ class NotificationType(str, Enum):
     SCHEDULED_TASK_AWAITING_APPROVAL = "scheduled_task_awaiting_approval"
     SCHEDULED_TASK_PRE_APPROVED_ACTION = "scheduled_task_pre_approved_action"
     APPROVAL_REQUESTED = "approval_requested"
+    ADMIN_BANNER = "admin_banner"
 
 
 class BlobType(str, Enum):

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -56,10 +56,10 @@ def set_admin_banner(
         logger.warning("Admin banner not set: tenant has no eligible users")
         return None
 
-    # DELETE here is uncommitted; batch_create_notifications commits once,
-    # making the swap atomic. Constant additional_data lets the unique index
-    # on (user_id, notif_type, COALESCE(additional_data, '{}'))
-    # serialize concurrent PUTs.
+    # Delete + insert in one transaction we commit ourselves, so the swap is
+    # atomic and owns its commit boundary instead of depending on the helper.
+    # Constant additional_data lets the unique index on
+    # (user_id, notif_type, COALESCE(additional_data, '{}')) serialize concurrent PUTs.
     db_session.query(Notification).filter(
         Notification.notif_type == NotificationType.ADMIN_BANNER
     ).delete(synchronize_session=False)
@@ -71,7 +71,9 @@ def set_admin_banner(
         title=title,
         description=content,
         additional_data={},
+        commit=False,
     )
+    db_session.commit()
     logger.info(
         "Admin banner set for %s eligible users (title=%s chars, content=%s chars)",
         len(user_ids),

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -53,6 +53,15 @@ def set_admin_banner(
     ).delete(synchronize_session=False)
 
     user_ids = list(db_session.scalars(_eligible_user_ids_query()).all())
+    if not user_ids:
+        db_session.commit()
+        logger.info(
+            "Admin banner cleared for tenant with no eligible users (title=%s chars, content=%s chars)",
+            len(title),
+            len(content) if content else 0,
+        )
+        return None
+
     batch_create_notifications(
         user_ids,
         NotificationType.ADMIN_BANNER,

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -1,5 +1,8 @@
+from uuid import UUID
+
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import Select
 
 from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import NotificationType
@@ -12,13 +15,11 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
-def _eligible_user_ids_query():  # type: ignore[no-untyped-def]
+def _eligible_user_ids_query() -> Select[tuple[UUID]]:
     return select(User.id).where(  # ty: ignore[no-matching-overload]
-        User.is_active == True,  # noqa: E712
+        User.is_active.is_(True),  # ty: ignore[unresolved-attribute]
         User.account_type.notin_([AccountType.BOT, AccountType.EXT_PERM_USER]),
-        User.email.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN).is_(  # ty: ignore[unresolved-attribute]
-            False
-        ),
+        ~User.email.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN),
     )
 
 

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -78,3 +78,36 @@ def set_admin_banner(
         len(content) if content else 0,
     )
     return get_active_admin_banner(db_session)
+
+
+def ensure_admin_banner_for_user(db_session: Session, user: User) -> None:
+    if not user.is_active:
+        return
+    if user.account_type in (AccountType.BOT, AccountType.EXT_PERM_USER):
+        return
+    if user.email.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN):
+        return
+
+    banner = get_active_admin_banner(db_session)
+    if banner is None:
+        return
+
+    existing_id = db_session.scalar(
+        select(Notification.id)
+        .where(
+            Notification.user_id == user.id,
+            Notification.notif_type == NotificationType.ADMIN_BANNER,
+        )
+        .limit(1)
+    )
+    if existing_id is not None:
+        return
+
+    batch_create_notifications(
+        [user.id],
+        NotificationType.ADMIN_BANNER,
+        db_session,
+        title=banner.title,
+        description=banner.description,
+        additional_data={},
+    )

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -24,6 +24,9 @@ def _eligible_user_ids_query() -> Select[tuple[UUID]]:
 
 
 def get_active_admin_banner(db_session: Session) -> Notification | None:
+    # No `dismissed` filter on purpose: a banner stays published until an admin
+    # clears it, regardless of per-user dismissals — and late-joiner minting in
+    # `ensure_admin_banner_for_user` relies on reading it while published.
     stmt = (
         select(Notification)
         .where(Notification.notif_type == NotificationType.ADMIN_BANNER)
@@ -45,6 +48,14 @@ def set_admin_banner(
     title: str,
     content: str | None,
 ) -> Notification | None:
+    # Resolve recipients first: with zero eligible users there is nobody to
+    # publish to, so return None and leave any existing banner untouched — the
+    # delete+insert swap below only runs once we know there are recipients.
+    user_ids = list(db_session.scalars(_eligible_user_ids_query()).all())
+    if not user_ids:
+        logger.warning("Admin banner not set: tenant has no eligible users")
+        return None
+
     # DELETE here is uncommitted; batch_create_notifications commits once,
     # making the swap atomic. Constant additional_data lets the unique index
     # on (user_id, notif_type, COALESCE(additional_data, '{}'))
@@ -52,16 +63,6 @@ def set_admin_banner(
     db_session.query(Notification).filter(
         Notification.notif_type == NotificationType.ADMIN_BANNER
     ).delete(synchronize_session=False)
-
-    user_ids = list(db_session.scalars(_eligible_user_ids_query()).all())
-    if not user_ids:
-        db_session.commit()
-        logger.info(
-            "Admin banner cleared for tenant with no eligible users (title=%s chars, content=%s chars)",
-            len(title),
-            len(content) if content else 0,
-        )
-        return None
 
     batch_create_notifications(
         user_ids,

--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -1,0 +1,70 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+from onyx.configs.constants import NotificationType
+from onyx.db.enums import AccountType
+from onyx.db.models import Notification
+from onyx.db.models import User
+from onyx.db.notification import batch_create_notifications
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def _eligible_user_ids_query():  # type: ignore[no-untyped-def]
+    return select(User.id).where(  # ty: ignore[no-matching-overload]
+        User.is_active == True,  # noqa: E712
+        User.account_type.notin_([AccountType.BOT, AccountType.EXT_PERM_USER]),
+        User.email.endswith(DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN).is_(  # ty: ignore[unresolved-attribute]
+            False
+        ),
+    )
+
+
+def get_active_admin_banner(db_session: Session) -> Notification | None:
+    stmt = (
+        select(Notification)
+        .where(Notification.notif_type == NotificationType.ADMIN_BANNER)
+        .order_by(Notification.first_shown.desc())
+        .limit(1)
+    )
+    return db_session.scalars(stmt).first()
+
+
+def clear_admin_banner(db_session: Session) -> None:
+    db_session.query(Notification).filter(
+        Notification.notif_type == NotificationType.ADMIN_BANNER
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+
+def set_admin_banner(
+    db_session: Session,
+    title: str,
+    content: str | None,
+) -> Notification | None:
+    # DELETE here is uncommitted; batch_create_notifications commits once,
+    # making the swap atomic. Constant additional_data lets the unique index
+    # on (user_id, notif_type, COALESCE(additional_data, '{}'))
+    # serialize concurrent PUTs.
+    db_session.query(Notification).filter(
+        Notification.notif_type == NotificationType.ADMIN_BANNER
+    ).delete(synchronize_session=False)
+
+    user_ids = list(db_session.scalars(_eligible_user_ids_query()).all())
+    batch_create_notifications(
+        user_ids,
+        NotificationType.ADMIN_BANNER,
+        db_session,
+        title=title,
+        description=content,
+        additional_data={},
+    )
+    logger.info(
+        "Admin banner set for %s eligible users (title=%s chars, content=%s chars)",
+        len(user_ids),
+        len(title),
+        len(content) if content else 0,
+    )
+    return get_active_admin_banner(db_session)

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -199,6 +199,7 @@ def batch_create_notifications(
     title: str,
     description: str | None = None,
     additional_data: dict | None = None,
+    commit: bool = True,
 ) -> set[UUID]:
     """
     Create notifications for multiple users in a single batch operation.
@@ -209,6 +210,9 @@ def batch_create_notifications(
     Returns the set of user_ids whose row was newly inserted (excludes conflicts).
     Callers that need to fire side effects only on fresh inserts (emails, webhooks)
     can iterate the returned set without re-triggering on idempotent retries.
+
+    Pass commit=False to defer the commit to the caller (e.g. to bundle this
+    insert with a preceding delete in one transaction).
 
     Relies on unique index on (user_id, notif_type, COALESCE(additional_data, '{}'))
     """
@@ -240,7 +244,8 @@ def batch_create_notifications(
     )
     result = db_session.execute(stmt)
     inserted_ids = set(result.scalars())
-    db_session.commit()
+    if commit:
+        db_session.commit()
     return inserted_ids  # ty: ignore[invalid-return-type]
 
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -78,6 +78,7 @@ from onyx.server.documents.credential import router as credential_router
 from onyx.server.documents.document import router as document_router
 from onyx.server.documents.standard_oauth import router as standard_oauth_router
 from onyx.server.documents.targeted_reindex import router as targeted_reindex_router
+from onyx.server.features.admin_banner.api import admin_router as admin_banner_router
 from onyx.server.features.build.api import router as build_router
 from onyx.server.features.build.webapp_proxy import public_build_router
 from onyx.server.features.default_assistant.api import (
@@ -522,6 +523,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, admin_agents_router)
     include_router_with_global_prefix_prepended(application, default_assistant_router)
     include_router_with_global_prefix_prepended(application, notification_router)
+    include_router_with_global_prefix_prepended(application, admin_banner_router)
     include_router_with_global_prefix_prepended(application, tool_router)
     include_router_with_global_prefix_prepended(application, admin_tool_router)
     include_router_with_global_prefix_prepended(application, oauth_config_router)

--- a/backend/onyx/server/features/admin_banner/api.py
+++ b/backend/onyx/server/features/admin_banner/api.py
@@ -12,6 +12,8 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import Notification
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 
 MAX_TITLE_LEN = 200
 MAX_CONTENT_LEN = 2000
@@ -55,8 +57,20 @@ def upsert_admin_banner(
     db_session: Session = Depends(get_session),
 ) -> AdminBannerResponse:
     title = request.title.strip()
-    content = request.content.strip() if request.content else None
-    banner = set_admin_banner(db_session, title=title, content=content or None)
+    if not title:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Title must include non-whitespace characters",
+        )
+
+    content: str | None
+    if request.content is None:
+        content = None
+    else:
+        stripped_content = request.content.strip()
+        content = stripped_content or None
+
+    banner = set_admin_banner(db_session, title=title, content=content)
     if banner is None:
         # No eligible users in tenant — banner can't be persisted.
         return AdminBannerResponse(title=title, content=content, created_at=None)

--- a/backend/onyx/server/features/admin_banner/api.py
+++ b/backend/onyx/server/features/admin_banner/api.py
@@ -72,8 +72,10 @@ def upsert_admin_banner(
 
     banner = set_admin_banner(db_session, title=title, content=content)
     if banner is None:
-        # No eligible users in tenant — banner can't be persisted.
-        return AdminBannerResponse(title=title, content=content, created_at=None)
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "No eligible users to receive the banner",
+        )
     return _to_response(banner)
 
 

--- a/backend/onyx/server/features/admin_banner/api.py
+++ b/backend/onyx/server/features/admin_banner/api.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter
+from fastapi import Depends
+from pydantic import BaseModel
+from pydantic import Field
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.db.admin_banner import clear_admin_banner
+from onyx.db.admin_banner import get_active_admin_banner
+from onyx.db.admin_banner import set_admin_banner
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import Notification
+from onyx.db.models import User
+
+MAX_TITLE_LEN = 200
+MAX_CONTENT_LEN = 2000
+
+
+class AdminBannerResponse(BaseModel):
+    title: str
+    content: str | None
+    created_at: str | None
+
+
+class AdminBannerUpdateRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=MAX_TITLE_LEN)
+    content: str | None = Field(default=None, max_length=MAX_CONTENT_LEN)
+
+
+admin_router = APIRouter(prefix="/admin/banner")
+
+
+def _to_response(banner: Notification) -> AdminBannerResponse:
+    return AdminBannerResponse(
+        title=banner.title,
+        content=banner.description,
+        created_at=banner.first_shown.isoformat() if banner.first_shown else None,
+    )
+
+
+@admin_router.get("")
+def get_admin_banner(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> AdminBannerResponse | None:
+    banner = get_active_admin_banner(db_session)
+    return _to_response(banner) if banner else None
+
+
+@admin_router.put("")
+def upsert_admin_banner(
+    request: AdminBannerUpdateRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> AdminBannerResponse:
+    title = request.title.strip()
+    content = request.content.strip() if request.content else None
+    banner = set_admin_banner(db_session, title=title, content=content or None)
+    if banner is None:
+        # No eligible users in tenant — banner can't be persisted.
+        return AdminBannerResponse(title=title, content=content, created_at=None)
+    return _to_response(banner)
+
+
+@admin_router.delete("", status_code=204)
+def delete_admin_banner(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    clear_admin_banner(db_session)

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -4,6 +4,7 @@ from fastapi import Query
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.db.admin_banner import ensure_admin_banner_for_user
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -55,6 +56,11 @@ def _check_for_notifications_to_create(
         ensure_release_notes_fresh_and_notify(db_session)
     except Exception:
         logger.exception("Failed to check for release notes in notifications endpoint")
+
+    try:
+        ensure_admin_banner_for_user(db_session, user)
+    except Exception:
+        logger.exception("Failed to ensure admin banner notification")
 
 
 @router.get("")

--- a/web/src/app/admin/configuration/banner/page.tsx
+++ b/web/src/app/admin/configuration/banner/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import SystemBannerPage from "@/refresh-pages/admin/SystemBannerPage";
+
+export default function Page() {
+  return <SystemBannerPage />;
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { TooltipProvider } from "@radix-ui/react-tooltip";
 import StatsOverlayLoader from "@/components/dev/StatsOverlayLoader";
 import { cn } from "@opal/utils";
 import AppHealthBanner from "@/sections/AppHealthBanner";
+import AdminBannerNotice from "@/sections/AdminBannerNotice";
 import LicenseExpiryBanner from "@/sections/LicenseExpiryBanner";
 import ProductGatingWrapper from "@/providers/ProductGatingWrapper";
 import SWRConfigProvider from "@/providers/SWRConfigProvider";
@@ -103,6 +104,7 @@ export default function Layout({ children }: LayoutProps) {
                 <SWRConfigProvider>
                   <AppHealthBanner />
                   <LicenseExpiryBanner />
+                  <AdminBannerNotice />
                   <AppProvider>
                     <DynamicMetadata />
                     <PostHogRuntimeInitializer />

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -83,6 +83,13 @@ export function AnnouncementBanner() {
                     Update here
                   </Link>
                 </p>
+              ) : notification.notif_type == "admin_banner" ? (
+                <p className="text-center">
+                  <span className="font-semibold">{notification.title}</span>
+                  {notification.description ? (
+                    <span className="ml-2">{notification.description}</span>
+                  ) : null}
+                </p>
               ) : null}
               <button
                 onClick={() => handleDismiss(notification.id)}

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -53,7 +53,11 @@ export function AnnouncementBanner() {
   return (
     <>
       {localNotifications
-        .filter((notification) => !notification.dismissed)
+        .filter(
+          (notification) =>
+            !notification.dismissed &&
+            notification.notif_type !== "admin_banner"
+        )
         .map((notification) => {
           return (
             <div
@@ -82,13 +86,6 @@ export function AnnouncementBanner() {
                   >
                     Update here
                   </Link>
-                </p>
-              ) : notification.notif_type == "admin_banner" ? (
-                <p className="text-center">
-                  <span className="font-semibold">{notification.title}</span>
-                  {notification.description ? (
-                    <span className="ml-2">{notification.description}</span>
-                  ) : null}
                 </p>
               ) : null}
               <button

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -7,6 +7,7 @@ import type { Route } from "next";
 import Cookies from "js-cookie";
 import { SvgX } from "@opal/icons";
 import { dismissNotification } from "@/lib/notifications/api";
+import { NotificationType } from "@/lib/notifications/interfaces";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { useSWRConfig } from "swr";
 const DISMISSED_NOTIFICATION_COOKIE_PREFIX = "dismissed_notification_";
@@ -56,7 +57,7 @@ export function AnnouncementBanner() {
         .filter(
           (notification) =>
             !notification.dismissed &&
-            notification.notif_type !== "admin_banner"
+            notification.notif_type !== NotificationType.ADMIN_BANNER
         )
         .map((notification) => {
           return (

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -6,6 +6,7 @@ import {
   SvgShareWebhook,
   SvgBarChart,
   SvgBookOpen,
+  SvgBullhorn,
   SvgBubbleText,
   SvgClipboard,
   SvgCpu,
@@ -208,6 +209,12 @@ export const ADMIN_ROUTES = {
     icon: SvgPaintBrush,
     title: "Appearance & Theming",
     sidebarLabel: "Appearance & Theming",
+  },
+  SYSTEM_BANNER: {
+    path: "/admin/configuration/banner",
+    icon: SvgBullhorn,
+    title: "System Banner",
+    sidebarLabel: "System Banner",
   },
   BILLING: {
     path: "/admin/billing",

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -16,6 +16,7 @@ export enum NotificationType {
   // SvgBullhorn
   RELEASE_NOTES = "release_notes",
   FEATURE_ANNOUNCEMENT = "feature_announcement",
+  ADMIN_BANNER = "admin_banner",
 }
 
 export interface Notification {

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -175,6 +175,7 @@ export const SWR_KEYS = {
   // ── Admin ─────────────────────────────────────────────────────────────────
   hooks: "/api/admin/hooks",
   hookSpecs: "/api/admin/hooks/specs",
+  adminBanner: "/api/admin/banner",
 
   // ── Slack Bots ────────────────────────────────────────────────────────────
   slackChannels: "/api/manage/admin/slack-app/channel",

--- a/web/src/refresh-pages/admin/SystemBannerPage.tsx
+++ b/web/src/refresh-pages/admin/SystemBannerPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 
 import { Button, Card, Text } from "@opal/components";
-import { Content } from "@opal/layouts";
+import { InputVertical, Section } from "@opal/layouts";
 
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -82,7 +82,10 @@ export default function SystemBannerPage() {
       setTitle(trimmedTitle);
       setContent(trimmedContent);
       setHasTouched(false);
-      await mutate(SWR_KEYS.adminBanner);
+      await Promise.all([
+        mutate(SWR_KEYS.adminBanner),
+        mutate(SWR_KEYS.notifications),
+      ]);
       toast.success("Banner published to all users");
     } catch (error) {
       const message =
@@ -103,7 +106,10 @@ export default function SystemBannerPage() {
       setTitle("");
       setContent("");
       setHasTouched(false);
-      await mutate(SWR_KEYS.adminBanner);
+      await Promise.all([
+        mutate(SWR_KEYS.adminBanner),
+        mutate(SWR_KEYS.notifications),
+      ]);
       toast.success("Banner cleared");
     } catch (error) {
       const message =
@@ -125,51 +131,42 @@ export default function SystemBannerPage() {
 
       <SettingsLayouts.Body>
         <Card border="solid" rounding="lg">
-          <div className="flex flex-col gap-spacing-paragraph p-spacing-paragraph">
-            <Content
-              sizePreset="main-ui"
-              variant="section"
+          <Section gap={1}>
+            <InputVertical
               title="Title"
-              description={`Shown in bold at the top of the banner. Max ${MAX_TITLE_LEN} characters.`}
-            />
-            <InputTypeIn
-              value={title}
-              onChange={(e) => {
-                setHasTouched(true);
-                setTitle(e.target.value.slice(0, MAX_TITLE_LEN));
-              }}
-              placeholder="e.g. Bedrock degraded - responses may be slow"
-              variant={isLoading ? "disabled" : "primary"}
-            />
+              subDescription={`Shown in bold at the top of the banner. Max ${MAX_TITLE_LEN} characters.`}
+              withLabel
+            >
+              <InputTypeIn
+                value={title}
+                onChange={(e) => {
+                  setHasTouched(true);
+                  setTitle(e.target.value.slice(0, MAX_TITLE_LEN));
+                }}
+                placeholder="e.g. Bedrock degraded - responses may be slow"
+                variant={isLoading ? "disabled" : "primary"}
+              />
+            </InputVertical>
 
-            <Content
-              sizePreset="main-ui"
-              variant="section"
-              title="Details (optional)"
-              description={`Additional context shown next to the title. Max ${MAX_CONTENT_LEN} characters.`}
-            />
-            <InputTextArea
-              value={content}
-              onChange={(e) => {
-                setHasTouched(true);
-                setContent(e.target.value.slice(0, MAX_CONTENT_LEN));
-              }}
-              placeholder="We're aware and tracking with AWS. No action needed."
-              rows={4}
-              variant={isLoading ? "disabled" : "primary"}
-            />
+            <InputVertical
+              title="Details"
+              suffix="optional"
+              subDescription={`Additional context shown next to the title. Max ${MAX_CONTENT_LEN} characters.`}
+              withLabel
+            >
+              <InputTextArea
+                value={content}
+                onChange={(e) => {
+                  setHasTouched(true);
+                  setContent(e.target.value.slice(0, MAX_CONTENT_LEN));
+                }}
+                placeholder="We're aware and tracking with AWS. No action needed."
+                rows={4}
+                variant={isLoading ? "disabled" : "primary"}
+              />
+            </InputVertical>
 
-            <div className="flex flex-row gap-spacing-paragraph">
-              <Button
-                variant="action"
-                prominence="primary"
-                disabled={
-                  saving || clearing || isLoading || !trimmedTitle || !isDirty
-                }
-                onClick={handleSave}
-              >
-                {isActive ? "Update banner" : "Publish banner"}
-              </Button>
+            <Section flexDirection="row" justifyContent="end" gap={0.5}>
               {isActive ? (
                 <Button
                   variant="danger"
@@ -180,7 +177,16 @@ export default function SystemBannerPage() {
                   Clear banner
                 </Button>
               ) : null}
-            </div>
+              <Button
+                prominence="primary"
+                disabled={
+                  saving || clearing || isLoading || !trimmedTitle || !isDirty
+                }
+                onClick={handleSave}
+              >
+                {isActive ? "Update banner" : "Publish banner"}
+              </Button>
+            </Section>
 
             {isActive && data?.created_at ? (
               <Text font="secondary-body" color="text-03">
@@ -189,7 +195,7 @@ export default function SystemBannerPage() {
                 ).toLocaleString()}.`}
               </Text>
             ) : null}
-          </div>
+          </Section>
         </Card>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/SystemBannerPage.tsx
+++ b/web/src/refresh-pages/admin/SystemBannerPage.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 
 import { Button, Card, Text } from "@opal/components";
-import { InputVertical, Section } from "@opal/layouts";
+import { InputVertical, Section, SettingsLayouts } from "@opal/layouts";
 
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -12,7 +12,6 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { toast } from "@/hooks/useToast";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
-import * as SettingsLayouts from "@/layouts/settings-layouts";
 
 const MAX_TITLE_LEN = 200;
 const MAX_CONTENT_LEN = 2000;

--- a/web/src/refresh-pages/admin/SystemBannerPage.tsx
+++ b/web/src/refresh-pages/admin/SystemBannerPage.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import useSWR, { mutate } from "swr";
+
+import { Button, Card, Text } from "@opal/components";
+import { Content } from "@opal/layouts";
+
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { toast } from "@/hooks/useToast";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import InputTextArea from "@/refresh-components/inputs/InputTextArea";
+import * as SettingsLayouts from "@/layouts/settings-layouts";
+
+const MAX_TITLE_LEN = 200;
+const MAX_CONTENT_LEN = 2000;
+const route = ADMIN_ROUTES.SYSTEM_BANNER;
+
+interface AdminBanner {
+  title: string;
+  content: string | null;
+  created_at: string | null;
+}
+
+export default function SystemBannerPage() {
+  const { data, isLoading } = useSWR<AdminBanner | null>(
+    SWR_KEYS.adminBanner,
+    errorHandlingFetcher
+  );
+
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const hydrated = useRef(false);
+
+  useEffect(() => {
+    if (!hydrated.current && data) {
+      setTitle(data.title);
+      setContent(data.content ?? "");
+      hydrated.current = true;
+    }
+  }, [data]);
+
+  const trimmedTitle = title.trim();
+  const isActive = data !== null && data !== undefined;
+  const isDirty = isActive
+    ? trimmedTitle !== data.title || (content.trim() || null) !== data.content
+    : trimmedTitle.length > 0;
+
+  async function handleSave() {
+    if (!trimmedTitle) {
+      toast.error("Title is required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const response = await fetch("/api/admin/banner", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: trimmedTitle,
+          content: content.trim() || null,
+        }),
+      });
+      if (!response.ok) {
+        const detail = (await response.json().catch(() => ({}))).detail;
+        throw new Error(detail || "Failed to save banner");
+      }
+      await mutate(SWR_KEYS.adminBanner);
+      toast.success("Banner published to all users");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save banner";
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleClear() {
+    setClearing(true);
+    try {
+      const response = await fetch("/api/admin/banner", { method: "DELETE" });
+      if (!response.ok && response.status !== 204) {
+        throw new Error("Failed to clear banner");
+      }
+      setTitle("");
+      setContent("");
+      await mutate(SWR_KEYS.adminBanner);
+      toast.success("Banner cleared");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to clear banner";
+      toast.error(message);
+    } finally {
+      setClearing(false);
+    }
+  }
+
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        description="Show a dismissible notice at the top of the app for every user. Use to communicate outages, maintenance windows, or upstream provider issues."
+        divider
+      />
+
+      <SettingsLayouts.Body>
+        <Card border="solid" rounding="lg">
+          <div className="flex flex-col gap-spacing-paragraph p-spacing-paragraph">
+            <Content
+              sizePreset="main-ui"
+              variant="section"
+              title="Title"
+              description={`Shown in bold at the top of the banner. Max ${MAX_TITLE_LEN} characters.`}
+            />
+            <InputTypeIn
+              value={title}
+              onChange={(e) => setTitle(e.target.value.slice(0, MAX_TITLE_LEN))}
+              placeholder="e.g. Bedrock degraded - responses may be slow"
+              variant={isLoading ? "disabled" : "primary"}
+            />
+
+            <Content
+              sizePreset="main-ui"
+              variant="section"
+              title="Details (optional)"
+              description={`Additional context shown next to the title. Max ${MAX_CONTENT_LEN} characters.`}
+            />
+            <InputTextArea
+              value={content}
+              onChange={(e) =>
+                setContent(e.target.value.slice(0, MAX_CONTENT_LEN))
+              }
+              placeholder="We're aware and tracking with AWS. No action needed."
+              rows={4}
+              variant={isLoading ? "disabled" : "primary"}
+            />
+
+            <div className="flex flex-row gap-spacing-paragraph">
+              <Button
+                variant="action"
+                prominence="primary"
+                disabled={
+                  saving || clearing || isLoading || !trimmedTitle || !isDirty
+                }
+                onClick={handleSave}
+              >
+                {isActive ? "Update banner" : "Publish banner"}
+              </Button>
+              {isActive ? (
+                <Button
+                  variant="danger"
+                  prominence="secondary"
+                  disabled={saving || clearing || isLoading}
+                  onClick={handleClear}
+                >
+                  Clear banner
+                </Button>
+              ) : null}
+            </div>
+
+            {isActive && data?.created_at ? (
+              <Text font="secondary-body" color="text-03">
+                {`Banner active since ${new Date(
+                  data.created_at
+                ).toLocaleString()}.`}
+              </Text>
+            ) : null}
+          </div>
+        </Card>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/refresh-pages/admin/SystemBannerPage.tsx
+++ b/web/src/refresh-pages/admin/SystemBannerPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 
 import { Button, Card, Text } from "@opal/components";
@@ -34,20 +34,30 @@ export default function SystemBannerPage() {
   const [content, setContent] = useState("");
   const [saving, setSaving] = useState(false);
   const [clearing, setClearing] = useState(false);
-  const hydrated = useRef(false);
+  const [hasTouched, setHasTouched] = useState(false);
 
   useEffect(() => {
-    if (!hydrated.current && data) {
+    if (data === undefined) {
+      return;
+    }
+    if (data === null) {
+      if (!hasTouched) {
+        setTitle("");
+        setContent("");
+      }
+      return;
+    }
+    if (!hasTouched) {
       setTitle(data.title);
       setContent(data.content ?? "");
-      hydrated.current = true;
     }
-  }, [data]);
+  }, [data, hasTouched]);
 
   const trimmedTitle = title.trim();
+  const trimmedContent = content.trim();
   const isActive = data !== null && data !== undefined;
   const isDirty = isActive
-    ? trimmedTitle !== data.title || (content.trim() || null) !== data.content
+    ? trimmedTitle !== data.title || (trimmedContent || null) !== data.content
     : trimmedTitle.length > 0;
 
   async function handleSave() {
@@ -62,13 +72,16 @@ export default function SystemBannerPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           title: trimmedTitle,
-          content: content.trim() || null,
+          content: trimmedContent || null,
         }),
       });
       if (!response.ok) {
         const detail = (await response.json().catch(() => ({}))).detail;
         throw new Error(detail || "Failed to save banner");
       }
+      setTitle(trimmedTitle);
+      setContent(trimmedContent);
+      setHasTouched(false);
       await mutate(SWR_KEYS.adminBanner);
       toast.success("Banner published to all users");
     } catch (error) {
@@ -84,11 +97,12 @@ export default function SystemBannerPage() {
     setClearing(true);
     try {
       const response = await fetch("/api/admin/banner", { method: "DELETE" });
-      if (!response.ok && response.status !== 204) {
+      if (!response.ok) {
         throw new Error("Failed to clear banner");
       }
       setTitle("");
       setContent("");
+      setHasTouched(false);
       await mutate(SWR_KEYS.adminBanner);
       toast.success("Banner cleared");
     } catch (error) {
@@ -120,7 +134,10 @@ export default function SystemBannerPage() {
             />
             <InputTypeIn
               value={title}
-              onChange={(e) => setTitle(e.target.value.slice(0, MAX_TITLE_LEN))}
+              onChange={(e) => {
+                setHasTouched(true);
+                setTitle(e.target.value.slice(0, MAX_TITLE_LEN));
+              }}
               placeholder="e.g. Bedrock degraded - responses may be slow"
               variant={isLoading ? "disabled" : "primary"}
             />
@@ -133,9 +150,10 @@ export default function SystemBannerPage() {
             />
             <InputTextArea
               value={content}
-              onChange={(e) =>
-                setContent(e.target.value.slice(0, MAX_CONTENT_LEN))
-              }
+              onChange={(e) => {
+                setHasTouched(true);
+                setContent(e.target.value.slice(0, MAX_CONTENT_LEN));
+              }}
               placeholder="We're aware and tracking with AWS. No action needed."
               rows={4}
               variant={isLoading ? "disabled" : "primary"}

--- a/web/src/sections/AdminBannerNotice.tsx
+++ b/web/src/sections/AdminBannerNotice.tsx
@@ -6,7 +6,10 @@ import useSWR from "swr";
 import { MessageCard } from "@opal/components";
 
 import { errorHandlingFetcher } from "@/lib/fetcher";
-import { Notification, NotificationType } from "@/lib/notifications/interfaces";
+import {
+  NotificationsResponse,
+  NotificationType,
+} from "@/lib/notifications/interfaces";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 const DISMISS_STORAGE_KEY = "admin-banner-dismissed";
@@ -65,7 +68,7 @@ function useMainContainerOffset(): { left: number; width: number } {
 }
 
 export default function AdminBannerNotice() {
-  const { data } = useSWR<Notification[]>(
+  const { data } = useSWR<NotificationsResponse>(
     SWR_KEYS.notifications,
     errorHandlingFetcher
   );
@@ -73,7 +76,7 @@ export default function AdminBannerNotice() {
   const [dismissedId, setDismissedId] = useState<number | null>(null);
 
   const banner = useMemo(() => {
-    return (data ?? []).find(
+    return (data?.notifications ?? []).find(
       (n) => n.notif_type === NotificationType.ADMIN_BANNER && !n.dismissed
     );
   }, [data]);

--- a/web/src/sections/AdminBannerNotice.tsx
+++ b/web/src/sections/AdminBannerNotice.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import useSWR from "swr";
+import { MessageCard } from "@opal/components";
+
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { Notification, NotificationType } from "@/lib/notifications/interfaces";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+const DISMISS_STORAGE_KEY = "admin-banner-dismissed";
+
+function dismissKey(notificationId: number): string {
+  return `${DISMISS_STORAGE_KEY}:${notificationId}`;
+}
+
+function useMainContainerOffset(): { left: number; width: number } {
+  const pathname = usePathname();
+  const [bounds, setBounds] = useState<{ left: number; width: number }>({
+    left: 0,
+    width: 0,
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let target: HTMLElement | null = null;
+    let frame = 0;
+
+    function update() {
+      const el = document.querySelector<HTMLElement>("[data-main-container]");
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        setBounds({ left: rect.left, width: rect.width });
+        if (target !== el) {
+          ro.disconnect();
+          ro.observe(el);
+          target = el;
+        }
+      } else {
+        setBounds({ left: 0, width: window.innerWidth });
+        target = null;
+      }
+    }
+
+    const ro = new ResizeObserver(update);
+    const mo = new MutationObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(update);
+    });
+
+    update();
+    mo.observe(document.body, { childList: true, subtree: true });
+    window.addEventListener("resize", update);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [pathname]);
+
+  return bounds;
+}
+
+export default function AdminBannerNotice() {
+  const { data } = useSWR<Notification[]>(
+    SWR_KEYS.notifications,
+    errorHandlingFetcher
+  );
+  const { left, width } = useMainContainerOffset();
+  const [dismissedId, setDismissedId] = useState<number | null>(null);
+
+  const banner = useMemo(() => {
+    return (data ?? []).find(
+      (n) => n.notif_type === NotificationType.ADMIN_BANNER && !n.dismissed
+    );
+  }, [data]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !banner) {
+      setDismissedId(null);
+      return;
+    }
+    const isDismissed =
+      window.localStorage.getItem(dismissKey(banner.id)) === "1";
+    setDismissedId(isDismissed ? banner.id : null);
+  }, [banner?.id]);
+
+  if (!banner || dismissedId === banner.id) {
+    return null;
+  }
+
+  async function handleDismiss() {
+    if (!banner) return;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(dismissKey(banner.id), "1");
+    }
+    setDismissedId(banner.id);
+    try {
+      await fetch(`/api/notifications/${banner.id}/dismiss`, {
+        method: "POST",
+      });
+    } catch {
+      // server-side dismiss is best-effort; localStorage already hides it
+    }
+  }
+
+  return (
+    <div
+      className="fixed top-3 z-toast flex justify-center px-3 pointer-events-none"
+      style={{ left, width: width || undefined }}
+    >
+      <div className="w-full max-w-3xl pointer-events-auto">
+        <MessageCard
+          variant="info"
+          title={banner.title}
+          description={banner.description ?? undefined}
+          onClose={handleDismiss}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -146,6 +146,7 @@ function buildItems(
   // 7. Organization (admin only)
   if (!isCurator) {
     addGated(SECTIONS.ORGANIZATION, ADMIN_ROUTES.THEME, Tier.BUSINESS);
+    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SYSTEM_BANNER);
     add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);


### PR DESCRIPTION
## Description

Adds an admin panel page that lets admins post a global banner visible to every user in the tenant. Reuses the existing `Notification` + dismiss pipeline; one `Notification` row per active user, `additional_data={}` so the unique index serializes concurrent PUTs.

**Backend**

- New `NotificationType.ADMIN_BANNER`.
- `db/admin_banner.py`: `set_admin_banner` / `clear_admin_banner` / `get_active_admin_banner` / `ensure_admin_banner_for_user` (lazy-mints the row on `/notifications` fetch so users created after publish still see the banner).
- Admin-only `GET / PUT / DELETE /api/admin/banner`. Title and content trimmed; whitespace-only title rejected with `OnyxError(INVALID_INPUT)`.

**Frontend**

- New page `/admin/configuration/banner` under the Organization sidebar section.
- `AnnouncementBanner` renders the new type; existing per-user dismiss flow handles the close button.
- Form re-syncs with server state on revalidation unless the admin is mid-edit.

Motivated by a customer needing to communicate upstream LLM outages (e.g. Bedrock) without redirecting traffic away from Onyx.

## How Has This Been Tested?

<!-- to be filled in -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check