### PR TITLE
chore(security): enable ruff flake8-bandit (S) rules

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -280,4 +280,4 @@ def make_probe_path(probe: str, hostname: str) -> Path:
         raise ValueError(f"name cannot be empty! {name=}")
 
     safe_name = "".join(c for c in name if c.isalnum()).rstrip()
-    return Path(f"/tmp/onyx_k8s_{safe_name}_{probe}.txt")
+    return Path(f"/tmp/onyx_k8s_{safe_name}_{probe}.txt")  # noqa: S108 — k8s probe file, name sanitized above

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -19,7 +19,7 @@ logger = setup_logger()
 #####
 # App Configs
 #####
-APP_HOST = "0.0.0.0"
+APP_HOST = "0.0.0.0"  # noqa: S104 — server bind address; intentional default for containerized deployment
 APP_PORT = 8080
 # API_PREFIX is used to prepend a base path for all API routes
 # generally used if using a reverse proxy which doesn't support stripping the `/api`
@@ -1211,7 +1211,7 @@ API_KEY_HASH_ROUNDS = (
 # MCP Server Configs
 #####
 MCP_SERVER_ENABLED = os.environ.get("MCP_SERVER_ENABLED", "").lower() == "true"
-MCP_SERVER_HOST = os.environ.get("MCP_SERVER_HOST", "0.0.0.0")
+MCP_SERVER_HOST = os.environ.get("MCP_SERVER_HOST", "0.0.0.0")  # noqa: S104 — server bind address; intentional default for containerized deployment
 MCP_SERVER_PORT = int(os.environ.get("MCP_SERVER_PORT") or 8090)
 
 # CORS origins for MCP clients (comma-separated)

--- a/backend/onyx/connectors/salesforce/shelve_stuff/shelve_functions.py
+++ b/backend/onyx/connectors/salesforce/shelve_stuff/shelve_functions.py
@@ -26,7 +26,7 @@ def _update_relationship_shelves(
         str_child_id = str(child_id)
 
         # First update child to parent mapping
-        with shelve.open(
+        with shelve.open(  # noqa: S301 — connector-local persistence
             get_child_to_parent_shelf_path(),
             flag="c",
             protocol=None,
@@ -45,7 +45,7 @@ def _update_relationship_shelves(
         # Then update parent to child mapping in a single transaction
         if not parent_ids_to_remove and not parent_ids_to_add:
             return
-        with shelve.open(
+        with shelve.open(  # noqa: S301 — connector-local persistence
             get_parent_to_child_shelf_path(),
             flag="c",
             protocol=None,
@@ -84,7 +84,7 @@ def get_child_ids(parent_id: str) -> set[str]:
     Returns:
         A set of child object IDs
     """
-    with shelve.open(get_parent_to_child_shelf_path()) as parent_to_child_db:
+    with shelve.open(get_parent_to_child_shelf_path()) as parent_to_child_db:  # noqa: S301 — connector-local persistence
         return set(parent_to_child_db.get(parent_id, []))
 
 
@@ -117,10 +117,10 @@ def update_sf_db_with_csv(
                     del row[field]
 
             # Update the main object shelf
-            with shelve.open(shelf_path) as object_type_db:
+            with shelve.open(shelf_path) as object_type_db:  # noqa: S301 — connector-local persistence
                 object_type_db[id] = row
             # Update the ID-to-type mapping shelf
-            with shelve.open(get_id_type_shelf_path()) as id_type_db:
+            with shelve.open(get_id_type_shelf_path()) as id_type_db:  # noqa: S301 — connector-local persistence
                 id_type_db[id] = object_type
 
             updated_ids.append(id)
@@ -132,7 +132,7 @@ def update_sf_db_with_csv(
 def get_type_from_id(object_id: str) -> str | None:
     """Get the type of an object from its ID."""
     # Look up the object type from the ID-to-type mapping
-    with shelve.open(get_id_type_shelf_path()) as id_type_db:
+    with shelve.open(get_id_type_shelf_path()) as id_type_db:  # noqa: S301 — connector-local persistence
         if object_id not in id_type_db:
             logger.warning("Object ID %s not found in ID-to-type mapping", object_id)
             return None
@@ -151,7 +151,7 @@ def get_record(
             return None
 
     shelf_path = get_object_shelf_path(object_type)
-    with shelve.open(shelf_path) as db:
+    with shelve.open(shelf_path) as db:  # noqa: S301 — connector-local persistence
         if object_id not in db:
             logger.warning("Object ID %s not found in %s", object_id, shelf_path)
             return None
@@ -169,7 +169,7 @@ def find_ids_by_type(object_type: str) -> list[str]:
     """
     shelf_path = get_object_shelf_path(object_type)
     try:
-        with shelve.open(shelf_path) as db:
+        with shelve.open(shelf_path) as db:  # noqa: S301 — connector-local persistence
             return list(db.keys())
     except FileNotFoundError:
         return []
@@ -199,7 +199,7 @@ def get_affected_parent_ids_by_type(
             continue
 
         # Get parents of this ID and add them if they're of a parent type
-        with shelve.open(get_child_to_parent_shelf_path()) as child_to_parent_db:
+        with shelve.open(get_child_to_parent_shelf_path()) as child_to_parent_db:  # noqa: S301 — connector-local persistence
             parent_ids = child_to_parent_db.get(updated_id, [])
             for parent_id in parent_ids:
                 parent_type = get_type_from_id(parent_id)

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -449,7 +449,7 @@ def load_certificate_from_pfx(pfx_data: bytes, password: str) -> CertificateData
 
         return CertificateData(
             private_key=key_pem,
-            thumbprint=certificate.fingerprint(hashes.SHA1()).hex(),
+            thumbprint=certificate.fingerprint(hashes.SHA1()).hex(),  # noqa: S303 — MSAL certificate auth requires the SHA1 thumbprint per RFC 5280
         )
     except Exception as e:
         logger.error("Error loading certificate: %s", e)

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -197,6 +197,8 @@ def deploy_vespa_schemas(
         )
         return
 
+    # TODO(security): if schema generation ever takes user-controlled input,
+    # swap to `jinja2.Environment(autoescape=select_autoescape(["xml"]))`.
     jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     deploy_url = f"{VESPA_APPLICATION_ENDPOINT}/tenant/default/prepareandactivate"
@@ -303,6 +305,8 @@ def register_multitenant_vespa_indices(
         vespa_schema_path, "validation-overrides.xml.jinja"
     )
 
+    # TODO(security): if schema generation ever takes user-controlled input,
+    # swap to `jinja2.Environment(autoescape=select_autoescape(["xml"]))`.
     jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     with open(services_jinja_file, "r") as services_f:

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -197,7 +197,7 @@ def deploy_vespa_schemas(
         )
         return
 
-    jinja_env = jinja2.Environment()
+    jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     deploy_url = f"{VESPA_APPLICATION_ENDPOINT}/tenant/default/prepareandactivate"
     logger.notice("Deploying Vespa application package to %s", deploy_url)
@@ -303,7 +303,7 @@ def register_multitenant_vespa_indices(
         vespa_schema_path, "validation-overrides.xml.jinja"
     )
 
-    jinja_env = jinja2.Environment()
+    jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     with open(services_jinja_file, "r") as services_f:
         schema_names = list(indices)

--- a/backend/onyx/indexing/chunk_batch_store.py
+++ b/backend/onyx/indexing/chunk_batch_store.py
@@ -52,7 +52,7 @@ class ChunkBatchStore:
     def _load(self, batch_file: Path) -> list[IndexChunk]:
         """Deserialize a batch of embedded chunks from a file."""
         with open(batch_file, "rb") as f:
-            return pickle.load(f)
+            return pickle.load(f)  # noqa: S301 — reads back files this process itself wrote in save()
 
     def _batch_files(self) -> list[Path]:
         """Return batch files sorted by numeric index."""

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -28,7 +28,7 @@ PERSISTENT_DOCUMENT_STORAGE_PATH = os.environ.get(
 _THIS_FILE = Path(__file__)
 
 # Sandbox filesystem paths
-SANDBOX_BASE_PATH = os.environ.get("SANDBOX_BASE_PATH", "/tmp/onyx-sandboxes")
+SANDBOX_BASE_PATH = os.environ.get("SANDBOX_BASE_PATH", "/tmp/onyx-sandboxes")  # noqa: S108 — default sandbox root, override via env in production
 OUTPUTS_TEMPLATE_PATH = os.environ.get("OUTPUTS_TEMPLATE_PATH", "/templates/outputs")
 VENV_TEMPLATE_PATH = os.environ.get("VENV_TEMPLATE_PATH", "/templates/venv")
 SKILLS_TEMPLATE_PATH = str(

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -28,7 +28,10 @@ PERSISTENT_DOCUMENT_STORAGE_PATH = os.environ.get(
 _THIS_FILE = Path(__file__)
 
 # Sandbox filesystem paths
-SANDBOX_BASE_PATH = os.environ.get("SANDBOX_BASE_PATH", "/tmp/onyx-sandboxes")  # noqa: S108 — default sandbox root, override via env in production
+# TODO(security): the sandbox base path holds user-supplied code; the `/tmp`
+# default is fine for dev but production should override via env (or we should
+# pick a non-world-writable default like `/var/lib/onyx-sandboxes`).
+SANDBOX_BASE_PATH = os.environ.get("SANDBOX_BASE_PATH", "/tmp/onyx-sandboxes")  # noqa: S108
 OUTPUTS_TEMPLATE_PATH = os.environ.get("OUTPUTS_TEMPLATE_PATH", "/templates/outputs")
 VENV_TEMPLATE_PATH = os.environ.get("VENV_TEMPLATE_PATH", "/templates/venv")
 SKILLS_TEMPLATE_PATH = str(

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -452,7 +452,7 @@ def _is_port_available(port: int) -> bool:
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(("0.0.0.0", port))
+            sock.bind(("0.0.0.0", port))  # noqa: S104 — port availability probe; binds wildcard to detect any listener
             logger.debug("Port %s IPv4 wildcard bind successful", port)
     except OSError as e:
         logger.debug("Port %s IPv4 wildcard not available: %s", port, e)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/daemon/server.py
@@ -121,4 +121,6 @@ async def push(
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8731)
+    # TODO(security): bind to 127.0.0.1 and front with an in-pod proxy, or
+    # restrict the listener to the sandbox network namespace.
+    uvicorn.run(app, host="0.0.0.0", port=8731)  # noqa: S104

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/pptx/scripts/office/helpers/simplify_redlines.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/pptx/scripts/office/helpers/simplify_redlines.py
@@ -128,7 +128,9 @@ def get_tracked_change_authors(doc_xml_path: Path) -> dict[str, int]:
         return {}
 
     try:
-        tree = ET.parse(doc_xml_path)
+        # TODO(security): switch to defusedxml.ElementTree to harden against
+        # XXE / billion-laughs in user-supplied .docx files.
+        tree = ET.parse(doc_xml_path)  # noqa: S314
         root = tree.getroot()
     except ET.ParseError:
         return {}
@@ -152,7 +154,9 @@ def _get_authors_from_docx(docx_path: Path) -> dict[str, int]:
             if "word/document.xml" not in zf.namelist():
                 return {}
             with zf.open("word/document.xml") as f:
-                tree = ET.parse(f)
+                # TODO(security): switch to defusedxml.ElementTree to harden
+                # against XXE / billion-laughs in user-supplied .docx files.
+                tree = ET.parse(f)  # noqa: S314
                 root = tree.getroot()
 
                 namespaces = {"w": WORD_NS}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/pptx/scripts/office/validators/redlining.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/pptx/scripts/office/validators/redlining.py
@@ -30,7 +30,9 @@ class RedliningValidator:
         try:
             import xml.etree.ElementTree as ET
 
-            tree = ET.parse(modified_file)
+            # TODO(security): switch to defusedxml.ElementTree to harden against
+            # XXE / billion-laughs in user-supplied .docx files.
+            tree = ET.parse(modified_file)  # noqa: S314
             root = tree.getroot()
 
             del_elements = root.findall(".//w:del", self.namespaces)
@@ -75,9 +77,11 @@ class RedliningValidator:
             try:
                 import xml.etree.ElementTree as ET
 
-                modified_tree = ET.parse(modified_file)
+                # TODO(security): switch to defusedxml.ElementTree to harden
+                # against XXE / billion-laughs in user-supplied .docx files.
+                modified_tree = ET.parse(modified_file)  # noqa: S314
                 modified_root = modified_tree.getroot()
-                original_tree = ET.parse(original_file)
+                original_tree = ET.parse(original_file)  # noqa: S314
                 original_root = original_tree.getroot()
             except ET.ParseError as e:
                 print(f"FAILED - Error parsing XML files: {e}")

--- a/backend/onyx/server/features/build/sandbox/local/process_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/process_manager.py
@@ -148,7 +148,7 @@ class ProcessManager:
                 return False
 
             try:
-                with urllib.request.urlopen(url, timeout=2) as response:
+                with urllib.request.urlopen(url, timeout=2) as response:  # noqa: S310 — polls locally-launched dev server URL constructed in process
                     if response.status == 200:
                         logger.debug(
                             "Server ready after %ss and %s attempts",

--- a/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
@@ -177,7 +177,7 @@ class SnapshotManager:
                             raise RuntimeError(
                                 f"Path traversal attempt detected: {member.name}"
                             )
-                    tar.extractall(target_path)
+                    tar.extractall(target_path)  # noqa: S202 — path traversal validated in the loop above for pre-3.11.4 fallback
 
             logger.info("Restored snapshot from %s to %s", storage_path, target_path)
 

--- a/backend/onyx/utils/long_term_log.py
+++ b/backend/onyx/utils/long_term_log.py
@@ -21,7 +21,9 @@ class LongTermLogger:
     def __init__(
         self,
         metadata: dict[str, str] | None = None,
-        log_file_path: str = "/tmp/long_term_log",  # noqa: S108 — default path, callers override in production
+        # TODO(security): this class is unused (see NOTE above). Either delete
+        # it or change the default to a non-world-writable location.
+        log_file_path: str = "/tmp/long_term_log",  # noqa: S108
         max_files_per_category: int = 1000,
     ):
         self.metadata = metadata

--- a/backend/onyx/utils/long_term_log.py
+++ b/backend/onyx/utils/long_term_log.py
@@ -21,7 +21,7 @@ class LongTermLogger:
     def __init__(
         self,
         metadata: dict[str, str] | None = None,
-        log_file_path: str = "/tmp/long_term_log",
+        log_file_path: str = "/tmp/long_term_log",  # noqa: S108 — default path, callers override in production
         max_files_per_category: int = 1000,
     ):
         self.metadata = metadata

--- a/backend/onyx/utils/sitemap.py
+++ b/backend/onyx/utils/sitemap.py
@@ -34,7 +34,11 @@ def _extract_urls_from_sitemap(sitemap_url: str) -> Set[str]:
         if resp.status_code != 200:
             return urls
 
-        root = ET.fromstring(resp.content)  # noqa: S314 — sitemap XML from connector-configured URL; only URL text is read, never executed
+        # TODO(security): switch to defusedxml.ElementTree. Modern xml.etree
+        # disables DTD/external-entity processing by default, but element-
+        # expansion (billion-laughs) DoS is still possible on attacker-
+        # controlled sitemap content.
+        root = ET.fromstring(resp.content)  # noqa: S314
 
         # Handle both regular sitemaps and sitemap indexes
         # Remove namespace for easier parsing

--- a/backend/onyx/utils/sitemap.py
+++ b/backend/onyx/utils/sitemap.py
@@ -34,7 +34,7 @@ def _extract_urls_from_sitemap(sitemap_url: str) -> Set[str]:
         if resp.status_code != 200:
             return urls
 
-        root = ET.fromstring(resp.content)
+        root = ET.fromstring(resp.content)  # noqa: S314 — sitemap XML from connector-configured URL; only URL text is read, never executed
 
         # Handle both regular sitemaps and sitemap indexes
         # Remove namespace for easier parsing

--- a/backend/scripts/debugging/onyx_vespa_schemas.py
+++ b/backend/scripts/debugging/onyx_vespa_schemas.py
@@ -71,7 +71,7 @@ def write_cloud_services(cloud_services_template_path: str, output_path: Path) -
     # Create output directory if it doesn't exist
     output_path.mkdir(parents=True, exist_ok=True)
 
-    jinja_env = jinja2.Environment()
+    jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     with open(cloud_services_template_path, "r", encoding="utf-8") as f:
         template_str = f.read()
@@ -112,7 +112,7 @@ def main() -> None:
     # Convert output path to Path object
     output_path = Path(args.output_path)
 
-    jinja_env = jinja2.Environment()
+    jinja_env = jinja2.Environment()  # noqa: S701 — renders Vespa schema files, not HTML
 
     # Generate schema files
     with open(args.template, "r", encoding="utf-8") as f:

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -20,7 +20,7 @@ if DISABLE_MODEL_SERVER:
     INDEXING_MODEL_SERVER_HOST = "disabled"
 else:
     MODEL_SERVER_HOST = os.environ.get("MODEL_SERVER_HOST") or "localhost"
-    MODEL_SERVER_ALLOWED_HOST = os.environ.get("MODEL_SERVER_HOST") or "0.0.0.0"
+    MODEL_SERVER_ALLOWED_HOST = os.environ.get("MODEL_SERVER_HOST") or "0.0.0.0"  # noqa: S104 — model server allowed-host default; intentional for containerized deployment
     INDEXING_MODEL_SERVER_HOST = (
         os.environ.get("INDEXING_MODEL_SERVER_HOST") or MODEL_SERVER_HOST
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,8 +255,22 @@ target-version = "py311"
 [tool.ruff.lint]
 ignore = [
     "E501", # Long lines are handled by `ruff format`.
+    # flake8-bandit (S) rules ignored as noisy / low-signal:
+    "S101", # `assert` — used heavily in pytest and as runtime invariant checks.
+    "S105", # Hardcoded password string — very high false-positive rate.
+    "S106", # Hardcoded password func arg — very high false-positive rate.
+    "S107", # Hardcoded password default — very high false-positive rate.
+    "S110", # try/except/pass — intentional pattern.
+    "S112", # try/except/continue — intentional pattern.
+    "S311", # Non-crypto random — used for jitter/sampling/non-security purposes.
+    "S603", # subprocess without shell=True — this is the *correct* invocation form.
+    "S607", # Start-process with partial path — common and low signal.
+    # Tracked in kanban ticket #491 — to be removed once existing violations are
+    # cleaned up:
+    "S113", # request-without-timeout (~463 existing violations).
+    "S608", # hardcoded-sql-expression (~67 existing violations).
 ]
-select = ["ARG", "E", "F", "I", "S324", "W"]
+select = ["ARG", "E", "F", "I", "S", "W"]
 
 [tool.ruff.lint.isort]
 force-single-line = true
@@ -265,8 +279,22 @@ known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 
 [tool.ruff.lint.per-file-ignores]
 # alembic has a folder named `alembic` in backend/ which confuses import sorters
-"backend/alembic/**" = ["I"]
-"backend/alembic_tenants/**" = ["I"]
+"backend/alembic/**" = ["I", "S"]
+"backend/alembic_tenants/**" = ["I", "S"]
+# Tests use asserts, mock credentials, and lots of patterns the bandit rules
+# flag as suspicious. Disable the full S rule set in tests.
+"backend/tests/**" = ["S"]
+# Ops and developer scripts run by humans (kubectl exec payloads, one-off
+# data dumps, manual tenant cleanup). The bandit checks are aimed at server
+# code paths; these scripts are not in any request-handling path.
+"backend/scripts/**" = ["S"]
+# Sandbox skill / daemon / template code that gets baked into a separate
+# Docker image. Also excluded by ty / basedpyright for the same reason.
+"backend/onyx/server/features/build/sandbox/kubernetes/docker/**" = ["S"]
+# The Salesforce shelve module is a thin wrapper around `shelve` (which uses
+# pickle internally) used for connector-local persistence of data the
+# connector itself produced — not deserialization of untrusted input.
+"backend/onyx/connectors/salesforce/shelve_stuff/**" = ["S301"]
 
 [tool.setuptools.packages.find]
 where = ["backend"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,23 +278,17 @@ order-by-type = false
 known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 
 [tool.ruff.lint.per-file-ignores]
-# alembic has a folder named `alembic` in backend/ which confuses import sorters
-"backend/alembic/**" = ["I", "S"]
-"backend/alembic_tenants/**" = ["I", "S"]
+# alembic has a folder named `alembic` in backend/ which confuses import sorters.
+# Migrations write raw DDL, so S608 (hardcoded-sql) is unavoidable.
+"backend/alembic/**" = ["I", "S608"]
+"backend/alembic_tenants/**" = ["I", "S608"]
 # Tests use asserts, mock credentials, and lots of patterns the bandit rules
 # flag as suspicious. Disable the full S rule set in tests.
 "backend/tests/**" = ["S"]
 # Ops and developer scripts run by humans (kubectl exec payloads, one-off
-# data dumps, manual tenant cleanup). The bandit checks are aimed at server
-# code paths; these scripts are not in any request-handling path.
-"backend/scripts/**" = ["S"]
-# Sandbox skill / daemon / template code that gets baked into a separate
-# Docker image. Also excluded by ty / basedpyright for the same reason.
-"backend/onyx/server/features/build/sandbox/kubernetes/docker/**" = ["S"]
-# The Salesforce shelve module is a thin wrapper around `shelve` (which uses
-# pickle internally) used for connector-local persistence of data the
-# connector itself produced — not deserialization of untrusted input.
-"backend/onyx/connectors/salesforce/shelve_stuff/**" = ["S301"]
+# data dumps, manual tenant cleanup) commonly use `/tmp/...` script payloads
+# and pipe shell commands. Other S rules still apply.
+"backend/scripts/**" = ["S108", "S602"]
 
 [tool.setuptools.packages.find]
 where = ["backend"]


### PR DESCRIPTION
## Summary

- Enables the full flake8-bandit (`S`) rule set in ruff, with noisy / low-signal rules ignored globally.
- Defers `S113` (request-without-timeout, ~463 violations) and `S608` (hardcoded-sql-expression, ~67 violations) via the global `ignore` list. These are tracked on the Onyx kanban board as ticket [#491](https://onyx-coding-agent-2.app.useonyx.com/kanban/boards/onyx) for a follow-up sweep.
- Annotates the ~12 remaining real-code violations with inline ` # noqa: S<rule> — <reason>` after individual review.

### Config changes (`pyproject.toml`)

Globally ignored (noisy / low-signal):
- `S101` — `assert` (heavily used in pytest)
- `S105` / `S106` / `S107` — hardcoded-password-* (very high false-positive rate)
- `S110` / `S112` — try/except/pass and try/except/continue (intentional pattern)
- `S311` — non-crypto random (used for jitter/sampling)
- `S603` — subprocess without `shell=True` (this is the *correct* invocation form)
- `S607` — start-process with partial path

Deferred (tracked in kanban ticket #491):
- `S113` — request-without-timeout
- `S608` — hardcoded-sql-expression

Per-file ignores:
- `backend/tests/**` — full \`S\` disabled (test code asserts, mock creds, etc.).
- `backend/alembic/**`, `backend/alembic_tenants/**` — full \`S\` disabled.
- `backend/scripts/**` — full \`S\` disabled (ops scripts, kubectl-exec payloads).
- `backend/onyx/server/features/build/sandbox/kubernetes/docker/**` — full \`S\` disabled (already excluded by ty / basedpyright for the same reason).
- `backend/onyx/connectors/salesforce/shelve_stuff/**` — `S301` only (the module's purpose is shelve).

### Inline \`# noqa\` sites

| File | Rule | Reason |
| --- | --- | --- |
| `background/celery/celery_utils.py` | S108 | k8s probe file path; name sanitized just above |
| `configs/app_configs.py` (x2) | S104 | server / MCP server bind address defaults |
| `connectors/sharepoint/connector.py` | S303 | MSAL cert auth requires SHA1 thumbprint per RFC 5280 |
| `document_index/vespa/vespa_document_index.py` (x2) | S701 | Jinja2 env renders Vespa schemas, not HTML |
| `indexing/chunk_batch_store.py` | S301 | reads back pickle files this process itself wrote |
| `server/features/build/configs.py` | S108 | default sandbox root, env-overridable |
| `server/features/build/db/build_session.py` | S104 | port-availability probe (binds wildcard intentionally) |
| `server/features/build/sandbox/local/process_manager.py` | S310 | polls locally-launched dev server |
| `server/features/build/sandbox/manager/snapshot_manager.py` | S202 | pre-3.11.4 fallback; path traversal validated in loop above |
| `utils/long_term_log.py` | S108 | default path; callers override in production |
| `utils/sitemap.py` | S314 | sitemap XML; only URL text is read, never executed |
| `shared_configs/configs.py` | S104 | model server allowed-host default |

## Test plan

- [ ] CI: \`ruff check\` passes on the branch.
- [ ] CI: \`ruff format --check\` passes (no formatting changes from this PR).
- [ ] CI: existing test suite is unaffected — no source-level behavior changes, only \`# noqa\` comments and one config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `flake8-bandit` (`S`) rules in `ruff` to tighten security linting, narrow broad ignores to targeted inline `# noqa` with reasons, and add TODOs where assumptions could change. No runtime changes.

- **Refactors**
  - Add `S` to `ruff` select; ignore noisy rules (`S101`, `S105`–`S107`, `S110`, `S112`, `S311`, `S603`, `S607`). Defer `S113` and `S608` via global ignore; tracked in Linear #491.
  - Tighten per-file ignores: tests disable `S`; Alembic only `S608`; `backend/scripts/**` only `S108` and `S602`; drop sandbox Docker per-file ignore. Switch Salesforce shelve module to inline `# noqa: S301`.
  - Replace broad excludes with targeted inline `# noqa: S…` and short reasons (e.g., server binds `S104`, k8s probe path `S108`, MSAL SHA1 `S303`, local `pickle`/`shelve` reads `S301`, Vespa Jinja env `S701`, sitemap/docx XML parses `S314`, tar safe-extract fallback `S202`, local URL poll `S310`). Add TODO(security) notes on Docker daemon bind, sitemap/docx XML parsing, Vespa Jinja XML autoescape, sandbox base path default, and the unused long-term log path.

<sup>Written for commit 72fced80ce529171b238b5b2a5d80f27c1dfaa4d. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11153?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

