### PR TITLE
fix(tests): poll retrieval to stabilize flaky update test

### DIFF
--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -61,7 +61,12 @@ def _retrieve_chunks_with_expected_boost(
         ):
             return retrieved
         time.sleep(poll_interval_s)
-    return retrieved
+    actual_boosts = [chunk.boost for chunk in retrieved]
+    pytest.fail(
+        f"Timed out after {timeout_s}s waiting for document {document_id!r}: "
+        f"expected {expected_chunk_count} chunk(s) with boost={expected_boost}, "
+        f"got {len(retrieved)} chunk(s) with boosts={actual_boosts}."
+    )
 
 
 # ------------------------------------------------------------------------------

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -369,20 +369,25 @@ class TestDocumentIndexNew:
             )
             document_index.update([update_request])
 
-            # Allow near-real-time updating to settle (needed for Vespa).
-            time.sleep(1)
-
-            # Postcondition.
+            # Postcondition. Poll until the eventually-consistent indexes
+            # reflect the updates rather than racing a fixed sleep against
+            # OpenSearch's ~1s refresh window.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
                 tenant_id=TEST_TENANT_ID,
             )
-            retrieved_doc1 = document_index.id_based_retrieval(
-                chunk_requests=[DocumentSectionRequest(document_id=doc1)],
+            retrieved_doc1 = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=doc1,
+                expected_chunk_count=3,
+                expected_boost=7,
                 filters=filters,
             )
-            retrieved_doc2 = document_index.id_based_retrieval(
-                chunk_requests=[DocumentSectionRequest(document_id=doc2)],
+            retrieved_doc2 = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=doc2,
+                expected_chunk_count=2,
+                expected_boost=7,
                 filters=filters,
             )
             assert len(retrieved_doc1) == 3

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -14,6 +14,7 @@ import pytest
 
 from onyx.configs.constants import PUBLIC_DOC_PAT
 from onyx.context.search.models import IndexFilters
+from onyx.context.search.models import InferenceChunk
 from onyx.db.enums import EmbeddingPrecision
 from onyx.document_index.interfaces_new import DocumentIndex as DocumentIndexNew
 from onyx.document_index.interfaces_new import DocumentSectionRequest
@@ -30,6 +31,38 @@ from tests.external_dependency_unit.document_index.conftest import make_chunk
 from tests.external_dependency_unit.document_index.conftest import (
     make_indexing_metadata,
 )
+
+
+def _retrieve_chunks_with_expected_boost(
+    document_index: DocumentIndexNew,
+    document_id: str,
+    expected_chunk_count: int,
+    expected_boost: int,
+    filters: IndexFilters,
+    timeout_s: float = 10.0,
+    poll_interval_s: float = 0.25,
+) -> list[InferenceChunk]:
+    """Polls id_based_retrieval until the retrieved chunks match the expected
+    count and boost, or the timeout is reached.
+
+    Document indexes are eventually consistent after updates (OpenSearch
+    refreshes on a ~1s interval, Vespa is near-real-time). Polling avoids
+    relying on a fixed sleep that races the refresh window.
+    """
+    deadline = time.time() + timeout_s
+    retrieved: list[InferenceChunk] = []
+    while time.time() < deadline:
+        retrieved = document_index.id_based_retrieval(
+            chunk_requests=[DocumentSectionRequest(document_id=document_id)],
+            filters=filters,
+        )
+        if len(retrieved) == expected_chunk_count and all(
+            chunk.boost == expected_boost for chunk in retrieved
+        ):
+            return retrieved
+        time.sleep(poll_interval_s)
+    return retrieved
+
 
 # ------------------------------------------------------------------------------
 # Fixtures
@@ -396,20 +429,25 @@ class TestDocumentIndexNew:
             )
             document_index.update([req1, req2])
 
-            # Allow near-real-time updating to settle (needed for Vespa).
-            time.sleep(1)
-
-            # Postcondition.
+            # Postcondition. Poll until the eventually-consistent indexes
+            # reflect the updates rather than racing a fixed sleep against
+            # OpenSearch's ~1s refresh window.
             filters = IndexFilters(
                 access_control_list=[PUBLIC_DOC_PAT],
                 tenant_id=TEST_TENANT_ID,
             )
-            retrieved_doc1 = document_index.id_based_retrieval(
-                chunk_requests=[DocumentSectionRequest(document_id=doc1)],
+            retrieved_doc1 = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=doc1,
+                expected_chunk_count=2,
+                expected_boost=3,
                 filters=filters,
             )
-            retrieved_doc2 = document_index.id_based_retrieval(
-                chunk_requests=[DocumentSectionRequest(document_id=doc2)],
+            retrieved_doc2 = _retrieve_chunks_with_expected_boost(
+                document_index=document_index,
+                document_id=doc2,
+                expected_chunk_count=1,
+                expected_boost=9,
                 filters=filters,
             )
             assert len(retrieved_doc1) == 2


### PR DESCRIPTION
## Summary
- `test_update_applies_each_request_independently` was flaky in CI ([failing run](https://github.com/onyx-dot-app/onyx/actions/runs/26050440994/job/76585455081)) because the fixed `time.sleep(1)` after `document_index.update(...)` could race OpenSearch's default ~1s `refresh_interval`, returning stale chunks from `id_based_retrieval` (which goes through the search API).
- Added a `_retrieve_chunks_with_expected_boost` polling helper that retries `id_based_retrieval` until the expected chunk count and boost are visible (10s timeout, 0.25s poll interval).
- Rewrote the postcondition of `test_update_applies_each_request_independently` to use the helper instead of fixed sleep + retrieve + assert.

## Test plan
- [ ] CI passes the `TestDocumentIndexNew` suite, including `test_update_applies_each_request_independently`
- [ ] Re-run a few times to confirm flakiness is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky update tests by polling `id_based_retrieval` until expected chunks and boosts are visible, avoiding races with OpenSearch’s ~1s refresh. This reduces CI flakiness in `TestDocumentIndexNew`.

- **Bug Fixes**
  - Added `_retrieve_chunks_with_expected_boost` polling helper (10s timeout, 250ms interval) with explicit `pytest.fail` on timeout showing expected vs. actual chunks/boosts.
  - Replaced fixed sleep + retrieve in `test_update_applies_each_request_independently` and `test_update_changes_boost_across_multiple_docs_in_single_request`.

<sup>Written for commit 2c2407f48aadf3be696d8cf201bf6778ff0157b3. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11176?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

