### PR TITLE
fix(deletion): release PG connection before document-index I/O in per-doc cleanup

### DIFF
--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -90,11 +90,16 @@ def document_by_cc_pair_cleanup_task(
     start = time.monotonic()
 
     completion_status = OnyxCeleryTaskCompletionStatus.UNDEFINED
+    action = "skip"
 
     try:
+        # Phase 1: read DB state, then release the connection before the
+        # Vespa HTTP call. Holding a pg transaction across the round-trip
+        # pins a pgbouncer slot for the duration and saturates the pool under
+        # bulk-deletion fan-out across the light worker fleet.
+        chunk_count: int | None = None
+        update_request: MetadataUpdateRequest | None = None
         with get_session_with_current_tenant() as db_session:
-            action = "skip"
-
             active_search_settings = get_active_search_settings(db_session)
             # This flow is for updates and deletion so we get all indices.
             document_indices = get_all_document_indices(
@@ -103,40 +108,10 @@ def document_by_cc_pair_cleanup_task(
                 httpx_client=HttpxPool.get("vespa"),
             )
 
-            retry_document_indices: list[RetryDocumentIndex] = [
-                RetryDocumentIndex(document_index)
-                for document_index in document_indices
-            ]
-
             count = get_document_connector_count(db_session, document_id)
             if count == 1:
-                # count == 1 means this is the only remaining cc_pair reference to the doc
-                # delete it from vespa and the db
-                action = "delete"
-
                 chunk_count = fetch_chunk_count_for_document(document_id, db_session)
-
-                for retry_document_index in retry_document_indices:
-                    _ = retry_document_index.delete(
-                        document_id,
-                        chunk_count=chunk_count,
-                    )
-
-                delete_document_references_from_kg(
-                    db_session=db_session,
-                    document_id=document_id,
-                )
-
-                delete_documents_complete(
-                    db_session=db_session,
-                    document_ids=[document_id],
-                )
-
-                completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
             elif count > 1:
-                action = "update"
-
-                # count > 1 means the document still has cc_pair references
                 doc = get_document(document_id, db_session)
                 if not doc:
                     return False
@@ -148,7 +123,6 @@ def document_by_cc_pair_cleanup_task(
                 )
 
                 doc_sets = fetch_document_sets_for_document(document_id, db_session)
-                update_doc_sets: set[str] = set(doc_sets)
 
                 update_request = MetadataUpdateRequest(
                     document_ids=[document_id],
@@ -158,18 +132,49 @@ def document_by_cc_pair_cleanup_task(
                         )
                     },
                     access=doc_access,
-                    document_sets=update_doc_sets,
+                    document_sets=set(doc_sets),
                     boost=doc.boost,
                     hidden=doc.hidden,
                 )
 
-                for retry_document_index in retry_document_indices:
-                    # TODO(andrei): Previously there was a comment here saying
-                    # it was ok if a doc did not exist in the document index. I
-                    # don't agree with that claim, so keep an eye on this task
-                    # to see if this raises.
-                    retry_document_index.update([update_request])
+        retry_document_indices: list[RetryDocumentIndex] = [
+            RetryDocumentIndex(document_index) for document_index in document_indices
+        ]
 
+        # Phase 2: Vespa I/O — no DB connection held.
+        if count == 1:
+            action = "delete"
+            for retry_document_index in retry_document_indices:
+                _ = retry_document_index.delete(
+                    document_id,
+                    chunk_count=chunk_count,
+                )
+        elif count > 1:
+            action = "update"
+            assert update_request is not None
+            for retry_document_index in retry_document_indices:
+                # TODO(andrei): Previously there was a comment here saying
+                # it was ok if a doc did not exist in the document index. I
+                # don't agree with that claim, so keep an eye on this task
+                # to see if this raises.
+                retry_document_index.update([update_request])
+
+        # Phase 3: write back to PG in a fresh transaction.
+        if count == 1:
+            with get_session_with_current_tenant() as db_session:
+                delete_document_references_from_kg(
+                    db_session=db_session,
+                    document_id=document_id,
+                )
+
+                delete_documents_complete(
+                    db_session=db_session,
+                    document_ids=[document_id],
+                )
+
+            completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
+        elif count > 1:
+            with get_session_with_current_tenant() as db_session:
                 # there are still other cc_pair references to the doc, so just resync to Vespa
                 delete_document_by_connector_credential_pair__no_commit(
                     db_session=db_session,
@@ -183,14 +188,14 @@ def document_by_cc_pair_cleanup_task(
                 mark_document_as_synced(document_id, db_session)
                 db_session.commit()
 
-                completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
-            else:
-                completion_status = OnyxCeleryTaskCompletionStatus.SKIPPED
+            completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
+        else:
+            completion_status = OnyxCeleryTaskCompletionStatus.SKIPPED
 
-            elapsed = time.monotonic() - start
-            task_logger.info(
-                f"doc={document_id} action={action} refcount={count} elapsed={elapsed:.2f}"
-            )
+        elapsed = time.monotonic() - start
+        task_logger.info(
+            f"doc={document_id} action={action} refcount={count} elapsed={elapsed:.2f}"
+        )
     except SoftTimeLimitExceeded:
         task_logger.info(f"SoftTimeLimitExceeded exception. doc={document_id}")
         completion_status = OnyxCeleryTaskCompletionStatus.SOFT_TIME_LIMIT

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -90,7 +90,7 @@ def document_by_cc_pair_cleanup_task(
     start = time.monotonic()
 
     completion_status = OnyxCeleryTaskCompletionStatus.UNDEFINED
-    action = "skip"
+    action: str = "skip"
 
     try:
         # Phase 1: read DB state, then release the connection before the

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -94,8 +94,9 @@ def document_by_cc_pair_cleanup_task(
 
     try:
         # Phase 1: read DB state, then release the connection before the
-        # Vespa HTTP call. Holding a pg transaction across the round-trip
-        # pins a pgbouncer slot for the duration and saturates the pool under
+        # document-index HTTP call (OpenSearch on cloud, Vespa on legacy
+        # deployments). Holding a pg transaction across the round-trip pins
+        # a pgbouncer slot for the duration and saturates the pool under
         # bulk-deletion fan-out across the light worker fleet.
         chunk_count: int | None = None
         update_request: MetadataUpdateRequest | None = None
@@ -141,7 +142,7 @@ def document_by_cc_pair_cleanup_task(
             RetryDocumentIndex(document_index) for document_index in document_indices
         ]
 
-        # Phase 2: Vespa I/O — no DB connection held.
+        # Phase 2: document-index I/O — no DB connection held.
         if count == 1:
             action = "delete"
             for retry_document_index in retry_document_indices:
@@ -175,7 +176,7 @@ def document_by_cc_pair_cleanup_task(
             completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
         elif count > 1:
             with get_session_with_current_tenant() as db_session:
-                # there are still other cc_pair references to the doc, so just resync to Vespa
+                # there are still other cc_pair references to the doc, so just resync to the document index
                 delete_document_by_connector_credential_pair__no_commit(
                     db_session=db_session,
                     document_id=document_id,

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -56,6 +56,15 @@ class OnyxCeleryTaskCompletionStatus(str, Enum):
     RETRYABLE_EXCEPTION = "retryable_exception"
 
 
+class DocumentCleanupAction(str, Enum):
+    """What the cleanup task will do for a given document based on its remaining
+    cc_pair reference count after the current cc_pair is removed."""
+
+    SKIP = "skip"
+    DELETE = "delete"
+    UPDATE = "update"
+
+
 @shared_task(
     name=OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_CLEANUP_TASK,
     soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
@@ -90,7 +99,8 @@ def document_by_cc_pair_cleanup_task(
     start = time.monotonic()
 
     completion_status = OnyxCeleryTaskCompletionStatus.UNDEFINED
-    action: str = "skip"
+    action: DocumentCleanupAction = DocumentCleanupAction.SKIP
+    count: int = 0
 
     try:
         # Phase 1: read DB state, then release the connection before the
@@ -102,20 +112,19 @@ def document_by_cc_pair_cleanup_task(
         update_request: MetadataUpdateRequest | None = None
         with get_session_with_current_tenant() as db_session:
             active_search_settings = get_active_search_settings(db_session)
-            # This flow is for updates and deletion so we get all indices.
-            document_indices = get_all_document_indices(
-                active_search_settings.primary,
-                active_search_settings.secondary,
-                httpx_client=HttpxPool.get("vespa"),
-            )
+            primary_search_settings = active_search_settings.primary
+            secondary_search_settings = active_search_settings.secondary
 
             count = get_document_connector_count(db_session, document_id)
             if count == 1:
+                action = DocumentCleanupAction.DELETE
                 chunk_count = fetch_chunk_count_for_document(document_id, db_session)
             elif count > 1:
                 doc = get_document(document_id, db_session)
                 if not doc:
                     return False
+
+                action = DocumentCleanupAction.UPDATE
 
                 # the below functions do not include cc_pairs being deleted.
                 # i.e. they will correctly omit access for the current cc_pair
@@ -138,20 +147,27 @@ def document_by_cc_pair_cleanup_task(
                     hidden=doc.hidden,
                 )
 
+        # Build document-index clients outside the DB session — construction
+        # can take a few seconds to connect to the document index server,
+        # and we don't want to pin a pgbouncer slot while that happens.
+        # This flow is for updates and deletion so we get all indices.
+        document_indices = get_all_document_indices(
+            primary_search_settings,
+            secondary_search_settings,
+            httpx_client=HttpxPool.get("vespa"),
+        )
         retry_document_indices: list[RetryDocumentIndex] = [
             RetryDocumentIndex(document_index) for document_index in document_indices
         ]
 
         # Phase 2: document-index I/O — no DB connection held.
-        if count == 1:
-            action = "delete"
+        if action == DocumentCleanupAction.DELETE:
             for retry_document_index in retry_document_indices:
                 _ = retry_document_index.delete(
                     document_id,
                     chunk_count=chunk_count,
                 )
-        elif count > 1:
-            action = "update"
+        elif action == DocumentCleanupAction.UPDATE:
             assert update_request is not None
             for retry_document_index in retry_document_indices:
                 # TODO(andrei): Previously there was a comment here saying
@@ -161,7 +177,7 @@ def document_by_cc_pair_cleanup_task(
                 retry_document_index.update([update_request])
 
         # Phase 3: write back to PG in a fresh transaction.
-        if count == 1:
+        if action == DocumentCleanupAction.DELETE:
             with get_session_with_current_tenant() as db_session:
                 delete_document_references_from_kg(
                     db_session=db_session,
@@ -174,7 +190,7 @@ def document_by_cc_pair_cleanup_task(
                 )
 
             completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
-        elif count > 1:
+        elif action == DocumentCleanupAction.UPDATE:
             with get_session_with_current_tenant() as db_session:
                 # there are still other cc_pair references to the doc, so just resync to the document index
                 delete_document_by_connector_credential_pair__no_commit(
@@ -195,7 +211,7 @@ def document_by_cc_pair_cleanup_task(
 
         elapsed = time.monotonic() - start
         task_logger.info(
-            f"doc={document_id} action={action} refcount={count} elapsed={elapsed:.2f}"
+            f"doc={document_id} action={action.value} refcount={count} elapsed={elapsed:.2f}"
         )
     except SoftTimeLimitExceeded:
         task_logger.info(f"SoftTimeLimitExceeded exception. doc={document_id}")


### PR DESCRIPTION
## Description

The per-document cleanup task (`document_by_cc_pair_cleanup_task`) held a SQLAlchemy session — and therefore a pgbouncer slot — open across the document-index HTTP delete/update call (OpenSearch on cloud where `ONYX_DISABLE_VESPA=true`, Vespa on legacy deployments). Under bulk-deletion fan-out across the light worker fleet (potentially 1000+ concurrent tasks for a large tenant), this saturated the pgbouncer pool with idle-in-transaction connections.

Observed today on the production managed_services cluster: ~947 of ~1051 pgbouncer server connections were idle-in-tx, all from `celery_worker_light_sync`, all running per-document SELECTs against the same tenant's schema. Pool was 97% saturated, average transaction time 17.4s, average client wait 5.9s. New API pods could not complete `warm_up_connections()` within the startup probe window and crash-looped.

This PR restructures the task into three explicit phases:

1. **Read** DB state inside a session, then exit the `with` block to release the connection.
2. **Document-index I/O** with no DB connection held. The HTTP round-trip no longer pins a pgbouncer slot.
3. **Write** back to PG in a fresh transaction.

Behavior is preserved on both branches:

- `count == 1`: SELECT chunk_count → document-index delete → KG cleanup + doc delete + commit (via `delete_documents_complete`).
- `count > 1`: SELECT doc/access/sets → document-index update → cc_pair detach + mark synced + commit.

Failure-mode notes:

- If the document-index call fails (phase 2): nothing has been written yet. Existing retry / max-retries-mark-dirty path handles this exactly as before.
- If phase 3 fails after phase 2 succeeded: document index is already updated/cleared. On retry, phase 1 sees the same state (count unchanged because phase 3 didn't run), phase 2 re-runs against the index (idempotent under the existing 404-tolerant handling), phase 3 finishes. Eventually consistent; same semantics as the existing partial-failure behavior.

## How Has This Been Tested?

- `pytest backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py` — all 5 tests pass, including the two cleanup-task tests (`test_count_1_branch_cleans_up_file`, `test_count_gt_1_branch_preserves_file`) which cover both branches.
- `pre-commit run` clean (ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check