### PR TITLE
sandbox id to uuid and update skills api plan

### DIFF
--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -16,6 +16,7 @@ multi-step admin flow (e.g. create row + replace grants) can roll back atomicall
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy import delete
@@ -26,6 +27,8 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
 from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
 from onyx.db.models import User
@@ -35,25 +38,17 @@ from onyx.db.utils import UNSET
 from onyx.db.utils import UnsetType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.skills.registry import CustomSkill
 
-# Name of the unique constraint on `skill.slug` (declared on the model and
-# created by the Skills V1 migration). Used to translate the specific
-# collision into `DUPLICATE_RESOURCE`.
 SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
 
 
-def _custom_skill_from_model(skill: Skill) -> CustomSkill:
-    return CustomSkill(
-        id=skill.id,
-        slug=skill.slug,
-        name=skill.name,
-        description=skill.description,
-        bundle_file_id=skill.bundle_file_id,
-        bundle_sha256=skill.bundle_sha256,
-        is_public=skill.is_public,
-        enabled=skill.enabled,
-    )
+@dataclass(frozen=True, kw_only=True)
+class SkillPatch:
+    slug: str | UnsetType = UNSET
+    name: str | UnsetType = UNSET
+    description: str | UnsetType = UNSET
+    is_public: bool | UnsetType = UNSET
+    enabled: bool | UnsetType = UNSET
 
 
 def _add_user_visibility_filter(
@@ -61,14 +56,8 @@ def _add_user_visibility_filter(
 ) -> Select[tuple[Skill]]:
     """Restrict a `select(Skill)` to rows the given user can see.
 
-    Mirrors `onyx.db.persona._add_user_filters` minus the direct user-grant
-    branch (no `Skill__User` table in V1). Admins bypass the filter; everyone
-    else — including `GLOBAL_CURATOR` and `CURATOR` — goes through the
-    is_public-or-group-grant path. The curator-specific elevated access in
-    persona exists to gate *editability* of curator-owned personas; skills
-    have no editability dimension at the user-read layer in V1 (only admins
-    mutate skills), so global-curators are intentionally treated the same as
-    regular users for visibility.
+    Admins bypass the filter; everyone else goes through the
+    is_public-or-group-grant path.
     """
     if user.role == UserRole.ADMIN:
         return stmt
@@ -87,49 +76,28 @@ def _add_user_visibility_filter(
     return stmt.where(or_(Skill.is_public.is_(True), group_grant_exists))
 
 
-def list_skills_for_user(user: User, db_session: Session) -> Sequence[CustomSkill]:
-    """Skills the user can use in a session.
-
-    Filtered to `enabled = True`: disabled skills never reach the materializer.
-    """
+def list_skills_for_user(user: User, db_session: Session) -> Sequence[Skill]:
     stmt = select(Skill).where(Skill.enabled.is_(True)).order_by(Skill.name)
     stmt = _add_user_visibility_filter(stmt, user)
-    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
+    return list(db_session.scalars(stmt))
 
 
 def fetch_skill_for_user(
     skill_id: UUID, user: User, db_session: Session
-) -> CustomSkill | None:
-    """Single-skill lookup with the same filter as `list_skills_for_user`.
-
-    Returns None when the skill does not exist, is disabled, or the user has
-    no grant — callers translate to 404 as needed.
-    """
+) -> Skill | None:
     stmt = select(Skill).where(Skill.id == skill_id).where(Skill.enabled.is_(True))
     stmt = _add_user_visibility_filter(stmt, user)
-    skill = db_session.scalars(stmt).one_or_none()
-    return _custom_skill_from_model(skill) if skill is not None else None
+    return db_session.scalars(stmt).one_or_none()
 
 
-def _fetch_skill_model_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
-    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
+def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> Skill | None:
     stmt = select(Skill).where(Skill.id == skill_id)
     return db_session.scalars(stmt).one_or_none()
 
 
-def fetch_skill_for_admin(skill_id: UUID, db_session: Session) -> CustomSkill | None:
-    """Admin lookup (no `enabled` filter — disabled skills are still visible)."""
-    skill = _fetch_skill_model_for_admin(skill_id, db_session)
-    return _custom_skill_from_model(skill) if skill is not None else None
-
-
-def list_skills_for_admin(db_session: Session) -> Sequence[CustomSkill]:
-    """All skills, for the admin UI.
-
-    Disabled skills are included so the admin can re-enable them.
-    """
+def list_skills_for_admin(db_session: Session) -> Sequence[Skill]:
     stmt = select(Skill).order_by(Skill.name)
-    return [_custom_skill_from_model(skill) for skill in db_session.scalars(stmt)]
+    return list(db_session.scalars(stmt))
 
 
 def create_skill(
@@ -142,15 +110,7 @@ def create_skill(
     is_public: bool,
     author_user_id: UUID | None,
     db_session: Session,
-) -> CustomSkill:
-    """Insert a new Skill row.
-
-    Slug collisions are caught two ways: a pre-check for the fast happy path,
-    and an IntegrityError handler on flush that translates the `uq_skill_slug`
-    constraint violation into `OnyxError(DUPLICATE_RESOURCE)` for the
-    concurrent-writer race. Both raise the same structured error so callers
-    never see a raw IntegrityError.
-    """
+) -> Skill:
     existing = db_session.scalars(select(Skill.id).where(Skill.slug == slug)).first()
     if existing is not None:
         raise OnyxError(
@@ -178,7 +138,7 @@ def create_skill(
                 f"A skill with slug '{slug}' already exists.",
             ) from e
         raise
-    return _custom_skill_from_model(skill)
+    return skill
 
 
 def replace_skill_bundle(
@@ -187,13 +147,13 @@ def replace_skill_bundle(
     new_bundle_file_id: str,
     new_bundle_sha256: str,
     db_session: Session,
-) -> tuple[CustomSkill, str]:
+) -> tuple[Skill, str]:
     """Swap a skill's bundle blob.
 
     Returns `(skill, old_bundle_file_id)` so the caller can delete the old
     blob from FileStore AFTER the transaction commits — never inline.
     """
-    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
@@ -204,54 +164,43 @@ def replace_skill_bundle(
     skill.bundle_file_id = new_bundle_file_id
     skill.bundle_sha256 = new_bundle_sha256
     db_session.flush()
-    return _custom_skill_from_model(skill), old_bundle_file_id
+    return skill, old_bundle_file_id
 
 
 def patch_skill(
     *,
     skill_id: UUID,
-    slug: str | UnsetType = UNSET,
-    name: str | UnsetType = UNSET,
-    description: str | UnsetType = UNSET,
-    is_public: bool | UnsetType = UNSET,
-    enabled: bool | UnsetType = UNSET,
+    patch: SkillPatch,
     db_session: Session,
-) -> CustomSkill:
-    """Partial update of admin-controlled metadata.
-
-    `UNSET` distinguishes "leave alone" from "set to None/falsy". Slug
-    uniqueness is re-checked when the slug changes (the `uq_skill_slug`
-    constraint is the DB backstop; this raises `DUPLICATE_RESOURCE` first
-    for a clean structured error).
-    """
-    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+) -> Skill:
+    skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
             f"Skill {skill_id} not found.",
         )
 
-    slug_changed = not isinstance(slug, UnsetType) and slug != skill.slug
+    slug_changed = not isinstance(patch.slug, UnsetType) and patch.slug != skill.slug
     if slug_changed:
-        assert not isinstance(slug, UnsetType)
+        assert not isinstance(patch.slug, UnsetType)
         clashing = db_session.scalars(
-            select(Skill.id).where(Skill.slug == slug).where(Skill.id != skill_id)
+            select(Skill.id).where(Skill.slug == patch.slug).where(Skill.id != skill_id)
         ).first()
         if clashing is not None:
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{slug}' already exists.",
+                f"A skill with slug '{patch.slug}' already exists.",
             )
-        skill.slug = slug
+        skill.slug = patch.slug
 
-    if not isinstance(name, UnsetType):
-        skill.name = name
-    if not isinstance(description, UnsetType):
-        skill.description = description
-    if not isinstance(is_public, UnsetType):
-        skill.is_public = is_public
-    if not isinstance(enabled, UnsetType):
-        skill.enabled = enabled
+    if not isinstance(patch.name, UnsetType):
+        skill.name = patch.name
+    if not isinstance(patch.description, UnsetType):
+        skill.description = patch.description
+    if not isinstance(patch.is_public, UnsetType):
+        skill.is_public = patch.is_public
+    if not isinstance(patch.enabled, UnsetType):
+        skill.enabled = patch.enabled
 
     try:
         db_session.flush()
@@ -259,20 +208,16 @@ def patch_skill(
         if slug_changed and is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{slug}' already exists.",
+                f"A skill with slug '{patch.slug}' already exists.",
             ) from e
         raise
-    return _custom_skill_from_model(skill)
+    return skill
 
 
 def replace_skill_grants(
     skill_id: UUID, group_ids: Sequence[int], db_session: Session
 ) -> None:
-    """Replace all group grants for a skill in a single transaction.
-
-    Dedups the input. Does not commit — the caller owns the transaction.
-    """
-    if _fetch_skill_model_for_admin(skill_id, db_session) is None:
+    if fetch_skill_for_admin(skill_id, db_session) is None:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
             f"Skill {skill_id} not found.",
@@ -286,24 +231,54 @@ def replace_skill_grants(
             continue
         seen.add(group_id)
         db_session.add(Skill__UserGroup(skill_id=skill_id, user_group_id=group_id))
-    db_session.flush()
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "One or more group IDs do not exist.",
+        ) from e
 
 
 def delete_skill(skill_id: UUID, db_session: Session) -> str | None:
-    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup.
-
-    Returns `None` if the skill did not exist (idempotent). The
-    `skill__user_group` rows cascade delete via the FK. The caller is
-    responsible for removing the bundle blob from the file store AFTER
-    the transaction commits; running sandbox pods keep their materialized
-    copy until the next bundle-sync cycle.
-    """
-    skill = _fetch_skill_model_for_admin(skill_id, db_session)
+    """Hard-delete a skill and return its `bundle_file_id` for caller cleanup."""
+    skill = fetch_skill_for_admin(skill_id, db_session)
     if skill is None:
         return None
-    # TODO: delete the bundle blob from S3 (file store) once the API caller
-    # wires this up — currently returned for the caller to handle.
     bundle_file_id = skill.bundle_file_id
     db_session.delete(skill)
     db_session.flush()
     return bundle_file_id
+
+
+def affected_user_ids_for_skill(skill: Skill, db_session: Session) -> set[UUID]:
+    """Return user IDs with an active sandbox who should have this skill.
+
+    Does not filter by ``enabled`` — callers use this for both enable and
+    disable transitions (the pushed fileset handles the actual filtering).
+    """
+    if skill.is_public:
+        stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
+        return set(db_session.scalars(stmt))
+
+    stmt = (
+        select(Sandbox.user_id)
+        .join(
+            User__UserGroup,
+            User__UserGroup.user_id == Sandbox.user_id,
+        )
+        .join(
+            Skill__UserGroup,
+            Skill__UserGroup.user_group_id == User__UserGroup.user_group_id,
+        )
+        .where(Skill__UserGroup.skill_id == skill.id)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+    )
+    return set(db_session.scalars(stmt))
+
+
+def get_group_ids_for_skill(skill_id: UUID, db_session: Session) -> list[int]:
+    stmt = select(Skill__UserGroup.user_group_id).where(
+        Skill__UserGroup.skill_id == skill_id
+    )
+    return list(db_session.scalars(stmt))

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -180,27 +180,29 @@ def patch_skill(
             f"Skill {skill_id} not found.",
         )
 
-    slug_changed = not isinstance(patch.slug, UnsetType) and patch.slug != skill.slug
-    if slug_changed:
-        assert not isinstance(patch.slug, UnsetType)
-        clashing = db_session.scalars(
-            select(Skill.id).where(Skill.slug == patch.slug).where(Skill.id != skill_id)
-        ).first()
-        if clashing is not None:
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{patch.slug}' already exists.",
-            )
-        skill.slug = patch.slug
+    # Apply simple field updates
+    for field in ("name", "description", "is_public", "enabled"):
+        value = getattr(patch, field)
+        if not isinstance(value, UnsetType):
+            setattr(skill, field, value)
 
-    if not isinstance(patch.name, UnsetType):
-        skill.name = patch.name
-    if not isinstance(patch.description, UnsetType):
-        skill.description = patch.description
-    if not isinstance(patch.is_public, UnsetType):
-        skill.is_public = patch.is_public
-    if not isinstance(patch.enabled, UnsetType):
-        skill.enabled = patch.enabled
+    # Slug requires a uniqueness pre-check
+    slug_changed = False
+    if not isinstance(patch.slug, UnsetType):
+        new_slug: str = patch.slug
+        if new_slug != skill.slug:
+            slug_changed = True
+            exists = db_session.scalars(
+                select(Skill.id)
+                .where(Skill.slug == new_slug)
+                .where(Skill.id != skill_id)
+            ).first()
+            if exists is not None:
+                raise OnyxError(
+                    OnyxErrorCode.DUPLICATE_RESOURCE,
+                    f"A skill with slug '{new_slug}' already exists.",
+                )
+            skill.slug = new_slug
 
     try:
         db_session.flush()

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -33,6 +33,7 @@ from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.db.utils import is_fk_violation
 from onyx.db.utils import is_unique_violation
 from onyx.db.utils import UNSET
 from onyx.db.utils import UnsetType
@@ -236,10 +237,12 @@ def replace_skill_grants(
     try:
         db_session.flush()
     except IntegrityError as e:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            "One or more group IDs do not exist.",
-        ) from e
+        if is_fk_violation(e):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "One or more group IDs do not exist.",
+            ) from e
+        raise
 
 
 def delete_skill(skill_id: UUID, db_session: Session) -> str | None:

--- a/backend/onyx/db/utils.py
+++ b/backend/onyx/db/utils.py
@@ -4,6 +4,7 @@ from typing import Final
 
 from psycopg2 import errorcodes
 from psycopg2 import OperationalError
+from psycopg2.errors import ForeignKeyViolation
 from psycopg2.errors import UniqueViolation
 from pydantic import BaseModel
 from sqlalchemy import inspect
@@ -39,6 +40,11 @@ def is_unique_violation(exc: IntegrityError, constraint: str) -> bool:
         isinstance(orig, UniqueViolation)
         and getattr(orig.diag, "constraint_name", None) == constraint
     )
+
+
+def is_fk_violation(exc: IntegrityError) -> bool:
+    """True iff the IntegrityError is a foreign-key violation."""
+    return isinstance(exc.orig, ForeignKeyViolation)
 
 
 def model_to_dict(model: Base) -> dict[str, Any]:

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -101,6 +101,8 @@ from onyx.server.features.persona.api import agents_router
 from onyx.server.features.persona.api import basic_router as persona_router
 from onyx.server.features.projects.api import router as projects_router
 from onyx.server.features.search.api import router as search_api_router
+from onyx.server.features.skill.api import admin_router as skill_admin_router
+from onyx.server.features.skill.api import user_router as skill_router
 from onyx.server.features.tool.api import admin_router as admin_tool_router
 from onyx.server.features.tool.api import router as tool_router
 from onyx.server.features.user_oauth_token.api import router as user_oauth_token_router
@@ -524,6 +526,8 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, federated_router)
     include_router_with_global_prefix_prepended(application, mcp_router)
     include_router_with_global_prefix_prepended(application, mcp_admin_router)
+    include_router_with_global_prefix_prepended(application, skill_router)
+    include_router_with_global_prefix_prepended(application, skill_admin_router)
 
     include_router_with_global_prefix_prepended(application, pat_router)
     include_router_with_global_prefix_prepended(application, captcha_router)

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -285,3 +285,21 @@ def delete_snapshot(db_session: Session, snapshot_id: UUID) -> bool:
     db_session.delete(snapshot)
     db_session.commit()
     return True
+
+
+def get_sandbox_user_map(user_ids: list[UUID], db_session: Session) -> dict[UUID, User]:
+    """Return ``{sandbox_id: user}`` for active sandboxes owned by *user_ids*.
+
+    Only sandboxes with ``status == RUNNING`` are included — sleeping or
+    terminated pods can't receive pushes.
+    """
+    if not user_ids:
+        return {}
+
+    stmt = (
+        select(Sandbox, User)
+        .join(User, User.id == Sandbox.user_id)  # ty: ignore[invalid-argument-type]
+        .where(Sandbox.user_id.in_(user_ids))
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+    )
+    return {row.Sandbox.id: row.User for row in db_session.execute(stmt)}

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -302,4 +302,4 @@ def get_sandbox_user_map(user_ids: list[UUID], db_session: Session) -> dict[UUID
         .where(Sandbox.user_id.in_(user_ids))
         .where(Sandbox.status == SandboxStatus.RUNNING)
     )
-    return {row.Sandbox.id: row.User for row in db_session.execute(stmt)}
+    return {row.Sandbox.id: row.User for row in db_session.execute(stmt).unique()}

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -424,7 +424,7 @@ class SandboxManager(ABC):
     def write_files_to_sandbox(
         self,
         *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: FileSet,
     ) -> None:
@@ -435,7 +435,7 @@ class SandboxManager(ABC):
     def push_to_sandbox(
         self,
         *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: FileSet,
         timeout_s: float = 30.0,
@@ -500,7 +500,7 @@ class SandboxManager(ABC):
         self,
         *,
         mount_path: str,
-        sandbox_files: dict[str, FileSet],
+        sandbox_files: dict[UUID, FileSet],
         timeout_s: float = 30.0,
     ) -> PushResult:
         """Push files to multiple sandboxes in parallel.
