### PR TITLE
feat(craft): backend-agnostic sandbox cleanup + snapshot stream helpers

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -7,16 +7,19 @@ class SandboxBackend(str, Enum):
     """Backend mode for sandbox operations.
 
     LOCAL: Development mode - no snapshots, no automatic cleanup
-    KUBERNETES: Production mode - full snapshots and cleanup
+    KUBERNETES: Production mode (Helm/cloud) - full snapshots and cleanup
+    DOCKER: Self-hosted docker-compose - api_server drives the Docker Engine
     """
 
     LOCAL = "local"
     KUBERNETES = "kubernetes"
+    DOCKER = "docker"
 
 
 # Sandbox backend mode (controls snapshot and cleanup behavior)
 # "local" = no snapshots, no cleanup (for development)
-# "kubernetes" = full snapshots and cleanup (for production)
+# "kubernetes" = full snapshots and cleanup (production Helm/cloud)
+# "docker" = full snapshots and cleanup (self-hosted docker-compose)
 SANDBOX_BACKEND = SandboxBackend(os.environ.get("SANDBOX_BACKEND", "local"))
 
 # Base directory path for persistent document storage (local filesystem)

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -265,6 +265,24 @@ class SandboxManager(ABC):
         ...
 
     @abstractmethod
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List session workspace IDs under a sandbox's sessions/ directory.
+
+        Used by idle cleanup to discover which sessions need snapshotting before
+        the sandbox is terminated. Implementations should filter out non-UUID
+        directory names.
+
+        Args:
+            sandbox_id: The sandbox ID
+
+        Returns:
+            List of session UUIDs found under sessions/. Returns an empty list
+            if the sandbox is not running, has no sessions, or the backend does
+            not support cleanup (e.g. local).
+        """
+        ...
+
+    @abstractmethod
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
         """Check if the sandbox is healthy.
 
@@ -642,6 +660,16 @@ def get_sandbox_manager() -> SandboxManager:
 
                     _sandbox_manager_instance = KubernetesSandboxManager()
                     logger.info("Using KubernetesSandboxManager for sandbox operations")
