### PR TITLE
chore(opensearch): Bump docker compose OpenSearch image tag to 3.6.0

### DIFF
--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -433,7 +433,7 @@ services:
         max-file: "6"
 
   opensearch:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
     # Controls whether this service runs. In order to enable it, add
     # opensearch-enabled to COMPOSE_PROFILES in the environment for this

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -237,7 +237,7 @@ services:
         max-file: "6"
 
   opensearch:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
     # Controls whether this service runs. In order to enable it, add
     # opensearch-enabled to COMPOSE_PROFILES in the environment for this

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -261,7 +261,7 @@ services:
         max-file: "6"
 
   opensearch:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
     # Controls whether this service runs. In order to enable it, add
     # opensearch-enabled to COMPOSE_PROFILES in the environment for this

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -280,7 +280,7 @@ services:
         max-file: "6"
 
   opensearch:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
     # Controls whether this service runs. In order to enable it, add
     # opensearch-enabled to COMPOSE_PROFILES in the environment for this

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -413,7 +413,7 @@ services:
         max-file: "6"
 
   opensearch:
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
     # Controls whether this service runs. In order to enable it, add
     # opensearch-enabled to COMPOSE_PROFILES in the environment for this


### PR DESCRIPTION
## Description
https://github.com/opensearch-project/k-NN/issues/3191 is alleged to have been fixed in 3.6.0.

## How Has This Been Tested?
'twas not, although a customer upgraded their Helm-managed OpenSearch version to 3.6.0 and things seemed to work.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update all Docker Compose profiles to use `opensearchproject/opensearch:3.6.0` to pick up the k-NN fix (opensearch-project/k-NN#3191) and stability improvements.

<sup>Written for commit c5c7af11d02c23cc7b2a05f70c47a294d0857196. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

