### PR TITLE
feat(admin): add Security and Hardening admin page stub

### DIFF
--- a/web/src/app/admin/security/page.tsx
+++ b/web/src/app/admin/security/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import * as SettingsLayouts from "@/layouts/settings-layouts";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+
+const route = ADMIN_ROUTES.SECURITY_HARDENING;
+
+export default function Page() {
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Body />
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -22,6 +22,7 @@ import {
   SvgPaintBrush,
   SvgProgressBars,
   SvgSearchMenu,
+  SvgShield,
   SvgTerminal,
   SvgThumbsUp,
   SvgUploadCloud,
@@ -238,6 +239,12 @@ export const ADMIN_ROUTES = {
     icon: SvgDownload,
     title: "Debug Logs",
     sidebarLabel: "Debug Logs",
+  },
+  SECURITY_HARDENING: {
+    path: "/admin/security",
+    icon: SvgShield,
+    title: "Security and Hardening",
+    sidebarLabel: "Security and Hardening",
   },
   // Prefix-only entries used for layout matching — not rendered as sidebar
   // items or page headers.


### PR DESCRIPTION
## Summary
- Adds a new `/admin/security` route titled "Security and Hardening" with the standard admin page chrome (shield icon, sticky header, settings layout).
- Registers a `SECURITY_HARDENING` entry in `web/src/lib/admin-routes.ts` so the page header pulls icon and title from the central route registry.
- Intentionally **not** wired into `AdminSidebar.tsx` while the page is a WIP — same convention as `/admin/debug`.

## Test plan
- [ ] Navigate to `http://localhost:3000/admin/security` while signed in as an admin and confirm the page renders with the shield icon + "Security and Hardening" header and an empty body.
- [ ] Confirm the admin sidebar does **not** display a "Security and Hardening" entry.
- [ ] Confirm `/admin/security` redirects to login when signed out (inherited from the shared admin layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `/admin/security` “Security and Hardening” admin page stub using the standard admin layout and header. Registers `SECURITY_HARDENING` in `ADMIN_ROUTES` (with shield icon and title) and intentionally leaves it out of the sidebar while the page is WIP.

<sup>Written for commit 45102758ce4cfc0feb8257d7fa86e28af0b980a4. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11200?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

