### PR TITLE
chore(logging, celery): Single source of truth for logging in celery workers

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -432,7 +432,7 @@ def _cli_loglevel_explicitly_set() -> bool:
     """
     Returns True iff --loglevel or -l was explicitly passed on the celery CLI.
 
-    The setup_logging signal handler receives a `loglevel` int regardless of
+    The setup_logging signal handler receives a ``loglevel`` int regardless of
     whether the operator actually passed --loglevel — when the flag is absent,
     Celery substitutes its own default. To distinguish "operator passed it" (CLI
     should win) from "Celery defaulted it" (LOG_LEVEL env should win) we have to
@@ -441,9 +441,9 @@ def _cli_loglevel_explicitly_set() -> bool:
     for arg in sys.argv:
         if arg == "--loglevel" or arg.startswith("--loglevel="):
             return True
-        # short form: `-l VALUE`, `-l=VALUE`, `-lVALUE` (the `arg == "-l"` case
-        # is subsumed by the startswith branch since "-l" starts with "-l" and
-        # doesn't start with "--")
+        # short form: ``-l VALUE``, ``-l=VALUE``, ``-lVALUE`` (the ``arg ==
+        # "-l"`` case is subsumed by the startswith branch since "-l" starts
+        # with "-l" and doesn't start with "--")
         if arg.startswith("-l") and not arg.startswith("--"):
             return True
     return False

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -441,8 +441,10 @@ def _cli_loglevel_explicitly_set() -> bool:
     for arg in sys.argv:
         if arg == "--loglevel" or arg.startswith("--loglevel="):
             return True
-        # short form: `-l VALUE`, `-l=VALUE`, `-lVALUE`
-        if arg == "-l" or (arg.startswith("-l") and not arg.startswith("--")):
+        # short form: `-l VALUE`, `-l=VALUE`, `-lVALUE` (the `arg == "-l"` case
+        # is subsumed by the startswith branch since "-l" starts with "-l" and
+        # doesn't start with "--")
+        if arg.startswith("-l") and not arg.startswith("--"):
             return True
     return False
 

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -429,13 +429,14 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
 
 
 def _cli_loglevel_explicitly_set() -> bool:
-    """Return True iff --loglevel or -l was explicitly passed on the celery CLI.
+    """
+    Returns True iff --loglevel or -l was explicitly passed on the celery CLI.
 
     The setup_logging signal handler receives a `loglevel` int regardless of
     whether the operator actually passed --loglevel — when the flag is absent,
-    Celery substitutes its own default. To distinguish "operator passed it"
-    (CLI should win) from "Celery defaulted it" (LOG_LEVEL env should win) we
-    have to inspect sys.argv ourselves.
+    Celery substitutes its own default. To distinguish "operator passed it" (CLI
+    should win) from "Celery defaulted it" (LOG_LEVEL env should win) we have to
+    inspect sys.argv ourselves.
     """
     for arg in sys.argv:
         if arg == "--loglevel" or arg.startswith("--loglevel="):
