### PR TITLE
Refactor sandbox idle cleanup around the sandbox manager

### DIFF
--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -264,6 +264,15 @@ class SandboxManager(ABC):
         """
         ...
 
+    def supports_idle_cleanup(self) -> bool:
+        """Whether this backend supports idle cleanup + sleep/snapshot flows."""
+        return False
+
+    @abstractmethod
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List valid session workspace IDs currently present in the sandbox."""
+        ...
+
     @abstractmethod
     def send_message(
         self,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -245,6 +245,47 @@ class KubernetesSandboxManager(SandboxManager):
         service_name = self._get_service_name(sandbox_id)
         return f"http://{service_name}.{self._namespace}.svc.cluster.local:{port}"
 
+    def supports_idle_cleanup(self) -> bool:
+        """Kubernetes sandboxes support snapshot-driven idle cleanup."""
+        return True
+
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List valid session workspace IDs in the pod's /workspace/sessions/."""
+        pod_name = self._get_pod_name(str(sandbox_id))
+        exec_command = [
+            "/bin/sh",
+            "-c",
+            'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
+        ]
+
+        try:
+            resp = k8s_stream(
+                self._stream_core_api.connect_get_namespaced_pod_exec,
+                name=pod_name,
+                namespace=self._namespace,
+                container="sandbox",
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
+
+            session_ids: list[UUID] = []
+            for line in resp.strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    session_ids.append(UUID(line))
+                except ValueError:
+                    continue
+            return session_ids
+
+        except ApiException as e:
+            logger.warning("Failed to list session workspaces for %s: %s", sandbox_id, e)
+            return []
+
     def _load_agent_instructions(
         self,
         provider: str | None = None,

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -676,6 +676,22 @@ class LocalSandboxManager(SandboxManager):
         outputs_path = session_path / "outputs"
         return outputs_path.exists()
 
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List valid session workspace IDs under this sandbox."""
+        sessions_path = self._get_sandbox_path(sandbox_id) / "sessions"
+        if not sessions_path.exists():
+            return []
+
+        session_ids: list[UUID] = []
+        for entry in sessions_path.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                session_ids.append(UUID(entry.name))
+            except ValueError:
+                continue
+        return session_ids
+
     def ensure_nextjs_running(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,7 +1,5 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
-from uuid import UUID
-
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
@@ -12,17 +10,12 @@ from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
-from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
-from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
 from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    KubernetesSandboxManager,
-)
 
 # Snapshot retention period in days
 SNAPSHOT_RETENTION_DAYS = 30
@@ -47,19 +40,11 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     4. Terminates the pod (but keeps the sandbox record)
     5. Marks the sandbox as SLEEPING (can be restored later)
 
-    NOTE: This task is a no-op for local backend - sandboxes persist until
-    manually terminated or server restart.
+    NOTE: This task is a no-op for backends that do not support idle cleanup.
 
     Args:
         tenant_id: The tenant ID for multi-tenant isolation
     """
-    # Skip cleanup for local backend - sandboxes persist until manual termination
-    if SANDBOX_BACKEND == SandboxBackend.LOCAL:
-        task_logger.debug(
-            "cleanup_idle_sandboxes_task skipped (local backend - cleanup disabled)"
-        )
-        return
-
     task_logger.info(f"cleanup_idle_sandboxes_task starting for tenant {tenant_id}")
 
     redis_client = get_redis_client(tenant_id=tenant_id)
@@ -84,10 +69,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
 
         sandbox_manager = get_sandbox_manager()
 
-        # Type guard for kubernetes-specific methods
-        if not isinstance(sandbox_manager, KubernetesSandboxManager):
+        if not sandbox_manager.supports_idle_cleanup():
             task_logger.debug(
-                "cleanup_idle_sandboxes_task skipped (not kubernetes backend)"
+                "cleanup_idle_sandboxes_task skipped (backend cleanup disabled)"
             )
             return
 
@@ -114,18 +98,16 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 task_logger.info(f"Putting sandbox {sandbox_id_str} to sleep")
 
                 try:
-                    # List session directories in the pod
-                    session_ids = _list_session_directories(sandbox_manager, sandbox_id)
+                    session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
                     task_logger.info(
                         f"Found {len(session_ids)} sessions in sandbox {sandbox_id_str}"
                     )
 
                     # Snapshot each session
-                    for session_id_str in session_ids:
+                    for session_id in session_ids:
                         try:
-                            session_id = UUID(session_id_str)
                             task_logger.debug(
-                                f"Creating snapshot for session {session_id_str}"
+                                f"Creating snapshot for session {session_id}"
                             )
                             snapshot_result = sandbox_manager.create_snapshot(
                                 sandbox_id, session_id, tenant_id
@@ -139,11 +121,11 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                     snapshot_result.size_bytes,
                                 )
                                 task_logger.debug(
-                                    f"Snapshot created for session {session_id_str}"
+                                    f"Snapshot created for session {session_id}"
                                 )
                         except Exception as e:
                             task_logger.warning(
-                                f"Failed to create snapshot for session {session_id_str}: {e}"
+                                f"Failed to create snapshot for session {session_id}: {e}"
                             )
                             # Continue with other sessions even if one fails
 
@@ -186,66 +168,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
             lock.release()
 
     task_logger.info("cleanup_idle_sandboxes_task completed")
-
-
-def _list_session_directories(
-    sandbox_manager: KubernetesSandboxManager,
-    sandbox_id: UUID,
-) -> list[str]:
-    """List session directory names in the pod's /workspace/sessions/.
-
-    Args:
-        sandbox_manager: The kubernetes sandbox manager
-        sandbox_id: The sandbox ID
-
-    Returns:
-        List of session ID strings (directory names)
-    """
-    from kubernetes.client.rest import ApiException
-    from kubernetes.stream import stream as k8s_stream
-
-    pod_name = sandbox_manager._get_pod_name(str(sandbox_id))
-
-    # List directories in /workspace/sessions/
-    exec_command = [
-        "/bin/sh",
-        "-c",
-        'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
-    ]
-
-    try:
-        resp = k8s_stream(
-            sandbox_manager._core_api.connect_get_namespaced_pod_exec,
-            name=pod_name,
-            namespace=sandbox_manager._namespace,
-            container="sandbox",
-            command=exec_command,
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
-        )
-
-        # Parse output - one directory name per line
-        session_ids = []
-        for line in resp.strip().split("\n"):
-            line = line.strip()
-            if line:
-                # Validate it looks like a UUID
-                try:
-                    UUID(line)
-                    session_ids.append(line)
-                except ValueError:
-                    # Not a valid UUID, skip
-                    pass
-
-        return session_ids
-
-    except ApiException as e:
-        task_logger.warning(f"Failed to list session directories: {e}")
-        return []
-
-
 # NOTE: in the future, may need to add this. For now, will do manual cleanup.
 # @shared_task(
 #     name=OnyxCeleryTask.CLEANUP_OLD_SNAPSHOTS,

--- a/backend/tests/unit/build/test_sandbox_cleanup_tasks.py
+++ b/backend/tests/unit/build/test_sandbox_cleanup_tasks.py
@@ -1,0 +1,124 @@
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.sandbox.tasks import tasks
+
+
+class DummyLock:
+    def acquire(self, blocking: bool = False) -> bool:  # noqa: ARG002
+        return True
+
+    def owned(self) -> bool:
+        return True
+
+    def release(self) -> None:
+        return None
+
+
+class DummyRedisClient:
+    def lock(self, *_args: object, **_kwargs: object) -> DummyLock:
+        return DummyLock()
+
+
+class NoCleanupManager:
+    def supports_idle_cleanup(self) -> bool:
+        return False
+
+
+class CleanupManager:
+    def __init__(self, session_ids: list) -> None:
+        self._session_ids = session_ids
+        self.snapshots: list[tuple] = []
+        self.terminated: list = []
+
+    def supports_idle_cleanup(self) -> bool:
+        return True
+
+    def list_session_workspaces(self, sandbox_id):
+        assert sandbox_id is not None
+        return self._session_ids
+
+    def create_snapshot(self, sandbox_id, session_id, tenant_id):
+        self.snapshots.append((sandbox_id, session_id, tenant_id))
+        return SimpleNamespace(
+            storage_path=f"snapshots/{session_id}.tar.gz",
+            size_bytes=123,
+        )
+
+    def terminate(self, sandbox_id):
+        self.terminated.append(sandbox_id)
+
+
+def test_cleanup_idle_sandboxes_task_skips_backends_without_idle_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tasks, "get_sandbox_manager", lambda: NoCleanupManager())
+    monkeypatch.setattr(
+        tasks, "get_redis_client", lambda tenant_id: DummyRedisClient()
+    )
+
+    tasks.cleanup_idle_sandboxes_task.run(tenant_id="tenant-a")
+
+
+def test_cleanup_idle_sandboxes_task_uses_manager_session_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_id = uuid4()
+    user_id = uuid4()
+    session_ids = [uuid4(), uuid4()]
+    manager = CleanupManager(session_ids)
+    sandbox = SimpleNamespace(id=sandbox_id, user_id=user_id)
+
+    class DummyDbSession:
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    class DummyDbContext:
+        def __enter__(self):
+            return DummyDbSession()
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    import onyx.server.features.build.db.sandbox as sandbox_db
+
+    monkeypatch.setattr(tasks, "get_sandbox_manager", lambda: manager)
+    monkeypatch.setattr(
+        tasks, "get_redis_client", lambda tenant_id: DummyRedisClient()
+    )
+    monkeypatch.setattr(
+        tasks, "get_session_with_current_tenant", lambda: DummyDbContext()
+    )
+    monkeypatch.setattr(
+        tasks, "maybe_mark_tenant_active", lambda tenant_id, caller: None
+    )
+    monkeypatch.setattr(tasks, "clear_nextjs_ports_for_user", lambda db, uid: 2)
+    monkeypatch.setattr(
+        tasks, "mark_user_sessions_idle__no_commit", lambda db, uid: 2
+    )
+    monkeypatch.setattr(
+        sandbox_db, "get_idle_sandboxes", lambda db, timeout: [sandbox]
+    )
+    monkeypatch.setattr(
+        sandbox_db,
+        "create_snapshot__no_commit",
+        lambda db, sid, path, size: None,
+    )
+    monkeypatch.setattr(
+        sandbox_db,
+        "update_sandbox_status__no_commit",
+        lambda db, sid, status: None,
+    )
+
+    tasks.cleanup_idle_sandboxes_task.run(tenant_id="tenant-a")
+
+    assert manager.snapshots == [
+        (sandbox_id, session_ids[0], "tenant-a"),
+        (sandbox_id, session_ids[1], "tenant-a"),
+    ]
+    assert manager.terminated == [sandbox_id]

--- a/backend/tests/unit/build/test_sandbox_cleanup_tasks.py
+++ b/backend/tests/unit/build/test_sandbox_cleanup_tasks.py
@@ -28,26 +28,26 @@ class NoCleanupManager:
 
 
 class CleanupManager:
-    def __init__(self, session_ids: list) -> None:
+    def __init__(self, session_ids: list[UUID]) -> None:
         self._session_ids = session_ids
-        self.snapshots: list[tuple] = []
-        self.terminated: list = []
+        self.snapshots: list[tuple[UUID, UUID, str]] = []
+        self.terminated: list[UUID] = []
 
     def supports_idle_cleanup(self) -> bool:
         return True
 
-    def list_session_workspaces(self, sandbox_id):
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
         assert sandbox_id is not None
         return self._session_ids
 
-    def create_snapshot(self, sandbox_id, session_id, tenant_id):
+    def create_snapshot(self, sandbox_id: UUID, session_id: UUID, tenant_id: str) -> SimpleNamespace:
         self.snapshots.append((sandbox_id, session_id, tenant_id))
         return SimpleNamespace(
             storage_path=f"snapshots/{session_id}.tar.gz",
             size_bytes=123,
         )
 
-    def terminate(self, sandbox_id):
+    def terminate(self, sandbox_id: UUID) -> None:
         self.terminated.append(sandbox_id)
 
 


### PR DESCRIPTION
Summary
- move session workspace listing onto the sandbox manager abstraction
- make idle cleanup depend on backend capability instead of Kubernetes-specific task branching
- add a focused unit test for the cleanup task behavior

Why
The idle cleanup task currently reaches into Kubernetes-specific implementation details. This makes the task layer own backend behavior that belongs in the sandbox manager, and it creates friction for adding other backends with snapshot or cleanup support.

This PR keeps the behavior narrow:
- supports_idle_cleanup() determines whether a backend participates in cleanup
- list_session_workspaces() lets each backend define how session workspaces are discovered
- the task only coordinates cleanup and snapshot flow

This matches the direction described in docs/craft/features/sandbox-backends.md and reduces backend-specific branching in the task layer.

Testing
- python3 -m py_compile backend/onyx/server/features/build/sandbox/base.py backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py backend/onyx/server/features/build/sandbox/tasks/tasks.py backend/tests/unit/build/test_sandbox_cleanup_tasks.py
- python3 -m pytest backend/tests/unit/build/test_sandbox_cleanup_tasks.py -q (blocked locally: missing fastapi_users during backend/tests/conftest.py import in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored sandbox idle cleanup to use the sandbox manager abstraction. The task is now backend-agnostic and skips backends that don’t opt in.

- **Refactors**
  - Added supports_idle_cleanup() and list_session_workspaces() to sandbox managers.
  - Implemented session listing in Kubernetes and local managers; removed Kubernetes-specific logic from the task.
  - Cleanup task now only coordinates snapshot and terminate; added unit tests covering opt-out backends and manager-based session listing.

<sup>Written for commit 59b25b778366d41dadb035e24c2b565ebf457e26. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

