### PR TITLE
docs(craft): infra todos

### DIFF
--- a/docs/craft/infra/todos.md
+++ b/docs/craft/infra/todos.md
@@ -2,11 +2,17 @@
 
 Things to codify so enabling Craft on a new cluster becomes "set `ENABLE_CRAFT=true` in values.yaml" instead of following a manual setup guide. Each item is independent — ship in any order.
 
-## 1. Helm template: sandbox ServiceAccount
+## 1. Helm template: sandbox namespace RBAC + ServiceAccount
 
-Render the sandbox-file-sync ServiceAccount via the Helm chart when `ENABLE_CRAFT=true`, including any IAM/workload-identity annotations required for S3 access. Source the role identifier from a configurable values block and mark it required so a misconfigured deploy fails fast.
+Render everything in the sandbox namespace required for Craft via the Helm chart when `ENABLE_CRAFT=true`:
 
-This removes the need for manual `kubectl annotate` steps and per-cluster raw SA manifests.
+- The sandbox ServiceAccount, with workload-identity annotations and the `eks.amazonaws.com/skip-containers=sandbox` annotation so only the sidecar container receives cloud credentials.
+- The sandbox-namespace Role granting `pods`, `pods/exec`, `services` verbs.
+- RoleBinding(s) attaching that Role to whichever workload ServiceAccount(s) call the K8s API to manage sandbox pods (typically the api-server SA and the relevant Celery worker SAs).
+
+Source identifiers (IAM role ARN, bound SA names) from a configurable values block and mark them required so a misconfigured deploy fails fast.
+
+This removes the need for manual `kubectl annotate` and `kubectl create rolebinding` steps when onboarding a new cluster. Existing clusters whose Role is currently shipped via raw manifests / external GitOps need a one-time cleanup so the chart becomes the single source of truth.
 
 ## 2. Terraform module: sandbox object store + workload-identity role
 
@@ -19,18 +25,24 @@ A shared Terraform module that provisions the cloud-side prerequisites for Craft
 
 Existing buckets/roles on already-deployed clusters need to be imported into module state, not recreated.
 
-## 3. Node-group metadata-service hardening
+## 3. Node-group security-group composition
+
+A dedicated sandbox node group must carry the same set of security groups that the cluster's regular managed node groups carry — typically the EKS cluster SG **plus** the shared node SG. If the launch template only attaches the cluster SG, pods on sandbox nodes can't reach pods on the regular node group (DNS, in-cluster service calls, etc.) because the shared node SG's ingress is self-referential.
+
+**Acceptance:** the Terraform launch template for the sandbox node group attaches both SGs by default, matching how EKS managed node groups normally provision.
+
+## 4. Node-group metadata-service hardening
 
 Enforce IMDSv2 with hop-limit 1 on the sandbox node group via Terraform so containers can't reach the instance metadata service. If a cluster's node group is currently managed outside Terraform, converting it is a prerequisite.
 
 **Acceptance:** from inside any sandbox pod, a curl to the metadata service times out.
 
-## 4. Network firewall (defense-in-depth)
+## 5. Network firewall (defense-in-depth)
 
 Replicate the production network-firewall setup in every region that runs Craft. The firewall should:
 
 - Block egress from sandbox subnets to RFC1918 ranges (lateral movement)
-- Block egress to the instance metadata service (belt-and-suspenders with item 3)
+- Block egress to the instance metadata service (belt-and-suspenders with item 4)
 - Subscribe to a managed threat-intelligence rule group
 - Sit in dedicated firewall subnets with sandbox-subnet route tables pointing `0.0.0.0/0` at the firewall endpoint
 
@@ -38,7 +50,7 @@ Replicate the production network-firewall setup in every region that runs Craft.
 
 ---
 
-## When items 1–3 land
+## When items 1–4 land
 
 Onboarding a new Craft cluster becomes:
 
@@ -46,4 +58,4 @@ Onboarding a new Craft cluster becomes:
 2. Copy `role_arn` and `bucket_name` from terraform outputs into the cluster's Helm values alongside `ENABLE_CRAFT: "true"`.
 3. `helm upgrade` (creates namespace, SA, network policy).
 
-Item 4 is independent and bolts on to any cluster after the rest is in place.
+Item 5 is independent and bolts on to any cluster after the rest is in place.


### PR DESCRIPTION
- **chore(craft): add infra todos and bump default sandbox image version**
- **more docs**

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the default sandbox image to `onyxdotapp/sandbox:v0.1.44` and expands the Craft infra TODOs to cover Helm-managed sandbox namespace RBAC/ServiceAccount and RoleBindings, sandbox node-group security-group composition, IMDSv2 hardening, and firewall guidance; onboarding now references items 1–4.

- **Dependencies**
  - Default sandbox image: `onyxdotapp/sandbox:v0.1.44` (was `v0.1.41`)

<sup>Written for commit c54210119bba2d198e05ad01cad6d30899f5d07c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11197?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

