### PR TITLE
chore(opensearch): Implement bulk updates

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -353,7 +353,8 @@ class OpenSearchIndexClient(OpenSearchClient):
         response_index = response.get("index", "")
         if response_index != self._index_name:
             raise RuntimeError(
-                f"OpenSearch responded with index name {response_index} when creating index {self._index_name}."
+                f"OpenSearch responded with index name {response_index} when creating index "
+                f"{self._index_name}."
             )
         logger.debug("Index %s created successfully.", self._index_name)
 
@@ -678,8 +679,9 @@ class OpenSearchIndexClient(OpenSearchClient):
             case "updated":
                 if not update_if_exists:
                     raise RuntimeError(
-                        f'The OpenSearch client returned result "updated" for indexing document chunk "{document_chunk_id}". '
-                        "This indicates that a document chunk with that ID already exists, which is not expected."
+                        f'The OpenSearch client returned result "updated" for indexing document '
+                        f'chunk "{document_chunk_id}". This indicates that a document chunk with '
+                        "that ID already exists, which is not expected."
                     )
             case _:
                 raise RuntimeError(
@@ -759,8 +761,8 @@ class OpenSearchIndexClient(OpenSearchClient):
             )
         if success != len(documents):
             raise RuntimeError(
-                f"OpenSearch reported no errors during bulk index but the number of successful operations "
-                f"({success}) does not match the number of documents ({len(documents)})."
+                "OpenSearch reported no errors during bulk index but the number of successful "
+                f"operations ({success}) does not match the number of documents ({len(documents)})."
             )
         logger.debug("Successfully bulk indexed %s documents.", len(documents))
 
@@ -849,7 +851,8 @@ class OpenSearchIndexClient(OpenSearchClient):
         if num_deleted != num_processed:
             raise RuntimeError(
                 f"Failed to delete some or all of the documents for index {self._index_name}. "
-                f"{num_deleted} documents were deleted out of {num_processed} documents that were processed."
+                f"{num_deleted} documents were deleted out of {num_processed} documents that were "
+                "processed."
             )
 
         logger.debug(
@@ -918,9 +921,65 @@ class OpenSearchIndexClient(OpenSearchClient):
                 return
             case _:
                 raise RuntimeError(
-                    f'The OpenSearch client returned result "{result_string}" for updating document chunk "{document_chunk_id}". '
-                    "This is unexpected."
+                    f'The OpenSearch client returned result "{result_string}" for updating '
+                    f'document chunk "{document_chunk_id}". This is unexpected.'
                 )
+
+    @log_function_time(
+        print_only=True,
+        debug_only=True,
+        include_args_subset={
+            "document_chunk_ids": len,
+            "properties_to_update": lambda x: x.keys(),
+        },
+    )
+    def bulk_update_documents(
+        self, document_chunk_ids: list[str], properties_to_update: dict[str, Any]
+    ) -> None:
+        """Bulk updates OpenSearch document chunks' properties.
+
+        The ``properties_to_update`` is applied to all the document chunks with
+        the given IDs.
+
+        Args:
+            document_chunk_ids: The OpenSearch IDs of the document chunks to
+                update.
+            properties_to_update: The properties of the document to update. Each
+                property should exist in the schema.
+        """
+        if not document_chunk_ids:
+            return
+        logger.debug(
+            "Bulk updating %s document chunks for index %s.",
+            len(document_chunk_ids),
+            self._index_name,
+        )
+        data = []
+        for document_chunk_id in document_chunk_ids:
+            data.append(
+                {
+                    "_index": self._index_name,
+                    "_id": document_chunk_id,
+                    "_op_type": "update",
+                    "doc": properties_to_update,
+                }
+            )
+        # max_retries is the number of times to retry a request if we get a 429.
+        success, errors = bulk(self._client, data, max_retries=3)
+        if errors:
+            raise RuntimeError(
+                f"Failed to bulk update document chunks for index {self._index_name}. Errors: "
+                f"{errors}"
+            )
+        if success != len(document_chunk_ids):
+            raise RuntimeError(
+                f"OpenSearch reported no errors during bulk update but the number of successful "
+                f"operations ({success}) does not match the number of document chunks "
+                f"({len(document_chunk_ids)})."
+            )
+        logger.debug(
+            "Successfully bulk updated %s document chunks.", len(document_chunk_ids)
+        )
 
     @log_function_time(print_only=True, debug_only=True, include_args=True)
     def get_document(self, document_chunk_id: str) -> DocumentChunk:
@@ -1096,8 +1155,8 @@ class OpenSearchIndexClient(OpenSearchClient):
         )
         if "_source" not in body or body["_source"] is not False:
             logger.warning(
-                "The body of the search request for document chunk IDs is missing the key, value pair of "
-                '"_source": False. This query will therefore be inefficient.'
+                "The body of the search request for document chunk IDs is missing the key, "
+                'value pair of "_source": False. This query will therefore be inefficient.'
             )
 
         params = {"phase_took": "true"}