+                elif SANDBOX_BACKEND == SandboxBackend.DOCKER:
+                    # The DockerSandboxManager module ships in a follow-up PR.
+                    # Until then, fail with a clear message rather than a
+                    # cryptic ModuleNotFoundError if someone sets
+                    # SANDBOX_BACKEND=docker against this version.
+                    raise NotImplementedError(
+                        "SANDBOX_BACKEND=docker is not available yet — "
+                        "DockerSandboxManager lands in a follow-up PR. "
+                        "Use SANDBOX_BACKEND=kubernetes or local for now."
+                    )
                 else:
                     raise ValueError(f"Unknown sandbox backend: {SANDBOX_BACKEND}")
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1458,6 +1458,51 @@ echo "Session cleanup complete"
             )
             return False
 
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List UUID session directories under /workspace/sessions/ in the pod.
+
+        Used by idle cleanup to discover sessions that need snapshotting.
+        Non-UUID directory names are silently filtered out.
+        """
+        pod_name = self._get_pod_name(str(sandbox_id))
+
+        exec_command = [
+            "/bin/sh",
+            "-c",
+            'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
+        ]
+
+        try:
+            resp = k8s_stream(
+                self._stream_core_api.connect_get_namespaced_pod_exec,
+                name=pod_name,
+                namespace=self._namespace,
+                container="sandbox",
+                command=exec_command,
+                stderr=True,
+                stdin=False,
+                stdout=True,
+                tty=False,
+            )
+        except ApiException as e:
+            logger.warning(
+                "Failed to list session directories for sandbox %s: %s",
+                sandbox_id,
+                e,
+            )
+            return []
+
+        result: list[UUID] = []
+        for raw_line in resp.strip().split("\n"):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                result.append(UUID(line))
+            except ValueError:
+                continue
+        return result
+
     def restore_snapshot(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/local/local_sandbox_manager.py
@@ -677,6 +677,27 @@ class LocalSandboxManager(SandboxManager):
         outputs_path = session_path / "outputs"
         return outputs_path.exists()
 
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        """List UUID session directories under the sandbox's sessions/.
+
+        Used by idle cleanup. Local sandboxes never participate in idle
+        cleanup, but returning the actual list keeps behavior consistent
+        with other backends and is useful for tests and ad-hoc tooling.
+        """
+        sessions_root = self._get_sandbox_path(sandbox_id) / "sessions"
+        if not sessions_root.exists():
+            return []
+
+        result: list[UUID] = []
+        for entry in sessions_root.iterdir():
+            if not entry.is_dir():
+                continue
+            try:
+                result.append(UUID(entry.name))
+            except ValueError:
+                continue
+        return result
+
     def ensure_nextjs_running(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
@@ -239,14 +239,23 @@ class SnapshotManager:
         }
 
         if size_hint is not None:
-            self._file_store.save_file(
-                content=stream,
-                display_name=display_name,
-                file_origin=FileOrigin.SANDBOX_SNAPSHOT,
-                file_type=SNAPSHOT_FILE_TYPE,
-                file_id=storage_path,
-                file_metadata=metadata,
-            )
+            try:
+                self._file_store.save_file(
+                    content=stream,
+                    display_name=display_name,
+                    file_origin=FileOrigin.SANDBOX_SNAPSHOT,
+                    file_type=SNAPSHOT_FILE_TYPE,
+                    file_id=storage_path,
+                    file_metadata=metadata,
+                )
+            except Exception as e:
+                logger.error(
+                    "Failed to create streamed snapshot for sandbox %s: %s",
+                    sandbox_id,
+                    e,
+                )
+                raise RuntimeError(f"Failed to create snapshot: {e}") from e
+
             logger.info(
                 "Created snapshot %s for sandbox %s, size: %s bytes (hint)",
                 snapshot_id,

--- a/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
+++ b/backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py
@@ -1,8 +1,10 @@
 """Snapshot management for sandbox state persistence."""
 
+import shutil
 import tarfile
 import tempfile
 from pathlib import Path
+from typing import IO
 from uuid import uuid4
 
 from onyx.configs.constants import FileOrigin
@@ -194,6 +196,134 @@ class SnapshotManager:
                         "Failed to cleanup temp file %s: %s", tmp_path, cleanup_error
                     )
             # Close the file IO if it's still open
+            try:
+                if file_io:
+                    file_io.close()
+            except Exception:
+                pass
+
+    def create_snapshot_from_stream(
+        self,
+        stream: IO[bytes],
+        sandbox_id: str,
+        tenant_id: str,
+        size_hint: int | None = None,
+    ) -> tuple[str, str, int]:
+        """Persist an already-built tar.gz byte stream as a snapshot.
+
+        This is used by backends (e.g. Docker) that produce the tar stream
+        inside the sandbox container via exec and stream it back to the
+        api_server, so no on-host outputs directory ever exists. The caller
+        is responsible for producing a valid tar.gz stream.
+
+        Args:
+            stream: Binary, readable stream of tar.gz bytes.
+            sandbox_id: Sandbox identifier (string form).
+            tenant_id: Tenant identifier for multi-tenant isolation.
+            size_hint: Optional precomputed size. If provided, avoids buffering
+                to disk to measure the size. Otherwise the stream is spooled
+                to a temp file and the size is reported from there.
+
+        Returns:
+            Tuple of (snapshot_id, storage_path, size_bytes).
+        """
+        snapshot_id = str(uuid4())
+        storage_path = (
+            f"sandbox-snapshots/{tenant_id}/{sandbox_id}/{snapshot_id}.tar.gz"
+        )
+        display_name = f"sandbox-snapshot-{sandbox_id}-{snapshot_id}.tar.gz"
+        metadata = {
+            "sandbox_id": sandbox_id,
+            "tenant_id": tenant_id,
+            "snapshot_id": snapshot_id,
+        }
+
+        if size_hint is not None:
+            self._file_store.save_file(
+                content=stream,
+                display_name=display_name,
+                file_origin=FileOrigin.SANDBOX_SNAPSHOT,
+                file_type=SNAPSHOT_FILE_TYPE,
+                file_id=storage_path,
+                file_metadata=metadata,
+            )
+            logger.info(
+                "Created snapshot %s for sandbox %s, size: %s bytes (hint)",
+                snapshot_id,
+                sandbox_id,
+                size_hint,
+            )
+            return snapshot_id, storage_path, size_hint
+
+        # Spool to a temp file so we can report the real size.
+        tmp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".tar.gz", delete=False
+            ) as tmp_file:
+                tmp_path = tmp_file.name
+                shutil.copyfileobj(stream, tmp_file)
+            size_bytes = Path(tmp_path).stat().st_size
+
+            with open(tmp_path, "rb") as f:
+                self._file_store.save_file(
+                    content=f,
+                    display_name=display_name,
+                    file_origin=FileOrigin.SANDBOX_SNAPSHOT,
+                    file_type=SNAPSHOT_FILE_TYPE,
+                    file_id=storage_path,
+                    file_metadata=metadata,
+                )
+
+            logger.info(
+                "Created snapshot %s for sandbox %s, size: %s bytes",
+                snapshot_id,
+                sandbox_id,
+                size_bytes,
+            )
+            return snapshot_id, storage_path, size_bytes
+        except Exception as e:
+            logger.error(
+                "Failed to create streamed snapshot for sandbox %s: %s",
+                sandbox_id,
+                e,
+            )
+            raise RuntimeError(f"Failed to create snapshot: {e}") from e
+        finally:
+            if tmp_path:
+                try:
+                    Path(tmp_path).unlink(missing_ok=True)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "Failed to cleanup temp file %s: %s",
+                        tmp_path,
+                        cleanup_error,
+                    )
+
+    def restore_snapshot_to_stream(
+        self,
+        storage_path: str,
+        write_stream: IO[bytes],
+    ) -> None:
+        """Stream a stored snapshot's bytes into a caller-provided writer.
+
+        Used by backends (e.g. Docker) that extract the archive inside the
+        sandbox container by piping bytes into a remote ``tar -x`` process,
+        avoiding an on-host extraction step.
+
+        Args:
+            storage_path: The file store path of the snapshot.
+            write_stream: Binary writable stream the bytes are written into.
+        """
+        file_io = None
+        try:
+            file_io = self._file_store.read_file(storage_path, use_tempfile=True)
+            shutil.copyfileobj(file_io, write_stream)
+            logger.info("Streamed snapshot %s to caller writer", storage_path)
+        except Exception as e:
+            logger.error("Failed to stream snapshot %s to writer: %s", storage_path, e)
+            raise RuntimeError(f"Failed to stream snapshot: {e}") from e
+        finally:
             try:
                 if file_io:
                     file_io.close()

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,7 +1,5 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
-from uuid import UUID
-
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
@@ -20,9 +18,6 @@ from onyx.server.features.build.db.build_session import (
     mark_user_sessions_idle__no_commit,
 )
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    KubernetesSandboxManager,
-)
 
 # Snapshot retention period in days
 SNAPSHOT_RETENTION_DAYS = 30
@@ -84,13 +79,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
 
         sandbox_manager = get_sandbox_manager()
 
-        # Type guard for kubernetes-specific methods
-        if not isinstance(sandbox_manager, KubernetesSandboxManager):
-            task_logger.debug(
-                "cleanup_idle_sandboxes_task skipped (not kubernetes backend)"
-            )
-            return
-
         with get_session_with_current_tenant() as db_session:
             idle_sandboxes = get_idle_sandboxes(
                 db_session, SANDBOX_IDLE_TIMEOUT_SECONDS
@@ -114,18 +102,20 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 task_logger.info(f"Putting sandbox {sandbox_id_str} to sleep")
 
                 try:
-                    # List session directories in the pod
-                    session_ids = _list_session_directories(sandbox_manager, sandbox_id)
+                    # List session directories in the sandbox via the
+                    # backend-agnostic manager API. K8s lists pod paths via
+                    # exec; Docker lists container paths via exec; Local
+                    # walks the on-disk sessions/ directory.
+                    session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
                     task_logger.info(
                         f"Found {len(session_ids)} sessions in sandbox {sandbox_id_str}"
                     )
 
                     # Snapshot each session
-                    for session_id_str in session_ids:
+                    for session_id in session_ids:
                         try:
-                            session_id = UUID(session_id_str)
                             task_logger.debug(
-                                f"Creating snapshot for session {session_id_str}"
+                                f"Creating snapshot for session {session_id}"
                             )
                             snapshot_result = sandbox_manager.create_snapshot(
                                 sandbox_id, session_id, tenant_id
@@ -139,11 +129,11 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                     snapshot_result.size_bytes,
                                 )
                                 task_logger.debug(
-                                    f"Snapshot created for session {session_id_str}"
+                                    f"Snapshot created for session {session_id}"
                                 )
                         except Exception as e:
                             task_logger.warning(
-                                f"Failed to create snapshot for session {session_id_str}: {e}"
+                                f"Failed to create snapshot for session {session_id}: {e}"
                             )
                             # Continue with other sessions even if one fails
 
@@ -186,64 +176,6 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
             lock.release()
 
     task_logger.info("cleanup_idle_sandboxes_task completed")
-
-
-def _list_session_directories(
-    sandbox_manager: KubernetesSandboxManager,
-    sandbox_id: UUID,
-) -> list[str]:
-    """List session directory names in the pod's /workspace/sessions/.
-
-    Args:
-        sandbox_manager: The kubernetes sandbox manager
-        sandbox_id: The sandbox ID
-
-    Returns:
-        List of session ID strings (directory names)
-    """
-    from kubernetes.client.rest import ApiException
-    from kubernetes.stream import stream as k8s_stream
-
-    pod_name = sandbox_manager._get_pod_name(str(sandbox_id))
-
-    # List directories in /workspace/sessions/
-    exec_command = [
-        "/bin/sh",
-        "-c",
-        'ls -1 /workspace/sessions/ 2>/dev/null || echo ""',
-    ]
-
-    try:
-        resp = k8s_stream(
-            sandbox_manager._core_api.connect_get_namespaced_pod_exec,
-            name=pod_name,
-            namespace=sandbox_manager._namespace,
-            container="sandbox",
-            command=exec_command,
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
-        )
-
-        # Parse output - one directory name per line
-        session_ids = []
-        for line in resp.strip().split("\n"):
-            line = line.strip()
-            if line:
-                # Validate it looks like a UUID
-                try:
-                    UUID(line)
-                    session_ids.append(line)
-                except ValueError:
-                    # Not a valid UUID, skip
-                    pass
-
-        return session_ids
-
-    except ApiException as e:
-        task_logger.warning(f"Failed to list session directories: {e}")
-        return []
 
 
 # NOTE: in the future, may need to add this. For now, will do manual cleanup.

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -155,6 +155,9 @@ class StubSandboxManager(SandboxManager):
         self.create_snapshot_count: int = 0
         self.restore_snapshot_count: int = 0
         self.session_workspace_exists_count: int = 0
+        self.list_session_workspaces_count: int = 0
+        self.list_session_workspaces_returns: list[UUID] = []
+        self.last_list_session_workspaces_payload: dict[str, Any] | None = None
         self.health_check_count: int = 0
         self.send_message_count: int = 0
         self.list_directory_count: int = 0
@@ -322,6 +325,11 @@ class StubSandboxManager(SandboxManager):
         if self.session_workspace_exists_returns is None:
             raise _not_configured("session_workspace_exists")
         return self.session_workspace_exists_returns
+
+    def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
+        self.list_session_workspaces_count += 1
+        self.last_list_session_workspaces_payload = {"sandbox_id": sandbox_id}
+        return list(self.list_session_workspaces_returns)
 
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
         self.health_check_count += 1

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -156,7 +156,7 @@ class StubSandboxManager(SandboxManager):
         self.restore_snapshot_count: int = 0
         self.session_workspace_exists_count: int = 0
         self.list_session_workspaces_count: int = 0
-        self.list_session_workspaces_returns: list[UUID] = []
+        self.list_session_workspaces_returns: list[UUID] | None = None
         self.last_list_session_workspaces_payload: dict[str, Any] | None = None
         self.health_check_count: int = 0
         self.send_message_count: int = 0
@@ -329,6 +329,8 @@ class StubSandboxManager(SandboxManager):
     def list_session_workspaces(self, sandbox_id: UUID) -> list[UUID]:
         self.list_session_workspaces_count += 1
         self.last_list_session_workspaces_payload = {"sandbox_id": sandbox_id}
+        if self.list_session_workspaces_returns is None:
+            raise _not_configured("list_session_workspaces")
         return list(self.list_session_workspaces_returns)
 
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -209,6 +209,7 @@ def test_null_heartbeat_sandbox_past_created_at_included(
     sandbox = make_sandbox(db_session, user)
     _backdate_created_at(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
 
+    stubbed_cleanup.list_session_workspaces_returns = []
     stubbed_cleanup.terminate_silent = True
 
     cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)
@@ -303,6 +304,7 @@ def test_sessions_marked_idle_and_nextjs_ports_cleared(
     db_session.refresh(session_b)
 
     _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
+    stubbed_cleanup.list_session_workspaces_returns = []
     stubbed_cleanup.terminate_silent = True
 
     cleanup_idle_sandboxes_task.run(tenant_id=TEST_TENANT_ID)

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -1,11 +1,11 @@
 """Idle cleanup (Celery task).
 
 Exercises ``cleanup_idle_sandboxes_task`` end-to-end against real Postgres +
