### PR TITLE
chore(opensearch): Fix `if <> is not None` control flow split in calling OpenSearch client

### DIFF
--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -303,9 +303,7 @@ class OpenSearchClient(AbstractContextManager):
         Returns:
             The raw cluster health response.
         """
-        if index is not None:
-            return self._client.cluster.health(index=index, level=level)
-        return self._client.cluster.health(level=level)
+        return self._client.cluster.health(index=index, level=level)
 
     @log_function_time(print_only=True, debug_only=True, include_args=True)
     def cat_shards(
@@ -328,10 +326,7 @@ class OpenSearchClient(AbstractContextManager):
         Returns:
             A list of dicts, one per shard, with the requested columns as keys.
         """
-        kwargs: dict[str, Any] = {"format": "json", "h": columns}
-        if index is not None:
-            kwargs["index"] = index
-        return self._client.cat.shards(**kwargs)
+        return self._client.cat.shards(format="json", h=columns, index=index)
 
     @log_function_time(print_only=True, debug_only=True, include_args=True)
     def allocation_explain(
@@ -364,9 +359,7 @@ class OpenSearchClient(AbstractContextManager):
             body["shard"] = shard
         if primary is not None:
             body["primary"] = primary
-        if body:
-            return self._client.cluster.allocation_explain(body=body)
-        return self._client.cluster.allocation_explain()
+        return self._client.cluster.allocation_explain(body=body or None)
 
     @log_function_time(print_only=True, debug_only=True)
     def reroute_retry_failed(self) -> dict[str, Any]:
@@ -1296,17 +1289,12 @@ class OpenSearchIndexClient(OpenSearchClient):
         with ctx:
             try:
                 t0 = time.perf_counter()
-                if search_pipeline_id:
-                    result = self._client.search(
-                        index=self._index_name,
-                        search_pipeline=search_pipeline_id,
-                        body=body,
-                        params=params,
-                    )
-                else:
-                    result = self._client.search(
-                        index=self._index_name, body=body, params=params
-                    )
+                result = self._client.search(
+                    index=self._index_name,
+                    search_pipeline=search_pipeline_id,
+                    body=body,
+                    params=params,
+                )
                 client_duration_s = time.perf_counter() - t0
                 hits, time_took, timed_out, phase_took, profile = (
                     self._get_hits_and_profile_from_search_result(result)


### PR DESCRIPTION
## Description
The OpenSearch client drops `None` params already.

## How Has This Been Tested?
Existing automated tests should cover us.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified `OpenSearch` client calls by removing if-not-None branches and passing optional params directly, relying on the client to drop `None`. This reduces branching in `cluster_health`, `cat_shards`, `allocation_explain`, and `search` without changing behavior.

<sup>Written for commit c4fa02b6287fcfbf8eb41f845253e31d96270ceb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

