### PR TITLE
fix: LiteLLM embedding test model name payload

### DIFF
--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -55,19 +55,21 @@ export async function connectEmbeddingProvider({
   providerType,
   apiKey,
   apiUrl,
+  modelName = "",
   apiVersion,
   deploymentName,
 }: {
   providerType: string;
   apiKey: string | null;
   apiUrl: string;
+  modelName?: string;
   apiVersion: string | null;
   deploymentName: string | null;
 }): Promise<void> {
   if (apiKey !== null) {
     const testResponse = await testEmbedding({
       provider_type: providerType,
-      modelName: "",
+      modelName,
       apiKey,
       apiUrl,
       apiVersion,

--- a/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
@@ -97,12 +97,14 @@ async function testAndSaveProviderCredentials({
   provider,
   apiKey,
   apiUrl = "",
+  modelName = "",
   apiVersion = null,
   deploymentName = null,
 }: {
   provider: EmbeddingProvider;
   apiKey: string | null;
   apiUrl?: string;
+  modelName?: string;
   apiVersion?: string | null;
   deploymentName?: string | null;
 }): Promise<boolean> {
@@ -111,6 +113,7 @@ async function testAndSaveProviderCredentials({
       providerType: provider.providerName,
       apiKey,
       apiUrl,
+      modelName,
       apiVersion,
       deploymentName,
     });
@@ -389,6 +392,7 @@ function LiteLLMProviderModal({
             provider,
             apiKey,
             apiUrl: values.apiUrl,
+            modelName: values.modelName.trim(),
           })
         ) {
           onSubmit({


### PR DESCRIPTION
Title:
Fix LiteLLM embedding test model name payload

Description:
## Description

Closes #11096

Pass the LiteLLM embedding model name from the admin UI form into the provider connection test request.

Previously, `connectEmbeddingProvider` always sent an empty `modelName` to `testEmbedding` for non-OpenAI providers. This caused LiteLLM embedding setup from the admin UI to call `/api/admin/embedding/test-embedding` with `model_name: ""`, even when the user entered a model name in the form.

The LiteLLM modal now forwards the trimmed form `modelName`, and the indexing service includes it in the test embedding payload.

## How Has This Been Tested?

Not run by author. Verification will be performed manually from the admin UI by configuring a LiteLLM embedding provider and confirming that the connection test request includes the entered `model_name`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the trimmed LiteLLM embedding `modelName` from the admin UI into the provider connection test. This ensures `/api/admin/embedding/test-embedding` receives the correct `model_name` instead of an empty string for non-OpenAI providers.

<sup>Written for commit b65ebaeae68631526ba01752d3196c002cb1df77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

