### PR TITLE
chore(ci): path-filter integration test workflow

### DIFF
--- a/.github/workflows/pr-integration-tests-skip.yml
+++ b/.github/workflows/pr-integration-tests-skip.yml
@@ -1,0 +1,31 @@
+name: Run Integration Tests v2 (Skip)
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths-ignore:
+      - "backend/**"
+      - "cli/**"
+      - "deployment/docker_compose/**"
+      - "docker-bake.hcl"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pr-integration-tests.yml"
+      - ".github/actions/setup-test-license/**"
+
+permissions:
+  contents: read
+
+jobs:
+  # This job immediately succeeds to satisfy branch protection rules when the
+  # paths: filter in pr-integration-tests.yml excludes the PR (e.g. web/-only).
+  # The actual integration tests remain enforced when relevant paths change.
+  # Matches the pattern in merge-group.yml.
+  required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Success
+        run: echo "Success"

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - main
       - "release/**"
+    paths:
+      - "backend/**"
+      - "cli/**"
+      - "deployment/docker_compose/**"
+      - "docker-bake.hcl"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pr-integration-tests.yml"
+      - ".github/actions/setup-test-license/**"
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
## Summary
- Adds a `paths:` allowlist to `pr-integration-tests.yml` so the workflow only runs on PRs that touch backend code, CLI, compose/bake files, Python deps, or the workflow/action itself.
- Skips the full Docker build + matrix run on PRs that only touch `web/`, `desktop/`, `docs/`, root markdown, etc.
- Follows the same pattern already in `pr-external-dependency-unit-tests.yml` and `pr-python-connector-tests.yml`.

## Test plan
- [ ] Open a `web/`-only PR and confirm this workflow does not run.
- [ ] Confirm branch protection does not block merge on the missing `required` check (workflow has a `required:` summary job — worth verifying this doesn't get stuck pending). If it does, follow up with a skip-workflow that posts the same check name.
- [ ] Open a `backend/`-only PR and confirm the workflow runs end-to-end.
- [ ] Confirm `merge_group` and `v*.*.*` tag pushes still run the full suite (paths filter does not apply to those triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a paths allowlist to `pr-integration-tests.yml` so the integration suite only runs when backend code, `cli/`, compose/bake files, Python deps (`pyproject.toml`, `uv.lock`), or the workflow/action change, saving a full Docker build + matrix on web/desktop/docs-only PRs. Add `pr-integration-tests-skip.yml` to emit a passing `required` check when those paths are excluded, avoiding blocked merges while keeping `merge_group` and `v*.*.*` tag pushes unchanged.

<sup>Written for commit fca3a2428f5b14162dac28e31dce4026e573a783. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11126?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

