### PR TITLE
chore(opensearch): Debug script can get detailed cluster health and do route retry

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -279,6 +279,111 @@ class OpenSearchClient(AbstractContextManager):
             )
         return indices
 
+    @log_function_time(print_only=True, debug_only=True, include_args=True)
+    def cluster_health(
+        self,
+        level: str = "cluster",
+        index: str | None = None,
+    ) -> dict[str, Any]:
+        """Gets the cluster health.
+
+        See the OpenSearch documentation for more information on the cluster
+        health API:
+        https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-health/
+
+        Args:
+            level: The level of detail. One of "cluster", "indices", "shards",
+                or "awareness_attributes". Defaults to "cluster".
+            index: Optionally scope the health response to a specific index.
+                Defaults to None (whole cluster).
+
+        Returns:
+            The raw cluster health response.
+        """
+        if index:
+            return self._client.cluster.health(index=index, level=level)
+        return self._client.cluster.health(level=level)
+
+    @log_function_time(print_only=True, debug_only=True, include_args=True)
+    def cat_shards(
+        self,
+        index: str | None = None,
+        columns: str = "index,shard,prirep,state,unassigned.reason,unassigned.for,node",
+    ) -> list[dict[str, Any]]:
+        """Lists shards in the cluster.
+
+        See the OpenSearch documentation for more information on the cat shards
+        API:
+        https://docs.opensearch.org/latest/api-reference/cat/cat-shards/
+
+        Args:
+            index: Optionally scope to a specific index. Defaults to None (all
+                indices).
+            columns: Comma-separated list of columns to return. Maps to the
+                ``h`` query parameter.
+
+        Returns:
+            A list of dicts, one per shard, with the requested columns as keys.
+        """
+        kwargs: dict[str, Any] = {"format": "json", "h": columns}
+        if index:
+            kwargs["index"] = index
+        return self._client.cat.shards(**kwargs)
+
+    @log_function_time(print_only=True, debug_only=True, include_args=True)
+    def allocation_explain(
+        self,
+        index: str | None = None,
+        shard: int | None = None,
+        primary: bool | None = None,
+    ) -> dict[str, Any]:
+        """Explains why a shard is or is not allocated.
+
+        With no args, OpenSearch picks an arbitrary unassigned shard to explain.
+        To scope to a specific shard, all three args must be provided together.
+
+        See the OpenSearch documentation for more information on the cluster
+        allocation explain API:
+        https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-allocation/
+
+        Args:
+            index: The index name.
+            shard: The shard ID.
+            primary: Whether the shard is a primary (True) or replica (False).
+
+        Returns:
+            The raw allocation explanation response.
+        """
+        body: dict[str, Any] = {}
+        if index is not None:
+            body["index"] = index
+        if shard is not None:
+            body["shard"] = shard
+        if primary is not None:
+            body["primary"] = primary
+        if body:
+            return self._client.cluster.allocation_explain(body=body)
+        return self._client.cluster.allocation_explain()
+
+    @log_function_time(print_only=True, debug_only=True)
+    def reroute_retry_failed(self) -> dict[str, Any]:
+        """Triggers a cluster reroute with retry_failed=true.
+
+        Useful when shards are stuck UNASSIGNED due to ALLOCATION_FAILED with
+        max retries exceeded (default 5). This resets the failure counter and
+        attempts allocation again. The cluster's own allocation_explain output
+        recommends this when the ``max_retry`` decider is blocking.
+
+        See the OpenSearch documentation for more information on the cluster
+        reroute API:
+        https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-reroute/
+
+        Returns:
+            The raw reroute response. Includes ``acknowledged`` and the
+                post-reroute cluster state.
+        """
+        return self._client.cluster.reroute(params={"retry_failed": "true"})
+
     @log_function_time(print_only=True, debug_only=True)
     def ping(self) -> bool:
         """Pings the OpenSearch cluster.

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -300,7 +300,7 @@ class OpenSearchClient(AbstractContextManager):
         Returns:
             The raw cluster health response.
         """