-Redis. The Kubernetes-only pod operations (``_list_session_directories``,
+Redis. The sandbox operations (``list_session_workspaces``,
 ``create_snapshot``, ``terminate``) are routed through the
-``StubSandboxManager`` from ``conftest.py`` after monkeypatching the module-
-level ``KubernetesSandboxManager`` reference so the task's ``isinstance``
-guard passes.
+``StubSandboxManager`` from ``conftest.py``. The task body is now
+backend-agnostic, so we only need to install the stub via
+``get_sandbox_manager`` and force ``SANDBOX_BACKEND`` away from ``LOCAL``.
 """
 
 from __future__ import annotations
@@ -58,25 +58,14 @@ def stubbed_cleanup(
 ) -> StubSandboxManager:
     """Wire the stub so the cleanup task runs entirely against it.
 
-    Patches three module-level symbols in
-    ``onyx.server.features.build.sandbox.tasks.tasks``:
-
-    - ``get_sandbox_manager`` -> returns the stub
-    - ``KubernetesSandboxManager`` -> the stub's class (the task does an
-      ``isinstance`` guard, which would otherwise reject our test double)
-    - ``_list_session_directories`` -> returns ``[]`` by default so we do
-      not try to ``kubectl exec`` into a nonexistent pod
+    The task body is backend-agnostic now: it calls
+    ``sandbox_manager.list_session_workspaces(sandbox_id)`` rather than a
+    Kubernetes-only helper, so we just need to redirect
+    ``get_sandbox_manager`` to the stub. Per-test bodies can override
+    ``stub.list_session_workspaces_returns`` to drive the snapshot loop.
     """
     monkeypatch.setattr(
         tasks_module, "get_sandbox_manager", lambda: stub_sandbox_manager
-    )
-    monkeypatch.setattr(
-        tasks_module, "KubernetesSandboxManager", type(stub_sandbox_manager)
-    )
-    monkeypatch.setattr(
-        tasks_module,
-        "_list_session_directories",
-        lambda _manager, _sandbox_id: [],
     )
     return stub_sandbox_manager
 
@@ -139,7 +128,6 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
     test_user: User,  # noqa: ARG001
     stubbed_cleanup: StubSandboxManager,
     short_idle_threshold: int,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Happy path: snapshot session, terminate pod, mark sandbox SLEEPING."""
     user = make_user(db_session)
