### PR TITLE
chore(ci): use GitHub App token for cherry-pick automation

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -97,14 +97,14 @@ jobs:
     steps:
       - name: Mint GitHub App installation token
         id: app-token
-        # ratchet:exclude — pin to a SHA once the App is provisioned.
-        uses: actions/create-github-app-token@v2
+
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ vars.CHERRY_PICK_APP_ID }}
           private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -112,7 +112,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # ratchet:astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: false
           version: "0.9.9"
@@ -189,7 +189,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 

--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -46,7 +46,6 @@ jobs:
             raunakab
             rohoswagger
             subash-mohan
-            trial2onyx
             wenxi-onyx
             weves
             yuhongsun96

--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -1,14 +1,10 @@
 name: Post-Merge Beta Cherry-Pick
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
 
-# SECURITY NOTE:
-# This workflow intentionally uses pull_request_target so post-merge automation can
-# use base-repo credentials. Do not checkout PR head refs in this workflow
-# (e.g. github.event.pull_request.head.sha). Only trusted base refs are allowed.
 permissions:
   contents: read
 
@@ -30,16 +26,13 @@ jobs:
       - name: Resolve merged PR and checkbox state
         id: gate
         env:
-          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # SECURITY: keep PR body in env/plain-text handling; avoid directly
-          # inlining github.event.pull_request.body into shell commands.
           PR_BODY: ${{ github.event.pull_request.body }}
           MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
           MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
-          # Explicit merger allowlist used because pull_request_target runs with
-          # the default GITHUB_TOKEN, which cannot reliably read org/team
-          # membership for this repository context.
+          # Explicit merger allowlist kept as defense-in-depth even though the
+          # cherry-pick job runs with a GitHub App installation token rather
+          # than the default GITHUB_TOKEN.
           ALLOWED_MERGERS: |
             acaprau
             bo-onyx
@@ -95,9 +88,6 @@ jobs:
     needs:
       - resolve-cherry-pick-request
     if: needs.resolve-cherry-pick-request.outputs.should_cherrypick == 'true' && needs.resolve-cherry-pick-request.result == 'success'
-    permissions:
-      contents: write
-      pull-requests: write
     outputs:
       cherry_pick_pr_url: ${{ steps.run_cherry_pick.outputs.pr_url }}
       cherry_pick_reason: ${{ steps.run_cherry_pick.outputs.reason }}
@@ -105,13 +95,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        # ratchet:exclude — pin to a SHA once the App is provisioned.
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.CHERRY_PICK_APP_ID }}
+          private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
-        # SECURITY: keep checkout pinned to trusted base branch; do not switch to PR head refs.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: true
           ref: main
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # ratchet:astral-sh/setup-uv@v8.1.0
@@ -119,16 +117,20 @@ jobs:
           enable-cache: false
           version: "0.9.9"
 
-      - name: Configure git identity
+      - name: Configure git identity as App
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          bot_user_id="$(gh api "/users/${APP_SLUG}[bot]" --jq .id)"
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
 
       - name: Create cherry-pick PR to latest release
         id: run_cherry_pick
         env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHERRY_PICK_ASSIGNEE: ${{ needs.resolve-cherry-pick-request.outputs.merged_by }}
           MERGE_COMMIT_SHA: ${{ needs.resolve-cherry-pick-request.outputs.merge_commit_sha }}
         run: |

--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -39,7 +39,6 @@ jobs:
             danelegend
             duo-onyx
             evan-onyx
-            jessicasingh7
             jmelahman
             joachim-danswer
             justin-tahara


### PR DESCRIPTION
## Summary
- Mint a GitHub App installation token (`actions/create-github-app-token@v2`) and use it for the cherry-pick checkout, `git push`, and `gh pr create` — so the resulting cherry-pick PR triggers downstream CI instead of being silenced by the `GITHUB_TOKEN` rule.
- Configure git identity from the App's slug (`<slug>[bot]` + `<id>+<slug>[bot]@users.noreply.github.com`) so the cherry-pick commit is attributed to the App.
- Swap the trigger from `pull_request_target` → `pull_request`. The workflow already gated on `head.repo.full_name == github.repository`, so base-repo credentials were never strictly required; this also removes the "no PR head ref checkout" footgun.
- Drop the now-unused job-level `contents: write` / `pull-requests: write` overrides — writes go through the App token.

## Required setup before this can run
- Create the App and install it on the repo with `Contents: read & write`, `Pull requests: read & write`, `Metadata: read`.
- Set repo variable `CHERRY_PICK_APP_ID` and repo secret `CHERRY_PICK_APP_PRIVATE_KEY`.
- Replace `# ratchet:exclude` on `actions/create-github-app-token@v2` with a pinned SHA.
- If release branches have branch protection, add the App as an allowed bypass actor.

## Test plan
- [ ] Merge a test PR into `main` with the cherry-pick checkbox checked and confirm the cherry-pick PR is opened by the App and has CI running on creation.
- [ ] Verify failure path: merge a PR that will hit a cherry-pick conflict and confirm the failure Slack notification still fires.
- [ ] Confirm the "merger not in allowlist" path still fails the gate and notifies Slack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a GitHub App installation token for the cherry-pick workflow so cherry-pick PRs trigger downstream CI and commits are attributed to the App. Also switch the workflow trigger to `pull_request`.

- **Refactors**
  - Mint token via `actions/create-github-app-token@v2` and use it for checkout, push, and `gh` commands.
  - Configure Git author as `<slug>[bot]` and derive the noreply email from the App user ID.
  - Switch trigger from `pull_request_target` to `pull_request`.
  - Keep an explicit merger allowlist (defense-in-depth) and update comments for the App-token context.
  - Remove job-level `contents`/`pull-requests` write permissions.

- **Migration**
  - Create and install a GitHub App with: Contents (R/W), Pull requests (R/W), Metadata (R).
  - Set repo variable `CHERRY_PICK_APP_ID` and secret `CHERRY_PICK_APP_PRIVATE_KEY`.
  - Pin `actions/create-github-app-token@v2` to a commit SHA.
  - If release branches are protected, allow the App as a bypass actor.

<sup>Written for commit 2916a8db4becbb7395e01004b7696c28e4b59da8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

