### PR TITLE
fix(backend): clean_model_name handles non-alphanumeric chars

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -193,7 +193,8 @@ WARM_UP_STRINGS = [
 
 
 def clean_model_name(model_str: str) -> str:
-    return model_str.replace("/", "_").replace("-", "_").replace(".", "_")
+    import re
+    return re.sub(r"[^a-zA-Z0-9_]", "_", model_str).strip("_")
 
 
 def build_model_server_url(

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -193,7 +194,6 @@ WARM_UP_STRINGS = [
 
 
 def clean_model_name(model_str: str) -> str:
-    import re
     return re.sub(r"[^a-zA-Z0-9_]", "_", model_str).strip("_")
 
 

--- a/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
+++ b/backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py
@@ -12,6 +12,7 @@ from litellm.exceptions import RateLimitError
 from tenacity import wait_none
 
 from onyx.llm.constants import LlmProviderNames
+from onyx.natural_language_processing.search_nlp_models import clean_model_name
 from onyx.natural_language_processing.search_nlp_models import CloudEmbedding
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from shared_configs.enums import EmbeddingProvider
@@ -33,6 +34,28 @@ async def mock_http_client() -> AsyncGenerator[AsyncMock, None]:
 @pytest.fixture
 def sample_embeddings() -> list[list[float]]:
     return [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # Cloudflare AI Gateway model id — leading @ would yield _cf_baai_bge_m3
+        # and Vespa rejects schema names starting with _.
+        ("@cf/baai/bge-m3", "cf_baai_bge_m3"),
+        # OpenAI-style names — same result as the old implementation.
+        ("text-embedding-ada-002", "text_embedding_ada_002"),
+        # Hugging Face-style namespaced names.
+        ("nomic-ai/nomic-embed-text-v1", "nomic_ai_nomic_embed_text_v1"),
+        # Litellm provider:model form.
+        ("openai:text-embedding-3-small", "openai_text_embedding_3_small"),
+        # Already-clean names pass through unchanged.
+        ("snowflake_arctic_embed_l_v2", "snowflake_arctic_embed_l_v2"),
+    ],
+)
+def test_clean_model_name_substitutes_non_alphanumeric(
+    raw: str, expected: str
+) -> None:
+    assert clean_model_name(raw) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`clean_model_name` is used to build Vespa schema names from model identifiers (e.g. `danswer_chunk_{clean_model_name(model)}`). It currently only substitutes `/`, `-`, and `.` with `_`, which means any other special character (`@`, `:`, `+`, etc.) ends up in the final schema name and Vespa rejects the application package with `INVALID_APPLICATION_PACKAGE`.

This trips on legitimately-formatted model identifiers like:

| Identifier | Old result | Outcome |
|---|---|---|
| `@cf/baai/bge-m3` (Cloudflare Workers AI) | `@cf_baai_bge_m3` | Vespa rejects `@` |
| `openai:text-embedding-3-small` (litellm-style provider prefix) | `openai:text_embedding_3_small` | Vespa rejects `:` |

We hit this trying to plug Cloudflare Workers AI (`@cf/baai/bge-m3`) into Onyx as a LiteLLM embedding provider and got `INVALID_APPLICATION_PACKAGE` from Vespa during reindex.

## Change

Replace the chain of `.replace()` calls with a single regex substitution that maps any non-`[a-zA-Z0-9_]` character to `_`, then `.strip("_")` so we don't emit leading/trailing underscores for identifiers that begin with a special char (e.g. `@cf/...` → `cf_baai_bge_m3` rather than `_cf_baai_bge_m3`).

Behavior on existing inputs is unchanged:
- `text-embedding-ada-002` → `text_embedding_ada_002` (same)
- `nomic-ai/nomic-embed-text-v1` → `nomic_ai_nomic_embed_text_v1` (same)
- `snowflake_arctic_embed_l_v2` → `snowflake_arctic_embed_l_v2` (same)

## Tests

Added a parametrized `test_clean_model_name_substitutes_non_alphanumeric` to `backend/tests/unit/onyx/natural_language_processing/test_search_nlp_models.py` covering both the original cases (regression) and the previously-broken ones (`@cf/...`, `openai:...`).

## Test plan

- [x] `ruff check` on the patched file passes
- [x] Parametrized pytest covers the regression + previously-broken cases
- [x] Verified end-to-end on a self-hosted Onyx deployment by switching the embedding provider to `@cf/baai/bge-m3` via the Cloudflare AI Gateway; reindex of ~14K documents now succeeds (Vespa accepted `danswer_chunk_cf_baai_bge_m3`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Vespa schema names generated from model IDs are always valid. Fixes reindex failures (INVALID_APPLICATION_PACKAGE) with identifiers like `@cf/baai/bge-m3` and `openai:text-embedding-3-small`.

- **Bug Fixes**
  - Use a single regex to replace any non-`[a-zA-Z0-9_]` char with `_`, then strip leading/trailing `_`; moved the `re` import to the module top; preserves prior behavior for existing names.
  - Add a parametrized unit test covering original cases and the previously failing ones.

<sup>Written for commit 294e84dea1f798f9a17e0944d78df3d5eeb42286. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