@@ -155,13 +143,9 @@ def test_idle_sandbox_snapshotted_then_terminated_then_sleep_status(
 
     _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
 
-    # Return our session id from the (stubbed) pod-directory listing so the
+    # Return our session id from the (stubbed) workspace listing so the
     # task tries to snapshot it.
-    monkeypatch.setattr(
-        tasks_module,
-        "_list_session_directories",
-        lambda _manager, _sandbox_id: [str(session_row.id)],
-    )
+    stubbed_cleanup.list_session_workspaces_returns = [session_row.id]
     stubbed_cleanup.create_snapshot_returns = SnapshotResult(
         storage_path=f"s3://snapshots/{sandbox.id}/{session_row.id}.tar.gz",
         size_bytes=1234,
@@ -263,11 +247,7 @@ def test_snapshot_failure_continues_to_termination(
 
     _backdate_heartbeat(db_session, sandbox, seconds_ago=short_idle_threshold * 4)
 
-    monkeypatch.setattr(
-        tasks_module,
-        "_list_session_directories",
-        lambda _manager, _sandbox_id: [str(session_row.id)],
-    )
+    stubbed_cleanup.list_session_workspaces_returns = [session_row.id]
 
     def _boom(
         _sandbox_id: object, _session_id: object, _tenant_id: object


### PR DESCRIPTION
## Description

Foundation PR for adding a Docker backend to Craft sandboxes (self-hosted docker-compose deployments). PR 1 of 4 — pure refactor of the shared `SandboxManager` interface; no new runtime behavior on K8s or local.

- Add `SandboxBackend.DOCKER` enum value. The factory raises `NotImplementedError` with a clear message until `DockerSandboxManager` lands in a follow-up PR.
- Add `SandboxManager.list_session_workspaces(sandbox_id) -> list[UUID]` to the abstract base.
  - K8s implementation lists via `kubectl exec ls /workspace/sessions/`.
  - Local implementation walks the on-disk `sessions/` directory.
- Move the K8s-specific `_list_session_directories` helper out of `cleanup_idle_sandboxes_task` and onto `KubernetesSandboxManager`. The cleanup task is now backend-agnostic; the `LOCAL` short-circuit at the top of the task is preserved so local sandboxes never get swept.
- Add `SnapshotManager.create_snapshot_from_stream` and `restore_snapshot_to_stream`. Future Docker backend will pipe tar streams through api_server-owned `FileStore` (MinIO/S3/Postgres, whatever is configured), so sandbox containers never receive storage credentials.
- Update `StubSandboxManager` + `test_idle_cleanup.py` to drive the new `list_session_workspaces` hook instead of monkeypatching the deleted module-level helper.

Follow-up PRs (not in this one):
- PR 2: `DockerSandboxManager` + Docker exec ACP client + external-dependency-unit tests against a real Docker daemon.
- PR 3: `docker-compose.yml` / `install.sh` / `env.template` wiring under `--include-craft`.
- PR 4: README + EC2 IMDS verification pass.

## How Has This Been Tested?

- Verified all touched modules import cleanly via `uv run python -c "..."`.
- `StubSandboxManager()` still instantiates against the now-extended abstract base.
- `_list_session_directories` and the K8s `isinstance` guard are fully gone — `grep` returns no remaining references in production code.
- Existing `backend/tests/external_dependency_unit/craft/test_idle_cleanup.py` tests cover the refactored cleanup task: stub drives the loop via `list_session_workspaces_returns`, and snapshot/terminate behavior is asserted via the same stub's call counters.
- Dedicated unit tests for the stream helpers and a new `test_idle_cleanup_backend_abstraction.py` will land with PR 2 per the implementation plan (no production caller exists for the stream helpers yet).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check