### PR TITLE
docs(dev): add local Kubernetes development workflow

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,6 +43,24 @@
       }
     },
     {
+      "name": "Run All Onyx Services (k8s)",
+      "configurations": [
+        "Web Server",
+        "API Server (k8s)",
+        "Celery primary (k8s)",
+        "Celery light (k8s)",
+        "Celery heavy (k8s)",
+        "Celery docfetching (k8s)",
+        "Celery docprocessing (k8s)",
+        "Celery user_file_processing (k8s)",
+        "Celery scheduled_tasks (k8s)",
+        "Celery beat (k8s)"
+      ],
+      "presentation": {
+        "group": "1"
+      }
+    },
+    {
       "name": "Celery",
       "configurations": [
         "Celery primary",
@@ -133,6 +151,32 @@
         "group": "2"
       },
       "consoleTitle": "API Server Console",
+      "justMyCode": false
+    },
+    {
+      "name": "API Server (k8s)",
+      "consoleName": "API Server (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "onyx.main:app",
+        "--reload",
+        "--port",
+        "8080"
+      ],
+      "presentation": {
+        "group": "2"
+      },
+      "consoleTitle": "API Server (k8s) Console",
       "justMyCode": false
     },
     {
@@ -475,6 +519,301 @@
         "hidden": true
       },
       "consoleTitle": "Celery beat Console"
