### PR TITLE
fix(monitoring): two OOM fixes for monitoring worker under heavy backlog

### DIFF
--- a/backend/onyx/background/celery/celery_redis.py
+++ b/backend/onyx/background/celery/celery_redis.py
@@ -80,14 +80,21 @@ def celery_get_unacked_task_ids(queue: str, r: Redis) -> set[str]:
 
     Unacked entries belonging to the indexing queues are "prefetched", so this gives
     us crucial visibility as to what tasks are in that state.
+
+    Uses a bytes-substring pre-filter to skip the json.loads call for entries
+    whose serialized message doesn't even contain the queue name. With a large
+    unacked backlog (10k+ entries) this avoids parsing tens of megabytes of
+    JSON per call — the dominant memory cost on the monitoring worker.
     """
     tasks: set[str] = set()
+    queue_marker = f'"{queue}"'.encode("utf-8")
 
     for _, v in r.hscan_iter("unacked"):
         v_bytes = cast(bytes, v)
-        v_str = v_bytes.decode("utf-8")
-        task = json.loads(v_str)
+        if queue_marker not in v_bytes:
+            continue
 
+        task = json.loads(v_bytes)
         task_description = task[0]
         task_queue = task[2]
 

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -761,7 +761,7 @@ def connector_pruning_generator_task(
 def monitor_ccpair_pruning_taskset(
     tenant_id: str,
     key_bytes: bytes,
-    r: TenantRedisClient,  # noqa: ARG001
+    r: TenantRedisClient,
     db_session: Session,
 ) -> None:
     fence_key = key_bytes.decode("utf-8")
@@ -782,11 +782,14 @@ def monitor_ccpair_pruning_taskset(
     if initial is None:
         return
 
-    remaining = redis_connector.prune.get_remaining()
-    task_logger.info(
-        f"Connector pruning progress: cc_pair={cc_pair_id} remaining={remaining} initial={initial}"
-    )
-    if remaining > 0:
+    # Check if the taskset still exists in Redis without reading its size.
+    # redis.exists() is O(1) and very cheap, whereas scard() on a large taskset
+    # (1M+ items during a big pruning fan-out) was OOMKilling the monitoring
+    # pod. Mirrors the deletion-side fix in #11155.
+    if r.exists(redis_connector.prune.taskset_key):
+        task_logger.info(
+            f"Connector pruning progress: cc_pair={cc_pair_id} initial={initial}"
+        )
         return
 
     mark_ccpair_as_pruned(int(cc_pair_id), db_session)


### PR DESCRIPTION
## Description

The \`celery-worker-monitoring\` pods on managed_services are still OOMKilling under the current deletion/pruning backlog (1.7M-task pruning taskset, ~10k unacked tasks). PR #11155 plugged one O(N) source but two remain:

1. **\`celery_get_unacked_task_ids\` JSON-parses every entry in the \`unacked\` hash**, even ones for queues we don't care about (\`backend/onyx/background/celery/celery_redis.py:78\`). The monitoring helper calls it twice per 30s beat for two different queues. With 10k+ unacked entries at ~2-3KB each, that's ~50 MB of transient Python objects every 30s — enough to cause allocator-fragmentation memory growth across the pod's lifetime (we measured ~25 MiB/min). Fix: cheap bytes-substring pre-filter on the queue marker before \`json.loads\`. Skips the parse for non-matching entries.

2. **Pruning monitor still uses \`scard\` via \`get_remaining()\`** (\`backend/onyx/background/celery/tasks/pruning/tasks.py:785\`). #11155 patched the equivalent on the deletion side but missed pruning. With the 1.7M-task pruning taskset on managed_services right now, this is the bigger contributor. Fix: replace with \`r.exists(prune.taskset_key)\` — the same O(1) pattern #11155 used for deletion. Use the cached \`initial\` count in the progress log instead of the live \`remaining\`.

### Changes

- \`backend/onyx/background/celery/celery_redis.py\` — \`celery_get_unacked_task_ids\` now pre-filters on a byte-encoded \`'"<queue>"'\` marker before \`json.loads\`. Public signature unchanged so all 5 call sites benefit transparently. Conservative: it's a substring containment check; false positives are tolerated (still hit the existing exact-match check downstream), false negatives are impossible because the JSON serializer always quotes the queue string.
- \`backend/onyx/background/celery/tasks/pruning/tasks.py\` — \`monitor_ccpair_pruning_taskset\` now checks \`r.exists(taskset_key)\` instead of \`get_remaining()\`. The \`r: TenantRedisClient\` arg is no longer \`noqa: ARG001\`.

## How Has This Been Tested?

- \`pre-commit run\` clean (ty, ruff, ruff format) on both touched files.
- The optimization is behavior-preserving by construction: the pre-filter check is followed by the same exact-match downstream check, and \`r.exists\` is the exact pattern used in the deletion monitor since #11155 (in production for hours without issue).
- No new tests because (a) the unacked optimization is a perf-only change to an existing function with no behavior change and (b) the pruning fix is a direct port of the already-tested #11155 deletion fix.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOMs in `celery-worker-monitoring` under heavy backlogs by cutting unnecessary JSON parsing of unacked entries and removing an O(N) Redis call in the pruning monitor. This reduces transient memory and allocator fragmentation during beats.

- **Bug Fixes**
  - `celery_get_unacked_task_ids`: add a bytes pre-filter on `'"<queue>"'` to skip `json.loads` for non-matching `unacked` entries; public signature unchanged.
  - `monitor_ccpair_pruning_taskset`: replace `scard`/`get_remaining()` with `r.exists(taskset_key)` and log only the cached `initial`; mirrors the deletion-side pattern.

<sup>Written for commit d95f252fb813b25b09250314954c4115345d12a7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