@@ -456,10 +457,10 @@ def on_setup_logging(
     # TODO: could unhardcode format and colorize and accept these as options from
     # celery's config
 
-    # Precedence: explicit --loglevel CLI flag > LOG_LEVEL env var > Celery default.
-    # An operator-supplied CLI flag is treated as a per-worker override; otherwise
-    # LOG_LEVEL is the single global knob across the API server, model servers,
-    # and all Celery workers.
+    # Precedence: explicit --loglevel CLI flag > LOG_LEVEL env var > Celery
+    # default. An operator-supplied CLI flag is treated as a per-worker
+    # override; otherwise LOG_LEVEL is the single global knob across the API
+    # server, model servers, and all Celery workers.
     env_log_level = os.environ.get("LOG_LEVEL")
     if _cli_loglevel_explicitly_set():
         effective_loglevel = loglevel

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -447,6 +447,33 @@ def _cli_loglevel_explicitly_set() -> bool:
     return False
 
 
+def _resolve_effective_loglevel(cli_loglevel: int) -> tuple[int, str]:
+    """
+    Returns the (level, human-readable explanation) for celery worker logging.
+
+    Precedence: explicit --loglevel CLI flag > LOG_LEVEL env var > Celery
+    default. An operator-supplied CLI flag is treated as a per-worker
+    override; otherwise LOG_LEVEL is the single global knob across the API
+    server, model servers, and all Celery workers.
+
+    Surfaces unrecognized LOG_LEVEL strings (e.g. "WARN" instead of
+    "WARNING") in the source string so the operator can see in the boot
+    log that their value silently fell back to INFO.
+    """
+    env_log_level = os.environ.get("LOG_LEVEL")
+    if _cli_loglevel_explicitly_set():
+        return cli_loglevel, "celery --loglevel CLI arg"
+    if env_log_level is not None:
+        effective = get_log_level_from_str(env_log_level)
+        parsed_name = logging.getLevelName(effective)
+        if parsed_name.upper() != env_log_level.upper():
+            return effective, (
+                f"LOG_LEVEL env var ({env_log_level!r} -> unrecognized, defaulted to {parsed_name})"
+            )
+        return effective, f"LOG_LEVEL env var ({env_log_level!r})"
+    return cli_loglevel, "celery default (no --loglevel, no LOG_LEVEL)"
+
+
 def on_setup_logging(
     loglevel: int,
     logfile: str | None,
@@ -457,20 +484,7 @@ def on_setup_logging(
     # TODO: could unhardcode format and colorize and accept these as options from
     # celery's config
 
-    # Precedence: explicit --loglevel CLI flag > LOG_LEVEL env var > Celery
-    # default. An operator-supplied CLI flag is treated as a per-worker
-    # override; otherwise LOG_LEVEL is the single global knob across the API
-    # server, model servers, and all Celery workers.
-    env_log_level = os.environ.get("LOG_LEVEL")
-    if _cli_loglevel_explicitly_set():
-        effective_loglevel = loglevel
-        loglevel_source = "celery --loglevel CLI arg"
-    elif env_log_level:
-        effective_loglevel = get_log_level_from_str(env_log_level)
-        loglevel_source = f"LOG_LEVEL env var ({env_log_level!r})"
-    else:
-        effective_loglevel = loglevel
-        loglevel_source = "celery default (no --loglevel, no LOG_LEVEL)"
+    effective_loglevel, loglevel_source = _resolve_effective_loglevel(loglevel)
 
     root_logger = logging.getLogger()
     root_logger.handlers = []

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -1,6 +1,7 @@
 import logging
 import multiprocessing
 import os
+import sys
 import time
 from typing import Any
 from typing import cast
@@ -47,6 +48,7 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_usergroup import RedisUserGroup
 from onyx.tracing.setup import setup_tracing
 from onyx.utils.logger import ColoredFormatter
+from onyx.utils.logger import get_log_level_from_str
 from onyx.utils.logger import LoggerContextVars
 from onyx.utils.logger import PlainFormatter
 from onyx.utils.logger import setup_logger
@@ -426,6 +428,24 @@ def on_worker_shutdown(sender: Any, **kwargs: Any) -> None:  # noqa: ARG001
         logger.exception("Failed to check if primary worker lock is owned")
 
 
+def _cli_loglevel_explicitly_set() -> bool:
+    """Return True iff --loglevel or -l was explicitly passed on the celery CLI.
+
+    The setup_logging signal handler receives a `loglevel` int regardless of
+    whether the operator actually passed --loglevel — when the flag is absent,
+    Celery substitutes its own default. To distinguish "operator passed it"
+    (CLI should win) from "Celery defaulted it" (LOG_LEVEL env should win) we
+    have to inspect sys.argv ourselves.
+    """
+    for arg in sys.argv:
+        if arg == "--loglevel" or arg.startswith("--loglevel="):
+            return True
+        # short form: `-l VALUE`, `-l=VALUE`, `-lVALUE`
+        if arg == "-l" or (arg.startswith("-l") and not arg.startswith("--")):
+            return True
+    return False
+
+
 def on_setup_logging(
     loglevel: int,
     logfile: str | None,
@@ -435,6 +455,26 @@ def on_setup_logging(
 ) -> None:
     # TODO: could unhardcode format and colorize and accept these as options from
     # celery's config
+
+    # Precedence: explicit --loglevel CLI flag > LOG_LEVEL env var > Celery default.
+    # An operator-supplied CLI flag is treated as a per-worker override; otherwise
+    # LOG_LEVEL is the single global knob across the API server, model servers,
+    # and all Celery workers.
+    env_log_level = os.environ.get("LOG_LEVEL")
+    if _cli_loglevel_explicitly_set():
+        effective_loglevel = loglevel
+        loglevel_source = "celery --loglevel CLI arg"
+    elif env_log_level:
+        effective_loglevel = get_log_level_from_str(env_log_level)
+        loglevel_source = f"LOG_LEVEL env var ({env_log_level!r})"
+    else:
+        effective_loglevel = loglevel
+        loglevel_source = "celery default (no --loglevel, no LOG_LEVEL)"
+    logger.info(
+        "Celery effective log level: %s (source: %s)",
+        logging.getLevelName(effective_loglevel),
+        loglevel_source,
+    )
 
     root_logger = logging.getLogger()
     root_logger.handlers = []
@@ -469,7 +509,7 @@ def on_setup_logging(
         root_file_handler.setFormatter(root_file_formatter)
         root_logger.addHandler(root_file_handler)
 
-    root_logger.setLevel(loglevel)
+    root_logger.setLevel(effective_loglevel)
 
     # Configure the task logger
     task_logger.handlers = []
@@ -494,7 +534,7 @@ def on_setup_logging(
         task_file_handler.setFormatter(task_file_formatter)
         task_logger.addHandler(task_file_handler)
 
-    task_logger.setLevel(loglevel)
+    task_logger.setLevel(effective_loglevel)
     task_logger.propagate = False
 
     # hide celery task received spam

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -471,11 +471,6 @@ def on_setup_logging(
     else:
         effective_loglevel = loglevel
         loglevel_source = "celery default (no --loglevel, no LOG_LEVEL)"
-    logger.info(
-        "Celery effective log level: %s (source: %s)",
-        logging.getLevelName(effective_loglevel),
-        loglevel_source,
-    )
 
     root_logger = logging.getLogger()
     root_logger.handlers = []
@@ -511,6 +506,16 @@ def on_setup_logging(
         root_logger.addHandler(root_file_handler)
 
     root_logger.setLevel(effective_loglevel)
+
+    # Emit the diagnostic after the root logger is configured so it goes through
+    # the fresh handler at the level we just chose. (Before this point Python's
+    # root logger defaults to WARNING, which would silently drop an INFO message
+    # in the no-LOG_LEVEL/no-CLI default case.)
+    logger.info(
+        "Celery effective log level: %s (source: %s)",
+        logging.getLevelName(effective_loglevel),
+        loglevel_source,
+    )
 
     # Configure the task logger
     task_logger.handlers = []

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -29,7 +29,6 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 # Vespa / Postgres)
 [program:celery_worker_primary]
 command=celery -A onyx.background.celery.versioned_apps.primary worker
-    --loglevel=INFO
     --hostname=primary@%%n
     -Q celery
 stdout_logfile=/var/log/celery_worker_primary.log
@@ -44,7 +43,6 @@ stopasgroup=true
 # user group syncing, deletion, etc.)
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
-    --loglevel=INFO
     --hostname=light@%%n
     -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
 stdout_logfile=/var/log/celery_worker_light.log
@@ -56,7 +54,6 @@ stopasgroup=true
 
 [program:celery_worker_heavy]
 command=celery -A onyx.background.celery.versioned_apps.heavy worker
-    --loglevel=INFO
     --hostname=heavy@%%n
     -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox
 stdout_logfile=/var/log/celery_worker_heavy.log
@@ -68,7 +65,6 @@ stopasgroup=true
 
 [program:celery_worker_docprocessing]
 command=celery -A onyx.background.celery.versioned_apps.docprocessing worker
-    --loglevel=INFO
     --hostname=docprocessing@%%n
     -Q docprocessing
 stdout_logfile=/var/log/celery_worker_docprocessing.log
@@ -80,7 +76,6 @@ stopasgroup=true
 
 [program:celery_worker_user_file_processing]
 command=celery -A onyx.background.celery.versioned_apps.user_file_processing worker
-    --loglevel=INFO
     --hostname=user_file_processing@%%n
     -Q user_file_processing,user_file_project_sync,user_file_delete
 stdout_logfile=/var/log/celery_worker_user_file_processing.log
@@ -95,7 +90,6 @@ stopasgroup=true
 # and would otherwise starve pruning / perms-sync / csv-export of slots.
 [program:celery_worker_scheduled_tasks]
 command=celery -A onyx.background.celery.versioned_apps.scheduled_tasks worker
-    --loglevel=INFO
     --hostname=scheduled_tasks@%%n
     -Q scheduled_tasks
 stdout_logfile=/var/log/celery_worker_scheduled_tasks.log
@@ -107,7 +101,6 @@ stopasgroup=true
 
 [program:celery_worker_docfetching]
 command=celery -A onyx.background.celery.versioned_apps.docfetching worker
-    --loglevel=INFO
     --hostname=docfetching@%%n
     -Q connector_doc_fetching
 stdout_logfile=/var/log/celery_worker_docfetching.log
@@ -119,7 +112,6 @@ stopasgroup=true
 
 [program:celery_worker_monitoring]
 command=celery -A onyx.background.celery.versioned_apps.monitoring worker
-    --loglevel=INFO
     --hostname=monitoring@%%n
     -Q monitoring
 stdout_logfile=/var/log/celery_worker_monitoring.log

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -44,7 +44,7 @@ def _snapshot_loggers() -> Generator[None, None, None]:
 def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
     """Replaces sys.argv with a celery-like invocation (plus any extra args).
 
-    Strips pytest's own argv so the --loglevel detector doesn't see e.g. `-v`
+    Strips pytest's own argv so the --loglevel detector doesn't see e.g. ``-v``
     from pytest's command line as a false short-flag match.
     """
     monkeypatch.setattr(sys, "argv", ["celery", "-A", "app", "worker", *extra])

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -1,0 +1,169 @@
+"""Unit tests for the LOG_LEVEL env var override in Celery's
+``setup_logging`` handler.
+
+Verifies the precedence rule in
+``onyx.background.celery.apps.app_base.on_setup_logging``:
+    explicit --loglevel CLI arg > LOG_LEVEL env var > Celery default.
+"""
+
+import logging
+import sys
+from collections.abc import Generator
+
+import pytest
+
+from onyx.background.celery.apps import app_base
+
+
+@pytest.fixture
+def _snapshot_loggers() -> Generator[None, None, None]:
+    """on_setup_logging mutates the root logger and the Celery task logger.
+
+    Snapshot and restore both so tests don't bleed into each other or the
+    rest of the suite.
+    """
+    root = logging.getLogger()
+    task = app_base.task_logger
+
+    root_handlers_before = list(root.handlers)
+    root_level_before = root.level
+    task_handlers_before = list(task.handlers)
+    task_level_before = task.level
+    task_propagate_before = task.propagate
+
+    yield
+
+    root.handlers = root_handlers_before
+    root.setLevel(root_level_before)
+    task.handlers = task_handlers_before
+    task.setLevel(task_level_before)
+    task.propagate = task_propagate_before
+
+
+def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
+    """Replace sys.argv with a celery-like invocation (plus any extra args).
+
+    Strips pytest's own argv so the --loglevel detector doesn't see e.g.
+    `-v` from pytest's command line as a false short-flag match.
+    """
+    monkeypatch.setattr(sys, "argv", ["celery", "-A", "app", "worker", *extra])
+
+
+def test_env_unset_cli_not_passed_falls_back_to_celery_default(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LOG_LEVEL", raising=False)
+    _clean_argv(monkeypatch)
+
+    # Celery would pass its own default here when --loglevel is absent.
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.WARNING
+    assert app_base.task_logger.level == logging.WARNING
+
+
+def test_env_set_cli_not_passed_env_wins(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch)
+
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,  # Celery default; should be ignored
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.DEBUG
+    assert app_base.task_logger.level == logging.DEBUG
+
+
+def test_env_empty_cli_not_passed_falls_back_to_celery_default(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "")
+    _clean_argv(monkeypatch)
+
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.WARNING
+    assert app_base.task_logger.level == logging.WARNING
+
+
+def test_cli_long_form_wins_over_env(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch, "--loglevel=INFO")
+
+    app_base.on_setup_logging(
+        loglevel=logging.INFO,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.INFO
+    assert app_base.task_logger.level == logging.INFO
+
+
+def test_cli_long_form_separate_token_wins_over_env(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch, "--loglevel", "WARNING")
+
+    app_base.on_setup_logging(
+        loglevel=logging.WARNING,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.WARNING
+    assert app_base.task_logger.level == logging.WARNING
+
+
+def test_cli_short_form_wins_over_env(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch, "-l", "ERROR")
+
+    app_base.on_setup_logging(
+        loglevel=logging.ERROR,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.ERROR
+    assert app_base.task_logger.level == logging.ERROR
+
+
+def test_env_loglevel_case_insensitive(
+    _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "warning")
+    _clean_argv(monkeypatch)
+
+    app_base.on_setup_logging(
+        loglevel=logging.DEBUG,
+        logfile=None,
+        format="",
+        colorize=False,
+    )
+
+    assert logging.getLogger().level == logging.WARNING
+    assert app_base.task_logger.level == logging.WARNING

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -1,5 +1,6 @@
-"""Unit tests for the LOG_LEVEL env var override in Celery's
-``setup_logging`` handler.
+"""
+Unit tests for the LOG_LEVEL env var override in Celery's ``setup_logging``
+handler.
 
 Verifies the precedence rule in
 ``onyx.background.celery.apps.app_base.on_setup_logging``:
@@ -19,8 +20,8 @@ from onyx.background.celery.apps import app_base
 def _snapshot_loggers() -> Generator[None, None, None]:
     """on_setup_logging mutates the root logger and the Celery task logger.
 
-    Snapshot and restore both so tests don't bleed into each other or the
-    rest of the suite.
+    Snapshot and restore both so tests don't bleed into each other or the rest
+    of the suite.
     """
     root = logging.getLogger()
     task = app_base.task_logger
@@ -41,10 +42,10 @@ def _snapshot_loggers() -> Generator[None, None, None]:
 
 
 def _clean_argv(monkeypatch: pytest.MonkeyPatch, *extra: str) -> None:
-    """Replace sys.argv with a celery-like invocation (plus any extra args).
+    """Replaces sys.argv with a celery-like invocation (plus any extra args).
 
-    Strips pytest's own argv so the --loglevel detector doesn't see e.g.
-    `-v` from pytest's command line as a false short-flag match.
+    Strips pytest's own argv so the --loglevel detector doesn't see e.g. `-v`
+    from pytest's command line as a false short-flag match.
     """
     monkeypatch.setattr(sys, "argv", ["celery", "-A", "app", "worker", *extra])
 

--- a/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
+++ b/backend/tests/unit/onyx/background/celery/test_app_base_logging.py
@@ -85,21 +85,21 @@ def test_env_set_cli_not_passed_env_wins(
     assert app_base.task_logger.level == logging.DEBUG
 
 
-def test_env_empty_cli_not_passed_falls_back_to_celery_default(
+def test_env_empty_string_falls_back_to_info(
     _snapshot_loggers: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("LOG_LEVEL", "")
     _clean_argv(monkeypatch)
 
     app_base.on_setup_logging(
-        loglevel=logging.WARNING,
+        loglevel=logging.WARNING,  # Celery default; should be ignored
         logfile=None,
         format="",
         colorize=False,
     )
 
-    assert logging.getLogger().level == logging.WARNING
-    assert app_base.task_logger.level == logging.WARNING
+    assert logging.getLogger().level == logging.INFO
+    assert app_base.task_logger.level == logging.INFO
 
 
 def test_cli_long_form_wins_over_env(
@@ -168,3 +168,64 @@ def test_env_loglevel_case_insensitive(
 
     assert logging.getLogger().level == logging.WARNING
     assert app_base.task_logger.level == logging.WARNING
+
+
+# Direct tests of the resolver helper so we can assert on the human-readable
+# source string without fighting on_setup_logging clearing root_logger.handlers
+# (which kills pytest's caplog handler).
+
+
+def test_resolve_unrecognized_env_loglevel_falls_back_to_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """LOG_LEVEL=WARN (common typo for WARNING) should fall back to INFO and
+    surface that fact in the source string so the boot log makes the silent
+    fallback discoverable.
+    """
+    monkeypatch.setenv("LOG_LEVEL", "WARN")
+    _clean_argv(monkeypatch)
+
+    level, source = app_base._resolve_effective_loglevel(cli_loglevel=logging.DEBUG)
+
+    assert level == logging.INFO
+    assert "'WARN'" in source
+    assert "unrecognized" in source
+    assert "INFO" in source
+
+
+def test_resolve_garbage_env_loglevel_falls_back_to_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "INVALID")
+    _clean_argv(monkeypatch)
+
+    level, source = app_base._resolve_effective_loglevel(cli_loglevel=logging.DEBUG)
+
+    assert level == logging.INFO
+    assert "'INVALID'" in source
+    assert "unrecognized" in source
+
+
+def test_resolve_valid_env_loglevel_has_clean_source_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch)
+
+    level, source = app_base._resolve_effective_loglevel(cli_loglevel=logging.WARNING)
+
+    assert level == logging.DEBUG
+    assert "unrecognized" not in source
+    assert "'DEBUG'" in source
+
+
+def test_resolve_cli_explicit_wins_source_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    _clean_argv(monkeypatch, "--loglevel=ERROR")
+
+    level, source = app_base._resolve_effective_loglevel(cli_loglevel=logging.ERROR)
+
+    assert level == logging.ERROR
+    assert "CLI" in source

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -142,6 +142,13 @@ USE_IAM_AUTH=false
 ## DEVELOPER, DEBUGGING, AND LOGGING
 ################################################################################
 ## Logging and Telemetry
+# LOG_LEVEL is the global knob for log verbosity across every Onyx process:
+# api_server, web_server, model servers, slack/discord bots, AND all Celery
+# workers (primary, light, heavy, docprocessing, docfetching, monitoring,
+# scheduled_tasks, user_file_processing, beat). For per-worker overrides,
+# explicitly add `--loglevel=<value>` to that worker's command in
+# backend/supervisord.conf — an explicit CLI flag takes precedence over
+# LOG_LEVEL inside the worker process.
 LOG_LEVEL=info
 LOG_ONYX_MODEL_INTERACTIONS=False
 # LOG_VESPA_TIMING_INFORMATION=

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -63,7 +63,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.beat",
               "beat",
-              {{ printf "--loglevel=%s" .Values.celery_beat.logLevel | quote }},
+              {{- with .Values.celery_beat.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
             ]
           resources:
             {{- toYaml .Values.celery_beat.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -68,7 +68,9 @@ spec:
               "--pool=threads",
               "--concurrency=2",
               "--prefetch-multiplier=1",
-              {{ printf "--loglevel=%s" .Values.celery_worker_docfetching.logLevel | quote }},
+              {{- with .Values.celery_worker_docfetching.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=docfetching@%n",
               "-Q",
               "connector_doc_fetching",

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing.yaml
@@ -68,7 +68,9 @@ spec:
               "--pool=threads",
               "--concurrency=6",
               "--prefetch-multiplier=1",
-              {{ printf "--loglevel=%s" .Values.celery_worker_docprocessing.logLevel | quote }},
+              {{- with .Values.celery_worker_docprocessing.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=docprocessing@%n",
               "-Q",
               "docprocessing",

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.heavy",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_heavy.logLevel | quote }},
+              {{- with .Values.celery_worker_heavy.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=heavy@%n",
               "-Q",
               "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox",

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.light",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_light.logLevel | quote }},
+              {{- with .Values.celery_worker_light.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=light@%n",
               "-Q",
               "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.monitoring",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_monitoring.logLevel | quote }},
+              {{- with .Values.celery_worker_monitoring.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=monitoring@%n",
               "-Q",
               "monitoring",

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.primary",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_primary.logLevel | quote }},
+              {{- with .Values.celery_worker_primary.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=primary@%n",
               "-Q",
               "celery,periodic_tasks",

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.scheduled_tasks",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_scheduled_tasks.logLevel | quote }},
+              {{- with .Values.celery_worker_scheduled_tasks.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=scheduled_tasks@%n",
               "-Q",
               "scheduled_tasks",

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -65,7 +65,9 @@ spec:
               "-A",
               "onyx.background.celery.versioned_apps.user_file_processing",
               "worker",
-              {{ printf "--loglevel=%s" .Values.celery_worker_user_file_processing.logLevel | quote }},
+              {{- with .Values.celery_worker_user_file_processing.logLevel }}
+              {{ printf "--loglevel=%s" . | quote }},
+              {{- end }}
               "--hostname=user-file-processing@%n",
               "-Q",
               "user_file_processing,user_file_project_sync,user_file_delete",

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -572,7 +572,11 @@ celery_shared:
 celery_beat:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   podAnnotations: {}
   podLabels:
     scope: onyx-backend-celery
@@ -594,7 +598,11 @@ celery_beat:
 celery_worker_heavy:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -629,7 +637,11 @@ celery_worker_heavy:
 celery_worker_docprocessing:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -664,7 +676,11 @@ celery_worker_docprocessing:
 celery_worker_light:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -699,7 +715,11 @@ celery_worker_light:
 celery_worker_monitoring:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -734,7 +754,11 @@ celery_worker_monitoring:
 celery_worker_primary:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -769,7 +793,11 @@ celery_worker_primary:
 celery_worker_user_file_processing:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -809,7 +837,11 @@ celery_worker_user_file_processing:
 celery_worker_scheduled_tasks:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -958,7 +990,11 @@ mcpServer:
 celery_worker_docfetching:
   extraEnv: []
   replicaCount: 1
-  logLevel: INFO
+  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
+  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
+  # only — this becomes `--loglevel=<value>` on the celery worker command and
+  # takes precedence over LOG_LEVEL inside the worker process.
+  logLevel: ""
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -1390,6 +1426,13 @@ configMap:
   # Logging
   # Optional Telemetry, please keep it on (nothing sensitive is collected)? <3
   DISABLE_TELEMETRY: ""
+  # LOG_LEVEL is the global knob for log verbosity across every Onyx process —
+  # api_server, model_server, slack/discord bots, AND all Celery workers.
+  # Empty (default) -> Python falls back to "info" for the api/model/etc
+  # processes; Celery workers also pick up "" -> info via this same env var.
+  # Per-worker overrides: set `.celery_worker_X.logLevel` below to an explicit
+  # value (INFO/DEBUG/etc.) — that will render `--loglevel=<value>` into the
+  # worker command and take precedence over LOG_LEVEL for that worker only.
   LOG_LEVEL: ""
   LOG_ALL_MODEL_INTERACTIONS: ""
   LOG_ONYX_MODEL_INTERACTIONS: ""

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -572,10 +572,10 @@ celery_shared:
 celery_beat:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   podAnnotations: {}
   podLabels:
@@ -598,10 +598,10 @@ celery_beat:
 celery_worker_heavy:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -637,10 +637,10 @@ celery_worker_heavy:
 celery_worker_docprocessing:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -676,10 +676,10 @@ celery_worker_docprocessing:
 celery_worker_light:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -715,10 +715,10 @@ celery_worker_light:
 celery_worker_monitoring:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -754,10 +754,10 @@ celery_worker_monitoring:
 celery_worker_primary:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -793,10 +793,10 @@ celery_worker_primary:
 celery_worker_user_file_processing:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -837,10 +837,10 @@ celery_worker_user_file_processing:
 celery_worker_scheduled_tasks:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -990,10 +990,10 @@ mcpServer:
 celery_worker_docfetching:
   extraEnv: []
   replicaCount: 1
-  # Per-worker log level override. Empty (default) means use the global LOG_LEVEL
-  # env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for this worker
-  # only — this becomes `--loglevel=<value>` on the celery worker command and
-  # takes precedence over LOG_LEVEL inside the worker process.
+  # Per-worker log level override. Empty (default) means use the global
+  # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
+  # this worker only — this becomes `--loglevel=<value>` on the celery worker
+  # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
   autoscaling:
     enabled: false
@@ -1427,12 +1427,12 @@ configMap:
   # Optional Telemetry, please keep it on (nothing sensitive is collected)? <3
   DISABLE_TELEMETRY: ""
   # LOG_LEVEL is the global knob for log verbosity across every Onyx process —
-  # api_server, model_server, slack/discord bots, AND all Celery workers.
-  # Empty (default) -> Python falls back to "info" for the api/model/etc
-  # processes; Celery workers also pick up "" -> info via this same env var.
-  # Per-worker overrides: set `.celery_worker_X.logLevel` below to an explicit
-  # value (INFO/DEBUG/etc.) — that will render `--loglevel=<value>` into the
-  # worker command and take precedence over LOG_LEVEL for that worker only.
+  # api_server, model_server, slack/discord bots, AND all Celery workers. Empty
+  # (default) -> Python falls back to "info" for the api/model/etc processes;
+  # Celery workers also pick up "" -> info via this same env var. Per-worker
+  # overrides: set `.celery_worker_X.logLevel` below to an explicit value
+  # (INFO/DEBUG/etc.) — that will render `--loglevel=<value>` into the worker
+  # command and take precedence over LOG_LEVEL for that worker only.
   LOG_LEVEL: ""
   LOG_ALL_MODEL_INTERACTIONS: ""
   LOG_ONYX_MODEL_INTERACTIONS: ""


### PR DESCRIPTION
## Description
This PR makes it such that the Celery log level precedence looks as follows: Celery default -(clobbered by)-> `LOG_LEVEL` env var set (same env var as the rest of the application) -(clobbered by)-> Celery task given explicit log level CLI command. As a result, by default we no longer pass in CLI args to Celery workers, although customers can still opt to do this in their self-hosted deploys.

## How Has This Been Tested?
Added automated tests for the log level logic.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Celery worker logging with the rest of the app. `LOG_LEVEL` now controls all workers (and beat) by default, while an explicit `--loglevel` remains a per-worker override.

- **Refactors**
  - Precedence: CLI `--loglevel` > `LOG_LEVEL` env var > Celery default; at startup we log the effective level and its source. Invalid or empty `LOG_LEVEL` falls back to INFO and is called out in the message.
  - Detect explicit CLI flags (`--loglevel`, `-l`) via `sys.argv` to treat them as overrides.
  - Config: removed hardcoded `--loglevel` from `backend/supervisord.conf`; Helm renders `--loglevel` only when `.logLevel` is set; defaults in `values.yaml` are `""` to defer to `LOG_LEVEL`.
  - Tests and docs: added unit tests for precedence, CLI forms, case-insensitive parsing, and empty/invalid fallback; documented `LOG_LEVEL` in `deployment/docker_compose/env.template` and Helm `values.yaml`.

- **Migration**
  - Set global verbosity with `LOG_LEVEL` (e.g., `info`, `debug`).
  - Per-worker override: Helm — set `.Values.celery_worker_*.logLevel` or `celery_beat.logLevel`; Supervisor — add `--loglevel=<value>` to that program’s command.

<sup>Written for commit 25c5321c1be3bc8f98f58f613dbb11252e27bce0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11190?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