@@ -514,7 +514,7 @@ class SandboxManager(ABC):
         all_failures: list[PushFailure] = []
         pushed = 0
 
-        def _push_one(sandbox_id: str) -> PushResult:
+        def _push_one(sandbox_id: UUID) -> PushResult:
             return self.push_to_sandbox(
                 sandbox_id=sandbox_id,
                 mount_path=mount_path,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -263,7 +263,7 @@ class KubernetesSandboxManager(SandboxManager):
             self._image,
         )
 
-    def _get_pod_name(self, sandbox_id: str) -> str:
+    def _get_pod_name(self, sandbox_id: str | UUID) -> str:
         """Generate pod name from sandbox ID."""
         return f"sandbox-{str(sandbox_id)[:8]}"
 
@@ -2439,7 +2439,7 @@ fi
     def write_files_to_sandbox(
         self,
         *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: FileSet,
     ) -> None:

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -1175,7 +1175,7 @@ class LocalSandboxManager(SandboxManager):
     def write_files_to_sandbox(
         self,
         *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: FileSet,
     ) -> None:

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -74,7 +74,7 @@ class FilesystemEntry(BaseModel):
 
 
 class PushFailure(BaseModel):
-    sandbox_id: str
+    sandbox_id: UUID
     reason: str
     detail: str | None = None
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -94,19 +94,23 @@ def create_custom_skill(
         file_type="application/zip",
     )
 
-    skill = create_skill(
-        slug=slug,
-        name=name,
-        description=description,
-        bundle_file_id=bundle_file_id,
-        bundle_sha256=sha,
-        is_public=is_public,
-        author_user_id=user.id,
-        db_session=db_session,
-    )
-    if parsed_group_ids:
-        replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
-    db_session.commit()
+    try:
+        skill = create_skill(
+            slug=slug,
+            name=name,
+            description=description,
+            bundle_file_id=bundle_file_id,
+            bundle_sha256=sha,
+            is_public=is_public,
+            author_user_id=user.id,
+            db_session=db_session,
+        )
+        if parsed_group_ids:
+            replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
+        db_session.commit()
+    except Exception:
+        _delete_old_bundle(file_store, bundle_file_id)
+        raise
 
     push_skill_to_affected_sandboxes(skill, db_session)
     return CustomSkillResponse.from_model(skill, group_ids=parsed_group_ids)
@@ -179,13 +183,17 @@ def replace_custom_skill_bundle(
         file_type="application/zip",
     )
 
-    updated, old_file_id = replace_skill_bundle(
-        skill_id=skill_id,
-        new_bundle_file_id=new_file_id,
-        new_bundle_sha256=sha,
-        db_session=db_session,
-    )
-    db_session.commit()
+    try:
+        updated, old_file_id = replace_skill_bundle(
+            skill_id=skill_id,
+            new_bundle_file_id=new_file_id,
+            new_bundle_sha256=sha,
+            db_session=db_session,
+        )
+        db_session.commit()
+    except Exception:
+        _delete_old_bundle(file_store, new_file_id)
+        raise
 
     push_skill_to_affected_sandboxes(updated, db_session)
     _delete_old_bundle(file_store, old_file_id)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -1,0 +1,280 @@
