### PR TITLE
chore: [Running GitHub actions for #10783]

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1415,7 +1415,7 @@ def get_litellm_available_models(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> list[LitellmFinalModelResponse]:
-    """Fetch available models from Litellm proxy /v1/models endpoint."""
+    """Fetch available models from LiteLLM proxy /v1/model/info endpoint."""
     api_key = _resolve_api_key(
         request.api_key, request.provider_name, request.api_base, db_session
     )
@@ -1436,14 +1436,20 @@ def get_litellm_available_models(
         try:
             model_details = LitellmModelDetails.model_validate(model)
 
+            litellm_params_model = model_details.get_litellm_params_model()
+
             # Skip embedding models
-            if is_embedding_model(model_details.id):
+            if is_embedding_model(litellm_params_model) or is_embedding_model(model_details.model_name):
                 continue
 
             results.append(
                 LitellmFinalModelResponse(
-                    provider_name=model_details.owned_by,
-                    model_name=model_details.id,
+                    provider_name=model_details.get_custom_llm_provider(),
+                    model_name=model_details.model_name,
+                    litellm_params_model=litellm_params_model,
+                    max_input_tokens=model_details.get_max_input_tokens(),
+                    supports_image_input=model_details.supports_image_input(),
+                    supports_reasoning=model_details.supports_reasoning(),
                 )
             )
         except Exception as e:
@@ -1469,6 +1475,8 @@ def get_litellm_available_models(
                 SyncModelEntry(
                     name=r.model_name,
                     display_name=r.model_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
                 )
                 for r in sorted_results
             ],
@@ -1479,9 +1487,9 @@ def get_litellm_available_models(
 
 
 def _get_litellm_models_response(api_key: str | None, api_base: str) -> dict:
-    """Perform GET to Litellm proxy /api/v1/models and return parsed JSON."""
+    """Perform GET to LiteLLM proxy /v1/model/info and return parsed JSON."""
     cleaned_api_base = api_base.strip().rstrip("/")
-    url = f"{cleaned_api_base}/v1/models"
+    url = f"{cleaned_api_base}/v1/model/info"
 
     return _get_openai_compatible_models_response(
         url=url,

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1439,7 +1439,9 @@ def get_litellm_available_models(
             litellm_params_model = model_details.get_litellm_params_model()
 
             # Skip embedding models
-            if is_embedding_model(litellm_params_model) or is_embedding_model(model_details.model_name):
+            if is_embedding_model(litellm_params_model) or is_embedding_model(
+                model_details.model_name
+            ):
                 continue
 
             results.append(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -449,17 +449,66 @@ class LitellmModelsRequest(BaseModel):
 
 
 class LitellmModelDetails(BaseModel):
-    """Response model for Litellm proxy /api/v1/models endpoint"""
+    """Response model for LiteLLM proxy /v1/model/info endpoint."""
 
-    id: str  # Model ID (e.g. "gpt-4o")
-    object: str  # "model"
-    created: int  # Unix timestamp in seconds
-    owned_by: str  # Provider name (e.g. "openai")
+    model_name: str
+    litellm_params: dict[str, Any] | None = None
+    model_info: dict[str, Any] | None = None
+
+    def get_custom_llm_provider(self) -> str:
+        """Returns .litellm_params.custom_llm_provider"""
+        if self.litellm_params:
+            return self.litellm_params.get("custom_llm_provider", "")
+
+        return ""
+
+    def get_litellm_params_model(self) -> str:
+        """Returns .litellm_params.model if available, otherwise falls back to
+        model_name."""
+        if self.litellm_params:
+            litellm_params_model = self.litellm_params.get("model")
+            if litellm_params_model:
+                return litellm_params_model
+
+        return self.model_name
+
+    def get_max_input_tokens(self) -> int | None:
+        if not self.model_info:
+            return None
+
+        # Prefer max_input_tokens, fall back to max_tokens.
+        for key in ("max_input_tokens", "max_tokens"):
+            value = self.model_info.get(key)
+
+            # bool is a subclass of int — exclude explicitly.
+            if isinstance(value, bool):
+                continue
+
+            if isinstance(value, int) and value > 0:
+                return value
+
+        return None
+
+    def supports_image_input(self) -> bool:
+        return self._supports_feature("supports_vision")
+
+    def supports_reasoning(self) -> bool:
+        return self._supports_feature("supports_reasoning")
+
+    def _supports_feature(self, feature_name: str) -> bool:
+        if not self.model_info:
+            return False
+
+        return bool(self.model_info.get(feature_name, False))
 
 
 class LitellmFinalModelResponse(BaseModel):
     provider_name: str  # Provider name (e.g. "openai")
-    model_name: str  # Model ID (e.g. "gpt-4o")
+    model_name: str  # Public Model Name
+    litellm_params_model: str  # LiteLLM Model Name
+    max_input_tokens: int | None = None
+    supports_image_input: bool = False
+    supports_reasoning: bool = False
 
 
 # Bifrost dynamic models fetch

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -456,9 +456,22 @@ class LitellmModelDetails(BaseModel):
     model_info: dict[str, Any] | None = None
 
     def get_custom_llm_provider(self) -> str:
-        """Returns .litellm_params.custom_llm_provider"""
+        """Returns the LiteLLM provider for this model.
+
+        Preference order:
+        1. litellm_params.custom_llm_provider (explicit override)
+        2. model_info.litellm_provider (reported by LiteLLM, e.g. "auto_router")
+        3. "" (empty string fallback)
+        """
         if self.litellm_params:
-            return self.litellm_params.get("custom_llm_provider", "")
+            provider = self.litellm_params.get("custom_llm_provider", "")
+            if provider:
+                return provider
+
+        if self.model_info:
+            provider = self.model_info.get("litellm_provider", "")
+            if provider:
+                return provider
 
         return ""
 

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -715,9 +715,9 @@ class TestGetLitellmAvailableModels:
 
             claude = next(r for r in results if r.model_name == "claude-3-5-sonnet")
             assert claude.provider_name == "anthropic"
-            # Demonstrates that model_name (friendly) and litellm_params_model
-            # (canonical) can differ — proxy routes on the friendly name while
-            # the canonical name is shown as display_name in the UI.
+            # Demonstrates that model_name (the name you call LiteLLM with) and
+            # litellm_params_model (the name LiteLLM uses when calling the provider)
+            # can differ.
             assert claude.litellm_params_model == "claude-3-5-sonnet-20241022"
 
     def test_provider_name_falls_back_to_model_info_litellm_provider(self) -> None:

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -720,6 +720,45 @@ class TestGetLitellmAvailableModels:
             # the canonical name is shown as display_name in the UI.
             assert claude.litellm_params_model == "claude-3-5-sonnet-20241022"
 
+    def test_provider_name_falls_back_to_model_info_litellm_provider(self) -> None:
+        """Test that provider_name falls back to model_info.litellm_provider when
+        litellm_params.custom_llm_provider is absent — e.g. auto_router entries."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+
+        mock_response_data = {
+            "data": [
+                {
+                    "model_name": "work-laptop-test",
+                    "litellm_params": {
+                        "model": "auto_router/complexity_router",
+                    },
+                    "model_info": {
+                        "litellm_provider": "auto_router",
+                        "max_input_tokens": 262144,
+                        "supports_vision": True,
+                        "supports_reasoning": True,
+                    },
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_http_response = MagicMock()
+            mock_http_response.json.return_value = mock_response_data
+            mock_http_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_http_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            router = next(r for r in results if r.model_name == "work-laptop-test")
+            assert router.provider_name == "auto_router"
+
     def test_capability_fields_populated_from_model_info(
         self, mock_litellm_response: dict
     ) -> None:

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -624,30 +624,48 @@ class TestGetLMStudioAvailableModels:
 
 
 class TestGetLitellmAvailableModels:
-    """Tests for the Litellm proxy model fetch endpoint."""
+    """Tests for the LiteLLM proxy model fetch endpoint (/v1/model/info)."""
 
     @pytest.fixture
     def mock_litellm_response(self) -> dict:
-        """Mock response from Litellm /v1/models endpoint."""
+        """Mock response from LiteLLM /v1/model/info endpoint."""
         return {
             "data": [
                 {
-                    "id": "gpt-4o",
-                    "object": "model",
-                    "created": 1700000000,
-                    "owned_by": "openai",
+                    "model_name": "gpt-4o",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "gpt-4o",
+                    },
+                    "model_info": {
+                        "max_input_tokens": 128000,
+                        "supports_vision": True,
+                        "supports_reasoning": False,
+                    },
                 },
                 {
-                    "id": "claude-3-5-sonnet",
-                    "object": "model",
-                    "created": 1700000001,
-                    "owned_by": "anthropic",
+                    "model_name": "claude-3-5-sonnet",
+                    "litellm_params": {
+                        "custom_llm_provider": "anthropic",
+                        "model": "claude-3-5-sonnet-20241022",
+                    },
+                    "model_info": {
+                        "max_input_tokens": 200000,
+                        "supports_vision": True,
+                        "supports_reasoning": False,
+                    },
                 },
                 {
-                    "id": "gemini-pro",
-                    "object": "model",
-                    "created": 1700000002,
-                    "owned_by": "google",
+                    "model_name": "gemini-pro",
+                    "litellm_params": {
+                        "custom_llm_provider": "google",
+                        "model": "gemini-pro",
+                    },
+                    "model_info": {
+                        "max_input_tokens": 32000,
+                        "supports_vision": False,
+                        "supports_reasoning": False,
+                    },
                 },
             ]
         }
@@ -693,9 +711,184 @@ class TestGetLitellmAvailableModels:
 
             gpt = next(r for r in results if r.model_name == "gpt-4o")
             assert gpt.provider_name == "openai"
+            assert gpt.litellm_params_model == "gpt-4o"
 
             claude = next(r for r in results if r.model_name == "claude-3-5-sonnet")
             assert claude.provider_name == "anthropic"
+            # Demonstrates that model_name (friendly) and litellm_params_model
+            # (canonical) can differ — proxy routes on the friendly name while
+            # the canonical name is shown as display_name in the UI.
+            assert claude.litellm_params_model == "claude-3-5-sonnet-20241022"
+
+    def test_capability_fields_populated_from_model_info(
+        self, mock_litellm_response: dict
+    ) -> None:
+        """Test that vision, reasoning, and token limit come from model_info."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_litellm_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            gpt = next(r for r in results if r.model_name == "gpt-4o")
+            assert gpt.supports_image_input is True
+            assert gpt.supports_reasoning is False
+            assert gpt.max_input_tokens == 128000
+
+            gemini = next(r for r in results if r.model_name == "gemini-pro")
+            assert gemini.supports_image_input is False
+
+    def test_reasoning_flag_populated(self) -> None:
+        """Test that supports_reasoning is populated when set in model_info."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "model_name": "o3",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "o3",
+                    },
+                    "model_info": {
+                        "max_input_tokens": 200000,
+                        "supports_vision": False,
+                        "supports_reasoning": True,
+                    },
+                }
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            assert len(results) == 1
+            assert results[0].supports_reasoning is True
+
+    def test_absent_model_info_defaults_to_safe_values(self) -> None:
+        """Test graceful degradation when model_info is absent."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "model_name": "mystery-model",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "mystery-model",
+                    },
+                    # model_info absent
+                }
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            assert len(results) == 1
+            assert results[0].max_input_tokens is None
+            assert results[0].supports_image_input is False
+            assert results[0].supports_reasoning is False
+
+    def test_max_tokens_fallback_when_max_input_tokens_absent(self) -> None:
+        """Test that max_tokens is used when max_input_tokens is absent."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "model_name": "some-model",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "some-model",
+                    },
+                    "model_info": {
+                        # max_input_tokens absent, max_tokens present
+                        "max_tokens": 32000,
+                    },
+                }
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            assert results[0].max_input_tokens == 32000
+
+    def test_bool_token_value_ignored(self) -> None:
+        """Test that bool values for token fields are ignored (bool is subclass of int)."""
+        from onyx.server.manage.llm.api import get_litellm_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "model_name": "some-model",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "some-model",
+                    },
+                    "model_info": {
+                        "max_input_tokens": True,  # bool — should be ignored
+                        "max_tokens": True,  # bool — should be ignored
+                    },
+                }
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = LitellmModelsRequest(
+                api_base="http://localhost:4000",
+                api_key="test-key",
+            )
+            results = get_litellm_available_models(request, MagicMock(), mock_session)
+
+            assert results[0].max_input_tokens is None
 
     def test_results_sorted_by_model_name(self, mock_litellm_response: dict) -> None:
         """Test that results are alphabetically sorted by model_name."""
@@ -764,12 +957,14 @@ class TestGetLitellmAvailableModels:
         response_with_bad_entry = {
             "data": [
                 {
-                    "id": "gpt-4o",
-                    "object": "model",
-                    "created": 1700000000,
-                    "owned_by": "openai",
+                    "model_name": "gpt-4o",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "gpt-4o",
+                    },
+                    "model_info": {},
                 },
-                # Missing required fields
+                # Missing required model_name field — will fail Pydantic validation
                 {"bad_field": "bad_value"},
             ]
         }
@@ -822,10 +1017,12 @@ class TestGetLitellmAvailableModels:
         mock_litellm_response = {
             "data": [
                 {
-                    "id": "gpt-4o",
-                    "object": "model",
-                    "created": 1700000000,
-                    "owned_by": "openai",
+                    "model_name": "gpt-4o",
+                    "litellm_params": {
+                        "custom_llm_provider": "openai",
+                        "model": "gpt-4o",
+                    },
+                    "model_info": {},
                 },
             ]
         }
@@ -842,9 +1039,9 @@ class TestGetLitellmAvailableModels:
             )
             get_litellm_available_models(request, MagicMock(), mock_session)
 
-            # Should call /v1/models without double slashes
+            # Should call /v1/model/info without double slashes
             call_args = mock_get.call_args
-            assert call_args[0][0] == "http://localhost:4000/v1/models"
+            assert call_args[0][0] == "http://localhost:4000/v1/model/info"
 
     def test_connection_failure_raises_onyx_error(self) -> None:
         """Test that connection failures are wrapped in OnyxError."""

--- a/web/src/interfaces/llm.ts
+++ b/web/src/interfaces/llm.ts
@@ -160,6 +160,10 @@ export interface LiteLLMProxyFetchParams {
 export interface LiteLLMProxyModelResponse {
   provider_name: string;
   model_name: string;
+  litellm_params_model: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
 }
 
 export interface BifrostFetchParams {

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -510,9 +510,9 @@ export const fetchLiteLLMProxyModels = async (
       name: modelData.model_name,
       display_name: modelData.model_name,
       is_visible: true,
-      max_input_tokens: null,
-      supports_image_input: false,
-      supports_reasoning: false,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
     }));
 
     return { models };


### PR DESCRIPTION
This PR runs GitHub Actions CI for #10783.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch LiteLLM model discovery to the /v1/model/info endpoint to expose richer model capabilities and improve provider detection. The API and UI now return token limits, vision/reasoning support, and the underlying LiteLLM model id.

- **New Features**
  - Backend now fetches from /v1/model/info and parses `litellm_params` and `model_info` to return: `litellm_params_model`, `max_input_tokens` (with `max_tokens` fallback), `supports_image_input`, and `supports_reasoning`.
  - Provider name falls back to `model_info.litellm_provider` when `custom_llm_provider` is absent (e.g., `auto_router`), and embedding models are skipped using both the displayed name and the LiteLLM model id.
  - Web updates: extended `LiteLLMProxyModelResponse` and propagate capability fields in `fetchLiteLLMProxyModels` so the UI shows accurate limits and capabilities.

<sup>Written for commit 40aa298dd77d4e449a64f5ee70a858e9fed6ecc4. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11124?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

