### PR TITLE
fix(ci): build opal package before vercel deploy-preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Pull Vercel Environment Information
         run: npx --yes ${{ env.VERCEL_CLI }} pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
+      - name: Build Opal package
+        working-directory: ./web
+        run: npm ci && npm run build --workspace=lib/opal
+
       - name: Build Project Artifacts
         run: npx --yes ${{ env.VERCEL_CLI }} build --token=${{ secrets.VERCEL_TOKEN }}
 


### PR DESCRIPTION
## Description

`vercel build` runs `npm run build` (Next.js) internally without first building the local `@onyx-ai/opal` workspace package. Since `lib/opal/dist/` is gitignored, `dist/root.css` doesn't exist when Next.js tries to resolve `@opal/root.css` from `globals.css`, causing the build to fail with:

```
Package path ./root.css is exported from package @onyx-ai/opal,
but no valid target file was found
```

Adds an explicit `npm ci && npm run build --workspace=lib/opal` step before `vercel build` so the dist artifacts are present.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes preview deployments by building the `@onyx-ai/opal` workspace before `vercel build`, ensuring `dist/root.css` exists and preventing Next.js build failures.

- **Bug Fixes**
  - Add CI step in `.github/workflows/preview.yml` to run `npm ci && npm run build --workspace=lib/opal` in `web` before the Vercel build.

<sup>Written for commit 3a8df056b5a12c42a8c9f1be1fb7a9d24c75ab84. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11204?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->