### PR TITLE
chore: jira perm sync logs

### DIFF
--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -17,9 +17,38 @@ HolderMap = dict[str, list[Holder]]
 
 logger = setup_logger()
 
+BROWSE_PROJECTS_PERMISSION = "BROWSE_PROJECTS"
+HOLDER_TYPE_ANYONE = "anyone"
+HOLDER_TYPE_APPLICATION_ROLE = "applicationRole"
+HOLDER_TYPE_USER = "user"
+HOLDER_TYPE_PROJECT_ROLE = "projectRole"
+HOLDER_TYPE_GROUP = "group"
+
+SUPPORTED_STATIC_HOLDER_TYPES = {
+    HOLDER_TYPE_ANYONE,
+    HOLDER_TYPE_APPLICATION_ROLE,
+    HOLDER_TYPE_USER,
+    HOLDER_TYPE_PROJECT_ROLE,
+    HOLDER_TYPE_GROUP,
+}
+
 
 def _get_role_id(holder: Holder) -> str | None:
     return holder.get("value") or holder.get("parameter")
+
+
+def _get_holder_counts(holder_map: HolderMap) -> dict[str, int]:
+    return {
+        holder_type: len(holders) for holder_type, holders in sorted(holder_map.items())
+    }
+
+
+def _get_unsupported_holder_counts(holder_map: HolderMap) -> dict[str, int]:
+    return {
+        holder_type: count
+        for holder_type, count in _get_holder_counts(holder_map).items()
+        if holder_type not in SUPPORTED_STATIC_HOLDER_TYPES
+    }
 
 
 def _build_holder_map(permissions: list[dict]) -> dict[str, list[Holder]]:
@@ -73,7 +102,7 @@ def _build_holder_map(permissions: list[dict]) -> dict[str, list[Holder]]:
         permission = Permission(**raw_perm.raw)  # ty: ignore[invalid-argument-type]
 
         # We only care about ability to browse through projects + issues (not other permissions such as read/write).
-        if permission.permission != "BROWSE_PROJECTS":
+        if permission.permission != BROWSE_PROJECTS_PERMISSION:
             continue
 
         # In order to associate this permission to some Atlassian entity, we need the "Holder".
@@ -98,24 +127,46 @@ def _build_holder_map(permissions: list[dict]) -> dict[str, list[Holder]]:
     return holder_map
 
 
-def _get_user_emails(user_holders: list[Holder]) -> list[str]:
+def _get_user_emails(jira_project: str, user_holders: list[Holder]) -> list[str]:
     emails = []
+    missing_user_object_count = 0
+    validation_error_count = 0
 
     for user_holder in user_holders:
         if "user" not in user_holder:
+            missing_user_object_count += 1
+            logger.warning(
+                "Jira project %s user holder has no expanded user object; holder=%s",
+                jira_project,
+                user_holder,
+            )
             continue
         raw_user_dict = user_holder["user"]
 
         try:
             user_model = User.model_validate(raw_user_dict)
         except ValidationError:
+            validation_error_count += 1
             logger.error(
-                "Expected to be able to serialize the raw-user-dict into an instance of `User`, but validation failed;raw_user_dict=%r",
+                "Jira project %s user holder expanded user failed validation; "
+                "raw_user_dict=%r",
+                jira_project,
                 raw_user_dict,
             )
             continue
 
         emails.append(user_model.email_address)
+
+    if user_holders and not emails:
+        logger.warning(
+            "Jira project %s resolved zero emails from direct user holders; "
+            "user_holder_count=%s missing_user_object_count=%s "
+            "validation_error_count=%s",
+            jira_project,
+            len(user_holders),
+            missing_user_object_count,
+            validation_error_count,
+        )
 
     return emails
 
