### PR TITLE
feat(craft): Terraform module for sandbox S3 bucket + IRSA role

### DIFF
--- a/deployment/terraform/modules/aws/craft_sandbox/main.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/main.tf
@@ -42,6 +42,24 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
   }
 }
 
+# Backstop against orphaned multipart-upload parts: aborts incomplete uploads
+# after 7 days. Does not expire completed objects — sandbox-snapshot retention
+# is a product decision and should be configured separately if/when needed.
+resource "aws_s3_bucket_lifecycle_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+
+  rule {
+    id     = "abort-incomplete-multipart-uploads"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
 resource "aws_iam_policy" "sandbox" {
   name = local.policy_name
 
@@ -55,6 +73,12 @@ resource "aws_iam_policy" "sandbox" {
           "s3:GetObject",
           "s3:PutObject",
           "s3:DeleteObject",
+          # AbortMultipartUpload is necessary so the file-sync sidecar can
+          # clean up parts from failed/abandoned uploads. Without it,
+          # orphaned parts accumulate silently (billed but invisible to
+          # `s3:ListBucket`). Paired with the lifecycle rule below as a
+          # backstop.
+          "s3:AbortMultipartUpload",
         ]
         Resource = "${aws_s3_bucket.sandbox.arn}/*"
       },

--- a/deployment/terraform/modules/aws/craft_sandbox/main.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/main.tf
@@ -1,0 +1,101 @@
+# Provisions the cloud-side prerequisites for the Craft sandbox feature on a
+# single EKS cluster:
+#   - S3 bucket (AES-256, public access blocked) for sandbox snapshots / file-sync
+#   - IAM policy granting RW on that bucket
+#   - IAM role assumable via IRSA by the sandbox-file-sync ServiceAccount
+#
+# Outputs (`role_arn`, `bucket_name`) wire into the Helm chart's
+# `craft.sandboxFileSyncRoleArn` and `configMap.SANDBOX_S3_BUCKET` values.
+
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+locals {
+  oidc_issuer    = trimprefix(var.cluster_oidc_issuer_url, "https://")
+  primary_sub    = "system:serviceaccount:${var.sandbox_namespace}:${var.service_account_name}"
+  trust_subjects = concat([local.primary_sub], var.extra_trust_subjects)
+
+  role_name   = coalesce(var.role_name, "SandboxFileSyncRole-${var.cluster_name}")
+  policy_name = coalesce(var.policy_name, "${var.cluster_name}-sandbox-s3-policy")
+}
+
+resource "aws_s3_bucket" "sandbox" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "sandbox" {
+  bucket                  = aws_s3_bucket.sandbox.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_iam_policy" "sandbox" {
+  name = local.policy_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "RWObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+        ]
+        Resource = "${aws_s3_bucket.sandbox.arn}/*"
+      },
+      {
+        Sid      = "ListBucket"
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.sandbox.arn
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role" "sandbox" {
+  name = local.role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_issuer}"
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oidc_issuer}:aud" = "sts.amazonaws.com"
+            "${local.oidc_issuer}:sub" = local.trust_subjects
+          }
+        }
+      }
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sandbox" {
+  role       = aws_iam_role.sandbox.name
+  policy_arn = aws_iam_policy.sandbox.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
@@ -1,0 +1,14 @@
+output "role_arn" {
+  description = "ARN of the IAM role. Set this as `craft.sandboxFileSyncRoleArn` in the Helm chart values."
+  value       = aws_iam_role.sandbox.arn
+}
+
+output "bucket_name" {
+  description = "Name of the sandbox S3 bucket. Set this as `configMap.SANDBOX_S3_BUCKET` in the Helm chart values."
+  value       = aws_s3_bucket.sandbox.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the sandbox S3 bucket."
+  value       = aws_s3_bucket.sandbox.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/variables.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/variables.tf
@@ -1,0 +1,50 @@
+variable "cluster_name" {
+  description = "EKS cluster name. Used for default resource naming."
+  type        = string
+}
+
+variable "cluster_oidc_issuer_url" {
+  description = "EKS cluster OIDC issuer URL (https://oidc.eks.<region>.amazonaws.com/id/<id>). The `https://` prefix is optional; the module strips it before use."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "Globally-unique S3 bucket name for sandbox snapshots / file-sync."
+  type        = string
+}
+
+variable "sandbox_namespace" {
+  description = "Kubernetes namespace where the sandbox-file-sync ServiceAccount lives. Must match `configMap.SANDBOX_NAMESPACE` in the Helm values."
+  type        = string
+  default     = "onyx-sandboxes"
+}
+
+variable "service_account_name" {
+  description = "Kubernetes ServiceAccount name bound to this IAM role via IRSA. Must match `configMap.SANDBOX_SERVICE_ACCOUNT_NAME` in the Helm values."
+  type        = string
+  default     = "sandbox-file-sync"
+}
+
+variable "extra_trust_subjects" {
+  description = "Additional `sub` claims (beyond the primary `system:serviceaccount:<sandbox_namespace>:<service_account_name>`) that may assume this role. Rarely needed; useful when migrating from an older configuration that bound a different SA to this role."
+  type        = list(string)
+  default     = []
+}
+
+variable "role_name" {
+  description = "Override for the IAM role name. Defaults to `SandboxFileSyncRole-<cluster_name>`."
+  type        = string
+  default     = null
+}
+
+variable "policy_name" {
+  description = "Override for the IAM policy name. Defaults to `<cluster_name>-sandbox-s3-policy`."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to provisioned AWS resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/versions.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.100"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Closes part of [docs/craft/infra/todos.md](https://github.com/onyx-dot-app/onyx/blob/main/docs/craft/infra/todos.md) item 2 (Terraform module: sandbox object store + workload-identity role). Paired with #11208 (chart-side template).

New module at `deployment/terraform/modules/aws/craft_sandbox/`:
- `aws_s3_bucket` for sandbox snapshots / file-sync (AES-256 SSE, all four public-access-block flags on).
- `aws_iam_policy` granting the sandbox SA `s3:GetObject` / `PutObject` / `DeleteObject` on bucket objects and `s3:ListBucket` on the bucket itself.
- `aws_iam_role` with an `AssumeRoleWithWebIdentity` trust policy scoped to the cluster's OIDC provider and `system:serviceaccount:<sandbox_namespace>:<service_account_name>` (defaults match the chart's defaults).
- Outputs `role_arn`, `bucket_name`, `bucket_arn` to wire into the Helm chart values:
  - `craft.sandboxFileSyncRoleArn = module.craft_sandbox.role_arn`
  - `configMap.SANDBOX_S3_BUCKET = module.craft_sandbox.bucket_name`

Inputs are documented in `variables.tf`; the defaults (`sandbox_namespace = "onyx-sandboxes"`, `service_account_name = "sandbox-file-sync"`, role/policy names derived from `cluster_name`) match what the chart in #11208 produces.

Together with #11208, onboarding a new Craft cluster goes from a manual `aws iam create-role` + `aws s3api create-bucket` + `kubectl annotate sa ...` runbook to two commands:

```bash
terraform apply
helm upgrade --install onyx onyx/onyx --values values.yaml \
  --set craft.sandboxFileSyncRoleArn=$(terraform output -raw role_arn) \
  --set configMap.SANDBOX_S3_BUCKET=$(terraform output -raw bucket_name)
```

## How Has This Been Tested?

- [x] `terraform validate` passes on a workspace that consumes the module
- [x] `terraform plan` against the existing st-dev workspace shows the 6 expected `will be created` entries (`aws_s3_bucket`, `aws_s3_bucket_public_access_block`, `aws_s3_bucket_server_side_encryption_configuration`, `aws_iam_policy`, `aws_iam_role`, `aws_iam_role_policy_attachment`) with the correct rendered names (`SandboxFileSyncRole-onyx-st-dev`, `onyx-st-dev-sandbox-s3-policy`, `onyx-sandbox-st-dev`) and the correct OIDC trust subject (`system:serviceaccount:onyx-sandboxes:sandbox-file-sync`)
- [x] Same plan against `craft-dev` workspace renders correct names for that cluster
- [ ] Real apply happens via the companion infra-side PR after importing the existing bucket + role for st-dev (so we don't recreate live state)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Terraform module that provisions the sandbox S3 bucket and an IRSA role for Craft on EKS. Adds multipart upload hygiene to prevent orphaned parts, making new-cluster setup a quick `terraform apply` + `helm upgrade`.

- **New Features**
  - Module at `deployment/terraform/modules/aws/craft_sandbox/` with outputs: `role_arn`, `bucket_name`, `bucket_arn`. Wire to Helm as `craft.sandboxFileSyncRoleArn` and `configMap.SANDBOX_S3_BUCKET`.
  - S3 bucket with AES-256 encryption, all public access blocked, and a lifecycle rule to abort incomplete multipart uploads after 7 days.
  - IAM policy: `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`, `s3:AbortMultipartUpload` on objects; `s3:ListBucket` on the bucket.
  - IRSA role with OIDC trust for `system:serviceaccount:<sandbox_namespace>:<service_account_name>` (defaults: `onyx-sandboxes` / `sandbox-file-sync`), plus optional `extra_trust_subjects`.

<sup>Written for commit 2de9325dc5c1e95b9a75529e66e8e234240a4133. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11213?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

