### PR TITLE
fix(sharepoint): skip per-site Graph failures instead of aborting run

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -276,6 +276,28 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # HTTP statuses we treat as transient and worth retrying.
 RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 
+# HTTP statuses that scope a Graph error to a single SharePoint site rather
+# than the whole connector run. 404 is the common case: Graph's tenant-wide
+# `getAllSites` is search-indexed and eventually consistent, so it returns
+# ephemeral sites (e.g. ServiceNow-style `/teams/INC...`) that have already
+# been deleted in SharePoint. 403 covers per-site permission loss (sensitivity
+# labels, sharing restrictions). 410 is a deleted site. 400 covers malformed
+# per-site URLs. 401 and other 5xx are tenant-wide and abort the run.
+PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({400, 403, 404, 410})
+
+
+def _is_per_site_graph_failure(e: ClientRequestException) -> bool:
+    """Classify a ClientRequestException as per-site (skip & report) or
+    tenant-wide (re-raise to abort the run).
+
+    `e.response` may be None when the office365 SDK wraps a transport-level
+    failure with no HTTP response; the retry layer (`sleep_and_retry`) owns
+    that path, so we treat None as "raise".
+    """
+    if e.response is None:
+        return False
+    return e.response.status_code in PER_SITE_GRAPH_FAILURE_STATUSES
+
 
 def _backoff_seconds(attempt: int, retry_after: str | None) -> int:
     """Honor a numeric Retry-After header when the server provides one,
@@ -2101,46 +2123,64 @@ class SharepointConnector(
 
             # Process site pages if flag is True
             if self.include_site_pages:
-                site_pages = self._fetch_site_pages(
-                    site_descriptor, start=start, end=end
-                )
-                for site_page in site_pages:
-                    logger.debug(
-                        "Processing site page: %s",
-                        site_page.get("webUrl", site_page.get("name", "Unknown")),
+                try:
+                    site_pages = self._fetch_site_pages(
+                        site_descriptor, start=start, end=end
                     )
-                    try:
-                        if include_permissions:
-                            ctx = self._create_rest_client_context(site_descriptor.url)
-                            doc_batch.append(
-                                _convert_sitepage_to_slim_document(
-                                    site_page,
-                                    ctx,
-                                    self.graph_client,
-                                    parent_hierarchy_raw_node_id=site_descriptor.url,
-                                    treat_sharing_link_as_public=self.treat_sharing_link_as_public,
-                                )
-                            )
-                        else:
-                            page_id = site_page.get("id")
-                            if page_id is None:
-                                raise ValueError("Site page ID is required")
-                            doc_batch.append(
-                                SlimDocument(
-                                    id=page_id,
-                                    external_access=ExternalAccess.empty(),
-                                    parent_hierarchy_raw_node_id=site_descriptor.url,
-                                )
-                            )
-                    except Exception as e:
-                        logger.warning(
-                            "Failed to process site page %s: %s",
+                    for site_page in site_pages:
+                        logger.debug(
+                            "Processing site page: %s",
                             site_page.get("webUrl", site_page.get("name", "Unknown")),
-                            e,
                         )
-                    if len(doc_batch) >= SLIM_BATCH_SIZE:
-                        yield doc_batch
-                        doc_batch = []
+                        try:
+                            if include_permissions:
+                                ctx = self._create_rest_client_context(
+                                    site_descriptor.url
+                                )
+                                doc_batch.append(
+                                    _convert_sitepage_to_slim_document(
+                                        site_page,
+                                        ctx,
+                                        self.graph_client,
+                                        parent_hierarchy_raw_node_id=site_descriptor.url,
+                                        treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                                    )
+                                )
+                            else:
+                                page_id = site_page.get("id")
+                                if page_id is None:
+                                    raise ValueError("Site page ID is required")
+                                doc_batch.append(
+                                    SlimDocument(
+                                        id=page_id,
+                                        external_access=ExternalAccess.empty(),
+                                        parent_hierarchy_raw_node_id=site_descriptor.url,
+                                    )
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to process site page %s: %s",
+                                site_page.get(
+                                    "webUrl", site_page.get("name", "Unknown")
+                                ),
+                                e,
+                            )
+                        if len(doc_batch) >= SLIM_BATCH_SIZE:
+                            yield doc_batch
+                            doc_batch = []
+                except ClientRequestException as e:
+                    if not _is_per_site_graph_failure(e):
+                        raise
+                    logger.warning(
+                        "Skipping slim site pages for %s: Graph returned %s (%s)",
+                        site_descriptor.url,
+                        (
+                            e.response.status_code
+                            if e.response is not None
+                            else "no response"
+                        ),
+                        e.code or "no code",
+                    )
         yield doc_batch
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -2773,32 +2813,55 @@ class SharepointConnector(
             site_descriptor = checkpoint.current_site_descriptor
             start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
             end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
-            site_pages = self._fetch_site_pages(
-                site_descriptor, start=start_dt, end=end_dt
-            )
-            for site_page in site_pages:
-                logger.debug(
-                    "Processing site page: %s",
-                    site_page.get("webUrl", site_page.get("name", "Unknown")),
+            try:
+                site_pages = self._fetch_site_pages(
+                    site_descriptor, start=start_dt, end=end_dt
                 )
-                client_ctx: ClientContext | None = None
-                if include_permissions:
-                    client_ctx = self._create_rest_client_context(site_descriptor.url)
-                yield (
-                    _convert_sitepage_to_document(
-                        site_page,
-                        site_descriptor.drive_name,
-                        client_ctx,
-                        self.graph_client,
-                        include_permissions=include_permissions,
-                        # Site pages have the site as their parent
-                        parent_hierarchy_raw_node_id=site_descriptor.url,
-                        treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                for site_page in site_pages:
+                    logger.debug(
+                        "Processing site page: %s",
+                        site_page.get("webUrl", site_page.get("name", "Unknown")),
                     )
+                    client_ctx: ClientContext | None = None
+                    if include_permissions:
+                        client_ctx = self._create_rest_client_context(
+                            site_descriptor.url
+                        )
+                    yield (
+                        _convert_sitepage_to_document(
+                            site_page,
+                            site_descriptor.drive_name,
+                            client_ctx,
+                            self.graph_client,
+                            include_permissions=include_permissions,
+                            # Site pages have the site as their parent
+                            parent_hierarchy_raw_node_id=site_descriptor.url,
+                            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                        )
+                    )
+                logger.info(
+                    "Finished processing site pages for site: %s",
+                    site_descriptor.url,
                 )
-            logger.info(
-                "Finished processing site pages for site: %s", site_descriptor.url
-            )
+            except ClientRequestException as e:
+                if not _is_per_site_graph_failure(e):
+                    raise
+                logger.warning(
+                    "Skipping site pages for %s: Graph returned %s (%s)",
+                    site_descriptor.url,
+                    (
+                        e.response.status_code
+                        if e.response is not None
+                        else "no response"
+                    ),
+                    e.code or "no code",
+                )
+                yield _create_entity_failure(
+                    site_descriptor.url,
+                    f"Failed to fetch site pages: {e}",
+                    (start_dt, end_dt),
+                    e,
+                )
 
         # If no more drives, move to next site if available
         if (

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -292,6 +292,9 @@ def _graph_error_code(response: requests.Response | None) -> str:
     try:
         return response.json().get("error", {}).get("code") or "<no code>"
     except Exception:
+        logger.debug(
+            "Failed to parse Graph error code from response body", exc_info=True
+        )
         return "<no code>"
 
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -276,28 +276,23 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # HTTP statuses we treat as transient and worth retrying.
 RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 
-# HTTP statuses that scope a Graph error to a single SharePoint site rather
-# than the whole connector run. 404 is the common case: Graph's tenant-wide
-# `getAllSites` is search-indexed and eventually consistent, so it returns
-# ephemeral sites (e.g. ServiceNow-style `/teams/INC...`) that have already
-# been deleted in SharePoint. 403 covers per-site permission loss (sensitivity
-# labels, sharing restrictions). 410 is a deleted site. 400 covers malformed
-# per-site URLs. 401 and other 5xx are tenant-wide and abort the run.
-# Applies to the whole per-site block (lookup + iteration + per-page fetches).
-PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({400, 403, 404, 410})
+PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({403, 404, 410})
 
 
-def _is_per_site_graph_failure(e: ClientRequestException) -> bool:
-    """Classify a ClientRequestException as per-site (skip & report) or
-    tenant-wide (re-raise to abort the run).
-
-    `e.response` may be None when the office365 SDK wraps a transport-level
-    failure with no HTTP response; the retry layer (`sleep_and_retry`) owns
-    that path, so we treat None as "raise".
-    """
+def _is_per_site_graph_failure(e: ClientRequestException | HTTPError) -> bool:
+    # response=None means a wrapped transport error; the retry layer owns it.
     if e.response is None:
         return False
     return e.response.status_code in PER_SITE_GRAPH_FAILURE_STATUSES
+
+
+def _graph_error_code(response: requests.Response | None) -> str:
+    if response is None:
+        return "<no response>"
+    try:
+        return response.json().get("error", {}).get("code") or "<no code>"
+    except Exception:
+        return "<no code>"
 
 
 def _backoff_seconds(attempt: int, retry_after: str | None) -> int:
@@ -2169,7 +2164,7 @@ class SharepointConnector(
                         if len(doc_batch) >= SLIM_BATCH_SIZE:
                             yield doc_batch
                             doc_batch = []
-                except ClientRequestException as e:
+                except (ClientRequestException, HTTPError) as e:
                     if not _is_per_site_graph_failure(e):
                         raise
                     # Slim sync can't yield ConnectorFailure; log-and-skip.
@@ -2181,7 +2176,8 @@ class SharepointConnector(
                             if e.response is not None
                             else "no response"
                         ),
-                        e.code or "<no code>",
+                        _graph_error_code(e.response),
+                        exc_info=True,
                     )
         yield doc_batch
 
@@ -2845,7 +2841,7 @@ class SharepointConnector(
                     "Finished processing site pages for site: %s",
                     site_descriptor.url,
                 )
-            except ClientRequestException as e:
+            except (ClientRequestException, HTTPError) as e:
                 if not _is_per_site_graph_failure(e):
                     raise
                 logger.warning(
@@ -2856,7 +2852,8 @@ class SharepointConnector(
                         if e.response is not None
                         else "no response"
                     ),
-                    e.code or "<no code>",
+                    _graph_error_code(e.response),
+                    exc_info=True,
                 )
                 yield _create_entity_failure(
                     site_descriptor.url,

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -283,6 +283,7 @@ RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 # been deleted in SharePoint. 403 covers per-site permission loss (sensitivity
 # labels, sharing restrictions). 410 is a deleted site. 400 covers malformed
 # per-site URLs. 401 and other 5xx are tenant-wide and abort the run.
+# Applies to the whole per-site block (lookup + iteration + per-page fetches).
 PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({400, 403, 404, 410})
 
 
@@ -2171,6 +2172,7 @@ class SharepointConnector(
                 except ClientRequestException as e:
                     if not _is_per_site_graph_failure(e):
                         raise
+                    # Slim sync can't yield ConnectorFailure; log-and-skip.
                     logger.warning(
                         "Skipping slim site pages for %s: Graph returned %s (%s)",
                         site_descriptor.url,
@@ -2179,7 +2181,7 @@ class SharepointConnector(
                             if e.response is not None
                             else "no response"
                         ),
-                        e.code or "no code",
+                        e.code or "<no code>",
                     )
         yield doc_batch
 
@@ -2854,7 +2856,7 @@ class SharepointConnector(
                         if e.response is not None
                         else "no response"
                     ),
-                    e.code or "no code",
+                    e.code or "<no code>",
                 )
                 yield _create_entity_failure(
                     site_descriptor.url,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -378,6 +378,20 @@ class TestIsPerSiteGraphFailure:
         assert exc.code == "itemNotFound"
         assert _is_per_site_graph_failure(exc) is True
 
+    @pytest.mark.parametrize("status_code", sorted(PER_SITE_GRAPH_FAILURE_STATUSES))
+    def test_per_site_http_errors_classify_as_per_site(
+        self, status_code: int
+    ) -> None:
+        exc = _make_http_error(status_code)
+        assert _is_per_site_graph_failure(exc) is True
+
+    @pytest.mark.parametrize("status_code", [401, 500, 502, 503, 504])
+    def test_tenant_wide_http_errors_classify_as_raise(
+        self, status_code: int
+    ) -> None:
+        exc = _make_http_error(status_code)
+        assert _is_per_site_graph_failure(exc) is False
+
 
 class TestFetchSitePagesPropagatesSiteLookup404:
     """When `site.execute_query()` itself raises (the site URL no longer

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -2,7 +2,10 @@
 
 Covers 404 handling (classic sites / no modern pages) and 400
 canvasLayout fallback (corrupt pages causing $expand=canvasLayout to
-fail on the LIST endpoint).
+fail on the LIST endpoint), plus the per-site failure classifier and
+propagation of `site.execute_query()` 404s out of `_fetch_site_pages`
+so the Phase 5 wrap in `_load_from_checkpoint` can convert them into a
+ConnectorFailure instead of crashing the connector run.
 """
 
 from __future__ import annotations
@@ -11,10 +14,13 @@ import json
 from typing import Any
 
 import pytest
+from office365.runtime.client_request_exception import ClientRequestException
 from requests import Response
 from requests.exceptions import HTTPError
 
+from onyx.connectors.sharepoint.connector import _is_per_site_graph_failure
 from onyx.connectors.sharepoint.connector import GRAPH_INVALID_REQUEST_CODE
+from onyx.connectors.sharepoint.connector import PER_SITE_GRAPH_FAILURE_STATUSES
 from onyx.connectors.sharepoint.connector import SharepointConnector
 from onyx.connectors.sharepoint.connector import SiteDescriptor
 
@@ -39,6 +45,19 @@ def _make_http_error(
     response._content = json.dumps(body).encode()
     response.headers["Content-Type"] = "application/json"
     return HTTPError(response=response)
+
+
+def _make_client_request_exception(
+    status_code: int,
+    error_code: str = "itemNotFound",
+    message: str = "Requested site could not be found",
+) -> ClientRequestException:
+    body = {"error": {"code": error_code, "message": message}}
+    response = Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode()
+    response.headers["Content-Type"] = "application/json"
+    return ClientRequestException(f"{status_code} Client Error", response=response)
 
 
 def _setup_connector(
@@ -325,3 +344,93 @@ class TestFetchSitePages400Fallback:
 
         with pytest.raises(HTTPError):
             list(connector._fetch_site_pages(_site_descriptor()))
+
+
+class TestIsPerSiteGraphFailure:
+    """Classifier the Phase 5 wrap in `_load_from_checkpoint` uses to
+    decide skip-this-site (yield ConnectorFailure) vs abort-the-run."""
+
+    @pytest.mark.parametrize("status_code", sorted(PER_SITE_GRAPH_FAILURE_STATUSES))
+    def test_per_site_statuses_classify_as_per_site(self, status_code: int) -> None:
+        exc = _make_client_request_exception(status_code)
+        assert _is_per_site_graph_failure(exc) is True
+
+    @pytest.mark.parametrize("status_code", [401, 500, 502, 503, 504])
+    def test_tenant_wide_statuses_classify_as_raise(self, status_code: int) -> None:
+        exc = _make_client_request_exception(status_code)
+        assert _is_per_site_graph_failure(exc) is False
+
+    def test_none_response_classifies_as_raise(self) -> None:
+        # Older SDK paths and transport-error wrappers can produce a
+        # ClientRequestException with response=None. The retry layer owns
+        # those, so we treat None as "not per-site".
+        exc = _make_client_request_exception(404)
+        exc.response = None  # type: ignore[assignment]
+        assert _is_per_site_graph_failure(exc) is False
+
+    def test_itemnotfound_404_is_per_site(self) -> None:
+        # Mirrors the production traceback exactly.
+        exc = _make_client_request_exception(
+            404,
+            error_code="itemNotFound",
+            message="Requested site could not be found",
+        )
+        assert exc.code == "itemNotFound"
+        assert _is_per_site_graph_failure(exc) is True
+
+
+class TestFetchSitePagesPropagatesSiteLookup404:
+    """When `site.execute_query()` itself raises (the site URL no longer
+    resolves), `_fetch_site_pages` must let the exception propagate so
+    the outer Phase 5 wrap can convert it into a ConnectorFailure and
+    continue to the next site.
+    """
+
+    def _setup_connector_with_failing_site_lookup(
+        self, status_code: int
+    ) -> SharepointConnector:
+        connector = SharepointConnector(sites=[SITE_URL])
+        connector.graph_api_base = "https://graph.microsoft.com/v1.0"
+
+        exc = _make_client_request_exception(status_code)
+
+        def raising_execute_query(self: Any) -> None:  # noqa: ARG001
+            raise exc
+
+        fake_site_query = type(
+            "Q",
+            (),
+            {"execute_query": raising_execute_query, "id": None},
+        )()
+        mock_sites = type(
+            "FakeSites",
+            (),
+            {
+                "get_by_url": staticmethod(
+                    lambda url: fake_site_query  # noqa: ARG005
+                ),
+            },
+        )()
+        connector._graph_client = type(  # ty: ignore[invalid-assignment]
+            "FakeGraphClient", (), {"sites": mock_sites}
+        )()
+        return connector
+
+    def test_404_propagates_so_outer_handler_can_skip(self) -> None:
+        connector = self._setup_connector_with_failing_site_lookup(404)
+
+        with pytest.raises(ClientRequestException) as excinfo:
+            list(connector._fetch_site_pages(_site_descriptor()))
+
+        # The exception must carry enough info for the outer handler to
+        # classify it as per-site rather than tenant-wide.
+        assert _is_per_site_graph_failure(excinfo.value) is True
+
+    def test_401_propagates_and_classifies_as_tenant_wide(self) -> None:
+        connector = self._setup_connector_with_failing_site_lookup(401)
+
+        with pytest.raises(ClientRequestException) as excinfo:
+            list(connector._fetch_site_pages(_site_descriptor()))
+
+        # 401 is tenant-wide — outer handler should re-raise on this one.
+        assert _is_per_site_graph_failure(excinfo.value) is False

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -379,16 +379,12 @@ class TestIsPerSiteGraphFailure:
         assert _is_per_site_graph_failure(exc) is True
 
     @pytest.mark.parametrize("status_code", sorted(PER_SITE_GRAPH_FAILURE_STATUSES))
-    def test_per_site_http_errors_classify_as_per_site(
-        self, status_code: int
-    ) -> None:
+    def test_per_site_http_errors_classify_as_per_site(self, status_code: int) -> None:
         exc = _make_http_error(status_code)
         assert _is_per_site_graph_failure(exc) is True
 
     @pytest.mark.parametrize("status_code", [401, 500, 502, 503, 504])
-    def test_tenant_wide_http_errors_classify_as_raise(
-        self, status_code: int
-    ) -> None:
+    def test_tenant_wide_http_errors_classify_as_raise(self, status_code: int) -> None:
         exc = _make_http_error(status_code)
         assert _is_per_site_graph_failure(exc) is False
 


### PR DESCRIPTION
## Description
- Stop the SharePoint connector from crashing the entire run when Graph returns a per-site error (400/403/404/410) — a deleted "ghost" site surfaced by tenant-wide `getAllSites` will now be skipped instead of failing every remaining site.
- Surface the skipped site as a `ConnectorFailure` in the full-sync path so admins can see which sites were dropped and why; the slim-sync path logs the skip (its generator type can't carry a failure object).
- Tenant-wide errors (401, 5xx) still abort the run as before — only narrowly-scoped per-site statuses are absorbed.

## How Has This Been Tested?
By running tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent SharePoint syncs from aborting on per-site Microsoft Graph errors by skipping affected sites instead. Per-site 403/404/410 now skip the site (logged in slim-sync; yielded as a `ConnectorFailure` with the time window in full-sync); tenant-wide errors (401, 5xx) still abort.

- **Bug Fixes**
  - Added `_is_per_site_graph_failure` with `PER_SITE_GRAPH_FAILURE_STATUSES={403, 404, 410}`; `response=None` is treated as non–per-site; retryables unchanged.
  - Wrapped site page fetching: slim logs-and-continues with status and Graph code via `_graph_error_code` (with `exc_info` and debug logging if parsing the code fails); full yields `_create_entity_failure` and continues.
  - Per-page processing errors are now logged and skipped without stopping the batch.
  - Expanded tests for `ClientRequestException`/`HTTPError` classification (including `response=None` and `itemNotFound` 404) and verified `site.execute_query()` 404/401 propagate for correct skip/abort handling.

<sup>Written for commit 7e3569841fc237cb01a00e431bcbe654bd58c9eb. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11193?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

