### PR TITLE
feat: pass all csvs to code interpreter

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -5,6 +5,7 @@ An overview can be found in the README.md file in this directory.
 
 import contextvars
 import io
+import os
 import queue
 import re
 import threading
@@ -84,6 +85,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile
+from onyx.file_store.utils import get_default_file_store
 from onyx.file_store.utils import load_in_memory_chat_files
 from onyx.file_store.utils import verify_user_files
 from onyx.hooks.executor import execute_hook
@@ -205,6 +207,59 @@ def _convert_loaded_files_to_chat_files(
                     content=loaded_file.content,
                 )
             )
+    return chat_files
+
+
+def _deduped_filename(filename: str, seen_filenames: set[str], file_id: str) -> str:
+    if filename not in seen_filenames:
+        seen_filenames.add(filename)
+        return filename
+
+    stem, suffix = os.path.splitext(filename)
+    deduped_filename = f"{stem}_{file_id}{suffix}"
+    seen_filenames.add(deduped_filename)
+    return deduped_filename
+
+
+def _load_context_user_files_for_tools(
+    user_files: list[UserFile],
+    existing_filenames: set[str],
+) -> list[ChatFile]:
+    """Load raw tabular project/persona files for code-interpreter staging."""
+    if not user_files:
+        return []
+
+    file_store = None
+    chat_files: list[ChatFile] = []
+    seen_file_ids: set[str] = set()
+
+    for user_file in user_files:
+        if user_file.file_id in seen_file_ids:
+            continue
+        seen_file_ids.add(user_file.file_id)
+
+        if not mime_type_to_chat_file_type(user_file.file_type).use_metadata_only():
+            continue
+
+        try:
+            if file_store is None:
+                file_store = get_default_file_store()
+            content = file_store.read_file(user_file.file_id, mode="b").read()
+        except Exception as e:
+            logger.warning(
+                "Failed to load context file %s for Python execution: %s",
+                user_file.id,
+                e,
+            )
+            continue
+
+        filename = _deduped_filename(
+            user_file.name or f"file_{user_file.id}",
+            existing_filenames,
+            str(user_file.id),
+        )
+        chat_files.append(ChatFile(filename=filename, content=content))
+
     return chat_files
 
 
@@ -811,6 +866,12 @@ def build_chat_turn(
     files = load_all_chat_files(chat_history, db_session)
     # Convert loaded files to ChatFile format for tools like PythonTool
     chat_files_for_tools = _convert_loaded_files_to_chat_files(files)
+    chat_files_for_tools.extend(
+        _load_context_user_files_for_tools(
+            context_user_files,
+            {chat_file.filename for chat_file in chat_files_for_tools},
+        )
+    )
 
     # ── Reserve assistant message ID(s) → yield to frontend ──────────────────
     if is_multi:

--- a/backend/tests/unit/onyx/tools/test_tool_runner_chat_files.py
+++ b/backend/tests/unit/onyx/tools/test_tool_runner_chat_files.py
@@ -5,8 +5,11 @@ These tests verify that chat files are properly passed to PythonTool
 through the PythonToolOverrideKwargs mechanism.
 """
 
+from unittest.mock import patch
+
 import pytest
 
+from onyx.db.models import UserFile
 from onyx.tools.models import ChatFile
 from onyx.tools.models import PythonToolOverrideKwargs
 
@@ -157,6 +160,93 @@ class TestChatFileConversion:
 
         chat_files = _convert_loaded_files_to_chat_files([])
         assert chat_files == []
+
+    def test_context_tabular_user_files_loaded_for_tools(self) -> None:
+        from uuid import uuid4
+
+        from onyx.chat.process_message import _load_context_user_files_for_tools
+
+        user_file_id = uuid4()
+        user_file = UserFile(
+            id=user_file_id,
+            user_id=uuid4(),
+            file_id="stored-xlsx-file",
+            name="review_results.xlsx",
+            file_type=(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            token_count=1000,
+        )
+        with patch(
+            "onyx.chat.process_message.get_default_file_store"
+        ) as mock_file_store_factory:
+            mock_file_store = mock_file_store_factory.return_value
+            mock_file_store.read_file.return_value.read.return_value = b"raw xlsx bytes"
+
+            chat_files = _load_context_user_files_for_tools(
+                [user_file],
+                existing_filenames=set(),
+            )
+
+        assert chat_files == [
+            ChatFile(filename="review_results.xlsx", content=b"raw xlsx bytes")
+        ]
+        mock_file_store.read_file.assert_called_once_with("stored-xlsx-file", mode="b")
+
+    def test_context_non_tabular_user_files_not_loaded_for_tools(self) -> None:
+        from uuid import uuid4
+
+        from onyx.chat.process_message import _load_context_user_files_for_tools
+
+        user_file = UserFile(
+            id=uuid4(),
+            user_id=uuid4(),
+            file_id="stored-pdf-file",
+            name="framework.pdf",
+            file_type="application/pdf",
+            token_count=1000,
+        )
+
+        with patch(
+            "onyx.chat.process_message.get_default_file_store"
+        ) as mock_file_store_factory:
+            chat_files = _load_context_user_files_for_tools(
+                [user_file],
+                existing_filenames=set(),
+            )
+
+        assert chat_files == []
+        mock_file_store_factory.assert_not_called()
+
+    def test_context_user_file_filename_collision_gets_suffix(self) -> None:
+        # Avoid overwriting an existing staged chat attachment with the same name.
+        from uuid import uuid4
+
+        from onyx.chat.process_message import _load_context_user_files_for_tools
+
+        user_file_id = uuid4()
+        user_file = UserFile(
+            id=user_file_id,
+            user_id=uuid4(),
+            file_id="stored-csv-file",
+            name="data.csv",
+            file_type="text/csv",
+            token_count=100,
+        )
+        with patch(
+            "onyx.chat.process_message.get_default_file_store"
+        ) as mock_file_store_factory:
+            mock_file_store = mock_file_store_factory.return_value
+            mock_file_store.read_file.return_value.read.return_value = b"a,b\n1,2"
+
+            chat_files = _load_context_user_files_for_tools(
+                [user_file],
+                existing_filenames={"data.csv"},
+            )
+
+        assert chat_files == [
+            ChatFile(filename=f"data_{user_file_id}.csv", content=b"a,b\n1,2")
+        ]
 
 
 class TestChatFileModel:


### PR DESCRIPTION
## Description

We previously were not passing project or persona files to the code interpreter. For now we just pass CSVs. I'm going to do a follow up as well that allows us to pass ALL files, and have that be a setting that's off by default since most of the time 

## How Has This Been Tested?

added tests and tested locally

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass project and persona CSV/XLSX files to the code interpreter so Python code can read raw tabular data during a chat. Deduplicates staged filenames to avoid collisions with existing chat attachments.

- **New Features**
  - Loads tabular context files from the default file store and stages them for tool execution.
  - Skips non-tabular files (e.g., PDFs) and logs read failures without breaking the chat turn.
  - Adds filename deduping by appending the file ID when a name is already in use.

<sup>Written for commit 8fedc9d1cfd5d16c001f8cad768eba02560dbf2d. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11136?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