@@ -1127,8 +1186,9 @@ class OpenSearchIndexClient(OpenSearchClient):
         # can return arbitrarily-many IDs.
         if len(hits) == DEFAULT_OPENSEARCH_MAX_RESULT_WINDOW:
             logger.warning(
-                "The search request for document chunk IDs returned the maximum number of results. "
-                "It is extremely likely that there are more hits in OpenSearch than the returned results."
+                "The search request for document chunk IDs returned the maximum number of "
+                "results. It is extremely likely that there are more hits in OpenSearch than the "
+                "returned results."
             )
 
         # Extract only the _id field from each hit.
@@ -1284,7 +1344,8 @@ def wait_for_opensearch_with_timeout(
             time_elapsed = time.monotonic() - time_start
             if time_elapsed > wait_limit_s:
                 logger.info(
-                    "[OpenSearch] Readiness probe did not succeed within the timeout (%s seconds).",
+                    "[OpenSearch] Readiness probe did not succeed within the timeout "
+                    "(%s seconds).",
                     wait_limit_s,
                 )
                 return False

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -859,7 +859,6 @@ class TestOpenSearchClient:
             chunk_index=0,
             content="Original content",
             tenant_state=tenant_state,
-            hidden=False,
         )
         test_client.index_document(document=doc, tenant_state=tenant_state)
 
@@ -907,6 +906,105 @@ class TestOpenSearchClient:
         with pytest.raises(NotFoundError, match="404"):
             test_client.update_document(
                 document_chunk_id="test_source__nonexistent__512__0",
+                properties_to_update={"hidden": True},
+            )
+
+    def test_bulk_update_documents(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tests bulk updating document chunks' properties."""
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        # Create documents to update.
+        docs = [
+            _create_test_document_chunk(
+                document_id="test-doc-bulk-update",
+                chunk_index=i,
+                content=f"Original content {i}",
+                tenant_state=tenant_state,
+            )
+            for i in range(5)
+        ]
+        test_client.bulk_index_documents(documents=docs, tenant_state=tenant_state)
+
+        # Under test.
+        doc_chunk_ids = [
+            get_opensearch_doc_chunk_id(
+                tenant_state=tenant_state,
+                document_id=doc.document_id,
+                chunk_index=doc.chunk_index,
+                max_chunk_size=doc.max_chunk_size,
+            )
+            for doc in docs
+        ]
+        properties_to_update = {
+            "hidden": True,
+            "global_boost": 7,
+        }
+        test_client.bulk_update_documents(
+            document_chunk_ids=doc_chunk_ids,
+            properties_to_update=properties_to_update,
+        )
+
+        # Postcondition.
+        # Retrieve each document and verify updates were applied.
+        for doc, doc_chunk_id in zip(docs, doc_chunk_ids):
+            updated_doc = test_client.get_document(document_chunk_id=doc_chunk_id)
+            assert updated_doc.hidden is True
+            assert updated_doc.global_boost == 7
+            # Other properties should remain unchanged.
+            assert updated_doc.document_id == doc.document_id
+            assert updated_doc.content == doc.content
+            assert updated_doc.public == doc.public
+
+    def test_bulk_update_documents_empty_list(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tests bulk updating with an empty list is a no-op."""
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        # Under test and postcondition.
+        # Should not raise.
+        test_client.bulk_update_documents(
+            document_chunk_ids=[],
+            properties_to_update={"hidden": True},
+        )
+
+    def test_bulk_update_nonexistent_documents(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tests bulk updating nonexistent document chunks raises."""
+        # Precondition.
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        # Under test and postcondition.
+        # Try to bulk update document chunks that do not exist.
+        with pytest.raises(Exception):
+            test_client.bulk_update_documents(
+                document_chunk_ids=[
+                    "test_source__nonexistent-1__512__0",
+                    "test_source__nonexistent-2__512__0",
+                ],
                 properties_to_update={"hidden": True},
             )
 


### PR DESCRIPTION
## Description
Bulk update calls are more performant and are less likely to result in `already_closed_exception` or `search_phase_execution_exception` errors, which we see as a result of a bug in OpenSearch, present in at least version 3.4.0 (see https://github.com/opensearch-project/k-NN/issues/3191).

Specifically for the OpenSearch bug:
> Why this helps: an _update API call acquires a per-shard reader context, calls UpdateHelper.prepare(), then releases. With bulk, the shard handles many prepare() calls under the same BulkShardRequest, so reader-context acquire/release happens once per shard per request rather than once per chunk. That cuts the rate of reader-context churn by ~chunks_per_doc for each doc you'd otherwise update sequentially. It does not remove the race (each item's prepare still clones StoredFieldsReader and hits the buggy DerivedSourceReaders path), it just narrows the window meaningfully.

## How Has This Been Tested?
Added external dependency tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk update support to the OpenSearch client to update properties on many document chunks in a single request. This speeds up large updates and reduces API calls with retries and strict result checks.

- **New Features**
  - Added `bulk_update_documents(document_chunk_ids, properties_to_update)` to `OpenSearchIndexClient` using OpenSearch `bulk` with `max_retries=3`.
  - Validates success count, raises on errors, and is a no-op for empty input.
  - Added tests for success, empty input, and nonexistent IDs.

<sup>Written for commit 27d4a5f360c03267a46c32e343d2a64aeeda593a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
