### PR TITLE
feat(deletion): switch fan-out to batched bulk cleanup task (3/3)

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -412,6 +412,15 @@ VESPA_CLOUD_KEY_PATH = os.environ.get("VESPA_CLOUD_KEY_PATH")
 # Number of documents in a batch during indexing (further batching done by chunks before passing to bi-encoder)
 INDEX_BATCH_SIZE = int(os.environ.get("INDEX_BATCH_SIZE") or 16)
 
+# How many doc IDs to bundle into one document_by_cc_pair_bulk_cleanup_task
+# dispatch. Larger → fewer Celery messages and less taskset bookkeeping; too
+# large → batch wall-clock pushes past LIGHT_SOFT_TIME_LIMIT (105s). At
+# ~30ms/doc inside one OpenSearch _bulk delete a batch of 100 is well under
+# that ceiling.
+CONNECTOR_CLEANUP_BATCH_SIZE = int(
+    os.environ.get("CONNECTOR_CLEANUP_BATCH_SIZE") or 100
+)
+
 MAX_DRIVE_WORKERS = int(os.environ.get("MAX_DRIVE_WORKERS", 4))
 
 # Below are intended to match the env variables names used by the official postgres docker image

--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -108,7 +108,9 @@ class RedisConnectorDelete:
         lock: RedisLock,
     ) -> int | None:
         """Returns None if the cc_pair doesn't exist.
-        Otherwise, returns an int with the number of generated tasks."""
+        Otherwise, returns the number of documents dispatched across all
+        batches. Callers persist this as `num_docs_synced`, so it must be a
+        doc count, not a batch count."""
         last_lock_time = time.monotonic()
 
         cc_pair = get_connector_credential_pair_from_id(
@@ -118,7 +120,7 @@ class RedisConnectorDelete:
         if not cc_pair:
             return None
 
-        num_tasks_sent = 0
+        num_docs_sent = 0
         batch: list[str] = []
 
         def _flush_batch() -> None:
@@ -127,7 +129,7 @@ class RedisConnectorDelete:
             One task ID = one batch. The taskset SADD + EXPIRE are pipelined
             so we do one round-trip to Redis per batch instead of two.
             """
-            nonlocal num_tasks_sent
+            nonlocal num_docs_sent
             if not batch:
                 return
 
@@ -156,7 +158,7 @@ class RedisConnectorDelete:
                 ignore_result=True,
             )
 
