### PR TITLE
chore(ci): path-filter playwright test workflow

### DIFF
--- a/.github/workflows/pr-playwright-tests-skip.yml
+++ b/.github/workflows/pr-playwright-tests-skip.yml
@@ -1,0 +1,31 @@
+name: Run Playwright Tests (Skip)
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths-ignore:
+      - "backend/**"
+      - "web/**"
+      - "deployment/docker_compose/**"
+      - "docker-bake.hcl"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pr-playwright-tests.yml"
+      - ".github/actions/setup-test-license/**"
+
+permissions:
+  contents: read
+
+jobs:
+  # This job immediately succeeds to satisfy branch protection rules when the
+  # paths: filter in pr-playwright-tests.yml excludes the PR (e.g. docs-only).
+  # The actual playwright tests remain enforced when relevant paths change.
+  # Matches the pattern in merge-group.yml and pr-integration-tests-skip.yml.
+  playwright-required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Success
+        run: echo "Success"

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -9,6 +9,15 @@ on:
     branches:
       - main
       - "release/**"
+    paths:
+      - "backend/**"
+      - "web/**"
+      - "deployment/docker_compose/**"
+      - "docker-bake.hcl"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pr-playwright-tests.yml"
+      - ".github/actions/setup-test-license/**"
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
## Summary
- Skip playwright tests on PRs that don't touch backend, web, or deployment paths
- Mirrors the pattern introduced for integration tests in #11126
- Adds a companion `pr-playwright-tests-skip.yml` that provides a fast-passing `playwright-required` check so branch protection stays satisfied on PRs the `paths:` filter excludes

## Test plan
- [ ] Confirm a docs-only / web/AGENTS.md-only PR triggers only the skip workflow and shows `playwright-required` as passing
- [ ] Confirm a PR touching `backend/**` or `web/**` runs the real playwright workflow
- [ ] Confirm `merge_group` events still run the full playwright suite (path filters don't apply to merge_group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Path-filter the PR Playwright workflow so tests run only when backend, web, or deployment paths change, and add a skip workflow to keep the `playwright-required` check green on docs-only PRs. This reduces CI load while preserving branch protection and merge-group coverage.

- **Refactors**
  - Updated `pr-playwright-tests.yml` to trigger only on changes to `backend/**`, `web/**`, `deployment/docker_compose/**`, `docker-bake.hcl`, `pyproject.toml`, `uv.lock`, `.github/workflows/pr-playwright-tests.yml`, and `.github/actions/setup-test-license/**`.
  - Added `pr-playwright-tests-skip.yml` that runs on other PRs and immediately passes `playwright-required` to satisfy protection rules.
  - `merge_group` remains unchanged and still runs the full Playwright suite.

<sup>Written for commit f7cd3f21a9b3b5df1bcce4d1018fa948b1626d5b. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11135?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

