### PR TITLE
chore: validate file args to code interpreter

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_utils.py
+++ b/backend/onyx/server/query_and_chat/chat_utils.py
@@ -2,17 +2,22 @@ from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_store.models import ChatFileType
 
 
+def _normalize_mime_type(mime_type: str) -> str:
+    return mime_type.split(";", 1)[0].strip().lower()
+
+
 def mime_type_to_chat_file_type(mime_type: str | None) -> ChatFileType:
     if mime_type is None:
         return ChatFileType.PLAIN_TEXT
 
-    if mime_type in OnyxMimeTypes.IMAGE_MIME_TYPES:
+    normalized_mime_type = _normalize_mime_type(mime_type)
+    if normalized_mime_type in OnyxMimeTypes.IMAGE_MIME_TYPES:
         return ChatFileType.IMAGE
 
-    if mime_type in OnyxMimeTypes.TABULAR_MIME_TYPES:
+    if normalized_mime_type in OnyxMimeTypes.TABULAR_MIME_TYPES:
         return ChatFileType.TABULAR
 
-    if mime_type in OnyxMimeTypes.DOCUMENT_MIME_TYPES:
+    if normalized_mime_type in OnyxMimeTypes.DOCUMENT_MIME_TYPES:
         return ChatFileType.DOC
 
     return ChatFileType.PLAIN_TEXT

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -1,5 +1,7 @@
 import hashlib
 import mimetypes
+import os
+import re
 from io import BytesIO
 from typing import Any
 from typing import cast
@@ -46,6 +48,41 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 CODE_FIELD = "code"
+CODE_INTERPRETER_DEFAULT_FILENAME = "file"
+CODE_INTERPRETER_FILENAME_MAX_LENGTH = 200
+CODE_INTERPRETER_UNSAFE_FILENAME_CHARS = re.compile(r"[\x00-\x1f/\\:\*\?\"<>\|]+")
+
+
+def _safe_code_interpreter_filename(filename: str) -> str:
+    sanitized = CODE_INTERPRETER_UNSAFE_FILENAME_CHARS.sub("_", filename)
+    sanitized = sanitized.strip().strip(".")
+    if not sanitized:
+        return CODE_INTERPRETER_DEFAULT_FILENAME
+
+    base, ext = os.path.splitext(sanitized)
+    if not base:
+        base = CODE_INTERPRETER_DEFAULT_FILENAME
+
+    max_base_len = max(1, CODE_INTERPRETER_FILENAME_MAX_LENGTH - len(ext))
+    return f"{base[:max_base_len]}{ext}"
+
+
+def _dedupe_code_interpreter_filename(
+    filename: str,
+    seen_filenames: set[str],
+    fallback_id: str,
+) -> str:
+    safe_filename = _safe_code_interpreter_filename(filename)
+    if safe_filename not in seen_filenames:
+        seen_filenames.add(safe_filename)
+        return safe_filename
+
+    base, ext = os.path.splitext(safe_filename)
+    suffix = f"_{fallback_id}{ext}"
+    max_base_len = max(1, CODE_INTERPRETER_FILENAME_MAX_LENGTH - len(suffix))
+    deduped_filename = f"{base[:max_base_len]}{suffix}"
+    seen_filenames.add(deduped_filename)
+    return deduped_filename
 
 
 class PythonTool(Tool[PythonToolOverrideKwargs]):
@@ -167,8 +204,13 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
         with CodeInterpreterClient() as client:
             # Stage chat files for execution
             files_to_stage: list[FileInput] = []
+            seen_filenames: set[str] = set()
             for ind, chat_file in enumerate(chat_files):
-                file_name = chat_file.filename or f"file_{ind}"
+                file_name = _dedupe_code_interpreter_filename(
+                    chat_file.filename,
+                    seen_filenames,
+                    str(ind),
+                )
                 try:
                     content_hash = hashlib.sha256(chat_file.content).hexdigest()
                     cache_key = (file_name, content_hash)

--- a/backend/tests/unit/onyx/server/query_and_chat/test_query_and_chat_chat_utils.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_query_and_chat_chat_utils.py
@@ -1,0 +1,21 @@
+from onyx.file_store.models import ChatFileType
+from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
+
+
+def test_mime_type_to_chat_file_type_strips_parameters() -> None:
+    assert (
+        mime_type_to_chat_file_type("text/csv; charset=utf-8") == ChatFileType.TABULAR
+    )
+    assert (
+        mime_type_to_chat_file_type("application/pdf; charset=binary")
+        == ChatFileType.DOC
+    )
+    assert (
+        mime_type_to_chat_file_type("image/png; name=image.png") == ChatFileType.IMAGE
+    )
+
+
+def test_mime_type_to_chat_file_type_normalizes_case_and_whitespace() -> None:
+    assert (
+        mime_type_to_chat_file_type(" Text/CSV ; charset=utf-8") == ChatFileType.TABULAR
+    )

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -163,6 +163,45 @@ def test_same_content_different_filename_uploaded_separately() -> None:
     assert client.upload_file.call_count == 2
 
 
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_unsafe_filename_sanitized_before_upload_and_stage() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.return_value = "safe-file-id"
+
+    files = [ChatFile(filename="../reports/q1.csv", content=b"data")]
+
+    _run_tool(tool, client, files)
+
+    client.upload_file.assert_called_once_with(b"data", "_reports_q1.csv")
+    _, kwargs = client.execute_streaming.call_args
+    assert kwargs["files"] == [{"path": "_reports_q1.csv", "file_id": "safe-file-id"}]
+
+
+@patch(f"{TOOL_MODULE}.CODE_INTERPRETER_BASE_URL", "http://fake:8000")
+def test_sanitized_filename_collisions_get_deduped() -> None:
+    tool = _make_tool()
+    client = MagicMock()
+    client.upload_file.side_effect = ["id-a", "id-b"]
+
+    files = [
+        ChatFile(filename="a/b.csv", content=b"first"),
+        ChatFile(filename="a_b.csv", content=b"second"),
+    ]
+
+    _run_tool(tool, client, files)
+
+    assert [call.args[1] for call in client.upload_file.call_args_list] == [
+        "a_b.csv",
+        "a_b_1.csv",
+    ]
+    _, kwargs = client.execute_streaming.call_args
+    assert kwargs["files"] == [
+        {"path": "a_b.csv", "file_id": "id-a"},
+        {"path": "a_b_1.csv", "file_id": "id-b"},
+    ]
+
+
 # ---------------------------------------------------------------------------
 # No cross-instance sharing: a fresh PythonTool re-uploads everything
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR safely stages project/persona tabular files for Code Interpreter by sanitizing execution filenames and deduping collisions. It also normalizes MIME types before chat file classification so values like text/csv; charset=utf-8 are correctly treated as tabular.

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes and dedupes chat file names before staging to the code interpreter, and normalizes MIME types for accurate file-type detection. This prevents upload/stage errors and fixes misclassification of tabular, document, and image files with parameters.

- **Bug Fixes**
  - Sanitize execution filenames (replace unsafe chars, trim dots, enforce 200-char max) and dedupe collisions with a stable suffix to ensure unique staged paths.
  - Normalize MIME types by stripping parameters and normalizing case/whitespace before classification so values like "text/csv; charset=utf-8" are treated correctly.

<sup>Written for commit 62a68bee179c4a2e47dd3ecf3e2a46faea3a24e0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11137?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

