### PR TITLE
fix: sharepoint download retries

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -584,6 +584,22 @@ STREAM_DOWNLOAD_MAX_RETRIES = 3
 STREAM_CHUNK_SIZE = 64 * 1024
 
 
+def _redact_url_for_logging(url: str, max_len: int = 120) -> str:
+    """Return a log-safe identifier for a URL.
+
+    Microsoft's ``@microsoft.graph.downloadUrl`` is a pre-authenticated link
+    whose query string carries a ``tempauth=`` JWT (and similar credential
+    parameters). Logging the raw URL — even truncated — can leak a working
+    download credential into log aggregators. Strip query and fragment, keep
+    just ``scheme://host/path`` truncated to ``max_len`` for grep-ability.
+    """
+    parts = urlsplit(url)
+    safe = f"{parts.scheme}://{parts.netloc}{parts.path}"
+    if len(safe) > max_len:
+        safe = safe[:max_len] + "..."
+    return safe
+
+
 def _stream_response_to_buffer_with_cap(
     request_factory: Callable[[], requests.Response],
     cap: int,
@@ -594,10 +610,9 @@ def _stream_response_to_buffer_with_cap(
     transport-level failures.
 
     SharePoint / Graph occasionally drop the TCP connection mid-body (surfaces
-    as `ChunkedEncodingError: IncompleteRead`, a subclass of
-    `requests.ConnectionError`). Each retry calls ``request_factory`` again to
-    obtain a fresh ``Response`` -- this also avoids reusing a stale socket from
-    urllib3's connection pool.
+    as `ChunkedEncodingError: IncompleteRead`). Each retry calls
+    ``request_factory`` again to obtain a fresh ``Response`` -- this also
+    avoids reusing a stale socket from urllib3's connection pool.
 
     Args:
         request_factory: Zero-arg callable that issues a streaming GET and
@@ -685,7 +700,7 @@ def _download_with_cap(url: str, timeout: int, cap: int) -> bytes:
         return requests.get(url, stream=True, timeout=timeout)
 
     return _stream_response_to_buffer_with_cap(
-        _factory, cap, description=f"downloadUrl:{url[:120]}"
+        _factory, cap, description=f"downloadUrl:{_redact_url_for_logging(url)}"
     )
 
 

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -7,6 +7,7 @@ import os
 import re
 import time
 from collections import deque
+from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterable
 from datetime import datetime
@@ -265,12 +266,17 @@ def _site_page_in_time_window(
 # problem rather than an HTTP error. These can occur both as bare exceptions
 # (older office365 SDK paths that don't wrap them) and as the underlying
 # cause of a ClientRequestException with no response (newer SDK wrapping in
-# `execute_query`'s `except requests.exceptions.RequestException`). Note
-# `ChunkedEncodingError` is a subclass of `requests.ConnectionError`, so
-# `ConnectionError` covers it.
+# `execute_query`'s `except requests.exceptions.RequestException`).
+#
+# Note: `requests.exceptions.ChunkedEncodingError` and `ContentDecodingError`
+# are NOT subclasses of `requests.exceptions.ConnectionError` — they're
+# siblings under `RequestException`. They have to be listed explicitly to be
+# treated as retryable mid-stream connection drops.
 TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
+    requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.ContentDecodingError,
 )
 
 # HTTP statuses we treat as transient and worth retrying.
@@ -560,44 +566,117 @@ def _probe_remote_size(url: str, timeout: int) -> int | None:
     return None
 
 
+# Number of retries (in addition to the initial attempt) for streaming
+# downloads that fail with a transient transport-level error such as
+# ChunkedEncodingError / IncompleteRead. SharePoint and the Graph API
+# occasionally close the connection mid-body, especially under throttling.
+STREAM_DOWNLOAD_MAX_RETRIES = 3
+STREAM_CHUNK_SIZE = 64 * 1024
+
+
+def _stream_response_to_buffer_with_cap(
+    request_factory: Callable[[], requests.Response],
+    cap: int,
+    description: str,
+    max_retries: int = STREAM_DOWNLOAD_MAX_RETRIES,
+) -> bytes:
+    """Stream a GET response into memory with a byte cap, retrying on transient
+    transport-level failures.
+
+    SharePoint / Graph occasionally drop the TCP connection mid-body (surfaces
+    as `ChunkedEncodingError: IncompleteRead`, a subclass of
+    `requests.ConnectionError`). Each retry calls ``request_factory`` again to
+    obtain a fresh ``Response`` -- this also avoids reusing a stale socket from
+    urllib3's connection pool.
+
+    Args:
+        request_factory: Zero-arg callable that issues a streaming GET and
+            returns the ``requests.Response``. Called once per attempt.
+        cap: Maximum number of bytes to read before raising ``SizeCapExceeded``.
+        description: Short label used in log messages.
+        max_retries: Number of retries beyond the initial attempt.
+
+    Raises:
+        SizeCapExceeded: when ``cap`` is exceeded (never retried).
+        requests.RequestException: when retries are exhausted; HTTPError from
+            ``raise_for_status`` is not retried here.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            with request_factory() as resp:
+                _log_and_raise_for_status(resp)
+
+                cl_header = resp.headers.get("Content-Length")
+                if cl_header and cl_header.isdigit() and int(cl_header) > cap:
+                    logger.warning(
+                        "Content-Length %s exceeds cap %s for %s; skipping download.",
+                        cl_header,
+                        cap,
+                        description,
+                    )
+                    raise SizeCapExceeded("pre_download")
+
+                buf = io.BytesIO()
+                for chunk in resp.iter_content(STREAM_CHUNK_SIZE):
+                    if not chunk:
+                        continue
+                    buf.write(chunk)
+                    if buf.tell() > cap:
+                        logger.warning(
+                            "Streaming download for %s exceeded cap %s bytes; "
+                            "aborting early.",
+                            description,
+                            cap,
+                        )
+                        raise SizeCapExceeded("during_download")
+                return buf.getvalue()
+        except TRANSIENT_TRANSPORT_EXCEPTIONS as e:
+            if attempt >= max_retries:
+                logger.warning(
+                    "Streaming download for %s failed after %s attempts: %s: %s",
+                    description,
+                    max_retries + 1,
+                    type(e).__name__,
+                    e,
+                )
+                raise
+            sleep_time = _backoff_seconds(attempt, retry_after=None)
+            logger.warning(
+                "Streaming download for %s hit transport error on attempt %s/%s: "
+                "%s: %s. Sleeping %ss before retry.",
+                description,
+                attempt + 1,
+                max_retries + 1,
+                type(e).__name__,
+                e,
+                sleep_time,
+            )
+            time.sleep(sleep_time)
+
+    # Defensive: the loop either returns or re-raises on the final attempt.
+    raise RuntimeError(
+        f"Unreachable: streaming download retry loop exited without resolution "
+        f"for {description}"
+    )
+
+
 def _download_with_cap(url: str, timeout: int, cap: int) -> bytes:
     """Stream download content with an upper bound on bytes read.
 
     Behavior:
     - Checks `Content-Length` first and aborts early if it exceeds `cap`.
     - Otherwise streams the body in chunks and stops once `cap` is surpassed.
+    - Retries on transient transport errors (e.g. mid-stream connection drops).
     - Raises `SizeCapExceeded` when the cap would be exceeded.
     - Returns the full bytes if the content fits within `cap`.
     """
-    with requests.get(url, stream=True, timeout=timeout) as resp:
-        _log_and_raise_for_status(resp)
 
-        # If the server provides Content-Length, prefer an early decision.
-        cl_header = resp.headers.get("Content-Length")
-        if cl_header and cl_header.isdigit():
-            content_len = int(cl_header)
-            if content_len > cap:
-                logger.warning(
-                    "Content-Length %s exceeds cap %s; skipping download.",
-                    content_len,
-                    cap,
-                )
-                raise SizeCapExceeded("pre_download")
+    def _factory() -> requests.Response:
+        return requests.get(url, stream=True, timeout=timeout)
 
-        buf = io.BytesIO()
-        # Stream in 64KB chunks; adjust if needed for slower networks.
-        for chunk in resp.iter_content(64 * 1024):
-            if not chunk:
-                continue
-            buf.write(chunk)
-            if buf.tell() > cap:
-                # Avoid keeping a large partial buffer; close and signal caller to skip.
-                logger.warning(
-                    "Streaming download exceeded cap %s bytes; aborting early.", cap
-                )
-                raise SizeCapExceeded("during_download")
-
-        return buf.getvalue()
+    return _stream_response_to_buffer_with_cap(
+        _factory, cap, description=f"downloadUrl:{url[:120]}"
+    )
 
 
 def _download_via_graph_api(
@@ -609,22 +688,22 @@ def _download_via_graph_api(
 ) -> bytes:
     """Download a drive item via the Graph API /content endpoint with a byte cap.
 
-    Raises SizeCapExceeded if the cap is exceeded.
+    Retries on transient transport errors. Raises SizeCapExceeded if the cap is
+    exceeded.
     """
     url = f"{graph_api_base}/drives/{drive_id}/items/{item_id}/content"
     headers = {"Authorization": f"Bearer {access_token}"}
-    with requests.get(
-        url, headers=headers, stream=True, timeout=REQUEST_TIMEOUT_SECONDS
-    ) as resp:
-        _log_and_raise_for_status(resp)
-        buf = io.BytesIO()
-        for chunk in resp.iter_content(64 * 1024):
-            if not chunk:
-                continue
-            buf.write(chunk)
-            if buf.tell() > bytes_allowed:
-                raise SizeCapExceeded("during_graph_api_download")
-        return buf.getvalue()
+
+    def _factory() -> requests.Response:
+        return requests.get(
+            url, headers=headers, stream=True, timeout=REQUEST_TIMEOUT_SECONDS
+        )
+
+    return _stream_response_to_buffer_with_cap(
+        _factory,
+        bytes_allowed,
+        description=f"graph_api(drive={drive_id},item={item_id})",
+    )
 
 
 def _convert_driveitem_to_document_with_permissions(

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -4,6 +4,7 @@ import fnmatch
 import html
 import io
 import os
+import random
 import re
 import time
 from collections import deque
@@ -283,17 +284,26 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
 RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 
 
-def _backoff_seconds(attempt: int, retry_after: str | None) -> int:
+def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
     """Honor a numeric Retry-After header when the server provides one,
-    otherwise fall back to capped exponential backoff (5s, 10s, 20s, …,
-    max 30s). The HTTP-date form of Retry-After is rare from SharePoint /
-    Graph in practice and falls through to exponential backoff."""
+    otherwise fall back to capped exponential backoff with equal jitter.
+
+    Base sequence is 5s, 10s, 20s, capped at 30s. The actual sleep is drawn
+    from ``[base/2, base]`` so that many documents failing at the same instant
+    (e.g. during a Graph throttling window) don't all retry on the same tick
+    and re-create the thundering herd. Server-provided Retry-After values are
+    used verbatim — those are an explicit instruction, not a guess.
+
+    The HTTP-date form of Retry-After is rare from SharePoint / Graph in
+    practice and falls through to the jittered exponential backoff.
+    """
     if retry_after:
         try:
-            return int(retry_after)
+            return float(retry_after)
         except ValueError:
             pass
-    return min(30, (2**attempt) * 5)
+    base = min(30, (2**attempt) * 5)
+    return base / 2 + random.uniform(0, base / 2)
 
 
 def sleep_and_retry(
@@ -320,7 +330,7 @@ def sleep_and_retry(
             sleep_time = _backoff_seconds(attempt, retry_after=None)
             logger.warning(
                 "Transport error on %s, attempt %s/%s: %s: %s. "
-                "Sleeping %ss before retry.",
+                "Sleeping %.1fs before retry.",
                 method_name,
                 attempt + 1,
                 max_retries + 1,
@@ -351,7 +361,7 @@ def sleep_and_retry(
                 sleep_time = _backoff_seconds(attempt, retry_after)
                 logger.warning(
                     "Retryable error on %s, attempt %s/%s: status=%s. "
-                    "Sleeping %ss before retry.",
+                    "Sleeping %.1fs before retry.",
                     method_name,
                     attempt + 1,
                     max_retries + 1,
@@ -643,7 +653,7 @@ def _stream_response_to_buffer_with_cap(
             sleep_time = _backoff_seconds(attempt, retry_after=None)
             logger.warning(
                 "Streaming download for %s hit transport error on attempt %s/%s: "
-                "%s: %s. Sleeping %ss before retry.",
+                "%s: %s. Sleeping %.1fs before retry.",
                 description,
                 attempt + 1,
                 max_retries + 1,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
@@ -1,0 +1,201 @@
+"""Unit tests for streaming-download retry behavior in the SharePoint connector.
+
+SharePoint and the Microsoft Graph API occasionally drop the TCP connection
+mid-body (surfaces as ``ChunkedEncodingError: IncompleteRead``). The download
+helpers must transparently retry these transport-level failures with a fresh
+HTTP request so that an isolated network blip does not turn into a permanent
+per-document failure (which then trips the indexing failure threshold).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from onyx.connectors.sharepoint import connector as sp_connector
+from onyx.connectors.sharepoint.connector import _download_via_graph_api
+from onyx.connectors.sharepoint.connector import _download_with_cap
+from onyx.connectors.sharepoint.connector import SizeCapExceeded
+
+CAP = 10 * 1024 * 1024  # 10 MiB cap; well above the byte payloads used in tests
+
+
+def _make_response(
+    chunks: list[bytes] | None = None,
+    raise_during_iter: Exception | None = None,
+    headers: dict[str, str] | None = None,
+    status: int = 200,
+) -> MagicMock:
+    """Build a MagicMock that quacks like a streaming requests.Response.
+
+    - ``chunks``: bytes the response will yield from ``iter_content``.
+    - ``raise_during_iter``: if set, ``iter_content`` will yield nothing and
+      raise this exception (simulates a mid-body connection drop).
+    - ``headers``: response headers (e.g. for Content-Length checks).
+    - ``status``: HTTP status code; non-2xx triggers ``raise_for_status``.
+    """
+    resp = MagicMock(spec=requests.Response)
+    resp.headers = headers or {}
+    resp.status_code = status
+    resp.text = ""
+
+    def _raise_for_status() -> None:
+        if status >= 400:
+            raise requests.HTTPError(f"{status} error", response=resp)
+
+    resp.raise_for_status.side_effect = _raise_for_status
+
+    def _iter_content(_chunk_size: int) -> Any:
+        if raise_during_iter is not None:
+            # Match real `requests` behavior: yield what we've buffered so far,
+            # then raise on the next read. For the failure case we yield
+            # nothing before raising, which is the simplest reproduction.
+            raise raise_during_iter
+        for c in chunks or []:
+            yield c
+
+    resp.iter_content.side_effect = _iter_content
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    return resp
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_download_with_cap_retries_on_chunked_encoding_error(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """A single mid-stream ChunkedEncodingError should be retried and succeed."""
+    failing_resp = _make_response(
+        raise_during_iter=requests.exceptions.ChunkedEncodingError(
+            "Connection broken: IncompleteRead(20480 bytes read, 476750 more expected)"
+        )
+    )
+    succeeding_resp = _make_response(chunks=[b"hello", b"world"])
+
+    mock_get.side_effect = [failing_resp, succeeding_resp]
+
+    result = _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert result == b"helloworld"
+    # Two HTTP requests means a fresh socket on retry, not a reused stale one.
+    assert mock_get.call_count == 2
+    mock_time.sleep.assert_called_once()
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_download_via_graph_api_retries_on_chunked_encoding_error(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """The Graph API helper retries the same way as the downloadUrl path."""
+    failing_resp = _make_response(
+        raise_during_iter=requests.exceptions.ChunkedEncodingError(
+            "Connection broken: IncompleteRead"
+        )
+    )
+    succeeding_resp = _make_response(chunks=[b"docbytes"])
+    mock_get.side_effect = [failing_resp, succeeding_resp]
+
+    result = _download_via_graph_api(
+        access_token="tok",
+        drive_id="drive-1",
+        item_id="item-1",
+        bytes_allowed=CAP,
+        graph_api_base="https://graph.microsoft.com/v1.0",
+    )
+
+    assert result == b"docbytes"
+    assert mock_get.call_count == 2
+    mock_time.sleep.assert_called_once()
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_download_with_cap_reraises_after_max_retries(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """Persistent transport errors should re-raise after retries are exhausted."""
+    mock_get.side_effect = [
+        _make_response(
+            raise_during_iter=requests.exceptions.ChunkedEncodingError("boom")
+        )
+        for _ in range(sp_connector.STREAM_DOWNLOAD_MAX_RETRIES + 1)
+    ]
+
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert mock_get.call_count == sp_connector.STREAM_DOWNLOAD_MAX_RETRIES + 1
+    # Sleep is invoked between attempts only, not after the final failure.
+    assert mock_time.sleep.call_count == sp_connector.STREAM_DOWNLOAD_MAX_RETRIES
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_size_cap_exceeded_is_not_retried_pre_download(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """A Content-Length over the cap raises immediately without retrying."""
+    mock_get.return_value = _make_response(
+        chunks=[],
+        headers={"Content-Length": str(CAP + 1)},
+    )
+
+    with pytest.raises(SizeCapExceeded):
+        _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert mock_get.call_count == 1
+    mock_time.sleep.assert_not_called()
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_size_cap_exceeded_is_not_retried_during_download(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """If the streamed body exceeds the cap, we abort once -- no retry."""
+    mock_get.return_value = _make_response(chunks=[b"x" * (CAP + 1)])
+
+    with pytest.raises(SizeCapExceeded):
+        _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert mock_get.call_count == 1
+    mock_time.sleep.assert_not_called()
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_http_error_from_raise_for_status_is_not_retried(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """HTTPError (4xx/5xx) is intentionally outside the transport-retry scope."""
+    mock_get.return_value = _make_response(status=404)
+
+    with pytest.raises(requests.HTTPError):
+        _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert mock_get.call_count == 1
+    mock_time.sleep.assert_not_called()
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_connection_error_before_iter_content_is_retried(
+    mock_get: MagicMock, mock_time: MagicMock
+) -> None:
+    """ConnectionError raised before streaming starts is also retried."""
+    mock_get.side_effect = [
+        requests.exceptions.ConnectionError("connection refused"),
+        _make_response(chunks=[b"ok"]),
+    ]
+
+    result = _download_with_cap("https://example/download", timeout=60, cap=CAP)
+
+    assert result == b"ok"
+    assert mock_get.call_count == 2
+    mock_time.sleep.assert_called_once()

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
@@ -19,6 +19,7 @@ import requests
 from onyx.connectors.sharepoint import connector as sp_connector
 from onyx.connectors.sharepoint.connector import _download_via_graph_api
 from onyx.connectors.sharepoint.connector import _download_with_cap
+from onyx.connectors.sharepoint.connector import _redact_url_for_logging
 from onyx.connectors.sharepoint.connector import SizeCapExceeded
 
 CAP = 10 * 1024 * 1024  # 10 MiB cap; well above the byte payloads used in tests
@@ -239,3 +240,70 @@ def test_backoff_seconds_falls_back_when_retry_after_unparseable() -> None:
             0, retry_after="Wed, 21 Oct 2026 07:28:00 GMT"
         )
         assert base / 2 <= s <= base
+
+
+# Sentinel value used in tests below to simulate a leaked credential parameter.
+# `@microsoft.graph.downloadUrl` query strings carry a JWT in `tempauth=`. We
+# use a clearly-fake marker (no real JWT prefix) so this test file is friendly
+# to credential scanners.
+_FAKE_TEMPAUTH = "TEST-FAKE-TEMPAUTH-DO-NOT-LOG"
+
+
+def test_redact_url_strips_query_string_with_tempauth() -> None:
+    """tempauth and other query parameters must never survive into the description."""
+    raw = (
+        "https://tenant.sharepoint.com/sites/Foo/_layouts/15/download.aspx"
+        f"?UniqueId=abc&Translate=false&tempauth={_FAKE_TEMPAUTH}&ApiVersion=2.1"
+    )
+    safe = _redact_url_for_logging(raw)
+    assert "tempauth" not in safe
+    assert _FAKE_TEMPAUTH not in safe
+    assert "?" not in safe
+    assert safe.startswith("https://tenant.sharepoint.com/sites/Foo/")
+
+
+def test_redact_url_truncates_overly_long_paths() -> None:
+    """Even after stripping the query, a runaway path is bounded for log size."""
+    raw = "https://tenant.sharepoint.com/" + "a" * 500
+    safe = _redact_url_for_logging(raw, max_len=80)
+    assert len(safe) <= 80 + len("...")
+    assert safe.endswith("...")
+
+
+@patch("onyx.connectors.sharepoint.connector.time")
+@patch("onyx.connectors.sharepoint.connector.logger")
+@patch("onyx.connectors.sharepoint.connector.requests.get")
+def test_download_with_cap_does_not_log_tempauth_token(
+    mock_get: MagicMock,
+    mock_logger: MagicMock,
+    mock_time: MagicMock,  # noqa: ARG001
+) -> None:
+    """A failing download must never write the preauthenticated URL to the logger.
+
+    Without redaction the description string would carry the full downloadUrl
+    (including ``tempauth=...``) into every retry/exhaustion log line, which is
+    a credential leak into log aggregators.
+    """
+    raw_url = (
+        "https://tenant.sharepoint.com/sites/Foo/_layouts/15/download.aspx"
+        f"?UniqueId=abc&tempauth={_FAKE_TEMPAUTH}&ApiVersion=2.1"
+    )
+    mock_get.side_effect = [
+        _make_response(
+            raise_during_iter=requests.exceptions.ChunkedEncodingError("boom")
+        )
+        for _ in range(sp_connector.STREAM_DOWNLOAD_MAX_RETRIES + 1)
+    ]
+
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        _download_with_cap(raw_url, timeout=60, cap=CAP)
+
+    # Flatten every positional/keyword arg from every logger call into one blob
+    # and assert no credential material made it through.
+    all_log_args: list[Any] = []
+    for call in mock_logger.warning.call_args_list + mock_logger.error.call_args_list:
+        all_log_args.extend(call.args)
+        all_log_args.extend(call.kwargs.values())
+    blob = " ".join(str(a) for a in all_log_args)
+    assert _FAKE_TEMPAUTH not in blob
+    assert "tempauth" not in blob

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
@@ -199,3 +199,43 @@ def test_connection_error_before_iter_content_is_retried(
     assert result == b"ok"
     assert mock_get.call_count == 2
     mock_time.sleep.assert_called_once()
+
+
+def test_backoff_seconds_uses_equal_jitter() -> None:
+    """Exponential backoff falls in [base/2, base] (equal jitter).
+
+    Base sequence: 5, 10, 20, 30 (capped). Each draw must respect the bounds
+    so retries spread out without violating the floor or the cap.
+    """
+    expected_bases = [5, 10, 20, 30, 30]
+    for attempt, base in enumerate(expected_bases):
+        samples = [
+            sp_connector._backoff_seconds(attempt, retry_after=None) for _ in range(50)
+        ]
+        for s in samples:
+            assert base / 2 <= s <= base, (
+                f"attempt={attempt} base={base} produced out-of-range sleep {s}"
+            )
+        # Sanity: with 50 samples we should see at least two distinct values
+        # (otherwise jitter isn't actually being applied).
+        assert len(set(samples)) > 1, (
+            f"attempt={attempt} produced no jitter spread: {samples[:5]}..."
+        )
+
+
+def test_backoff_seconds_respects_retry_after_header_verbatim() -> None:
+    """Server-provided Retry-After is an instruction; jitter must not be applied."""
+    for raw in ("0", "1", "12", "120"):
+        # Repeat to make sure we don't accidentally jitter on this path.
+        for _ in range(10):
+            assert sp_connector._backoff_seconds(0, retry_after=raw) == float(raw)
+
+
+def test_backoff_seconds_falls_back_when_retry_after_unparseable() -> None:
+    """Non-numeric Retry-After (HTTP-date) falls through to jittered backoff."""
+    base = 5  # attempt=0
+    for _ in range(20):
+        s = sp_connector._backoff_seconds(
+            0, retry_after="Wed, 21 Oct 2026 07:28:00 GMT"
+        )
+        assert base / 2 <= s <= base


### PR DESCRIPTION
## Description

We were previously not retrying file downloads for sharepoint; now we do (with backoff)

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry/backoff for SharePoint streaming downloads to handle transient drops and stabilize indexing. Also redacts pre-auth `downloadUrl` query params in logs to prevent credential leakage.

- **Bug Fixes**
  - Retries on `requests` transport errors (`ConnectionError`, `Timeout`, `ChunkedEncodingError`, `ContentDecodingError`) up to 3 times with exponential backoff and equal jitter; honors numeric `Retry-After`; no retries on HTTP errors or `SizeCapExceeded`.
  - Applies to both `downloadUrl` and Graph API `/content` via `_stream_response_to_buffer_with_cap`.
  - Redacts `@microsoft.graph.downloadUrl` query strings (e.g., `tempauth`) from log messages.
  - Added tests for jitter bounds, `Retry-After` (numeric and HTTP-date), retry success/exhaustion, non-retry paths, and log redaction.

<sup>Written for commit 4c67f54dbf7f28fab822068ab59cac4f28d22ed6. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11221?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

