### PR TITLE
chore: [Running GitHub actions for #10785]

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -384,6 +384,7 @@ class LLMModelFlowType(str, PyEnum):
     CHAT = "chat"
     VISION = "vision"
     CONTEXTUAL_RAG = "contextual_rag"
+    REASONING = "reasoning"
 
 
 class HookPoint(str, PyEnum):

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -308,6 +308,8 @@ def upsert_llm_provider(
         supported_flows = [LLMModelFlowType.CHAT]
         if model_config.supports_image_input:
             supported_flows.append(LLMModelFlowType.VISION)
+        if model_config.supports_reasoning:
+            supported_flows.append(LLMModelFlowType.REASONING)
 
         existing = existing_by_name.get(model_config.name)
         if existing:
@@ -387,6 +389,8 @@ def sync_model_configurations(
             supported_flows = [LLMModelFlowType.CHAT]
             if model.supports_image_input:
                 supported_flows.append(LLMModelFlowType.VISION)
+            if model.supports_reasoning:
+                supported_flows.append(LLMModelFlowType.REASONING)
 
             insert_new_model_configuration__no_commit(
                 db_session=db_session,

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1466,6 +1466,7 @@ def get_lm_studio_available_models(
                     display_name=r.display_name,
                     max_input_tokens=r.max_input_tokens,
                     supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
                 )
                 for r in sorted_results
             ],
@@ -1694,6 +1695,7 @@ def get_bifrost_available_models(
                     display_name=r.display_name,
                     max_input_tokens=r.max_input_tokens,
                     supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
                 )
                 for r in sorted_results
             ],
@@ -1788,6 +1790,7 @@ def get_openai_compatible_server_available_models(
                     display_name=r.display_name,
                     max_input_tokens=r.max_input_tokens,
                     supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
                 )
                 for r in sorted_results
             ],

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1546,6 +1546,7 @@ def get_litellm_available_models(
                     display_name=r.model_name,
                     max_input_tokens=r.max_input_tokens,
                     supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
                 )
                 for r in sorted_results
             ],

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -174,6 +174,7 @@ class ModelConfigurationUpsertRequest(BaseModel):
     is_visible: bool
     max_input_tokens: int | None = None
     supports_image_input: bool | None = None
+    supports_reasoning: bool | None = None
     display_name: str | None = None  # For dynamic providers, from source API
 
     @classmethod
@@ -185,6 +186,10 @@ class ModelConfigurationUpsertRequest(BaseModel):
             is_visible=model_configuration_model.is_visible,
             max_input_tokens=model_configuration_model.max_input_tokens,
             supports_image_input=model_configuration_model.supports_image_input,
+            supports_reasoning=(
+                LLMModelFlowType.REASONING
+                in model_configuration_model.llm_model_flow_types
+            ),
             display_name=model_configuration_model.display_name,
         )
 
@@ -228,10 +233,16 @@ class ModelConfigurationView(BaseModel):
                     LLMModelFlowType.VISION
                     in model_configuration_model.llm_model_flow_types
                 ),
-                # Infer reasoning support from model name/display name
-                supports_reasoning=is_reasoning_model(
-                    model_configuration_model.name,
-                    model_configuration_model.display_name or "",
+                # Prefer the stored REASONING flow; fall back to a substring
+                # heuristic on model name/display name for legacy rows that
+                # were saved before the flow existed.
+                supports_reasoning=(
+                    LLMModelFlowType.REASONING
+                    in model_configuration_model.llm_model_flow_types
+                    or is_reasoning_model(
+                        model_configuration_model.name,
+                        model_configuration_model.display_name or "",
+                    )
                 ),
                 display_name=model_configuration_model.display_name,
                 provider_display_name=None,  # Not needed for dynamic providers
@@ -276,8 +287,14 @@ class ModelConfigurationView(BaseModel):
                     model_configuration_model.name, provider_name
                 )
             ),
