### PR TITLE
feat(dev): hot-reload + breakpoints for celery workers via watchfiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,13 +1,11 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "compounds": [
     {
-      // Dummy entry used to label the group
       "name": "--- Compound ---",
-      "configurations": ["--- Individual ---"],
+      "configurations": [
+        "--- Individual ---"
+      ],
       "presentation": {
         "group": "1"
       }
@@ -35,7 +33,11 @@
     },
     {
       "name": "Web / Model / API",
-      "configurations": ["Web Server", "Model Server", "API Server"],
+      "configurations": [
+        "Web Server",
+        "Model Server",
+        "API Server"
+      ],
       "presentation": {
         "group": "1"
       }
@@ -61,7 +63,6 @@
   ],
   "configurations": [
     {
-      // Dummy entry used to label the group
       "name": "--- Individual ---",
       "type": "node",
       "request": "launch",
@@ -77,7 +78,10 @@
       "cwd": "${workspaceRoot}/web",
       "runtimeExecutable": "npm",
       "envFile": "${workspaceFolder}/.vscode/.env.web",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
       "presentation": {
         "group": "2"
       },
@@ -96,7 +100,12 @@
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
       },
-      "args": ["model_server.main:app", "--reload", "--port", "9000"],
+      "args": [
+        "model_server.main:app",
+        "--reload",
+        "--port",
+        "9000"
+      ],
       "presentation": {
         "group": "2"
       },
@@ -114,7 +123,12 @@
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
       },
-      "args": ["onyx.main:app", "--reload", "--port", "8080"],
+      "args": [
+        "onyx.main:app",
+        "--reload",
+        "--port",
+        "8080"
+      ],
       "presentation": {
         "group": "2"
       },
@@ -189,7 +203,8 @@
       "name": "Celery primary",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -210,7 +225,8 @@
         "celery"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery primary Console"
     },
@@ -218,7 +234,8 @@
       "name": "Celery light",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -239,7 +256,8 @@
         "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,index_attempt_cleanup,opensearch_migration"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery light Console"
     },
@@ -247,7 +265,8 @@
       "name": "Celery heavy",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -268,7 +287,8 @@
         "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery heavy Console",
       "justMyCode": false
@@ -277,7 +297,8 @@
       "name": "Celery monitoring",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -298,7 +319,8 @@
         "monitoring"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery monitoring Console"
     },
@@ -306,7 +328,8 @@
       "name": "Celery user_file_processing",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -327,7 +350,8 @@
         "user_file_processing,user_file_project_sync,user_file_delete"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery user_file_processing Console",
       "justMyCode": false
@@ -336,7 +360,8 @@
       "name": "Celery scheduled_tasks",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -357,7 +382,8 @@
         "scheduled_tasks"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery scheduled_tasks Console",
       "justMyCode": false
@@ -366,7 +392,8 @@
       "name": "Celery docfetching",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -386,7 +413,8 @@
         "connector_doc_fetching"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery docfetching Console",
       "justMyCode": false
@@ -395,7 +423,8 @@
       "name": "Celery docprocessing",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -416,7 +445,8 @@
         "docprocessing"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery docprocessing Console",
       "justMyCode": false
@@ -425,7 +455,8 @@
       "name": "Celery beat",
       "type": "debugpy",
       "request": "launch",
-      "module": "celery",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
       "cwd": "${workspaceFolder}/backend",
       "envFile": "${workspaceFolder}/.vscode/.env",
       "env": {
@@ -440,7 +471,8 @@
         "--loglevel=INFO"
       ],
       "presentation": {
-        "group": "2"
+        "group": "2",
+        "hidden": true
       },
       "consoleTitle": "Celery beat Console"
     },
@@ -459,8 +491,6 @@
       },
       "args": [
         "-v"
-        // Specify a specific module/test to run or provide nothing to run all tests
-        // "tests/unit/onyx/llm/answering/test_prune_and_merge.py"
       ],
       "presentation": {
         "group": "2"
@@ -468,7 +498,6 @@
       "consoleTitle": "Pytest Console"
     },
     {
-      // Dummy entry used to label the group
       "name": "--- Tasks ---",
       "type": "node",
       "request": "launch",
@@ -482,7 +511,11 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "docker",
-      "runtimeArgs": ["compose", "up", "-d"],
+      "runtimeArgs": [
+        "compose",
+        "up",
+        "-d"
+      ],
       "cwd": "${workspaceFolder}/profiling",
       "console": "integratedTerminal",
       "presentation": {
@@ -520,12 +553,12 @@
         "PYTHONUNBUFFERED": "1",
         "PYTHONPATH": "."
       },
-      "args": ["--verbose"],
+      "args": [
+        "--verbose"
+      ],
       "consoleTitle": "Eval CLI Console"
     },
     {
-      // Celery jobs launched through a single background script (legacy)
-      // Recommend using the "Celery (all)" compound launch instead.
       "name": "Background Jobs",
       "consoleName": "Background Jobs",
       "type": "debugpy",
@@ -571,7 +604,6 @@
       "consoleTitle": "Build Sandbox Templates"
     },
     {
-      // Dummy entry used to label the group
       "name": "--- Database ---",
       "type": "node",
       "request": "launch",
@@ -685,7 +717,6 @@
       }
     },
     {
-      // script to generate the openapi schema
       "name": "Onyx OpenAPI Schema Generator",
       "type": "debugpy",
       "request": "launch",
@@ -696,10 +727,13 @@
         "PYTHONUNBUFFERED": "1",
         "PYTHONPATH": "backend"
       },
