### PR TITLE
fix(dev): subscribe celery debug workers to sandbox and checkpoint…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -297,7 +297,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
       ],
       "presentation": {
         "group": "2",
@@ -328,7 +328,7 @@
         "--loglevel=INFO",
         "--hostname=heavy@%n",
         "-Q",
-        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation"
+        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox"
       ],
       "presentation": {
         "group": "2",
@@ -578,7 +578,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
       ],
       "presentation": {
         "group": "2",
@@ -611,7 +611,7 @@
         "--loglevel=INFO",
         "--hostname=heavy@%n",
         "-Q",
-        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation"
+        "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox"
       ],
       "presentation": {
         "group": "2",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -77,6 +77,24 @@
         "group": "1"
       },
       "stopAll": true
+    },
+    {
+      "name": "Celery (k8s)",
+      "configurations": [
+        "Celery primary (k8s)",
+        "Celery light (k8s)",
+        "Celery heavy (k8s)",
+        "Celery monitoring (k8s)",
+        "Celery user_file_processing (k8s)",
+        "Celery scheduled_tasks (k8s)",
+        "Celery docfetching (k8s)",
+        "Celery docprocessing (k8s)",
+        "Celery beat (k8s)"
+      ],
+      "presentation": {
+        "group": "1"
+      },
+      "stopAll": true
     }
   ],
   "configurations": [


### PR DESCRIPTION
## Description

The Helm chart's heavy worker consumes the `sandbox` queue and the light worker consumes `checkpoint_cleanup`, but the VS Code debug launch configs did not. As a result, in the local debugger setup, tasks enqueued to those queues (notably `cleanup_idle_sandboxes`, scheduled every 15 min by beat) had no consumer and pods/checkpoints were never cleaned up.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align VS Code Celery debug configs with Helm and add a `Celery (k8s)` compound group to launch all k8s workers. Fixes missing consumers in debug so cleanup jobs run.

- **Bug Fixes**
  - Heavy worker now listens to `sandbox`.
  - Light worker now listens to `checkpoint_cleanup`.

- **New Features**
  - Added `Celery (k8s)` compound launch to start the full k8s worker set together.

<sup>Written for commit bd30c54d7840d1ae01824758ee4ecd405f9d003e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11130?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