-            supports_reasoning=model_is_reasoning_model(
-                model_configuration_model.name, provider_name
+            # Prefer the stored REASONING flow; fall back to LiteLLM-based
+            # detection for legacy rows that were saved before the flow existed.
+            supports_reasoning=(
+                LLMModelFlowType.REASONING
+                in model_configuration_model.llm_model_flow_types
+                or model_is_reasoning_model(
+                    model_configuration_model.name, provider_name
+                )
             ),
             # Populate display fields from parsed model name
             display_name=display_name,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -440,6 +440,7 @@ class SyncModelEntry(BaseModel):
     display_name: str
     max_input_tokens: int | None = None
     supports_image_input: bool = False
+    supports_reasoning: bool = False
 
 
 class LitellmModelsRequest(BaseModel):

--- a/backend/tests/unit/onyx/db/test_llm_sync.py
+++ b/backend/tests/unit/onyx/db/test_llm_sync.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import sync_model_configurations
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import SyncModelEntry
@@ -134,6 +135,38 @@ class TestSyncModelConfigurations:
                     provider_name="nonexistent",
                     models=[SyncModelEntry(name="model", display_name="Model")],
                 )
+
+    def test_inserts_reasoning_flow_when_supports_reasoning(self) -> None:
+        """Test that a REASONING flow row is created when supports_reasoning=True."""
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = []
+
+        mock_session = MagicMock()
+
+        with patch(
+            "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+        ):
+            models = [
+                SyncModelEntry(
+                    name="deepseek-r1",
+                    display_name="DeepSeek R1",
+                    max_input_tokens=65536,
+                    supports_image_input=True,
+                    supports_reasoning=True,
+                ),
+            ]
+
+            result = sync_model_configurations(
+                db_session=mock_session,
+                provider_name=LlmProviderNames.OPENAI,
+                models=models,
+            )
+
+            assert result == 1
+            # 1 model insert + 3 flow inserts (CHAT + VISION + REASONING)
+            assert mock_session.execute.call_count == 4
+            mock_session.commit.assert_called_once()
 
     def test_handles_missing_optional_fields(self) -> None:
         """Test that optional fields default correctly."""

--- a/backend/tests/unit/onyx/db/test_llm_sync.py
+++ b/backend/tests/unit/onyx/db/test_llm_sync.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 
-from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import sync_model_configurations
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import SyncModelEntry

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from onyx.db.enums import LLMModelFlowType
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.llm.models import BifrostFinalModelResponse
 from onyx.server.manage.llm.models import BifrostModelsRequest
@@ -621,6 +622,53 @@ class TestGetLMStudioAvailableModels:
             request = LMStudioModelsRequest(api_base="http://localhost:1234")
             with pytest.raises(OnyxError):
                 get_lm_studio_available_models(request, MagicMock(), mock_session)
+
+    def test_syncs_supports_reasoning_to_db(self) -> None:
+        """Test that supports_reasoning=True from the API is persisted as a REASONING flow."""
+        from onyx.server.manage.llm.api import get_lm_studio_available_models
+
+        mock_session = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = []
+
+        response = {
+            "models": [
+                {
+                    "key": "lmstudio-community/DeepSeek-R1-8B",
+                    "type": "llm",
+                    "display_name": "DeepSeek R1 8B",
+                    "max_context_length": 65536,
+                    # Reasoning explicitly set in capabilities
+                    "capabilities": {"reasoning": True},
+                },
+            ]
+        }
+
+        with (
+            patch("onyx.server.manage.llm.api.httpx") as mock_httpx,
+            patch(
+                "onyx.db.llm.fetch_existing_llm_provider", return_value=mock_provider
+            ),
+        ):
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_response
+
+            request = LMStudioModelsRequest(
+                api_base="http://localhost:1234",
+                provider_name="my-lm-studio",
+            )
+            get_lm_studio_available_models(request, MagicMock(), mock_session)
+
+        # Inspect execute calls for a REASONING flow insert.
+        inserted_flow_types = [
+            call.args[0].compile().params.get("llm_model_flow_type")
+            for call in mock_session.execute.call_args_list
+            if hasattr(call.args[0], "compile")
+        ]
+        assert LLMModelFlowType.REASONING in inserted_flow_types
 
 
 class TestGetLitellmAvailableModels:

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -14,8 +14,8 @@ from onyx.db.enums import LLMModelFlowType
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationView
 
-
 # ModelConfigurationView.from_model — dynamic provider branch
+
 
 class TestModelConfigurationViewFromModelDynamic:
     """Tests for the dynamic/custom-config branch of ModelConfigurationView.from_model."""
@@ -79,6 +79,7 @@ class TestModelConfigurationViewFromModelDynamic:
 
 
 # ModelConfigurationView.from_model — static provider branch
+
 
 class TestModelConfigurationViewFromModelStatic:
     """Tests for the static provider branch of ModelConfigurationView.from_model."""
@@ -164,6 +165,7 @@ class TestModelConfigurationViewFromModelStatic:
 
 # ModelConfigurationUpsertRequest.from_model
 
+
 class TestModelConfigurationUpsertRequestFromModel:
     """Tests for ModelConfigurationUpsertRequest.from_model."""
 
@@ -206,5 +208,7 @@ def _make_model_config(
     mc.max_input_tokens = max_input_tokens
     mc.is_visible = is_visible
     mc.supports_image_input = supports_image_input
-    mc.llm_model_flow_types = flow_types if flow_types is not None else [LLMModelFlowType.CHAT]
+    mc.llm_model_flow_types = (
+        flow_types if flow_types is not None else [LLMModelFlowType.CHAT]
+    )
     return mc

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -1,0 +1,210 @@
+"""Tests for ModelConfigurationView.from_model and ModelConfigurationUpsertRequest.from_model.
+
+These tests verify the flow plumbing:
+- Stored flow takes precedence over the heuristic on the read path.
+- Heuristic fires correctly when no flow is stored (legacy / static providers).
+- ModelConfigurationUpsertRequest.from_model correctly derives supports_reasoning
+  from the stored flow.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.db.enums import LLMModelFlowType
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.manage.llm.models import ModelConfigurationView
+
+
+# ModelConfigurationView.from_model — dynamic provider branch
+
+class TestModelConfigurationViewFromModelDynamic:
+    """Tests for the dynamic/custom-config branch of ModelConfigurationView.from_model."""
+
+    # In DYNAMIC_LLM_PROVIDERS
+    DYNAMIC_PROVIDER = "lm_studio"
+
+    def test_supports_reasoning_from_stored_flow(self) -> None:
+        """Stored REASONING flow → supports_reasoning=True regardless of model name."""
+        mc = _make_model_config(
+            name="My Custom Bot",
+            display_name="My Custom Bot",
+            flow_types=[
+                LLMModelFlowType.CHAT,
+                LLMModelFlowType.REASONING,
+            ],
+        )
+
+        view = ModelConfigurationView.from_model(mc, self.DYNAMIC_PROVIDER)
+
+        assert view.supports_reasoning is True
+
+    def test_supports_reasoning_falls_back_to_name_heuristic(self) -> None:
+        """No stored flow but name matches heuristic → supports_reasoning=True."""
+        mc = _make_model_config(
+            name="deepseek-r1-8b",
+            display_name="DeepSeek R1 8B",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = ModelConfigurationView.from_model(mc, self.DYNAMIC_PROVIDER)
+
+        assert view.supports_reasoning is True
+
+    def test_supports_reasoning_false_when_no_flow_and_no_name_match(self) -> None:
+        """No stored flow and generic name → supports_reasoning=False."""
+        mc = _make_model_config(
+            name="llama-3-8b",
+            display_name="Llama 3 8B",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = ModelConfigurationView.from_model(mc, self.DYNAMIC_PROVIDER)
+
+        assert view.supports_reasoning is False
+
+    def test_stored_flow_wins_over_non_matching_name(self) -> None:
+        """Stored REASONING flow wins even when name wouldn't match the heuristic."""
+        mc = _make_model_config(
+            name="friendly-chat-bot",
+            display_name="Friendly Chat Bot",
+            flow_types=[
+                LLMModelFlowType.CHAT,
+                LLMModelFlowType.REASONING,
+            ],
+        )
+
+        view = ModelConfigurationView.from_model(mc, self.DYNAMIC_PROVIDER)
+
+        assert view.supports_reasoning is True
+
+
+# ModelConfigurationView.from_model — static provider branch
+
+class TestModelConfigurationViewFromModelStatic:
+    """Tests for the static provider branch of ModelConfigurationView.from_model."""
+
+    # NOT in DYNAMIC_LLM_PROVIDERS
+    STATIC_PROVIDER = "openai"
+
+    def test_supports_reasoning_from_stored_flow(self) -> None:
+        """Stored REASONING flow → True even when model_is_reasoning_model returns False."""
+        mc = _make_model_config(
+            name="o3",
+            # No display_name forces static branch
+            display_name=None,
+            flow_types=[
+                LLMModelFlowType.CHAT,
+                LLMModelFlowType.REASONING,
+            ],
+        )
+
+        view = self._patched_static_view(mc, model_is_reasoning=False)
+
+        assert view.supports_reasoning is True
+
+    def test_supports_reasoning_falls_back_to_litellm_heuristic(self) -> None:
+        """No stored flow but model_is_reasoning_model returns True → True."""
+        mc = _make_model_config(
+            name="o3",
+            display_name=None,
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._patched_static_view(mc, model_is_reasoning=True)
+
+        assert view.supports_reasoning is True
+
+    def test_supports_reasoning_false_when_no_flow_and_heuristic_returns_false(
+        self,
+    ) -> None:
+        """No stored flow and model_is_reasoning_model returns False → False."""
+        mc = _make_model_config(
+            name="gpt-4o",
+            display_name=None,
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._patched_static_view(mc, model_is_reasoning=False)
+
+        assert view.supports_reasoning is False
+
+    def _patched_static_view(
+        self,
+        mc: MagicMock,
+        model_is_reasoning: bool = False,
+    ) -> ModelConfigurationView:
+        """Call from_model with the LiteLLM-touching helpers patched out."""
+        with (
+            patch(
+                "onyx.server.manage.llm.models.model_is_reasoning_model",
+                return_value=model_is_reasoning,
+            ),
+            patch(
+                "onyx.server.manage.llm.models.get_max_input_tokens",
+                return_value=128000,
+            ),
+            patch(
+                "onyx.server.manage.llm.models.litellm_thinks_model_supports_image_input",
+                return_value=False,
+            ),
+            patch(
+                "onyx.llm.model_name_parser.parse_litellm_model_name",
+            ) as mock_parse,
+        ):
+            mock_parsed = MagicMock()
+            mock_parsed.display_name = mc.name
+            mock_parsed.provider_display_name = self.STATIC_PROVIDER
+            mock_parsed.vendor = None
+            mock_parsed.version = None
+            mock_parsed.region = None
+            mock_parse.return_value = mock_parsed
+
+            return ModelConfigurationView.from_model(mc, self.STATIC_PROVIDER)
+
+
+# ModelConfigurationUpsertRequest.from_model
+
+class TestModelConfigurationUpsertRequestFromModel:
+    """Tests for ModelConfigurationUpsertRequest.from_model."""
+
+    def test_supports_reasoning_true_when_reasoning_flow_present(self) -> None:
+        """REASONING flow row present → supports_reasoning=True in upsert request."""
+        mc = _make_model_config(
+            flow_types=[
+                LLMModelFlowType.CHAT,
+                LLMModelFlowType.REASONING,
+            ],
+        )
+
+        req = ModelConfigurationUpsertRequest.from_model(mc)
+
+        assert req.supports_reasoning is True
+
+    def test_supports_reasoning_false_when_reasoning_flow_absent(self) -> None:
+        """No REASONING flow row → supports_reasoning=False in upsert request."""
+        mc = _make_model_config(
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        req = ModelConfigurationUpsertRequest.from_model(mc)
+
+        assert req.supports_reasoning is False
+
+
+def _make_model_config(
+    name: str = "some-model",
+    display_name: str | None = "Some Model",
+    flow_types: list[LLMModelFlowType] | None = None,
+    max_input_tokens: int | None = None,
+    is_visible: bool = True,
+    supports_image_input: bool | None = None,
+) -> MagicMock:
+    """Build a minimal mock ModelConfiguration DB row."""
+    mc = MagicMock()
+    mc.name = name
+    mc.display_name = display_name
+    mc.max_input_tokens = max_input_tokens
+    mc.is_visible = is_visible
+    mc.supports_image_input = supports_image_input
+    mc.llm_model_flow_types = flow_types if flow_types is not None else [LLMModelFlowType.CHAT]
+    return mc


### PR DESCRIPTION
This PR runs GitHub Actions CI for #10785.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the REASONING model flow and wire supports_reasoning through DB sync/upsert and management APIs to surface reasoning-capable models. This runs CI for #10785 and should be closed after CI passes.

- **New Features**
  - Added `LLMModelFlowType.REASONING`; sync/upsert store this flow when `supports_reasoning` is true; `SyncModelEntry` now includes `supports_reasoning`.
  - Fetch endpoints for `lm_studio`, `bifrost`, `openai_compatible`, and `litellm` return `supports_reasoning` and persist it during sync.
  - `ModelConfigurationView.from_model` and `ModelConfigurationUpsertRequest.from_model` prefer stored REASONING flow; fall back to name/LiteLLM heuristics for legacy rows; tests cover inserts, API propagation, and view/upsert behavior.

<sup>Written for commit 5e93061452f0d2155af1445f0b93c298cddc0ff8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11129?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