+import io
+import json
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import File
+from fastapi import Form
+from fastapi import UploadFile
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import Permission
+from onyx.auth.permissions import require_permission
+from onyx.auth.users import current_curator_or_admin_user
+from onyx.configs.constants import FileOrigin
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.models import User
+from onyx.db.skill import affected_user_ids_for_skill
+from onyx.db.skill import create_skill
+from onyx.db.skill import delete_skill
+from onyx.db.skill import fetch_skill_for_admin
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.skill import list_skills_for_admin
+from onyx.db.skill import list_skills_for_user
+from onyx.db.skill import patch_skill
+from onyx.db.skill import replace_skill_bundle
+from onyx.db.skill import replace_skill_grants
+from onyx.db.utils import UnsetType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import FileStore
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import BuiltinSkillResponse
+from onyx.server.features.skill.models import CustomSkillResponse
+from onyx.server.features.skill.models import GrantsReplace
+from onyx.server.features.skill.models import SkillPatchRequest
+from onyx.server.features.skill.models import SkillsList
+from onyx.skills.bundle import check_slug
+from onyx.skills.bundle import compute_bundle_sha256
+from onyx.skills.bundle import validate_custom_bundle
+from onyx.skills.push import push_skill_to_affected_sandboxes
+from onyx.skills.push import push_skills_for_users
+from onyx.skills.registry import BuiltinSkillRegistry
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+admin_router = APIRouter(prefix="/admin/skills")
+user_router = APIRouter(prefix="/skills")
+
+
+@admin_router.get("")
+def list_skills_admin(
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> SkillsList:
+    registry = BuiltinSkillRegistry.instance()
+    builtins = [
+        BuiltinSkillResponse.from_builtin(b, db_session) for b in registry.list_all()
+    ]
+    customs = list_skills_for_admin(db_session=db_session)
+    return SkillsList(
+        builtins=builtins,
+        customs=[
+            CustomSkillResponse.from_model(
+                c, group_ids=get_group_ids_for_skill(c.id, db_session)
+            )
+            for c in customs
+        ],
+    )
+
+
+@admin_router.post("/custom")
+def create_custom_skill(
+    slug: str = Form(...),
+    name: str = Form(...),
+    description: str = Form(...),
+    is_public: bool = Form(False),
+    group_ids: str = Form("[]"),
+    bundle: UploadFile = File(...),
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> CustomSkillResponse:
+    bundle_bytes = bundle.file.read()
+    validate_custom_bundle(bundle_bytes, slug=slug)
+    sha = compute_bundle_sha256(bundle_bytes)
+    parsed_group_ids = _parse_group_ids(group_ids)
+
+    file_store = get_default_file_store()
+    bundle_file_id = file_store.save_file(
+        content=io.BytesIO(bundle_bytes),
+        display_name=f"{slug}.zip",
+        file_origin=FileOrigin.SKILL_BUNDLE,
+        file_type="application/zip",
+    )
+
+    skill = create_skill(
+        slug=slug,
+        name=name,
+        description=description,
+        bundle_file_id=bundle_file_id,
+        bundle_sha256=sha,
+        is_public=is_public,
+        author_user_id=user.id,
+        db_session=db_session,
+    )
+    if parsed_group_ids:
+        replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
+    db_session.commit()
+
+    push_skill_to_affected_sandboxes(skill, db_session)
+    return CustomSkillResponse.from_model(skill, group_ids=parsed_group_ids)
+
+
+@admin_router.patch("/custom/{skill_id}")
+def patch_custom_skill(
+    skill_id: UUID,
+    patch_req: SkillPatchRequest,
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> CustomSkillResponse:
+    domain_patch = patch_req.to_domain()
+
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    if not isinstance(domain_patch.slug, UnsetType):
+        check_slug(domain_patch.slug)
+        if domain_patch.slug in BuiltinSkillRegistry.instance().reserved_slugs():
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT, "Slug reserved by a built-in skill"
+            )
+
+    # Snapshot before patch — SQLAlchemy identity map means the ORM object
+    # is mutated in-place by patch_skill, so we can't compare before/after.
+    old_is_public = skill.is_public
+    old_enabled = skill.enabled
+    old_slug = skill.slug
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+
+    updated = patch_skill(skill_id=skill_id, patch=domain_patch, db_session=db_session)
+    db_session.commit()
+
+    visibility_changed = (
+        old_is_public != updated.is_public
+        or old_enabled != updated.enabled
+        or old_slug != updated.slug
+    )
+    if visibility_changed:
+        after_affected = affected_user_ids_for_skill(updated, db_session)
+        push_skills_for_users(before_affected | after_affected, db_session)
+
+    return CustomSkillResponse.from_model(
+        updated, group_ids=get_group_ids_for_skill(skill_id, db_session)
+    )
+
+
+@admin_router.put("/custom/{skill_id}/bundle")
+def replace_custom_skill_bundle(
+    skill_id: UUID,
+    bundle: UploadFile = File(...),
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> CustomSkillResponse:
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    bundle_bytes = bundle.file.read()
+    validate_custom_bundle(bundle_bytes, slug=skill.slug)
+    sha = compute_bundle_sha256(bundle_bytes)
+
+    file_store = get_default_file_store()
+    new_file_id = file_store.save_file(
+        content=io.BytesIO(bundle_bytes),
+        display_name=f"{skill.slug}.zip",
+        file_origin=FileOrigin.SKILL_BUNDLE,
+        file_type="application/zip",
+    )
+
+    updated, old_file_id = replace_skill_bundle(
+        skill_id=skill_id,
+        new_bundle_file_id=new_file_id,
+        new_bundle_sha256=sha,
+        db_session=db_session,
+    )
+    db_session.commit()
+
+    push_skill_to_affected_sandboxes(updated, db_session)
+    _delete_old_bundle(file_store, old_file_id)
+    return CustomSkillResponse.from_model(
+        updated, group_ids=get_group_ids_for_skill(skill_id, db_session)
+    )
+
+
+@admin_router.put("/custom/{skill_id}/grants")
+def replace_custom_skill_grants(
+    skill_id: UUID,
+    body: GrantsReplace,
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> CustomSkillResponse:
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    before_affected = affected_user_ids_for_skill(skill, db_session)
+
+    replace_skill_grants(skill_id, body.group_ids, db_session=db_session)
+    db_session.commit()
+
+    updated = fetch_skill_for_admin(skill_id, db_session)
+    if updated is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+    after_affected = affected_user_ids_for_skill(updated, db_session)
+    push_skills_for_users(before_affected | after_affected, db_session)
+
+    return CustomSkillResponse.from_model(updated, group_ids=body.group_ids)
+
+
+@admin_router.delete("/custom/{skill_id}")
+def delete_custom_skill(
+    skill_id: UUID,
+    _: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> None:
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    affected = affected_user_ids_for_skill(skill, db_session)
+    old_file_id = delete_skill(skill_id, db_session)
+    db_session.commit()
+
+    push_skills_for_users(affected, db_session)
+    if old_file_id is not None:
+        _delete_old_bundle(get_default_file_store(), old_file_id)
+
+
+@user_router.get("")
+def list_skills_for_current_user(
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SkillsList:
+    registry = BuiltinSkillRegistry.instance()
+    builtins = [
+        BuiltinSkillResponse.from_builtin(b, db_session)
+        for b in registry.list_available(db_session)
+    ]
+    customs = list_skills_for_user(user=user, db_session=db_session)
+    return SkillsList(
+        builtins=builtins,
+        customs=[CustomSkillResponse.from_model(c, group_ids=[]) for c in customs],
+    )
+
+
+def _parse_group_ids(raw: str) -> list[int]:
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "group_ids must be a JSON array of integers",
+        )
+    if not isinstance(parsed, list) or not all(
+        isinstance(g, int) and not isinstance(g, bool) for g in parsed
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "group_ids must be a JSON array of integers",
+        )
+    return parsed
+
+
+def _delete_old_bundle(file_store: FileStore, file_id: str) -> None:
+    try:
+        file_store.delete_file(file_id, error_on_missing=False)
+    except Exception:
+        logger.warning("Failed to delete old bundle blob %s", file_id, exc_info=True)

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -1,0 +1,94 @@
+"""Pydantic request and response models for the skills API."""
+
+import datetime
+from typing import Any
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import model_validator
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Skill
+from onyx.db.skill import SkillPatch
+from onyx.skills.registry import BuiltinSkill
+
+
+class BuiltinSkillResponse(BaseModel):
+    source: Literal["builtin"] = "builtin"
+    slug: str
+    name: str
+    description: str
+    is_available: bool
+    unavailable_reason: str | None = None
+
+    @classmethod
+    def from_builtin(
+        cls, skill: BuiltinSkill, db_session: Session
+    ) -> "BuiltinSkillResponse":
+        return cls(
+            slug=skill.slug,
+            name=skill.name,
+            description=skill.description,
+            is_available=skill.is_available(db_session),
+            unavailable_reason=skill.unavailable_reason,
+        )
+
+
+class CustomSkillResponse(BaseModel):
+    source: Literal["custom"] = "custom"
+    id: UUID
+    slug: str
+    name: str
+    description: str
+    is_public: bool
+    enabled: bool
+    author_user_id: UUID | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    granted_group_ids: list[int] = []
+
+    @classmethod
+    def from_model(cls, skill: Skill, group_ids: list[int]) -> "CustomSkillResponse":
+        return cls(
+            id=skill.id,
+            slug=skill.slug,
+            name=skill.name,
+            description=skill.description,
+            is_public=skill.is_public,
+            enabled=skill.enabled,
+            author_user_id=skill.author_user_id,
+            created_at=skill.created_at,
+            updated_at=skill.updated_at,
+            granted_group_ids=group_ids,
+        )
+
+
+class SkillsList(BaseModel):
+    builtins: list[BuiltinSkillResponse]
+    customs: list[CustomSkillResponse]
+
+
+class SkillPatchRequest(BaseModel):
+    slug: str | None = None
+    name: str | None = None
+    description: str | None = None
+    is_public: bool | None = None
+    enabled: bool | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_explicit_nulls(cls, data: Any) -> Any:
+        """Omitting a field = 'leave unchanged'. Sending null = invalid."""
+        if isinstance(data, dict):
+            for field in ("slug", "name", "description", "is_public", "enabled"):
+                if field in data and data[field] is None:
+                    raise ValueError(f"{field} cannot be null")
+        return data
+
+    def to_domain(self) -> SkillPatch:
+        return SkillPatch(**{f: getattr(self, f) for f in self.model_fields_set})
+
+
+class GrantsReplace(BaseModel):
+    group_ids: list[int]

--- a/backend/onyx/skills/bundle.py
+++ b/backend/onyx/skills/bundle.py
@@ -1,7 +1,4 @@
-"""Custom skill bundle validation and helpers.
-
-See docs/craft/features/skills/skills_plan.md §5.
-"""
+"""Custom skill bundle validation and helpers."""
 
 from __future__ import annotations
 
@@ -29,7 +26,7 @@ SLUG_REGEX: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 _ZIP_UNIX_CREATE_SYSTEM: Final[int] = 3
 
 
-def _check_slug(slug: str) -> None:
+def check_slug(slug: str) -> None:
     if not SLUG_REGEX.match(slug):
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"invalid slug '{slug}'")
 
@@ -94,7 +91,7 @@ def validate_custom_bundle(
             SKILL.md, traversal, symlink, template, unreadable entry).
         OnyxError(PAYLOAD_TOO_LARGE): per-file or total size cap exceeded.
     """
-    _check_slug(slug)
+    check_slug(slug)
     if slug in BuiltinSkillRegistry.instance().reserved_slugs():
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, f"slug '{slug}' is reserved")
 

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -1,0 +1,95 @@
+"""Skill bundle push helpers.
+
+``build_skills_fileset_for_user`` builds the flat ``FileSet`` consumed by
+``SandboxManager.push_to_sandboxes``.  ``hydrate_sandbox_skills`` is the
+single-pod helper called from ``setup_session_workspace`` for cold-start
+hydration.  ``push_skills_for_users`` is the multi-sandbox fan-out used
+after admin mutations.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.db.skill import affected_user_ids_for_skill
+from onyx.db.skill import list_skills_for_user
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build.db.sandbox import get_sandbox_user_map
+from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.models import FileSet
+from onyx.server.features.build.sandbox.models import PushResult
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+SKILLS_MOUNT_PATH = "/workspace/managed/skills"
+
+
+def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
+    """Build the flat FileSet for all skills visible to *user*.
+
+    Each skill's bundle zip is stored in the file store. The returned dict
+    maps ``{slug}.zip`` to raw zip bytes. The sandbox daemon extracts these
+    under the mount path.
+    """
+    skills = list_skills_for_user(user=user, db_session=db_session)
+    file_store = get_default_file_store()
+
+    files: FileSet = {}
+    for skill in skills:
+        try:
+            blob = file_store.read_file(skill.bundle_file_id)
+            files[f"{skill.slug}.zip"] = blob.read()
+        except Exception:
+            logger.warning(
+                "Failed to read bundle for skill %s (%s), skipping",
+                skill.slug,
+                skill.bundle_file_id,
+            )
+    return files
+
+
+def hydrate_sandbox_skills(
+    sandbox_id: UUID,
+    user: User,
+    db_session: Session,
+) -> PushResult:
+    """Push all visible skills to a single sandbox (cold-start hydration)."""
+    files = build_skills_fileset_for_user(user, db_session)
+    return get_sandbox_manager().push_to_sandbox(
+        sandbox_id=sandbox_id,
+        mount_path=SKILLS_MOUNT_PATH,
+        files=files,
+    )
+
+
+def push_skill_to_affected_sandboxes(skill: Skill, db_session: Session) -> None:
+    """Resolve affected users for *skill* and push updated filesets."""
+    user_ids = affected_user_ids_for_skill(skill, db_session)
+    push_skills_for_users(user_ids, db_session)
+
+
+def push_skills_for_users(user_ids: set[UUID], db_session: Session) -> None:
+    """Rebuild and push the full skills fileset for each user's sandbox."""
+    if not user_ids:
+        return
+    try:
+        sandbox_map = get_sandbox_user_map(list(user_ids), db_session)
+        sandbox_files = {
+            sid: build_skills_fileset_for_user(user, db_session)
+            for sid, user in sandbox_map.items()
+        }
+        result = get_sandbox_manager().push_to_sandboxes(
+            mount_path=SKILLS_MOUNT_PATH,
+            sandbox_files=sandbox_files,
+        )
+        if result.failures:
+            logger.warning(
+                "Skill push partially failed: %d/%d sandboxes",
+                len(result.failures),
+                result.targets,
+            )
+    except Exception:
+        logger.exception("Failed to push skills to sandboxes")

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -1,12 +1,7 @@
-"""Skill bundle push helpers.
+"""Push skill bundles to running sandboxes."""
 
-``build_skills_fileset_for_user`` builds the flat ``FileSet`` consumed by
-``SandboxManager.push_to_sandboxes``.  ``hydrate_sandbox_skills`` is the
-single-pod helper called from ``setup_session_workspace`` for cold-start
-hydration.  ``push_skills_for_users`` is the multi-sandbox fan-out used
-after admin mutations.
-"""
-
+import io
+import zipfile
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -28,12 +23,7 @@ SKILLS_MOUNT_PATH = "/workspace/managed/skills"
 
 
 def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
-    """Build the flat FileSet for all skills visible to *user*.
-
-    Each skill's bundle zip is stored in the file store. The returned dict
-    maps ``{slug}.zip`` to raw zip bytes. The sandbox daemon extracts these
-    under the mount path.
-    """
+    """Extract all visible skill bundles into a ``{slug}/`` directory tree."""
     skills = list_skills_for_user(user=user, db_session=db_session)
     file_store = get_default_file_store()
 
@@ -41,7 +31,12 @@ def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
     for skill in skills:
         try:
             blob = file_store.read_file(skill.bundle_file_id)
-            files[f"{skill.slug}.zip"] = blob.read()
+            zip_bytes = blob.read()
+            with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+                for info in zf.infolist():
+                    if info.is_dir():
+                        continue
+                    files[f"{skill.slug}/{info.filename}"] = zf.read(info)
         except Exception:
             logger.warning(
                 "Failed to read bundle for skill %s (%s), skipping",

--- a/backend/onyx/skills/registry.py
+++ b/backend/onyx/skills/registry.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from threading import Lock
 from typing import ClassVar
 from typing import Literal
-from uuid import UUID
 
 import yaml
 from pydantic import BaseModel
@@ -24,12 +23,19 @@ _SLUG_ERROR = (
 )
 
 
-class Skill(BaseModel):
-    """Common skill metadata shared by built-in and custom skill views."""
+class BuiltinSkill(BaseModel):
+    """In-memory entry for an on-disk built-in skill."""
 
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    source: Literal["builtin"] = "builtin"
     slug: str
     name: str
     description: str
+    source_dir: Path
+    has_template: bool
+    is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
+    unavailable_reason: str | None = None
 
     @field_validator("slug")
     @classmethod
@@ -37,29 +43,6 @@ class Skill(BaseModel):
         if not _SLUG_REGEX.fullmatch(slug):
             raise ValueError(_SLUG_ERROR)
         return slug
-
-
-class BuiltinSkill(Skill):
-    """In-memory entry for an on-disk built-in skill."""
-
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
-
-    source: Literal["builtin"] = "builtin"
-    source_dir: Path
-    has_template: bool
-    is_available: Callable[[Session], bool] = _DEFAULT_IS_AVAILABLE
-    unavailable_reason: str | None = None
-
-
-class CustomSkill(Skill):
-    """DB-backed skill metadata needed by skill consumers."""
-
-    source: Literal["custom"] = "custom"
-    id: UUID
-    bundle_file_id: str
-    bundle_sha256: str
-    is_public: bool
-    enabled: bool
 
 
 def _select_skill_definition_path(source_dir: Path) -> tuple[Path, bool]:

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -1,0 +1,178 @@
+import io
+import json
+import zipfile
+from uuid import uuid4
+
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.test_models import DATestSkill
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def build_minimal_bundle(slug: str) -> bytes:
+    """Build a minimal valid skill bundle zip with SKILL.md."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "SKILL.md",
+            f"---\nname: {slug}\ndescription: Test skill {slug}\n---\n\nSkill instructions.",
+        )
+    return buf.getvalue()
+
+
+class SkillManager:
+    @staticmethod
+    def create_custom(
+        user_performing_action: DATestUser,
+        *,
+        slug: str | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        is_public: bool = False,
+        group_ids: list[int] | None = None,
+        bundle_bytes: bytes | None = None,
+    ) -> DATestSkill:
+        slug = slug or f"test-skill-{uuid4().hex[:8]}"
+        name = name or f"Test Skill {slug}"
+        description = description or f"Description for {slug}"
+        if bundle_bytes is None:
+            bundle_bytes = build_minimal_bundle(slug)
+
+        response = requests.post(
+            f"{API_SERVER_URL}/admin/skills/custom",
+            data={
+                "slug": slug,
+                "name": name,
+                "description": description,
+                "is_public": str(is_public).lower(),
+                "group_ids": json.dumps(group_ids or []),
+            },
+            files={
+                "bundle": (
+                    f"{slug}.zip",
+                    io.BytesIO(bundle_bytes),
+                    "application/zip",
+                )
+            },
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return DATestSkill(
+            id=data["id"],
+            slug=data["slug"],
+            name=data["name"],
+            description=data["description"],
+            is_public=data["is_public"],
+            enabled=data["enabled"],
+            granted_group_ids=data.get("granted_group_ids", []),
+        )
+
+    @staticmethod
+    def patch_custom(
+        skill: DATestSkill,
+        user_performing_action: DATestUser,
+        **fields: object,
+    ) -> DATestSkill:
+        response = requests.patch(
+            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
+            json=fields,
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return DATestSkill(
+            id=data["id"],
+            slug=data["slug"],
+            name=data["name"],
+            description=data["description"],
+            is_public=data["is_public"],
+            enabled=data["enabled"],
+            granted_group_ids=data.get("granted_group_ids", []),
+        )
+
+    @staticmethod
+    def replace_bundle(
+        skill: DATestSkill,
+        bundle_bytes: bytes,
+        user_performing_action: DATestUser,
+    ) -> DATestSkill:
+        response = requests.put(
+            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}/bundle",
+            files={
+                "bundle": (
+                    f"{skill.slug}.zip",
+                    io.BytesIO(bundle_bytes),
+                    "application/zip",
+                )
+            },
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return DATestSkill(
+            id=data["id"],
+            slug=data["slug"],
+            name=data["name"],
+            description=data["description"],
+            is_public=data["is_public"],
+            enabled=data["enabled"],
+            granted_group_ids=data.get("granted_group_ids", []),
+        )
+
+    @staticmethod
+    def replace_grants(
+        skill: DATestSkill,
+        group_ids: list[int],
+        user_performing_action: DATestUser,
+    ) -> DATestSkill:
+        response = requests.put(
+            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}/grants",
+            json={"group_ids": group_ids},
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+        return DATestSkill(
+            id=data["id"],
+            slug=data["slug"],
+            name=data["name"],
+            description=data["description"],
+            is_public=data["is_public"],
+            enabled=data["enabled"],
+            granted_group_ids=data.get("granted_group_ids", []),
+        )
+
+    @staticmethod
+    def delete_custom(
+        skill: DATestSkill,
+        user_performing_action: DATestUser,
+    ) -> None:
+        response = requests.delete(
+            f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+
+    @staticmethod
+    def list_all(
+        user_performing_action: DATestUser,
+    ) -> dict:
+        response = requests.get(
+            f"{API_SERVER_URL}/admin/skills",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def list_for_user(
+        user_performing_action: DATestUser,
+    ) -> dict:
+        response = requests.get(
+            f"{API_SERVER_URL}/skills",
+            headers=user_performing_action.headers,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -315,3 +315,13 @@ class DATestDiscordChannelConfig(BaseModel):
     thread_only_mode: bool = False
     require_bot_invocation: bool = True
     persona_override_id: int | None = None
+
+
+class DATestSkill(BaseModel):
+    id: UUID | None = None
+    slug: str
+    name: str
+    description: str
+    is_public: bool = False
+    enabled: bool = True
+    granted_group_ids: list[int] = Field(default_factory=list)

--- a/backend/tests/integration/tests/skills/conftest.py
+++ b/backend/tests/integration/tests/skills/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_db(reset: None) -> None:  # noqa: ARG001
+    """Auto-reset DB before each skills test."""

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -1,0 +1,103 @@
+import io
+import zipfile
+
+import pytest
+import requests
+
+from tests.integration.common_utils.managers.skill import build_minimal_bundle
+from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_create_and_list_skill(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="test-create")
+    assert skill.id is not None
+    assert skill.slug == "test-create"
+    assert skill.enabled is True
+
+    skills_list = SkillManager.list_all(admin_user)
+    custom_slugs = [c["slug"] for c in skills_list["customs"]]
+    assert "test-create" in custom_slugs
+
+
+def test_patch_skill_metadata(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="patch-test")
+
+    updated = SkillManager.patch_custom(
+        skill,
+        admin_user,
+        name="New Name",
+        description="New desc",
+        is_public=True,
+    )
+    assert updated.name == "New Name"
+    assert updated.description == "New desc"
+    assert updated.is_public is True
+
+    disabled = SkillManager.patch_custom(skill, admin_user, enabled=False)
+    assert disabled.enabled is False
+
+
+def test_replace_bundle(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="bundle-test")
+    new_bundle = build_minimal_bundle("bundle-test")
+    updated = SkillManager.replace_bundle(skill, new_bundle, admin_user)
+    assert updated.slug == "bundle-test"
+
+
+def test_delete_skill(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="delete-test")
+    SkillManager.delete_custom(skill, admin_user)
+
+    skills_list = SkillManager.list_all(admin_user)
+    custom_slugs = [c["slug"] for c in skills_list["customs"]]
+    assert "delete-test" not in custom_slugs
+
+
+def test_duplicate_slug_rejected(admin_user: DATestUser) -> None:
+    SkillManager.create_custom(admin_user, slug="dupe-slug")
+    with pytest.raises(requests.HTTPError) as exc_info:
+        SkillManager.create_custom(admin_user, slug="dupe-slug")
+    assert exc_info.value.response.status_code == 409
+
+
+def test_bundle_missing_skill_md(admin_user: DATestUser) -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("readme.txt", "no skill.md here")
+    bad_bundle = buf.getvalue()
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        SkillManager.create_custom(
+            admin_user, slug="bad-bundle", bundle_bytes=bad_bundle
+        )
+    assert exc_info.value.response.status_code == 400
+
+
+def test_bundle_with_template_rejected(admin_user: DATestUser) -> None:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", "---\nname: t\ndescription: t\n---\nok")
+        zf.writestr("SKILL.md.template", "should not be here")
+    bad_bundle = buf.getvalue()
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        SkillManager.create_custom(
+            admin_user, slug="template-bundle", bundle_bytes=bad_bundle
+        )
+    assert exc_info.value.response.status_code == 400
+
+
+def test_grants_replace(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="grants-test", is_public=False)
+    updated = SkillManager.replace_grants(skill, [], admin_user)
+    assert updated.granted_group_ids == []
+
+
+def test_patch_slug_to_duplicate(admin_user: DATestUser) -> None:
+    SkillManager.create_custom(admin_user, slug="slug-a")
+    skill_b = SkillManager.create_custom(admin_user, slug="slug-b")
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        SkillManager.patch_custom(skill_b, admin_user, slug="slug-a")
+    assert exc_info.value.response.status_code == 409

--- a/backend/tests/integration/tests/skills/test_skills_user.py
+++ b/backend/tests/integration/tests/skills/test_skills_user.py
@@ -1,0 +1,77 @@
+import pytest
+import requests
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.managers.skill import SkillManager
+from tests.integration.common_utils.test_models import DATestUser
+
+
+def test_non_admin_cannot_create(basic_user: DATestUser) -> None:
+    with pytest.raises(requests.HTTPError) as exc_info:
+        SkillManager.create_custom(basic_user, slug="unauthorized")
+    assert exc_info.value.response.status_code == 403
+
+
+def test_public_skill_visible_to_all_users(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    SkillManager.create_custom(admin_user, slug="public-skill", is_public=True)
+
+    user_skills = SkillManager.list_for_user(basic_user)
+    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    assert "public-skill" in custom_slugs
+
+
+def test_private_skill_not_visible_without_grant(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    SkillManager.create_custom(admin_user, slug="private-skill", is_public=False)
+
+    user_skills = SkillManager.list_for_user(basic_user)
+    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    assert "private-skill" not in custom_slugs
+
+
+def test_disabled_skill_not_in_user_list(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    skill = SkillManager.create_custom(
+        admin_user, slug="disabled-skill", is_public=True
+    )
+    SkillManager.patch_custom(skill, admin_user, enabled=False)
+
+    user_skills = SkillManager.list_for_user(basic_user)
+    custom_slugs = [c["slug"] for c in user_skills["customs"]]
+    assert "disabled-skill" not in custom_slugs
+
+
+def test_disabled_skill_in_admin_list(admin_user: DATestUser) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="admin-disabled")
+    SkillManager.patch_custom(skill, admin_user, enabled=False)
+
+    admin_skills = SkillManager.list_all(admin_user)
+    custom_slugs = [c["slug"] for c in admin_skills["customs"]]
+    assert "admin-disabled" in custom_slugs
+
+
+def test_non_admin_cannot_list_admin(basic_user: DATestUser) -> None:
+    response = requests.get(
+        f"{API_SERVER_URL}/admin/skills",
+        headers=basic_user.headers,
+    )
+    assert response.status_code == 403
+
+
+def test_non_admin_cannot_delete(
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    skill = SkillManager.create_custom(admin_user, slug="no-delete")
+    response = requests.delete(
+        f"{API_SERVER_URL}/admin/skills/custom/{skill.id}",
+        headers=basic_user.headers,
+    )
+    assert response.status_code == 403

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_push_orchestration.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_push_orchestration.py
@@ -39,7 +39,7 @@ class StubSandboxManager(SandboxManager):
     def write_files_to_sandbox(
         self,
         *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: FileSet,
     ) -> None:
@@ -181,6 +181,11 @@ class StubSandboxManager(SandboxManager):
         raise NotImplementedError
 
 
+SB_1 = UUID("00000000-0000-0000-0000-000000000001")
+SB_2 = UUID("00000000-0000-0000-0000-000000000002")
+SB_FAIL = UUID("00000000-0000-0000-0000-0000000000ff")
+
+
 # ---------------------------------------------------------------------------
 # push_to_sandbox tests
 # ---------------------------------------------------------------------------
@@ -201,7 +206,7 @@ def test_push_to_sandbox_happy_path(
     mgr: StubSandboxManager,
 ) -> None:
     result = mgr.push_to_sandbox(
-        sandbox_id="sb-1",
+        sandbox_id=SB_1,
         mount_path="/workspace/managed/skills",
         files=_sample_files(),
     )
@@ -209,7 +214,7 @@ def test_push_to_sandbox_happy_path(
     assert result.succeeded == 1
     assert result.failures == []
     assert len(mgr.write_calls) == 1
-    assert mgr.write_calls[0]["sandbox_id"] == "sb-1"
+    assert mgr.write_calls[0]["sandbox_id"] == SB_1
 
 
 @patch("onyx.server.features.build.sandbox.base.time.sleep")
@@ -219,7 +224,7 @@ def test_push_to_sandbox_fatal_write_error(
 ) -> None:
     mgr.set_write_side_effect(FatalWriteError("bad auth"))
     result = mgr.push_to_sandbox(
-        sandbox_id="sb-1",
+        sandbox_id=SB_1,
         mount_path="/workspace/managed/skills",
         files=_sample_files(),
     )
@@ -239,7 +244,7 @@ def test_push_to_sandbox_retriable_all_attempts_fail(
 ) -> None:
     mgr.set_write_side_effect(RetriableWriteError("timeout"))
     result = mgr.push_to_sandbox(
-        sandbox_id="sb-1",
+        sandbox_id=SB_1,
         mount_path="/workspace/managed/skills",
         files=_sample_files(),
     )
@@ -261,7 +266,7 @@ def test_push_to_sandbox_retriable_then_success(
         [RetriableWriteError("transient"), RetriableWriteError("transient"), None]
     )
     result = mgr.push_to_sandbox(
-        sandbox_id="sb-1",
+        sandbox_id=SB_1,
         mount_path="/workspace/managed/skills",
         files=_sample_files(),
     )
@@ -279,7 +284,7 @@ def test_push_to_sandbox_unexpected_exception(
     """Unexpected exceptions are caught and converted to PushFailure, not re-raised."""
     mgr.set_write_side_effect(RuntimeError("boom"))
     result = mgr.push_to_sandbox(
-        sandbox_id="sb-1",
+        sandbox_id=SB_1,
         mount_path="/workspace/managed/skills",
         files=_sample_files(),
     )
@@ -316,10 +321,11 @@ def test_push_to_sandboxes_multiple_all_succeed(
     mock_sleep: Any,  # noqa: ARG001
     mgr: StubSandboxManager,
 ) -> None:
-    sandbox_files: dict[str, FileSet] = {
-        "sb-1": {"a.txt": b"aaa"},
-        "sb-2": {"b.txt": b"bbb"},
-        "sb-3": {"c.txt": b"ccc"},
+    sb_3 = UUID("00000000-0000-0000-0000-000000000003")
+    sandbox_files: dict[UUID, FileSet] = {
+        SB_1: {"a.txt": b"aaa"},
+        SB_2: {"b.txt": b"bbb"},
+        sb_3: {"c.txt": b"ccc"},
     }
     result = mgr.push_to_sandboxes(
         mount_path="/workspace/managed/skills",
@@ -336,25 +342,28 @@ def test_push_to_sandboxes_mixed_success_and_failure(
 ) -> None:
     """Some sandboxes succeed, some fail with FatalWriteError."""
 
+    sb_ok_1 = UUID("00000000-0000-0000-0000-000000000011")
+    sb_ok_2 = UUID("00000000-0000-0000-0000-000000000012")
+
     class MixedStub(StubSandboxManager):
         def write_files_to_sandbox(
             self,
             *,
-            sandbox_id: str,
+            sandbox_id: UUID,
             mount_path: str,
             files: FileSet,
         ) -> None:
             self.write_calls.append(
                 {"sandbox_id": sandbox_id, "mount_path": mount_path, "files": files}
             )
-            if sandbox_id == "sb-fail":
+            if sandbox_id == SB_FAIL:
                 raise FatalWriteError("pod missing")
 
     mgr = MixedStub()
-    sandbox_files: dict[str, FileSet] = {
-        "sb-ok-1": {"a.txt": b"aaa"},
-        "sb-fail": {"b.txt": b"bbb"},
-        "sb-ok-2": {"c.txt": b"ccc"},
+    sandbox_files: dict[UUID, FileSet] = {
+        sb_ok_1: {"a.txt": b"aaa"},
+        SB_FAIL: {"b.txt": b"bbb"},
+        sb_ok_2: {"c.txt": b"ccc"},
     }
     result = mgr.push_to_sandboxes(
         mount_path="/workspace/managed/skills",
@@ -363,5 +372,5 @@ def test_push_to_sandboxes_mixed_success_and_failure(
     assert result.targets == 3
     assert result.succeeded == 2
     assert len(result.failures) == 1
-    assert result.failures[0].sandbox_id == "sb-fail"
+    assert result.failures[0].sandbox_id == SB_FAIL
     assert result.failures[0].reason == "write_error"

--- a/backend/tests/unit/onyx/skills/test_bundle.py
+++ b/backend/tests/unit/onyx/skills/test_bundle.py
@@ -1,4 +1,4 @@
-"""Unit tests for the custom skill bundle validator (spec §5)."""
+"""Unit tests for the custom skill bundle validator."""
 
 from __future__ import annotations
 
@@ -64,7 +64,7 @@ def test_valid_bundle_accepted() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Failure modes — one test per rule from spec §5
+# Failure modes
 # ---------------------------------------------------------------------------
 
 
@@ -206,7 +206,7 @@ def test_sha256_differs_for_same_content_different_timestamps() -> None:
     """compute_bundle_sha256 is a raw-bytes hash — same contents repacked with
     different timestamps deliberately hash differently.
 
-    Spec §5: ``deterministic over raw bytes`` — we want to detect "this is the
+    ``deterministic over raw bytes`` — we want to detect "this is the
     exact same upload," not "the contents match."
     """
     entries = [
@@ -365,7 +365,7 @@ def test_safe_unzip_rejects_unsupported_compression(tmp_path: Path) -> None:
 
 
 def test_size_violation_returns_413() -> None:
-    """Spec §5 size-cap violations should return HTTP 413, not 400."""
+    """Size-cap violations should return HTTP 413, not 400."""
     zip_bytes = _build_zip(
         [
             ("SKILL.md", VALID_SKILL_MD),

--- a/backend/tests/unit/onyx/skills/test_registry.py
+++ b/backend/tests/unit/onyx/skills/test_registry.py
@@ -1,14 +1,11 @@
 from pathlib import Path
 from typing import cast
-from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
 from onyx.skills.registry import BuiltinSkill
 from onyx.skills.registry import BuiltinSkillRegistry
-from onyx.skills.registry import CustomSkill
-from onyx.skills.registry import Skill
 
 
 def _write_skill(
@@ -55,38 +52,6 @@ def test_register_rejects_invalid_slug(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="start with a lowercase letter"):
         registry.register("Invalid_Slug", skill_dir)
-
-
-def test_shared_skill_shape_is_mutable() -> None:
-    skill = Skill(slug="editable", name="Before", description="Before")
-
-    skill.name = "After"
-    skill.description = "After"
-
-    assert skill.name == "After"
-    assert skill.description == "After"
-
-
-def test_custom_skill_shape_matches_editable_db_metadata() -> None:
-    skill = CustomSkill(
-        id=uuid4(),
-        slug="custom",
-        name="Before",
-        description="Before",
-        bundle_file_id="file-id",
-        bundle_sha256="a" * 64,
-        is_public=False,
-        enabled=True,
-    )
-
-    skill.name = "After"
-    skill.description = "After"
-    skill.enabled = False
-
-    assert skill.source == "custom"
-    assert skill.name == "After"
-    assert skill.description == "After"
-    assert skill.enabled is False
 
 
 def test_builtin_skill_is_frozen(tmp_path: Path) -> None:

--- a/backend/tests/unit/onyx/skills/test_skill_patch.py
+++ b/backend/tests/unit/onyx/skills/test_skill_patch.py
@@ -1,0 +1,68 @@
+"""Unit tests for SkillPatchRequest — sentinel mapping and null rejection."""
+
+import pytest
+from pydantic import ValidationError
+
+from onyx.db.utils import UnsetType
+from onyx.server.features.skill.models import SkillPatchRequest
+
+
+def test_omitted_fields_produce_unset() -> None:
+    """Fields not included in the request should produce UNSET in the domain object."""
+    req = SkillPatchRequest(name="hello")
+    patch = req.to_domain()
+
+    assert patch.name == "hello"
+    assert isinstance(patch.slug, UnsetType)
+    assert isinstance(patch.description, UnsetType)
+    assert isinstance(patch.is_public, UnsetType)
+    assert isinstance(patch.enabled, UnsetType)
+
+
+def test_all_fields_sent() -> None:
+    """All fields explicitly sent should appear in the domain object."""
+    req = SkillPatchRequest(
+        slug="new-slug",
+        name="New Name",
+        description="New desc",
+        is_public=True,
+        enabled=False,
+    )
+    patch = req.to_domain()
+
+    assert patch.slug == "new-slug"
+    assert patch.name == "New Name"
+    assert patch.description == "New desc"
+    assert patch.is_public is True
+    assert patch.enabled is False
+
+
+def test_false_values_not_treated_as_unset() -> None:
+    """Explicitly sending False should NOT produce UNSET."""
+    req = SkillPatchRequest(is_public=False, enabled=False)
+    patch = req.to_domain()
+
+    assert patch.is_public is False
+    assert patch.enabled is False
+    assert isinstance(patch.slug, UnsetType)
+
+
+def test_empty_request_all_unset() -> None:
+    """An empty request should have all fields as UNSET."""
+    req = SkillPatchRequest()
+    patch = req.to_domain()
+
+    assert isinstance(patch.slug, UnsetType)
+    assert isinstance(patch.name, UnsetType)
+    assert isinstance(patch.description, UnsetType)
+    assert isinstance(patch.is_public, UnsetType)
+    assert isinstance(patch.enabled, UnsetType)
+
+
+@pytest.mark.parametrize(
+    "field", ["slug", "name", "description", "is_public", "enabled"]
+)
+def test_explicit_null_rejected(field: str) -> None:
+    """Sending field=null (not omitting it) should raise ValidationError."""
+    with pytest.raises(ValidationError, match=f"{field} cannot be null"):
+        SkillPatchRequest.model_validate({field: None})

--- a/docs/craft/features/sandbox-file-push.md
+++ b/docs/craft/features/sandbox-file-push.md
@@ -66,7 +66,7 @@ The push API lives on `SandboxManager` (`backend/onyx/server/features/build/sand
 class SandboxManager(ABC):
     @abstractmethod
     def write_files_to_sandbox(
-        self, *, sandbox_id: str, mount_path: str, files: dict[str, bytes],
+        self, *, sandbox_id: UUID, mount_path: str, files: dict[str, bytes],
     ) -> None: ...
 ```
 
@@ -98,7 +98,7 @@ The push API is **synchronous**, matching Onyx's codebase conventions (sync Fast
 # backend/onyx/server/features/build/sandbox/models.py
 
 class PushFailure(BaseModel):
-    sandbox_id: str
+    sandbox_id: UUID
     reason: str                  # "timeout" | "write_error" | "not_found"
     detail: str | None = None
 
@@ -121,7 +121,7 @@ class SandboxManager(ABC):
     # ---- Concrete defaults; shared across backends ----
     def push_to_sandbox(
         self, *,
-        sandbox_id: str,
+        sandbox_id: UUID,
         mount_path: str,
         files: dict[str, bytes],
         timeout_s: float = 30.0,
@@ -141,7 +141,7 @@ class SandboxManager(ABC):
     # ---- Backend-specific; one abstract method ----
     @abstractmethod
     def write_files_to_sandbox(
-        self, *, sandbox_id: str, mount_path: str, files: dict[str, bytes],
+        self, *, sandbox_id: UUID, mount_path: str, files: dict[str, bytes],
     ) -> None:
         """Write atomically. Raise RetriableWriteError for transients,
         FatalWriteError for permanent failures."""

--- a/docs/craft/features/skills/skills-api-plan.md
+++ b/docs/craft/features/skills/skills-api-plan.md
@@ -318,7 +318,7 @@ def replace_custom_skill_bundle(...) -> CustomSkillResponse:
     skill = fetch_skill_for_admin(skill_id, db_session)
     validate_custom_bundle(bundle_bytes, slug=skill.slug)
     sha = compute_bundle_sha256(bundle_bytes)
-    new_file_id = filestore.write(bundle_bytes)
+    new_file_id = file_store.write(bundle_bytes)
 
     updated, old_file_id = replace_skill_bundle(
         skill_id=skill_id, new_bundle_file_id=new_file_id,

--- a/docs/craft/features/skills/skills-api-plan.md
+++ b/docs/craft/features/skills/skills-api-plan.md
@@ -15,7 +15,9 @@ Add `/admin/skills` (admin CRUD) and `/skills` (user read) HTTP endpoints, backe
 - Extending `SandboxManager` with the push API and per-backend `write_files_to_sandbox` implementation (separate workstream — see `sandbox-file-push.md`).
 - Built-in skill source files / registrations (registry exists; registering specific built-ins is a separate workstream).
 - Cold-start hydration plumbing in `setup_session_workspace` (owned by the push-primitive workstream).
-- Orphan-blob sweep job.
+- Orphan-blob sweep job (delete/replace endpoints capture the old `bundle_file_id` but do not delete it inline — deferred to a periodic cleanup task).
+- Built-in availability flip push triggers (built-in availability is a function of external state, not an API mutation; sandboxes re-converge on next session start/wakeup).
+- `GET /skills/{slug_or_id}` single-skill endpoint (deferred unless a concrete UI need arises; DB layer has `fetch_skill_for_user` ready).
 - Front-end work.
 
 ## 3. File Layout
@@ -24,7 +26,6 @@ New files (all under `backend/onyx/server/features/skill/`):
 
 ```
 backend/onyx/server/features/skill/
-├── __init__.py
 ├── api.py                   # routers, endpoints
 └── models.py                # Pydantic request/response models
 ```
@@ -32,14 +33,22 @@ backend/onyx/server/features/skill/
 Plus the skills-side push helpers, co-located with the skills module:
 
 ```
-backend/onyx/skills/push.py  # build_skills_files_for_user(user, db),
-                             # push_to_pod(sandbox_id, user, db)
+backend/onyx/skills/push.py  # build_skills_files_for_user, push_to_pod, affected_users_for_skill
 ```
 
-`build_skills_files_for_user` returns the flat path-to-bytes dict used as values in the `sandbox_files` mapping passed to `SandboxManager.push_to_sandboxes`; `push_to_pod` is the cold-start single-pod helper called from `setup_session_workspace`, internally calling `get_sandbox_manager().push_to_sandbox(...)` (see sandbox-file-push.md §11 and §12). Depends on `SandboxManager` gaining the push methods, but `backend/onyx/skills/push.py` itself does not change shape.
+Plus a new DB helper for sandbox-to-user resolution:
+
+```
+backend/onyx/db/sandbox.py   # get_sandbox_user_map(user_ids, db_session) -> dict[UUID, User]
+```
+
+`get_sandbox_user_map` queries the sandbox DB for active sandboxes belonging to the given users, returning `{sandbox_id: user}`. This is the caller's responsibility per the push API contract — `SandboxManager` has no DB access.
+
+`build_skills_files_for_user` returns the flat `FileSet` (`dict[str, bytes]`) used as values in the `sandbox_files` mapping passed to `push_to_sandboxes`. `push_to_pod` is the cold-start single-pod helper called from `setup_session_workspace`, calling `get_sandbox_manager().push_to_sandbox(sandbox_id=sandbox_id, ...)`.
 
 Modified files:
 - `backend/onyx/main.py` — register the two routers.
+- `backend/onyx/db/skill.py` — extend `CustomSkill` with `author_user_id`, `created_at`, `updated_at` (see §4 notes).
 
 New test files:
 - `backend/tests/integration/common_utils/managers/skill.py` — `SkillManager`.
@@ -51,25 +60,27 @@ New test files:
 
 Keep them flat and explicit. No `response_model=` on endpoint decorators (per CLAUDE.md); use return-type annotations only.
 
+### Response models
+
 ```python
 class SkillSource(str, Enum):
     BUILTIN = "builtin"
     CUSTOM = "custom"
 
-class BuiltinSkillSnapshot(BaseModel):
-    source: Literal[SkillSource.BUILTIN] = SkillSource.BUILTIN
+class SkillSnapshot(BaseModel):
+    source: SkillSource
     slug: str
     name: str
     description: str
+
+class BuiltinSkillSnapshot(SkillSnapshot):
+    source: Literal[SkillSource.BUILTIN] = SkillSource.BUILTIN
     is_available: bool
     unavailable_reason: str | None
 
-class CustomSkillSnapshot(BaseModel):
+class CustomSkillSnapshot(SkillSnapshot):
     source: Literal[SkillSource.CUSTOM] = SkillSource.CUSTOM
     id: UUID
-    slug: str
-    name: str
-    description: str
     is_public: bool
     enabled: bool
     bundle_sha256: str
@@ -79,41 +90,61 @@ class CustomSkillSnapshot(BaseModel):
     updated_at: datetime
 
     @classmethod
-    def from_model(cls, skill: Skill, *, include_grants: bool) -> "CustomSkillSnapshot": ...
+    def from_model(
+        cls, skill: CustomSkill, group_ids: list[int],
+    ) -> "CustomSkillSnapshot": ...
 
-class SkillsAdminList(BaseModel):
+class SkillsList(BaseModel):
     builtins: list[BuiltinSkillSnapshot]
     customs: list[CustomSkillSnapshot]
+```
 
-class SkillsUserList(BaseModel):
-    builtins: list[BuiltinSkillSnapshot]
-    customs: list[CustomSkillSnapshot]   # grants omitted for user view
+### Request models
 
-class CustomSkillCreateForm:
-    """Multipart form — defined as `Form()` params in the endpoint, not a BaseModel."""
-    # slug: str, name: str, description: str, is_public: bool = False,
-    # group_ids: list[int] = [], bundle: UploadFile
-
-class CustomSkillPatch(BaseModel):
+```python
+class SkillPatchRequest(BaseModel):
     slug: str | None = None
     name: str | None = None
     description: str | None = None
     is_public: bool | None = None
     enabled: bool | None = None
 
+    def to_domain(self) -> SkillPatch:
+        return SkillPatch(**{
+            f: getattr(self, f) for f in self.model_fields_set
+        })
+
 class GrantsReplace(BaseModel):
     group_ids: list[int]
 ```
 
-Notes:
-- `CustomSkillPatch` uses `None` for "not provided" to match FastAPI ergonomics, but the endpoint must translate `None` → `UNSET` before calling `patch_skill` (which uses the existing sentinel).
-- Listing is non-paginated in V1 (skill counts will be tiny). If/when needed, add `PaginatedReturn[CustomSkillSnapshot]` per the persona pattern.
+### Domain patch object
+
+Lives in `backend/onyx/db/skill.py` alongside the existing `UNSET` sentinel:
+
+```python
+@dataclass(frozen=True, kw_only=True)
+class SkillPatch:
+    slug: str | Unset = UNSET
+    name: str | Unset = UNSET
+    description: str | Unset = UNSET
+    is_public: bool | Unset = UNSET
+    enabled: bool | Unset = UNSET
+```
+
+The endpoint receives `SkillPatchRequest` (Pydantic, `None` = not sent), calls `to_domain()` which uses `model_fields_set` to distinguish "sent" from "not sent", producing a `SkillPatch` (frozen dataclass, `UNSET` = not sent). `patch_skill` in the DB layer receives `SkillPatch` directly — no translation at the boundary.
+
+### Notes on `CustomSkill` enrichment
+
+The DB layer's `CustomSkill` (in `backend/onyx/skills/registry.py`) currently lacks `author_user_id`, `created_at`, and `updated_at`. The `_custom_skill_from_model` helper in `db/skill.py` must be extended to populate these from the ORM `Skill` model. Group grant IDs are not on `CustomSkill` — they're fetched separately via the `skill.groups` ORM relationship. `from_model` takes `CustomSkill` + a pre-fetched `group_ids` list.
+
+Listing is non-paginated in V1 (skill counts will be tiny). If/when needed, add `PaginatedReturn[CustomSkillSnapshot]` per the persona pattern.
 
 ## 5. Routes (`api.py`)
 
 ```python
-admin_router = APIRouter(prefix="/admin/skills", tags=["skills"])
-user_router = APIRouter(prefix="/skills", tags=["skills"])
+admin_router = APIRouter(prefix="/admin/skills")
+user_router = APIRouter(prefix="/skills")
 ```
 
 ### Admin endpoints
@@ -123,7 +154,7 @@ user_router = APIRouter(prefix="/skills", tags=["skills"])
 def list_skills_admin(
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> SkillsAdminList: ...
+) -> SkillsList: ...
 
 @admin_router.post("/custom")
 def create_custom_skill(
@@ -131,7 +162,7 @@ def create_custom_skill(
     name: str = Form(...),
     description: str = Form(...),
     is_public: bool = Form(False),
-    group_ids: list[int] = Form(default_factory=list),
+    group_ids: str = Form("[]"),       # JSON-encoded list[int]
     bundle: UploadFile = File(...),
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
@@ -140,7 +171,7 @@ def create_custom_skill(
 @admin_router.patch("/custom/{skill_id}")
 def patch_custom_skill(
     skill_id: UUID,
-    patch: CustomSkillPatch,
+    patch: SkillPatchRequest,
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillSnapshot: ...
@@ -169,6 +200,8 @@ def delete_custom_skill(
 ) -> None: ...
 ```
 
+Note: `group_ids` in the create endpoint is a JSON-encoded string (`"[1, 2, 3]"`) parsed server-side, avoiding FastAPI's awkward repeated-form-field semantics for list-typed `Form()` params.
+
 ### User endpoints
 
 ```python
@@ -176,32 +209,25 @@ def delete_custom_skill(
 def list_skills_for_current_user(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> SkillsUserList: ...
+) -> SkillsList: ...
 ```
-
-A single-skill GET is **optional** in V1 — only add if a concrete UI need exists.
 
 ## 6. Endpoint Implementation Sketches
 
-Every mutation follows the same shape: validate → write to DB + FileStore → commit → compute the set of affected users → query DB for their sandbox_ids → build the sandbox_id-to-files mapping → push via `get_sandbox_manager().push_to_sandboxes(...)` (imported from `onyx.server.features.build.sandbox.base`). "Push" is a snapshot of the user's `mount_path`, so removing a skill = pushing the user's new file dict without that skill. There is no separate "unpush" call.
+Every mutation follows the same shape: validate → write to DB + FileStore → commit → compute affected users → resolve sandbox_ids via `get_sandbox_user_map` → build per-sandbox file sets → push via `push_to_sandboxes`. "Push" is a full snapshot of the user's `mount_path`, so removing a skill = pushing the user's new file dict without that skill.
 
-`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/skills/push.py`) returns the set of users with an active sandbox who should have this skill in their bundle — the uploader, plus all tenant users if `is_public`, plus members of granted groups. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
+`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/skills/push.py`) returns the set of users with an active sandbox who should have this skill in their bundle. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
 
 ### `POST /admin/skills/custom`
 
 ```python
 def create_custom_skill(...) -> CustomSkillSnapshot:
     bundle_bytes = bundle.file.read()
-    if len(bundle_bytes) > MAX_BUNDLE_BYTES:
-        raise OnyxError(OnyxErrorCode.INVALID_REQUEST, "Bundle exceeds size limit")
-
-    validate_custom_bundle(bundle_bytes, slug=slug)        # raises OnyxError on failure
+    validate_custom_bundle(bundle_bytes, slug=slug)    # checks size, format, reserved slugs
     sha = compute_bundle_sha256(bundle_bytes)
+    parsed_group_ids = json.loads(group_ids)
 
-    if slug in BuiltinSkillRegistry.instance().reserved_slugs():
-        raise OnyxError(OnyxErrorCode.INVALID_REQUEST, "Slug reserved by a built-in skill")
-
-    bundle_file_id = filestore.write(bundle_bytes)         # for persistence + cold start
+    bundle_file_id = filestore.write(bundle_bytes)
 
     skill = create_skill(
         slug=slug, name=name, description=description,
@@ -209,40 +235,38 @@ def create_custom_skill(...) -> CustomSkillSnapshot:
         is_public=is_public, author_user_id=user.id,
         db_session=db_session,
     )
-    if group_ids:
-        replace_skill_grants(skill.id, group_ids, db_session=db_session)
+    if parsed_group_ids:
+        replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
     db_session.commit()
 
-    affected = affected_users_for_skill(skill, db_session)
-    sandbox_ids = get_active_sandbox_ids_for_users([u.id for u in affected], db_session)
-    sandbox_files = {sid: build_skills_files_for_user(u, db_session) for sid, u in sandbox_ids.items()}
-    get_sandbox_manager().push_to_sandboxes(
-        mount_path="/workspace/managed/skills",
-        sandbox_files=sandbox_files,
-    )
-    return CustomSkillSnapshot.from_model(<refetch with grants>, include_grants=True)
+    _push_skill_to_affected_sandboxes(skill, db_session)
+    return CustomSkillSnapshot.from_model(skill, group_ids=parsed_group_ids)
 ```
 
 ### `PATCH /admin/skills/custom/{id}`
 
 ```python
 def patch_custom_skill(...) -> CustomSkillSnapshot:
-    before = fetch_skill_for_admin(skill_id, db_session)
-    before_affected = affected_users_for_skill(before, db_session)
+    domain_patch = patch.to_domain()
 
-    updated = patch_skill(skill_id, <translated patch>, db_session=db_session)
+    before = fetch_skill_for_admin(skill_id, db_session)
+    if before is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
+
+    # Reject slug change to a reserved built-in slug
+    if domain_patch.slug is not UNSET:
+        if domain_patch.slug in BuiltinSkillRegistry.instance().reserved_slugs():
+            raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Slug reserved by a built-in skill")
+
+    before_affected = affected_users_for_skill(before, db_session)
+    updated = patch_skill(skill_id, patch=domain_patch, db_session=db_session)
     db_session.commit()
 
     if visibility_or_enabled_changed(before, updated):
         after_affected = affected_users_for_skill(updated, db_session)
-        users = before_affected | after_affected
-        sandbox_ids = get_active_sandbox_ids_for_users([u.id for u in users], db_session)
-        sandbox_files = {sid: build_skills_files_for_user(u, db_session) for sid, u in sandbox_ids.items()}
-        get_sandbox_manager().push_to_sandboxes(
-            mount_path="/workspace/managed/skills",
-            sandbox_files=sandbox_files,
-        )
-    return CustomSkillSnapshot.from_model(updated, include_grants=True)
+        _push_skills_to_sandboxes(before_affected | after_affected, db_session)
+
+    return CustomSkillSnapshot.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
 ### `PUT /admin/skills/custom/{id}/bundle`
@@ -250,24 +274,20 @@ def patch_custom_skill(...) -> CustomSkillSnapshot:
 ```python
 def replace_custom_skill_bundle(...) -> CustomSkillSnapshot:
     bundle_bytes = bundle.file.read()
-    validate_custom_bundle(bundle_bytes, slug=<existing slug>)
+    skill = fetch_skill_for_admin(skill_id, db_session)
+    validate_custom_bundle(bundle_bytes, slug=skill.slug)
     sha = compute_bundle_sha256(bundle_bytes)
     new_file_id = filestore.write(bundle_bytes)
 
-    updated, _old_file_id = replace_skill_bundle(
+    updated, old_file_id = replace_skill_bundle(
         skill_id=skill_id, new_bundle_file_id=new_file_id,
         new_bundle_sha256=sha, db_session=db_session,
     )
     db_session.commit()
+    # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
-    affected = affected_users_for_skill(updated, db_session)
-    sandbox_ids = get_active_sandbox_ids_for_users([u.id for u in affected], db_session)
-    sandbox_files = {sid: build_skills_files_for_user(u, db_session) for sid, u in sandbox_ids.items()}
-    get_sandbox_manager().push_to_sandboxes(
-        mount_path="/workspace/managed/skills",
-        sandbox_files=sandbox_files,
-    )
-    return CustomSkillSnapshot.from_model(updated, include_grants=True)
+    _push_skill_to_affected_sandboxes(updated, db_session)
+    return CustomSkillSnapshot.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
 ### `PUT /admin/skills/custom/{id}/grants`
@@ -282,14 +302,9 @@ def replace_custom_skill_grants(...) -> CustomSkillSnapshot:
 
     updated = fetch_skill_for_admin(skill_id, db_session)
     after_affected = affected_users_for_skill(updated, db_session)
-    users = before_affected | after_affected   # gainers get the skill, losers get it removed
-    sandbox_ids = get_active_sandbox_ids_for_users([u.id for u in users], db_session)
-    sandbox_files = {sid: build_skills_files_for_user(u, db_session) for sid, u in sandbox_ids.items()}
-    get_sandbox_manager().push_to_sandboxes(
-        mount_path="/workspace/managed/skills",
-        sandbox_files=sandbox_files,
-    )
-    return CustomSkillSnapshot.from_model(updated, include_grants=True)
+    _push_skills_to_sandboxes(before_affected | after_affected, db_session)
+
+    return CustomSkillSnapshot.from_model(updated, group_ids=body.group_ids)
 ```
 
 ### `DELETE /admin/skills/custom/{id}`
@@ -301,22 +316,17 @@ def delete_custom_skill(...) -> None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
 
     affected = affected_users_for_skill(skill, db_session)
-    delete_skill(skill_id, db_session)
+    old_file_id = delete_skill(skill_id, db_session)
     db_session.commit()
+    # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
-    # Push each previously-affected user their new (skill-free) file dict.
-    sandbox_ids = get_active_sandbox_ids_for_users([u.id for u in affected], db_session)
-    sandbox_files = {sid: build_skills_files_for_user(u, db_session) for sid, u in sandbox_ids.items()}
-    get_sandbox_manager().push_to_sandboxes(
-        mount_path="/workspace/managed/skills",
-        sandbox_files=sandbox_files,
-    )
+    _push_skills_to_sandboxes(affected, db_session)
 ```
 
 ### `GET /skills` (user)
 
 ```python
-def list_skills_for_current_user(...) -> SkillsUserList:
+def list_skills_for_current_user(...) -> SkillsList:
     registry = BuiltinSkillRegistry.instance()
     builtins = [
         BuiltinSkillSnapshot(slug=b.slug, name=b.name, description=b.description,
@@ -324,15 +334,36 @@ def list_skills_for_current_user(...) -> SkillsUserList:
         for b in registry.list_available(db_session)
     ]
     customs = list_skills_for_user(user=user, db_session=db_session)
-    return SkillsUserList(
+    return SkillsList(
         builtins=builtins,
-        customs=[CustomSkillSnapshot.from_model(c, include_grants=False) for c in customs],
+        customs=[CustomSkillSnapshot.from_model(c, group_ids=[]) for c in customs],
     )
 ```
 
 ### `GET /admin/skills`
 
-Like the user list but returns **all** built-ins (with availability metadata) and **all** custom rows including disabled ones (via `list_skills_for_admin`) with grants populated.
+Like the user list but uses `registry.list_all()` (not `list_available`) and computes `is_available` / `unavailable_reason` per-skill by calling `skill.is_available(db_session)`. Custom skills returned via `list_skills_for_admin` include disabled ones. Group grants fetched per-skill.
+
+### Shared push helper
+
+```python
+def _push_skill_to_affected_sandboxes(skill: CustomSkill, db_session: Session) -> None:
+    affected = affected_users_for_skill(skill, db_session)
+    _push_skills_to_sandboxes(affected, db_session)
+
+def _push_skills_to_sandboxes(users: set[User], db_session: Session) -> None:
+    if not users:
+        return
+    sandbox_map = get_sandbox_user_map([u.id for u in users], db_session)
+    sandbox_files = {
+        sid: build_skills_files_for_user(user, db_session)
+        for sid, user in sandbox_map.items()
+    }
+    get_sandbox_manager().push_to_sandboxes(
+        mount_path="/workspace/managed/skills",
+        sandbox_files=sandbox_files,
+    )
+```
 
 ## 7. Router Registration
 
@@ -348,7 +379,7 @@ include_router_with_global_prefix_prepended(application, admin_skill_router)
 
 ## 8. Tests
 
-The default test type for this work is **integration**, since the value is the wire-level contract. Add unit tests only where logic is sufficiently tricky (e.g., the `CustomSkillPatch` → `UNSET` translation).
+The default test type for this work is **integration**, since the value is the wire-level contract. Add unit tests only where logic is sufficiently tricky.
 
 ### `SkillManager` (`backend/tests/integration/common_utils/managers/skill.py`)
 
@@ -358,8 +389,8 @@ Mirror the `PersonaManager` shape — static methods, real HTTP, returns `DATest
 - `replace_bundle(skill, bundle_bytes, user_performing_action) -> DATestSkill`
 - `replace_grants(skill, group_ids, user_performing_action) -> None`
 - `delete_custom(skill, user_performing_action) -> None`
-- `list_admin(user_performing_action) -> SkillsAdminList`
-- `list_for_user(user_performing_action) -> SkillsUserList`
+- `list_all(user_performing_action) -> SkillsList`
+- `list_for_user(user_performing_action) -> SkillsList`
 - `verify(skill, user_performing_action) -> bool`
 
 Add a small helper that builds a valid in-memory zip (with `SKILL.md` + frontmatter) for upload tests.
@@ -368,11 +399,13 @@ Add a small helper that builds a valid in-memory zip (with `SKILL.md` + frontmat
 Cover the admin happy paths plus the load-bearing error cases:
 - create → list → patch (slug, name, description, is_public, enabled) → replace bundle → delete.
 - duplicate slug → 4xx with `DUPLICATE_RESOURCE`.
-- slug clashing with a registered built-in → 4xx with `INVALID_REQUEST`.
+- slug clashing with a registered built-in → 4xx with `INVALID_INPUT`.
+- PATCH slug to a reserved built-in slug → 4xx with `INVALID_INPUT`.
 - bundle missing `SKILL.md` → 4xx.
 - bundle with a `.template` file → 4xx.
 - bundle over size limit → 4xx.
 - grants replace: empty list → no rows; non-empty list → exact rows present.
+- grants replace with non-existent group ID → 4xx (FK violation).
 - delete is idempotent (404 on second call is acceptable).
 
 ### `test_skills_user.py`
@@ -382,36 +415,36 @@ Cover the admin happy paths plus the load-bearing error cases:
 - Disabled skill never appears in user list.
 - Built-ins with `is_available=False` are absent from user list and present-with-reason in admin list.
 
-### Unit test (small)
-`CustomSkillPatch` translation to the `UNSET` sentinel preserves the difference between "not provided" and "set to null" (where applicable).
+### Unit tests
+- `SkillPatchRequest.to_domain()` correctly maps `model_fields_set` to `UNSET` — verifies that omitted fields produce `UNSET`, explicitly-sent fields (including `None` for nullable fields) produce their value.
 
 ## 9. Suggested Subagent Decomposition
 
-**Hard dependency**: this work depends on `SandboxManager` having `push_to_sandbox` / `push_to_sandboxes` methods landed (see sandbox-file-push.md workstream); can be stubbed for testing in the meantime. Under test, swap in a `SandboxManager` subclass that records `push_to_sandboxes` calls and asserts on the recorded calls.
+**Hard dependency**: this work depends on `SandboxManager` having `push_to_sandbox` / `push_to_sandboxes` methods landed (see sandbox-file-push.md workstream); can be stubbed for testing in the meantime.
 
 Stage 1 (sequential — establishes the contract):
-- **A. Models + skeleton router** — write `models.py`, `api.py` with route signatures returning `NotImplementedError`, and register them in `main.py`. Output: typecheck-clean skeleton.
+- **A. Models + skeleton router** — write `models.py`, `api.py` with route signatures returning `NotImplementedError`, and register them in `main.py`. Extend `CustomSkill` in `registry.py` with `author_user_id`, `created_at`, `updated_at`. Add `SkillPatch` dataclass to `db/skill.py`. Add `get_sandbox_user_map` to `db/sandbox.py`. Output: typecheck-clean skeleton.
 
 Stage 2 (parallel — independent feature slices, all consume Stage 1 output):
-- **B. Admin write endpoints** — `POST/PATCH/PUT/DELETE` on `/admin/skills/custom*`. Owns the create / patch / replace-bundle / grants / delete code paths. Owns `backend/onyx/skills/push.py` (`build_skills_files_for_user`, `affected_users_for_skill`, `push_to_pod`). Consumes — does **not** build — the `SandboxManager` push API; that's a separate parallel workstream (see `sandbox-file-push.md`).
-- **C. Read endpoints (admin + user)** — `GET /admin/skills` and `GET /skills`. Owns the built-in/custom merge logic and the `from_model` factories.
+- **B. Admin write endpoints** — `POST/PATCH/PUT/DELETE` on `/admin/skills/custom*`. Owns the create / patch / replace-bundle / grants / delete code paths. Owns `backend/onyx/skills/push.py` (`build_skills_files_for_user`, `affected_users_for_skill`, `push_to_pod`). Consumes the `SandboxManager` push API.
+- **C. Read endpoints (admin + user)** — `GET /admin/skills` and `GET /skills`. Owns the built-in/custom merge logic and the `from_model` factories. Must not import from `push.py`.
 - **D. Test scaffolding** — `SkillManager`, `DATestSkill`, the zip-builder helper, and the directory `backend/tests/integration/tests/skills/`. Stubs out one happy-path test per file to lock the manager API.
 
 Stage 3 (parallel — depends on B/C/D being landed):
 - **E. Admin test suite** — fills out `test_skills_admin.py` against the real B endpoints.
 - **F. User test suite** — fills out `test_skills_user.py`.
-- **G. Unit test for patch sentinel translation.**
-
-The Stage 1 skeleton is the synchronization point that lets Stages 2 and 3 run in parallel without merge churn. Each Stage-2 agent should be told which other files are off-limits to avoid stepping on each other.
+- **G. Unit test for `SkillPatchRequest.to_domain()` sentinel mapping.**
 
 ## 10. Conventions Checklist
 
 For any subagent touching this code:
 
-- Raise `OnyxError(OnyxErrorCode.*)` — never `HTTPException`, never raw status codes.
+- Raise `OnyxError(OnyxErrorCode.*)` — never `HTTPException`, never raw status codes. Use `INVALID_INPUT` (not `INVALID_REQUEST`, which doesn't exist) for validation errors.
 - Do **not** use `response_model=` on endpoint decorators; rely on return-type annotations.
 - DB ops live in `backend/onyx/db/skill.py` — endpoints must not run SQL directly.
 - Commit transactions at the endpoint boundary; DB-layer functions only flush.
-- `get_sandbox_manager().push_to_sandboxes(...)` runs **after** `db_session.commit()`. Push failures are logged inside `SandboxManager` and recorded in the returned `PushResult` (from `backend/onyx/server/features/build/sandbox/models.py`) — they don't surface as request errors, and the request still returns success on partial pod-level failure (the next mutation or cold-start hydration re-converges).
-- Strict typing — no `Any` unless unavoidable; same on the TS side if any client work follows.
+- `push_to_sandboxes` runs **after** `db_session.commit()`. Push failures are logged inside `SandboxManager` and recorded in the returned `PushResult` (from `backend/onyx/server/features/build/sandbox/models.py`) — they don't surface as request errors. The request returns success on partial pod-level failure (the next mutation or cold-start hydration re-converges). This latency is acceptable for V1; for large tenants with many active sandboxes, the synchronous fan-out could move to a background task in a future iteration.
+- `validate_custom_bundle` already checks reserved slugs, size limits, and bundle format. Don't duplicate these checks in the endpoint — let the validator be the single source of truth. The one exception is the PATCH endpoint, which must check reserved slugs for slug changes (the validator only runs on bundle uploads).
+- Capture `old_file_id` from `delete_skill` and `replace_skill_bundle` but do not delete inline. Orphan-blob cleanup is deferred to a periodic sweep.
+- Strict typing — no `Any` unless unavoidable.
 - Use existing fixtures (`admin_user`, `basic_user`, `reset`) for integration tests; don't construct users manually.

--- a/docs/craft/features/skills/skills-api-plan.md
+++ b/docs/craft/features/skills/skills-api-plan.md
@@ -20,6 +20,10 @@ Add `/admin/skills` (admin CRUD) and `/skills` (user read) HTTP endpoints, backe
 - `GET /skills/{slug_or_id}` single-skill endpoint (deferred unless a concrete UI need arises; DB layer has `fetch_skill_for_user` ready).
 - Front-end work.
 
+### Design decision: built-ins stay in-memory
+
+Built-in skills live in the `BuiltinSkillRegistry` singleton and are **not** seeded to the database. They are merged with DB-backed custom skills at query time in the list endpoints. This was decided because multi-tenant cloud (~20k tenants) makes DB seeding impractical — there is no "iterate all tenants on deploy" path. The in-memory registry is populated once at app boot and shared across tenants.
+
 ## 3. File Layout
 
 New files (all under `backend/onyx/server/features/skill/`):
@@ -39,7 +43,7 @@ backend/onyx/skills/push.py  # build_skills_files_for_user, push_to_pod
 Plus a new DB helper for sandbox-to-user resolution:
 
 ```
-backend/onyx/db/sandbox.py   # get_sandbox_user_map(user_ids, db_session) -> dict[UUID, User]
+backend/onyx/server/features/build/db/sandbox.py   # get_sandbox_user_map(user_ids, db_session) -> dict[UUID, User]
 ```
 
 `get_sandbox_user_map` queries the sandbox DB for active sandboxes belonging to the given users, returning `{sandbox_id: user}`. This is the caller's responsibility per the push API contract — `SandboxManager` has no DB access.
@@ -48,8 +52,7 @@ backend/onyx/db/sandbox.py   # get_sandbox_user_map(user_ids, db_session) -> dic
 
 Modified files:
 - `backend/onyx/main.py` — register the two routers.
-- `backend/onyx/skills/registry.py` — add `author_user_id`, `created_at`, `updated_at` fields to `CustomSkill`.
-- `backend/onyx/db/skill.py` — update `_custom_skill_from_model` to populate the new fields; refactor `patch_skill` to accept `SkillPatch`; add `affected_users_for_skill`.
+- `backend/onyx/db/skill.py` — refactor `patch_skill` to accept `SkillPatch`; add `affected_users_for_skill` and `get_group_ids_for_skill`.
 
 New test files:
 - `backend/tests/integration/common_utils/managers/skill.py` — `SkillManager`.
@@ -63,7 +66,10 @@ Keep them flat and explicit. No `response_model=` on endpoint decorators (per CL
 
 ### Response models
 
-Thin wrappers around the existing domain models in `backend/onyx/skills/registry.py`. The domain models (`Skill`, `BuiltinSkill`, `CustomSkill`) are the source of truth for field definitions. The response models handle two things the domain models can't: (1) `BuiltinSkill.is_available` is a `Callable` that can't serialize — the response evaluates it to a `bool`, and (2) `CustomSkill` doesn't carry group grants — the response adds `granted_group_ids`.
+Two-layer pattern: ORM model (or `BuiltinSkill`) -> Pydantic response. There is no intermediate domain model. This matches the Persona/Tool convention used throughout the codebase.
+
+- `BuiltinSkillResponse.from_skill(builtin, db_session)` converts an in-memory `BuiltinSkill` to a serializable response, evaluating the `is_available` callable to a `bool`.
+- `CustomSkillResponse.from_model(orm_skill, group_ids)` converts an ORM `Skill` object directly to a response, adding `granted_group_ids`. No intermediate `CustomSkill` domain class exists.
 
 ```python
 class BuiltinSkillResponse(BaseModel):
@@ -73,7 +79,7 @@ class BuiltinSkillResponse(BaseModel):
     name: str
     description: str
     is_available: bool
-    unavailable_reason: str | None
+    unavailable_reason: str | None = None
 
     @classmethod
     def from_skill(cls, skill: BuiltinSkill, db_session: Session) -> "BuiltinSkillResponse":
@@ -83,21 +89,36 @@ class BuiltinSkillResponse(BaseModel):
             unavailable_reason=skill.unavailable_reason,
         )
 
-class CustomSkillResponse(CustomSkill):
-    """Extends CustomSkill with granted_group_ids. Excludes bundle_file_id from serialization."""
-    bundle_file_id: str = Field(exclude=True)
+class CustomSkillResponse(BaseModel):
+    """Converts ORM Skill -> API response. Adds granted_group_ids."""
+    source: Literal["custom"] = "custom"
+    id: UUID
+    slug: str
+    name: str
+    description: str
+    is_public: bool
+    enabled: bool
+    author_user_id: UUID | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
 
     @classmethod
-    def from_skill(cls, skill: CustomSkill, group_ids: list[int]) -> "CustomSkillResponse":
-        return cls(**skill.model_dump(), granted_group_ids=group_ids)
+    def from_model(cls, skill: Skill, group_ids: list[int]) -> "CustomSkillResponse":
+        return cls(
+            id=skill.id, slug=skill.slug, name=skill.name,
+            description=skill.description, is_public=skill.is_public,
+            enabled=skill.enabled, author_user_id=skill.author_user_id,
+            created_at=skill.created_at, updated_at=skill.updated_at,
+            granted_group_ids=group_ids,
+        )
 
 class SkillsList(BaseModel):
     builtins: list[BuiltinSkillResponse]
     customs: list[CustomSkillResponse]
 ```
 
-`CustomSkillResponse` inherits all fields from `CustomSkill` (which inherits from `Skill`) — no field duplication. `bundle_file_id` is excluded from serialization via `Field(exclude=True)` on the response model.
+`CustomSkillResponse` is a standalone `BaseModel` — it reads fields directly from the ORM `Skill` object. `bundle_file_id` is simply not included in the response fields (no need for `Field(exclude=True)`).
 
 `BuiltinSkillResponse` can't extend `BuiltinSkill` because the `Callable` field and `source_dir`/`has_template` internals shouldn't leak. It duplicates the 4 base fields (`slug`, `name`, `description`, `source`) — acceptable for 4 fields.
 
@@ -138,9 +159,9 @@ The endpoint receives `SkillPatchRequest` (Pydantic, `None` = not sent), calls `
 
 The existing `patch_skill` function in `db/skill.py` currently takes individual keyword arguments. It should be refactored to accept a `SkillPatch` directly, keeping the DB layer's interface clean.
 
-### Notes on `CustomSkill` enrichment
+### Notes on ORM -> response conversion
 
-The DB layer's `CustomSkill` (in `backend/onyx/skills/registry.py`) currently lacks `author_user_id`, `created_at`, and `updated_at`. The `_custom_skill_from_model` helper in `db/skill.py` must be extended to populate these from the ORM `Skill` model. Group grant IDs are not on `CustomSkill` — they're fetched separately via the `skill.groups` ORM relationship. `from_model` takes `CustomSkill` + a pre-fetched `group_ids` list.
+The DB layer returns ORM `Skill` objects directly — there is no intermediate `CustomSkill` domain class. `CustomSkillResponse.from_model(orm_skill, group_ids)` reads all needed fields (`id`, `slug`, `name`, `description`, `is_public`, `enabled`, `author_user_id`, `created_at`, `updated_at`) from the ORM object. Group grant IDs are fetched separately via `get_group_ids_for_skill(skill_id, db_session)` in `db/skill.py` and passed in.
 
 Listing is non-paginated in V1 (skill counts will be tiny). If/when needed, add `PaginatedReturn[CustomSkillResponse]` per the persona pattern.
 
@@ -222,7 +243,7 @@ def list_skills_for_current_user(
 
 Every mutation follows the same shape: validate → write to DB + FileStore → commit → compute affected users → resolve sandbox_ids via `get_sandbox_user_map` → build per-sandbox file sets → push via `push_to_sandboxes`. "Push" is a full snapshot of the user's `mount_path`, so removing a skill = pushing the user's new file dict without that skill.
 
-`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/db/skill.py` — it queries users and user-group relationships, which per CLAUDE.md must live under `backend/onyx/db/`) returns the set of users with an active sandbox who should have this skill in their bundle. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
+`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/db/skill.py` — it queries users and user-group relationships, which per CLAUDE.md must live under `backend/onyx/db/`) returns the set of user IDs (`set[UUID]`) with an active sandbox who should have this skill in their bundle. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
 
 ### `POST /admin/skills/custom`
 
@@ -249,7 +270,7 @@ def create_custom_skill(...) -> CustomSkillResponse:
     db_session.commit()
 
     _push_skill_to_affected_sandboxes(skill, db_session)
-    return CustomSkillResponse.from_skill(skill, group_ids=parsed_group_ids)
+    return CustomSkillResponse.from_model(skill, group_ids=parsed_group_ids)
 ```
 
 ### `PATCH /admin/skills/custom/{id}`
@@ -277,13 +298,13 @@ def patch_custom_skill(...) -> CustomSkillResponse:
         after_affected = affected_users_for_skill(updated, db_session)
         _push_skills_to_sandboxes(before_affected | after_affected, db_session)
 
-    return CustomSkillResponse.from_skill(updated, group_ids=_get_group_ids(skill_id, db_session))
+    return CustomSkillResponse.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
 `_visibility_changed` is a local helper in `api.py`:
 
 ```python
-def _visibility_changed(before: CustomSkill, after: CustomSkill) -> bool:
+def _visibility_changed(before: Skill, after: Skill) -> bool:
     return (before.is_public != after.is_public
             or before.enabled != after.enabled
             or before.slug != after.slug)
@@ -307,7 +328,7 @@ def replace_custom_skill_bundle(...) -> CustomSkillResponse:
     # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
     _push_skill_to_affected_sandboxes(updated, db_session)
-    return CustomSkillResponse.from_skill(updated, group_ids=_get_group_ids(skill_id, db_session))
+    return CustomSkillResponse.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
 ### `PUT /admin/skills/custom/{id}/grants`
@@ -324,7 +345,7 @@ def replace_custom_skill_grants(...) -> CustomSkillResponse:
     after_affected = affected_users_for_skill(updated, db_session)
     _push_skills_to_sandboxes(before_affected | after_affected, db_session)
 
-    return CustomSkillResponse.from_skill(updated, group_ids=body.group_ids)
+    return CustomSkillResponse.from_model(updated, group_ids=body.group_ids)
 ```
 
 ### `DELETE /admin/skills/custom/{id}`
@@ -356,7 +377,7 @@ def list_skills_for_current_user(...) -> SkillsList:
     return SkillsList(
         builtins=builtins,
         # Users don't see grant details — group_ids always empty in user view
-        customs=[CustomSkillResponse.from_skill(c, group_ids=[]) for c in customs],
+        customs=[CustomSkillResponse.from_model(c, group_ids=[]) for c in customs],
     )
 ```
 
@@ -375,7 +396,7 @@ def list_skills_admin(...) -> SkillsList:
     return SkillsList(
         builtins=builtins,
         customs=[
-            CustomSkillResponse.from_skill(c, group_ids=_get_group_ids(c.id, db_session))
+            CustomSkillResponse.from_model(c, group_ids=_get_group_ids(c.id, db_session))
             for c in customs
         ],
     )
@@ -384,7 +405,7 @@ def list_skills_admin(...) -> SkillsList:
 ### Shared push helper
 
 ```python
-def _push_skill_to_affected_sandboxes(skill: CustomSkill, db_session: Session) -> None:
+def _push_skill_to_affected_sandboxes(skill: Skill, db_session: Session) -> None:
     affected = affected_users_for_skill(skill, db_session)
     _push_skills_to_sandboxes(affected, db_session)
 
@@ -460,7 +481,7 @@ Cover the admin happy paths plus the load-bearing error cases:
 **Hard dependency**: this work depends on `SandboxManager` having `push_to_sandbox` / `push_to_sandboxes` methods landed (see sandbox-file-push.md workstream); can be stubbed for testing in the meantime.
 
 Stage 1 (sequential — establishes the contract):
-- **A. Models + skeleton router** — write `models.py`, `api.py` with route signatures returning `NotImplementedError`, and register them in `main.py`. Extend `CustomSkill` in `registry.py` with `author_user_id`, `created_at`, `updated_at`. Add `SkillPatch` dataclass to `db/skill.py`. Add `get_sandbox_user_map` to `db/sandbox.py`. Output: typecheck-clean skeleton.
+- **A. Models + skeleton router** — write `models.py`, `api.py` with route signatures returning `NotImplementedError`, and register them in `main.py`. Add `SkillPatch` dataclass to `db/skill.py`. Add `get_sandbox_user_map` to `backend/onyx/server/features/build/db/sandbox.py`. Output: typecheck-clean skeleton.
 
 Stage 2 (parallel — independent feature slices, all consume Stage 1 output):
 - **B. Admin write endpoints** — `POST/PATCH/PUT/DELETE` on `/admin/skills/custom*`. Owns the create / patch / replace-bundle / grants / delete code paths. Owns `backend/onyx/skills/push.py` (`build_skills_files_for_user`, `push_to_pod`) and `affected_users_for_skill` in `backend/onyx/db/skill.py`. Consumes the `SandboxManager` push API.

--- a/docs/craft/features/skills/skills-api-plan.md
+++ b/docs/craft/features/skills/skills-api-plan.md
@@ -33,7 +33,7 @@ backend/onyx/server/features/skill/
 Plus the skills-side push helpers, co-located with the skills module:
 
 ```
-backend/onyx/skills/push.py  # build_skills_files_for_user, push_to_pod, affected_users_for_skill
+backend/onyx/skills/push.py  # build_skills_files_for_user, push_to_pod
 ```
 
 Plus a new DB helper for sandbox-to-user resolution:
@@ -48,7 +48,8 @@ backend/onyx/db/sandbox.py   # get_sandbox_user_map(user_ids, db_session) -> dic
 
 Modified files:
 - `backend/onyx/main.py` — register the two routers.
-- `backend/onyx/db/skill.py` — extend `CustomSkill` with `author_user_id`, `created_at`, `updated_at` (see §4 notes).
+- `backend/onyx/skills/registry.py` — add `author_user_id`, `created_at`, `updated_at` fields to `CustomSkill`.
+- `backend/onyx/db/skill.py` — update `_custom_skill_from_model` to populate the new fields; refactor `patch_skill` to accept `SkillPatch`; add `affected_users_for_skill`.
 
 New test files:
 - `backend/tests/integration/common_utils/managers/skill.py` — `SkillManager`.
@@ -62,42 +63,43 @@ Keep them flat and explicit. No `response_model=` on endpoint decorators (per CL
 
 ### Response models
 
-```python
-class SkillSource(str, Enum):
-    BUILTIN = "builtin"
-    CUSTOM = "custom"
+Thin wrappers around the existing domain models in `backend/onyx/skills/registry.py`. The domain models (`Skill`, `BuiltinSkill`, `CustomSkill`) are the source of truth for field definitions. The response models handle two things the domain models can't: (1) `BuiltinSkill.is_available` is a `Callable` that can't serialize — the response evaluates it to a `bool`, and (2) `CustomSkill` doesn't carry group grants — the response adds `granted_group_ids`.
 
-class SkillSnapshot(BaseModel):
-    source: SkillSource
+```python
+class BuiltinSkillResponse(BaseModel):
+    """Thin wrapper — evaluates the is_available callable to a bool."""
+    source: Literal["builtin"] = "builtin"
     slug: str
     name: str
     description: str
-
-class BuiltinSkillSnapshot(SkillSnapshot):
-    source: Literal[SkillSource.BUILTIN] = SkillSource.BUILTIN
     is_available: bool
     unavailable_reason: str | None
 
-class CustomSkillSnapshot(SkillSnapshot):
-    source: Literal[SkillSource.CUSTOM] = SkillSource.CUSTOM
-    id: UUID
-    is_public: bool
-    enabled: bool
-    bundle_sha256: str
-    author_user_id: UUID | None
-    granted_group_ids: list[int]   # admin view; empty for user view
-    created_at: datetime
-    updated_at: datetime
+    @classmethod
+    def from_skill(cls, skill: BuiltinSkill, db_session: Session) -> "BuiltinSkillResponse":
+        return cls(
+            slug=skill.slug, name=skill.name, description=skill.description,
+            is_available=skill.is_available(db_session),
+            unavailable_reason=skill.unavailable_reason,
+        )
+
+class CustomSkillResponse(CustomSkill):
+    """Extends CustomSkill with granted_group_ids. Excludes bundle_file_id from serialization."""
+    bundle_file_id: str = Field(exclude=True)
+    granted_group_ids: list[int] = []
 
     @classmethod
-    def from_model(
-        cls, skill: CustomSkill, group_ids: list[int],
-    ) -> "CustomSkillSnapshot": ...
+    def from_skill(cls, skill: CustomSkill, group_ids: list[int]) -> "CustomSkillResponse":
+        return cls(**skill.model_dump(), granted_group_ids=group_ids)
 
 class SkillsList(BaseModel):
-    builtins: list[BuiltinSkillSnapshot]
-    customs: list[CustomSkillSnapshot]
+    builtins: list[BuiltinSkillResponse]
+    customs: list[CustomSkillResponse]
 ```
+
+`CustomSkillResponse` inherits all fields from `CustomSkill` (which inherits from `Skill`) — no field duplication. `bundle_file_id` is excluded from serialization via `Field(exclude=True)` on the response model.
+
+`BuiltinSkillResponse` can't extend `BuiltinSkill` because the `Callable` field and `source_dir`/`has_template` internals shouldn't leak. It duplicates the 4 base fields (`slug`, `name`, `description`, `source`) — acceptable for 4 fields.
 
 ### Request models
 
@@ -125,20 +127,22 @@ Lives in `backend/onyx/db/skill.py` alongside the existing `UNSET` sentinel:
 ```python
 @dataclass(frozen=True, kw_only=True)
 class SkillPatch:
-    slug: str | Unset = UNSET
-    name: str | Unset = UNSET
-    description: str | Unset = UNSET
-    is_public: bool | Unset = UNSET
-    enabled: bool | Unset = UNSET
+    slug: str | UnsetType = UNSET
+    name: str | UnsetType = UNSET
+    description: str | UnsetType = UNSET
+    is_public: bool | UnsetType = UNSET
+    enabled: bool | UnsetType = UNSET
 ```
 
 The endpoint receives `SkillPatchRequest` (Pydantic, `None` = not sent), calls `to_domain()` which uses `model_fields_set` to distinguish "sent" from "not sent", producing a `SkillPatch` (frozen dataclass, `UNSET` = not sent). `patch_skill` in the DB layer receives `SkillPatch` directly — no translation at the boundary.
+
+The existing `patch_skill` function in `db/skill.py` currently takes individual keyword arguments. It should be refactored to accept a `SkillPatch` directly, keeping the DB layer's interface clean.
 
 ### Notes on `CustomSkill` enrichment
 
 The DB layer's `CustomSkill` (in `backend/onyx/skills/registry.py`) currently lacks `author_user_id`, `created_at`, and `updated_at`. The `_custom_skill_from_model` helper in `db/skill.py` must be extended to populate these from the ORM `Skill` model. Group grant IDs are not on `CustomSkill` — they're fetched separately via the `skill.groups` ORM relationship. `from_model` takes `CustomSkill` + a pre-fetched `group_ids` list.
 
-Listing is non-paginated in V1 (skill counts will be tiny). If/when needed, add `PaginatedReturn[CustomSkillSnapshot]` per the persona pattern.
+Listing is non-paginated in V1 (skill counts will be tiny). If/when needed, add `PaginatedReturn[CustomSkillResponse]` per the persona pattern.
 
 ## 5. Routes (`api.py`)
 
@@ -166,7 +170,7 @@ def create_custom_skill(
     bundle: UploadFile = File(...),
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> CustomSkillSnapshot: ...
+) -> CustomSkillResponse: ...
 
 @admin_router.patch("/custom/{skill_id}")
 def patch_custom_skill(
@@ -174,7 +178,7 @@ def patch_custom_skill(
     patch: SkillPatchRequest,
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> CustomSkillSnapshot: ...
+) -> CustomSkillResponse: ...
 
 @admin_router.put("/custom/{skill_id}/bundle")
 def replace_custom_skill_bundle(
@@ -182,7 +186,7 @@ def replace_custom_skill_bundle(
     bundle: UploadFile = File(...),
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> CustomSkillSnapshot: ...
+) -> CustomSkillResponse: ...
 
 @admin_router.put("/custom/{skill_id}/grants")
 def replace_custom_skill_grants(
@@ -190,7 +194,7 @@ def replace_custom_skill_grants(
     body: GrantsReplace,
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
-) -> CustomSkillSnapshot: ...
+) -> CustomSkillResponse: ...
 
 @admin_router.delete("/custom/{skill_id}")
 def delete_custom_skill(
@@ -201,6 +205,8 @@ def delete_custom_skill(
 ```
 
 Note: `group_ids` in the create endpoint is a JSON-encoded string (`"[1, 2, 3]"`) parsed server-side, avoiding FastAPI's awkward repeated-form-field semantics for list-typed `Form()` params.
+
+Note: create uses multipart (bundle file upload requires it); patch and grants use JSON bodies.
 
 ### User endpoints
 
@@ -216,16 +222,19 @@ def list_skills_for_current_user(
 
 Every mutation follows the same shape: validate → write to DB + FileStore → commit → compute affected users → resolve sandbox_ids via `get_sandbox_user_map` → build per-sandbox file sets → push via `push_to_sandboxes`. "Push" is a full snapshot of the user's `mount_path`, so removing a skill = pushing the user's new file dict without that skill.
 
-`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/skills/push.py`) returns the set of users with an active sandbox who should have this skill in their bundle. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
+`affected_users_for_skill(skill, db_session)` (helper in `backend/onyx/db/skill.py` — it queries users and user-group relationships, which per CLAUDE.md must live under `backend/onyx/db/`) returns the set of users with an active sandbox who should have this skill in their bundle. For visibility/grant transitions, the caller takes the union of the before-and-after sets so users who lost access also get re-pushed (without the skill).
 
 ### `POST /admin/skills/custom`
 
 ```python
-def create_custom_skill(...) -> CustomSkillSnapshot:
+def create_custom_skill(...) -> CustomSkillResponse:
     bundle_bytes = bundle.file.read()
     validate_custom_bundle(bundle_bytes, slug=slug)    # checks size, format, reserved slugs
     sha = compute_bundle_sha256(bundle_bytes)
-    parsed_group_ids = json.loads(group_ids)
+    try:
+        parsed_group_ids: list[int] = json.loads(group_ids)
+    except (json.JSONDecodeError, TypeError):
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "group_ids must be a JSON array of integers")
 
     bundle_file_id = filestore.write(bundle_bytes)
 
@@ -240,13 +249,15 @@ def create_custom_skill(...) -> CustomSkillSnapshot:
     db_session.commit()
 
     _push_skill_to_affected_sandboxes(skill, db_session)
-    return CustomSkillSnapshot.from_model(skill, group_ids=parsed_group_ids)
+    return CustomSkillResponse.from_skill(skill, group_ids=parsed_group_ids)
 ```
 
 ### `PATCH /admin/skills/custom/{id}`
 
+PATCH is the one mutation that conditionally pushes — only when visibility or enabled status changed. Slug/name/description changes don't affect which users see the skill, so no push is needed.
+
 ```python
-def patch_custom_skill(...) -> CustomSkillSnapshot:
+def patch_custom_skill(...) -> CustomSkillResponse:
     domain_patch = patch.to_domain()
 
     before = fetch_skill_for_admin(skill_id, db_session)
@@ -262,17 +273,26 @@ def patch_custom_skill(...) -> CustomSkillSnapshot:
     updated = patch_skill(skill_id, patch=domain_patch, db_session=db_session)
     db_session.commit()
 
-    if visibility_or_enabled_changed(before, updated):
+    if _visibility_changed(before, updated):
         after_affected = affected_users_for_skill(updated, db_session)
         _push_skills_to_sandboxes(before_affected | after_affected, db_session)
 
-    return CustomSkillSnapshot.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
+    return CustomSkillResponse.from_skill(updated, group_ids=_get_group_ids(skill_id, db_session))
+```
+
+`_visibility_changed` is a local helper in `api.py`:
+
+```python
+def _visibility_changed(before: CustomSkill, after: CustomSkill) -> bool:
+    return (before.is_public != after.is_public
+            or before.enabled != after.enabled
+            or before.slug != after.slug)
 ```
 
 ### `PUT /admin/skills/custom/{id}/bundle`
 
 ```python
-def replace_custom_skill_bundle(...) -> CustomSkillSnapshot:
+def replace_custom_skill_bundle(...) -> CustomSkillResponse:
     bundle_bytes = bundle.file.read()
     skill = fetch_skill_for_admin(skill_id, db_session)
     validate_custom_bundle(bundle_bytes, slug=skill.slug)
@@ -287,13 +307,13 @@ def replace_custom_skill_bundle(...) -> CustomSkillSnapshot:
     # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
     _push_skill_to_affected_sandboxes(updated, db_session)
-    return CustomSkillSnapshot.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
+    return CustomSkillResponse.from_skill(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
 ### `PUT /admin/skills/custom/{id}/grants`
 
 ```python
-def replace_custom_skill_grants(...) -> CustomSkillSnapshot:
+def replace_custom_skill_grants(...) -> CustomSkillResponse:
     before = fetch_skill_for_admin(skill_id, db_session)
     before_affected = affected_users_for_skill(before, db_session)
 
@@ -304,7 +324,7 @@ def replace_custom_skill_grants(...) -> CustomSkillSnapshot:
     after_affected = affected_users_for_skill(updated, db_session)
     _push_skills_to_sandboxes(before_affected | after_affected, db_session)
 
-    return CustomSkillSnapshot.from_model(updated, group_ids=body.group_ids)
+    return CustomSkillResponse.from_skill(updated, group_ids=body.group_ids)
 ```
 
 ### `DELETE /admin/skills/custom/{id}`
@@ -329,20 +349,37 @@ def delete_custom_skill(...) -> None:
 def list_skills_for_current_user(...) -> SkillsList:
     registry = BuiltinSkillRegistry.instance()
     builtins = [
-        BuiltinSkillSnapshot(slug=b.slug, name=b.name, description=b.description,
-                             is_available=True, unavailable_reason=None)
+        BuiltinSkillResponse.from_skill(b, db_session)
         for b in registry.list_available(db_session)
     ]
     customs = list_skills_for_user(user=user, db_session=db_session)
     return SkillsList(
         builtins=builtins,
-        customs=[CustomSkillSnapshot.from_model(c, group_ids=[]) for c in customs],
+        # Users don't see grant details — group_ids always empty in user view
+        customs=[CustomSkillResponse.from_skill(c, group_ids=[]) for c in customs],
     )
 ```
 
 ### `GET /admin/skills`
 
 Like the user list but uses `registry.list_all()` (not `list_available`) and computes `is_available` / `unavailable_reason` per-skill by calling `skill.is_available(db_session)`. Custom skills returned via `list_skills_for_admin` include disabled ones. Group grants fetched per-skill.
+
+```python
+def list_skills_admin(...) -> SkillsList:
+    registry = BuiltinSkillRegistry.instance()
+    builtins = [
+        BuiltinSkillResponse.from_skill(b, db_session)
+        for b in registry.list_all()
+    ]
+    customs = list_skills_for_admin(db_session=db_session)
+    return SkillsList(
+        builtins=builtins,
+        customs=[
+            CustomSkillResponse.from_skill(c, group_ids=_get_group_ids(c.id, db_session))
+            for c in customs
+        ],
+    )
+```
 
 ### Shared push helper
 
@@ -426,7 +463,7 @@ Stage 1 (sequential — establishes the contract):
 - **A. Models + skeleton router** — write `models.py`, `api.py` with route signatures returning `NotImplementedError`, and register them in `main.py`. Extend `CustomSkill` in `registry.py` with `author_user_id`, `created_at`, `updated_at`. Add `SkillPatch` dataclass to `db/skill.py`. Add `get_sandbox_user_map` to `db/sandbox.py`. Output: typecheck-clean skeleton.
 
 Stage 2 (parallel — independent feature slices, all consume Stage 1 output):
-- **B. Admin write endpoints** — `POST/PATCH/PUT/DELETE` on `/admin/skills/custom*`. Owns the create / patch / replace-bundle / grants / delete code paths. Owns `backend/onyx/skills/push.py` (`build_skills_files_for_user`, `affected_users_for_skill`, `push_to_pod`). Consumes the `SandboxManager` push API.
+- **B. Admin write endpoints** — `POST/PATCH/PUT/DELETE` on `/admin/skills/custom*`. Owns the create / patch / replace-bundle / grants / delete code paths. Owns `backend/onyx/skills/push.py` (`build_skills_files_for_user`, `push_to_pod`) and `affected_users_for_skill` in `backend/onyx/db/skill.py`. Consumes the `SandboxManager` push API.
 - **C. Read endpoints (admin + user)** — `GET /admin/skills` and `GET /skills`. Owns the built-in/custom merge logic and the `from_model` factories. Must not import from `push.py`.
 - **D. Test scaffolding** — `SkillManager`, `DATestSkill`, the zip-builder helper, and the directory `backend/tests/integration/tests/skills/`. Stubs out one happy-path test per file to lock the manager API.
 

--- a/docs/craft/features/skills/skills-api-plan.md
+++ b/docs/craft/features/skills/skills-api-plan.md
@@ -15,7 +15,7 @@ Add `/admin/skills` (admin CRUD) and `/skills` (user read) HTTP endpoints, backe
 - Extending `SandboxManager` with the push API and per-backend `write_files_to_sandbox` implementation (separate workstream — see `sandbox-file-push.md`).
 - Built-in skill source files / registrations (registry exists; registering specific built-ins is a separate workstream).
 - Cold-start hydration plumbing in `setup_session_workspace` (owned by the push-primitive workstream).
-- Orphan-blob sweep job (delete/replace endpoints capture the old `bundle_file_id` but do not delete it inline — deferred to a periodic cleanup task).
+- ~~Orphan-blob sweep job~~ — resolved: delete/replace endpoints now clean up old blobs inline via `_delete_old_bundle` (best-effort, logs on failure).
 - Built-in availability flip push triggers (built-in availability is a function of external state, not an API mutation; sandboxes re-converge on next session start/wakeup).
 - `GET /skills/{slug_or_id}` single-skill endpoint (deferred unless a concrete UI need arises; DB layer has `fetch_skill_for_user` ready).
 - Front-end work.
@@ -325,9 +325,9 @@ def replace_custom_skill_bundle(...) -> CustomSkillResponse:
         new_bundle_sha256=sha, db_session=db_session,
     )
     db_session.commit()
-    # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
     _push_skill_to_affected_sandboxes(updated, db_session)
+    _delete_old_bundle(file_store, old_file_id)
     return CustomSkillResponse.from_model(updated, group_ids=_get_group_ids(skill_id, db_session))
 ```
 
@@ -359,9 +359,10 @@ def delete_custom_skill(...) -> None:
     affected = affected_users_for_skill(skill, db_session)
     old_file_id = delete_skill(skill_id, db_session)
     db_session.commit()
-    # old_file_id captured but not deleted inline (deferred to orphan-blob sweep)
 
     _push_skills_to_sandboxes(affected, db_session)
+    if old_file_id is not None:
+        _delete_old_bundle(get_default_file_store(), old_file_id)
 ```
 
 ### `GET /skills` (user)
@@ -502,7 +503,7 @@ For any subagent touching this code:
 - DB ops live in `backend/onyx/db/skill.py` — endpoints must not run SQL directly.
 - Commit transactions at the endpoint boundary; DB-layer functions only flush.
 - `push_to_sandboxes` runs **after** `db_session.commit()`. Push failures are logged inside `SandboxManager` and recorded in the returned `PushResult` (from `backend/onyx/server/features/build/sandbox/models.py`) — they don't surface as request errors. The request returns success on partial pod-level failure (the next mutation or cold-start hydration re-converges). This latency is acceptable for V1; for large tenants with many active sandboxes, the synchronous fan-out could move to a background task in a future iteration.
-- `validate_custom_bundle` already checks reserved slugs, size limits, and bundle format. Don't duplicate these checks in the endpoint — let the validator be the single source of truth. The one exception is the PATCH endpoint, which must check reserved slugs for slug changes (the validator only runs on bundle uploads).
-- Capture `old_file_id` from `delete_skill` and `replace_skill_bundle` but do not delete inline. Orphan-blob cleanup is deferred to a periodic sweep.
+- `validate_custom_bundle` already checks reserved slugs, size limits, and bundle format. Don't duplicate these checks in the endpoint — let the validator be the single source of truth. The PATCH endpoint additionally validates slug format via `check_slug()` and checks reserved slugs (the validator only runs on bundle uploads).
+- Old bundle blobs are deleted inline via `_delete_old_bundle` (best-effort with warning log on failure) after commit + push. No periodic sweep needed.
 - Strict typing — no `Any` unless unavoidable.
 - Use existing fixtures (`admin_user`, `basic_user`, `reset`) for integration tests; don't construct users manually.

--- a/docs/craft/features/skills/skills-db-layer-status.md
+++ b/docs/craft/features/skills/skills-db-layer-status.md
@@ -43,17 +43,21 @@ No direct user-grant table exists (deferred).
 All functions flush but do **not** commit; callers control transaction boundaries.
 
 ### Reads
-- `list_skills_for_user(user, db_session) -> Sequence[CustomSkill]` — visibility-filtered, `enabled=True` only.
-- `fetch_skill_for_user(skill_id, user, db_session) -> CustomSkill | None`
-- `list_skills_for_admin(db_session) -> Sequence[CustomSkill]` — unrestricted.
-- `fetch_skill_for_admin(skill_id, db_session) -> CustomSkill | None` — includes disabled skills.
+- `list_skills_for_user(user, db_session) -> Sequence[Skill]` — visibility-filtered, `enabled=True` only.
+- `fetch_skill_for_user(skill_id, user, db_session) -> Skill | None`
+- `list_skills_for_admin(db_session) -> Sequence[Skill]` — unrestricted.
+- `fetch_skill_for_admin(skill_id, db_session) -> Skill | None` — includes disabled skills.
+- `get_group_ids_for_skill(skill_id, db_session) -> list[int]` — returns granted group IDs for a skill.
 
 ### Writes
-- `create_skill(slug, name, description, bundle_file_id, bundle_sha256, is_public, author_user_id, db_session) -> CustomSkill` — pre-checks slug, converts `IntegrityError` into `OnyxError(DUPLICATE_RESOURCE)`.
-- `patch_skill(skill_id, slug=UNSET, name=UNSET, description=UNSET, is_public=UNSET, enabled=UNSET, db_session) -> CustomSkill` — uses an `UNSET` sentinel so `None` is distinguishable from "not provided".
-- `replace_skill_bundle(skill_id, new_bundle_file_id, new_bundle_sha256, db_session) -> tuple[CustomSkill, old_bundle_file_id]` — caller deletes the old blob after commit.
+- `create_skill(slug, name, description, bundle_file_id, bundle_sha256, is_public, author_user_id, db_session) -> Skill` — pre-checks slug, converts `IntegrityError` into `OnyxError(DUPLICATE_RESOURCE)`.
+- `patch_skill(skill_id, patch=SkillPatch, db_session) -> Skill` — accepts a `SkillPatch` frozen dataclass; uses `UNSET` sentinels so `None` is distinguishable from "not provided".
+- `replace_skill_bundle(skill_id, new_bundle_file_id, new_bundle_sha256, db_session) -> tuple[Skill, old_bundle_file_id]` — caller deletes the old blob after commit.
 - `replace_skill_grants(skill_id, group_ids, db_session) -> None` — atomic delete-and-insert; deduplicates.
 - `delete_skill(skill_id, db_session) -> str | None` — hard-delete; returns `bundle_file_id` for post-commit blob cleanup; idempotent.
+
+### Affected users
+- `affected_users_for_skill(skill, db_session) -> set[UUID]` — returns user IDs with an active sandbox who should have this skill.
 
 ### Visibility filter
 `_add_user_visibility_filter()` enforces `is_public OR user is in a granted group`, mirroring the persona visibility pattern.
@@ -63,10 +67,10 @@ All functions flush but do **not** commit; callers control transaction boundarie
 In-memory, process-wide singleton populated at app boot. Not DB-backed (built-ins are code artifacts).
 
 Key types:
-- `Skill` — shared metadata base (`slug`, `name`, `description`).
-- `BuiltinSkill` — adds `source = "builtin"`, `source_dir: Path`, `has_template: bool`, `is_available: Callable[[Session], bool]`, `unavailable_reason: str | None`.
-- `CustomSkill` — adds `source = "custom"`, `id`, `bundle_file_id`, `bundle_sha256`, `is_public`, `enabled`. Returned by the CRUD module.
+- `BuiltinSkill` — standalone `BaseModel` with `source = "builtin"`, `slug`, `name`, `description`, `source_dir: Path`, `has_template: bool`, `is_available: Callable[[Session], bool]`, `unavailable_reason: str | None`. Has its own slug validator.
 - `BuiltinSkillRegistry` — `register()`, `list_all()`, `list_available(db)`, `get(slug)`, `reserved_slugs()`, plus `_reset_for_testing()`.
+
+There is no `Skill` base class or `CustomSkill` domain model in the registry. Custom skills are represented solely by the ORM `Skill` model (in `db/models.py`) and the `CustomSkillResponse` Pydantic model (in `server/features/skill/models.py`). The DB CRUD module returns ORM `Skill` objects directly.
 
 `register()` parses YAML frontmatter from `SKILL.md` or `SKILL.md.template` to populate `name` and `description`. Slug regex enforced; duplicate registration raises.
 


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the Skills API (admin CRUD and user read) with end-to-end push of skill bundles to running sandboxes, and standardizes sandbox IDs to UUIDs across push interfaces. Built-ins are served from the in‑memory registry; custom skills are DB-backed with grants and are pushed/unpushed on changes.

- New Features
  - Added `GET /admin/skills`, `POST /admin/skills/custom`, `PATCH /admin/skills/custom/{id}`, `PUT /admin/skills/custom/{id}/bundle`, `PUT /admin/skills/custom/{id}/grants`, `DELETE /admin/skills/custom/{id}`, and `GET /skills` in `backend/onyx/server/features/skill/api.py`.
  - New response/request models in `backend/onyx/server/features/skill/models.py` (`BuiltinSkillResponse`, `CustomSkillResponse`, `SkillsList`, `SkillPatchRequest`, `GrantsReplace`).
  - Push pipeline in `onyx/skills/push.py`: builds per-user FileSets by unzipping bundles into `{slug}/...`, and pushes after commits via `push_to_sandbox`/`push_to_sandboxes`.
  - Visibility propagation: computes affected users with `affected_user_ids_for_skill` and re-pushes on enable/disable, slug changes, grants, and bundle updates.
  - Robust file handling: validates uploads, computes SHA256, stores via FileStore, and deletes old blobs after successful commit; cleans up newly uploaded blobs on failure.

- Refactors
  - Switched sandbox IDs from `str` to `UUID` across `SandboxManager` methods, models, and docs (`sandbox_id: UUID`; `PushFailure.sandbox_id: UUID`).
  - DB layer (`onyx/db/skill.py`): return ORM `Skill` objects; added `SkillPatch` dataclass and `patch_skill(skill_id, patch=...)`; added `get_group_ids_for_skill` and `affected_user_ids_for_skill`; improved error mapping with `is_unique_violation` and new `is_fk_violation`.
  - Sandbox DB helper `get_sandbox_user_map(user_ids, db_session)` to resolve `{sandbox_id: user}` for active sandboxes.
  - Bundle helpers: exposed `check_slug`; validator remains the single source of truth for size/format/reserved slug checks.
  - Registered routers in `main.py`; added comprehensive integration tests for admin/user flows and unit tests for patch sentinel mapping and push orchestration; updated docs under `docs/craft/features/*`.

<sup>Written for commit f2ab0dd51b44971b0951da47b7291611dce07e51. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

