### PR TITLE
chore(claude): ignore .claude/worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ plans/
 # Added context for LLMs
 .claude/CLAUDE.md
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Description

Add .claude/worktrees to .gitignore to prevent temporary git worktree data from being committed. The .claude/worktrees directory is created by the Claude Code environment and contains local development state that should not be tracked in the repository.

## How Has This Been Tested?

Verified that .gitignore properly excludes the .claude/worktrees directory from git tracking.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.claude/worktrees/` to `.gitignore` to keep Claude Code’s temporary worktree data out of the repo. This prevents committing local development state.

<sup>Written for commit a01607a748b2da71eda8f4fe9a2d35808addcb2c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

