### PR TITLE
 chore: [Running GitHub actions for #11110]

### DIFF
--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -55,19 +55,21 @@ export async function connectEmbeddingProvider({
   providerType,
   apiKey,
   apiUrl,
+  modelName = "",
   apiVersion,
   deploymentName,
 }: {
   providerType: string;
   apiKey: string | null;
   apiUrl: string;
+  modelName?: string;
   apiVersion: string | null;
   deploymentName: string | null;
 }): Promise<void> {
   if (apiKey !== null) {
     const testResponse = await testEmbedding({
       provider_type: providerType,
-      modelName: "",
+      modelName,
       apiKey,
       apiUrl,
       apiVersion,

--- a/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
@@ -97,12 +97,14 @@ async function testAndSaveProviderCredentials({
   provider,
   apiKey,
   apiUrl = "",
+  modelName = "",
   apiVersion = null,
   deploymentName = null,
 }: {
   provider: EmbeddingProvider;
   apiKey: string | null;
   apiUrl?: string;
+  modelName?: string;
   apiVersion?: string | null;
   deploymentName?: string | null;
 }): Promise<boolean> {
@@ -111,6 +113,7 @@ async function testAndSaveProviderCredentials({
       providerType: provider.providerName,
       apiKey,
       apiUrl,
+      modelName,
       apiVersion,
       deploymentName,
     });
@@ -389,6 +392,7 @@ function LiteLLMProviderModal({
             provider,
             apiKey,
             apiUrl: values.apiUrl,
+            modelName: values.modelName.trim(),
           })
         ) {
           onSubmit({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes LiteLLM embedding setup by sending the user-entered model name from the admin UI to the backend test request. Prevents empty model_name payloads and unblocks provider validation (related to #11110).

- **Bug Fixes**
  - Pass trimmed `modelName` from the LiteLLM modal to `connectEmbeddingProvider`.
  - Update `connectEmbeddingProvider` to accept and forward `modelName` to `testEmbedding` instead of using an empty string.

<sup>Written for commit b65ebaeae68631526ba01752d3196c002cb1df77. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11131?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

