### PR TITLE
feat(craft): toggleable sandbox node group + IMDSv2 hardening

### DIFF
--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -27,7 +27,7 @@ module "eks" {
     ami_type = "AL2023_x86_64_STANDARD"
   }
 
-  eks_managed_node_groups = {
+  eks_managed_node_groups = merge({
     for k, v in var.eks_managed_node_groups : k => merge(v,
       {
         instance_types = v.instance_types != null ? v.instance_types : (
@@ -45,7 +45,9 @@ module "eks" {
         subnet_ids = var.main_node_subnet_ids
       } : {}
     )
-  }
+    },
+    var.craft_sandbox_node_group != null ? { sandbox = var.craft_sandbox_node_group } : {}
+  )
 
   tags = var.tags
 }

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -1,4 +1,18 @@
 locals {
+  # Default-supply IMDSv2 + hop-limit 1 for the sandbox NG so omitting
+  # metadata_options is safe by default; explicit overrides are validated in
+  # the craft_sandbox_node_group variable definition.
+  craft_sandbox_normalized = var.craft_sandbox_node_group != null ? merge(
+    {
+      metadata_options = {
+        http_endpoint               = "enabled"
+        http_tokens                 = "required"
+        http_put_response_hop_limit = 1
+      }
+    },
+    var.craft_sandbox_node_group,
+  ) : null
+
   s3_bucket_arns = [for name in var.s3_bucket_names : {
     bucket_arn     = "arn:aws:s3:::${name}"
     bucket_objects = "arn:aws:s3:::${name}/*"
@@ -46,7 +60,7 @@ module "eks" {
       } : {}
     )
     },
-    var.craft_sandbox_node_group != null ? { sandbox = var.craft_sandbox_node_group } : {}
+    local.craft_sandbox_normalized != null ? { craft_sandbox = local.craft_sandbox_normalized } : {}
   )
 
   tags = var.tags

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -1,16 +1,22 @@
 locals {
   # Default-supply IMDSv2 + hop-limit 1 for the sandbox NG so omitting
-  # metadata_options is safe by default; explicit overrides are validated in
-  # the craft_sandbox_node_group variable definition.
+  # metadata_options is safe by default. metadata_options is deep-merged so
+  # explicit per-field overrides don't erase the hardened siblings (e.g. a
+  # caller setting only http_endpoint still inherits http_tokens = required
+  # and hop_limit = 1). The variable's validation block also rejects
+  # explicit weakenings of the security-relevant fields.
   craft_sandbox_normalized = var.craft_sandbox_node_group != null ? merge(
-    {
-      metadata_options = {
-        http_endpoint               = "enabled"
-        http_tokens                 = "required"
-        http_put_response_hop_limit = 1
-      }
-    },
     var.craft_sandbox_node_group,
+    {
+      metadata_options = merge(
+        {
+          http_endpoint               = "enabled"
+          http_tokens                 = "required"
+          http_put_response_hop_limit = 1
+        },
+        coalesce(try(var.craft_sandbox_node_group.metadata_options, null), {}),
+      )
+    },
   ) : null
 
   s3_bucket_arns = [for name in var.s3_bucket_names : {

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -191,12 +191,38 @@ variable "cloudwatch_log_group_retention_in_days" {
 }
 
 variable "craft_sandbox_node_group" {
-  type        = any
+  type = object({
+    name                            = optional(string)
+    use_name_prefix                 = optional(bool)
+    instance_types                  = optional(list(string))
+    capacity_type                   = optional(string)
+    ami_type                        = optional(string)
+    min_size                        = optional(number)
+    max_size                        = optional(number)
+    desired_size                    = optional(number)
+    iam_role_use_name_prefix        = optional(bool)
+    iam_role_name                   = optional(string)
+    launch_template_use_name_prefix = optional(bool)
+    launch_template_name            = optional(string)
+    subnet_ids                      = optional(list(string))
+    metadata_options = optional(object({
+      http_endpoint               = optional(string)
+      http_tokens                 = optional(string)
+      http_put_response_hop_limit = optional(number)
+    }))
+    labels = optional(map(string))
+    taints = optional(list(object({
+      key    = string
+      value  = optional(string)
+      effect = string
+    })))
+    block_device_mappings = optional(any)
+    tags                  = optional(map(string))
+  })
   description = <<-EOT
     Optional sandbox node group for the Craft feature. When non-null, the
     module adds a `craft_sandbox` entry to its `eks_managed_node_groups`
-    map. Pass the per-NG config (instance_types, min/max_size,
-    iam_role_name, taints, labels, etc.) as a map; everything is forwarded
+    map. Pass the per-NG config as a typed object; everything is forwarded
     to terraform-aws-modules/eks/aws.
 
     Codifies items 3 + 4 of docs/craft/infra/todos.md:
@@ -204,11 +230,11 @@ variable "craft_sandbox_node_group" {
         means the upstream module auto-attaches both the cluster primary SG
         (via EKS default) and the cluster's shared node SG (via the LT) to
         sandbox instances, matching the regular node groups.
-      * Item 4 (IMDSv2 hop limit 1): if you omit `metadata_options`, the
-        module supplies a hardened default (`http_tokens = "required"`,
-        `http_put_response_hop_limit = 1`). Explicit overrides are
-        validated below — IMDSv1 / hop-limit > 1 is rejected so the
-        security property holds by construction, not by convention.
+      * Item 4 (IMDSv2 hop limit 1): the module deep-merges your
+        `metadata_options` over hardened defaults (`http_endpoint=enabled`,
+        `http_tokens=required`, `http_put_response_hop_limit=1`). Omit
+        metadata_options to inherit the defaults; per-field overrides are
+        accepted but rejected below if they weaken IMDSv2 or hop-limit.
 
     Leave null for clusters that don't run Craft.
   EOT
@@ -219,10 +245,10 @@ variable "craft_sandbox_node_group" {
       var.craft_sandbox_node_group == null
       || try(var.craft_sandbox_node_group.metadata_options, null) == null
       || (
-        try(var.craft_sandbox_node_group.metadata_options.http_tokens, "") == "required"
-        && try(var.craft_sandbox_node_group.metadata_options.http_put_response_hop_limit, 0) == 1
+        coalesce(try(var.craft_sandbox_node_group.metadata_options.http_tokens, null), "required") == "required"
+        && coalesce(try(var.craft_sandbox_node_group.metadata_options.http_put_response_hop_limit, null), 1) == 1
       )
     )
-    error_message = "craft_sandbox_node_group.metadata_options must enforce IMDSv2 (http_tokens = \"required\") and hop-limit 1 (http_put_response_hop_limit = 1). Omit metadata_options entirely to use the module's hardened defaults."
+    error_message = "craft_sandbox_node_group.metadata_options, if any field is set, must keep IMDSv2 (http_tokens = \"required\") and hop-limit 1 (http_put_response_hop_limit = 1). Omit metadata_options entirely to inherit the module's hardened defaults."
   }
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -194,21 +194,35 @@ variable "craft_sandbox_node_group" {
   type        = any
   description = <<-EOT
     Optional sandbox node group for the Craft feature. When non-null, the
-    module adds a `sandbox` entry to its `eks_managed_node_groups` map. Pass
-    the per-NG config (instance_types, min/max_size, iam_role_name, taints,
-    labels, metadata_options, etc.) as a map; everything is forwarded
-    verbatim to terraform-aws-modules/eks/aws.
+    module adds a `craft_sandbox` entry to its `eks_managed_node_groups`
+    map. Pass the per-NG config (instance_types, min/max_size,
+    iam_role_name, taints, labels, etc.) as a map; everything is forwarded
+    to terraform-aws-modules/eks/aws.
 
     Codifies items 3 + 4 of docs/craft/infra/todos.md:
-      * Items 3 (SG composition): being in this map means the upstream EKS
-        module auto-attaches both the cluster primary SG (via EKS default)
-        and the cluster's shared node SG (via the LT) to sandbox instances,
-        matching the regular node groups.
-      * Item 4 (IMDSv2 hop limit 1): callers should set
-        `metadata_options = { http_tokens = "required", http_put_response_hop_limit = 1 }`
-        so containers cannot reach the instance metadata service.
+      * Item 3 (SG composition): being in the EKS managed node groups map
+        means the upstream module auto-attaches both the cluster primary SG
+        (via EKS default) and the cluster's shared node SG (via the LT) to
+        sandbox instances, matching the regular node groups.
+      * Item 4 (IMDSv2 hop limit 1): if you omit `metadata_options`, the
+        module supplies a hardened default (`http_tokens = "required"`,
+        `http_put_response_hop_limit = 1`). Explicit overrides are
+        validated below — IMDSv1 / hop-limit > 1 is rejected so the
+        security property holds by construction, not by convention.
 
     Leave null for clusters that don't run Craft.
   EOT
   default     = null
+
+  validation {
+    condition = (
+      var.craft_sandbox_node_group == null
+      || try(var.craft_sandbox_node_group.metadata_options, null) == null
+      || (
+        try(var.craft_sandbox_node_group.metadata_options.http_tokens, "") == "required"
+        && try(var.craft_sandbox_node_group.metadata_options.http_put_response_hop_limit, 0) == 1
+      )
+    )
+    error_message = "craft_sandbox_node_group.metadata_options must enforce IMDSv2 (http_tokens = \"required\") and hop-limit 1 (http_put_response_hop_limit = 1). Omit metadata_options entirely to use the module's hardened defaults."
+  }
 }

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -189,3 +189,26 @@ variable "cloudwatch_log_group_retention_in_days" {
     error_message = "Must be a valid CloudWatch retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653)."
   }
 }
+
+variable "craft_sandbox_node_group" {
+  type        = any
+  description = <<-EOT
+    Optional sandbox node group for the Craft feature. When non-null, the
+    module adds a `sandbox` entry to its `eks_managed_node_groups` map. Pass
+    the per-NG config (instance_types, min/max_size, iam_role_name, taints,
+    labels, metadata_options, etc.) as a map; everything is forwarded
+    verbatim to terraform-aws-modules/eks/aws.
+
+    Codifies items 3 + 4 of docs/craft/infra/todos.md:
+      * Items 3 (SG composition): being in this map means the upstream EKS
+        module auto-attaches both the cluster primary SG (via EKS default)
+        and the cluster's shared node SG (via the LT) to sandbox instances,
+        matching the regular node groups.
+      * Item 4 (IMDSv2 hop limit 1): callers should set
+        `metadata_options = { http_tokens = "required", http_put_response_hop_limit = 1 }`
+        so containers cannot reach the instance metadata service.
+
+    Leave null for clusters that don't run Craft.
+  EOT
+  default     = null
+}

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -91,6 +91,9 @@ module "eks" {
   # Control plane logging
   cluster_enabled_log_types              = var.eks_cluster_enabled_log_types
   cloudwatch_log_group_retention_in_days = var.eks_cloudwatch_log_group_retention_in_days
+
+  # Forwarded to eks/main.tf so callers can opt into the Craft sandbox node group.
+  craft_sandbox_node_group = var.craft_sandbox_node_group
 }
 
 module "waf" {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -293,3 +293,9 @@ variable "eks_cloudwatch_log_group_retention_in_days" {
     error_message = "Must be a valid CloudWatch retention value (0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653)."
   }
 }
+
+variable "craft_sandbox_node_group" {
+  type        = any
+  description = "Forwarded to the eks module's craft_sandbox_node_group input. When non-null, adds a `sandbox` entry to the cluster's EKS managed node group map (used by the Craft feature). See deployment/terraform/modules/aws/eks for the full input shape."
+  default     = null
+}


### PR DESCRIPTION
## Description

Closes items 3 + 4 of [docs/craft/infra/todos.md](https://github.com/onyx-dot-app/onyx/blob/main/docs/craft/infra/todos.md). Builds on #11208 (chart RBAC) and #11213 (sandbox bucket/IRSA TF module).

Adds a `craft_sandbox_node_group` input to the eks module (passed through from the composite onyx module). When non-null, the module appends a `sandbox` entry to its `eks_managed_node_groups` map; leave null on clusters that don't run Craft and no resources are provisioned.

**Item 3 — security-group composition:** by living inside `terraform-aws-modules/eks/aws`'s `eks_managed_node_groups` map, the sandbox NG automatically gets the cluster primary SG (via EKS default at the node-group level) and the cluster's shared node SG (via the LT, set by the upstream module). Sandbox pods can now reach pods on the regular node groups — the previous failure mode (DNS / in-cluster service calls timing out) was caused by the shared node SG's self-referential ingress not matching sandbox-node traffic when only the cluster SG was attached.

**Item 4 — IMDSv2 + hop-limit 1:** callers pass `metadata_options` in the input object; the upstream module wires it directly into the LT. Recommended caller config:

```hcl
metadata_options = {
  http_endpoint               = "enabled"
  http_tokens                 = "required"
  http_put_response_hop_limit = 1
}
```

Sample caller (e.g. for a customer deploying Craft):

```hcl
module "onyx" {
  source = "github.com/onyx-dot-app/onyx//deployment/terraform/modules/aws/onyx"
  # ... cluster, vpc, postgres, etc. inputs ...

  craft_sandbox_node_group = {
    name                            = "sandbox-nodes"
    use_name_prefix                 = false
    instance_types                  = ["m5.large"]
    min_size                        = 0
    max_size                        = 4
    desired_size                    = 1
    iam_role_use_name_prefix        = false
    iam_role_name                   = "${var.cluster_name}-sandbox-node-role"
    launch_template_use_name_prefix = false
    launch_template_name            = "${var.cluster_name}-sandbox-node-launch-template"
    metadata_options = {
      http_endpoint               = "enabled"
      http_tokens                 = "required"
      http_put_response_hop_limit = 1
    }
    labels = { "onyx.app/workload" = "sandbox" }
    taints = [{ key = "workload", value = "sandbox", effect = "NO_SCHEDULE" }]
  }
}
```

## How Has This Been Tested?

- [x] `terraform validate` passes against a workspace that consumes the composite onyx module with the new input
- [x] `terraform plan` against the same workspace produces 7 new sandbox resources (NG, IAM role, 3 policy attachments, LT, user_data validator) with the correct rendered names, label, taint, and `metadata_options` (verified `http_put_response_hop_limit = 1`)
- [x] `terraform plan` with `craft_sandbox_node_group = null` produces zero sandbox resources (opt-in works)
- [ ] Real apply happens via the companion infra-side PR after importing the existing sandbox NG on the test-staging cluster and rotating the dev cluster's legacy NG (runbook in the cdy-side PR)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Craft sandbox EKS node group with correct SG wiring and default IMDSv2 hardening; now deep-merges `metadata_options` and strongly types the input for safer defaults and clearer errors. Uses a dedicated `craft_sandbox` map key to avoid collisions.

- **New Features**
  - Added `craft_sandbox_node_group` input (forwarded from `onyx` to `eks`) and merged into `eks_managed_node_groups` as `craft_sandbox`.
  - SG composition matches regular nodes (cluster primary SG + shared node SG via `terraform-aws-modules/eks/aws`), fixing in-cluster DNS/service timeouts.
  - Defaults `metadata_options` to IMDSv2 (`http_tokens="required"`, `http_put_response_hop_limit=1`) and rejects weaker settings via validation.

<sup>Written for commit 432f100c33ce14a73ff4c806807bb3c41fb4fdee. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11216?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

