### PR TITLE
fix: jira perm sync dc v10

### DIFF
--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from typing import cast
 
 from jira import JIRA
 from jira.resources import PermissionScheme
@@ -43,17 +42,13 @@ def _get_role_id(holder: Holder) -> str | None:
 # depending on Jira version and endpoint.
 def _get_obj_value(obj: object, field: str) -> object | None:
     if isinstance(obj, dict):
-        obj_dict = cast(dict[str, object], obj)
-        return obj_dict.get(field)
+        return obj.get(field)  # ty: ignore[invalid-argument-type]
     return getattr(obj, field, None)
 
 
 def _get_raw_value(obj: object, field: str) -> object | None:
     raw = _get_obj_value(obj, "raw")
-    if not isinstance(raw, dict):
-        return None
-    raw_dict = cast(dict[str, object], raw)
-    return raw_dict.get(field)
+    return _get_obj_value(raw, field)
 
 
 def _get_first_str_value(obj: object, fields: tuple[str, ...]) -> str | None:
@@ -222,15 +217,13 @@ def _get_user_emails(jira_project: str, user_holders: list[Holder]) -> list[str]
 
 
 def _get_actor_group_name(actor: object) -> str | None:
-    actor_group = _get_obj_value(actor, "actorGroup")
-    if actor_group is not None:
+    for actor_group in [
+        _get_obj_value(actor, "actorGroup"),
+        _get_raw_value(actor, "actorGroup"),
+    ]:
+        if actor_group is None:
+            continue
         group_name = _get_first_str_value(actor_group, ("name", "displayName"))
-        if group_name:
-            return group_name
-
-    raw_actor_group = _get_raw_value(actor, "actorGroup")
-    if raw_actor_group is not None:
-        group_name = _get_first_str_value(raw_actor_group, ("name", "displayName"))
         if group_name:
             return group_name
 
