### PR TITLE
chore(opensearch, grafana): Add more granular tables for search latency by type

### DIFF
--- a/deployment/helm/charts/onyx/dashboards/opensearch-search-latency.json
+++ b/deployment/helm/charts/onyx/dashboards/opensearch-search-latency.json
@@ -142,11 +142,52 @@
       ]
     },
     {
-      "title": "Client-Side Latency by Search Type (P95)",
-      "description": "P95 client-side latency broken down by search type (hybrid, keyword, semantic, random, doc_id_retrieval).",
+      "title": "Client-Side Latency by Search Type (P50)",
+      "description": "P50 client-side latency broken down by search type (hybrid, keyword, semantic, random, doc_id_retrieval).",
       "type": "timeseries",
       "gridPos": { "h": 10, "w": 12, "x": 0, "y": 10 },
       "id": 3,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.5, sum by (search_type, le) (rate(onyx_opensearch_search_client_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{ search_type }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Client-Side Latency by Search Type (P95)",
+      "description": "P95 client-side latency broken down by search type (hybrid, keyword, semantic, random, doc_id_retrieval).",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 10 },
+      "id": 4,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -183,11 +224,52 @@
       ]
     },
     {
+      "title": "Client-Side Latency by Search Type (P99)",
+      "description": "P99 client-side latency broken down by search type (hybrid, keyword, semantic, random, doc_id_retrieval).",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 20 },
+      "id": 5,
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "unit": "s",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum by (search_type, le) (rate(onyx_opensearch_search_client_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{ search_type }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "title": "Search Throughput by Type",
       "description": "Search attempts per second broken down by search type. Includes both successes and failures — pair with the failure rate panel below for context.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 10 },
-      "id": 4,
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 20 },
+      "id": 6,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -227,8 +309,8 @@
       "title": "Concurrent Searches In Progress",
       "description": "Number of OpenSearch searches currently in flight, broken down by search type. Summed across all instances.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 20 },
-      "id": 5,
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 30 },
+      "id": 7,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -267,8 +349,8 @@
       "title": "Client vs Server Latency Overhead (P50 / P95)",
       "description": "Per-request overhead (client wall-clock minus server 'took'), sampled when both are known. Reveals network, serialization, and untracked OpenSearch overhead. Quantiles are computed from the dedicated overhead histogram so the values reflect actual per-request differences rather than subtracting two independent quantile series.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 20 },
-      "id": 6,
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 30 },
+      "id": 8,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -314,8 +396,8 @@
       "title": "Search Failure Rate",
       "description": "Fraction of OpenSearch search attempts that raised an exception, over a 5-minute window. Overall plus a per-search-type breakdown.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 30 },
-      "id": 7,
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 40 },
+      "id": 9,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {
@@ -369,8 +451,8 @@
       "title": "Search Errors by Type",
       "description": "Search errors per second, broken down by search_type and the Python exception class name.",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 30 },
-      "id": 8,
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 40 },
+      "id": 10,
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
## Description
We want to also be able to see p50 and p99 for different search types.

## How Has This Been Tested?
'twasn't.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds P50, P95, and P99 client-side latency panels by search type to the OpenSearch Grafana dashboard for more granular performance insights. Repositions existing panels to accommodate the new charts.

- **New Features**
  - Renamed the previous P95 panel to P50 and added new P95 and P99 timeseries panels.
  - Panels compute quantiles via Prometheus `histogram_quantile` over `rate(onyx_opensearch_search_client_duration_seconds_bucket[5m])` grouped by `search_type`.
  - Adjusted layout and IDs for throughput, in-flight, overhead, failure rate, and error panels; no changes to their queries.

<sup>Written for commit a4734394e09a2423bf432824ae65ecdb727d5a39. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11186?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

