### PR TITLE
fix(opal): build dist via prepare hook on npm ci

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -13,20 +13,19 @@ FROM base AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy package files first for better layer caching
-# This layer will be cached unless package.json or package-lock.json changes
-COPY package.json package-lock.json ./
-COPY lib/opal/package.json ./lib/opal/
+# Copy package files + the full opal workspace source so that opal's `prepare`
+# lifecycle hook (which runs during `npm ci` for workspace packages) can build
+# `dist/` artifacts before Next.js resolves package exports. opal's tsconfig
+# extends web's `tsconfig.json`, so that file must also be present at install
+# time for the DTS build to succeed.
+COPY package.json package-lock.json tsconfig.json ./
+COPY lib/opal/ ./lib/opal/
 
-# Install dependencies
+# Install dependencies. opal's `prepare` script builds dist/ as part of install.
 RUN npm ci
 
-# pull in source code / package.json / package-lock.json
+# pull in remaining source code
 COPY . .
-
-# Build the opal design-system package so dist/ artifacts (colors.css, root.css,
-# styles.css, JS bundles) exist before Next.js resolves package exports.
-RUN npm run build --workspace=lib/opal
 
 # needed to get the `standalone` dir we expect later
 ENV NEXT_PRIVATE_STANDALONE=true

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -64,7 +64,7 @@
   },
   "scripts": {
     "build": "tsup && node scripts/bundle-css.mjs",
-    "prepublishOnly": "npm run build"
+    "prepare": "npm run build"
   },
   "dependencies": {
     "clsx": "^2.0.0",


### PR DESCRIPTION
## Description

**Bug:** Storybook Deploy and Vercel Deploy-Preview fail on `main` after #11122:

```
Package path ./root.css is exported from package @onyx-ai/opal, but no valid target file was found
```

**Cause:** `./root.css` / `./colors.css` exports resolve to `./dist/*.css`. `dist/` is gitignored; only the web Dockerfile builds opal before `next build`. Every other consumer (Vercel, Storybook, fresh `npm ci`, local dev) sees the export with no target on disk.

**Fix:**
- Replace `prepublishOnly: npm run build` with `prepare: npm run build` in `web/lib/opal/package.json`. `prepare` fires automatically on `npm ci` for workspace packages (npm 7+), so `dist/` is populated as part of install — regardless of which downstream command runs next. `prepare` also covers the publish lifecycle, so it strictly subsumes `prepublishOnly`.
- Adjust `web/Dockerfile` to copy `lib/opal/` before `npm ci` so the prepare hook has source to build, and drop the now-redundant explicit `npm run build --workspace=lib/opal` step.

**Trade-off:** the Docker install layer cache invalidates on opal source changes. That's correct: opal is a workspace dependency, so install state legitimately depends on it. ~5s extra on opal-source diffs.

Verified locally: `rm -rf web/lib/opal/dist && npm ci` → `dist/{root,colors,styles}.css` present (~31s, +~5s vs prior install).

## How Has This Been Tested?



## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check