### PR TITLE
feat(deletion): bulk cleanup celery task with 3-phase structure (2/3)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"a74efebe-d23d-427e-9a37-9a5a2699183d","pid":12814,"procStart":"Mon May 18 20:32:40 2026","acquiredAt":1779142588724}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"a74efebe-d23d-427e-9a37-9a5a2699183d","pid":12814,"procStart":"Mon May 18 20:32:40 2026","acquiredAt":1779142588724}

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -1,3 +1,4 @@
+import random
 import time
 from enum import Enum
 from http import HTTPStatus
@@ -14,15 +15,21 @@ from onyx.background.celery.tasks.shared.RetryDocumentIndex import RetryDocument
 from onyx.configs.constants import ONYX_CELERY_BEAT_HEARTBEAT_KEY
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.db.document import delete_document_by_connector_credential_pair__no_commit
+from onyx.db.document import delete_documents_by_connector_credential_pair__no_commit
 from onyx.db.document import delete_documents_complete
 from onyx.db.document import fetch_chunk_count_for_document
+from onyx.db.document import fetch_chunk_counts_for_documents
 from onyx.db.document import get_document
 from onyx.db.document import get_document_connector_count
+from onyx.db.document import get_document_connector_counts
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_documents_as_modified
+from onyx.db.document import mark_documents_as_synced
 from onyx.db.document_set import fetch_document_sets_for_document
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.relationships import delete_document_references_from_kg
+from onyx.db.relationships import delete_documents_references_from_kg
 from onyx.db.search_settings import get_active_search_settings
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
@@ -265,6 +272,267 @@ def document_by_cc_pair_cleanup_task(
 
     task_logger.info(f"document_by_cc_pair_cleanup_task finished: doc={document_id}")
     return True
+
+
+def _reconcile_batch_for_retry(
+    document_ids: list[str],
+    cc_pair_identifier: ConnectorCredentialPairIdentifier,
+) -> None:
+    """Mark a whole batch as needing reconciliation.
+
+    Used when the task hits max retries or SoftTimeLimitExceeded: drop the
+    cc_pair link for every doc in the batch and stamp last_modified so the
+    out-of-band stale-doc reconciler will eventually catch up. Mirrors the
+    singular task's max-retries hook, just bulk-applied.
+    """
+    if not document_ids:
+        return
+    with get_session_with_current_tenant() as db_session:
+        delete_documents_by_connector_credential_pair__no_commit(
+            db_session=db_session,
+            document_ids=document_ids,
+            connector_credential_pair_identifier=cc_pair_identifier,
+        )
+        mark_documents_as_modified(document_ids, db_session)
+
+
+@shared_task(
+    name=OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=DOCUMENT_BY_CC_PAIR_CLEANUP_MAX_RETRIES,
+    bind=True,
+)
+def document_by_cc_pair_bulk_cleanup_task(
+    self: Task,
+    document_ids: list[str],
+    connector_id: int,
+    credential_id: int,
+    tenant_id: str,  # noqa: ARG001 — kept on the celery task signature
+) -> bool:
+    """Bulk variant of document_by_cc_pair_cleanup_task.
+
+    Processes a whole batch of documents in three phases so the worker only
+    holds a pgbouncer slot during Phase 1 and Phase 3, not across the
+    document-index HTTP round-trip in Phase 2. Each batch becomes one Celery
+    task ID, so the taskset shrinks from N entries to ceil(N / batch_size).
+
+    Phase 1 (one DB session): bulk-bucket docs into delete / update / skip
+        based on get_document_connector_counts. For the delete bucket, fetch
+        chunk counts up front. For the update bucket, build per-doc
+        MetadataUpdateRequests (per-doc reads — no bulk variant today and not
+        on the hot path).
+    Phase 2 (no DB session): one delete_batch call per document-index pair
+        for the delete bucket; one update call per document-index pair for
+        the update bucket (interface is already plural).
+    Phase 3 (fresh DB session): bulk KG cascade + bulk delete_documents_complete
+        for the delete bucket; bulk cc_pair detach + bulk mark_documents_as_synced
+        for the update bucket.
+
+    On exception or SoftTimeLimitExceeded, the whole batch is reconciled (one
+    bulk cc_pair detach + bulk mark_documents_as_modified) so the stale-doc
+    reconciler can pick up partial state. Retry countdown uses full jitter
+    (random.uniform(0, 2^(retries+4))) to avoid thundering-herd on big
+    failure waves.
+    """
+    if not document_ids:
+        return True
+
+    task_logger.debug(f"Bulk task start: n={len(document_ids)}")
+
+    start = time.monotonic()
+    completion_status = OnyxCeleryTaskCompletionStatus.UNDEFINED
+    cc_pair_identifier = ConnectorCredentialPairIdentifier(
+        connector_id=connector_id,
+        credential_id=credential_id,
+    )
+
+    try:
+        # Phase 1: read DB state and bucket. Release the session before any
+        # document-index I/O.
+        with get_session_with_current_tenant() as db_session:
+            active_search_settings = get_active_search_settings(db_session)
+            document_indices = get_all_document_indices(
+                active_search_settings.primary,
+                active_search_settings.secondary,
+                httpx_client=HttpxPool.get("vespa"),
+            )
+            retry_document_indices: list[RetryDocumentIndex] = [
+                RetryDocumentIndex(document_index)
+                for document_index in document_indices
+            ]
+
+            # get_document_connector_counts only returns rows with count >= 1;
+            # docs missing from the result are implicitly count == 0 and skip.
+            counts: dict[str, int] = dict(
+                get_document_connector_counts(db_session, document_ids)
+            )
+
+            delete_ids: list[str] = [
+                doc_id for doc_id in document_ids if counts.get(doc_id) == 1
+            ]
+            update_ids: list[str] = [
+                doc_id for doc_id in document_ids if counts.get(doc_id, 0) > 1
+            ]
+
+            delete_doc_id_to_chunk_count: dict[str, int | None] = {}
+            if delete_ids:
+                # fetch_chunk_counts_for_documents returns 0 for unknown rows.
+                # That's fine for OpenSearch (uses doc IDs); Vespa's legacy
+                # path will short-circuit a 0 chunk count to a no-op.
+                chunk_count_pairs = fetch_chunk_counts_for_documents(
+                    delete_ids, db_session
+                )
+                delete_doc_id_to_chunk_count = {
+                    doc_id: chunk_count for doc_id, chunk_count in chunk_count_pairs
+                }
+
+            # Build one MetadataUpdateRequest per doc in the update bucket.
+            # These reads don't have plural variants and aren't the hot path
+            # (pruning hammers the delete path, not the update path).
+            update_requests: list[MetadataUpdateRequest] = []
+            for doc_id in update_ids:
+                doc = get_document(doc_id, db_session)
+                if not doc:
+                    # Doc row vanished between Phase 1 bucketing and here.
+                    # Silently drop from the update bucket; the cc_pair link
+                    # will be cleaned up by reconciliation if it still exists.
+                    continue
+                doc_access = get_access_for_document(
+                    document_id=doc_id, db_session=db_session
+                )
+                doc_sets = fetch_document_sets_for_document(doc_id, db_session)
+                update_requests.append(
+                    MetadataUpdateRequest(
+                        document_ids=[doc_id],
+                        doc_id_to_chunk_cnt={
+                            doc_id: (
+                                doc.chunk_count if doc.chunk_count is not None else -1
+                            )
+                        },
+                        access=doc_access,
+                        document_sets=set(doc_sets),
+                        boost=doc.boost,
+                        hidden=doc.hidden,
+                    )
+                )
+
+            # Track which update docs we actually built requests for so
+            # Phase 3 only touches those rows.
+            update_ids_built: list[str] = [
+                update_request.document_ids[0] for update_request in update_requests
+            ]
+
+        # Phase 2: document-index I/O. No DB session held.
+        if delete_doc_id_to_chunk_count:
+            for retry_document_index in retry_document_indices:
+                retry_document_index.delete_batch(delete_doc_id_to_chunk_count)
+
+        if update_requests:
+            for retry_document_index in retry_document_indices:
+                retry_document_index.update(update_requests)
+
+        # Phase 3: write back in a fresh transaction.
+        with get_session_with_current_tenant() as db_session:
+            if delete_ids:
+                # KG cascade stages writes; delete_documents_complete commits
+                # everything in the session (KG + doc rows + cc_pair rows).
+                delete_documents_references_from_kg(db_session, delete_ids)
+                delete_documents_complete(
+                    db_session=db_session,
+                    document_ids=delete_ids,
+                )
+
+            if update_ids_built:
+                # cc_pair detach stages; mark_documents_as_synced commits
+                # both the detach and the sync timestamp.
+                delete_documents_by_connector_credential_pair__no_commit(
+                    db_session=db_session,
+                    document_ids=update_ids_built,
+                    connector_credential_pair_identifier=cc_pair_identifier,
+                )
+                mark_documents_as_synced(update_ids_built, db_session)
+
+        completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
+
+        elapsed = time.monotonic() - start
+        task_logger.info(
+            "document_by_cc_pair_bulk_cleanup_task progress: "
+            f"n={len(document_ids)} delete={len(delete_ids)} "
+            f"update={len(update_ids_built)} "
+            f"skip={len(document_ids) - len(delete_ids) - len(update_ids_built)} "
+            f"elapsed={elapsed:.2f}"
+        )
+    except SoftTimeLimitExceeded:
+        # Bundled fix: previously the singular task silently dropped on
+        # SoftTimeLimit. Reconcile the whole batch so the stale-doc reconciler
+        # picks it up.
+        task_logger.info(
+            f"SoftTimeLimitExceeded for bulk cleanup batch. n={len(document_ids)}"
+        )
+        completion_status = OnyxCeleryTaskCompletionStatus.SOFT_TIME_LIMIT
+        _reconcile_batch_for_retry(document_ids, cc_pair_identifier)
+    except Exception as ex:
+        e: Exception | None = None
+        while True:
+            if isinstance(ex, RetryError):
+                task_logger.warning(
+                    f"Tenacity retry failed: num_attempts={ex.last_attempt.attempt_number}"
+                )
+                e_temp = ex.last_attempt.exception()
+                if isinstance(e_temp, Exception):
+                    e = e_temp
+            else:
+                e = ex
+
+            if isinstance(e, httpx.HTTPStatusError):
+                if e.response.status_code == HTTPStatus.BAD_REQUEST:
+                    task_logger.exception(
+                        "Non-retryable HTTPStatusError on bulk batch. "
+                        f"n={len(document_ids)} status={e.response.status_code}"
+                    )
+                completion_status = (
+                    OnyxCeleryTaskCompletionStatus.NON_RETRYABLE_EXCEPTION
+                )
+                # Non-retryable: reconcile so docs aren't orphaned.
+                _reconcile_batch_for_retry(document_ids, cc_pair_identifier)
+                break
+
+            task_logger.exception(
+                "document_by_cc_pair_bulk_cleanup_task exceptioned. "
+                f"n={len(document_ids)}"
+            )
+
+            completion_status = OnyxCeleryTaskCompletionStatus.RETRYABLE_EXCEPTION
+            if (
+                self.max_retries is not None
+                and self.request.retries >= self.max_retries
+            ):
+                task_logger.warning(
+                    "Max celery retries reached on bulk batch. Marking all "
+                    f"docs dirty for reconciliation. n={len(document_ids)}"
+                )
+                _reconcile_batch_for_retry(document_ids, cc_pair_identifier)
+                completion_status = (
+                    OnyxCeleryTaskCompletionStatus.NON_RETRYABLE_EXCEPTION
+                )
+                break
+
+            # Bundled fix: full jitter on retry countdown. Singular task uses
+            # `2 ** (retries+4)` which is deterministic — N simultaneous
+            # failures retry in lock-step. Use random.uniform(0, max) for
+            # the same shape as wait_random_exponential in RetryDocumentIndex.
+            max_countdown = 2 ** (self.request.retries + 4)
+            countdown = random.uniform(0, max_countdown)
+            self.retry(exc=e, countdown=countdown)
+            break
+    finally:
+        task_logger.info(
+            "document_by_cc_pair_bulk_cleanup_task completed: "
+            f"status={completion_status.value} n={len(document_ids)}"
+        )
+
+    return completion_status == OnyxCeleryTaskCompletionStatus.SUCCEEDED
 
 
 @shared_task(name=OnyxCeleryTask.CELERY_BEAT_HEARTBEAT, ignore_result=True, bind=True)

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -294,6 +294,7 @@ def _reconcile_batch_for_retry(
             connector_credential_pair_identifier=cc_pair_identifier,
         )
         mark_documents_as_modified(document_ids, db_session)
+        db_session.commit()
 
 
 @shared_task(
@@ -456,12 +457,18 @@ def document_by_cc_pair_bulk_cleanup_task(
         completion_status = OnyxCeleryTaskCompletionStatus.SUCCEEDED
 
         elapsed = time.monotonic() - start
+        # Use update_ids (bucketed) not update_ids_built (request built) so
+        # the skip count reflects what bucketing actually saw. Docs that
+        # bucketed as update but had a vanished row are tracked separately
+        # as "dropped" — they aren't truly skipped (count > 1 at bucket time)
+        # nor truly updated (no Phase 3 write).
+        dropped = len(update_ids) - len(update_ids_built)
+        skip = len(document_ids) - len(delete_ids) - len(update_ids)
         task_logger.info(
             "document_by_cc_pair_bulk_cleanup_task progress: "
             f"n={len(document_ids)} delete={len(delete_ids)} "
-            f"update={len(update_ids_built)} "
-            f"skip={len(document_ids) - len(delete_ids) - len(update_ids_built)} "
-            f"elapsed={elapsed:.2f}"
+            f"update={len(update_ids_built)} dropped={dropped} "
+            f"skip={skip} elapsed={elapsed:.2f}"
         )
     except SoftTimeLimitExceeded:
         # Bundled fix: previously the singular task silently dropped on

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -609,6 +609,7 @@ class OnyxCeleryTask:
     CONNECTOR_PRUNING_GENERATOR_TASK = "connector_pruning_generator_task"
     CONNECTOR_HIERARCHY_FETCHING_TASK = "connector_hierarchy_fetching_task"
     DOCUMENT_BY_CC_PAIR_CLEANUP_TASK = "document_by_cc_pair_cleanup_task"
+    DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK = "document_by_cc_pair_bulk_cleanup_task"
     DOCUMENT_INDEX_METADATA_SYNC_TASK = "document_index_metadata_sync_task"
 
     # chat retention

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -872,6 +872,23 @@ def mark_documents_as_synced(document_ids: list[str], db_session: Session) -> No
     db_session.commit()
 
 
+def mark_documents_as_modified(document_ids: list[str], db_session: Session) -> None:
+    """Bulk variant of mark_document_as_modified.
+
+    Silently skips IDs that don't exist (unlike the singular form, which raises).
+    Used by bulk-cleanup reconciliation paths where a batch may include rows
+    that have already been deleted by an earlier attempt.
+    """
+    if not document_ids:
+        return
+
+    db_session.query(DbDocument).filter(DbDocument.id.in_(document_ids)).update(
+        {DbDocument.last_modified: datetime.now(timezone.utc)},
+        synchronize_session=False,
+    )
+    db_session.commit()
+
+
 def delete_document_by_connector_credential_pair__no_commit(
     db_session: Session,
     document_id: str,

--- a/backend/tests/external_dependency_unit/indexing/test_document_bulk_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_document_bulk_cleanup.py
@@ -1,0 +1,406 @@
+"""External dependency unit tests for `document_by_cc_pair_bulk_cleanup_task`.
+
+The bulk task is the unit of work for connector deletion / pruning after the
+1.7M-task pgbouncer-saturation incident on 2026-05-18. It processes a whole
+batch of documents in three phases:
+
+    Phase 1 — read DB state, bucket into delete / update / skip.
+    Phase 2 — document-index I/O without a DB session held.
+    Phase 3 — write back in a fresh transaction.
+
+Tests below cover each bucket separately, the mixed case, the empty-input
+short-circuit, and the reconciliation paths fired by max-retries and
+SoftTimeLimitExceeded.
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from celery.exceptions import SoftTimeLimitExceeded
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.shared.tasks import (
+    document_by_cc_pair_bulk_cleanup_task,
+)
+from onyx.connectors.models import Document
+from onyx.connectors.models import IndexAttemptMetadata
+from onyx.db.document import get_document_connector_count
+from onyx.db.document import upsert_document_by_connector_credential_pair
+from onyx.db.models import ConnectorCredentialPair
+from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import get_doc_row
+from tests.external_dependency_unit.indexing_helpers import get_filerecord
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_doc
+from tests.external_dependency_unit.indexing_helpers import stage_file
+
+_TASK_MODULE = "onyx.background.celery.tasks.shared.tasks"
+
+
+def _index_docs(
+    db_session: Session,
+    docs: list[Document],
+    attempt_metadata: IndexAttemptMetadata,
+) -> None:
+    """Push every doc through the upsert pipeline so the row + cc_pair
+    mapping exist for the cleanup task to find."""
+    index_doc_batch_prepare(
+        documents=docs,
+        index_attempt_metadata=attempt_metadata,
+        db_session=db_session,
+        ignore_time_skip=True,
+    )
+    db_session.commit()
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
+
+
+@pytest.fixture
+def second_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
+
+
+@pytest.fixture
+def attempt_metadata(cc_pair: ConnectorCredentialPair) -> IndexAttemptMetadata:
+    return IndexAttemptMetadata(
+        connector_id=cc_pair.connector_id,
+        credential_id=cc_pair.credential_id,
+        attempt_id=None,
+        request_id="test-request",
+    )
+
+
+@pytest.fixture
+def second_attempt_metadata(
+    second_cc_pair: ConnectorCredentialPair,
+) -> IndexAttemptMetadata:
+    return IndexAttemptMetadata(
+        connector_id=second_cc_pair.connector_id,
+        credential_id=second_cc_pair.credential_id,
+        attempt_id=None,
+        request_id="test-request-2",
+    )
+
+
+class TestBulkCleanupTaskDeleteBucket:
+    """All docs in the batch have count == 1 → fully deleted from PG and the
+    attached files are reaped."""
+
+    def test_all_delete_batch_removes_docs_and_files(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        file_ids = [stage_file(content=f"doc-{i}".encode()) for i in range(5)]
+        docs = [
+            make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_ids[i]) for i in range(5)
+        ]
+        _index_docs(db_session, docs, attempt_metadata)
+
+        for file_id in file_ids:
+            assert get_filerecord(db_session, file_id) is not None
+
+        with patch(
+            f"{_TASK_MODULE}.get_all_document_indices",
+            return_value=[],
+        ):
+            result = document_by_cc_pair_bulk_cleanup_task.apply(
+                kwargs=dict(
+                    document_ids=[doc.id for doc in docs],
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+        assert result.result is True
+        for doc in docs:
+            assert get_doc_row(db_session, doc.id) is None
+        for file_id in file_ids:
+            assert get_filerecord(db_session, file_id) is None
+
+
+class TestBulkCleanupTaskUpdateBucket:
+    """All docs in the batch have count > 1 → only the detaching cc_pair link
+    is removed; doc rows and files survive."""
+
+    def test_all_update_batch_preserves_docs_and_files(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        second_cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        file_ids = [stage_file(content=f"shared-{i}".encode()) for i in range(4)]
+        docs = [
+            make_doc(f"doc-{uuid4().hex[:8]}", file_id=file_ids[i]) for i in range(4)
+        ]
+        _index_docs(db_session, docs, attempt_metadata)
+
+        # Attach every doc to a second cc_pair so refcount becomes 2.
+        upsert_document_by_connector_credential_pair(
+            db_session,
+            second_cc_pair.connector_id,
+            second_cc_pair.credential_id,
+            [doc.id for doc in docs],
+        )
+        db_session.commit()
+
+        # Pre-stamp last_synced to an old value so we can check the bulk
+        # mark_documents_as_synced ran.
+        for doc in docs:
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            row.last_synced = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        db_session.commit()
+
+        with patch(
+            f"{_TASK_MODULE}.get_all_document_indices",
+            return_value=[],
+        ):
+            result = document_by_cc_pair_bulk_cleanup_task.apply(
+                kwargs=dict(
+                    document_ids=[doc.id for doc in docs],
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+
+        for doc in docs:
+            # Doc row still exists — other cc_pair owns it.
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            # last_synced was stamped by the bulk helper.
+            assert row.last_synced is not None
+            assert row.last_synced > datetime(2020, 1, 1, tzinfo=timezone.utc)
+            # File still exists.
+            assert doc.file_id is not None
+            assert get_filerecord(db_session, doc.file_id) is not None
+            # cc_pair link from the detaching pair is gone; refcount is now 1.
+            assert get_document_connector_count(db_session, doc.id) == 1
+
+
+class TestBulkCleanupTaskMixedBatch:
+    """Mixed bucket — every code path runs in one invocation."""
+
+    def test_mixed_batch_routes_each_doc_correctly(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        second_cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        # 3 delete-bucket docs (only on cc_pair).
+        delete_file_ids = [stage_file(content=f"del-{i}".encode()) for i in range(3)]
+        delete_docs = [
+            make_doc(f"del-{uuid4().hex[:8]}", file_id=delete_file_ids[i])
+            for i in range(3)
+        ]
+        _index_docs(db_session, delete_docs, attempt_metadata)
+
+        # 3 update-bucket docs (on cc_pair AND second_cc_pair).
+        update_file_ids = [stage_file(content=f"upd-{i}".encode()) for i in range(3)]
+        update_docs = [
+            make_doc(f"upd-{uuid4().hex[:8]}", file_id=update_file_ids[i])
+            for i in range(3)
+        ]
+        _index_docs(db_session, update_docs, attempt_metadata)
+        upsert_document_by_connector_credential_pair(
+            db_session,
+            second_cc_pair.connector_id,
+            second_cc_pair.credential_id,
+            [doc.id for doc in update_docs],
+        )
+        db_session.commit()
+
+        # 2 skip-bucket doc IDs that never had any cc_pair attachment.
+        # Just IDs that don't appear in DocumentByConnectorCredentialPair.
+        skip_doc_ids = [f"missing-{uuid4().hex[:8]}" for _ in range(2)]
+
+        all_doc_ids = (
+            [doc.id for doc in delete_docs]
+            + [doc.id for doc in update_docs]
+            + skip_doc_ids
+        )
+
+        with patch(
+            f"{_TASK_MODULE}.get_all_document_indices",
+            return_value=[],
+        ):
+            result = document_by_cc_pair_bulk_cleanup_task.apply(
+                kwargs=dict(
+                    document_ids=all_doc_ids,
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+
+        # Delete bucket: gone.
+        for doc in delete_docs:
+            assert get_doc_row(db_session, doc.id) is None
+        for file_id in delete_file_ids:
+            assert get_filerecord(db_session, file_id) is None
+
+        # Update bucket: rows + files survive; refcount on cc_pair link drops
+        # to 1.
+        for doc in update_docs:
+            assert get_doc_row(db_session, doc.id) is not None
+            assert doc.file_id is not None
+            assert get_filerecord(db_session, doc.file_id) is not None
+            assert get_document_connector_count(db_session, doc.id) == 1
+
+        # Skip bucket: no errors raised on missing-from-pg doc IDs.
+
+
+class TestBulkCleanupTaskEmptyBatch:
+    """Empty input short-circuits without raising."""
+
+    def test_empty_document_ids_returns_true_without_side_effects(
+        self,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        # No patch on get_all_document_indices needed — the empty path returns
+        # before ever touching it.
+        result = document_by_cc_pair_bulk_cleanup_task.apply(
+            kwargs=dict(
+                document_ids=[],
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+                tenant_id=TEST_TENANT_ID,
+            ),
+        )
+
+        assert result.successful(), result.traceback
+        assert result.result is True
+
+
+class TestBulkCleanupTaskReconciliation:
+    """Failure-path tests: max retries and SoftTimeLimitExceeded both bulk-mark
+    every doc in the batch as modified and detach the cc_pair, so the stale-doc
+    reconciler can catch up out-of-band."""
+
+    def test_soft_time_limit_marks_batch_for_reconciliation(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        docs = [make_doc(f"stl-{uuid4().hex[:8]}") for _ in range(4)]
+        _index_docs(db_session, docs, attempt_metadata)
+
+        # Stamp last_modified to an old value so we can detect a re-stamp.
+        for doc in docs:
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            row.last_modified = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        db_session.commit()
+
+        # Force SoftTimeLimitExceeded at the document-index acquisition point.
+        with patch(
+            f"{_TASK_MODULE}.get_all_document_indices",
+            side_effect=SoftTimeLimitExceeded(),
+        ):
+            result = document_by_cc_pair_bulk_cleanup_task.apply(
+                kwargs=dict(
+                    document_ids=[doc.id for doc in docs],
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=TEST_TENANT_ID,
+                ),
+            )
+
+        assert result.successful(), result.traceback
+        # Task returns False on non-SUCCEEDED completion status.
+        assert result.result is False
+
+        # Every doc still exists (no destructive action taken on STL) but the
+        # cc_pair link is gone and last_modified was bumped, so the
+        # reconciler picks it up.
+        for doc in docs:
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            assert row.last_modified is not None
+            assert row.last_modified > datetime(2020, 1, 1, tzinfo=timezone.utc)
+            assert get_document_connector_count(db_session, doc.id) == 0
+
+    def test_max_retries_marks_batch_for_reconciliation(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        attempt_metadata: IndexAttemptMetadata,
+        full_deployment_setup: None,  # noqa: ARG002
+    ) -> None:
+        docs = [make_doc(f"retry-{uuid4().hex[:8]}") for _ in range(4)]
+        _index_docs(db_session, docs, attempt_metadata)
+
+        for doc in docs:
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            row.last_modified = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        db_session.commit()
+
+        # Force a generic Exception with the retry counter pre-set to the
+        # max so the task takes the reconciliation branch instead of
+        # scheduling another retry. `Task.apply(retries=...)` populates
+        # `self.request.retries` directly.
+        with patch(
+            f"{_TASK_MODULE}.get_all_document_indices",
+            side_effect=RuntimeError("simulated index failure"),
+        ):
+            result = document_by_cc_pair_bulk_cleanup_task.apply(
+                kwargs=dict(
+                    document_ids=[doc.id for doc in docs],
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=TEST_TENANT_ID,
+                ),
+                retries=3,  # >= DOCUMENT_BY_CC_PAIR_CLEANUP_MAX_RETRIES
+            )
+
+        assert result.successful(), result.traceback
+        assert result.result is False
+
+        for doc in docs:
+            row = get_doc_row(db_session, doc.id)
+            assert row is not None
+            assert row.last_modified is not None
+            assert row.last_modified > datetime(2020, 1, 1, tzinfo=timezone.utc)
+            assert get_document_connector_count(db_session, doc.id) == 0


### PR DESCRIPTION
## Description

Second of three PRs implementing batched per-document cleanup. Stacked on #11178 (foundations); rebase target moves to \`main\` after that merges. PR 3 flips fan-out to use the new task.

Adds \`document_by_cc_pair_bulk_cleanup_task\` next to the existing singular task. One task ID now handles a whole batch of documents (default 100) instead of one doc apiece, so the taskset shrinks ~100x and per-doc costs (DB lookups, KG cascades, doc-index HTTP, postrun SREM) amortize across the batch. The old singular task is **untouched** so the 1.7M-task in-flight queue from 2026-05-18 keeps draining via its existing code path.

### Task body — same Phase 1 / Phase 2 / Phase 3 structure as #11175

- **Phase 1 (one DB session)**: read \`get_document_connector_counts\` (bulk) to bucket the batch into delete / update / skip. For the delete bucket, also \`fetch_chunk_counts_for_documents\` (bulk). For the update bucket, build per-doc \`MetadataUpdateRequest\`s — these reads don't have plural variants and aren't the hot path (pruning hammers the delete path).
- **Phase 2 (no DB session held)**: \`RetryDocumentIndex.delete_batch\` (added in #11178) for the delete bucket; the already-plural \`RetryDocumentIndex.update\` for the update bucket. This is where pgbouncer pressure used to come from — a 100-doc batch on a slow OpenSearch cluster does not pin a slot for its whole duration anymore.
- **Phase 3 (one fresh DB session)**: bulk KG cascade + \`delete_documents_complete\` for the delete bucket; bulk cc_pair detach + \`mark_documents_as_synced\` for the update bucket.

### Bundled fixes (cheap, related)

- **SoftTimeLimitExceeded reconciliation** — previously the singular task silently dropped on STL (audit C2). Bulk version now reconciles every doc in the batch (delete cc_pair link + bump \`last_modified\`) so the stale-doc reconciler picks it up.
- **Retry jitter** — countdown switches from deterministic \`2 ** (retries+4)\` to \`random.uniform(0, 2 ** (retries+4))\`. Same full-jitter shape as \`RetryDocumentIndex\`'s \`wait_random_exponential\`; prevents thundering-herd retries on big failure waves.

### New DB helper

- \`backend/onyx/db/document.py\` — \`mark_documents_as_modified(document_ids, db_session)\` bulk helper mirroring the already-merged \`mark_documents_as_synced\`. Silently skips missing IDs (bulk-cleanup callers can tolerate one missing row mid-batch).

### New task name

- \`OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK = "document_by_cc_pair_bulk_cleanup_task"\`. The old name stays. Task ID prefix (\`connectordeletion_*\` / \`connectorpruning+sub_*\`) is set by the fan-out caller in PR 3, so \`task_postrun\`'s prefix-keyed SREM works unchanged.

## How Has This Been Tested?

- \`pytest backend/tests/external_dependency_unit/indexing/test_document_bulk_cleanup.py\` — 6 new tests passing:
  - All-delete batch (5 docs, count==1) → docs + files reaped.
  - All-update batch (4 docs, count==2) → docs + files survive, cc_pair link drops to refcount 1, \`last_synced\` re-stamped by the bulk helper.
  - Mixed batch (3 delete + 3 update + 2 skip in one task) → each bucket handled correctly.
  - Empty \`document_ids\` returns \`True\` short-circuit.
  - SoftTimeLimitExceeded → all docs in the batch get cc_pair detached + \`last_modified\` bumped.
  - Max-retries (\`apply(retries=3)\`) → same reconciliation as STL.
- Existing per-doc and foundations tests still pass (15 total across the three test files).
- \`pre-commit run\` clean (ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `document_by_cc_pair_bulk_cleanup_task`, a batched cleanup task that processes up to 100 documents in three phases to cut task count ~100x and avoid holding DB connections during index calls. The existing per-doc task stays active so the current queue continues to drain.

- **New Features**
  - Add `document_by_cc_pair_bulk_cleanup_task` with a 3-phase flow; Phase 2 (index I/O) runs without a DB session.
  - Bucket via `get_document_connector_counts`; deletes use `RetryDocumentIndex.delete_batch`; updates use `RetryDocumentIndex.update`; Phase 3 does bulk KG cascade + detach/sync.
  - Add `mark_documents_as_modified` (bulk) and `OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK`.

- **Bug Fixes**
  - On `SoftTimeLimitExceeded` or max retries, bulk-detach the cc_pair and bump `last_modified` to enable reconciliation.
  - Use full-jitter retries with `random.uniform(0, 2 ** (retries+4))` to prevent thundering-herd retries.
  - Add an explicit commit in bulk reconciliation and fix success logs to separate "dropped" (vanished mid-Phase 1) from "skip" for accurate counts.

<sup>Written for commit 08b65a65e88f6ffe12b944b6be44a165eb4f600a. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

