### PR TITLE
feat(craft): template sandbox RBAC + ServiceAccount in helm chart

### DIFF
--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -37,7 +37,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.serviceAccountName" . }}-sandbox-binding
+  name: {{ include "onyx.fullname" . }}-sandbox-binding
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -1,0 +1,69 @@
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+{{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $saName := .Values.configMap.SANDBOX_SERVICE_ACCOUNT_NAME | default "sandbox-file-sync" }}
+{{- $craft := .Values.craft | default dict }}
+{{- $roleArn := required "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=\"true\" (IAM role ARN to bind to the sandbox-file-sync ServiceAccount via IRSA)" $craft.sandboxFileSyncRoleArn }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ $roleArn | quote }}
+    eks.amazonaws.com/skip-containers: sandbox
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: api-server-role
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "onyx.serviceAccountName" . }}-sandbox-binding
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: api-server-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "onyx.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- range $extraSa := $craft.extraBoundServiceAccounts | default list }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $extraSa.name }}-sandbox-binding
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: api-server-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ $extraSa.name }}
+    namespace: {{ $extraSa.namespace | default $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -3,6 +3,7 @@
 {{- $saName := .Values.configMap.SANDBOX_SERVICE_ACCOUNT_NAME | default "sandbox-file-sync" }}
 {{- $craft := .Values.craft | default dict }}
 {{- $roleArn := required "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=\"true\" (IAM role ARN to bind to the sandbox-file-sync ServiceAccount via IRSA)" $craft.sandboxFileSyncRoleArn }}
+{{- $roleName := printf "%s-api-server-role" (include "onyx.fullname" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -18,7 +19,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: api-server-role
+  name: {{ $roleName }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -28,7 +29,7 @@ rules:
     verbs: ["create", "get", "list", "watch", "delete"]
   - apiGroups: [""]
     resources: ["pods/exec"]
-    verbs: ["create", "get"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "get", "list", "watch", "delete"]
@@ -43,7 +44,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: api-server-role
+  name: {{ $roleName }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "onyx.serviceAccountName" . }}
@@ -60,7 +61,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: api-server-role
+  name: {{ $roleName }}
 subjects:
   - kind: ServiceAccount
     name: {{ $extraSa.name }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -54,7 +54,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $extraSa.name }}-sandbox-binding
+  name: {{ printf "%s-%s-%s-sandbox-binding" (include "onyx.fullname" $) ($extraSa.namespace | default $.Release.Namespace) $extraSa.name | trunc 63 | trimSuffix "-" }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" $ | nindent 4 }}

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -95,6 +95,11 @@ codeInterpreter:
 
 # ---- Craft / Sandbox ----
 
+# IRSA isn't functional on local kind clusters, but the chart requires a non-empty
+# value when ENABLE_CRAFT=true. The annotation is harmless on kind.
+craft:
+  sandboxFileSyncRoleArn: "arn:aws:iam::000000000000:role/localdev-sandbox-placeholder"
+
 configMap:
   ENABLE_CRAFT: "true"
   SANDBOX_API_SERVER_URL: "http://onyx-api-service.onyx.svc.cluster.local:8080"

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1309,6 +1309,27 @@ auth:
     values:
       private_key: ""
 
+# -- Craft (sandbox code-execution feature) configuration. Used only when
+# `configMap.ENABLE_CRAFT` is set to "true". Templated by sandbox-namespace.yaml,
+# sandbox-rbac.yaml and network-policy-sandbox-push.yaml. When ENABLE_CRAFT is
+# unset/false, the entire craft block is ignored.
+craft:
+  # -- IAM role ARN granted to the sandbox ServiceAccount via IRSA. The role's
+  # trust policy must permit the cluster's OIDC provider + sandbox namespace +
+  # ServiceAccount name (see configMap.SANDBOX_NAMESPACE and
+  # configMap.SANDBOX_SERVICE_ACCOUNT_NAME). Required when ENABLE_CRAFT="true";
+  # otherwise helm install/upgrade will fail fast with a clear error.
+  sandboxFileSyncRoleArn: ""
+  # -- Additional workload ServiceAccounts (beyond the chart's main
+  # `onyx.serviceAccountName`) that need to manage sandbox pods. Most clusters
+  # leave this empty — the main workload SA covers api-server and Celery
+  # workers. Set if you've split Celery workers onto a dedicated SA.
+  # Example:
+  #   extraBoundServiceAccounts:
+  #     - name: celery-worker-sandbox-sa
+  #       namespace: onyx
+  extraBoundServiceAccounts: []
+
 configMap:
   # WARNING: do NOT copy hostname keys from a docker-compose .env into this
   # block. The compose stack uses underscored service names (e.g. `api_server`,
@@ -1405,6 +1426,9 @@ configMap:
   # Sandbox config — always "kubernetes" for Helm deployments
   SANDBOX_BACKEND: "kubernetes"
   SANDBOX_NAMESPACE: "onyx-sandboxes"
+  # ServiceAccount that runs the sandbox file-sync sidecar (in the
+  # SANDBOX_NAMESPACE). Created by sandbox-rbac.yaml when ENABLE_CRAFT="true".
+  SANDBOX_SERVICE_ACCOUNT_NAME: "sandbox-file-sync"
 
 # -- Additional arbitrary manifests to render as part of the release. Each entry
 # may be either a YAML mapping (a single Kubernetes object) or a multi-line


### PR DESCRIPTION
## Description

Closes part of [docs/craft/infra/todos.md](https://github.com/onyx-dot-app/onyx/blob/main/docs/craft/infra/todos.md) item 1 (Helm template: sandbox namespace RBAC + ServiceAccount).

When `configMap.ENABLE_CRAFT="true"` the chart now renders, in the sandbox namespace:
- `sandbox-file-sync` ServiceAccount with `eks.amazonaws.com/role-arn` (from required `craft.sandboxFileSyncRoleArn`) and `eks.amazonaws.com/skip-containers: sandbox` annotations — only the file-sync sidecar receives cloud credentials, the user-code container does not.
- Role `api-server-role` granting `pods`, `pods/exec`, `services`.
- RoleBinding from that Role to the chart's main workload ServiceAccount (`onyx.serviceAccountName`).
- Optional extra RoleBindings via `craft.extraBoundServiceAccounts` for clusters that split Celery workers onto a dedicated SA.

`craft.sandboxFileSyncRoleArn` is required when ENABLE_CRAFT is on — a misconfigured deploy fails fast with a clear message instead of silently producing an SA without IRSA. `values-localdev.yaml` gets a placeholder ARN so localdev keeps rendering (IRSA is a no-op on kind anyway).

Removes the manual `kubectl apply` / `kubectl annotate` steps from the onboarding guide.

## How Has This Been Tested?

- [x] `helm template . --set configMap.ENABLE_CRAFT=true ...` (without role ARN) errors with the required-value message at `templates/sandbox-rbac.yaml:5`
- [x] `helm template . --set configMap.ENABLE_CRAFT=true --set craft.sandboxFileSyncRoleArn=arn:aws:iam::...:role/test` renders SA + Role + RoleBinding with correct annotations and `api-server-role` rules
- [x] `helm template .` (defaults, `ENABLE_CRAFT` unset) renders zero sandbox-rbac resources
- [x] `helm lint .` and `helm lint . -f values-localdev.yaml` pass
- [ ] On a cluster with `ENABLE_CRAFT=true`, `helm upgrade` adopts pre-existing Helm-labeled resources cleanly (existing namespace + network-policy-sandbox-push already managed); SA/Role/RoleBinding need a one-time relabel-or-recreate where they were applied imperatively

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Helm templating for Craft sandbox RBAC and the `sandbox-file-sync` ServiceAccount. Enabling Craft now only needs `configMap.ENABLE_CRAFT="true"` and `craft.sandboxFileSyncRoleArn`, removing manual kubectl steps.

- New Features
  - Renders `sandbox-file-sync` ServiceAccount in the sandbox namespace with IRSA (`eks.amazonaws.com/role-arn`) and `eks.amazonaws.com/skip-containers: sandbox`.
  - Adds release-prefixed `api-server-role` with:
    - pods: create/get/list/watch/delete
    - pods/exec: create
    - services: create/get/list/watch/delete
  - Release-scoped primary RoleBinding binds the role to `onyx.serviceAccountName`; extra bindings via `craft.extraBoundServiceAccounts` use release+namespace-scoped names to prevent collisions.
  - Requires `craft.sandboxFileSyncRoleArn` when enabled; adds a placeholder in `values-localdev.yaml`.
  - No sandbox RBAC manifests render when Craft is disabled.

- Migration
  - Set `configMap.ENABLE_CRAFT="true"` and provide `craft.sandboxFileSyncRoleArn`.
  - Optionally set `craft.extraBoundServiceAccounts` if Celery runs on a separate ServiceAccount.
  - Existing manually applied SA/Role/RoleBinding may need relabel or recreate for Helm adoption.

<sup>Written for commit ef52ed06e03ba7f328e1c69640ffa27e6c00f85f. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

