### PR TITLE
fix(ci): use client-id for create-github-app-token

### DIFF
--- a/.github/workflows/post-merge-beta-cherry-pick.yml
+++ b/.github/workflows/post-merge-beta-cherry-pick.yml
@@ -98,7 +98,7 @@ jobs:
 
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ vars.CHERRY_PICK_APP_ID }}
+          client-id: ${{ vars.CHERRY_PICK_APP_ID }}
           private-key: ${{ secrets.CHERRY_PICK_APP_PRIVATE_KEY }}
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- `actions/create-github-app-token` deprecated `app-id` in favor of `client-id`; the workflow was emitting deprecation warnings plus an empty-input failure on the cherry-pick job.
- Switch the input key to `client-id` while keeping the existing `vars.CHERRY_PICK_APP_ID` variable name — the variable must now hold the GitHub App's Client ID rather than the numeric App ID.

## Test plan
- [ ] Confirm `vars.CHERRY_PICK_APP_ID` is set to the App's Client ID
- [ ] Merge a PR with the cherry-pick checkbox checked and verify the workflow mints a token and opens a cherry-pick PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `actions/create-github-app-token` to use `client-id` in the post-merge cherry-pick workflow to remove deprecation warnings and fix empty-input failures.

- **Migration**
  - Set `vars.CHERRY_PICK_APP_ID` to the GitHub App Client ID (not the numeric App ID).

<sup>Written for commit c2e553e7d4c970b55697db9075feccbeecf48e48. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

