### PR TITLE
chore(cli): increase search timeout

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -23,15 +23,15 @@ import (
 // Client is the Onyx API client.
 //
 // Three http.Clients are kept so each call site can pick a timeout matched to
-// its expected work: 30s for quick JSON endpoints, 60s for /search (which
+// its expected work: 3min for quick JSON endpoints, 5min for /search (which
 // runs LLM query expansion + relevance selection), and 5min for streaming
 // chat responses and uploads.
 type Client struct {
 	baseURL             string
 	apiKey              string
-	httpClient          *http.Client // 30s
-	searchHTTPClient    *http.Client // 60s
-	streamingHTTPClient *http.Client // 5min
+	httpClient          *http.Client
+	searchHTTPClient    *http.Client
+	streamingHTTPClient *http.Client
 }
 
 // NewClient creates a new API client from config.
@@ -48,11 +48,11 @@ func NewClient(cfg config.OnyxCliConfig) *Client {
 		baseURL: config.APIURL(cfg.ServerURL),
 		apiKey:  cfg.APIKey,
 		httpClient: &http.Client{
-			Timeout:   30 * time.Second,
+			Timeout:   3 * time.Minute,
 			Transport: transport,
 		},
 		searchHTTPClient: &http.Client{
-			Timeout:   60 * time.Second,
+			Timeout:   5 * time.Minute,
 			Transport: transport,
 		},
 		streamingHTTPClient: &http.Client{


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased API client timeouts to reduce flakiness for long searches and slow networks. Default requests: 30s → 3m; `/search`: 60s → 5m; streaming remains 5m.

<sup>Written for commit 464a8115ac1bcd9d3b40de3f57ca79731b02c44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

