### PR TITLE
feat(opal): export logos in dist + bump to 0.1.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,7 +136,7 @@ repos:
         language: system
         entry: bash -c 'cd web && npm install --no-save'
         pass_filenames: false
-        files: ^web/package(-lock)?\.json$
+        files: ^web/(package(-lock)?\.json|lib/opal/package\.json)$
         stages: [post-checkout, post-merge, post-rewrite]
       - id: npm-install-check
         name: npm install --package-lock-only
@@ -144,7 +144,7 @@ repos:
         language: system
         entry: bash -c 'cd web && npm install --package-lock-only'
         pass_filenames: false
-        files: ^web/package(-lock)?\.json$
+        files: ^web/(package(-lock)?\.json|lib/opal/package\.json)$
 
       - id: oxfmt
         name: oxfmt

--- a/web/lib/opal/NOTICE.md
+++ b/web/lib/opal/NOTICE.md
@@ -1,0 +1,20 @@
+# Third-party trademark notice
+
+The `@onyx-ai/opal/logos` subpath ships brand marks (logos, wordmarks) of
+third-party products and services that Onyx integrates with — including
+but not limited to Anthropic, OpenAI, Google, Microsoft, Slack, GitHub,
+GitLab, Notion, Confluence, Dropbox, Salesforce, and others.
+
+All such marks remain the property of their respective owners. Onyx
+makes **no claim of ownership, sponsorship, endorsement, affiliation,
+or trademark** over any third-party mark distributed in this package.
+
+These marks are shipped solely for **nominative use** — to identify the
+external products, integrations, and providers that Onyx connects to —
+inside Onyx's first-party UI and consumers of `@onyx-ai/opal`.
+
+If you are a trademark owner and would like a mark adjusted or removed,
+please open an issue at <https://github.com/onyx-dot-app/onyx/issues>.
+
+The Opal source code (everything except the marks themselves) is
+licensed under the MIT License — see `package.json`.

--- a/web/lib/opal/README.md
+++ b/web/lib/opal/README.md
@@ -166,3 +166,10 @@ The tag pattern must match `opal/v*.*.*` for the workflow to fire.
 - Types/interfaces are declared at the top of `components.tsx` without `export`; everything is
   re-exported from a single `export { Foo, type FooProps };` block at the bottom.
 - See `web/AGENTS.md` for broader frontend standards.
+
+## Third-party trademarks
+
+The `@onyx-ai/opal/logos` subpath ships brand marks of third-party
+products Onyx integrates with. Marks remain the property of their
+respective owners; Onyx claims no trademark over them. See
+[`NOTICE.md`](./NOTICE.md) for details.

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -19,7 +19,8 @@
   "files": [
     "dist",
     "tailwind-preset.cjs",
-    "README.md"
+    "README.md",
+    "NOTICE.md"
   ],
   "main": "./dist/components/index.js",
   "types": "./dist/components/index.d.ts",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {
@@ -43,6 +43,10 @@
     "./illustrations": {
       "types": "./dist/illustrations/index.d.ts",
       "import": "./dist/illustrations/index.js"
+    },
+    "./logos": {
+      "types": "./dist/logos/index.d.ts",
+      "import": "./dist/logos/index.js"
     },
     "./types": {
       "types": "./dist/types.d.ts",

--- a/web/lib/opal/tsup.config.ts
+++ b/web/lib/opal/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "src/core/index.ts",
     "src/icons/index.ts",
     "src/illustrations/index.ts",
+    "src/logos/index.ts",
     "src/types.ts",
     "src/utils.ts",
   ],

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -135,7 +135,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",


### PR DESCRIPTION
## Description

**Bug:** `web/lib/opal/src/logos/` (Claude, OpenAI, OnyxLogo, etc.) ships in the monorepo but not in the published `@onyx-ai/opal` npm package — `import { SvgClaude } from \"@onyx-ai/opal/logos\"` fails.

**Cause:** `src/logos/index.ts` isn't listed in tsup `entry`, and `./logos` isn't declared under `exports` in package.json.

**Fix:** Add `src/logos/index.ts` to tsup entries and `./logos` to package.json exports. Bump to `0.1.3`.

Verified `npm run build` emits `dist/logos/index.{js,d.ts}` and the generated `index.d.ts` re-exports `SvgClaude`, `SvgOpenai`, `SvgOnyxLogo`, etc.

## How Has This Been Tested?



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check