### PR TITLE
refactor(infra): Set CloudWatch log retention defaults to 365 days for compliance

### DIFF
--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -181,8 +181,8 @@ variable "cluster_enabled_log_types" {
 
 variable "cloudwatch_log_group_retention_in_days" {
   type        = number
-  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire)"
-  default     = 30
+  description = "Number of days to retain EKS control plane logs in CloudWatch (0 = never expire). Default 365 = 12 months + some buffer for compliance."
+  default     = 365
 
   validation {
     condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.cloudwatch_log_group_retention_in_days)

--- a/deployment/terraform/modules/aws/waf/variables.tf
+++ b/deployment/terraform/modules/aws/waf/variables.tf
@@ -47,6 +47,6 @@ variable "enable_logging" {
 
 variable "log_retention_days" {
   type        = number
-  description = "Number of days to retain WAF logs"
-  default     = 90
+  description = "Number of days to retain WAF logs. Default 365 = 12 months + some buffer for compliance."
+  default     = 365
 }


### PR DESCRIPTION
## Summary

Updates EKS and WAF Terraform module variable defaults to enforce 365-day CloudWatch log retention across all clusters and WAF policies. This ensures compliance with Vanta's log retention requirements.

## Changes

- **EKS module** (`deployment/terraform/modules/aws/eks/variables.tf`): `cloudwatch_log_group_retention_in_days` default `30 → 365` days
- **WAF module** (`deployment/terraform/modules/aws/waf/variables.tf`): `log_retention_days` default `90 → 365` days

## Rationale

Vanta compliance test "Server logs retained for 365 days (AWS)" was failing for 7 log groups due to insufficient retention policies. This change codifies the 365-day retention requirement at the module level, preventing accidental future misconfigurations.

## Affected Log Groups (Already Patched via AWS CLI)

✓ `/aws/eks/onyx-st-dev/cluster` (us-west-2)  
✓ `/aws/waf/onyx` (us-west-2)  
✓ `/aws/waf/playlist` (us-east-1)  
✓ `/aws/eks/playlist-prod/cluster` (us-east-1)  
✓ `/aws/waf/multi-tenant` (us-west-1)  
✓ `/aws/eks/onyx-craft-dev/cluster` (us-west-2)  
✓ `/aws/eks/agent-wiki-dev-wiki/cluster` (us-west-2) [OVERDUE - fixed 2026-05-18]

All 7 log groups were manually updated to 365-day retention via AWS CLI before this PR. Terraform will now maintain these settings and prevent regression.

## Test Plan

- [ ] Vanta compliance test "Server logs retained for 365 days (AWS)" passes
- [ ] terraform plan shows no changes (existing resources already have 365-day retention)
- [ ] New EKS clusters and WAF policies will default to 365-day retention

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set CloudWatch log retention defaults to 365 days in the EKS and WAF Terraform modules to meet Vanta’s 1-year requirement and prevent future misconfigurations. Existing resources are already at 365, so plans should be a no-op.

- **Refactors**
  - EKS: `cloudwatch_log_group_retention_in_days` default 30 → 365 (updated description).
  - WAF: `log_retention_days` default 90 → 365 (updated description).

- **Migration**
  - No changes expected on apply for existing stacks.
  - New EKS clusters and WAF policies will default to 365-day retention.

<sup>Written for commit defc3da32c9f6584f8f169f2a04294b9a2501be7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

