### PR TITLE
chore(opensearch, prometheus): Emit telemetry on search failures

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -25,7 +25,8 @@ from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
 from onyx.document_index.opensearch.search import DEFAULT_OPENSEARCH_MAX_RESULT_WINDOW
 from onyx.server.metrics.opensearch_search import observe_opensearch_search
-from onyx.server.metrics.opensearch_search import track_opensearch_search_in_progress
+from onyx.server.metrics.opensearch_search import record_opensearch_search_error
+from onyx.server.metrics.opensearch_search import track_opensearch_search
 from onyx.utils.logger import setup_logger
 from onyx.utils.timing import log_function_time
 
@@ -1185,26 +1186,30 @@ class OpenSearchIndexClient(OpenSearchClient):
         result: dict[str, Any]
         params = {"phase_took": "true"}
         ctx = self._get_emit_metrics_context_manager(search_type)
-        t0 = time.perf_counter()
         with ctx:
-            if search_pipeline_id:
-                result = self._client.search(
-                    index=self._index_name,
-                    search_pipeline=search_pipeline_id,
-                    body=body,
-                    params=params,
+            try:
+                t0 = time.perf_counter()
+                if search_pipeline_id:
+                    result = self._client.search(
+                        index=self._index_name,
+                        search_pipeline=search_pipeline_id,
+                        body=body,
+                        params=params,
+                    )
+                else:
+                    result = self._client.search(
+                        index=self._index_name, body=body, params=params
+                    )
+                client_duration_s = time.perf_counter() - t0
+                hits, time_took, timed_out, phase_took, profile = (
+                    self._get_hits_and_profile_from_search_result(result)
                 )
-            else:
-                result = self._client.search(
-                    index=self._index_name, body=body, params=params
-                )
-        client_duration_s = time.perf_counter() - t0
-
-        hits, time_took, timed_out, phase_took, profile = (
-            self._get_hits_and_profile_from_search_result(result)
-        )
-        if self._emit_metrics:
-            observe_opensearch_search(search_type, client_duration_s, time_took)
+                if self._emit_metrics:
+                    observe_opensearch_search(search_type, client_duration_s, time_took)
+            except Exception as e:
+                if self._emit_metrics:
+                    record_opensearch_search_error(search_type, e)
+                raise
         self._log_search_result_perf(
             time_took=time_took,
             timed_out=timed_out,
@@ -1284,18 +1289,22 @@ class OpenSearchIndexClient(OpenSearchClient):
 
         params = {"phase_took": "true"}
         ctx = self._get_emit_metrics_context_manager(search_type)
-        t0 = time.perf_counter()
         with ctx:
-            result: dict[str, Any] = self._client.search(
-                index=self._index_name, body=body, params=params
-            )
-        client_duration_s = time.perf_counter() - t0
-
-        hits, time_took, timed_out, phase_took, profile = (
-            self._get_hits_and_profile_from_search_result(result)
-        )
-        if self._emit_metrics:
-            observe_opensearch_search(search_type, client_duration_s, time_took)
+            try:
+                t0 = time.perf_counter()
+                result: dict[str, Any] = self._client.search(
+                    index=self._index_name, body=body, params=params
+                )
+                client_duration_s = time.perf_counter() - t0
+                hits, time_took, timed_out, phase_took, profile = (
+                    self._get_hits_and_profile_from_search_result(result)
+                )
+                if self._emit_metrics:
+                    observe_opensearch_search(search_type, client_duration_s, time_took)
+            except Exception as e:
+                if self._emit_metrics:
+                    record_opensearch_search_error(search_type, e)
+                raise
         self._log_search_result_perf(
             time_took=time_took,
             timed_out=timed_out,
@@ -1425,12 +1434,12 @@ class OpenSearchIndexClient(OpenSearchClient):
         self, search_type: OpenSearchSearchType
     ) -> AbstractContextManager[None]:
         """
-        Returns a context manager that tracks in-flight OpenSearch searches via
-        a Gauge if emit_metrics is True, otherwise returns a null context
-        manager.
+        Returns the OpenSearch search tracking context manager (which bumps the
+        attempt counter and the in-flight gauge) if emit_metrics is True,
+        otherwise returns a null context manager.
         """
         return (
-            track_opensearch_search_in_progress(search_type)
+            track_opensearch_search(search_type)
             if self._emit_metrics
             else nullcontext()
         )

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -99,8 +99,6 @@ class OpenSearchUpdateError(Exception):
     exceptions update calls can raise.
     """
 
-    pass
-
 
 class OpenSearchIndexError(Exception):
     """
@@ -109,7 +107,11 @@ class OpenSearchIndexError(Exception):
     exceptions index calls can raise.
     """
 
-    pass
+
+class OpenSearchServerSideTimeout(Exception):
+    """
+    A server-side timeout occurred when searching an OpenSearch index.
+    """
 
 
 def get_new_body_without_vectors(body: dict[str, Any]) -> dict[str, Any]:
@@ -1204,21 +1206,26 @@ class OpenSearchIndexClient(OpenSearchClient):
                 hits, time_took, timed_out, phase_took, profile = (
                     self._get_hits_and_profile_from_search_result(result)
                 )
+                # Inside the try/except so that server-side timeouts (which
+                # raise inside this helper) land in
+                # record_opensearch_search_error and never reach
+                # observe_opensearch_search — keeping the latency histograms
+                # clean of timed-out queries.
+                self._log_search_result_perf(
+                    time_took=time_took,
+                    timed_out=timed_out,
+                    phase_took=phase_took,
+                    profile=profile,
+                    body=body,
+                    search_pipeline_id=search_pipeline_id,
+                    raise_on_timeout=True,
+                )
                 if self._emit_metrics:
                     observe_opensearch_search(search_type, client_duration_s, time_took)
             except Exception as e:
                 if self._emit_metrics:
                     record_opensearch_search_error(search_type, e)
                 raise
-        self._log_search_result_perf(
-            time_took=time_took,
-            timed_out=timed_out,
-            phase_took=phase_took,
-            profile=profile,
-            body=body,
-            search_pipeline_id=search_pipeline_id,
-            raise_on_timeout=True,
-        )
 
         search_hits: list[SearchHit[DocumentChunkWithoutVectors]] = []
         for hit in hits:
@@ -1299,20 +1306,25 @@ class OpenSearchIndexClient(OpenSearchClient):
                 hits, time_took, timed_out, phase_took, profile = (
                     self._get_hits_and_profile_from_search_result(result)
                 )
+                # Inside the try/except so that server-side timeouts (which
+                # raise inside this helper) land in
+                # record_opensearch_search_error and never reach
+                # observe_opensearch_search — keeping the latency histograms
+                # clean of timed-out queries.
+                self._log_search_result_perf(
+                    time_took=time_took,
+                    timed_out=timed_out,
+                    phase_took=phase_took,
+                    profile=profile,
+                    body=body,
+                    raise_on_timeout=True,
+                )
                 if self._emit_metrics:
                     observe_opensearch_search(search_type, client_duration_s, time_took)
             except Exception as e:
                 if self._emit_metrics:
                     record_opensearch_search_error(search_type, e)
                 raise
-        self._log_search_result_perf(
-            time_took=time_took,
-            timed_out=timed_out,
-            phase_took=phase_took,
-            profile=profile,
-            body=body,
-            raise_on_timeout=True,
-        )
 
         # TODO(andrei): Implement scroll/point in time for results so that we
         # can return arbitrarily-many IDs.
@@ -1428,7 +1440,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             error_str = f"OpenSearch client error: Search timed out for index {self._index_name}."
             logger.error(error_str)
             if raise_on_timeout:
-                raise RuntimeError(error_str)
+                raise OpenSearchServerSideTimeout(error_str)
 
     def _get_emit_metrics_context_manager(
         self, search_type: OpenSearchSearchType

--- a/backend/onyx/server/metrics/opensearch_search.py
+++ b/backend/onyx/server/metrics/opensearch_search.py
@@ -1,7 +1,13 @@
-"""Prometheus metrics for OpenSearch search latency and throughput.
+"""Prometheus metrics for OpenSearch search latency, throughput, and errors.
 
 Tracks client-side round-trip latency, server-side execution time (from
-OpenSearch's ``took`` field), total search count, and in-flight concurrency.
+OpenSearch's ``took`` field), total search attempts, in-flight concurrency, and
+per-error-type failure counts.
+
+``onyx_opensearch_search_total`` counts attempts (incremented on entry to the
+``track_opensearch_search`` context manager that wraps every request), so
+``onyx_opensearch_search_errors_total / onyx_opensearch_search_total`` is a
+meaningful failure rate.
 """
 
 import logging
@@ -47,8 +53,16 @@ _server_duration = Histogram(
 
 _search_total = Counter(
     "onyx_opensearch_search_total",
-    "Total number of search requests sent to OpenSearch",
+    "Total number of OpenSearch search attempts (incremented before send, so this "
+    "counts both successes and failures)",
     ["search_type"],
+)
+
+_search_errors = Counter(
+    "onyx_opensearch_search_errors_total",
+    "Total number of OpenSearch search attempts that errored, labeled by the error "
+    "type",
+    ["search_type", "error_type"],
 )
 
 _searches_in_progress = Gauge(
@@ -58,12 +72,31 @@ _searches_in_progress = Gauge(
 )
 
 
+def record_opensearch_search_error(
+    search_type: OpenSearchSearchType, exc: BaseException
+) -> None:
+    """Increments the search-error counter, labeled by exception class name."""
+    try:
+        _search_errors.labels(
+            search_type=search_type.value, error_type=type(exc).__name__
+        ).inc()
+    except Exception:
+        logger.warning(
+            "Failed to record OpenSearch search error metric.", exc_info=True
+        )
+
+
 def observe_opensearch_search(
     search_type: OpenSearchSearchType,
     client_duration_s: float,
     server_took_ms: int | None,
 ) -> None:
-    """Records latency and throughput metrics for a completed OpenSearch search.
+    """
+    Records latency histograms for a successfully-completed OpenSearch search.
+
+    The attempt counter is incremented on entry to ``track_opensearch_search``
+    so that failures count toward the denominator. This function should only be
+    called on the success path.
 
     Args:
         search_type: The type of search.
@@ -74,7 +107,6 @@ def observe_opensearch_search(
     """
     try:
         label = search_type.value
-        _search_total.labels(search_type=label).inc()
         _client_duration.labels(search_type=label).observe(client_duration_s)
         if server_took_ms is not None:
             _server_duration.labels(search_type=label).observe(server_took_ms / 1000.0)
@@ -83,12 +115,24 @@ def observe_opensearch_search(
 
 
 @contextmanager
-def track_opensearch_search_in_progress(
+def track_opensearch_search(
     search_type: OpenSearchSearchType,
 ) -> Generator[None, None, None]:
-    """Context manager that tracks in-flight OpenSearch searches via a Gauge."""
-    incremented = False
+    """Wraps an OpenSearch search call.
+
+    On entry: increments ``onyx_opensearch_search_total`` (the attempt
+    counter) and ``onyx_opensearch_searches_in_progress`` (the in-flight
+    gauge). On exit: decrements the gauge. Both increments are best-effort —
+    a metrics failure must not break the underlying search.
+    """
     label = search_type.value
+    try:
+        _search_total.labels(search_type=label).inc()
+    except Exception:
+        logger.warning(
+            "Failed to record OpenSearch search attempt metric.", exc_info=True
+        )
+    incremented = False
     try:
         _searches_in_progress.labels(search_type=label).inc()
         incremented = True

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from opensearchpy import ConflictError
@@ -25,11 +26,13 @@ from onyx.context.search.models import IndexFilters
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.client import OpenSearchIndexError
+from onyx.document_index.opensearch.client import OpenSearchServerSideTimeout
 from onyx.document_index.opensearch.client import OpenSearchUpdateError
 from onyx.document_index.opensearch.client import wait_for_opensearch_with_timeout
 from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
 from onyx.document_index.opensearch.constants import HybridSearchNormalizationPipeline
 from onyx.document_index.opensearch.constants import HybridSearchSubqueryConfiguration
+from onyx.document_index.opensearch.constants import OpenSearchSearchType
 from onyx.document_index.opensearch.opensearch_document_index import (
     generate_opensearch_filtered_access_control_list,
 )
@@ -2340,3 +2343,107 @@ class TestOpenSearchClient:
         )
         assert results[1].score
         assert 0.0 < results[1].score < 1.0
+
+
+class TestSearchFailureMetrics:
+    """Regression coverage for the OpenSearch search failure-rate metric.
+
+    Before the fix, ``self._log_search_result_perf(..., raise_on_timeout=True)``
+    ran after the metrics ``try/except`` block. When OpenSearch returned
+    ``"timed_out": true`` in the response body, the helper raised
+    ``RuntimeError`` outside the ``except`` arm, so the failure never reached
+    ``record_opensearch_search_error`` and ``observe_opensearch_search`` had
+    already been called with the timed-out duration.
+    """
+
+    @staticmethod
+    def _timed_out_response() -> dict[str, Any]:
+        """
+        A minimally-valid mock OpenSearch search response with timed_out=true.
+        """
+        return {
+            "took": 1234,
+            "timed_out": True,
+            "hits": {"hits": []},
+        }
+
+    @staticmethod
+    def _make_client_with_canned_response(
+        monkeypatch: pytest.MonkeyPatch, response: dict[str, Any]
+    ) -> OpenSearchIndexClient:
+        """
+        Patches the OpenSearch class imported by ``client_module`` so that
+        ``OpenSearchIndexClient.__init__`` constructs a mocked underlying client
+        whose ``.search`` returns a mocked response. Lets us drive the timeout
+        code path without hitting a real OpenSearch.
+        """
+        mock_underlying = MagicMock()
+        mock_underlying.search.return_value = response
+        monkeypatch.setattr(
+            client_module, "OpenSearch", MagicMock(return_value=mock_underlying)
+        )
+        return OpenSearchIndexClient(index_name="test_index")
+
+    def test_search_records_error_on_server_side_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Precondition.
+        # Stub the metric boundary functions so we can assert the client routes
+        # a timed-out response through the error path rather than the success
+        # path.
+        record_error_mock = MagicMock()
+        observe_mock = MagicMock()
+        monkeypatch.setattr(
+            client_module, "record_opensearch_search_error", record_error_mock
+        )
+        monkeypatch.setattr(client_module, "observe_opensearch_search", observe_mock)
+
+        client = self._make_client_with_canned_response(
+            monkeypatch, self._timed_out_response()
+        )
+
+        # Under test.
+        with pytest.raises(OpenSearchServerSideTimeout, match="timed out"):
+            client.search(
+                body={},
+                search_pipeline_id=None,
+                search_type=OpenSearchSearchType.HYBRID,
+            )
+
+        # Postcondition.
+        # The timed-out search was recorded as an error and was NOT observed in
+        # the latency histograms.
+        assert record_error_mock.call_count == 1
+        recorded_search_type, recorded_exc = record_error_mock.call_args.args
+        assert recorded_search_type == OpenSearchSearchType.HYBRID
+        assert isinstance(recorded_exc, OpenSearchServerSideTimeout)
+        assert observe_mock.call_count == 0
+
+    def test_search_for_document_ids_records_error_on_server_side_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Precondition.
+        record_error_mock = MagicMock()
+        observe_mock = MagicMock()
+        monkeypatch.setattr(
+            client_module, "record_opensearch_search_error", record_error_mock
+        )
+        monkeypatch.setattr(client_module, "observe_opensearch_search", observe_mock)
+
+        client = self._make_client_with_canned_response(
+            monkeypatch, self._timed_out_response()
+        )
+
+        # Under test.
+        with pytest.raises(OpenSearchServerSideTimeout, match="timed out"):
+            client.search_for_document_ids(
+                body={"_source": False},
+                search_type=OpenSearchSearchType.KEYWORD,
+            )
+
+        # Postcondition.
+        assert record_error_mock.call_count == 1
+        recorded_search_type, recorded_exc = record_error_mock.call_args.args
+        assert recorded_search_type == OpenSearchSearchType.KEYWORD
+        assert isinstance(recorded_exc, OpenSearchServerSideTimeout)
+        assert observe_mock.call_count == 0

--- a/backend/tests/unit/server/metrics/test_opensearch_search_metrics.py
+++ b/backend/tests/unit/server/metrics/test_opensearch_search_metrics.py
@@ -57,16 +57,25 @@ class TestRecordOpenSearchSearchError:
 
     def test_exceptions_do_not_propagate(self) -> None:
         # Precondition.
+        # _search_errors has two labels (search_type, error_type), so we can't
+        # call .labels() with a single label in the test setup — that itself
+        # raises ValueError before patching takes effect. Instead, patch .labels
+        # on the counter and have the returned child's .inc() raise when the
+        # production code reaches it.
         search_type = OpenSearchSearchType.RANDOM
-        with patch.object(
-            _search_errors.labels(search_type=search_type.value),
-            "inc",
-            side_effect=RuntimeError("boom"),
-        ):
+        with patch.object(_search_errors, "labels") as labels_mock:
+            labels_mock.return_value.inc.side_effect = RuntimeError("boom")
+
             # Under test and postcondition.
             # Should not raise.
             record_opensearch_search_error(
                 search_type, ValueError("simulated search failure")
+            )
+
+            # Sanity check: the production code reached the fully-labeled child
+            # for this specific error_type.
+            labels_mock.assert_called_once_with(
+                search_type=search_type.value, error_type="ValueError"
             )
 
 

--- a/backend/tests/unit/server/metrics/test_opensearch_search_metrics.py
+++ b/backend/tests/unit/server/metrics/test_opensearch_search_metrics.py
@@ -4,37 +4,115 @@ from unittest.mock import patch
 
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
 from onyx.server.metrics.opensearch_search import _client_duration
+from onyx.server.metrics.opensearch_search import _search_errors
 from onyx.server.metrics.opensearch_search import _search_total
 from onyx.server.metrics.opensearch_search import _searches_in_progress
 from onyx.server.metrics.opensearch_search import _server_duration
 from onyx.server.metrics.opensearch_search import observe_opensearch_search
-from onyx.server.metrics.opensearch_search import track_opensearch_search_in_progress
+from onyx.server.metrics.opensearch_search import record_opensearch_search_error
+from onyx.server.metrics.opensearch_search import track_opensearch_search
+
+
+class TestRecordOpenSearchSearchError:
+    def test_increments_error_counter_with_exception_class_name(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.HYBRID
+        error_type = "ValueError"
+        before = _search_errors.labels(
+            search_type=search_type.value, error_type=error_type
+        )._value.get()
+
+        # Under test.
+        record_opensearch_search_error(search_type, ValueError("boom"))
+
+        # Postcondition.
+        after = _search_errors.labels(
+            search_type=search_type.value, error_type=error_type
+        )._value.get()
+        assert after == before + 1
+
+    def test_distinguishes_error_types(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.KEYWORD
+        before_value = _search_errors.labels(
+            search_type=search_type.value, error_type="ValueError"
+        )._value.get()
+        before_runtime = _search_errors.labels(
+            search_type=search_type.value, error_type="RuntimeError"
+        )._value.get()
+
+        # Under test.
+        record_opensearch_search_error(search_type, ValueError("a"))
+        record_opensearch_search_error(search_type, RuntimeError("b"))
+
+        # Postcondition.
+        after_value = _search_errors.labels(
+            search_type=search_type.value, error_type="ValueError"
+        )._value.get()
+        after_runtime = _search_errors.labels(
+            search_type=search_type.value, error_type="RuntimeError"
+        )._value.get()
+        assert after_value == before_value + 1
+        assert after_runtime == before_runtime + 1
+
+    def test_exceptions_do_not_propagate(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.RANDOM
+        with patch.object(
+            _search_errors.labels(search_type=search_type.value),
+            "inc",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Under test and postcondition.
+            # Should not raise.
+            record_opensearch_search_error(
+                search_type, ValueError("simulated search failure")
+            )
 
 
 class TestObserveOpenSearchSearch:
-    def test_increments_counter(self) -> None:
+    def test_does_not_increment_attempt_counter(self) -> None:
+        # Precondition.
+        # observe_opensearch_search must not touch _search_total; the attempt
+        # counter is the responsibility of record_opensearch_search_attempt so
+        # that failures count toward the denominator.
         search_type = OpenSearchSearchType.HYBRID
         before = _search_total.labels(search_type=search_type.value)._value.get()
+
+        # Under test.
         observe_opensearch_search(search_type, 0.1, 50)
+
+        # Postcondition.
         after = _search_total.labels(search_type=search_type.value)._value.get()
-        assert after == before + 1
+        assert after == before
 
     def test_observes_client_duration(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.KEYWORD
         before_sum = _client_duration.labels(search_type=search_type.value)._sum.get()
+
+        # Under test.
         observe_opensearch_search(search_type, 0.25, 100)
+
+        # Postcondition.
         after_sum = _client_duration.labels(search_type=search_type.value)._sum.get()
         assert after_sum == before_sum + 0.25
 
     def test_observes_server_duration(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.SEMANTIC
         before_sum = _server_duration.labels(search_type=search_type.value)._sum.get()
+
+        # Under test.
         observe_opensearch_search(search_type, 0.3, 200)
+
+        # Postcondition.
         after_sum = _server_duration.labels(search_type=search_type.value)._sum.get()
         # 200ms should be recorded as 0.2s.
         assert after_sum == before_sum + 0.2
 
     def test_server_took_none_skips_server_histogram(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.UNKNOWN
         before_server = _server_duration.labels(
             search_type=search_type.value
@@ -42,82 +120,142 @@ class TestObserveOpenSearchSearch:
         before_client = _client_duration.labels(
             search_type=search_type.value
         )._sum.get()
-        before_total = _search_total.labels(search_type=search_type.value)._value.get()
 
+        # Under test.
         observe_opensearch_search(search_type, 0.1, None)
 
+        # Postcondition.
         # Server histogram should NOT be observed.
         after_server = _server_duration.labels(search_type=search_type.value)._sum.get()
         assert after_server == before_server
 
-        # Client histogram and counter should still work.
+        # Client histogram should still work.
         after_client = _client_duration.labels(search_type=search_type.value)._sum.get()
-        after_total = _search_total.labels(search_type=search_type.value)._value.get()
         assert after_client == before_client + 0.1
-        assert after_total == before_total + 1
 
     def test_exceptions_do_not_propagate(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.RANDOM
         with patch.object(
-            _search_total.labels(search_type=search_type.value),
-            "inc",
+            _client_duration.labels(search_type=search_type.value),
+            "observe",
             side_effect=RuntimeError("boom"),
         ):
+            # Under test and postcondition.
             # Should not raise.
             observe_opensearch_search(search_type, 0.1, 50)
 
 
-class TestTrackOpenSearchSearchInProgress:
+class TestTrackOpenSearchSearch:
     def test_gauge_increments_and_decrements(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.HYBRID
         before = _searches_in_progress.labels(
             search_type=search_type.value
         )._value.get()
 
-        with track_opensearch_search_in_progress(search_type):
+        # Under test.
+        with track_opensearch_search(search_type):
             during = _searches_in_progress.labels(
                 search_type=search_type.value
             )._value.get()
+
+            # Postcondition.
             assert during == before + 1
 
         after = _searches_in_progress.labels(search_type=search_type.value)._value.get()
         assert after == before
 
     def test_gauge_decrements_on_exception(self) -> None:
+        # Precondition.
         search_type = OpenSearchSearchType.SEMANTIC
         before = _searches_in_progress.labels(
             search_type=search_type.value
         )._value.get()
 
+        # Under test.
         raised = False
         try:
-            with track_opensearch_search_in_progress(search_type):
+            with track_opensearch_search(search_type):
                 raise ValueError("simulated search failure")
         except ValueError:
             raised = True
+
+        # Postcondition.
         assert raised
 
         after = _searches_in_progress.labels(search_type=search_type.value)._value.get()
         assert after == before
 
-    def test_inc_exception_does_not_break_search(self) -> None:
+    def test_increments_attempt_counter_on_entry(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.HYBRID
+        before = _search_total.labels(search_type=search_type.value)._value.get()
+
+        # Under test.
+        with track_opensearch_search(search_type):
+            during = _search_total.labels(search_type=search_type.value)._value.get()
+
+            # Postcondition.
+            assert during == before + 1
+
+        after = _search_total.labels(search_type=search_type.value)._value.get()
+        # Counter does not decrement on exit.
+        assert after == before + 1
+
+    def test_attempt_counter_increments_even_when_body_raises(self) -> None:
+        # Precondition.
+        # Failures must still count in the denominator of the failure rate.
         search_type = OpenSearchSearchType.KEYWORD
+        before = _search_total.labels(search_type=search_type.value)._value.get()
+
+        # Under test.
+        try:
+            with track_opensearch_search(search_type):
+                raise ValueError("simulated search failure")
+        except ValueError:
+            pass
+
+        # Postcondition.
+        after = _search_total.labels(search_type=search_type.value)._value.get()
+        assert after == before + 1
+
+    def test_inc_exception_does_not_break_search(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.RANDOM
         before = _searches_in_progress.labels(
             search_type=search_type.value
         )._value.get()
 
+        # Under test.
         with patch.object(
             _searches_in_progress.labels(search_type=search_type.value),
             "inc",
             side_effect=RuntimeError("boom"),
         ):
             # Context manager should still yield without decrementing.
-            with track_opensearch_search_in_progress(search_type):
+            with track_opensearch_search(search_type):
                 # Search logic would execute here.
                 during = _searches_in_progress.labels(
                     search_type=search_type.value
                 )._value.get()
+
+                # Postcondition.
                 assert during == before
 
         after = _searches_in_progress.labels(search_type=search_type.value)._value.get()
         assert after == before
+
+    def test_attempt_counter_failure_does_not_break_search(self) -> None:
+        # Precondition.
+        search_type = OpenSearchSearchType.UNKNOWN
+
+        # Under test and postcondition.
+        with patch.object(
+            _search_total.labels(search_type=search_type.value),
+            "inc",
+            side_effect=RuntimeError("boom"),
+        ):
+            # Context manager should still yield.
+            with track_opensearch_search(search_type):
+                pass


### PR DESCRIPTION
## Description
Emit telemetry when a search fails. This PR also moves search counter increment into what was previously just the search gauge context manager, as this manager is entered for every search so it is a good place to add a counter increment. Failures are counted by invoking a separate function. `_get_hits_and_profile_from_search_result` was also moved into the context manager, as an exception raised from here would cause a search to fail, so we should also count failures from that.

## How Has This Been Tested?
Added additional automated tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus telemetry for OpenSearch search failures and attempts, and ensures server-side timeouts are counted as errors and excluded from latency histograms.

- **New Features**
  - Added `onyx_opensearch_search_errors_total` (labeled by `error_type`).
  - Increment `onyx_opensearch_search_total` on entry to `track_opensearch_search`; `observe_opensearch_search` records latency on success only.
  - Wrapped search and result parsing in `try/except`; on error calls `record_opensearch_search_error` then re-raises. Server-side timeouts now flow through the error path, keeping latency histograms clean.
  - Expanded tests for attempts, error counts, timeout behavior, latency histograms, and in-flight gauge.

- **Migration**
  - Renamed `track_opensearch_search_in_progress` to `track_opensearch_search`.
  - Server-side timeouts now raise `OpenSearchServerSideTimeout` (was `RuntimeError`).

<sup>Written for commit 055a27c6eb76cbda61816b1d9f013ef2a348ab05. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11163?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

