### PR TITLE
fix(ollama): honor Modelfile num_ctx when fetching models

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1208,6 +1208,13 @@ def get_ollama_available_models(
             context_limit = ollama_model_details.model_info.get(
                 architecture + ".context_length", None
             )
+            # Prefer an explicit Modelfile `num_ctx` over the architectural
+            # maximum so operators who cap context to fit VRAM aren't silently
+            # overridden. Falls back to context_length when no Modelfile value
+            # is set (preserves PR #8385's fix for silent truncation).
+            modelfile_num_ctx = ollama_model_details.parsed_num_ctx()
+            if modelfile_num_ctx is not None:
+                context_limit = modelfile_num_ctx
             supports_image_input = ollama_model_details.supports_image_input()
         except ValidationError as e:
             logger.warning(

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1205,8 +1205,9 @@ def get_ollama_available_models(
             architecture = ollama_model_details.model_info.get(
                 "general.architecture", ""
             )
-            context_limit = ollama_model_details.num_ctx or ollama_model_details.model_info.get(
-                architecture + ".context_length"
+            context_limit = (
+                ollama_model_details.num_ctx
+                or ollama_model_details.model_info.get(architecture + ".context_length")
             )
             supports_image_input = ollama_model_details.supports_image_input()
         except ValidationError as e:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1208,7 +1208,7 @@ def get_ollama_available_models(
             context_limit = ollama_model_details.model_info.get(
                 architecture + ".context_length", None
             )
-            modelfile_num_ctx: int | None = ollama_model_details.parsed_num_ctx()
+            modelfile_num_ctx = ollama_model_details.parsed_num_ctx
             if modelfile_num_ctx is not None:
                 context_limit = modelfile_num_ctx
             supports_image_input = ollama_model_details.supports_image_input()

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1208,11 +1208,7 @@ def get_ollama_available_models(
             context_limit = ollama_model_details.model_info.get(
                 architecture + ".context_length", None
             )
-            # Prefer an explicit Modelfile `num_ctx` over the architectural
-            # maximum so operators who cap context to fit VRAM aren't silently
-            # overridden. Falls back to context_length when no Modelfile value
-            # is set (preserves PR #8385's fix for silent truncation).
-            modelfile_num_ctx = ollama_model_details.parsed_num_ctx()
+            modelfile_num_ctx: int | None = ollama_model_details.parsed_num_ctx()
             if modelfile_num_ctx is not None:
                 context_limit = modelfile_num_ctx
             supports_image_input = ollama_model_details.supports_image_input()

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1208,7 +1208,7 @@ def get_ollama_available_models(
             context_limit = ollama_model_details.model_info.get(
                 architecture + ".context_length", None
             )
-            modelfile_num_ctx = ollama_model_details.parsed_num_ctx
+            modelfile_num_ctx = ollama_model_details.num_ctx
             if modelfile_num_ctx is not None:
                 context_limit = modelfile_num_ctx
             supports_image_input = ollama_model_details.supports_image_input()

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1205,12 +1205,9 @@ def get_ollama_available_models(
             architecture = ollama_model_details.model_info.get(
                 "general.architecture", ""
             )
-            context_limit = ollama_model_details.model_info.get(
-                architecture + ".context_length", None
+            context_limit = ollama_model_details.num_ctx or ollama_model_details.model_info.get(
+                architecture + ".context_length"
             )
-            modelfile_num_ctx = ollama_model_details.num_ctx
-            if modelfile_num_ctx is not None:
-                context_limit = modelfile_num_ctx
             supports_image_input = ollama_model_details.supports_image_input()
         except ValidationError as e:
             logger.warning(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any
 from typing import Generic
 from typing import TYPE_CHECKING
@@ -360,7 +361,8 @@ class OllamaModelDetails(BaseModel):
         """Check if this model supports image input"""
         return "vision" in self.capabilities
 
-    def _parse_parameters(self) -> dict[str, str]:
+    @cached_property
+    def _parsed_parameters(self) -> dict[str, str]:
         parsed: dict[str, str] = {}
         for line in (self.parameters or "").splitlines():
             tokens = line.split(maxsplit=1)
@@ -370,7 +372,7 @@ class OllamaModelDetails(BaseModel):
 
     @property
     def num_ctx(self) -> int | None:
-        raw = self._parse_parameters().get("num_ctx")
+        raw = self._parsed_parameters.get("num_ctx")
         if raw is None:
             return None
         try:

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -368,6 +368,7 @@ class OllamaModelDetails(BaseModel):
                 parsed[tokens[0]] = tokens[1].strip()
         return parsed
 
+    @property
     def parsed_num_ctx(self) -> int | None:
         raw = self._parse_parameters().get("num_ctx")
         if raw is None:

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -369,7 +369,7 @@ class OllamaModelDetails(BaseModel):
         return parsed
 
     @property
-    def parsed_num_ctx(self) -> int | None:
+    def num_ctx(self) -> int | None:
         raw = self._parse_parameters().get("num_ctx")
         if raw is None:
             return None

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -349,6 +349,9 @@ class OllamaModelDetails(BaseModel):
 
     model_info: dict[str, Any]
     capabilities: list[str] = []
+    # Newline-delimited "<key>  <value>" pairs from the Modelfile, e.g.
+    # "num_ctx 8192\ntemperature 0.6\n". Empty when no PARAMETERs are set.
+    parameters: str = ""
 
     def supports_completion(self) -> bool:
         """Check if this model supports completion/chat"""
@@ -357,6 +360,23 @@ class OllamaModelDetails(BaseModel):
     def supports_image_input(self) -> bool:
         """Check if this model supports image input"""
         return "vision" in self.capabilities
+
+    def parsed_num_ctx(self) -> int | None:
+        """Return the Modelfile-configured `num_ctx`, if any.
+
+        Honors an explicit Modelfile `PARAMETER num_ctx <N>` so operators
+        can cap context to fit their VRAM budget without Onyx silently
+        overriding it with the model's architectural maximum.
+        """
+        for line in self.parameters.splitlines():
+            tokens = line.split(maxsplit=1)
+            if len(tokens) == 2 and tokens[0] == "num_ctx":
+                try:
+                    value = int(tokens[1].strip())
+                except ValueError:
+                    return None
+                return value if value > 0 else None
+        return None
 
 
 # OpenRouter dynamic models fetch

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -349,9 +349,8 @@ class OllamaModelDetails(BaseModel):
 
     model_info: dict[str, Any]
     capabilities: list[str] = []
-    # Newline-delimited "<key>  <value>" pairs from the Modelfile, e.g.
-    # "num_ctx 8192\ntemperature 0.6\n". Empty when no PARAMETERs are set.
-    parameters: str = ""
+    # Newline-delimited "<key>  <value>" pairs from the Modelfile.
+    parameters: str | None = None
 
     def supports_completion(self) -> bool:
         """Check if this model supports completion/chat"""
@@ -361,22 +360,23 @@ class OllamaModelDetails(BaseModel):
         """Check if this model supports image input"""
         return "vision" in self.capabilities
 
-    def parsed_num_ctx(self) -> int | None:
-        """Return the Modelfile-configured `num_ctx`, if any.
-
-        Honors an explicit Modelfile `PARAMETER num_ctx <N>` so operators
-        can cap context to fit their VRAM budget without Onyx silently
-        overriding it with the model's architectural maximum.
-        """
-        for line in self.parameters.splitlines():
+    def _parse_parameters(self) -> dict[str, str]:
+        parsed: dict[str, str] = {}
+        for line in (self.parameters or "").splitlines():
             tokens = line.split(maxsplit=1)
-            if len(tokens) == 2 and tokens[0] == "num_ctx":
-                try:
-                    value = int(tokens[1].strip())
-                except ValueError:
-                    return None
-                return value if value > 0 else None
-        return None
+            if len(tokens) == 2:
+                parsed[tokens[0]] = tokens[1].strip()
+        return parsed
+
+    def parsed_num_ctx(self) -> int | None:
+        raw = self._parse_parameters().get("num_ctx")
+        if raw is None:
+            return None
+        try:
+            value = int(raw)
+        except ValueError:
+            return None
+        return value if value > 0 else None
 
 
 # OpenRouter dynamic models fetch

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -150,6 +150,75 @@ class TestGetOllamaAvailableModels:
             mock_session.execute.assert_not_called()
             mock_session.commit.assert_not_called()
 
+    def test_prefers_modelfile_num_ctx_over_architecture_context_length(
+        self, mock_ollama_tags_response: dict
+    ) -> None:
+        """When the Modelfile sets PARAMETER num_ctx, it should win over the
+        architectural maximum so operators can cap context to fit VRAM."""
+        from onyx.server.manage.llm.api import get_ollama_available_models
+
+        show_response = {
+            "model_info": {
+                "general.architecture": "qwen3moe",
+                "qwen3moe.context_length": 262144,
+            },
+            "capabilities": ["completion"],
+            "parameters": (
+                "top_k                          20\n"
+                "top_p                          0.95\n"
+                "num_ctx                        8192\n"
+                "temperature                    0.6"
+            ),
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_get_response = MagicMock()
+            mock_get_response.json.return_value = mock_ollama_tags_response
+            mock_get_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_get_response
+
+            mock_post_response = MagicMock()
+            mock_post_response.json.return_value = show_response
+            mock_post_response.raise_for_status = MagicMock()
+            mock_httpx.post.return_value = mock_post_response
+
+            request = OllamaModelsRequest(api_base="http://localhost:11434")
+            results = get_ollama_available_models(request, MagicMock(), MagicMock())
+
+            assert all(r.max_input_tokens == 8192 for r in results)
+
+    def test_falls_back_to_architecture_context_length_without_num_ctx(
+        self, mock_ollama_tags_response: dict
+    ) -> None:
+        """Absent a Modelfile num_ctx, behavior matches the pre-fix path:
+        use the architecture's context_length."""
+        from onyx.server.manage.llm.api import get_ollama_available_models
+
+        show_response = {
+            "model_info": {
+                "general.architecture": "llama",
+                "llama.context_length": 32768,
+            },
+            "capabilities": ["completion"],
+            "parameters": "temperature                    0.6",
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_get_response = MagicMock()
+            mock_get_response.json.return_value = mock_ollama_tags_response
+            mock_get_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_get_response
+
+            mock_post_response = MagicMock()
+            mock_post_response.json.return_value = show_response
+            mock_post_response.raise_for_status = MagicMock()
+            mock_httpx.post.return_value = mock_post_response
+
+            request = OllamaModelsRequest(api_base="http://localhost:11434")
+            results = get_ollama_available_models(request, MagicMock(), MagicMock())
+
+            assert all(r.max_input_tokens == 32768 for r in results)
+
 
 class TestGetOpenRouterAvailableModels:
     """Tests for the OpenRouter model fetch endpoint."""

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -153,8 +153,6 @@ class TestGetOllamaAvailableModels:
     def test_prefers_modelfile_num_ctx_over_architecture_context_length(
         self, mock_ollama_tags_response: dict
     ) -> None:
-        """When the Modelfile sets PARAMETER num_ctx, it should win over the
-        architectural maximum so operators can cap context to fit VRAM."""
         from onyx.server.manage.llm.api import get_ollama_available_models
 
         show_response = {
@@ -190,8 +188,6 @@ class TestGetOllamaAvailableModels:
     def test_falls_back_to_architecture_context_length_without_num_ctx(
         self, mock_ollama_tags_response: dict
     ) -> None:
-        """Absent a Modelfile num_ctx, behavior matches the pre-fix path:
-        use the architecture's context_length."""
         from onyx.server.manage.llm.api import get_ollama_available_models
 
         show_response = {
@@ -218,6 +214,37 @@ class TestGetOllamaAvailableModels:
             results = get_ollama_available_models(request, MagicMock(), MagicMock())
 
             assert all(r.max_input_tokens == 32768 for r in results)
+
+    def test_handles_null_parameters_field(
+        self, mock_ollama_tags_response: dict
+    ) -> None:
+        from onyx.server.manage.llm.api import get_ollama_available_models
+
+        show_response = {
+            "model_info": {
+                "general.architecture": "llama",
+                "llama.context_length": 16384,
+            },
+            "capabilities": ["completion"],
+            "parameters": None,
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx") as mock_httpx:
+            mock_get_response = MagicMock()
+            mock_get_response.json.return_value = mock_ollama_tags_response
+            mock_get_response.raise_for_status = MagicMock()
+            mock_httpx.get.return_value = mock_get_response
+
+            mock_post_response = MagicMock()
+            mock_post_response.json.return_value = show_response
+            mock_post_response.raise_for_status = MagicMock()
+            mock_httpx.post.return_value = mock_post_response
+
+            request = OllamaModelsRequest(api_base="http://localhost:11434")
+            results = get_ollama_available_models(request, MagicMock(), MagicMock())
+
+            assert len(results) == 3
+            assert all(r.max_input_tokens == 16384 for r in results)
 
 
 class TestGetOpenRouterAvailableModels:


### PR DESCRIPTION
## Summary

- Parse the `parameters` blob from Ollama's `/api/show` response and prefer an explicit `PARAMETER num_ctx <N>` over `<arch>.context_length` when storing a model's `max_input_tokens`.
- Falls back to the architectural context length when no Modelfile value is set, preserving #8385's fix for silent context truncation.
- `_build_model_kwargs` in `factory.py` is intentionally untouched — it already echoes whatever `max_input_tokens` is stored, so fixing the value at fetch time fixes the whole chain.

Closes #9364.

### Why

[PR #8385](https://github.com/onyx-dot-app/onyx/pull/8385) started passing each model's architectural `context_length` as `num_ctx` for `OLLAMA_CHAT`. For users who cap `num_ctx` in their Modelfile to fit VRAM (e.g. `qwen3-30b-a3b-8k` with `PARAMETER num_ctx 8192`), Onyx silently overrode that with the model's full `262144`, spilling onto CPU/RAM (100% GPU → 27%/73% CPU/GPU, 19 GB → 33 GB resident in the issue reporter's case).

After this change Onyx honors the Modelfile value when present, and keeps the previous behavior when no `num_ctx` is set (so single-turn truncation on Ollama defaults is still avoided).

## Test plan

<img width="2880" height="1920" alt="20260519_17h43m23s_grim" src="https://github.com/user-attachments/assets/a3a7111d-538b-4ee0-be2e-81f5fd42a726" />


- [x] `pytest backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py::TestGetOllamaAvailableModels` — 5/5 pass, includes two new cases (Modelfile `num_ctx` wins; fallback to architecture max).
- [x] `pytest backend/tests/unit/onyx/llm/test_factory.py` — 8/8 pass, no regression in `_build_model_kwargs` behavior.
- [ ] Manual: set `PARAMETER num_ctx 8192` in a Modelfile, re-fetch models from the Ollama provider modal, verify `ollama ps` shows `CONTEXT 8192` and `100% GPU` after sending a chat.
- [ ] Manual: model with no Modelfile `num_ctx` still gets the architecture context_length stored (verify via psql `SELECT name, max_input_tokens FROM model_configuration`).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Modelfile `num_ctx` when fetching Ollama models so `max_input_tokens` respects operator caps and avoids GPU/CPU spill. If no Modelfile value is set, fall back to the architecture `context_length` to preserve the previous truncation fix.

- **Bug Fixes**
  - Parse `parameters` from Ollama `/api/show`; prefer Modelfile `num_ctx` over `<arch>.context_length`, with fallback.
  - Add `parameters` to `OllamaModelDetails` with null-safe handling.
  - Tests for Modelfile override, architecture fallback, and `parameters: null`.

- **Refactors**
  - Cache parsed Modelfile parameters via `@cached_property`; expose `num_ctx` as a property.
  - Use `details.num_ctx` in `get_ollama_available_models`.
  - Collapse context-limit resolution to a single or-chain.

<sup>Written for commit ad88c3c103d00f645d79be45fc1f0fbde6134aa9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11160?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->