### PR TITLE
fix(chat): always return chat_session_id from non-streaming send-chat-message

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -651,6 +651,15 @@ def handle_send_chat_message(
             external_state_container=state_container,
         )
         result = gather_stream_full(packets, state_container)
+        # CreateChatSessionID is only yielded for newly-created sessions, so for
+        # follow-up messages on an existing session the aggregated response would
+        # otherwise omit chat_session_id. Backfill it from the request so the
+        # field is always present for non-streaming clients.
+        if (
+            result.chat_session_id is None
+            and chat_message_req.chat_session_id is not None
+        ):
+            result.chat_session_id = chat_message_req.chat_session_id
         return result
 
     # Streaming path, normal Onyx UI behavior


### PR DESCRIPTION
## Description

When `/api/chat/send-chat-message` is called with `stream: false`, the aggregated `ChatFullResponse` only included `chat_session_id` for **newly-created** sessions. For follow-up messages on an existing session, the field came back as `null` because `gather_stream_full` populates `chat_session_id` exclusively from `CreateChatSessionID` packets — and that packet is only yielded when a new session is created (see `process_message.py:587-596`).

Result: clients using the non-streaming API saw the session ID on the first call but not on retries / subsequent calls within the same session, even though the session was well-defined the whole time. Reported by a customer driving a structured tool-calling workflow against the API.

Fix: in the non-streaming path, backfill `result.chat_session_id` from the request when it's missing. Streaming behavior is unchanged.

Issues #2 (forced_tool_id non-determinism on Claude — `tool_choice` is silently downgraded to `auto` in `multi_llm.py:533-536`) and #3 (typed refusal contract when forced tool isn't invoked) are tracked separately and not addressed here.

## How Has This Been Tested?

Manual reasoning + read-through of the relevant call sites:
- `chat_backend.py` non-streaming path (`handle_send_chat_message`) is the only production caller of `gather_stream_full`; other callers are eval-only.
- Types match (`UUID | None` on both `SendMessageRequest.chat_session_id` and `ChatFullResponse.chat_session_id`).
- No behavior change when a new session is created (the `CreateChatSessionID` packet still sets the field first, and the backfill is gated on `is None`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure non-streaming send-chat-message responses always include chat_session_id, including follow-ups on existing sessions. Fixes missing IDs caused by only emitting CreateChatSessionID for new sessions.

- **Bug Fixes**
  - Backfill chat_session_id from the request when the aggregated result is None in the non-streaming path.
  - No changes to streaming behavior or new-session creation.

<sup>Written for commit baa24865daa208bb94442a7c6a7002dd9f80fd3b. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11177?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