-            num_tasks_sent += 1
+            num_docs_sent += len(batch)
             batch.clear()
 
         stmt = construct_document_id_select_for_connector_credential_pair(
@@ -178,7 +180,7 @@ class RedisConnectorDelete:
         # Flush the trailing partial batch.
         _flush_batch()
 
-        return num_tasks_sent
+        return num_docs_sent
 
     def reset(self) -> None:
         self.redis.srem(OnyxRedisConstants.ACTIVE_FENCES, self.fence_key)

--- a/backend/onyx/redis/redis_connector_delete.py
+++ b/backend/onyx/redis/redis_connector_delete.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import CONNECTOR_CLEANUP_BATCH_SIZE
 from onyx.configs.app_configs import DB_YIELD_PER_DEFAULT
 from onyx.configs.constants import CELERY_VESPA_SYNC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
@@ -118,6 +119,45 @@ class RedisConnectorDelete:
             return None
 
         num_tasks_sent = 0
+        batch: list[str] = []
+
+        def _flush_batch() -> None:
+            """Dispatch one bulk cleanup task for the accumulated doc IDs.
+
+            One task ID = one batch. The taskset SADD + EXPIRE are pipelined
+            so we do one round-trip to Redis per batch instead of two.
+            """
+            nonlocal num_tasks_sent
+            if not batch:
+                return
+
+            custom_task_id = self._generate_task_id()
+
+            # Pipeline the SADD + EXPIRE so the bookkeeping is one Redis
+            # round-trip per batch. Must happen BEFORE send_task so the
+            # task_postrun handler can never see the task ID before we've
+            # recorded it.
+            pipe = self.redis.pipeline()
+            pipe.sadd(self.taskset_key, custom_task_id)
+            pipe.expire(self.taskset_key, self.TASKSET_TTL)
+            pipe.execute()
+
+            celery_app.send_task(
+                OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK,
+                kwargs=dict(
+                    document_ids=list(batch),
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                    tenant_id=self.tenant_id,
+                ),
+                queue=OnyxCeleryQueues.CONNECTOR_DELETION,
+                task_id=custom_task_id,
+                priority=OnyxCeleryPriority.MEDIUM,
+                ignore_result=True,
+            )
+
+            num_tasks_sent += 1
+            batch.clear()
 
         stmt = construct_document_id_select_for_connector_credential_pair(
             cc_pair.connector_id, cc_pair.credential_id
@@ -131,29 +171,12 @@ class RedisConnectorDelete:
                 lock.reacquire()
                 last_lock_time = current_time
 
-            custom_task_id = self._generate_task_id()
+            batch.append(doc_id)
+            if len(batch) >= CONNECTOR_CLEANUP_BATCH_SIZE:
+                _flush_batch()
 
-            # add to the tracking taskset in redis BEFORE creating the celery task.
-            # note that for the moment we are using a single taskset key, not differentiated by cc_pair id
-            self.redis.sadd(self.taskset_key, custom_task_id)
-            self.redis.expire(self.taskset_key, self.TASKSET_TTL)
-
-            # Priority on sync's triggered by new indexing should be medium
-            celery_app.send_task(
-                OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_CLEANUP_TASK,
-                kwargs=dict(
-                    document_id=doc_id,
-                    connector_id=cc_pair.connector_id,
-                    credential_id=cc_pair.credential_id,
-                    tenant_id=self.tenant_id,
-                ),
-                queue=OnyxCeleryQueues.CONNECTOR_DELETION,
-                task_id=custom_task_id,
-                priority=OnyxCeleryPriority.MEDIUM,
-                ignore_result=True,
-            )
-
-            num_tasks_sent += 1
+        # Flush the trailing partial batch.
+        _flush_batch()
 
         return num_tasks_sent
 

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -167,7 +167,9 @@ class RedisConnectorPrune:
         if not cc_pair:
             return None
 
-        num_tasks_sent = 0
+        # Returned to the caller and persisted as `num_docs_synced` /
+        # `num_pruned` — must be a doc count, not a batch count.
+        num_docs_sent = 0
         batch: list[str] = []
 
         def _flush_batch() -> None:
@@ -176,7 +178,7 @@ class RedisConnectorPrune:
             One task ID = one batch. The taskset SADD + EXPIRE are pipelined
             so we do one round-trip to Redis per batch instead of two.
             """
-            nonlocal num_tasks_sent
+            nonlocal num_docs_sent
             if not batch:
                 return
 
@@ -206,7 +208,7 @@ class RedisConnectorPrune:
                 ignore_result=True,
             )
 
-            num_tasks_sent += 1
+            num_docs_sent += len(batch)
             batch.clear()
 
         for doc_id in documents_to_prune:
@@ -224,7 +226,7 @@ class RedisConnectorPrune:
         # Flush the trailing partial batch.
         _flush_batch()
 
-        return num_tasks_sent
+        return num_docs_sent
 
     def reset(self) -> None:
         self.redis.srem(OnyxRedisConstants.ACTIVE_FENCES, self.fence_key)

--- a/backend/onyx/redis/redis_connector_prune.py
+++ b/backend/onyx/redis/redis_connector_prune.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import CONNECTOR_CLEANUP_BATCH_SIZE
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_PRUNING_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
@@ -159,7 +160,6 @@ class RedisConnectorPrune:
     ) -> int | None:
         last_lock_time = time.monotonic()
 
-        async_results = []
         cc_pair = get_connector_credential_pair_from_id(
             db_session=db_session,
             cc_pair_id=int(self.id),
@@ -167,29 +167,35 @@ class RedisConnectorPrune:
         if not cc_pair:
             return None
 
-        for doc_id in documents_to_prune:
-            current_time = time.monotonic()
-            if lock and current_time - last_lock_time >= (
-                CELERY_GENERIC_BEAT_LOCK_TIMEOUT / 4
-            ):
-                lock.reacquire()
-                last_lock_time = current_time
+        num_tasks_sent = 0
+        batch: list[str] = []
 
-            # celery's default task id format is "dd32ded3-00aa-4884-8b21-42f8332e7fac"
-            # the actual redis key is "celery-task-meta-dd32ded3-00aa-4884-8b21-42f8332e7fac"
-            # we prefix the task id so it's easier to keep track of who created the task
-            # aka "documentset_1_6dd32ded3-00aa-4884-8b21-42f8332e7fac"
+        def _flush_batch() -> None:
+            """Dispatch one bulk cleanup task for the accumulated doc IDs.
+
+            One task ID = one batch. The taskset SADD + EXPIRE are pipelined
+            so we do one round-trip to Redis per batch instead of two.
+            """
+            nonlocal num_tasks_sent
+            if not batch:
+                return
+
+            # Task ID prefix is the existing per-cc-pair subtask prefix so
+            # task_postrun's prefix-keyed SREM works unchanged.
             custom_task_id = f"{self.subtask_prefix}_{uuid4()}"
 
-            # add to the tracking taskset in redis BEFORE creating the celery task.
-            self.redis.sadd(self.taskset_key, custom_task_id)
-            self.redis.expire(self.taskset_key, self.TASKSET_TTL)
+            # Pipeline the SADD + EXPIRE — one round-trip per batch. Must
+            # happen BEFORE send_task so task_postrun can never see the task
+            # ID before we've recorded it.
+            pipe = self.redis.pipeline()
+            pipe.sadd(self.taskset_key, custom_task_id)
+            pipe.expire(self.taskset_key, self.TASKSET_TTL)
+            pipe.execute()
 
-            # Priority on sync's triggered by new indexing should be medium
-            result = celery_app.send_task(
-                OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_CLEANUP_TASK,
+            celery_app.send_task(
+                OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK,
                 kwargs=dict(
-                    document_id=doc_id,
+                    document_ids=list(batch),
                     connector_id=cc_pair.connector_id,
                     credential_id=cc_pair.credential_id,
                     tenant_id=self.tenant_id,
@@ -200,9 +206,25 @@ class RedisConnectorPrune:
                 ignore_result=True,
             )
 
-            async_results.append(result)
+            num_tasks_sent += 1
+            batch.clear()
 
-        return len(async_results)
+        for doc_id in documents_to_prune:
+            current_time = time.monotonic()
+            if lock and current_time - last_lock_time >= (
+                CELERY_GENERIC_BEAT_LOCK_TIMEOUT / 4
+            ):
+                lock.reacquire()
+                last_lock_time = current_time
+
+            batch.append(doc_id)
+            if len(batch) >= CONNECTOR_CLEANUP_BATCH_SIZE:
+                _flush_batch()
+
+        # Flush the trailing partial batch.
+        _flush_batch()
+
+        return num_tasks_sent
 
     def reset(self) -> None:
         self.redis.srem(OnyxRedisConstants.ACTIVE_FENCES, self.fence_key)

--- a/backend/tests/external_dependency_unit/redis/test_redis_connector_fanout.py
+++ b/backend/tests/external_dependency_unit/redis/test_redis_connector_fanout.py
@@ -1,0 +1,285 @@
+"""External dependency unit tests for the batched deletion / pruning fan-out.
+
+After PR #11185 introduced `document_by_cc_pair_bulk_cleanup_task`, the fan-out
+in `RedisConnectorDelete.generate_tasks` and `RedisConnectorPrune.generate_tasks`
+switches from "one task per doc" to "one task per batch of
+CONNECTOR_CLEANUP_BATCH_SIZE docs". The on-disk effects to verify here:
+
+- One taskset SREM per BATCH instead of per doc (i.e. `taskset.scard()`
+  reflects the batch count, not the doc count).
+- The dispatched task uses the BULK task name and carries the full set of
+  doc IDs split across batches.
+- Trailing partial batches are flushed.
+- Empty input dispatches zero tasks.
+
+We capture `celery_app.send_task` invocations rather than running the task —
+this isolates the fan-out logic from the task body (which has its own coverage
+in `test_document_bulk_cleanup.py`).
+"""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.app_configs import CONNECTOR_CLEANUP_BATCH_SIZE
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.connectors.models import IndexAttemptMetadata
+from onyx.db.models import ConnectorCredentialPair
+from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
+from onyx.redis.redis_connector_delete import RedisConnectorDelete
+from onyx.redis.redis_connector_prune import RedisConnectorPrune
+from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.redis.redis_pool import get_redis_client
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_doc
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        cleanup_cc_pair(db_session, pair)
+
+
+@pytest.fixture
+def cleanup_tenant_redis() -> Generator[None, None, None]:
+    """Wipe all keys this tenant touched after the test, so taskset / fence
+    leftovers don't leak between runs."""
+    yield
+    raw = get_raw_redis_client()
+    pattern = f"{TEST_TENANT_ID}:connector*"
+    keys = list(raw.scan_iter(match=pattern))
+    if keys:
+        raw.delete(*keys)
+
+
+def _index_n_docs(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    n: int,
+    label: str,
+) -> list[str]:
+    """Index `n` docs against the cc_pair so generate_tasks has rows to find.
+    Returns the list of doc IDs created."""
+    docs = [make_doc(f"{label}-{uuid4().hex[:8]}") for _ in range(n)]
+    index_doc_batch_prepare(
+        documents=docs,
+        index_attempt_metadata=IndexAttemptMetadata(
+            connector_id=cc_pair.connector_id,
+            credential_id=cc_pair.credential_id,
+            attempt_id=None,
+            request_id="test-request",
+        ),
+        db_session=db_session,
+        ignore_time_skip=True,
+    )
+    db_session.commit()
+    return [doc.id for doc in docs]
+
+
+def _send_task_recorder() -> tuple[MagicMock, list[dict[str, Any]]]:
+    """Return a (mock, captured) pair. Each entry on `captured` is a flat
+    dict {"name": <task name>, "document_ids": [...], "queue": ..., ...},
+    merging the positional task-name arg with the call's kwargs."""
+    captured: list[dict[str, Any]] = []
+
+    def _record(*args: Any, **kwargs: Any) -> MagicMock:
+        entry: dict[str, Any] = {}
+        if args:
+            entry["name"] = args[0]
+        entry.update(kwargs)
+        captured.append(entry)
+        return MagicMock()
+
+    mock = MagicMock(side_effect=_record)
+    return mock, captured
+
+
+class TestRedisConnectorDeleteFanout:
+    """`RedisConnectorDelete.generate_tasks` batches over docs attached to the
+    cc_pair."""
+
+    def test_taskset_shrinks_to_one_entry_per_batch(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+        cleanup_tenant_redis: None,  # noqa: ARG002
+    ) -> None:
+        """250 docs at batch size 100 → 3 batches → 3 taskset entries
+        (not 250)."""
+        n_docs = (CONNECTOR_CLEANUP_BATCH_SIZE * 2) + (
+            CONNECTOR_CLEANUP_BATCH_SIZE // 2
+        )
+        doc_ids = _index_n_docs(db_session, cc_pair, n_docs, "del")
+
+        rcd = RedisConnectorDelete(
+            tenant_id=TEST_TENANT_ID,
+            id=cc_pair.id,
+            redis=get_redis_client(tenant_id=TEST_TENANT_ID),
+        )
+
+        mock_app = MagicMock()
+        send_task_mock, captured = _send_task_recorder()
+        mock_app.send_task = send_task_mock
+        mock_lock = MagicMock()
+
+        num_tasks = rcd.generate_tasks(mock_app, db_session, mock_lock)
+
+        expected_batches = 3
+        assert num_tasks == expected_batches
+        assert send_task_mock.call_count == expected_batches
+
+        # Every dispatched task uses the BULK task name.
+        for kwargs in captured:
+            assert (
+                kwargs["name"] == OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK
+            )
+
+        # Every doc ID lands in exactly one batch.
+        dispatched_doc_ids: list[str] = []
+        for kwargs in captured:
+            dispatched_doc_ids.extend(kwargs["kwargs"]["document_ids"])
+        assert sorted(dispatched_doc_ids) == sorted(doc_ids)
+
+        # Batch sizes: two full, one trailing.
+        sizes = [len(kwargs["kwargs"]["document_ids"]) for kwargs in captured]
+        assert sizes.count(CONNECTOR_CLEANUP_BATCH_SIZE) == 2
+        assert sizes.count(CONNECTOR_CLEANUP_BATCH_SIZE // 2) == 1
+
+        # Taskset has one entry per batch, not per doc.
+        assert rcd.get_remaining() == expected_batches
+
+    def test_exact_batch_size_does_not_flush_empty_trailing_batch(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+        cleanup_tenant_redis: None,  # noqa: ARG002
+    ) -> None:
+        """N == batch_size: exactly one batch. The trailing flush is a no-op
+        for an empty buffer — must not enqueue a phantom empty task."""
+        _index_n_docs(db_session, cc_pair, CONNECTOR_CLEANUP_BATCH_SIZE, "exact")
+
+        rcd = RedisConnectorDelete(
+            tenant_id=TEST_TENANT_ID,
+            id=cc_pair.id,
+            redis=get_redis_client(tenant_id=TEST_TENANT_ID),
+        )
+
+        mock_app = MagicMock()
+        send_task_mock, captured = _send_task_recorder()
+        mock_app.send_task = send_task_mock
+
+        num_tasks = rcd.generate_tasks(mock_app, db_session, MagicMock())
+
+        assert num_tasks == 1
+        assert send_task_mock.call_count == 1
+        assert (
+            len(captured[0]["kwargs"]["document_ids"]) == CONNECTOR_CLEANUP_BATCH_SIZE
+        )
+
+    def test_empty_cc_pair_dispatches_zero_tasks(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+        cleanup_tenant_redis: None,  # noqa: ARG002
+    ) -> None:
+        """No docs attached → no batches, no taskset entries."""
+        rcd = RedisConnectorDelete(
+            tenant_id=TEST_TENANT_ID,
+            id=cc_pair.id,
+            redis=get_redis_client(tenant_id=TEST_TENANT_ID),
+        )
+
+        mock_app = MagicMock()
+        send_task_mock, _ = _send_task_recorder()
+        mock_app.send_task = send_task_mock
+
+        num_tasks = rcd.generate_tasks(mock_app, db_session, MagicMock())
+
+        assert num_tasks == 0
+        assert send_task_mock.call_count == 0
+        assert rcd.get_remaining() == 0
+
+
+class TestRedisConnectorPruneFanout:
+    """`RedisConnectorPrune.generate_tasks` takes an explicit set of doc IDs
+    (the diff between what's in PG and what the connector re-fetched) and
+    batches over that set."""
+
+    def test_taskset_shrinks_to_one_entry_per_batch(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+        cleanup_tenant_redis: None,  # noqa: ARG002
+    ) -> None:
+        # 175 docs at batch 100 → 2 batches.
+        documents_to_prune = {f"prune-{uuid4().hex[:8]}" for _ in range(175)}
+
+        rcp = RedisConnectorPrune(
+            tenant_id=TEST_TENANT_ID,
+            id=cc_pair.id,
+            redis=get_redis_client(tenant_id=TEST_TENANT_ID),
+        )
+
+        mock_app = MagicMock()
+        send_task_mock, captured = _send_task_recorder()
+        mock_app.send_task = send_task_mock
+
+        num_tasks = rcp.generate_tasks(documents_to_prune, mock_app, db_session, None)
+
+        assert num_tasks == 2
+        assert send_task_mock.call_count == 2
+
+        for kwargs in captured:
+            assert (
+                kwargs["name"] == OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK
+            )
+
+        dispatched_doc_ids: set[str] = set()
+        for kwargs in captured:
+            dispatched_doc_ids.update(kwargs["kwargs"]["document_ids"])
+        assert dispatched_doc_ids == documents_to_prune
+
+        # One taskset entry per batch.
+        assert rcp.taskset_key
+        raw = get_raw_redis_client()
+        prefixed = f"{TEST_TENANT_ID}:{rcp.taskset_key}"
+        assert raw.scard(prefixed) == 2
+
+    def test_empty_set_dispatches_zero_tasks(
+        self,
+        db_session: Session,
+        cc_pair: ConnectorCredentialPair,
+        full_deployment_setup: None,  # noqa: ARG002
+        cleanup_tenant_redis: None,  # noqa: ARG002
+    ) -> None:
+        rcp = RedisConnectorPrune(
+            tenant_id=TEST_TENANT_ID,
+            id=cc_pair.id,
+            redis=get_redis_client(tenant_id=TEST_TENANT_ID),
+        )
+
+        mock_app = MagicMock()
+        send_task_mock, _ = _send_task_recorder()
+        mock_app.send_task = send_task_mock
+
+        num_tasks = rcp.generate_tasks(set(), mock_app, db_session, None)
+
+        assert num_tasks == 0
+        assert send_task_mock.call_count == 0

--- a/backend/tests/external_dependency_unit/redis/test_redis_connector_fanout.py
+++ b/backend/tests/external_dependency_unit/redis/test_redis_connector_fanout.py
@@ -136,10 +136,12 @@ class TestRedisConnectorDeleteFanout:
         mock_app.send_task = send_task_mock
         mock_lock = MagicMock()
 
-        num_tasks = rcd.generate_tasks(mock_app, db_session, mock_lock)
+        num_docs = rcd.generate_tasks(mock_app, db_session, mock_lock)
 
         expected_batches = 3
-        assert num_tasks == expected_batches
+        # Return value is doc count (callers persist as `num_docs_synced`),
+        # not batch count.
+        assert num_docs == n_docs
         assert send_task_mock.call_count == expected_batches
 
         # Every dispatched task uses the BULK task name.
@@ -183,9 +185,9 @@ class TestRedisConnectorDeleteFanout:
         send_task_mock, captured = _send_task_recorder()
         mock_app.send_task = send_task_mock
 
-        num_tasks = rcd.generate_tasks(mock_app, db_session, MagicMock())
+        num_docs = rcd.generate_tasks(mock_app, db_session, MagicMock())
 
-        assert num_tasks == 1
+        assert num_docs == CONNECTOR_CLEANUP_BATCH_SIZE
         assert send_task_mock.call_count == 1
         assert (
             len(captured[0]["kwargs"]["document_ids"]) == CONNECTOR_CLEANUP_BATCH_SIZE
@@ -209,9 +211,9 @@ class TestRedisConnectorDeleteFanout:
         send_task_mock, _ = _send_task_recorder()
         mock_app.send_task = send_task_mock
 
-        num_tasks = rcd.generate_tasks(mock_app, db_session, MagicMock())
+        num_docs = rcd.generate_tasks(mock_app, db_session, MagicMock())
 
-        assert num_tasks == 0
+        assert num_docs == 0
         assert send_task_mock.call_count == 0
         assert rcd.get_remaining() == 0
 
@@ -241,9 +243,11 @@ class TestRedisConnectorPruneFanout:
         send_task_mock, captured = _send_task_recorder()
         mock_app.send_task = send_task_mock
 
-        num_tasks = rcp.generate_tasks(documents_to_prune, mock_app, db_session, None)
+        num_docs = rcp.generate_tasks(documents_to_prune, mock_app, db_session, None)
 
-        assert num_tasks == 2
+        # Return value is doc count (callers persist as `num_docs_synced` /
+        # `num_pruned`), not batch count.
+        assert num_docs == len(documents_to_prune)
         assert send_task_mock.call_count == 2
 
         for kwargs in captured:
@@ -279,7 +283,7 @@ class TestRedisConnectorPruneFanout:
         send_task_mock, _ = _send_task_recorder()
         mock_app.send_task = send_task_mock
 
-        num_tasks = rcp.generate_tasks(set(), mock_app, db_session, None)
+        num_docs = rcp.generate_tasks(set(), mock_app, db_session, None)
 
-        assert num_tasks == 0
+        assert num_docs == 0
         assert send_task_mock.call_count == 0


### PR DESCRIPTION
## Description

Third of three PRs implementing batched per-document cleanup. Stacked on #11185 (bulk task body); rebase target moves to \`main\` after #11178 → #11185 → this PR land in order. After this lands, the per-doc \`document_by_cc_pair_cleanup_task\` is unused for new work and can be deprecated.

Both connector deletion and connector pruning now accumulate doc IDs into batches of \`CONNECTOR_CLEANUP_BATCH_SIZE\` (default 100, env-tunable) and dispatch one \`document_by_cc_pair_bulk_cleanup_task\` per batch instead of one singular task per doc.

### Net effect on the 2026-05-18 workload

The pruning fan-out that crash-looped the API tier (1.7M tasks from one tenant) becomes ~17k batches at the default batch size — 100x fewer Celery messages, 100x smaller taskset, 100x fewer \`task_postrun\` SREMs. Combined with PR #11185's 3-phase task structure, each batch only holds a pgbouncer slot during Phase 1 + Phase 3 of the bulk task — never across the document-index HTTP round-trip in Phase 2.

### Changes

- \`backend/onyx/configs/app_configs.py\` — \`CONNECTOR_CLEANUP_BATCH_SIZE\` config var (default 100). Sized so \`batch × p99-per-doc-time\` stays under \`LIGHT_SOFT_TIME_LIMIT = 105s\`; at ~30ms/doc inside one OpenSearch \`_bulk\` delete that's a comfortable margin.
- \`backend/onyx/redis/redis_connector_delete.py\` — \`generate_tasks\` accumulates into a buffer and flushes via \`celery_app.send_task(OnyxCeleryTask.DOCUMENT_BY_CC_PAIR_BULK_CLEANUP_TASK, kwargs=dict(document_ids=[...], ...))\`. Trailing partial batches are flushed at the end of the loop.
- \`backend/onyx/redis/redis_connector_prune.py\` — same change.
- Taskset \`SADD + EXPIRE\` are pipelined per batch — one Redis round-trip each instead of two.

### What does **not** change

- Task ID prefix is unchanged (\`connectordeletion_<cc_pair_id>_<uuid>\` / \`connectorpruning+sub_<cc_pair_id>_<uuid>\`), so the prefix-keyed \`task_postrun\` handler in \`apps/app_base.py:206-216\` needs no changes — it removes the same one task ID per Celery completion, the only difference being that one completion now represents 100 docs of work instead of 1.
- Fence / active / generator-progress keys.
- The beat controllers (\`check_for_connector_deletion_task\`, \`check_for_pruning\`).
- The finalization check at \`connector_deletion/tasks.py:421-441\` — it queries PG for remaining \`DocumentByConnectorCredentialPair\` rows, agnostic to how they got removed.

### Observability note

\`RedisConnectorDelete.get_remaining()\` returns \`scard(taskset)\`. Today it equals "remaining docs"; after this PR it equals "remaining batches". UI / dashboards that surface this value as a doc count will need to multiply by batch_size — or just relabel.

## How Has This Been Tested?

- \`pytest backend/tests/external_dependency_unit/redis/test_redis_connector_fanout.py\` — 5 new tests passing against real Postgres + Redis:
  - 250-doc input → 3 batches at 100/100/50 → 3 taskset entries (not 250), all dispatched docs accounted for.
  - Exact-batch-size case (N == batch_size) flushes one batch and does not emit a phantom empty trailing batch.
  - Empty input dispatches zero tasks, taskset stays empty.
  - Same coverage on the pruning path with 175-doc input → 2 batches.
- Full regression: 20 tests across the three stacked PRs (4 foundations + 5 singular task + 6 bulk task + 5 fan-out) all pass.
- \`pre-commit run\` clean (ty, ruff, ruff format).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch the connector deletion and pruning fan-out to send one bulk cleanup task per batch instead of per document, cutting Celery messages and Redis taskset churn on large workloads. Also fix `generate_tasks` to return a document count so SyncRecord and logs stay accurate.

- **Refactors**
  - Fan-out now batches doc IDs and dispatches `document_by_cc_pair_bulk_cleanup_task` per batch.
  - Added `CONNECTOR_CLEANUP_BATCH_SIZE` env (default 100).
  - Pipelines taskset `SADD` + `EXPIRE` per batch to cut Redis round-trips.
  - Keeps existing task ID prefixes and beat controllers unchanged.
  - `generate_tasks` now returns a doc count (not batch count) to keep `num_docs_synced`/pruning metrics correct.

- **Migration**
  - `RedisConnectorDelete.get_remaining()` now counts batches, not documents; update UI/dashboards to relabel or multiply by batch size.

<sup>Written for commit ef5d5c9426268564511e904aece422800888efea. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11188?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

