### PR TITLE
feat(deletion): foundations for batched document cleanup (1/3)

### DIFF
--- a/backend/onyx/background/celery/tasks/shared/RetryDocumentIndex.py
+++ b/backend/onyx/background/celery/tasks/shared/RetryDocumentIndex.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import httpx
 from tenacity import retry
 from tenacity import retry_if_exception_type
@@ -34,6 +36,17 @@ class RetryDocumentIndex:
         chunk_count: int | None = None,
     ) -> int:
         return self.index.delete(doc_id, chunk_count=chunk_count)
+
+    @retry(
+        retry=retry_if_exception_type(httpx.ReadTimeout),
+        wait=wait_random_exponential(multiplier=1, max=MAX_WAIT),
+        stop=stop_after_delay(STOP_AFTER),
+    )
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],
+    ) -> int:
+        return self.index.delete_batch(doc_id_to_chunk_count)
 
     @retry(
         retry=retry_if_exception_type(httpx.ReadTimeout),

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -855,6 +855,23 @@ def mark_document_as_synced(document_id: str, db_session: Session) -> None:
     db_session.commit()
 
 
+def mark_documents_as_synced(document_ids: list[str], db_session: Session) -> None:
+    """Bulk variant of mark_document_as_synced.
+
+    Silently skips IDs that don't exist (unlike the singular form, which raises).
+    The caller is in a bulk-cleanup context where one missing row should not
+    abort the batch.
+    """
+    if not document_ids:
+        return
+
+    db_session.query(DbDocument).filter(DbDocument.id.in_(document_ids)).update(
+        {DbDocument.last_synced: datetime.now(timezone.utc)},
+        synchronize_session=False,
+    )
+    db_session.commit()
+
+
 def delete_document_by_connector_credential_pair__no_commit(
     db_session: Session,
     document_id: str,

--- a/backend/onyx/db/relationships.py
+++ b/backend/onyx/db/relationships.py
@@ -571,24 +571,30 @@ def get_relationship_types_of_entity_types(
 
 
 def delete_document_references_from_kg(db_session: Session, document_id: str) -> None:
-    # Delete relationships from normalized stage
+    delete_documents_references_from_kg(db_session, [document_id])
+
+
+def delete_documents_references_from_kg(
+    db_session: Session, document_ids: list[str]
+) -> None:
+    """Bulk-delete KG entities and relationships referencing the given document IDs."""
+    if not document_ids:
+        return
+
     db_session.query(KGRelationship).filter(
-        KGRelationship.source_document == document_id
+        KGRelationship.source_document.in_(document_ids)
     ).delete(synchronize_session=False)
 
-    # Delete relationships from extraction staging
     db_session.query(KGRelationshipExtractionStaging).filter(
-        KGRelationshipExtractionStaging.source_document == document_id
+        KGRelationshipExtractionStaging.source_document.in_(document_ids)
     ).delete(synchronize_session=False)
 
-    # Delete entities from normalized stage
-    db_session.query(KGEntity).filter(KGEntity.document_id == document_id).delete(
+    db_session.query(KGEntity).filter(KGEntity.document_id.in_(document_ids)).delete(
         synchronize_session=False
     )
 
-    # Delete entities from extraction staging
     db_session.query(KGEntityExtractionStaging).filter(
-        KGEntityExtractionStaging.document_id == document_id
+        KGEntityExtractionStaging.document_id.in_(document_ids)
     ).delete(synchronize_session=False)
 
     db_session.flush()

--- a/backend/onyx/document_index/disabled.py
+++ b/backend/onyx/document_index/disabled.py
@@ -6,6 +6,7 @@ out against a nonexistent Vespa/OpenSearch instance.
 """
 
 from collections.abc import Iterable
+from collections.abc import Mapping
 
 from onyx.context.search.enums import QueryType
 from onyx.context.search.models import IndexFilters
@@ -49,6 +50,12 @@ class DisabledDocumentIndex(DocumentIndex):
         self,
         document_id: str,  # noqa: ARG002
         chunk_count: int | None = None,  # noqa: ARG002
+    ) -> int:
+        raise RuntimeError(VECTOR_DB_DISABLED_ERROR)
+
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],  # noqa: ARG002
     ) -> int:
         raise RuntimeError(VECTOR_DB_DISABLED_ERROR)
 

--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -1,5 +1,6 @@
 import abc
 from collections.abc import Iterable
+from collections.abc import Mapping
 from typing import Self
 
 from pydantic import BaseModel
@@ -250,8 +251,6 @@ class Deletable(abc.ABC):
     @abc.abstractmethod
     def delete(
         self,
-        # TODO(andrei): Fine for now but this can probably be a batch operation
-        # that takes in a list of IDs.
         document_id: str,
         chunk_count: int | None = None,
         # TODO(andrei): Shouldn't this also have some acl filtering at minimum?
@@ -273,6 +272,29 @@ class Deletable(abc.ABC):
 
         Returns:
             The number of chunks deleted.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],
+    ) -> int:
+        """Hard-delete all chunks for each of the supplied document IDs.
+
+        Backends are expected to amortize across docs (e.g. one OpenSearch
+        delete_by_query, or a shared httpx client + thread pool for Vespa) so
+        that batch cost is far below `len(doc_id_to_chunk_count)` calls to
+        `delete()`. Missing document IDs are treated as no-ops.
+
+        Args:
+            doc_id_to_chunk_count: Per-doc chunk counts. Used by backends that
+                benefit from knowing the count up front (Vespa's chunk-id
+                derived path); other backends may ignore it. None means
+                unknown.
+
+        Returns:
+            Total number of chunks deleted across all supplied document IDs.
         """
         raise NotImplementedError
 

--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -287,6 +287,11 @@ class Deletable(abc.ABC):
         that batch cost is far below `len(doc_id_to_chunk_count)` calls to
         `delete()`. Missing document IDs are treated as no-ops.
 
+        Callers are responsible for bounding batch size. The OpenSearch
+        backend caps a single batch at MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY
+        (65,536 doc ids) and will raise ValueError above that. An empty
+        mapping is always a no-op (returns 0).
+
         Args:
             doc_id_to_chunk_count: Per-doc chunk counts. Used by backends that
                 benefit from knowing the count up front (Vespa's chunk-id

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterable
+from collections.abc import Mapping
 from typing import Any
 
 from opensearchpy.helpers.errors import BulkIndexError
@@ -539,6 +540,25 @@ class OpenSearchDocumentIndex(DocumentIndex):
 
         return self._client.delete_by_query(query_body)
 
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],  # noqa: ARG002
+    ) -> int:
+        document_ids = list(doc_id_to_chunk_count.keys())
+        if not document_ids:
+            return 0
+
+        logger.debug(
+            "[OpenSearchDocumentIndex] Bulk-deleting %d documents from index %s.",
+            len(document_ids),
+            self._index_name,
+        )
+        query_body = DocumentQuery.delete_from_document_ids_query(
+            document_ids=document_ids,
+            tenant_state=self._tenant_state,
+        )
+        return self._client.delete_by_query(query_body)
+
     def update(
         self,
         update_requests: list[MetadataUpdateRequest],
@@ -969,6 +989,15 @@ class OpenSearchIndexPair(DocumentIndex):
         total = self._primary.delete(document_id, chunk_count)
         if self._secondary is not None:
             total += self._secondary.delete(document_id, chunk_count)
+        return total
+
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],
+    ) -> int:
+        total = self._primary.delete_batch(doc_id_to_chunk_count)
+        if self._secondary is not None:
+            total += self._secondary.delete_batch(doc_id_to_chunk_count)
         return total
 
     def update(self, update_requests: list[MetadataUpdateRequest]) -> None:

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -312,6 +312,40 @@ class DocumentQuery:
         return final_delete_query
 
     @staticmethod
+    def delete_from_document_ids_query(
+        document_ids: list[str],
+        tenant_state: TenantState,
+    ) -> dict[str, Any]:
+        """Bulk variant of `delete_from_document_id_query`.
+
+        Filters via `attached_document_ids` so OpenSearch can use a
+        Lucene-optimized terms query in one delete_by_query round-trip.
+        """
+        filter_clauses = DocumentQuery._get_search_filters(
+            tenant_state=tenant_state,
+            include_hidden=True,
+            access_control_list=None,
+            source_types=[],
+            tags=[],
+            document_sets=[],
+            project_id_filter=None,
+            persona_id_filter=None,
+            time_cutoff=None,
+            min_chunk_index=None,
+            max_chunk_index=None,
+            max_chunk_size=None,
+            attached_document_ids=document_ids,
+        )
+        final_delete_query: dict[str, Any] = {
+            "query": {"bool": {"filter": filter_clauses}},
+            "timeout": f"{DEFAULT_OPENSEARCH_QUERY_TIMEOUT_S}s",
+        }
+        if not OPENSEARCH_PROFILING_DISABLED:
+            final_delete_query["profile"] = True
+
+        return final_delete_query
+
+    @staticmethod
     def get_hybrid_search_query(
         query_text: str,
         query_vector: list[float],

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -320,7 +320,21 @@ class DocumentQuery:
 
         Filters via `attached_document_ids` so OpenSearch can use a
         Lucene-optimized terms query in one delete_by_query round-trip.
+
+        Raises:
+            ValueError: document_ids is empty. An empty list would cause
+                `_get_search_filters` to omit the document filter entirely
+                (no knowledge_scope trigger), which on a delete_by_query
+                path would broaden the delete to every chunk in the tenant.
+            ValueError: len(document_ids) > MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY
+                (raised from `_get_attached_document_id_filter`).
         """
+        if not document_ids:
+            raise ValueError(
+                "delete_from_document_ids_query requires a non-empty document_ids "
+                "list — an empty list would broaden delete_by_query to every chunk "
+                "in the tenant."
+            )
         filter_clauses = DocumentQuery._get_search_filters(
             tenant_state=tenant_state,
             include_hidden=True,

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -9,6 +9,7 @@ import urllib.parse
 import zipfile
 from collections.abc import Generator
 from collections.abc import Iterable
+from collections.abc import Mapping
 from datetime import datetime
 from datetime import timedelta
 from typing import Any
@@ -769,23 +770,33 @@ class VespaDocumentIndex(DocumentIndex):
         ]
 
     def delete(self, document_id: str, chunk_count: int | None = None) -> int:
-        total_chunks_deleted = 0
+        return self.delete_batch({document_id: chunk_count})
 
-        sanitized_doc_id = replace_invalid_doc_id_characters(document_id)
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],
+    ) -> int:
+        if not doc_id_to_chunk_count:
+            return 0
+
+        total_chunks_deleted = 0
 
         with (
             concurrent.futures.ThreadPoolExecutor(max_workers=NUM_THREADS) as executor,
             self._httpx_client_context as http_client,
         ):
-            enriched_doc_info = _enrich_basic_chunk_info(
-                index_name=self._index_name,
-                http_client=http_client,
-                document_id=sanitized_doc_id,
-                previous_chunk_count=chunk_count,
-                new_chunk_count=0,
-            )
+            enriched_doc_infos = [
+                _enrich_basic_chunk_info(
+                    index_name=self._index_name,
+                    http_client=http_client,
+                    document_id=replace_invalid_doc_id_characters(document_id),
+                    previous_chunk_count=chunk_count,
+                    new_chunk_count=0,
+                )
+                for document_id, chunk_count in doc_id_to_chunk_count.items()
+            ]
             chunks_to_delete = get_document_chunk_ids(
-                enriched_document_info_list=[enriched_doc_info],
+                enriched_document_info_list=enriched_doc_infos,
                 tenant_id=self._tenant_id,
                 large_chunks_enabled=self._large_chunks_enabled,
             )
@@ -1284,6 +1295,15 @@ class VespaIndexPair(DocumentIndex):
         total = self._primary.delete(document_id, chunk_count)
         if self._secondary is not None:
             total += self._secondary.delete(document_id, chunk_count)
+        return total
+
+    def delete_batch(
+        self,
+        doc_id_to_chunk_count: Mapping[str, int | None],
+    ) -> int:
+        total = self._primary.delete_batch(doc_id_to_chunk_count)
+        if self._secondary is not None:
+            total += self._secondary.delete_batch(doc_id_to_chunk_count)
         return total
 
     def update(self, update_requests: list[MetadataUpdateRequest]) -> None:

--- a/backend/tests/external_dependency_unit/document_index/test_document_index.py
+++ b/backend/tests/external_dependency_unit/document_index/test_document_index.py
@@ -459,3 +459,107 @@ class TestDocumentIndexNew:
             assert len(retrieved) == 2
             for chunk in retrieved:
                 assert chunk.boost == 0
+
+
+class TestDocumentIndexNewDelete:
+    """Tests for the new DocumentIndex.delete_batch() bulk delete entrypoint."""
+
+    def test_delete_batch_removes_all_listed_docs(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        for document_index in document_indices:
+            doc1 = f"test_batch_del_a_{uuid.uuid4().hex[:8]}"
+            doc2 = f"test_batch_del_b_{uuid.uuid4().hex[:8]}"
+            doc3 = f"test_batch_del_c_{uuid.uuid4().hex[:8]}"
+            chunks = [
+                make_chunk(doc1, chunk_id=0),
+                make_chunk(doc1, chunk_id=1),
+                make_chunk(doc2, chunk_id=0),
+                make_chunk(doc3, chunk_id=0),
+            ]
+            metadata = make_indexing_metadata(
+                [doc1, doc2, doc3], old_counts=[0, 0, 0], new_counts=[2, 1, 1]
+            )
+            document_index.index(chunks=chunks, indexing_metadata=metadata)
+            time.sleep(1)
+
+            chunks_deleted = document_index.delete_batch({doc1: 2, doc2: 1, doc3: 1})
+            time.sleep(1)
+
+            assert chunks_deleted == 4
+
+            filters = IndexFilters(
+                access_control_list=[PUBLIC_DOC_PAT],
+                tenant_id=TEST_TENANT_ID,
+            )
+            for doc_id in (doc1, doc2, doc3):
+                assert (
+                    document_index.id_based_retrieval(
+                        chunk_requests=[DocumentSectionRequest(document_id=doc_id)],
+                        filters=filters,
+                    )
+                    == []
+                )
+
+    def test_delete_batch_does_not_touch_unlisted_docs(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        for document_index in document_indices:
+            kept_doc = f"test_batch_del_keep_{uuid.uuid4().hex[:8]}"
+            removed_doc = f"test_batch_del_remove_{uuid.uuid4().hex[:8]}"
+            chunks = [
+                make_chunk(kept_doc, chunk_id=0),
+                make_chunk(removed_doc, chunk_id=0),
+            ]
+            metadata = make_indexing_metadata(
+                [kept_doc, removed_doc], old_counts=[0, 0], new_counts=[1, 1]
+            )
+            document_index.index(chunks=chunks, indexing_metadata=metadata)
+            time.sleep(1)
+
+            document_index.delete_batch({removed_doc: 1})
+            time.sleep(1)
+
+            filters = IndexFilters(
+                access_control_list=[PUBLIC_DOC_PAT],
+                tenant_id=TEST_TENANT_ID,
+            )
+            assert (
+                len(
+                    document_index.id_based_retrieval(
+                        chunk_requests=[DocumentSectionRequest(document_id=kept_doc)],
+                        filters=filters,
+                    )
+                )
+                == 1
+            )
+            assert (
+                document_index.id_based_retrieval(
+                    chunk_requests=[DocumentSectionRequest(document_id=removed_doc)],
+                    filters=filters,
+                )
+                == []
+            )
+
+    def test_delete_batch_empty_mapping_is_noop(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        for document_index in document_indices:
+            assert document_index.delete_batch({}) == 0
+
+    def test_delete_batch_missing_doc_id_is_noop(
+        self,
+        document_indices: list[DocumentIndexNew],
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        for document_index in document_indices:
+            doc_id = f"test_batch_del_missing_{uuid.uuid4().hex[:8]}"
+            # Doc was never indexed — backends should treat this as a no-op,
+            # not raise.
+            assert document_index.delete_batch({doc_id: None}) == 0


### PR DESCRIPTION
## Description

First of three PRs implementing batched per-document cleanup so connector deletion and pruning amortize their per-doc costs (PG, KG cascade, document-index HTTP calls) across batches of N docs instead of paying them per doc. See \`plans/batch-document-cleanup-tasks.md\` for the full rationale; production hit a 1.7M-task pgbouncer-saturating queue on 2026-05-18 from one tenant's pruning fan-out.

This PR is purely **additive** — new bulk DB helpers, a new \`Deletable.delete_batch\` interface method with backend implementations, and a tenacity-wrapped \`RetryDocumentIndex.delete_batch\`. Nothing calls any of these yet. PR 2 will add the batched Celery task; PR 3 flips fan-out to use it.

### Changes

- \`backend/onyx/db/relationships.py\` — new \`delete_documents_references_from_kg(db_session, document_ids)\` bulk helper. The existing singular form now delegates to it.
- \`backend/onyx/db/document.py\` — new \`mark_documents_as_synced(document_ids, db_session)\` bulk helper. Silently skips missing IDs (the bulk-cleanup caller can tolerate one missing row mid-batch).
- \`backend/onyx/document_index/interfaces_new.py\` — new abstract \`Deletable.delete_batch(doc_id_to_chunk_count)\` returning total chunks deleted.
- \`backend/onyx/document_index/opensearch/opensearch_document_index.py\` + \`search.py\` — implements \`delete_batch\` via a single \`delete_by_query\` round-trip filtered by a Lucene-optimized \`terms\` clause on document IDs.
- \`backend/onyx/document_index/vespa/vespa_document_index.py\` — implements \`delete_batch\` reusing one \`ThreadPoolExecutor\` + one \`httpx_client\` across all docs in the batch (avoids tearing them down between docs). The singular \`delete()\` now delegates to \`delete_batch({doc_id: chunk_count})\`.
- \`backend/onyx/document_index/disabled.py\` — \`DisabledDocumentIndex.delete_batch\` raises like the rest of the disabled methods.
- \`backend/onyx/background/celery/tasks/shared/RetryDocumentIndex.py\` — \`delete_batch\` wrapper reusing the existing tenacity/jitter decorator pattern.

No call sites change in this PR. Singular \`delete()\` is preserved on every backend.

## How Has This Been Tested?

- \`pytest backend/tests/external_dependency_unit/document_index/test_document_index.py::TestDocumentIndexNewDelete\` — 4 new tests passing against real OpenSearch and Vespa, covering: bulk delete removes all listed docs, bulk delete does not touch unlisted docs, empty mapping is a no-op, missing doc ID is a no-op.
- Existing \`pytest backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py\` — 5 pre-existing per-doc tests still pass (Vespa \`delete()\` now delegates to \`delete_batch()\` so this confirms no regression).
- \`pre-commit run\` clean (ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the foundations for batched document cleanup so deletion/pruning amortize work across many docs instead of per-doc calls. Also documents batch limits and adds a safety guard in OpenSearch bulk delete to prevent tenant-wide deletes on empty input.

- New Features
  - DB: `delete_documents_references_from_kg()` and `mark_documents_as_synced()` bulk helpers; singular variants delegate; empty input is a no-op.
  - Interface: add `Deletable.delete_batch(doc_id_to_chunk_count)` returning total chunks; missing IDs are no-ops; empty mapping returns 0; docs note OpenSearch’s 65,536-term cap for `terms` queries.
  - OpenSearch + Vespa: implement `delete_batch` (OpenSearch uses one `delete_by_query` with a `terms` filter; Vespa reuses one `ThreadPoolExecutor` and one `httpx` client; `delete()` delegates to `delete_batch`).
  - Retry: `RetryDocumentIndex.delete_batch` adds `tenacity`-based retries for `httpx.ReadTimeout`.

- Bug Fixes
  - OpenSearch: guard `delete_from_document_ids_query` against an empty list and raise `ValueError` to avoid broadening `delete_by_query` to all chunks in a tenant.

<sup>Written for commit 9a08e780a32f96d0bc2e907e167a9ffc57728525. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