+    },
+    {
+      "name": "Celery primary (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.primary",
+        "worker",
+        "--pool=threads",
+        "--concurrency=4",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=primary@%n",
+        "-Q",
+        "celery"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery primary (k8s) Console"
+    },
+    {
+      "name": "Celery light (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.light",
+        "worker",
+        "--pool=threads",
+        "--concurrency=64",
+        "--prefetch-multiplier=8",
+        "--loglevel=INFO",
+        "--hostname=light@%n",
+        "-Q",
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,index_attempt_cleanup,opensearch_migration"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery light (k8s) Console"
+    },
+    {
+      "name": "Celery heavy (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.heavy",
+        "worker",
+        "--pool=threads",
+        "--concurrency=4",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=heavy@%n",
+        "-Q",
+        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery heavy (k8s) Console",
+      "justMyCode": false
+    },
+    {
+      "name": "Celery monitoring (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.monitoring",
+        "worker",
+        "--pool=threads",
+        "--concurrency=1",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=monitoring@%n",
+        "-Q",
+        "monitoring"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery monitoring (k8s) Console"
+    },
+    {
+      "name": "Celery user_file_processing (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.user_file_processing",
+        "worker",
+        "--pool=threads",
+        "--concurrency=2",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=user_file_processing@%n",
+        "-Q",
+        "user_file_processing,user_file_project_sync,user_file_delete"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery user_file_processing (k8s) Console",
+      "justMyCode": false
+    },
+    {
+      "name": "Celery scheduled_tasks (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "INFO",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.scheduled_tasks",
+        "worker",
+        "--pool=threads",
+        "--concurrency=4",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=scheduled_tasks@%n",
+        "-Q",
+        "scheduled_tasks"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery scheduled_tasks (k8s) Console",
+      "justMyCode": false
+    },
+    {
+      "name": "Celery docfetching (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.docfetching",
+        "worker",
+        "--pool=threads",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=docfetching@%n",
+        "-Q",
+        "connector_doc_fetching"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery docfetching (k8s) Console",
+      "justMyCode": false
+    },
+    {
+      "name": "Celery docprocessing (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "ENABLE_MULTIPASS_INDEXING": "false",
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.docprocessing",
+        "worker",
+        "--pool=threads",
+        "--prefetch-multiplier=1",
+        "--loglevel=INFO",
+        "--hostname=docprocessing@%n",
+        "-Q",
+        "docprocessing"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery docprocessing (k8s) Console",
+      "justMyCode": false
+    },
+    {
+      "name": "Celery beat (k8s)",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/backend/scripts/dev_celery_reload.py",
+      "subProcess": true,
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env.k8s",
+      "preLaunchTask": "k8s: telepresence intercept api_server",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1",
+        "PYTHONPATH": ".",
+        "SANDBOX_BACKEND": "kubernetes"
+      },
+      "args": [
+        "-A",
+        "onyx.background.celery.versioned_apps.beat",
+        "beat",
+        "--loglevel=INFO"
+      ],
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      },
+      "consoleTitle": "Celery beat (k8s) Console"
     },
     {
       "name": "Pytest",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -179,7 +179,7 @@
       "command": "bash",
       "args": [
         "-c",
-        "set -e; telepresence connect -n onyx; telepresence leave onyx-api-server 2>/dev/null || true; telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false --env-file ${workspaceFolder}/.vscode/.env.k8s; if [ -f ${workspaceFolder}/.vscode/.env.k8s.local ]; then echo '' >> ${workspaceFolder}/.vscode/.env.k8s; cat ${workspaceFolder}/.vscode/.env.k8s.local >> ${workspaceFolder}/.vscode/.env.k8s; fi"
+        "set -e; telepresence connect -n onyx; telepresence leave onyx-api-server 2>/dev/null || true; telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false --env-file \"${workspaceFolder}/.vscode/.env.k8s\"; if [ -f \"${workspaceFolder}/.vscode/.env.k8s.local\" ]; then echo '' >> \"${workspaceFolder}/.vscode/.env.k8s\"; cat \"${workspaceFolder}/.vscode/.env.k8s.local\" >> \"${workspaceFolder}/.vscode/.env.k8s\"; fi"
       ],
       "presentation": {
         "reveal": "silent",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -103,6 +103,102 @@
       },
       "command": "npx",
       "args": ["orval", "--config", "orval.config.js"]
+    },
+    {
+      "label": "k8s: cluster up",
+      "detail": "Create the kind cluster + helm install Onyx. Idempotent.",
+      "type": "shell",
+      "command": "${workspaceFolder}/deployment/helm/dev/k8s-up.sh",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: cluster down (full teardown)",
+      "detail": "Delete the kind cluster and all data.",
+      "type": "shell",
+      "command": "${workspaceFolder}/deployment/helm/dev/k8s-down.sh",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: pause cluster (data preserved)",
+      "detail": "Stop the kind node container. All cluster state and PVC data survive; resume with 'k8s: resume cluster'.",
+      "type": "shell",
+      "command": "docker",
+      "args": ["stop", "onyx-dev-control-plane"],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: resume cluster",
+      "detail": "Start the kind node container previously paused with 'k8s: pause cluster'. Kubelet reconciles pods automatically.",
+      "type": "shell",
+      "command": "docker",
+      "args": ["start", "onyx-dev-control-plane"],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: telepresence connect",
+      "detail": "Bridge host DNS into the cluster (cluster DNS resolves from laptop).",
+      "type": "shell",
+      "command": "telepresence",
+      "args": ["connect", "-n", "onyx"],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: telepresence intercept api_server",
+      "detail": "Idempotently connect + intercept api_server. Writes cluster env to .vscode/.env.k8s. Wired as preLaunchTask on every (k8s) launch config.",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-c",
+        "set -e; telepresence connect -n onyx; telepresence leave onyx-api-server 2>/dev/null || true; telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false --env-file ${workspaceFolder}/.vscode/.env.k8s; if [ -f ${workspaceFolder}/.vscode/.env.k8s.local ]; then echo '' >> ${workspaceFolder}/.vscode/.env.k8s; cat ${workspaceFolder}/.vscode/.env.k8s.local >> ${workspaceFolder}/.vscode/.env.k8s; fi"
+      ],
+      "presentation": {
+        "reveal": "silent",
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "k8s: telepresence quit",
+      "detail": "Tear down all telepresence intercepts and disconnect.",
+      "type": "shell",
+      "command": "telepresence",
+      "args": ["quit"],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,6 +280,10 @@ Now, visit http://localhost:3000 in your browser. You should see the Onyx onboar
 
 You've successfully set up a local Onyx instance!
 
+### Running on a Local Kubernetes Cluster
+
+For Onyx Craft development with `SANDBOX_BACKEND=kubernetes`, see [Local Kubernetes Development](/docs/dev/local-kubernetes.md).
+
 ### Running in Docker
 
 You can run the full Onyx application stack from pre-built images including all external software dependencies.

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -25,6 +25,7 @@ The sandbox system provides isolated execution environments where OpenCode agent
    - Automatic snapshots to S3
    - Auto-cleanup of idle sandboxes
    - Production-ready with resource isolation
+   - For local-cluster development, see [docs/dev/local-kubernetes.md](/docs/dev/local-kubernetes.md).
 
 ### Directory Structure
 

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -19,6 +19,7 @@ Example launch.json entry:
     subProcess: true
 """
 
+import os
 import sys
 
 from watchfiles import run_process
@@ -33,7 +34,5 @@ def _run(argv: list[str]) -> None:
 
 if __name__ == "__main__":
     celery_argv = ["celery", *sys.argv[1:]]
-    import os
-
     watch_paths = [p for p in ("./onyx", "./ee") if os.path.isdir(p)]
     run_process(*watch_paths, target=_run, args=(celery_argv,))

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -30,6 +30,8 @@ If you are upgrading from an earlier 0.4.x release, note:
 
 # Local testing
 
+> This section covers chart-maintainer testing; for the Onyx Craft local-kind developer workflow, see [docs/dev/local-kubernetes.md](/docs/dev/local-kubernetes.md).
+
 ## One time setup
 * brew install kind
 * Ensure you have no config at ~/.kube/config

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -1,0 +1,181 @@
+# Onyx local-dev overlay for kind/minikube/k3d.
+#
+# Shrinks resources and disables prod-only features so the chart fits on a
+# laptop. Pairs with telepresence intercept so api_server / celery / web run
+# in your vscode debugger while the rest of the stack runs in-cluster.
+#
+# See docs/dev/local-kubernetes.md for the full workflow.
+
+# Track nightly `edge` builds instead of `latest` (a released tag) — keeps
+# in-cluster images closer to main, reducing schema/code skew with local
+# source. Always-pull so kind picks up edge updates.
+global:
+  version: edge
+  pullPolicy: Always
+
+# ---- Persistence (kept on, sized for a laptop) ----
+
+postgresql:
+  cluster:
+    storage:
+      size: 2Gi
+
+vespa:
+  volumeClaimTemplates:
+    - metadata:
+        name: vespa-storage
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 5Gi
+        storageClassName: ""
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+
+opensearch:
+  persistence:
+    enabled: true
+    size: 5Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+  opensearchJavaOpts: "-Xmx1g -Xms1g"
+
+minio:
+  persistence:
+    enabled: true
+    size: 5Gi
+  # Upstream chart defaults to a 16 GiB memory request.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+# ---- Networking (port-forward instead of ingress) ----
+
+ingress:
+  enabled: false
+
+letsencrypt:
+  enabled: false
+
+nginx:
+  controller:
+    service:
+      # kind has no LoadBalancer provider.
+      type: ClusterIP
+
+# ---- Monitoring ----
+
+monitoring:
+  grafana:
+    dashboards:
+      enabled: false
+  serviceMonitors:
+    enabled: false
+
+# ---- Code interpreter ----
+
+codeInterpreter:
+  enabled: false
+
+# ---- App pods ----
+#
+# Scaled to 0 since you run these locally via telepresence intercept.
+# api stays at 1: `telepresence intercept onyx-api-server` needs a Deployment
+# with a running pod template to inject the traffic-agent sidecar (the main
+# container is free to CrashLoopBackOff).
+
+api:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+webserver:
+  replicaCount: 0
+
+celery_beat:
+  replicaCount: 0
+
+celery_worker_primary:
+  replicaCount: 0
+
+celery_worker_light:
+  replicaCount: 0
+
+celery_worker_heavy:
+  replicaCount: 0
+
+celery_worker_docfetching:
+  replicaCount: 0
+
+celery_worker_docprocessing:
+  replicaCount: 0
+
+celery_worker_user_file_processing:
+  replicaCount: 0
+
+celery_worker_scheduled_tasks:
+  replicaCount: 0
+
+celery_worker_monitoring:
+  replicaCount: 0
+
+# slackbot / discordbot / mcpServer use .enabled (not replicaCount).
+slackbot:
+  enabled: false
+
+discordbot:
+  enabled: false
+
+mcpServer:
+  enabled: false
+
+inferenceCapability:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+indexCapability:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+
+redis:
+  redisStandalone:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1,6 +1,11 @@
 # Default values for onyx.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+#
+# Companion overlays in this directory:
+#   - values-lite.yaml      Minimal deploy (no vector DB / Redis / model servers).
+#   - values-localdev.yaml  Laptop-sized overlay for kind/minikube; see
+#                           /docs/dev/local-kubernetes.md for the full workflow.
 
 global:
   # Global version for all Onyx components (overrides .Chart.AppVersion)

--- a/deployment/helm/dev/k8s-down.sh
+++ b/deployment/helm/dev/k8s-down.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# k8s-down.sh — tear down the Onyx dev cluster.
+#
+# Default: uninstall the helm release and delete the kind cluster (wipes data).
+# --keep-cluster preserves the cluster and its PVCs for reinstall.
+#
+# Usage:
+#   deployment/helm/dev/k8s-down.sh
+#   deployment/helm/dev/k8s-down.sh --keep-cluster
+#
+# Flags:
+#   --cluster-name <name>   kind cluster name (default: onyx-dev)
+#   --namespace <ns>        k8s namespace (default: onyx)
+#   --keep-cluster          uninstall Onyx but keep the kind cluster
+
+set -euo pipefail
+
+CLUSTER_NAME="onyx-dev"
+NAMESPACE="onyx"
+KEEP_CLUSTER=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name) CLUSTER_NAME="$2"; shift 2 ;;
+    --namespace)    NAMESPACE="$2"; shift 2 ;;
+    --keep-cluster) KEEP_CLUSTER=1; shift ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  echo "kind cluster '$CLUSTER_NAME' does not exist; nothing to do"
+  exit 0
+fi
+
+kubectl config use-context "kind-$CLUSTER_NAME" >/dev/null
+
+# Same context safety guard as k8s-up.sh — the 'onyx' namespace exists in prod
+# EKS too, so refuse anything but the exact expected kind context.
+EXPECTED_CTX="kind-$CLUSTER_NAME"
+CURRENT_CTX="$(kubectl config current-context)"
+if [[ "$CURRENT_CTX" != "$EXPECTED_CTX" ]]; then
+  echo "refusing to operate: current kubectl context is '$CURRENT_CTX'" >&2
+  echo "expected '$EXPECTED_CTX' — pass --cluster-name to target a different kind cluster" >&2
+  exit 1
+fi
+
+if [[ "$KEEP_CLUSTER" -eq 1 ]]; then
+  # PVCs are intentionally left intact so the next install reuses postgres /
+  # opensearch / vespa / minio data. For a clean slate, omit --keep-cluster
+  # or run: kubectl -n $NAMESPACE delete pvc --all
+  echo "uninstalling helm release 'onyx' in namespace '$NAMESPACE' ..."
+  helm uninstall onyx -n "$NAMESPACE" 2>/dev/null || true
+
+  echo "done. cluster 'kind-$CLUSTER_NAME' is preserved (PVCs intact)."
+else
+  echo "deleting kind cluster '$CLUSTER_NAME' (this wipes all cluster data) ..."
+  kind delete cluster --name "$CLUSTER_NAME"
+fi

--- a/deployment/helm/dev/k8s-up.sh
+++ b/deployment/helm/dev/k8s-up.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# k8s-up.sh — bring up an Onyx dev cluster on the local machine.
+#
+# Idempotent. See docs/dev/local-kubernetes.md for the full workflow.
+#
+# Usage:
+#   deployment/helm/dev/k8s-up.sh
+#   deployment/helm/dev/k8s-up.sh --opensearch-password 'YourStrongPwHere'
+#
+# Flags:
+#   --cluster-name <name>          kind cluster name (default: onyx-dev)
+#   --namespace <ns>               k8s namespace (default: onyx)
+#   --opensearch-password <pw>     admin password on first install
+#                                  (default: generated, printed at the end)
+#   --skip-cluster-create          skip kind create (use an existing cluster)
+#   --skip-helm                    only create the cluster, don't install Onyx
+
+set -euo pipefail
+
+CLUSTER_NAME="onyx-dev"
+NAMESPACE="onyx"
+OPENSEARCH_PASSWORD=""
+SKIP_CLUSTER_CREATE=0
+SKIP_HELM=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/../charts/onyx" && pwd)"
+VALUES_OVERLAY="$CHART_DIR/values-localdev.yaml"
+
+require() {
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "error: '$bin' is required but not on PATH" >&2
+    echo "see docs/dev/local-kubernetes.md for installation" >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name)         CLUSTER_NAME="$2"; shift 2 ;;
+    --namespace)            NAMESPACE="$2"; shift 2 ;;
+    --opensearch-password)  OPENSEARCH_PASSWORD="$2"; shift 2 ;;
+    --skip-cluster-create)  SKIP_CLUSTER_CREATE=1; shift ;;
+    --skip-helm)            SKIP_HELM=1; shift ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+require kind
+require helm
+require kubectl
+
+# ---- 1. kind cluster ----
+
+if [[ "$SKIP_CLUSTER_CREATE" -eq 0 ]]; then
+  if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+    echo "kind cluster '$CLUSTER_NAME' already exists; skipping create"
+  else
+    echo "creating kind cluster '$CLUSTER_NAME' ..."
+    kind create cluster --name "$CLUSTER_NAME"
+  fi
+fi
+
+kubectl config use-context "kind-$CLUSTER_NAME" >/dev/null
+
+# Refuse to operate unless the current context is exactly the expected kind
+# cluster: the 'onyx' namespace exists in prod EKS too, and other kind clusters
+# may also be present.
+EXPECTED_CTX="kind-$CLUSTER_NAME"
+CURRENT_CTX="$(kubectl config current-context)"
+if [[ "$CURRENT_CTX" != "$EXPECTED_CTX" ]]; then
+  echo "refusing to operate: current kubectl context is '$CURRENT_CTX'" >&2
+  echo "expected '$EXPECTED_CTX' — pass --cluster-name to target a different kind cluster" >&2
+  exit 1
+fi
+
+# ---- 2. helm install / upgrade ----
+
+if [[ "$SKIP_HELM" -eq 1 ]]; then
+  echo "skipping helm install (--skip-helm)"
+  exit 0
+fi
+
+kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 \
+  || kubectl create namespace "$NAMESPACE"
+
+# Use an isolated helm repo config: helm matches chart deps by repo NAME, so a
+# stale dev-global repo with a colliding name (we've seen this with
+# 'code-interpreter') can shadow ours and break the install.
+echo "preparing isolated helm repo config ..."
+HELM_DEV_HOME="$(mktemp -d -t onyx-dev-helm-XXXXXX)"
+export HELM_REPOSITORY_CONFIG="$HELM_DEV_HOME/repositories.yaml"
+export HELM_REPOSITORY_CACHE="$HELM_DEV_HOME/cache"
+mkdir -p "$HELM_REPOSITORY_CACHE"
+trap 'rm -rf "$HELM_DEV_HOME"' EXIT
+
+# Repo names must match the dep names in Chart.yaml.
+helm repo add cloudnative-pg  https://cloudnative-pg.github.io/charts          >/dev/null
+helm repo add vespa           https://onyx-dot-app.github.io/vespa-helm-charts >/dev/null
+helm repo add opensearch      https://opensearch-project.github.io/helm-charts >/dev/null
+helm repo add ingress-nginx   https://kubernetes.github.io/ingress-nginx       >/dev/null
+helm repo add redis-ot        https://ot-container-kit.github.io/helm-charts   >/dev/null
+helm repo add minio           https://charts.min.io/                           >/dev/null
+helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/  >/dev/null
+helm repo update >/dev/null
+
+echo "updating chart dependencies ..."
+helm dependency update "$CHART_DIR" >/dev/null
+
+# Generate a password on first install only; upgrades reuse the existing Secret.
+PW_FLAG=()
+if ! kubectl -n "$NAMESPACE" get secret onyx-opensearch >/dev/null 2>&1; then
+  if [[ -z "$OPENSEARCH_PASSWORD" ]]; then
+    # Prefix 'Aa1!' satisfies OpenSearch's complexity rule (upper/lower/digit/symbol).
+    OPENSEARCH_PASSWORD="Aa1!$(openssl rand -hex 12)"
+    echo "generated opensearch admin password: $OPENSEARCH_PASSWORD"
+    echo "(stored in k8s Secret onyx-opensearch — retrieve with:"
+    echo "  kubectl -n $NAMESPACE get secret onyx-opensearch -o jsonpath='{.data.opensearch_admin_password}' | base64 -d)"
+  fi
+  PW_FLAG=(--set "auth.opensearch.values.opensearch_admin_password=$OPENSEARCH_PASSWORD")
+fi
+
+echo "helm upgrade --install onyx ..."
+# ${PW_FLAG[@]+"${PW_FLAG[@]}"} expands to nothing when empty; bare
+# "${PW_FLAG[@]}" errors under `set -u` on subsequent runs.
+helm upgrade --install onyx "$CHART_DIR" \
+  -n "$NAMESPACE" \
+  -f "$VALUES_OVERLAY" \
+  ${PW_FLAG[@]+"${PW_FLAG[@]}"}
+
+# ---- 3. next steps ----
+
+cat <<EOF
+
+cluster: kind-$CLUSTER_NAME
+namespace: $NAMESPACE
+context: $(kubectl config current-context)
+
+next steps:
+  1. watch pods come up:
+       kubectl -n $NAMESPACE get pods -w
+
+  2. (optional) connect your host to cluster DNS so you can run api_server
+     locally and have it reach in-cluster services:
+       telepresence helm install        # one-time, installs traffic-manager
+       telepresence connect -n $NAMESPACE
+
+  3. for features that depend on api_server-source pod identity (e.g.
+     NetworkPolicies, in-pod auth via injected env), intercept instead:
+       telepresence intercept onyx-api-server \\
+         --namespace $NAMESPACE \\
+         --port 8080:8080 \\
+         --env-file .vscode/.env.k8s
+
+  4. open vscode and run the "Run All Onyx Services" launch profile.
+
+teardown:
+  deployment/helm/dev/k8s-down.sh
+
+EOF

--- a/docs/dev/local-kubernetes.md
+++ b/docs/dev/local-kubernetes.md
@@ -1,0 +1,221 @@
+# Local Kubernetes Development
+
+How to develop Onyx against a local kind cluster, with the vscode debugger
+attached to api_server / celery / web.
+
+## When you need this
+
+The default path in [CONTRIBUTING.md](/CONTRIBUTING.md) (docker-compose deps +
+vscode debugger + `SANDBOX_BACKEND=local`) is faster and covers ~90% of the
+codebase. Use it unless you're working on **Onyx Craft (build mode)** with
+`SANDBOX_BACKEND=kubernetes`: sandboxes are real pods, so anything touching
+the pod spec, the sandbox image, or the cluster-side push / auth paths must
+be exercised on a real cluster.
+
+## Prerequisites
+
+Builds on the CONTRIBUTING.md prereqs (Python 3.11, uv, Node.js 22, the venv,
+`.vscode/.env`). Docker Desktop must be running with at least 8 CPU / 16 GB
+allocated.
+
+```bash
+brew install kind helm kubectl
+
+curl -fLo /opt/homebrew/bin/telepresence \
+  https://github.com/telepresenceio/telepresence/releases/latest/download/telepresence-darwin-arm64
+chmod +x /opt/homebrew/bin/telepresence
+```
+
+The telepresence network daemon needs sudo for DNS + VPN setup. vscode's
+preLaunchTask can't answer an interactive prompt, so pick one:
+
+**A. Passwordless sudo (set once)**
+
+```bash
+echo "$USER ALL=(ALL) NOPASSWD: /opt/homebrew/bin/telepresence" \
+  | sudo tee /etc/sudoers.d/telepresence
+sudo chmod 0440 /etc/sudoers.d/telepresence
+```
+
+**B. Manual `connect` once per dev session**
+
+One sudo prompt at session start; the daemon stays alive afterward:
+
+```bash
+telepresence connect -n onyx
+```
+
+## One-time setup
+
+Bring up the cluster:
+
+```bash
+deployment/helm/dev/k8s-up.sh
+```
+
+Or run the **`k8s: cluster up`** vscode task. The script is idempotent and
+refuses to run unless your kubectl context is exactly `kind-onyx-dev` (the
+`onyx` namespace also exists in prod EKS).
+
+Watch pods (vespa and CNPG-postgres take a minute or two on first boot):
+
+```bash
+kubectl -n onyx get pods -w
+```
+
+Install the in-cluster telepresence traffic-manager (once per cluster):
+
+```bash
+telepresence helm install
+```
+
+The chart pins images to the `:edge` tag in
+[`values-localdev.yaml`](/deployment/helm/charts/onyx/values-localdev.yaml)
+with `pullPolicy: Always`, so in-cluster pods track nightly builds off `main`
+rather than the released `:latest`.
+
+**Known issue: CNPG operator on Docker Desktop k8s.** CloudNativePG fails
+with `unable to setup PKI infrastructure: no operator deployment found`
+against Docker Desktop's bundled kubernetes. Use kind (the default in
+`k8s-up.sh`) or a deployed dev cluster (`st-dev`).
+
+## Daily workflow
+
+### vscode tasks
+
+All cluster + telepresence commands are exposed as tasks (Cmd+Shift+P → Tasks:
+Run Task):
+
+- `k8s: cluster up` — bring up or reconcile the cluster.
+- `k8s: pause cluster (data preserved)` — stop the kind node container at end of day.
+- `k8s: resume cluster` — start it back up; kubelet reconciles pods.
+- `k8s: cluster down (full teardown)` — delete the kind cluster and all PVC data.
+- `k8s: telepresence connect`, `... intercept api_server`, `... quit`.
+
+### Run your local processes
+
+Open the debug panel and pick **Run All Onyx Services (k8s)** — web + api +
+every celery worker + beat. Model server stays in-cluster.
+
+Each `(k8s)` config has `telepresence intercept onyx-api-server` as its
+`preLaunchTask`. vscode dedupes the task across the compound, so one run
+connects + (re)creates the intercept idempotently. No manual telepresence
+invocation needed.
+
+The intercept points cluster ingress to your local api_server using the same
+labels, secrets, and service account as the real pod — NetworkPolicies and
+pod-selector auth work transparently.
+
+Celery workers aren't intercepted (no inbound HTTP); they reach in-cluster
+redis via telepresence's DNS bridge. The chart scales in-cluster celery to 0
+so your local workers are the only consumers.
+
+Both api and celery hot-reload — api via uvicorn's `--reload`, celery via
+`watchfiles.run_process` (`backend/scripts/dev_celery_reload.py`); breakpoints
+work in both because debugpy follows the reloader's fork (`subProcess: true`).
+
+Individual `Celery <name> (k8s)` configs are hidden from the picker
+(`presentation.hidden: true`); flip `hidden` to `false` in
+`.vscode/launch.json` to run a single worker.
+
+Every `(k8s)` profile sources `.vscode/.env.k8s` (written by
+`telepresence intercept --env-file`) and sets `SANDBOX_BACKEND=kubernetes`.
+
+Visit `http://localhost:3000` once running.
+
+### Iteration loop
+
+| What you changed | Cycle time | What to do |
+|---|---|---|
+| Python in api_server / celery / model_server | ~instant | uvicorn / debugpy reloads. No cluster touch. |
+| Frontend (`web/`) | ~instant | Next.js HMR. |
+| Helm chart templates / values | 10–30s | Re-run `k8s-up.sh`. |
+| Backend image (`Dockerfile`) | 60–180s | `docker build` → `kind load docker-image` → `kubectl rollout restart`. |
+| Sandbox image (`backend/onyx/server/features/build/sandbox/kubernetes/docker/`) | 60–180s | Same. New sandboxes pick up the new image immediately. |
+
+### Building and loading local images
+
+```bash
+docker build -t onyxdotapp/onyx-backend:dev backend/
+kind load docker-image onyxdotapp/onyx-backend:dev --name onyx-dev
+
+# Point the chart at it (once per session)
+helm upgrade onyx deployment/helm/charts/onyx \
+  -n onyx \
+  -f deployment/helm/charts/onyx/values-localdev.yaml \
+  --set api.image.tag=dev \
+  --set api.image.pullPolicy=IfNotPresent \
+  --set celery_shared.image.tag=dev
+
+kubectl -n onyx rollout restart deployment/onyx-api-server
+```
+
+`kind load` ships straight to the kind node's containerd — no registry push.
+
+### Avoid this loop when you can
+
+For logic that doesn't depend on cluster-only behavior (safe-extract, push
+wire format, tarball round-trips), drive it from unit /
+external-dependency-unit tests against a temp dir. See
+[`backend/tests/README.md`](/backend/tests/README.md).
+
+### End of day
+
+Run **`k8s: pause cluster`** (or `docker stop onyx-dev-control-plane`) to stop
+the kind node container. PVC data lives inside that container, so postgres,
+redis, opensearch, vespa, and minio state all survive. Resume with
+**`k8s: resume cluster`** — the kubelet reconciles pods automatically.
+
+Reach for **`k8s: cluster down (full teardown)`** only when you want a clean
+slate: it runs `kind delete cluster`, destroying the node container and all
+PVC data.
+
+## Data persistence
+
+Persistence is enabled in `values-localdev.yaml` with shrunk PVCs. kind PVCs
+are host-paths inside the kind node container.
+
+| Action | Data survives? |
+|---|---|
+| `helm upgrade` | yes |
+| `kubectl rollout restart` | yes |
+| Docker Desktop restart / laptop reboot | yes |
+| `k8s: pause cluster` / `docker stop` of the node container | yes |
+| `k8s: cluster down` / `k8s-down.sh` (full teardown) | no |
+
+Clean slate without nuking the cluster:
+
+```bash
+kubectl -n onyx delete pvc --all
+deployment/helm/dev/k8s-up.sh
+```
+
+## `.env.k8s.local`
+
+`.env.k8s` is regenerated each preLaunchTask run by `telepresence intercept
+--env-file`; `.env.k8s.local` is then appended (last-wins). Neither is
+checked in.
+
+Start `.env.k8s.local` from your `.vscode/.env`, then **remove** any keys
+that should come from the cluster — overriding these breaks DNS or auth into
+cluster services:
+
+- `POSTGRES_*`, `REDIS_*`, `OPENSEARCH_*`, `VESPA_HOST`
+- `S3_*` (MinIO endpoint + creds)
+- `MODEL_SERVER_HOST`, `INDEXING_MODEL_SERVER_HOST`
+- `INTERNAL_URL`
+
+Also drop `SANDBOX_BACKEND=local`-only keys (`SANDBOX_BASE_PATH`,
+`OUTPUTS_TEMPLATE_PATH`, `VENV_TEMPLATE_PATH`,
+`PERSISTENT_DOCUMENT_STORAGE_PATH`).
+
+Keep personal vars: API keys (OPENAI, BRAINTRUST, EXA), log levels,
+password-rule relaxations, feature flags, OAuth client IDs.
+
+## References
+
+- [CONTRIBUTING.md — Development Setup](/CONTRIBUTING.md#development-setup)
+- [deployment/helm/README.md](/deployment/helm/README.md)
+- [backend/onyx/server/features/build/sandbox/README.md](/backend/onyx/server/features/build/sandbox/README.md)
+- [Telepresence docs](https://www.telepresence.io/docs/)
+- [kind docs](https://kind.sigs.k8s.io/)


### PR DESCRIPTION
## Description

Adds a complete kind + telepresence + vscode workflow for developing Onyx Craft (build mode) features that need a real cluster. The default docker-compose + `SANDBOX_BACKEND=local` dev path stays the primary recommendation for everything else.

**What's new:**

- **`docs/dev/local-kubernetes.md`** — the canonical guide: prereqs, one-time setup, daily workflow, iteration loop, persistence model, end-of-day pause/resume via `docker stop|start` of the kind node container.
- **`deployment/helm/dev/k8s-up.sh` / `k8s-down.sh`** — idempotent bring-up/teardown scripts. `k8s-up.sh` guards against running against a non-`kind-onyx-dev` kubectl context (the `onyx` namespace also exists in prod EKS).
- **`deployment/helm/charts/onyx/values-localdev.yaml`** — laptop overlay that shrinks resources, disables prod-only features (ingress, letsencrypt, monitoring, codeInterpreter), and pins images to `:edge` / `Always` pull so in-cluster pods track `main`. Sibling to the existing `values-lite.yaml`.
- **`.vscode/launch.json`** — 10 new `(k8s)` configs (api + 9 celery) wired with `telepresence intercept onyx-api-server` as `preLaunchTask`. New `Run All Onyx Services (k8s)` compound. The non-k8s celery hot-reload wiring from the prior PR is unchanged.
- **`.vscode/tasks.json`** — `k8s: cluster up/down/pause/resume`, telepresence connect/intercept/quit. The intercept task is idempotent and serves as the `preLaunchTask` for every k8s launch config.
- Cross-links from `CONTRIBUTING.md`, `deployment/helm/README.md`, `backend/onyx/server/features/build/sandbox/README.md` so the dev doc is discoverable from the natural entry points. `values.yaml` gains a "Companion overlays" comment block pointing at `values-localdev.yaml`.

**Depends on:**
- #11111 — chart fixes (without these, `helm install` fails on a fresh cluster)
- #11112 — celery hot-reload wiring (the k8s launch configs reuse `dev_celery_reload.py`)

Merge those two first; this PR will rebase cleanly afterward (the helm/README.md addition is in a different section from #11111's, so no real conflict).

## How Has This Been Tested?

Manually exercised end-to-end on macOS arm64:
- `k8s: cluster up` task brings up kind + helm-installs the chart with `values-localdev.yaml`.
- `Run All Onyx Services (k8s)` launches web/api/celery locally with the intercept-injected env from the cluster.
- Verified breakpoints hit in the locally-running api server (via intercept) and celery workers.
- Ran `alembic upgrade head` against cluster postgres through the telepresence DNS bridge; 131 tables created, alembic head matches.
- `k8s: pause cluster` followed by `k8s: resume cluster`: all PVCs Bound, postgres table count and alembic head preserved across the cycle.
- `k8s: cluster down (full teardown)` deletes the kind cluster cleanly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local Kubernetes dev workflow using `kind` + `telepresence` + VS Code so you can run API and Celery locally against a real cluster. Also adds Celery hot-reload with working breakpoints and fixes a VS Code task quoting issue.

- **New Features**
  - Local cluster kit: `docs/dev/local-kubernetes.md`, `k8s-up.sh`/`k8s-down.sh` (idempotent, context-safe), and `values-localdev.yaml` (smaller resources, prod-only features off, images pinned to `:edge`, app pods scaled to 0 except API).
  - VS Code integration: new `(k8s)` launch configs with an idempotent preLaunchTask that intercepts `onyx-api-server`, writes `.vscode/.env.k8s`, and appends `.env.k8s.local`; new “Run All Onyx Services (k8s)” compound and cluster/telepresence tasks including pause/resume.
  - Celery DX: workers launched via `backend/scripts/dev_celery_reload.py` for hot reload with working breakpoints.

- **Bug Fixes**
  - Quote `${workspaceFolder}` paths in the telepresence intercept task to handle spaces in project paths.

<sup>Written for commit b1404189d61078c11e65ae5c1410d1997d54db45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