@@ -525,6 +518,9 @@ def _build_external_access_from_holder_map(
 
     external_user_emails = set(user_emails + project_role_user_emails)
     external_user_group_ids = set(project_role_groups + direct_groups)
+    has_supported_static_holders = any(
+        holder_type in holder_map for holder_type in SUPPORTED_STATIC_HOLDER_TYPES
+    )
 
     if not external_user_group_ids:
         logger.warning(
@@ -545,13 +541,24 @@ def _build_external_access_from_holder_map(
         )
 
     if not external_user_emails and not external_user_group_ids:
-        logger.error(
-            "Jira project %s resolved to empty private ExternalAccess; "
-            "holder_counts=%s unsupported_holder_counts=%s",
-            jira_project,
-            holder_counts,
-            unsupported_holder_counts,
-        )
+        if has_supported_static_holders:
+            logger.error(
+                "Jira project %s resolved to empty private ExternalAccess; "
+                "holder_counts=%s unsupported_holder_counts=%s",
+                jira_project,
+                holder_counts,
+                unsupported_holder_counts,
+            )
+        else:
+            logger.warning(
+                "Jira project %s resolved to empty private ExternalAccess from "
+                "unsupported or dynamic-only %s holders; holder_counts=%s "
+                "unsupported_holder_counts=%s",
+                jira_project,
+                BROWSE_PROJECTS_PERMISSION,
+                holder_counts,
+                unsupported_holder_counts,
+            )
 
     return ExternalAccess(
         external_user_emails=external_user_emails,

--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from typing import cast
 
 from jira import JIRA
 from jira.resources import PermissionScheme
@@ -10,6 +11,7 @@ from ee.onyx.external_permissions.jira.models import User
 from onyx.access.models import ExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.utils import JIRA_CLOUD_API_VERSION
 from onyx.utils.logger import setup_logger
 
 HolderMap = dict[str, list[Holder]]
@@ -35,6 +37,38 @@ SUPPORTED_STATIC_HOLDER_TYPES = {
 
 def _get_role_id(holder: Holder) -> str | None:
     return holder.get("value") or holder.get("parameter")
+
+
+# Jira SDK resources expose fields as attributes, raw dicts, or nested raw payloads
+# depending on Jira version and endpoint.
+def _get_obj_value(obj: object, field: str) -> object | None:
+    if isinstance(obj, dict):
+        obj_dict = cast(dict[str, object], obj)
+        return obj_dict.get(field)
+    return getattr(obj, field, None)
+
+
+def _get_raw_value(obj: object, field: str) -> object | None:
+    raw = _get_obj_value(obj, "raw")
+    if not isinstance(raw, dict):
+        return None
+    raw_dict = cast(dict[str, object], raw)
+    return raw_dict.get(field)
+
+
+def _get_first_str_value(obj: object, fields: tuple[str, ...]) -> str | None:
+    for field in fields:
+        value = _get_obj_value(obj, field) or _get_raw_value(obj, field)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _is_cloud_client(jira_client: JIRA) -> bool:
+    try:
+        return jira_client._options["rest_api_version"] == JIRA_CLOUD_API_VERSION
+    except Exception:
+        return False
 
 
 def _get_holder_counts(holder_map: HolderMap) -> dict[str, int]:
@@ -127,48 +161,133 @@ def _build_holder_map(permissions: list[dict]) -> dict[str, list[Holder]]:
     return holder_map
 
 
+def _get_user_email_from_holder(
+    jira_project: str,
+    user_holder: Holder,
+) -> str | None:
+    if "user" not in user_holder:
+        logger.warning(
+            "Jira project %s user holder has no expanded user object; holder=%s",
+            jira_project,
+            user_holder,
+        )
+        return None
+
+    raw_user_dict = user_holder["user"]
+
+    try:
+        user_model = User.model_validate(raw_user_dict)
+        return user_model.email_address
+    except ValidationError:
+        email = _get_first_str_value(raw_user_dict, ("emailAddress", "email_address"))
+        if email:
+            logger.info(
+                "Jira project %s user holder used fallback email parsing for expanded "
+                "user with fields=%s",
+                jira_project,
+                sorted(raw_user_dict.keys()) if isinstance(raw_user_dict, dict) else [],
+            )
+            return email
+
+        logger.error(
+            "Jira project %s user holder expanded user failed validation and had no "
+            "fallback email; raw_user_dict=%r",
+            jira_project,
+            raw_user_dict,
+        )
+        return None
+
+
 def _get_user_emails(jira_project: str, user_holders: list[Holder]) -> list[str]:
     emails = []
-    missing_user_object_count = 0
-    validation_error_count = 0
+    missing_email_count = 0
 
     for user_holder in user_holders:
-        if "user" not in user_holder:
-            missing_user_object_count += 1
-            logger.warning(
-                "Jira project %s user holder has no expanded user object; holder=%s",
-                jira_project,
-                user_holder,
-            )
+        email = _get_user_email_from_holder(jira_project, user_holder)
+        if not email:
+            missing_email_count += 1
             continue
-        raw_user_dict = user_holder["user"]
-
-        try:
-            user_model = User.model_validate(raw_user_dict)
-        except ValidationError:
-            validation_error_count += 1
-            logger.error(
-                "Jira project %s user holder expanded user failed validation; "
-                "raw_user_dict=%r",
-                jira_project,
-                raw_user_dict,
-            )
-            continue
-
-        emails.append(user_model.email_address)
+        emails.append(email)
 
     if user_holders and not emails:
         logger.warning(
             "Jira project %s resolved zero emails from direct user holders; "
-            "user_holder_count=%s missing_user_object_count=%s "
-            "validation_error_count=%s",
+            "user_holder_count=%s missing_email_count=%s",
             jira_project,
             len(user_holders),
-            missing_user_object_count,
-            validation_error_count,
+            missing_email_count,
         )
 
     return emails
+
+
+def _get_actor_group_name(actor: object) -> str | None:
+    actor_group = _get_obj_value(actor, "actorGroup")
+    if actor_group is not None:
+        group_name = _get_first_str_value(actor_group, ("name", "displayName"))
+        if group_name:
+            return group_name
+
+    raw_actor_group = _get_raw_value(actor, "actorGroup")
+    if raw_actor_group is not None:
+        group_name = _get_first_str_value(raw_actor_group, ("name", "displayName"))
+        if group_name:
+            return group_name
+
+    return _get_first_str_value(actor, ("parameter", "name", "displayName"))
+
+
+def _get_user_lookup_id(jira_client: JIRA, actor_user: object) -> str | None:
+    if _is_cloud_client(jira_client):
+        return _get_first_str_value(actor_user, ("accountId", "name", "key"))
+    return _get_first_str_value(actor_user, ("name", "key", "accountId"))
+
+
+def _get_actor_user_email(
+    jira_client: JIRA,
+    jira_project: str,
+    role_id: str,
+    actor_user: object,
+) -> str | None:
+    embedded_email = _get_first_str_value(actor_user, ("emailAddress", "email_address"))
+    if embedded_email:
+        return embedded_email
+
+    user_lookup_id = _get_user_lookup_id(jira_client, actor_user)
+    if not user_lookup_id:
+        logger.error(
+            "Jira project %s project role %s actorUser has no usable user identifier; "
+            "actor_user=%s",
+            jira_project,
+            role_id,
+            actor_user,
+        )
+        return None
+
+    user = jira_client.user(id=user_lookup_id)
+    account_type = getattr(user, "accountType", None)
+    if account_type is not None and account_type != "atlassian":
+        logger.info(
+            "Skipping Jira project %s project role %s user %s because it is not an "
+            "atlassian user",
+            jira_project,
+            role_id,
+            user_lookup_id,
+        )
+        return None
+
+    email = getattr(user, "emailAddress", None)
+    if email:
+        return email
+
+    logger.warning(
+        "Jira project %s project role %s user email was not available; "
+        "user_lookup_id=%s",
+        jira_project,
+        role_id,
+        user_lookup_id,
+    )
+    return None
 
 
 def _get_user_emails_and_groups_from_project_roles(
@@ -228,12 +347,13 @@ def _get_user_emails_and_groups_from_project_roles(
             continue
 
         for actor in role.actors:
+            actor_group = _get_obj_value(actor, "actorGroup") or _get_raw_value(
+                actor, "actorGroup"
+            )
             # Handle group actors
-            if hasattr(actor, "actorGroup"):
+            if actor_group is not None:
                 actor_group_seen_count += 1
-                group_name = getattr(actor.actorGroup, "name", None) or getattr(
-                    actor.actorGroup, "displayName", None
-                )
+                group_name = _get_actor_group_name(actor)
                 if group_name:
                     groups.append(group_name)
                 else:
@@ -243,40 +363,24 @@ def _get_user_emails_and_groups_from_project_roles(
                         "name/displayName; actor_group=%s",
                         jira_project,
                         role_id,
-                        actor.actorGroup,
+                        actor_group,
                     )
                 continue
 
+            actor_user = _get_obj_value(actor, "actorUser") or _get_raw_value(
+                actor, "actorUser"
+            )
             # Handle user actors
-            if hasattr(actor, "actorUser"):
+            if actor_user is not None:
                 actor_user_seen_count += 1
-                account_id = getattr(actor.actorUser, "accountId", None)
-                if not account_id:
-                    logger.error(
-                        "Jira project %s project role %s actorUser has no accountId; "
-                        "actor_user=%s",
-                        jira_project,
-                        role_id,
-                        actor.actorUser,
-                    )
-                    continue
-
-                user = jira_client.user(id=account_id)
-                if not hasattr(user, "accountType") or user.accountType != "atlassian":
-                    logger.info(
-                        "Skipping user %s because it is not an atlassian user",
-                        account_id,
-                    )
-                    continue
-
-                if not hasattr(user, "emailAddress"):
-                    msg = f"User's email address was not able to be retrieved;  {actor.actorUser.accountId=}"
-                    if hasattr(user, "displayName"):
-                        msg += f" {actor.displayName=}"
-                    logger.warning(msg)
-                    continue
-
-                emails.append(user.emailAddress)
+                email = _get_actor_user_email(
+                    jira_client=jira_client,
+                    jira_project=jira_project,
+                    role_id=role_id,
+                    actor_user=actor_user,
+                )
+                if email:
+                    emails.append(email)
                 continue
 
             unsupported_actor_count += 1

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
@@ -1,5 +1,8 @@
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+from pytest import LogCaptureFixture
 
 from ee.onyx.external_permissions.jira.page_access import get_project_permissions
 from onyx.connectors.jira.utils import JIRA_CLOUD_API_VERSION
@@ -163,16 +166,20 @@ def test_project_role_group_actor_uses_raw_actor_group_fallback() -> None:
     assert external_access.is_public is False
 
 
-def test_dynamic_only_holders_remain_empty_private_access() -> None:
+def test_dynamic_only_holders_remain_empty_private_access(
+    caplog: LogCaptureFixture,
+) -> None:
     jira_client = _jira_client(JIRA_SERVER_API_VERSION)
     jira_client.project_permissionscheme.return_value = _project_permissions(
         _permission({"type": "reporter"}),
         _permission({"type": "assignee"}),
     )
 
-    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+    with caplog.at_level(logging.WARNING):
+        external_access = get_project_permissions(jira_client, PROJECT_KEY)
 
     assert external_access is not None
     assert external_access.external_user_emails == set()
     assert external_access.external_user_group_ids == set()
     assert external_access.is_public is False
+    assert all(record.levelno < logging.ERROR for record in caplog.records)

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
@@ -1,0 +1,178 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ee.onyx.external_permissions.jira.page_access import get_project_permissions
+from onyx.connectors.jira.utils import JIRA_CLOUD_API_VERSION
+from onyx.connectors.jira.utils import JIRA_SERVER_API_VERSION
+
+PROJECT_KEY = "PROJ"
+
+
+def _permission(holder: dict) -> SimpleNamespace:
+    return SimpleNamespace(
+        raw={
+            "id": 1,
+            "permission": "BROWSE_PROJECTS",
+            "holder": holder,
+        }
+    )
+
+
+def _project_permissions(*permissions: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(permissions=list(permissions))
+
+
+def _jira_client(rest_api_version: str) -> MagicMock:
+    jira_client = MagicMock()
+    jira_client._options = {"rest_api_version": rest_api_version}
+    return jira_client
+
+
+def test_cloud_direct_user_holder_still_uses_account_id_shape() -> None:
+    jira_client = _jira_client(JIRA_CLOUD_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission(
+            {
+                "type": "user",
+                "value": "cloud-account-id",
+                "user": {
+                    "accountId": "cloud-account-id",
+                    "emailAddress": "cloud@example.com",
+                    "displayName": "Cloud User",
+                    "active": True,
+                },
+            }
+        )
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"cloud@example.com"}
+    assert external_access.external_user_group_ids == set()
+    assert external_access.is_public is False
+
+
+def test_dc_direct_user_holder_accepts_email_without_account_id() -> None:
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission(
+            {
+                "type": "user",
+                "parameter": "dc-user",
+                "user": {
+                    "name": "dc-user",
+                    "key": "JIRAUSER10000",
+                    "emailAddress": "dc-user@example.com",
+                    "displayName": "DC User",
+                    "active": True,
+                },
+            }
+        )
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"dc-user@example.com"}
+    assert external_access.external_user_group_ids == set()
+    assert external_access.is_public is False
+
+
+def test_direct_group_holders_preserve_value_and_parameter_shapes() -> None:
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "group", "value": "cloud-group"}),
+        _permission({"type": "group", "parameter": "dc-group"}),
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == set()
+    assert external_access.external_user_group_ids == {"cloud-group", "dc-group"}
+    assert external_access.is_public is False
+
+
+def test_project_role_preserves_cloud_account_id_and_group_name_paths() -> None:
+    jira_client = _jira_client(JIRA_CLOUD_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "value": "10010"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(actorGroup=SimpleNamespace(name="jira-users")),
+            SimpleNamespace(
+                actorUser=SimpleNamespace(accountId="cloud-account-id"),
+            ),
+        ]
+    )
+    jira_client.user.return_value = SimpleNamespace(
+        accountType="atlassian",
+        emailAddress="cloud-role-user@example.com",
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"cloud-role-user@example.com"}
+    assert external_access.external_user_group_ids == {"jira-users"}
+    jira_client.user.assert_called_once_with(id="cloud-account-id")
+
+
+def test_project_role_dc_user_actor_uses_name_for_lookup() -> None:
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10010"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(
+                actorUser=SimpleNamespace(name="dc-user", key="JIRAUSER10000"),
+            ),
+        ]
+    )
+    jira_client.user.return_value = SimpleNamespace(
+        emailAddress="dc-role-user@example.com",
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"dc-role-user@example.com"}
+    assert external_access.external_user_group_ids == set()
+    jira_client.user.assert_called_once_with(id="dc-user")
+
+
+def test_project_role_group_actor_uses_raw_actor_group_fallback() -> None:
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10010"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(raw={"actorGroup": {"name": "raw-dc-group"}}),
+        ]
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == set()
+    assert external_access.external_user_group_ids == {"raw-dc-group"}
+    assert external_access.is_public is False
+
+
+def test_dynamic_only_holders_remain_empty_private_access() -> None:
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "reporter"}),
+        _permission({"type": "assignee"}),
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == set()
+    assert external_access.external_user_group_ids == set()
+    assert external_access.is_public is False


### PR DESCRIPTION
## Description

Adjust perm sync implementation to account for newer things in the Jira Data Center v10 SDK

## How Has This Been Tested?

added tests. All code should be backwards compatible, i.e. if perm sync worked for your Jira instance it should still work.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Jira permission sync to support Jira Data Center v10 SDK and mixed Cloud/DC shapes. Improves user/group resolution and logging while keeping behavior the same.

- **Bug Fixes**
  - Normalize Cloud/DC holder and role shapes across attributes, raw dicts, and nested raw payloads; support both value/parameter forms.
  - Resolve user emails from direct holders and role actors: prefer embedded email; else look up by id (Cloud: accountId/name/key; DC: name/key/accountId); skip non-Atlassian users.
  - Read project role group names from actorGroup (with raw fallback) and include direct group holders; treat "anyone" and "applicationRole" as public.
  - Tweak logging: warn (not error) for dynamic-only/unsupported holders that produce empty private access; clearer messages for missing identifiers/emails. Added unit tests for Cloud/DC direct users, direct groups, raw actorGroup, and dynamic-only cases.

<sup>Written for commit 708807ec623cedaf9ea83afd5209de87149155ba. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11187?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