@@ -131,12 +182,26 @@ def _get_user_emails_and_groups_from_project_roles(
     """
     # Get role IDs - Cloud uses "value", Data Center uses "parameter"
     role_ids = []
+    missing_role_id_count = 0
     for holder in project_role_holders:
         role_id = _get_role_id(holder)
         if role_id:
             role_ids.append(role_id)
         else:
-            logger.warning("No value or parameter in projectRole holder: %s", holder)
+            missing_role_id_count += 1
+            logger.warning(
+                "Jira project %s projectRole holder has no value or parameter: %s",
+                jira_project,
+                holder,
+            )
+
+    if not role_ids:
+        logger.warning(
+            "Jira project %s has %s projectRole holders but none had a usable role id; "
+            "project-role groups will be empty",
+            jira_project,
+            len(project_role_holders),
+        )
 
     roles = [
         jira_client.project_role(project=jira_project, id=role_id)
@@ -145,27 +210,55 @@ def _get_user_emails_and_groups_from_project_roles(
 
     emails = []
     groups = []
+    actor_group_seen_count = 0
+    actor_group_missing_name_count = 0
+    actor_user_seen_count = 0
+    roles_without_actors_count = 0
+    unsupported_actor_count = 0
 
-    for role in roles:
+    for role_id, role in zip(role_ids, roles, strict=True):
         if not hasattr(role, "actors"):
-            logger.warning("Project role %s has no actors attribute", role)
+            roles_without_actors_count += 1
+            logger.warning(
+                "Jira project %s project role %s has no actors attribute; "
+                "this role cannot contribute users or groups",
+                jira_project,
+                role_id,
+            )
             continue
 
         for actor in role.actors:
             # Handle group actors
             if hasattr(actor, "actorGroup"):
+                actor_group_seen_count += 1
                 group_name = getattr(actor.actorGroup, "name", None) or getattr(
                     actor.actorGroup, "displayName", None
                 )
                 if group_name:
                     groups.append(group_name)
+                else:
+                    actor_group_missing_name_count += 1
+                    logger.warning(
+                        "Jira project %s project role %s has actorGroup with no "
+                        "name/displayName; actor_group=%s",
+                        jira_project,
+                        role_id,
+                        actor.actorGroup,
+                    )
                 continue
 
             # Handle user actors
             if hasattr(actor, "actorUser"):
+                actor_user_seen_count += 1
                 account_id = getattr(actor.actorUser, "accountId", None)
                 if not account_id:
-                    logger.error("No accountId in actorUser: %s", actor.actorUser)
+                    logger.error(
+                        "Jira project %s project role %s actorUser has no accountId; "
+                        "actor_user=%s",
+                        jira_project,
+                        role_id,
+                        actor.actorUser,
+                    )
                     continue
 
                 user = jira_client.user(id=account_id)
@@ -186,7 +279,33 @@ def _get_user_emails_and_groups_from_project_roles(
                 emails.append(user.emailAddress)
                 continue
 
-            logger.debug("Skipping actor type: %s", actor)
+            unsupported_actor_count += 1
+            logger.warning(
+                "Jira project %s project role %s has unsupported actor shape; actor=%s",
+                jira_project,
+                role_id,
+                actor,
+            )
+
+    if project_role_holders and not groups:
+        logger.warning(
+            "Jira project %s resolved zero groups from projectRole holders; "
+            "project_role_holder_count=%s valid_role_id_count=%s "
+            "missing_role_id_count=%s roles_fetched=%s roles_without_actors=%s "
+            "actor_group_seen=%s actor_group_missing_name=%s actor_user_seen=%s "
+            "user_email_count=%s unsupported_actor_count=%s",
+            jira_project,
+            len(project_role_holders),
+            len(role_ids),
+            missing_role_id_count,
+            len(roles),
+            roles_without_actors_count,
+            actor_group_seen_count,
+            actor_group_missing_name_count,
+            actor_user_seen_count,
+            len(emails),
+            unsupported_actor_count,
+        )
 
     return emails, groups
 
@@ -204,50 +323,131 @@ def _build_external_access_from_holder_map(
         - "projectRole": Project roles containing users and/or groups
         - "group": Groups directly assigned in the permission scheme
     """
+    holder_counts = _get_holder_counts(holder_map)
+    unsupported_holder_counts = _get_unsupported_holder_counts(holder_map)
+    if not holder_map:
+        logger.warning(
+            "Jira project %s has no usable %s permission holders; "
+            "external access will resolve to empty private access",
+            jira_project,
+            BROWSE_PROJECTS_PERMISSION,
+        )
+    if unsupported_holder_counts:
+        logger.warning(
+            "Jira project %s has unsupported %s holder types that do not map to "
+            "static Onyx ACLs; unsupported_holder_counts=%s all_holder_counts=%s",
+            jira_project,
+            BROWSE_PROJECTS_PERMISSION,
+            unsupported_holder_counts,
+            holder_counts,
+        )
+
     # Public access - anyone can view
-    if "anyone" in holder_map:
+    if HOLDER_TYPE_ANYONE in holder_map:
+        logger.info(
+            "Jira project %s has anyone holder; resolving as public external access "
+            "with empty explicit groups",
+            jira_project,
+        )
         return ExternalAccess(
             external_user_emails=set(), external_user_group_ids=set(), is_public=True
         )
 
     # applicationRole means all users with a Jira license can access - treat as public
-    if "applicationRole" in holder_map:
+    if HOLDER_TYPE_APPLICATION_ROLE in holder_map:
+        logger.info(
+            "Jira project %s has applicationRole holder; resolving as public external "
+            "access with empty explicit groups",
+            jira_project,
+        )
         return ExternalAccess(
             external_user_emails=set(), external_user_group_ids=set(), is_public=True
         )
 
     # Get emails from explicit user holders
     user_emails = (
-        _get_user_emails(user_holders=holder_map["user"])
-        if "user" in holder_map
+        _get_user_emails(
+            jira_project=jira_project,
+            user_holders=holder_map[HOLDER_TYPE_USER],
+        )
+        if HOLDER_TYPE_USER in holder_map
         else []
     )
 
     # Get emails and groups from project roles
     project_role_user_emails: list[str] = []
     project_role_groups: list[str] = []
-    if "projectRole" in holder_map:
+    if HOLDER_TYPE_PROJECT_ROLE in holder_map:
         project_role_user_emails, project_role_groups = (
             _get_user_emails_and_groups_from_project_roles(
                 jira_client=jira_client,
                 jira_project=jira_project,
-                project_role_holders=holder_map["projectRole"],
+                project_role_holders=holder_map[HOLDER_TYPE_PROJECT_ROLE],
             )
+        )
+    else:
+        logger.info(
+            "Jira project %s has no projectRole holders; project-role groups will be empty",
+            jira_project,
         )
 
     # Get groups directly assigned in permission scheme (common in Data Center)
     # Format: {'type': 'group', 'parameter': 'group-name', 'expand': 'group'}
     direct_groups: list[str] = []
-    if "group" in holder_map:
-        for group_holder in holder_map["group"]:
+    if HOLDER_TYPE_GROUP in holder_map:
+        for group_holder in holder_map[HOLDER_TYPE_GROUP]:
             group_name = _get_role_id(group_holder)
             if group_name:
                 direct_groups.append(group_name)
             else:
-                logger.error("No parameter/value in group holder: %s", group_holder)
+                logger.error(
+                    "Jira project %s group holder has no parameter/value; holder=%s",
+                    jira_project,
+                    group_holder,
+                )
+        if not direct_groups:
+            logger.warning(
+                "Jira project %s has %s direct group holders but resolved zero direct "
+                "groups; group_holders=%s",
+                jira_project,
+                len(holder_map[HOLDER_TYPE_GROUP]),
+                holder_map[HOLDER_TYPE_GROUP],
+            )
+    else:
+        logger.info(
+            "Jira project %s has no direct group holders; direct groups will be empty",
+            jira_project,
+        )
 
     external_user_emails = set(user_emails + project_role_user_emails)
     external_user_group_ids = set(project_role_groups + direct_groups)
+
+    if not external_user_group_ids:
+        logger.warning(
+            "Jira project %s resolved zero external groups; holder_counts=%s "
+            "unsupported_holder_counts=%s direct_group_holder_count=%s "
+            "direct_group_count=%s project_role_holder_count=%s "
+            "project_role_group_count=%s explicit_user_email_count=%s "
+            "project_role_user_email_count=%s",
+            jira_project,
+            holder_counts,
+            unsupported_holder_counts,
+            len(holder_map.get(HOLDER_TYPE_GROUP, [])),
+            len(direct_groups),
+            len(holder_map.get(HOLDER_TYPE_PROJECT_ROLE, [])),
+            len(project_role_groups),
+            len(user_emails),
+            len(project_role_user_emails),
+        )
+
+    if not external_user_emails and not external_user_group_ids:
+        logger.error(
+            "Jira project %s resolved to empty private ExternalAccess; "
+            "holder_counts=%s unsupported_holder_counts=%s",
+            jira_project,
+            holder_counts,
+            unsupported_holder_counts,
+        )
 
     return ExternalAccess(
         external_user_emails=external_user_emails,
@@ -280,6 +480,15 @@ def get_project_permissions(
         return None
 
     holder_map = _build_holder_map(permissions=project_permissions.permissions)
+    logger.info(
+        "Jira project %s %s holder summary; permission_count=%s holder_counts=%s "
+        "unsupported_holder_counts=%s",
+        jira_project,
+        BROWSE_PROJECTS_PERMISSION,
+        len(project_permissions.permissions),
+        _get_holder_counts(holder_map),
+        _get_unsupported_holder_counts(holder_map),
+    )
 
     external_access = _build_external_access_from_holder_map(
         jira_client=jira_client, jira_project=jira_project, holder_map=holder_map


### PR DESCRIPTION
## Description

some logs to make the failure modes clearer for jira perm sync

## How Has This Been Tested?

n/a just logs

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detailed logging to Jira permission sync to surface failure modes and empty/unsupported cases. Improves observability during holder parsing and project role resolution with no behavior changes.

- **Refactors**
  - Added holder type constants and helper functions to count holder types and unsupported types.
  - Logged per-project permission holder summaries for `BROWSE_PROJECTS`.
  - Added warnings/errors for missing user objects, validation failures, missing role IDs, absent actors, unsupported actors, and nameless groups.
  - Logged outcomes that resolve to public access (`anyone`/`applicationRole`) and cases with empty groups/emails or empty private `ExternalAccess`.

<sup>Written for commit 3addaeb23dffee87289548466a2802dc5c170329. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11184?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

