### PR TITLE
chore(opal): build opal locally after npm i

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "web",
       "version": "1.0.0-dev",
+      "hasInstallScript": true,
       "workspaces": [
         "lib/opal"
       ],
@@ -9855,6 +9856,7 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
     "lib/opal"
   ],
   "scripts": {
+    "postinstall": "npm run build --workspace=@onyx-ai/opal",
     "dev": "next dev",
     "dev:profile": "NEXT_PUBLIC_ENABLE_STATS=true next dev",
     "build": "next build",


### PR DESCRIPTION
## Description

non-FE-gang don't have Opal built locally, but `web/src/app/globals.css` imports `@onyx-ai/opal/root.css` from the workspace-linked package's `dist/`. Postinstall now builds Opal so the import resolves on a fresh npm i.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically builds `@onyx-ai/opal` after `npm i` so the web app always has a compiled local package. Adds a `postinstall` script in `web/package.json` to run `npm run build --workspace=@onyx-ai/opal`.

<sup>Written for commit 76c3c61150c95632a803aa2095be64eb85e7625a. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

