### PR TITLE
feat(enterprise-settings): add custom help link and hide-branding toggle

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -137,8 +137,8 @@ def admin_ee_put_settings(
     # writes to those fields when tier < ENTERPRISE so the FE disabled state
     # cannot be bypassed by crafting a request. Uses FEATURE_NOT_AVAILABLE
     # (402) to match the tier_gate middleware shape.
-    existing = load_settings()
     if not tier_at_least(get_tier(), Tier.ENTERPRISE):
+        existing = load_settings()
         if (
             settings.custom_help_link_url != existing.custom_help_link_url
             or settings.custom_help_link_label != existing.custom_help_link_label

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -27,6 +27,7 @@ from ee.onyx.server.scim.auth import generate_scim_token
 from ee.onyx.server.scim.models import ScimTokenCreate
 from ee.onyx.server.scim.models import ScimTokenCreatedResponse
 from ee.onyx.server.scim.models import ScimTokenResponse
+from ee.onyx.utils.tier import get_tier
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_user_with_expired_token
 from onyx.auth.users import get_user_manager
@@ -34,7 +35,11 @@ from onyx.auth.users import UserManager
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.settings.models import Tier
+from onyx.server.settings.tier_order import tier_at_least
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
@@ -128,6 +133,26 @@ def admin_ee_put_settings(
     settings: EnterpriseSettings,
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> None:
+    # Custom help link and Onyx-branding toggle are Enterprise-only. Block
+    # writes to those fields when tier < ENTERPRISE so the FE disabled state
+    # cannot be bypassed by crafting a request. Uses FEATURE_NOT_AVAILABLE
+    # (402) to match the tier_gate middleware shape.
+    existing = load_settings()
+    if not tier_at_least(get_tier(), Tier.ENTERPRISE):
+        if (
+            settings.custom_help_link_url != existing.custom_help_link_url
+            or settings.custom_help_link_label != existing.custom_help_link_label
+        ):
+            raise OnyxError(
+                OnyxErrorCode.FEATURE_NOT_AVAILABLE,
+                "Custom help link requires the Enterprise plan.",
+            )
+        if settings.hide_onyx_branding != existing.hide_onyx_branding:
+            raise OnyxError(
+                OnyxErrorCode.FEATURE_NOT_AVAILABLE,
+                "Hiding Onyx branding requires the Enterprise plan.",
+            )
+
     store_settings(settings)
 
 

--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -70,8 +70,10 @@ class EnterpriseSettings(BaseModel):
         if not v:
             return v
         parsed = urlparse(v)
-        if parsed.scheme not in ("http", "https"):
-            raise ValueError("custom_help_link_url must use http or https")
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError(
+                "custom_help_link_url must be an absolute http or https URL"
+            )
         return v
 
     def check_validity(self) -> None:

--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -1,9 +1,11 @@
 from enum import Enum
 from typing import Any
 from typing import List
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import field_validator
 
 
 class NavigationItem(BaseModel):
@@ -61,6 +63,16 @@ class EnterpriseSettings(BaseModel):
 
     # hide the "Powered by Onyx" tagline under the sidebar logo
     hide_onyx_branding: bool | None = None
+
+    @field_validator("custom_help_link_url")
+    @classmethod
+    def _validate_help_link_scheme(cls, v: str | None) -> str | None:
+        if not v:
+            return v
+        parsed = urlparse(v)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("custom_help_link_url must use http or https")
+        return v
 
     def check_validity(self) -> None:
         return

--- a/backend/ee/onyx/server/enterprise_settings/models.py
+++ b/backend/ee/onyx/server/enterprise_settings/models.py
@@ -54,6 +54,14 @@ class EnterpriseSettings(BaseModel):
     show_first_visit_notice: bool | None = None
     custom_greeting_message: str | None = None
 
+    # custom help link surfaced in the profile dropdown alongside the
+    # built-in "Help & FAQ" item
+    custom_help_link_url: str | None = None
+    custom_help_link_label: str | None = None
+
+    # hide the "Powered by Onyx" tagline under the sidebar logo
+    hide_onyx_branding: bool | None = None
+
     def check_validity(self) -> None:
         return
 

--- a/backend/ee/onyx/utils/tier.py
+++ b/backend/ee/onyx/utils/tier.py
@@ -39,6 +39,7 @@ from onyx.server.settings.models import ApplicationStatus
 from onyx.server.settings.models import Tier
 from onyx.server.settings.tier_order import tier_at_least
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -89,6 +90,15 @@ def tier_from_license_metadata(metadata: object | None) -> Tier:
 
 
 def _self_hosted_tier() -> Tier:
+    if not LICENSE_ENFORCEMENT_ENABLED:
+        # Mirrors apply_license_status_to_settings (settings/api.py:87-92):
+        # legacy / dev-mode self-host where EE code is loaded via
+        # ENABLE_PAID_ENTERPRISE_EDITION_FEATURES but no license is required.
+        # Treat as ENTERPRISE so tier_gate doesn't 402 EE endpoints.
+        return (
+            Tier.ENTERPRISE if global_version.is_ee_version() else Tier.COMMUNITY
+        )
+
     try:
         metadata = get_cached_license_metadata()
     except RedisError as e:

--- a/backend/ee/onyx/utils/tier.py
+++ b/backend/ee/onyx/utils/tier.py
@@ -95,9 +95,7 @@ def _self_hosted_tier() -> Tier:
         # legacy / dev-mode self-host where EE code is loaded via
         # ENABLE_PAID_ENTERPRISE_EDITION_FEATURES but no license is required.
         # Treat as ENTERPRISE so tier_gate doesn't 402 EE endpoints.
-        return (
-            Tier.ENTERPRISE if global_version.is_ee_version() else Tier.COMMUNITY
-        )
+        return Tier.ENTERPRISE if global_version.is_ee_version() else Tier.COMMUNITY
 
     try:
         metadata = get_cached_license_metadata()

--- a/backend/tests/unit/ee/onyx/utils/test_tier.py
+++ b/backend/tests/unit/ee/onyx/utils/test_tier.py
@@ -86,6 +86,46 @@ class TestSelfHostedTierCacheFailure:
             get_tier()
 
 
+@patch("ee.onyx.utils.tier.MULTI_TENANT", False)
+class TestSelfHostedTierLegacyBypass:
+    """`_self_hosted_tier` must mirror `apply_license_status_to_settings`
+    and `require_business_tier_for_sync_access` for the legacy
+    LICENSE_ENFORCEMENT_ENABLED=False case: treat as ENTERPRISE so tier_gate
+    doesn't 402 dev / legacy installs that load EE code but have no license.
+    """
+
+    @patch("ee.onyx.utils.tier.LICENSE_ENFORCEMENT_ENABLED", False)
+    @patch("ee.onyx.utils.tier.global_version")
+    @patch("ee.onyx.utils.tier.get_cached_license_metadata")
+    def test_ee_loaded_returns_enterprise_without_license_lookup(
+        self,
+        mock_get_cached: MagicMock,
+        mock_global_version: MagicMock,
+    ) -> None:
+        from ee.onyx.utils.tier import get_tier
+
+        mock_global_version.is_ee_version.return_value = True
+
+        assert get_tier() == Tier.ENTERPRISE
+        mock_get_cached.assert_not_called()
+
+    @patch("ee.onyx.utils.tier.LICENSE_ENFORCEMENT_ENABLED", False)
+    @patch("ee.onyx.utils.tier.global_version")
+    @patch("ee.onyx.utils.tier.get_cached_license_metadata")
+    def test_ee_not_loaded_returns_community(
+        self,
+        mock_get_cached: MagicMock,
+        mock_global_version: MagicMock,
+    ) -> None:
+        """Without EE code paths loaded there's nothing to upgrade to."""
+        from ee.onyx.utils.tier import get_tier
+
+        mock_global_version.is_ee_version.return_value = False
+
+        assert get_tier() == Tier.COMMUNITY
+        mock_get_cached.assert_not_called()
+
+
 class TestTierFromLicenseMetadata:
     """All branches of `tier_from_license_metadata` (tier.py:67-83).
 

--- a/backend/tests/unit/ee/onyx/utils/test_tier.py
+++ b/backend/tests/unit/ee/onyx/utils/test_tier.py
@@ -29,9 +29,17 @@ def _metadata(
     return m
 
 
+@patch("ee.onyx.utils.tier.LICENSE_ENFORCEMENT_ENABLED", True)
 @patch("ee.onyx.utils.tier.MULTI_TENANT", False)
 class TestSelfHostedTierCacheFailure:
-    """`_self_hosted_tier` must not leak RedisError to callers."""
+    """`_self_hosted_tier` must not leak RedisError to callers.
+
+    `LICENSE_ENFORCEMENT_ENABLED` is patched to True so the legacy
+    no-enforcement bypass (which short-circuits to ENTERPRISE) doesn't
+    mask the cache/db code paths under test. CI sets the env var to
+    False by default, so without this patch the assertions accidentally
+    pass-by-luck on the cache-hit path and fail on every other path.
+    """
 
     @patch("ee.onyx.utils.tier.get_cached_license_metadata")
     def test_cache_hit_returns_cached_tier(self, mock_get_cached: MagicMock) -> None:

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -8,7 +8,8 @@ import InputTextArea from "@/refresh-components/inputs/InputTextArea";
 import Switch from "@/refresh-components/inputs/Switch";
 import CharacterCount from "@/refresh-components/CharacterCount";
 import InputImage from "@/refresh-components/inputs/InputImage";
-import { Button, Divider } from "@opal/components";
+import { Button, Divider, Tag } from "@opal/components";
+import { Disabled } from "@opal/core";
 import { useFormikContext } from "formik";
 import {
   forwardRef,
@@ -20,6 +21,9 @@ import {
 } from "react";
 import type { PreviewHighlightTarget } from "./Preview";
 import { SvgEdit } from "@opal/icons";
+import { useTierAtLeast } from "@/hooks/useTierAtLeast";
+import { Tier } from "@/interfaces/settings";
+import { planTagProps } from "@/lib/tier-badge";
 
 interface AppearanceThemeSettingsProps {
   selectedLogo: File | null;
@@ -48,6 +52,7 @@ export const AppearanceThemeSettings = forwardRef<
   ref
 ) {
   const { values, errors, setFieldValue } = useFormikContext<any>();
+  const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const applicationNameInputRef = useRef<HTMLInputElement>(null);
   const greetingMessageInputRef = useRef<HTMLInputElement>(null);
@@ -443,71 +448,99 @@ export const AppearanceThemeSettings = forwardRef<
         />
       </FormField>
 
-      <div className="flex gap-2 items-start">
-        <FormField
-          state={errors.custom_help_link_url ? "error" : "idle"}
-          className="flex-1"
-        >
-          <FormField.Label>Custom Help Link</FormField.Label>
-          <FormField.Control asChild>
-            <InputTypeIn
-              ref={customHelpLinkUrlInputRef}
-              data-label="custom-help-link-url-input"
-              showClearButton
-              placeholder="https://docs.onyx.app"
-              variant={errors.custom_help_link_url ? "error" : undefined}
-              value={values.custom_help_link_url}
-              onChange={(e) =>
-                setFieldValue("custom_help_link_url", e.target.value)
-              }
+      <Disabled
+        disabled={!enterpriseTier}
+        tooltip="Custom help link is an Enterprise Plan feature."
+      >
+        <div className="flex gap-2 items-start">
+          <FormField
+            state={errors.custom_help_link_url ? "error" : "idle"}
+            className="flex-1"
+          >
+            <FormField.Label>
+              Custom Help Link
+              {!enterpriseTier && (
+                <Tag {...planTagProps("enterprise")} size="sm" />
+              )}
+            </FormField.Label>
+            <FormField.Control asChild>
+              <InputTypeIn
+                ref={customHelpLinkUrlInputRef}
+                data-label="custom-help-link-url-input"
+                showClearButton
+                placeholder="https://docs.onyx.app"
+                variant={
+                  !enterpriseTier
+                    ? "disabled"
+                    : errors.custom_help_link_url
+                      ? "error"
+                      : undefined
+                }
+                value={values.custom_help_link_url}
+                onChange={(e) =>
+                  setFieldValue("custom_help_link_url", e.target.value)
+                }
+              />
+            </FormField.Control>
+            <FormField.Description>
+              Add a custom help link in the user menu in addition to the Onyx
+              documentation.
+            </FormField.Description>
+            <FormField.Message
+              messages={{ error: errors.custom_help_link_url as string }}
             />
-          </FormField.Control>
-          <FormField.Description>
-            Add a custom help link in the user menu in addition to the Onyx
-            documentation.
-          </FormField.Description>
-          <FormField.Message
-            messages={{ error: errors.custom_help_link_url as string }}
-          />
-        </FormField>
-        <FormField state="idle" className="flex-1">
-          <FormField.Label className="invisible" aria-hidden="true">
-            Custom Help Link Label
-          </FormField.Label>
-          <FormField.Control asChild>
-            <InputTypeIn
-              aria-label="Custom Help Link Label"
-              data-label="custom-help-link-label-input"
-              showClearButton
-              placeholder="Link label"
-              value={values.custom_help_link_label}
-              onChange={(e) =>
-                setFieldValue("custom_help_link_label", e.target.value)
-              }
-            />
-          </FormField.Control>
-        </FormField>
-      </div>
-
-      <FormField state="idle" className="gap-0">
-        <div className="flex justify-between items-center">
-          <FormField.Label>Hide Onyx Branding</FormField.Label>
-          <FormField.Control>
-            <Switch
-              aria-label="Hide Onyx Branding"
-              data-label="hide-onyx-branding-toggle"
-              checked={values.hide_onyx_branding}
-              onCheckedChange={(checked) =>
-                setFieldValue("hide_onyx_branding", checked)
-              }
-            />
-          </FormField.Control>
+          </FormField>
+          <FormField state="idle" className="flex-1">
+            <FormField.Label className="invisible" aria-hidden="true">
+              Custom Help Link Label
+            </FormField.Label>
+            <FormField.Control asChild>
+              <InputTypeIn
+                aria-label="Custom Help Link Label"
+                data-label="custom-help-link-label-input"
+                showClearButton
+                placeholder="Link label"
+                variant={!enterpriseTier ? "disabled" : undefined}
+                value={values.custom_help_link_label}
+                onChange={(e) =>
+                  setFieldValue("custom_help_link_label", e.target.value)
+                }
+              />
+            </FormField.Control>
+          </FormField>
         </div>
-        <FormField.Description>
-          Remove &ldquo;powered by Onyx&rdquo; and other Onyx branding presence
-          in the app.
-        </FormField.Description>
-      </FormField>
+      </Disabled>
+
+      <Disabled
+        disabled={!enterpriseTier}
+        tooltip="Hiding Onyx branding is an Enterprise Plan feature."
+      >
+        <FormField state="idle" className="gap-0">
+          <div className="flex justify-between items-center">
+            <FormField.Label>
+              Hide Onyx Branding
+              {!enterpriseTier && (
+                <Tag {...planTagProps("enterprise")} size="sm" />
+              )}
+            </FormField.Label>
+            <FormField.Control>
+              <Switch
+                aria-label="Hide Onyx Branding"
+                data-label="hide-onyx-branding-toggle"
+                checked={values.hide_onyx_branding}
+                onCheckedChange={(checked) =>
+                  setFieldValue("hide_onyx_branding", checked)
+                }
+                disabled={!enterpriseTier}
+              />
+            </FormField.Control>
+          </div>
+          <FormField.Description>
+            Remove &ldquo;powered by Onyx&rdquo; and other Onyx branding
+            presence in the app.
+          </FormField.Description>
+        </FormField>
+      </Disabled>
 
       <Divider />
 

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -56,6 +56,7 @@ export const AppearanceThemeSettings = forwardRef<
   const noticeHeaderInputRef = useRef<HTMLInputElement>(null);
   const noticeContentInputRef = useRef<HTMLTextAreaElement>(null);
   const consentPromptTextAreaRef = useRef<HTMLTextAreaElement>(null);
+  const customHelpLinkUrlInputRef = useRef<HTMLInputElement>(null);
   const prevShowFirstVisitNoticeRef = useRef<boolean>(
     Boolean(values.show_first_visit_notice)
   );
@@ -96,6 +97,7 @@ export const AppearanceThemeSettings = forwardRef<
         { name: "custom_popup_header", ref: noticeHeaderInputRef },
         { name: "custom_popup_content", ref: noticeContentInputRef },
         { name: "consent_screen_prompt", ref: consentPromptTextAreaRef },
+        { name: "custom_help_link_url", ref: customHelpLinkUrlInputRef },
       ];
       for (const field of fieldRefs) {
         if (errors[field.name] && field.ref.current) {
@@ -439,6 +441,72 @@ export const AppearanceThemeSettings = forwardRef<
         <FormField.Message
           messages={{ error: errors.custom_lower_disclaimer_content as string }}
         />
+      </FormField>
+
+      <div className="flex gap-2 items-start">
+        <FormField
+          state={errors.custom_help_link_url ? "error" : "idle"}
+          className="flex-1"
+        >
+          <FormField.Label>Custom Help Link</FormField.Label>
+          <FormField.Control asChild>
+            <InputTypeIn
+              ref={customHelpLinkUrlInputRef}
+              data-label="custom-help-link-url-input"
+              showClearButton
+              placeholder="https://docs.onyx.app"
+              variant={errors.custom_help_link_url ? "error" : undefined}
+              value={values.custom_help_link_url}
+              onChange={(e) =>
+                setFieldValue("custom_help_link_url", e.target.value)
+              }
+            />
+          </FormField.Control>
+          <FormField.Description>
+            Add a custom help link in the user menu in addition to the Onyx
+            documentation.
+          </FormField.Description>
+          <FormField.Message
+            messages={{ error: errors.custom_help_link_url as string }}
+          />
+        </FormField>
+        <FormField state="idle" className="flex-1">
+          <FormField.Label className="invisible" aria-hidden="true">
+            Custom Help Link Label
+          </FormField.Label>
+          <FormField.Control asChild>
+            <InputTypeIn
+              aria-label="Custom Help Link Label"
+              data-label="custom-help-link-label-input"
+              showClearButton
+              placeholder="Link label"
+              value={values.custom_help_link_label}
+              onChange={(e) =>
+                setFieldValue("custom_help_link_label", e.target.value)
+              }
+            />
+          </FormField.Control>
+        </FormField>
+      </div>
+
+      <FormField state="idle" className="gap-0">
+        <div className="flex justify-between items-center">
+          <FormField.Label>Hide Onyx Branding</FormField.Label>
+          <FormField.Control>
+            <Switch
+              aria-label="Hide Onyx Branding"
+              data-label="hide-onyx-branding-toggle"
+              checked={values.hide_onyx_branding}
+              onCheckedChange={(checked) =>
+                setFieldValue("hide_onyx_branding", checked)
+              }
+            />
+          </FormField.Control>
+        </div>
+        <FormField.Description>
+          Remove &ldquo;powered by Onyx&rdquo; and other Onyx branding presence
+          in the app.
+        </FormField.Description>
       </FormField>
 
       <Divider />

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -125,6 +125,25 @@ export default function ThemePage() {
         then: (schema) => schema.required("Notice Consent Prompt is required"),
         otherwise: (schema) => schema.nullable(),
       }),
+    custom_help_link_label: Yup.string().nullable(),
+    custom_help_link_url: Yup.string()
+      .nullable()
+      .when("custom_help_link_label", {
+        is: (label: string | null | undefined) =>
+          typeof label === "string" && label.trim().length > 0,
+        then: (schema) =>
+          schema
+            .required("URL is required when a label is set")
+            .url("Must be a valid URL"),
+        otherwise: (schema) =>
+          schema.test(
+            "optional-url",
+            "Must be a valid URL",
+            (value) =>
+              value == null || value === "" || Yup.string().url().isValidSync(value)
+          ),
+      }),
+    hide_onyx_branding: Yup.boolean().nullable(),
   });
 
   return (
@@ -146,6 +165,10 @@ export default function ThemePage() {
         enable_consent_screen:
           enterpriseSettings?.enable_consent_screen || false,
         consent_screen_prompt: enterpriseSettings?.consent_screen_prompt || "",
+        custom_help_link_url: enterpriseSettings?.custom_help_link_url || "",
+        custom_help_link_label:
+          enterpriseSettings?.custom_help_link_label || "",
+        hide_onyx_branding: enterpriseSettings?.hide_onyx_branding || false,
       }}
       validationSchema={validationSchema}
       validateOnChange={false}
@@ -190,6 +213,10 @@ export default function ThemePage() {
           show_first_visit_notice: values.show_first_visit_notice || null,
           enable_consent_screen: values.enable_consent_screen || null,
           consent_screen_prompt: values.consent_screen_prompt || null,
+          custom_help_link_url: values.custom_help_link_url?.trim() || null,
+          custom_help_link_label:
+            values.custom_help_link_label?.trim() || null,
+          hide_onyx_branding: values.hide_onyx_branding || null,
         });
 
         // Important: after a successful save, reset Formik's "baseline" so

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -140,7 +140,9 @@ export default function ThemePage() {
             "optional-url",
             "Must be a valid URL",
             (value) =>
-              value == null || value === "" || Yup.string().url().isValidSync(value)
+              value == null ||
+              value === "" ||
+              Yup.string().url().isValidSync(value)
           ),
       }),
     hide_onyx_branding: Yup.boolean().nullable(),
@@ -214,8 +216,7 @@ export default function ThemePage() {
           enable_consent_screen: values.enable_consent_screen || null,
           consent_screen_prompt: values.consent_screen_prompt || null,
           custom_help_link_url: values.custom_help_link_url?.trim() || null,
-          custom_help_link_label:
-            values.custom_help_link_label?.trim() || null,
+          custom_help_link_label: values.custom_help_link_label?.trim() || null,
           hide_onyx_branding: values.hide_onyx_branding ?? null,
         });
 

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -216,7 +216,7 @@ export default function ThemePage() {
           custom_help_link_url: values.custom_help_link_url?.trim() || null,
           custom_help_link_label:
             values.custom_help_link_label?.trim() || null,
-          hide_onyx_branding: values.hide_onyx_branding || null,
+          hide_onyx_branding: values.hide_onyx_branding ?? null,
         });
 
         // Important: after a successful save, reset Formik's "baseline" so

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -113,6 +113,13 @@ export interface EnterpriseSettings {
   consent_screen_prompt: string | null;
   show_first_visit_notice: boolean | null;
   custom_greeting_message: string | null;
+
+  // Custom help link surfaced in the profile dropdown alongside "Help & FAQ".
+  custom_help_link_url: string | null;
+  custom_help_link_label: string | null;
+
+  // Hide the "Powered by Onyx" tagline under the sidebar logo.
+  hide_onyx_branding: boolean | null;
 }
 
 export interface CombinedSettings {

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -66,16 +66,17 @@ export default function Logo({ folded, size, className }: LogoProps) {
             {opts.includeName && (
               <Truncated headingH3>{applicationName}</Truncated>
             )}
-            {!NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED && (
-              <Text
-                secondaryBody
-                text03
-                className={"line-clamp-1 truncate"}
-                nowrap
-              >
-                Powered by Onyx
-              </Text>
-            )}
+            {!NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED &&
+              !settings.enterpriseSettings?.hide_onyx_branding && (
+                <Text
+                  secondaryBody
+                  text03
+                  className={"line-clamp-1 truncate"}
+                  nowrap
+                >
+                  Powered by Onyx
+                </Text>
+              )}
           </div>
         )}
       </div>

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -17,6 +17,7 @@ import { SidebarTab, LineItemButton } from "@opal/components";
 import NotificationsPopover from "@/sections/sidebar/NotificationsPopover";
 import {
   SvgBell,
+  SvgExternalLink,
   SvgHelpCircle,
   SvgLogOut,
   SvgSliders,
@@ -130,6 +131,22 @@ function SettingsPopover({
           href="https://docs.onyx.app"
           target="_blank"
         />,
+        settings?.enterpriseSettings?.custom_help_link_url && (
+          <LineItemButton
+            key="custom-help-link"
+            data-testid="Settings/custom-help-link"
+            sizePreset="main-ui"
+            variant="section"
+            rounding="sm"
+            icon={SvgExternalLink}
+            title={
+              settings.enterpriseSettings.custom_help_link_label ||
+              settings.enterpriseSettings.custom_help_link_url
+            }
+            href={settings.enterpriseSettings.custom_help_link_url}
+            target="_blank"
+          />
+        ),
         showLogin && (
           <LineItemButton
             key="log-in"

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -134,7 +134,6 @@ function SettingsPopover({
         settings?.enterpriseSettings?.custom_help_link_url && (
           <LineItemButton
             key="custom-help-link"
-            data-testid="Settings/custom-help-link"
             sizePreset="main-ui"
             variant="section"
             rounding="sm"

--- a/web/tests/e2e/admin/theme/AppearanceThemePage.ts
+++ b/web/tests/e2e/admin/theme/AppearanceThemePage.ts
@@ -7,11 +7,28 @@
  * should drive the page through this class.
  */
 
-import { expect, type Locator, type Page, type Response } from "@playwright/test";
+import {
+  expect,
+  type Locator,
+  type Page,
+  type Response,
+} from "@playwright/test";
 
 const ENTERPRISE_SETTINGS_PUT = (r: Response) =>
   r.url().includes("/api/admin/enterprise-settings") &&
   r.request().method() === "PUT";
+
+/**
+ * SWR revalidation `GET /api/enterprise-settings` fired by `mutate()` after
+ * a successful save. The popover renders straight from this SWR cache, so
+ * waiting for this GET (in addition to the PUT) guarantees the sidebar
+ * popover reflects the new values before we assert on them.
+ */
+const ENTERPRISE_SETTINGS_GET = (r: Response) => {
+  if (r.request().method() !== "GET") return false;
+  const pathname = new URL(r.url()).pathname;
+  return pathname === "/api/enterprise-settings";
+};
 
 export class AppearanceThemePage {
   readonly page: Page;
@@ -68,18 +85,23 @@ export class AppearanceThemePage {
   }
 
   /**
-   * Click "Apply Changes" while a `waitForResponse` is already armed.
+   * Click "Apply Changes" and wait for both the PUT and the subsequent SWR
+   * revalidation GET. Both promises MUST be armed before the click — a
+   * post-click `waitForResponse` can miss fast responses and flake.
    *
-   * The promise MUST be created before the click to avoid a race where the
-   * response lands before Playwright registers the listener.
+   * Returns the PUT response so callers can assert on the status code.
    */
   async saveAndWaitForPut(timeoutMs = 10_000): Promise<Response> {
-    const responsePromise = this.page.waitForResponse(ENTERPRISE_SETTINGS_PUT, {
+    const putPromise = this.page.waitForResponse(ENTERPRISE_SETTINGS_PUT, {
+      timeout: timeoutMs,
+    });
+    const getPromise = this.page.waitForResponse(ENTERPRISE_SETTINGS_GET, {
       timeout: timeoutMs,
     });
     await expect(this.saveButton).toBeEnabled();
     await this.saveButton.click();
-    return responsePromise;
+    const [putResponse] = await Promise.all([putPromise, getPromise]);
+    return putResponse;
   }
 
   /** Click Apply Changes without waiting for a PUT — for validation failure paths. */

--- a/web/tests/e2e/admin/theme/AppearanceThemePage.ts
+++ b/web/tests/e2e/admin/theme/AppearanceThemePage.ts
@@ -41,7 +41,6 @@ export class AppearanceThemePage {
 
   // Sidebar / popover
   readonly userDropdownTrigger: Locator;
-  readonly customHelpLinkItem: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -57,7 +56,17 @@ export class AppearanceThemePage {
     this.saveButton = page.getByRole("button", { name: "Apply Changes" });
 
     this.userDropdownTrigger = page.locator("#onyx-user-dropdown");
-    this.customHelpLinkItem = page.getByTestId("Settings/custom-help-link");
+  }
+
+  /**
+   * The custom help link is rendered by Opal's `LineItemButton`, which
+   * forwards `href` to an underlying `<a>` but drops arbitrary props such
+   * as `data-testid` somewhere in the `LineItemButton → ContentAction →
+   * Content` chain. Locating by `href` is reliable and reflects what the
+   * user actually clicks on.
+   */
+  customHelpLinkAnchor(url: string): Locator {
+    return this.page.locator(`a[href="${url}"]`);
   }
 
   // ---------------------------------------------------------------------------
@@ -124,18 +133,28 @@ export class AppearanceThemePage {
     await this.userDropdownTrigger.click();
   }
 
-  async expectCustomHelpLinkVisible(label: string, url: string) {
-    await expect(this.customHelpLinkItem).toBeVisible({ timeout: 5_000 });
-    await expect(this.customHelpLinkItem).toContainText(label);
-    // LineItemButton with href renders an <a> with that href under the hood
+  /**
+   * Reload + wait for the admin form to be back. Use after a save to clear
+   * any SWR cache / React render races — once the page comes back up the
+   * sidebar reads enterprise settings fresh from the server.
+   */
+  async reloadAndWaitForForm(timeoutMs = 10_000) {
+    await this.page.reload();
     await expect(
-      this.customHelpLinkItem.locator(`a[href="${url}"]`)
-    ).toHaveCount(1);
+      this.page.locator('[data-label="application-name-input"]')
+    ).toBeVisible({ timeout: timeoutMs });
   }
 
-  async expectCustomHelpLinkContainsText(text: string) {
-    await expect(this.customHelpLinkItem).toBeVisible({ timeout: 5_000 });
-    await expect(this.customHelpLinkItem).toContainText(text);
+  async expectCustomHelpLinkVisible(label: string, url: string) {
+    const link = this.customHelpLinkAnchor(url);
+    await expect(link).toBeVisible({ timeout: 5_000 });
+    await expect(link).toContainText(label);
+  }
+
+  async expectCustomHelpLinkContainsText(url: string, text: string) {
+    const link = this.customHelpLinkAnchor(url);
+    await expect(link).toBeVisible({ timeout: 5_000 });
+    await expect(link).toContainText(text);
   }
 
   async expectPoweredByOnyxVisible() {

--- a/web/tests/e2e/admin/theme/AppearanceThemePage.ts
+++ b/web/tests/e2e/admin/theme/AppearanceThemePage.ts
@@ -34,6 +34,7 @@ export class AppearanceThemePage {
   readonly page: Page;
 
   // Form inputs
+  readonly applicationNameInput: Locator;
   readonly customHelpLinkUrlInput: Locator;
   readonly customHelpLinkLabelInput: Locator;
   readonly hideBrandingToggle: Locator;
@@ -44,6 +45,9 @@ export class AppearanceThemePage {
 
   constructor(page: Page) {
     this.page = page;
+    this.applicationNameInput = page.locator(
+      '[data-label="application-name-input"]'
+    );
     this.customHelpLinkUrlInput = page.locator(
       '[data-label="custom-help-link-url-input"]'
     );
@@ -72,6 +76,10 @@ export class AppearanceThemePage {
   // ---------------------------------------------------------------------------
   // Form interactions
   // ---------------------------------------------------------------------------
+
+  async setApplicationName(name: string) {
+    await this.applicationNameInput.fill(name);
+  }
 
   async fillCustomHelpLink(url: string, label?: string) {
     await this.customHelpLinkUrlInput.fill(url);
@@ -157,16 +165,23 @@ export class AppearanceThemePage {
     await expect(link).toContainText(text);
   }
 
+  /**
+   * Locator for the Logo's tagline, scoped exactly so it doesn't also match
+   * the toggle's helper text on the same page ("Remove 'powered by Onyx'
+   * and other Onyx branding..."). `getByText` is case-insensitive +
+   * substring by default; `exact: true` makes it strict equality on the
+   * element's full text content.
+   */
+  private get poweredByOnyxTagline(): Locator {
+    return this.page.getByText("Powered by Onyx", { exact: true });
+  }
+
   async expectPoweredByOnyxVisible() {
-    await expect(this.page.getByText("Powered by Onyx").first()).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(this.poweredByOnyxTagline).toBeVisible({ timeout: 5_000 });
   }
 
   async expectPoweredByOnyxAbsent() {
-    await expect(this.page.getByText("Powered by Onyx")).toHaveCount(0, {
-      timeout: 5_000,
-    });
+    await expect(this.poweredByOnyxTagline).toHaveCount(0, { timeout: 5_000 });
   }
 
   // ---------------------------------------------------------------------------

--- a/web/tests/e2e/admin/theme/AppearanceThemePage.ts
+++ b/web/tests/e2e/admin/theme/AppearanceThemePage.ts
@@ -1,0 +1,138 @@
+/**
+ * Page Object Model for the Admin Appearance / Theme page (/admin/theme).
+ *
+ * Encapsulates locators and interactions for the custom help link and
+ * hide-onyx-branding controls so specs stay declarative. Existing tests in
+ * `appearance_theme_settings.spec.ts` still use inline locators; new tests
+ * should drive the page through this class.
+ */
+
+import { expect, type Locator, type Page, type Response } from "@playwright/test";
+
+const ENTERPRISE_SETTINGS_PUT = (r: Response) =>
+  r.url().includes("/api/admin/enterprise-settings") &&
+  r.request().method() === "PUT";
+
+export class AppearanceThemePage {
+  readonly page: Page;
+
+  // Form inputs
+  readonly customHelpLinkUrlInput: Locator;
+  readonly customHelpLinkLabelInput: Locator;
+  readonly hideBrandingToggle: Locator;
+  readonly saveButton: Locator;
+
+  // Sidebar / popover
+  readonly userDropdownTrigger: Locator;
+  readonly customHelpLinkItem: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.customHelpLinkUrlInput = page.locator(
+      '[data-label="custom-help-link-url-input"]'
+    );
+    this.customHelpLinkLabelInput = page.locator(
+      '[data-label="custom-help-link-label-input"]'
+    );
+    this.hideBrandingToggle = page.locator(
+      '[data-label="hide-onyx-branding-toggle"]'
+    );
+    this.saveButton = page.getByRole("button", { name: "Apply Changes" });
+
+    this.userDropdownTrigger = page.locator("#onyx-user-dropdown");
+    this.customHelpLinkItem = page.getByTestId("Settings/custom-help-link");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Form interactions
+  // ---------------------------------------------------------------------------
+
+  async fillCustomHelpLink(url: string, label?: string) {
+    await this.customHelpLinkUrlInput.fill(url);
+    if (label !== undefined) {
+      await this.customHelpLinkLabelInput.fill(label);
+    }
+  }
+
+  async fillCustomHelpLinkLabelOnly(label: string) {
+    await this.customHelpLinkLabelInput.fill(label);
+  }
+
+  async clearCustomHelpLinkLabel() {
+    await this.customHelpLinkLabelInput.clear();
+  }
+
+  async toggleHideBranding() {
+    await this.hideBrandingToggle.scrollIntoViewIfNeeded();
+    await this.hideBrandingToggle.click();
+  }
+
+  /**
+   * Click "Apply Changes" while a `waitForResponse` is already armed.
+   *
+   * The promise MUST be created before the click to avoid a race where the
+   * response lands before Playwright registers the listener.
+   */
+  async saveAndWaitForPut(timeoutMs = 10_000): Promise<Response> {
+    const responsePromise = this.page.waitForResponse(ENTERPRISE_SETTINGS_PUT, {
+      timeout: timeoutMs,
+    });
+    await expect(this.saveButton).toBeEnabled();
+    await this.saveButton.click();
+    return responsePromise;
+  }
+
+  /** Click Apply Changes without waiting for a PUT — for validation failure paths. */
+  async clickSave() {
+    await expect(this.saveButton).toBeEnabled();
+    await this.saveButton.click();
+  }
+
+  async expectSaveSuccessToast(timeoutMs = 5_000) {
+    await expect(this.page.getByText(/successfully/i)).toBeVisible({
+      timeout: timeoutMs,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Popover / sidebar
+  // ---------------------------------------------------------------------------
+
+  async openUserDropdown() {
+    await this.userDropdownTrigger.click();
+  }
+
+  async expectCustomHelpLinkVisible(label: string, url: string) {
+    await expect(this.customHelpLinkItem).toBeVisible({ timeout: 5_000 });
+    await expect(this.customHelpLinkItem).toContainText(label);
+    // LineItemButton with href renders an <a> with that href under the hood
+    await expect(
+      this.customHelpLinkItem.locator(`a[href="${url}"]`)
+    ).toHaveCount(1);
+  }
+
+  async expectCustomHelpLinkContainsText(text: string) {
+    await expect(this.customHelpLinkItem).toBeVisible({ timeout: 5_000 });
+    await expect(this.customHelpLinkItem).toContainText(text);
+  }
+
+  async expectPoweredByOnyxVisible() {
+    await expect(this.page.getByText("Powered by Onyx").first()).toBeVisible({
+      timeout: 5_000,
+    });
+  }
+
+  async expectPoweredByOnyxAbsent() {
+    await expect(this.page.getByText("Powered by Onyx")).toHaveCount(0, {
+      timeout: 5_000,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Validation
+  // ---------------------------------------------------------------------------
+
+  async expectValidationMessage(text: string) {
+    await expect(this.page.getByText(text)).toBeVisible({ timeout: 5_000 });
+  }
+}

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@tests/e2e/fixtures/eeFeatures";
 import { loginAs } from "@tests/e2e/utils/auth";
+import { AppearanceThemePage } from "@tests/e2e/admin/theme/AppearanceThemePage";
 
 test.describe("Appearance Theme Settings @exclusive", () => {
   const TEST_VALUES = {
@@ -247,121 +248,71 @@ test.describe("Appearance Theme Settings @exclusive", () => {
   test("custom help link appears in the profile popover with the configured label", async ({
     page,
   }) => {
-    const urlInput = page.locator('[data-label="custom-help-link-url-input"]');
-    const labelInput = page.locator(
-      '[data-label="custom-help-link-label-input"]'
-    );
-    await urlInput.fill(TEST_VALUES.customHelpLinkUrl);
-    await labelInput.fill(TEST_VALUES.customHelpLinkLabel);
-
-    const saveButton = page.getByRole("button", { name: "Apply Changes" });
-    await expect(saveButton).toBeEnabled();
-    await saveButton.click();
-    const response = await page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/admin/enterprise-settings") &&
-        r.request().method() === "PUT",
-      { timeout: 10000 }
-    );
-    expect(response.status()).toBe(200);
-    await expect(page.getByText(/successfully/i)).toBeVisible({
-      timeout: 5000,
-    });
-
-    // Open the profile popover from the sidebar
-    await page.locator("#onyx-user-dropdown").click();
-
-    const customHelpItem = page.getByTestId("Settings/custom-help-link");
-    await expect(customHelpItem).toBeVisible({ timeout: 5000 });
-    await expect(customHelpItem).toContainText(
+    const themePage = new AppearanceThemePage(page);
+    await themePage.fillCustomHelpLink(
+      TEST_VALUES.customHelpLinkUrl,
       TEST_VALUES.customHelpLinkLabel
     );
-    // LineItemButton with href renders an <a> with that href under the hood
-    await expect(
-      customHelpItem.locator(`a[href="${TEST_VALUES.customHelpLinkUrl}"]`)
-    ).toHaveCount(1);
+
+    const response = await themePage.saveAndWaitForPut();
+    expect(response.status()).toBe(200);
+    await themePage.expectSaveSuccessToast();
+
+    await themePage.openUserDropdown();
+    await themePage.expectCustomHelpLinkVisible(
+      TEST_VALUES.customHelpLinkLabel,
+      TEST_VALUES.customHelpLinkUrl
+    );
   });
 
   test("custom help link uses the URL as the title when the label is empty", async ({
     page,
   }) => {
-    const urlInput = page.locator('[data-label="custom-help-link-url-input"]');
-    await urlInput.fill(TEST_VALUES.customHelpLinkUrl);
+    const themePage = new AppearanceThemePage(page);
+    await themePage.fillCustomHelpLink(TEST_VALUES.customHelpLinkUrl);
 
-    const saveButton = page.getByRole("button", { name: "Apply Changes" });
-    await expect(saveButton).toBeEnabled();
-    await saveButton.click();
-    const response = await page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/admin/enterprise-settings") &&
-        r.request().method() === "PUT",
-      { timeout: 10000 }
-    );
+    const response = await themePage.saveAndWaitForPut();
     expect(response.status()).toBe(200);
-    await expect(page.getByText(/successfully/i)).toBeVisible({
-      timeout: 5000,
-    });
+    await themePage.expectSaveSuccessToast();
 
-    await page.locator("#onyx-user-dropdown").click();
-    const customHelpItem = page.getByTestId("Settings/custom-help-link");
-    await expect(customHelpItem).toBeVisible({ timeout: 5000 });
+    await themePage.openUserDropdown();
     // Falls back to URL itself as the displayed title
-    await expect(customHelpItem).toContainText(TEST_VALUES.customHelpLinkUrl);
+    await themePage.expectCustomHelpLinkContainsText(
+      TEST_VALUES.customHelpLinkUrl
+    );
   });
 
   test("validation fails when the label is set but the URL is empty", async ({
     page,
   }) => {
-    const labelInput = page.locator(
-      '[data-label="custom-help-link-label-input"]'
+    const themePage = new AppearanceThemePage(page);
+    await themePage.fillCustomHelpLinkLabelOnly(TEST_VALUES.customHelpLinkLabel);
+
+    // Should NOT trigger a PUT — assert error message becomes visible
+    await themePage.clickSave();
+    await themePage.expectValidationMessage(
+      "URL is required when a label is set"
     );
-    await labelInput.fill(TEST_VALUES.customHelpLinkLabel);
-
-    const saveButton = page.getByRole("button", { name: "Apply Changes" });
-    await expect(saveButton).toBeEnabled();
-    await saveButton.click();
-
-    // Should NOT trigger a PUT — assert error message becomes visible and form
-    // didn't post by checking for the validation copy
-    await expect(page.getByText("URL is required when a label is set")).toBeVisible({
-      timeout: 5000,
-    });
 
     // Clean up: clear the orphan label before afterEach runs
-    await labelInput.clear();
+    await themePage.clearCustomHelpLinkLabel();
   });
 
   test("Hide Onyx Branding toggle removes the 'Powered by Onyx' tagline", async ({
     page,
   }) => {
+    const themePage = new AppearanceThemePage(page);
+
     // Sanity: tagline should be visible by default in the sidebar
-    await expect(page.getByText("Powered by Onyx").first()).toBeVisible({
-      timeout: 5000,
-    });
+    await themePage.expectPoweredByOnyxVisible();
 
-    const hideBrandingToggle = page.locator(
-      '[data-label="hide-onyx-branding-toggle"]'
-    );
-    await hideBrandingToggle.scrollIntoViewIfNeeded();
-    await hideBrandingToggle.click();
+    await themePage.toggleHideBranding();
 
-    const saveButton = page.getByRole("button", { name: "Apply Changes" });
-    await expect(saveButton).toBeEnabled();
-    await saveButton.click();
-    const response = await page.waitForResponse(
-      (r) =>
-        r.url().includes("/api/admin/enterprise-settings") &&
-        r.request().method() === "PUT",
-      { timeout: 10000 }
-    );
+    const response = await themePage.saveAndWaitForPut();
     expect(response.status()).toBe(200);
-    await expect(page.getByText(/successfully/i)).toBeVisible({
-      timeout: 5000,
-    });
+    await themePage.expectSaveSuccessToast();
 
     // After SWR revalidation the tagline should be gone from the sidebar
-    await expect(page.getByText("Powered by Onyx")).toHaveCount(0, {
-      timeout: 5000,
-    });
+    await themePage.expectPoweredByOnyxAbsent();
   });
 });

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -75,7 +75,9 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     const helpLinkUrlInput = page.locator(
       '[data-label="custom-help-link-url-input"]'
     );
-    if (await helpLinkUrlInput.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (
+      await helpLinkUrlInput.isVisible({ timeout: 1000 }).catch(() => false)
+    ) {
       await helpLinkUrlInput.clear();
     }
     const helpLinkLabelInput = page.locator(
@@ -92,9 +94,7 @@ test.describe("Appearance Theme Settings @exclusive", () => {
       '[data-label="hide-onyx-branding-toggle"]'
     );
     if (
-      await hideBrandingToggle
-        .isVisible({ timeout: 1000 })
-        .catch(() => false)
+      await hideBrandingToggle.isVisible({ timeout: 1000 }).catch(() => false)
     ) {
       const hideBrandingState =
         await hideBrandingToggle.getAttribute("aria-checked");
@@ -286,7 +286,9 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     page,
   }) => {
     const themePage = new AppearanceThemePage(page);
-    await themePage.fillCustomHelpLinkLabelOnly(TEST_VALUES.customHelpLinkLabel);
+    await themePage.fillCustomHelpLinkLabelOnly(
+      TEST_VALUES.customHelpLinkLabel
+    );
 
     // Should NOT trigger a PUT — assert error message becomes visible
     await themePage.clickSave();

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -10,6 +10,8 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     noticeHeader: "Important Notice",
     noticeContent: "Please read and agree to continue",
     consentPrompt: "I agree to the terms",
+    customHelpLinkUrl: "https://help.example.com",
+    customHelpLinkLabel: "Support Portal",
   };
 
   test.beforeEach(async ({ page, eeEnabled }) => {
@@ -66,6 +68,39 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     if (isChecked === "true") {
       await noticeToggle.click();
       await page.waitForTimeout(300);
+    }
+
+    // Clear custom help link URL + label
+    const helpLinkUrlInput = page.locator(
+      '[data-label="custom-help-link-url-input"]'
+    );
+    if (await helpLinkUrlInput.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await helpLinkUrlInput.clear();
+    }
+    const helpLinkLabelInput = page.locator(
+      '[data-label="custom-help-link-label-input"]'
+    );
+    if (
+      await helpLinkLabelInput.isVisible({ timeout: 1000 }).catch(() => false)
+    ) {
+      await helpLinkLabelInput.clear();
+    }
+
+    // Disable hide-onyx-branding toggle if enabled
+    const hideBrandingToggle = page.locator(
+      '[data-label="hide-onyx-branding-toggle"]'
+    );
+    if (
+      await hideBrandingToggle
+        .isVisible({ timeout: 1000 })
+        .catch(() => false)
+    ) {
+      const hideBrandingState =
+        await hideBrandingToggle.getAttribute("aria-checked");
+      if (hideBrandingState === "true") {
+        await hideBrandingToggle.click();
+        await page.waitForTimeout(300);
+      }
     }
 
     // Save reset
@@ -207,5 +242,126 @@ test.describe("Appearance Theme Settings @exclusive", () => {
 
     // 20. Verify chat footer content
     await expect(page.getByText(TEST_VALUES.chatFooter)).toBeVisible();
+  });
+
+  test("custom help link appears in the profile popover with the configured label", async ({
+    page,
+  }) => {
+    const urlInput = page.locator('[data-label="custom-help-link-url-input"]');
+    const labelInput = page.locator(
+      '[data-label="custom-help-link-label-input"]'
+    );
+    await urlInput.fill(TEST_VALUES.customHelpLinkUrl);
+    await labelInput.fill(TEST_VALUES.customHelpLinkLabel);
+
+    const saveButton = page.getByRole("button", { name: "Apply Changes" });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    const response = await page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/admin/enterprise-settings") &&
+        r.request().method() === "PUT",
+      { timeout: 10000 }
+    );
+    expect(response.status()).toBe(200);
+    await expect(page.getByText(/successfully/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Open the profile popover from the sidebar
+    await page.locator("#onyx-user-dropdown").click();
+
+    const customHelpItem = page.getByTestId("Settings/custom-help-link");
+    await expect(customHelpItem).toBeVisible({ timeout: 5000 });
+    await expect(customHelpItem).toContainText(
+      TEST_VALUES.customHelpLinkLabel
+    );
+    // LineItemButton with href renders an <a> with that href under the hood
+    await expect(
+      customHelpItem.locator(`a[href="${TEST_VALUES.customHelpLinkUrl}"]`)
+    ).toHaveCount(1);
+  });
+
+  test("custom help link uses the URL as the title when the label is empty", async ({
+    page,
+  }) => {
+    const urlInput = page.locator('[data-label="custom-help-link-url-input"]');
+    await urlInput.fill(TEST_VALUES.customHelpLinkUrl);
+
+    const saveButton = page.getByRole("button", { name: "Apply Changes" });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    const response = await page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/admin/enterprise-settings") &&
+        r.request().method() === "PUT",
+      { timeout: 10000 }
+    );
+    expect(response.status()).toBe(200);
+    await expect(page.getByText(/successfully/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    await page.locator("#onyx-user-dropdown").click();
+    const customHelpItem = page.getByTestId("Settings/custom-help-link");
+    await expect(customHelpItem).toBeVisible({ timeout: 5000 });
+    // Falls back to URL itself as the displayed title
+    await expect(customHelpItem).toContainText(TEST_VALUES.customHelpLinkUrl);
+  });
+
+  test("validation fails when the label is set but the URL is empty", async ({
+    page,
+  }) => {
+    const labelInput = page.locator(
+      '[data-label="custom-help-link-label-input"]'
+    );
+    await labelInput.fill(TEST_VALUES.customHelpLinkLabel);
+
+    const saveButton = page.getByRole("button", { name: "Apply Changes" });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+
+    // Should NOT trigger a PUT — assert error message becomes visible and form
+    // didn't post by checking for the validation copy
+    await expect(page.getByText("URL is required when a label is set")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Clean up: clear the orphan label before afterEach runs
+    await labelInput.clear();
+  });
+
+  test("Hide Onyx Branding toggle removes the 'Powered by Onyx' tagline", async ({
+    page,
+  }) => {
+    // Sanity: tagline should be visible by default in the sidebar
+    await expect(page.getByText("Powered by Onyx").first()).toBeVisible({
+      timeout: 5000,
+    });
+
+    const hideBrandingToggle = page.locator(
+      '[data-label="hide-onyx-branding-toggle"]'
+    );
+    await hideBrandingToggle.scrollIntoViewIfNeeded();
+    await hideBrandingToggle.click();
+
+    const saveButton = page.getByRole("button", { name: "Apply Changes" });
+    await expect(saveButton).toBeEnabled();
+    await saveButton.click();
+    const response = await page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/admin/enterprise-settings") &&
+        r.request().method() === "PUT",
+      { timeout: 10000 }
+    );
+    expect(response.status()).toBe(200);
+    await expect(page.getByText(/successfully/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // After SWR revalidation the tagline should be gone from the sidebar
+    await expect(page.getByText("Powered by Onyx")).toHaveCount(0, {
+      timeout: 5000,
+    });
   });
 });

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -312,7 +312,16 @@ test.describe("Appearance Theme Settings @exclusive", () => {
   }) => {
     const themePage = new AppearanceThemePage(page);
 
-    // Sanity: tagline should be visible by default in the sidebar
+    // The sidebar's "Powered by Onyx" tagline only renders alongside an
+    // application name (the Logo's logo_and_name fall-through path), so
+    // first set a name and save a baseline that we can then assert against.
+    await themePage.setApplicationName(TEST_VALUES.applicationName);
+    const baselineResponse = await themePage.saveAndWaitForPut();
+    expect(baselineResponse.status()).toBe(200);
+    await themePage.expectSaveSuccessToast();
+    await themePage.reloadAndWaitForForm();
+
+    // Sanity: tagline now visible alongside the application name
     await themePage.expectPoweredByOnyxVisible();
 
     await themePage.toggleHideBranding();

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -258,6 +258,10 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     expect(response.status()).toBe(200);
     await themePage.expectSaveSuccessToast();
 
+    // Reload so the sidebar reads enterprise settings fresh — avoids any
+    // SWR cache / React render race after `mutate()`.
+    await themePage.reloadAndWaitForForm();
+
     await themePage.openUserDropdown();
     await themePage.expectCustomHelpLinkVisible(
       TEST_VALUES.customHelpLinkLabel,
@@ -275,9 +279,12 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     expect(response.status()).toBe(200);
     await themePage.expectSaveSuccessToast();
 
+    await themePage.reloadAndWaitForForm();
+
     await themePage.openUserDropdown();
     // Falls back to URL itself as the displayed title
     await themePage.expectCustomHelpLinkContainsText(
+      TEST_VALUES.customHelpLinkUrl,
       TEST_VALUES.customHelpLinkUrl
     );
   });
@@ -314,7 +321,9 @@ test.describe("Appearance Theme Settings @exclusive", () => {
     expect(response.status()).toBe(200);
     await themePage.expectSaveSuccessToast();
 
-    // After SWR revalidation the tagline should be gone from the sidebar
+    // Reload to read the persisted setting fresh — the sidebar then re-
+    // renders the Logo without the tagline.
+    await themePage.reloadAndWaitForForm();
     await themePage.expectPoweredByOnyxAbsent();
   });
 });


### PR DESCRIPTION
## Description
  - Add `custom_help_link_url` / `custom_help_link_label` and `hide_onyx_branding` fields to `EnterpriseSettings`, surfaced in the admin Appearance page behind a Disabled wrapper with an Enterprise plan tag.
  - Render the custom help link in the profile dropdown next to "Help & FAQ", and gate the "Powered by Onyx" sidebar tagline on the new toggle.
  - Enforce Enterprise tier on `PUT /admin/enterprise-settings` for the new fields, returning `FEATURE_NOT_AVAILABLE` (402) so the FE disabled state cannot be bypassed by a crafted request.
  
<img width="962" height="1208" alt="Screenshot 2026-05-18 at 4 10 41 PM" src="https://github.com/user-attachments/assets/5bfbd6e4-512e-4cbb-a2f2-1432dbb0f7ce" />
<img width="977" height="1129" alt="Screenshot 2026-05-18 at 4 11 43 PM" src="https://github.com/user-attachments/assets/1cb480dc-3bc4-4ec1-a997-2ecffc1d84eb" />

## How Has This Been Tested?
  - Backend unit tests for tier resolution: `backend/tests/unit/ee/onyx/utils/test_tier.py`.
  - Frontend Playwright spec for the Appearance page `web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts`.
  - Manually verified the admin form (disabled state on non-Enterprise, URL validation, save round-trip) and the help link +
   branding toggle in the sidebar / profile dropdown.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Enterprise-only settings for a custom help link and a hide-branding toggle. The Appearance page shows gated controls, the profile menu renders the link, and the sidebar tagline now hides with the toggle and only shows when an application name is set.

- **New Features**
  - Added `custom_help_link_url`, `custom_help_link_label`, and `hide_onyx_branding` to `EnterpriseSettings` (backend requires absolute http/https).
  - Admin > Appearance: Enterprise-gated with plan tag and tooltip; URL must be valid and is required when a label is set.
  - Profile menu: renders the custom help link (uses label or falls back to the URL). Sidebar: hides “Powered by Onyx” when enabled and only renders the tagline when an application name is set.
  - API: blocks writes to these fields on non-Enterprise with `FEATURE_NOT_AVAILABLE` (402).
  - Tests: Playwright E2E cover validation, popover rendering, branding toggle, and SWR revalidation; added page object and stable locators.

- **Bug Fixes**
  - Self-hosted legacy/dev: when `LICENSE_ENFORCEMENT_ENABLED=false` and EE code is loaded, treat tier as `ENTERPRISE` to avoid erroneous 402s on EE endpoints (tests patched to exercise cache/db paths).
  - Tightened URL validation to require a host (`parsed.netloc`) and fixed E2E flakiness by locating the popover link via `href` and reloading after save to ensure SWR caches refresh.

<sup>Written for commit 2d529c7480b31a61e29d00ae9c6a54d82c90e8bc. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

