### PR TITLE
fix(craft sidecar): drop explicit imagePullPolicy, let kubelet default by tag

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -381,7 +381,10 @@ class KubernetesSandboxManager(SandboxManager):
         sandbox_container = client.V1Container(
             name="sandbox",
             image=self._image,
-            image_pull_policy="IfNotPresent",
+            # No explicit imagePullPolicy: kubelet picks the right default based
+            # on the tag — `Always` for `:latest`/untagged, `IfNotPresent` for
+            # pinned tags. Hardcoding `IfNotPresent` made nodes serve stale
+            # `:latest` images after the registry tag moved.
             command=["/workspace/entrypoint.sh"],
             ports=sandbox_ports,
             env=[
@@ -414,7 +417,8 @@ class KubernetesSandboxManager(SandboxManager):
         sidecar_container = client.V1Container(
             name="sidecar",
             image=self._image,
-            image_pull_policy="IfNotPresent",
+            # See sandbox_container above — kubelet's default picks the right
+            # policy from the tag.
             command=["/workspace/sidecar-entrypoint.sh"],
             ports=[
                 client.V1ContainerPort(


### PR DESCRIPTION
## Description

Drops the explicit `imagePullPolicy: IfNotPresent` from both containers in `_create_sandbox_pod()`. Lets kubelet apply its tag-based default instead: `Always` for `:latest` / untagged, `IfNotPresent` for pinned tags.

## Why

Hardcoding `IfNotPresent` meant nodes kept serving stale `:latest` images after the registry tag moved. Concretely on craft-dev this evening: the api-server rolled to a build with the new two-container sidecar spec, but the sandbox node still had the old `onyxdotapp/sandbox:latest` cached (without `sidecar-entrypoint.sh`). The kubelet skipped pulling per the pinned policy and every new sandbox pod started with `exec: "/workspace/sidecar-entrypoint.sh": no such file or directory`.

With this change, the next pod that asks for `onyxdotapp/sandbox:latest` will have kubelet hit the registry, compare digests, and pull if the tag has moved. Pinned-tag deploys (e.g. `:v0.1.42`) continue to use `IfNotPresent` and avoid the round-trip.

## How Has This Been Tested?

- 79 sandbox unit tests pass.
- Stale-image scenario reproduced on craft-dev (events showed `Pulled` reported as "already present on machine" against the old digest).
- After a manual `ctr -n k8s.io images rm` on the sandbox node, fresh sessions provisioned correctly — proving the issue was caching, not the image itself.
- With this fix, no manual cache invalidation will be required when `:latest` moves.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed explicit imagePullPolicy from the sandbox and sidecar containers so kubelet uses tag-based defaults. Prevents stale `:latest` images and keeps pinned-tag behavior unchanged.

- **Bug Fixes**
  - Dropped `imagePullPolicy: IfNotPresent` for both containers in `_create_sandbox_pod()`.
  - Kubelet now pulls on `:latest`/untagged (`Always`) and uses cache for pinned tags (`IfNotPresent`).
  - Stops stale images from missing `sidecar-entrypoint.sh`; no manual cache invalidation needed.

<sup>Written for commit 2fd8090d0845374b5d7bacd76d9182afd456cce9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11191?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