-      "args": ["--filename", "backend/generated/openapi.json", "--generate-python-client"]
+      "args": [
+        "--filename",
+        "backend/generated/openapi.json",
+        "--generate-python-client"
+      ]
     },
     {
-      // script to debug multi tenant db issues
       "name": "Onyx DB Manager (Top Chunks)",
       "type": "debugpy",
       "request": "launch",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,9 @@ Before starting, make sure the Docker Daemon is running.
 
 **Features:**
 
-- Hot reload is enabled for the web server and API servers
+- Hot reload is enabled for the web server, API server, and celery workers
+  (celery is wrapped in `backend/scripts/dev_celery_reload.py` so breakpoints
+  survive reloads — debugpy follows the watchfiles fork via `subProcess: true`)
 - Python debugging is configured with debugpy
 - Environment variables are loaded from `.vscode/.env`
 - Console output is organized in the integrated terminal with labeled tabs

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -32,5 +32,5 @@ def _run(argv: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    celery_argv = ["celery", *sys.argv[1:]]
+    celery_argv: list[str] = ["celery", *sys.argv[1:]]
     run_process("./onyx", target=_run, args=(celery_argv,))

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -1,0 +1,36 @@
+"""Run a celery worker with watchfiles hot-reload, preserving VSCode breakpoints.
+
+LOAD-BEARING: referenced by every "Celery <name>" configuration in
+.vscode/launch.json (both local and k8s variants). Deleting or renaming this
+file will break the vscode debugger for celery. See also CONTRIBUTING.md
+("VSCode Debugger") and docs/dev/local-kubernetes.md.
+
+The reloader runs inside the debugged process and re-launches via fork;
+debugpy follows the fork when launch.json sets `subProcess: true`. The
+`watchmedo auto-restart -- celery worker` pattern spawns celery as a bare
+subprocess that debugpy can't attach to.
+
+Args after the script name are forwarded verbatim to celery's CLI.
+
+Example launch.json entry:
+    program: ${workspaceFolder}/backend/scripts/dev_celery_reload.py
+    args: ["-A", "onyx.background.celery.versioned_apps.primary", "worker",
+           "--pool=threads", "-Q", "celery", ...]
+    subProcess: true
+"""
+
+import sys
+
+from watchfiles import run_process
+
+
+def _run(argv: list[str]) -> None:
+    from celery.__main__ import main  # ty: ignore[unresolved-import]
+
+    sys.argv[:] = argv
+    main()
+
+
+if __name__ == "__main__":
+    celery_argv = ["celery", *sys.argv[1:]]
+    run_process("./onyx", target=_run, args=(celery_argv,))

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -32,5 +32,8 @@ def _run(argv: list[str]) -> None:
 
 
 if __name__ == "__main__":
-    celery_argv: list[str] = ["celery", *sys.argv[1:]]
-    run_process("./onyx", target=_run, args=(celery_argv,))
+    celery_argv = ["celery", *sys.argv[1:]]
+    import os
+
+    watch_paths = [p for p in ("./onyx", "./ee") if os.path.isdir(p)]
+    run_process(*watch_paths, target=_run, args=(celery_argv,))


### PR DESCRIPTION
## Description

VSCode celery launch profiles previously had no hot reload — every code change required manually stopping and restarting each worker. The classic `watchmedo auto-restart -- celery worker` pattern provides reload but breaks breakpoints, because watchmedo spawns celery as a non-Python-argv subprocess that debugpy can't follow into.

This PR wraps celery in a new `backend/scripts/dev_celery_reload.py` that uses `watchfiles.run_process` to re-launch on `.py` changes. The reloader runs inside the debugged Python process and re-launches via fork, which debugpy follows when the launch config sets `subProcess: true`. **Both hot reload and breakpoints work simultaneously.**

- `watchfiles` is already installed transitively via uvicorn — no new dependency.
- All 9 celery launch profiles (primary, light, heavy, monitoring, user_file_processing, scheduled_tasks, docfetching, docprocessing, beat) are rewired to use the new wrapper.
- Per-worker configs are hidden from the launch picker (`presentation.hidden: true`) so the existing `Run All Onyx Services` and `Celery` compounds remain the canonical entry points.
- `CONTRIBUTING.md` "Features" list under "Using the Debugger" is updated to mention celery hot reload alongside web / API.

## How Has This Been Tested?

- Ran `Run All Onyx Services` from the debug panel; all 9 celery workers started.
- Set a breakpoint inside a celery task and triggered the task — breakpoint hit in vscode.
- Edited a worker source file and saved — saw watchfiles trigger a re-spawn in the worker's console, then immediately set another breakpoint, triggered the task, and confirmed the breakpoint hits in the freshly-reloaded worker.
- Confirmed `presentation.hidden: true` keeps individual worker configs out of the run picker; the compounds still launch them.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add hot-reload for Celery workers in VSCode without losing breakpoints by wrapping `celery` with a `watchfiles` reloader. All worker configs restart on .py changes, keep breakpoints via `subProcess: true`, and launch through existing compounds.

- **New Features**
  - Added `backend/scripts/dev_celery_reload.py` using `watchfiles.run_process`; runs inside the debugged process so `debugpy` follows forks.
  - Watches `backend/onyx` and `backend/ee`; forwards all args to `celery`.
  - Rewired 9 Celery launch configs to use the wrapper; set `subProcess: true`; hid individual configs so compounds remain the entry points.
  - Documented Celery hot reload in CONTRIBUTING; no new dependency — `watchfiles` comes via `uvicorn`.

<sup>Written for commit 4abf357d4721b88d6251da287e6aee9931094985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