-        if index:
+        if index is not None:
             return self._client.cluster.health(index=index, level=level)
         return self._client.cluster.health(level=level)
 
@@ -326,7 +326,7 @@ class OpenSearchClient(AbstractContextManager):
             A list of dicts, one per shard, with the requested columns as keys.
         """
         kwargs: dict[str, Any] = {"format": "json", "h": columns}
-        if index:
+        if index is not None:
             kwargs["index"] = index
         return self._client.cat.shards(**kwargs)
 
@@ -382,7 +382,7 @@ class OpenSearchClient(AbstractContextManager):
             The raw reroute response. Includes ``acknowledged`` and the
                 post-reroute cluster state.
         """
-        return self._client.cluster.reroute(params={"retry_failed": "true"})
+        return self._client.cluster.reroute(retry_failed=True)
 
     @log_function_time(print_only=True, debug_only=True)
     def ping(self) -> bool:

--- a/backend/scripts/debugging/opensearch/opensearch_debug.py
+++ b/backend/scripts/debugging/opensearch/opensearch_debug.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """A utility to interact with OpenSearch.
 
-Usage:
-    source .venv/bin/activate
-    python backend/scripts/debugging/opensearch/opensearch_debug.py --help
-    python backend/scripts/debugging/opensearch/opensearch_debug.py list
-    python backend/scripts/debugging/opensearch/opensearch_debug.py delete
-        <index_name>
+Example Usage:
+    Assuming running from ~/onyx/
+        source .venv/bin/activate
+        python backend/scripts/debugging/opensearch/opensearch_debug.py --help
+        python backend/scripts/debugging/opensearch/opensearch_debug.py list
+        python backend/scripts/debugging/opensearch/opensearch_debug.py delete
+            <index_name>
 
 Environment Variables:
     OPENSEARCH_HOST: OpenSearch host
@@ -101,6 +102,76 @@ def close_index(client: OpenSearchIndexClient) -> None:
     print(f"Index '{client._index_name}' closed.")
 
 
+def reroute_retry_failed(client: OpenSearchClient) -> None:
+    print(
+        "About to call POST /_cluster/reroute?retry_failed=true.\n"
+        "This resets the failed-allocation retry counter and re-attempts allocation\n"
+        "for shards stuck UNASSIGNED with reason=ALLOCATION_FAILED."
+    )
+    confirm = input("Proceed? (yes/no): ")
+    if confirm.lower() != "yes":
+        print("Aborted.")
+        return
+
+    response = client.reroute_retry_failed()
+    print("Reroute response (state omitted by default):")
+    print(f"  acknowledged: {response.get('acknowledged')}")
+    print()
+    print("Post-reroute top-level cluster health:")
+    health = client.cluster_health()
+    print(f"  status: {health.get('status')}")
+    print(f"  active_primary_shards: {health.get('active_primary_shards')}")
+    print(f"  active_shards: {health.get('active_shards')}")
+    print(f"  unassigned_shards: {health.get('unassigned_shards')}")
+    print(f"  initializing_shards: {health.get('initializing_shards')}")
+    print()
+    print(
+        "If status is still 'red', re-run 'health' to inspect the new "
+        "allocation_explain output for the affected shards."
+    )
+
+
+def diagnose_health(client: OpenSearchClient) -> None:
+    def banner(s: str) -> None:
+        print("\n" + "=" * 80 + "\n" + s + "\n" + "=" * 80)
+
+    banner("1) cluster.health() -- top-level summary")
+    print(json.dumps(client.cluster_health(), indent=2))
+
+    banner('2) cluster.health(level="indices") -- per-index status (non-green only)')
+    per_index = client.cluster_health(level="indices").get("indices", {})
+    non_green = {k: v for k, v in per_index.items() if v.get("status") != "green"}
+    print(f"non-green indices: {len(non_green)} / {len(per_index)}")
+    print(json.dumps(non_green, indent=2))
+
+    banner("3) cat.shards() -- non-STARTED shards")
+    shards = client.cat_shards()
+    bad = [s for s in shards if s.get("state") != "STARTED"]
+    print(f"total shards: {len(shards)}; non-STARTED: {len(bad)}")
+    print(json.dumps(bad, indent=2))
+
+    banner("4) cluster.allocation_explain() -- per unassigned shard (cap 10)")
+    unassigned = [s for s in bad if s.get("state") == "UNASSIGNED"]
+    for s in unassigned[:10]:
+        explain_args: dict[str, Any] = {
+            "index": s["index"],
+            "shard": int(s["shard"]),
+            "primary": s["prirep"] == "p",
+        }
+        print(f"\n--- {explain_args} ---")
+        try:
+            print(json.dumps(client.allocation_explain(**explain_args), indent=2))
+        except Exception as e:
+            print(f"ERROR: {e!r}")
+
+    if not unassigned:
+        print("\nNo UNASSIGNED shards. Calling allocation_explain() with no body:")
+        try:
+            print(json.dumps(client.allocation_explain(), indent=2))
+        except Exception as e:
+            print(f"(expected if everything is green) ERROR: {e!r}")
+
+
 def main() -> None:
     def add_standard_arguments(parser: argparse.ArgumentParser) -> None:
         parser.add_argument(
@@ -160,6 +231,24 @@ def main() -> None:
     )
 
     subparsers.add_parser("list", help="List all indices with info.")
+
+    subparsers.add_parser(
+        "health",
+        help=(
+            "Diagnose cluster health. Reports overall status, non-green "
+            "indices, non-STARTED shards, and allocation explanations for "
+            "unassigned shards."
+        ),
+    )
+
+    subparsers.add_parser(
+        "reroute-retry-failed",
+        help=(
+            "Call POST /_cluster/reroute?retry_failed=true to retry allocation "
+            "for shards stuck UNASSIGNED with reason=ALLOCATION_FAILED after "
+            "exceeding the max retry count. Confirms before sending."
+        ),
+    )
 
     delete_parser = subparsers.add_parser("delete", help="Delete an index.")
     delete_parser.add_argument("index", help="Index name.", type=str)
@@ -223,6 +312,8 @@ def main() -> None:
     print(f"MULTI_TENANT: {MULTI_TENANT}")
     print()
 
+    cluster_only_commands = {"list", "health", "reroute-retry-failed"}
+
     with (
         OpenSearchClient(
             host=host,
@@ -231,7 +322,7 @@ def main() -> None:
             use_ssl=not args.no_ssl,
             verify_certs=not args.no_verify_certs,
         )
-        if args.command == "list"
+        if args.command in cluster_only_commands
         else OpenSearchIndexClient(
             index_name=args.index,
             host=host,
@@ -247,6 +338,10 @@ def main() -> None:
 
         if args.command == "list":
             list_indices(client)
+        elif args.command == "health":
+            diagnose_health(client)
+        elif args.command == "reroute-retry-failed":
+            reroute_retry_failed(client)
         elif args.command == "delete":
             delete_index(client)
         elif args.command == "get":


### PR DESCRIPTION
## Description
Nice stuff that would've been nice to have in the debug script for https://onyx-company.slack.com/archives/C0B2DDCLU1G/p1778725200847579 and other stuff.

## How Has This Been Tested?
Ran the script.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detailed OpenSearch cluster diagnostics and a safe reroute retry to the debug script to investigate red/unassigned shards and reattempt shard allocation. Extends the OpenSearch client with health, shard, allocation, and reroute helpers used by the script.

- **New Features**
  - Client: `cluster_health()`, `cat_shards()`, `allocation_explain()`, `reroute_retry_failed()`.
  - Script:
    - `health` prints cluster summary, non-green indices, non-STARTED shards, and allocation explanations (capped).
    - `reroute-retry-failed` confirms, calls cluster reroute with `retry_failed=true`, and shows post-reroute health.

<sup>Written for commit a1babf4f1b51b0f3aba20a57a4a0e0d5003727a6. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11138?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

