### PR TITLE
refactor(craft): shared ACPExecClient base across K8s + Docker

### DIFF
--- a/backend/onyx/server/features/build/sandbox/acp/base.py
+++ b/backend/onyx/server/features/build/sandbox/acp/base.py
@@ -1,0 +1,639 @@
+"""Shared base for ACP exec clients across sandbox transports.
+
+The Kubernetes and Docker sandbox backends both run ``opencode acp`` as a
+subprocess in the sandbox container and shuttle JSON-RPC messages over a
+transport-specific stream (a kubernetes exec WebSocket for K8s, a
+multiplexed Docker exec socket for Docker). The JSON-RPC protocol, state
+machine, session lifecycle, and event dispatch are identical between the
+two — only the transport differs.
+
+``ACPExecClientBase`` factors out the protocol layer. Subclasses provide
+five hooks for transport open/close/poll/write/read; the base owns
+everything else.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Generator
+from dataclasses import dataclass
+from dataclasses import field
+from queue import Empty
+from queue import Queue
+from typing import Any
+from typing import cast
+from typing import ClassVar
+
+from acp.schema import AgentMessageChunk
+from acp.schema import AgentPlanUpdate
+from acp.schema import AgentThoughtChunk
+from acp.schema import CurrentModeUpdate
+from acp.schema import Error
+from acp.schema import PromptResponse
+from acp.schema import ToolCallProgress
+from acp.schema import ToolCallStart
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import ACP_MESSAGE_TIMEOUT
+from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
+from onyx.server.features.build.sandbox.base import SSEKeepalive
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+ACP_PROTOCOL_VERSION = 1
+
+
+ACPEvent = (
+    AgentMessageChunk
+    | AgentThoughtChunk
+    | ToolCallStart
+    | ToolCallProgress
+    | AgentPlanUpdate
+    | CurrentModeUpdate
+    | PromptResponse
+    | Error
+    | SSEKeepalive
+)
+
+
+@dataclass
+class ACPSession:
+    """Represents an active ACP session."""
+
+    session_id: str
+    cwd: str
+
+
+@dataclass
+class ACPClientState:
+    """Internal state for the ACP client."""
+
+    initialized: bool = False
+    sessions: dict[str, ACPSession] = field(default_factory=dict)
+    next_request_id: int = 0
+    agent_capabilities: dict[str, Any] = field(default_factory=dict)
+    agent_info: dict[str, Any] = field(default_factory=dict)
+
+
+class ACPExecClientBase(ABC):
+    """Transport-agnostic ACP JSON-RPC client.
+
+    Subclasses must define ``transport_name`` (``"k8s"`` / ``"docker"``)
+    and implement the five abstract transport hooks below.
+    """
+
+    # ``transport_name`` drives the log prefix (``[K8S-ACP]`` / ``[DOCKER-ACP]``)
+    # and the ``context=`` value the packet logger receives.
+    transport_name: ClassVar[str]
+
+    def __init__(
+        self,
+        *,
+        client_info: dict[str, Any],
+        client_capabilities: dict[str, Any] | None = None,
+    ) -> None:
+        self._client_info = client_info
+        self._client_capabilities = client_capabilities or {
+            "fs": {"readTextFile": True, "writeTextFile": True},
+            "terminal": True,
+        }
+        self._state = ACPClientState()
+        self._response_queue: Queue[dict[str, Any]] = Queue()
+        self._reader_thread: threading.Thread | None = None
+        self._stop_reader = threading.Event()
+
+    # ------------------------------------------------------------------
+    # Transport hooks — subclass-specific
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _open_transport(self, cwd: str) -> None:
+        """Open the transport and spawn ``opencode acp --cwd <cwd>``."""
+
+    @abstractmethod
+    def _close_transport(self) -> None:
+        """Close the transport. Must be idempotent and not raise."""
+
+    @abstractmethod
+    def _is_transport_open(self) -> bool:
+        """Return True if the transport is still usable for I/O."""
+
+    @abstractmethod
+    def _write_line(self, line: str) -> None:
+        """Write one newline-terminated JSON-RPC line to the transport."""
+
+    @abstractmethod
+    def _read_responses_loop(self) -> None:
+        """Reader loop: parse incoming JSON lines and dispatch via
+        :meth:`_enqueue_message`. Must respect ``self._stop_reader``."""
+
+    @abstractmethod
+    def _log_target(self) -> str:
+        """Identifier for log lines (e.g. ``"pod=sandbox-abc"`` or
+        ``"container=foo"``)."""
+
+    # ------------------------------------------------------------------
+    # Logging helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _log_prefix(self) -> str:
+        return f"[{self.transport_name.upper()}-ACP]"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, cwd: str = "/workspace", timeout: float = 30.0) -> None:
+        """Open the transport, spawn the reader thread, and initialize ACP."""
+        if self._is_transport_open():
+            raise RuntimeError("Client already started. Call stop() first.")
+
+        logger.info(
+            "%s Starting client: %s cwd=%s", self._log_prefix, self._log_target(), cwd
+        )
+
+        try:
+            self._open_transport(cwd)
+
+            self._stop_reader.clear()
+            self._reader_thread = threading.Thread(
+                target=self._read_responses_loop, daemon=True
+            )
+            self._reader_thread.start()
+
+            # Give opencode a moment to boot before sending initialize.
+            time.sleep(0.5)
+
+            self._initialize(timeout=timeout)
+
+            logger.info("%s Client started: %s", self._log_prefix, self._log_target())
+        except Exception as e:
+            logger.error(
+                "%s Client start failed: %s error=%s",
+                self._log_prefix,
+                self._log_target(),
+                e,
+            )
+            self.stop()
+            raise RuntimeError(
+                f"Failed to start {self.transport_name} ACP exec client: {e}"
+            ) from e
+
+    def stop(self) -> None:
+        """Tear down the reader thread and close the transport."""
+        session_ids = list(self._state.sessions.keys())
+        logger.info(
+            "%s Stopping client: %s sessions=%s",
+            self._log_prefix,
+            self._log_target(),
+            session_ids,
+        )
+        self._stop_reader.set()
+
+        try:
+            self._close_transport()
+        except Exception:
+            # ``_close_transport`` should swallow its own errors, but guard
+            # so stop() never raises mid-cleanup.
+            pass
+
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=2.0)
+            self._reader_thread = None
+
+        self._state = ACPClientState()
+
+    def _enqueue_message(self, message: dict[str, Any]) -> None:
+        """Log and enqueue a parsed JSON-RPC message from the reader."""
+        packet_logger = get_packet_logger()
+        packet_logger.log_jsonrpc_raw_message(
+            "IN", message, context=self.transport_name
+        )
+        self._response_queue.put(message)
+
+    # ------------------------------------------------------------------
+    # JSON-RPC primitives
+    # ------------------------------------------------------------------
+
+    def _get_next_id(self) -> int:
+        request_id = self._state.next_request_id
+        self._state.next_request_id += 1
+        return request_id
+
+    def _send_request(self, method: str, params: dict[str, Any] | None = None) -> int:
+        if not self._is_transport_open():
+            raise RuntimeError("Exec session not open")
+
+        request_id = self._get_next_id()
+        request: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
+        if params is not None:
+            request["params"] = params
+
+        packet_logger = get_packet_logger()
+        packet_logger.log_jsonrpc_request(
+            method, request_id, params, context=self.transport_name
+        )
+
+        self._write_line(json.dumps(request) + "\n")
+        return request_id
+
+    def _send_notification(
+        self, method: str, params: dict[str, Any] | None = None
+    ) -> None:
+        if not self._is_transport_open():
+            return
+
+        notification: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            notification["params"] = params
+
+        packet_logger = get_packet_logger()
+        packet_logger.log_jsonrpc_request(
+            method, None, params, context=self.transport_name
+        )
+
+        try:
+            self._write_line(json.dumps(notification) + "\n")
+        except OSError:
+            return
+
+    def _wait_for_response(
+        self, request_id: int, timeout: float = 30.0
+    ) -> dict[str, Any]:
+        start_time = time.time()
+
+        while True:
+            remaining = timeout - (time.time() - start_time)
+            if remaining <= 0:
+                raise RuntimeError(
+                    f"Timeout waiting for response to request {request_id}"
+                )
+
+            try:
+                message = self._response_queue.get(timeout=min(remaining, 1.0))
+
+                if message.get("id") == request_id:
+                    if "error" in message:
+                        error = message["error"]
+                        raise RuntimeError(
+                            f"ACP error {error.get('code')}: {error.get('message')}"
+                        )
+                    return cast("dict[str, Any]", message.get("result", {}))
+
+                # Not our response — put it back for the next consumer.
+                self._response_queue.put(message)
+
+            except Empty:
+                continue
+
+    # ------------------------------------------------------------------
+    # ACP protocol
+    # ------------------------------------------------------------------
+
+    def _initialize(self, timeout: float = 30.0) -> dict[str, Any]:
+        params = {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": self._client_capabilities,
+            "clientInfo": self._client_info,
+        }
+
+        request_id = self._send_request("initialize", params)
+        result = self._wait_for_response(request_id, timeout)
+
+        self._state.initialized = True
+        self._state.agent_capabilities = result.get("agentCapabilities", {})
+        self._state.agent_info = result.get("agentInfo", {})
+
+        return result
+
+    def _create_session(self, cwd: str, timeout: float = 30.0) -> str:
+        params = {"cwd": cwd, "mcpServers": []}
+
+        request_id = self._send_request("session/new", params)
+        result = self._wait_for_response(request_id, timeout)
+
+        session_id = result.get("sessionId")
+        if not session_id:
+            raise RuntimeError("No session ID returned from session/new")
+
+        self._state.sessions[session_id] = ACPSession(session_id=session_id, cwd=cwd)
+        logger.info(
+            "%s Created session: acp_session=%s cwd=%s",
+            self._log_prefix,
+            session_id,
+            cwd,
+        )
+
+        return session_id
+
+    def _list_sessions(self, cwd: str, timeout: float = 10.0) -> list[dict[str, Any]]:
+        try:
+            request_id = self._send_request("session/list", {"cwd": cwd})
+            result = self._wait_for_response(request_id, timeout)
+            sessions = cast("list[dict[str, Any]]", result.get("sessions", []))
+            logger.info(
+                "%s session/list: %s sessions for cwd=%s",
+                self._log_prefix,
+                len(sessions),
+                cwd,
+            )
+            return sessions
+        except Exception as e:
+            logger.info("%s session/list unavailable: %s", self._log_prefix, e)
+            return []
+
+    def _resume_session(self, session_id: str, cwd: str, timeout: float = 30.0) -> str:
+        params = {"sessionId": session_id, "cwd": cwd, "mcpServers": []}
+
+        request_id = self._send_request("session/resume", params)
+        result = self._wait_for_response(request_id, timeout)
+
+        resumed_id = result.get("sessionId", session_id)
+        self._state.sessions[resumed_id] = ACPSession(session_id=resumed_id, cwd=cwd)
+
+        logger.info(
+            "%s Resumed session: acp_session=%s cwd=%s",
+            self._log_prefix,
+            resumed_id,
+            cwd,
+        )
+        return resumed_id
+
+    def _try_resume_existing_session(self, cwd: str, timeout: float) -> str | None:
+        sessions = self._list_sessions(cwd, timeout=min(timeout, 10.0))
+        if not sessions:
+            return None
+
+        target = sessions[0]
+        target_id = target.get("sessionId")
+        if not target_id:
+            logger.warning(
+                "%s session/list returned session without sessionId", self._log_prefix
+            )
+            return None
+
+        logger.info(
+            "%s Resuming existing session: acp_session=%s (found %s)",
+            self._log_prefix,
+            target_id,
+            len(sessions),
+        )
+
+        try:
+            return self._resume_session(target_id, cwd, timeout)
+        except Exception as e:
+            logger.warning(
+                "%s session/resume failed for %s: %s, falling back to session/new",
+                self._log_prefix,
+                target_id,
+                e,
+            )
+            return None
+
+    def resume_or_create_session(self, cwd: str, timeout: float = 30.0) -> str:
+        if not self._state.initialized:
+            raise RuntimeError("Client not initialized. Call start() first.")
+
+        resumed_id = self._try_resume_existing_session(cwd, timeout)
+        if resumed_id:
+            return resumed_id
+
+        return self._create_session(cwd=cwd, timeout=timeout)
+
+    def send_message(
+        self,
+        message: str,
+        session_id: str,
+        timeout: float = ACP_MESSAGE_TIMEOUT,
+    ) -> Generator[ACPEvent, None, None]:
+        if session_id not in self._state.sessions:
+            raise RuntimeError(
+                f"Unknown session {session_id}. "
+                f"Known sessions: {list(self._state.sessions.keys())}"
+            )
+        packet_logger = get_packet_logger()
+
+        logger.info(
+            "%s Sending prompt: acp_session=%s %s queue_backlog=%s",
+            self._log_prefix,
+            session_id,
+            self._log_target(),
+            self._response_queue.qsize(),
+        )
+
+        prompt_content = [{"type": "text", "text": message}]
+        params = {"sessionId": session_id, "prompt": prompt_content}
+
+        request_id = self._send_request("session/prompt", params)
+        start_time = time.time()
+        last_event_time = time.time()
+        events_yielded = 0
+        completion_reason = "unknown"
+
+        while True:
+            remaining = timeout - (time.time() - start_time)
+            if remaining <= 0:
+                completion_reason = "timeout"
+                logger.warning(
+                    "%s Prompt timeout: acp_session=%s events=%s, sending session/cancel",
+                    self._log_prefix,
+                    session_id,
+                    events_yielded,
+                )
+                try:
+                    self.cancel(session_id=session_id)
+                except Exception as cancel_err:
+                    logger.warning(
+                        "%s session/cancel failed on timeout: %s",
+                        self._log_prefix,
+                        cancel_err,
+                    )
+                yield Error(code=-1, message="Timeout waiting for response")
+                break
+
+            try:
+                message_data = self._response_queue.get(timeout=min(remaining, 1.0))
+                last_event_time = time.time()
+            except Empty:
+                idle_time = time.time() - last_event_time
+                if idle_time >= SSE_KEEPALIVE_INTERVAL:
+                    yield SSEKeepalive()
+                    last_event_time = time.time()
+                continue
+
+            msg_id = message_data.get("id")
+            is_response = "method" not in message_data and (
+                msg_id == request_id
+                or (msg_id is not None and str(msg_id) == str(request_id))
+            )
+            if is_response:
+                completion_reason = "jsonrpc_response"
+                if "error" in message_data:
+                    error_data = message_data["error"]
+                    completion_reason = "jsonrpc_error"
+                    logger.warning("%s Prompt error: %s", self._log_prefix, error_data)
+                    packet_logger.log_jsonrpc_response(
+                        request_id, error=error_data, context=self.transport_name
+                    )
+                    yield Error(
+                        code=error_data.get("code", -1),
+                        message=error_data.get("message", "Unknown error"),
+                    )
+                else:
+                    result = message_data.get("result", {})
+                    packet_logger.log_jsonrpc_response(
+                        request_id, result=result, context=self.transport_name
+                    )
+                    try:
+                        prompt_response = PromptResponse.model_validate(result)
+                        events_yielded += 1
+                        yield prompt_response
+                    except ValidationError as e:
+                        logger.error(
+                            "%s PromptResponse validation failed: %s",
+                            self._log_prefix,
+                            e,
+                        )
+
+                elapsed_ms = (time.time() - start_time) * 1000
+                logger.info(
+                    "%s Prompt complete: reason=%s acp_session=%s events=%s elapsed=%sms",
+                    self._log_prefix,
+                    completion_reason,
+                    session_id,
+                    events_yielded,
+                    format(elapsed_ms, ".0f"),
+                )
+                break
+
+            if message_data.get("method") == "session/update":
+                params_data = message_data.get("params", {})
+                update = params_data.get("update", {})
+
+                prompt_complete = False
+                for event in self._process_session_update(update):
+                    events_yielded += 1
+                    yield event
+                    if isinstance(event, PromptResponse):
+                        prompt_complete = True
+                        break
+
+                if prompt_complete:
+                    completion_reason = "prompt_response_via_notification"
+                    elapsed_ms = (time.time() - start_time) * 1000
+                    logger.info(
+                        "%s Prompt complete: reason=%s acp_session=%s events=%s elapsed=%sms",
+                        self._log_prefix,
+                        completion_reason,
+                        session_id,
+                        events_yielded,
+                        format(elapsed_ms, ".0f"),
+                    )
+                    break
+
+            elif "method" in message_data and "id" in message_data:
+                logger.debug(
+                    "%s Unsupported agent request: method=%s",
+                    self._log_prefix,
+                    message_data["method"],
+                )
+                self._send_error_response(
+                    message_data["id"],
+                    -32601,
+                    f"Method not supported: {message_data['method']}",
+                )
+
+            else:
+                logger.warning(
+                    "%s Unhandled message: id=%s method=%s keys=%s",
+                    self._log_prefix,
+                    message_data.get("id"),
+                    message_data.get("method"),
+                    list(message_data.keys()),
+                )
+
+    def _process_session_update(
+        self, update: dict[str, Any]
+    ) -> Generator[ACPEvent, None, None]:
+        """Process a session/update notification and yield typed ACP events."""
+        update_type = update.get("sessionUpdate")
+        if not isinstance(update_type, str):
+            return
+
+        # ``prompt_response`` is included because some ACP versions emit it as
+        # a notification *without* a corresponding JSON-RPC response — we
+        # accept either signal as turn completion (first wins).
+        type_map: dict[str, type[BaseModel]] = {
+            "agent_message_chunk": AgentMessageChunk,
+            "agent_thought_chunk": AgentThoughtChunk,
+            "tool_call": ToolCallStart,
+            "tool_call_update": ToolCallProgress,
+            "plan": AgentPlanUpdate,
+            "current_mode_update": CurrentModeUpdate,
+            "prompt_response": PromptResponse,
+        }
+
+        model_class = type_map.get(update_type)
+        if model_class is not None:
+            try:
+                yield cast(ACPEvent, model_class.model_validate(update))
+            except ValidationError as e:
+                logger.warning(
+                    "%s Validation error for %s: %s",
+                    self._log_prefix,
+                    update_type,
+                    e,
+                )
+        elif update_type not in (
+            "user_message_chunk",
+            "available_commands_update",
+            "session_info_update",
+            "usage_update",
+        ):
+            logger.debug("%s Unknown update type: %s", self._log_prefix, update_type)
+
+    def _send_error_response(self, request_id: int, code: int, message: str) -> None:
+        if not self._is_transport_open():
+            return
+
+        response = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+        try:
+            self._write_line(json.dumps(response) + "\n")
+        except OSError:
+            return
+
+    def cancel(self, session_id: str | None = None) -> None:
+        if session_id:
+            if session_id in self._state.sessions:
+                self._send_notification("session/cancel", {"sessionId": session_id})
+        else:
+            for sid in list(self._state.sessions):
+                self._send_notification("session/cancel", {"sessionId": sid})
+
+    @property
+    def is_running(self) -> bool:
+        return self._is_transport_open()
+
+    def __enter__(self) -> "ACPExecClientBase":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.stop()

--- a/backend/onyx/server/features/build/sandbox/acp/base.py
+++ b/backend/onyx/server/features/build/sandbox/acp/base.py
@@ -91,8 +91,20 @@ class ACPExecClientBase(ABC):
     """
 
     # ``transport_name`` drives the log prefix (``[K8S-ACP]`` / ``[DOCKER-ACP]``)
-    # and the ``context=`` value the packet logger receives.
+    # and the ``context=`` value the packet logger receives. Enforced via
+    # ``__init_subclass__`` below since Python has no ``@abstractmethod``
+    # equivalent for class variables.
     transport_name: ClassVar[str]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if "transport_name" not in cls.__dict__ or not isinstance(
+            cls.__dict__["transport_name"], str
+        ):
+            raise TypeError(
+                f"{cls.__name__} must define a `transport_name: ClassVar[str]` "
+                "class attribute (e.g. 'k8s', 'docker')."
+            )
 
     def __init__(
         self,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -80,8 +80,8 @@ from onyx.server.features.build.configs import SANDBOX_DOCKER_MEMORY_LIMIT
 from onyx.server.features.build.configs import SANDBOX_DOCKER_NETWORK
 from onyx.server.features.build.configs import SANDBOX_DOCKER_SOCKET
 from onyx.server.features.build.configs import SANDBOX_DOCKER_VOLUME_PREFIX
+from onyx.server.features.build.sandbox.acp.base import ACPEvent
 from onyx.server.features.build.sandbox.base import SandboxManager
-from onyx.server.features.build.sandbox.docker.internal.acp_exec_client import ACPEvent
 from onyx.server.features.build.sandbox.docker.internal.acp_exec_client import (
     DockerACPExecClient,
 )

--- a/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
@@ -24,12 +24,7 @@ from docker import DockerClient
 from docker.errors import APIError
 from docker.errors import NotFound
 
-from onyx.server.features.build.sandbox.acp.base import ACP_PROTOCOL_VERSION
-from onyx.server.features.build.sandbox.acp.base import ACPClientState
-from onyx.server.features.build.sandbox.acp.base import ACPEvent as ACPEvent
 from onyx.server.features.build.sandbox.acp.base import ACPExecClientBase
-from onyx.server.features.build.sandbox.acp.base import ACPSession
-from onyx.server.features.build.sandbox.base import SSEKeepalive as SSEKeepalive
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
     _FRAME_HEADER_BYTES,
 )
@@ -52,18 +47,6 @@ DEFAULT_CLIENT_INFO = {
     "title": "Onyx Sandbox Agent Client (Docker Exec)",
     "version": "1.0.0",
 }
-
-
-# Re-exported for back-compat with external imports.
-__all__ = [
-    "ACP_PROTOCOL_VERSION",
-    "ACPClientState",
-    "ACPEvent",
-    "ACPSession",
-    "DEFAULT_CLIENT_INFO",
-    "DockerACPExecClient",
-    "SSEKeepalive",
-]
 
 
 class DockerACPExecClient(ACPExecClientBase):

--- a/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
@@ -82,9 +82,6 @@ class DockerACPExecClient(ACPExecClientBase):
         return f"container={self._container_name}"
 
     def _open_transport(self, cwd: str) -> None:
-        if self._socket is not None:
-            raise RuntimeError("Client already started. Call stop() first.")
-
         data_dir = shlex.quote(f"{cwd}/.opencode-data")
         safe_cwd = shlex.quote(cwd)
         cmd = [

--- a/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py
@@ -2,10 +2,8 @@
 
 This is the Docker analogue of
 ``onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client``.
-
-It runs ``opencode acp`` inside the sandbox container via the Docker Engine
-exec API and shuttles JSON-RPC messages between api_server and the agent
-over the multiplexed exec stream.
+The shared JSON-RPC protocol lives on :class:`ACPExecClientBase`; this
+subclass owns the multiplexed-docker-exec transport.
 
 Each message creates an ephemeral client (start → resume_or_create_session →
 send_message → stop) so only a single ``opencode`` process ever operates on
@@ -19,33 +17,22 @@ import shlex
 import socket
 import struct
 import threading
-import time
-from collections.abc import Generator
-from dataclasses import dataclass
-from dataclasses import field
-from queue import Empty
-from queue import Queue
 from typing import Any
-from typing import cast
+from typing import ClassVar
 
-from acp.schema import AgentMessageChunk
-from acp.schema import AgentPlanUpdate
-from acp.schema import AgentThoughtChunk
-from acp.schema import CurrentModeUpdate
-from acp.schema import Error
-from acp.schema import PromptResponse
-from acp.schema import ToolCallProgress
-from acp.schema import ToolCallStart
 from docker import DockerClient
 from docker.errors import APIError
 from docker.errors import NotFound
-from pydantic import BaseModel
-from pydantic import ValidationError
 
-from onyx.server.features.build.api.packet_logger import get_packet_logger
-from onyx.server.features.build.configs import ACP_MESSAGE_TIMEOUT
-from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
+from onyx.server.features.build.sandbox.acp.base import ACP_PROTOCOL_VERSION
+from onyx.server.features.build.sandbox.acp.base import ACPClientState
+from onyx.server.features.build.sandbox.acp.base import ACPEvent as ACPEvent
+from onyx.server.features.build.sandbox.acp.base import ACPExecClientBase
+from onyx.server.features.build.sandbox.acp.base import ACPSession
 from onyx.server.features.build.sandbox.base import SSEKeepalive as SSEKeepalive
+from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
+    _FRAME_HEADER_BYTES,
+)
 from onyx.server.features.build.sandbox.docker.internal.exec_helpers import (
     _FRAME_STDERR,
 )
@@ -59,7 +46,6 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-ACP_PROTOCOL_VERSION = 1
 
 DEFAULT_CLIENT_INFO = {
     "name": "onyx-sandbox-docker-exec",
@@ -67,44 +53,23 @@ DEFAULT_CLIENT_INFO = {
     "version": "1.0.0",
 }
 
-# Header for docker multiplexed exec streams.
-_FRAME_HEADER_BYTES = 8
+
+# Re-exported for back-compat with external imports.
+__all__ = [
+    "ACP_PROTOCOL_VERSION",
+    "ACPClientState",
+    "ACPEvent",
+    "ACPSession",
+    "DEFAULT_CLIENT_INFO",
+    "DockerACPExecClient",
+    "SSEKeepalive",
+]
 
 
-ACPEvent = (
-    AgentMessageChunk
-    | AgentThoughtChunk
-    | ToolCallStart
-    | ToolCallProgress
-    | AgentPlanUpdate
-    | CurrentModeUpdate
-    | PromptResponse
-    | Error
-    | SSEKeepalive
-)
+class DockerACPExecClient(ACPExecClientBase):
+    """ACP client that talks JSON-RPC over a ``docker exec`` socket."""
 
-
-@dataclass
-class ACPSession:
-    session_id: str
-    cwd: str
-
-
-@dataclass
-class ACPClientState:
-    initialized: bool = False
-    sessions: dict[str, ACPSession] = field(default_factory=dict)
-    next_request_id: int = 0
-    agent_capabilities: dict[str, Any] = field(default_factory=dict)
-    agent_info: dict[str, Any] = field(default_factory=dict)
-
-
-class DockerACPExecClient:
-    """ACP client that talks JSON-RPC over a ``docker exec`` socket.
-
-    Mirrors the K8s ``ACPExecClient`` but uses the Docker Engine API for
-    process management.
-    """
+    transport_name: ClassVar[str] = "docker"
 
     def __init__(
         self,
@@ -115,24 +80,25 @@ class DockerACPExecClient:
         client_info: dict[str, Any] | None = None,
         client_capabilities: dict[str, Any] | None = None,
     ) -> None:
+        super().__init__(
+            client_info=client_info or DEFAULT_CLIENT_INFO,
+            client_capabilities=client_capabilities,
+        )
         self._docker = docker_client
         self._container_name = container_name
         self._user = user
-        self._client_info = client_info or DEFAULT_CLIENT_INFO
-        self._client_capabilities = client_capabilities or {
-            "fs": {"readTextFile": True, "writeTextFile": True},
-            "terminal": True,
-        }
-        self._state = ACPClientState()
         self._exec_id: str | None = None
         self._socket: socket.socket | None = None
         self._socket_lock = threading.Lock()
-        self._response_queue: Queue[dict[str, Any]] = Queue()
-        self._reader_thread: threading.Thread | None = None
-        self._stop_reader = threading.Event()
 
-    def start(self, cwd: str = "/workspace", timeout: float = 30.0) -> None:
-        """Start ``opencode acp`` in the sandbox container and ACP-initialize."""
+    # ------------------------------------------------------------------
+    # Transport hooks
+    # ------------------------------------------------------------------
+
+    def _log_target(self) -> str:
+        return f"container={self._container_name}"
+
+    def _open_transport(self, cwd: str) -> None:
         if self._socket is not None:
             raise RuntimeError("Client already started. Call stop() first.")
 
@@ -143,12 +109,6 @@ class DockerACPExecClient:
             "-c",
             f"XDG_DATA_HOME={data_dir} exec opencode acp --cwd {safe_cwd}",
         ]
-
-        logger.info(
-            "[DOCKER-ACP] Starting client: container=%s cwd=%s",
-            self._container_name,
-            cwd,
-        )
 
         try:
             api = self._docker.api
@@ -166,35 +126,35 @@ class DockerACPExecClient:
             self._socket = _unwrap_socket(wrapped_sock)
             # Make recv() return promptly so the reader can poll for shutdown.
             self._socket.settimeout(0.5)
-
-            self._stop_reader.clear()
-            self._reader_thread = threading.Thread(
-                target=self._read_responses, daemon=True
-            )
-            self._reader_thread.start()
-
-            # Let opencode boot before sending the initialize.
-            time.sleep(0.5)
-            self._initialize(timeout=timeout)
-            logger.info(
-                "[DOCKER-ACP] Client started: container=%s", self._container_name
-            )
         except (APIError, NotFound) as e:
-            logger.error(
-                "[DOCKER-ACP] start failed: container=%s err=%s",
-                self._container_name,
-                e,
-            )
-            self.stop()
-            raise RuntimeError(f"Failed to start docker ACP exec client: {e}") from e
-        except Exception:
-            self.stop()
-            raise
+            raise RuntimeError(f"docker exec failed: {e}") from e
 
-    def _read_responses(self) -> None:
-        """Background thread: parse multiplexed frames into JSON-RPC messages."""
+    def _close_transport(self) -> None:
+        if self._socket is not None:
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+            self._socket = None
+        self._exec_id = None
+
+    def _is_transport_open(self) -> bool:
+        return self._socket is not None
+
+    def _write_line(self, line: str) -> None:
+        sock = self._socket
+        if sock is None:
+            raise RuntimeError("Docker exec socket not open")
+        with self._socket_lock:
+            sock.sendall(line.encode("utf-8"))
+
+    def _read_responses_loop(self) -> None:
+        """Parse multiplexed docker-exec frames into JSON-RPC messages."""
         buffer = ""
-        packet_logger = get_packet_logger()
 
         while not self._stop_reader.is_set():
             sock = self._socket
@@ -222,8 +182,9 @@ class DockerACPExecClient:
 
             if stream_type == _FRAME_STDERR:
                 logger.warning(
-                    "[DOCKER-ACP] stderr container=%s: %s",
-                    self._container_name,
+                    "%s stderr %s: %s",
+                    self._log_prefix,
+                    self._log_target(),
                     payload.decode("utf-8", errors="replace").strip()[:500],
                 )
                 continue
@@ -240,22 +201,23 @@ class DockerACPExecClient:
                     message = json.loads(line)
                 except json.JSONDecodeError:
                     logger.warning(
-                        "[DOCKER-ACP] Invalid JSON from agent: %s", line[:100]
+                        "%s Invalid JSON from agent: %s",
+                        self._log_prefix,
+                        line[:100],
                     )
                     continue
-                packet_logger.log_jsonrpc_raw_message("IN", message, context="docker")
-                self._response_queue.put(message)
+                self._enqueue_message(message)
 
     def _recv_exact(self, sock: socket.socket, n: int) -> bytes:
         """Read exactly ``n`` bytes, retrying through ``socket.timeout``.
 
-        The socket has a short read timeout (set in ``start``) so the reader
-        thread can periodically check ``_stop_reader`` for shutdown. That
-        timeout must NOT be allowed to discard partial bytes mid-frame —
-        Docker's multiplexed exec stream sends a fixed 8-byte header followed
-        by ``length`` bytes of payload, and if we drop 3 of those 8 header
-        bytes the next read interprets the remaining 5 as the start of a new
-        header, corrupting all downstream framing.
+        The socket has a short read timeout (set in ``_open_transport``) so
+        the reader thread can periodically check ``_stop_reader`` for
+        shutdown. That timeout must NOT be allowed to discard partial bytes
+        mid-frame — Docker's multiplexed exec stream sends a fixed 8-byte
+        header followed by ``length`` bytes of payload, and if we drop 3
+        of those 8 header bytes the next read interprets the remaining 5
+        as the start of a new header, corrupting all downstream framing.
 
         Returns partial data (``len < n``) only on EOF or shutdown.
         """
@@ -273,331 +235,3 @@ class DockerACPExecClient:
                 return bytes(buf)
             buf.extend(chunk)
         return bytes(buf)
-
-    def stop(self) -> None:
-        session_ids = list(self._state.sessions.keys())
-        logger.info(
-            "[DOCKER-ACP] Stopping client: container=%s sessions=%s",
-            self._container_name,
-            session_ids,
-        )
-        self._stop_reader.set()
-
-        if self._socket is not None:
-            try:
-                self._socket.shutdown(socket.SHUT_RDWR)
-            except OSError:
-                pass
-            try:
-                self._socket.close()
-            except OSError:
-                pass
-            self._socket = None
-
-        if self._reader_thread is not None:
-            self._reader_thread.join(timeout=2.0)
-            self._reader_thread = None
-
-        self._exec_id = None
-        self._state = ACPClientState()
-
-    def _get_next_id(self) -> int:
-        request_id = self._state.next_request_id
-        self._state.next_request_id += 1
-        return request_id
-
-    def _send_raw(self, line: str) -> None:
-        if self._socket is None:
-            raise RuntimeError("Docker exec socket not open")
-        with self._socket_lock:
-            self._socket.sendall(line.encode("utf-8"))
-
-    def _send_request(self, method: str, params: dict[str, Any] | None = None) -> int:
-        request_id = self._get_next_id()
-        request: dict[str, Any] = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-        }
-        if params is not None:
-            request["params"] = params
-
-        packet_logger = get_packet_logger()
-        packet_logger.log_jsonrpc_request(method, request_id, params, context="docker")
-        self._send_raw(json.dumps(request) + "\n")
-        return request_id
-
-    def _send_notification(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> None:
-        if self._socket is None:
-            return
-        notification: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
-        if params is not None:
-            notification["params"] = params
-        packet_logger = get_packet_logger()
-        packet_logger.log_jsonrpc_request(method, None, params, context="docker")
-        try:
-            self._send_raw(json.dumps(notification) + "\n")
-        except OSError:
-            return
-
-    def _wait_for_response(
-        self, request_id: int, timeout: float = 30.0
-    ) -> dict[str, Any]:
-        start_time = time.time()
-        while True:
-            remaining = timeout - (time.time() - start_time)
-            if remaining <= 0:
-                raise RuntimeError(
-                    f"Timeout waiting for response to request {request_id}"
-                )
-            try:
-                message = self._response_queue.get(timeout=min(remaining, 1.0))
-                if message.get("id") == request_id:
-                    if "error" in message:
-                        error = message["error"]
-                        raise RuntimeError(
-                            f"ACP error {error.get('code')}: {error.get('message')}"
-                        )
-                    return message.get("result", {})
-                self._response_queue.put(message)
-            except Empty:
-                continue
-
-    def _initialize(self, timeout: float = 30.0) -> dict[str, Any]:
-        params = {
-            "protocolVersion": ACP_PROTOCOL_VERSION,
-            "clientCapabilities": self._client_capabilities,
-            "clientInfo": self._client_info,
-        }
-        request_id = self._send_request("initialize", params)
-        result = self._wait_for_response(request_id, timeout)
-        self._state.initialized = True
-        self._state.agent_capabilities = result.get("agentCapabilities", {})
-        self._state.agent_info = result.get("agentInfo", {})
-        return result
-
-    def _create_session(self, cwd: str, timeout: float = 30.0) -> str:
-        params = {"cwd": cwd, "mcpServers": []}
-        request_id = self._send_request("session/new", params)
-        result = self._wait_for_response(request_id, timeout)
-        session_id = result.get("sessionId")
-        if not session_id:
-            raise RuntimeError("No session ID returned from session/new")
-        self._state.sessions[session_id] = ACPSession(session_id=session_id, cwd=cwd)
-        logger.info(
-            "[DOCKER-ACP] Created session: acp_session=%s cwd=%s", session_id, cwd
-        )
-        return session_id
-
-    def _list_sessions(self, cwd: str, timeout: float = 10.0) -> list[dict[str, Any]]:
-        try:
-            request_id = self._send_request("session/list", {"cwd": cwd})
-            result = self._wait_for_response(request_id, timeout)
-            return cast("list[dict[str, Any]]", result.get("sessions", []))
-        except Exception as e:
-            logger.info("[DOCKER-ACP] session/list unavailable: %s", e)
-            return []
-
-    def _resume_session(self, session_id: str, cwd: str, timeout: float = 30.0) -> str:
-        params = {"sessionId": session_id, "cwd": cwd, "mcpServers": []}
-        request_id = self._send_request("session/resume", params)
-        result = self._wait_for_response(request_id, timeout)
-        resumed_id = result.get("sessionId", session_id)
-        self._state.sessions[resumed_id] = ACPSession(session_id=resumed_id, cwd=cwd)
-        logger.info(
-            "[DOCKER-ACP] Resumed session: acp_session=%s cwd=%s", resumed_id, cwd
-        )
-        return resumed_id
-
-    def _try_resume_existing_session(self, cwd: str, timeout: float) -> str | None:
-        sessions = self._list_sessions(cwd, timeout=min(timeout, 10.0))
-        if not sessions:
-            return None
-        target = sessions[0]
-        target_id = target.get("sessionId")
-        if not target_id:
-            return None
-        try:
-            return self._resume_session(target_id, cwd, timeout)
-        except Exception as e:
-            logger.warning(
-                "[DOCKER-ACP] session/resume failed for %s: %s, falling back to session/new",
-                target_id,
-                e,
-            )
-            return None
-
-    def resume_or_create_session(self, cwd: str, timeout: float = 30.0) -> str:
-        if not self._state.initialized:
-            raise RuntimeError("Client not initialized. Call start() first.")
-        resumed_id = self._try_resume_existing_session(cwd, timeout)
-        if resumed_id:
-            return resumed_id
-        return self._create_session(cwd=cwd, timeout=timeout)
-
-    def send_message(
-        self,
-        message: str,
-        session_id: str,
-        timeout: float = ACP_MESSAGE_TIMEOUT,
-    ) -> Generator[ACPEvent, None, None]:
-        if session_id not in self._state.sessions:
-            raise RuntimeError(
-                f"Unknown session {session_id}. "
-                f"Known: {list(self._state.sessions.keys())}"
-            )
-        packet_logger = get_packet_logger()
-
-        prompt_content = [{"type": "text", "text": message}]
-        params = {"sessionId": session_id, "prompt": prompt_content}
-        request_id = self._send_request("session/prompt", params)
-        start_time = time.time()
-        last_event_time = time.time()
-        events_yielded = 0
-        completion_reason = "unknown"
-
-        while True:
-            remaining = timeout - (time.time() - start_time)
-            if remaining <= 0:
-                completion_reason = "timeout"
-                logger.warning(
-                    "[DOCKER-ACP] Prompt timeout: acp_session=%s events=%s",
-                    session_id,
-                    events_yielded,
-                )
-                try:
-                    self.cancel(session_id=session_id)
-                except Exception as cancel_err:
-                    logger.warning(
-                        "[DOCKER-ACP] session/cancel failed on timeout: %s", cancel_err
-                    )
-                yield Error(code=-1, message="Timeout waiting for response")
-                break
-
-            try:
-                message_data = self._response_queue.get(timeout=min(remaining, 1.0))
-                last_event_time = time.time()
-            except Empty:
-                idle_time = time.time() - last_event_time
-                if idle_time >= SSE_KEEPALIVE_INTERVAL:
-                    yield SSEKeepalive()
-                    last_event_time = time.time()
-                continue
-
-            msg_id = message_data.get("id")
-            is_response = "method" not in message_data and (
-                msg_id == request_id
-                or (msg_id is not None and str(msg_id) == str(request_id))
-            )
-            if is_response:
-                completion_reason = "jsonrpc_response"
-                if "error" in message_data:
-                    error_data = message_data["error"]
-                    completion_reason = "jsonrpc_error"
-                    packet_logger.log_jsonrpc_response(
-                        request_id, error=error_data, context="docker"
-                    )
-                    yield Error(
-                        code=error_data.get("code", -1),
-                        message=error_data.get("message", "Unknown error"),
-                    )
-                else:
-                    result = message_data.get("result", {})
-                    packet_logger.log_jsonrpc_response(
-                        request_id, result=result, context="docker"
-                    )
-                    try:
-                        prompt_response = PromptResponse.model_validate(result)
-                        events_yielded += 1
-                        yield prompt_response
-                    except ValidationError as e:
-                        logger.error(
-                            "[DOCKER-ACP] PromptResponse validation failed: %s", e
-                        )
-                elapsed_ms = (time.time() - start_time) * 1000
-                logger.info(
-                    "[DOCKER-ACP] Prompt complete: reason=%s acp_session=%s events=%s elapsed=%sms",
-                    completion_reason,
-                    session_id,
-                    events_yielded,
-                    format(elapsed_ms, ".0f"),
-                )
-                break
-
-            if message_data.get("method") == "session/update":
-                params_data = message_data.get("params", {})
-                update = params_data.get("update", {})
-                prompt_complete = False
-                for event in self._process_session_update(update):
-                    events_yielded += 1
-                    yield event
-                    if isinstance(event, PromptResponse):
-                        prompt_complete = True
-                        break
-                if prompt_complete:
-                    completion_reason = "prompt_response_via_notification"
-                    break
-
-            elif "method" in message_data and "id" in message_data:
-                self._send_error_response(
-                    message_data["id"],
-                    -32601,
-                    f"Method not supported: {message_data['method']}",
-                )
-
-    def _process_session_update(
-        self, update: dict[str, Any]
-    ) -> Generator[ACPEvent, None, None]:
-        update_type = update.get("sessionUpdate")
-        if not isinstance(update_type, str):
-            return
-        type_map: dict[str, type[BaseModel]] = {
-            "agent_message_chunk": AgentMessageChunk,
-            "agent_thought_chunk": AgentThoughtChunk,
-            "tool_call": ToolCallStart,
-            "tool_call_update": ToolCallProgress,
-            "plan": AgentPlanUpdate,
-            "current_mode_update": CurrentModeUpdate,
-            "prompt_response": PromptResponse,
-        }
-        model_class = type_map.get(update_type)
-        if model_class is not None:
-            try:
-                yield cast(ACPEvent, model_class.model_validate(update))
-            except ValidationError as e:
-                logger.warning(
-                    "[DOCKER-ACP] Validation error for %s: %s", update_type, e
-                )
-
-    def _send_error_response(self, request_id: int, code: int, message: str) -> None:
-        if self._socket is None:
-            return
-        response = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "error": {"code": code, "message": message},
-        }
-        try:
-            self._send_raw(json.dumps(response) + "\n")
-        except OSError:
-            return
-
-    def cancel(self, session_id: str | None = None) -> None:
-        if session_id:
-            if session_id in self._state.sessions:
-                self._send_notification("session/cancel", {"sessionId": session_id})
-        else:
-            for sid in list(self._state.sessions):
-                self._send_notification("session/cancel", {"sessionId": sid})
-
-    @property
-    def is_running(self) -> bool:
-        return self._socket is not None
-
-    def __enter__(self) -> "DockerACPExecClient":
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self.stop()

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/__init__.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/__init__.py
@@ -2,11 +2,3 @@
 
 These modules are implementation details and should only be used by KubernetesSandboxManager.
 """
-
-from onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client import (
-    ACPEvent,
-)
-
-__all__ = [
-    "ACPEvent",
-]

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
@@ -22,12 +22,7 @@ from kubernetes import config
 from kubernetes.stream import stream as k8s_stream
 from kubernetes.stream.ws_client import WSClient
 
-from onyx.server.features.build.sandbox.acp.base import ACP_PROTOCOL_VERSION
-from onyx.server.features.build.sandbox.acp.base import ACPClientState
-from onyx.server.features.build.sandbox.acp.base import ACPEvent as ACPEvent
 from onyx.server.features.build.sandbox.acp.base import ACPExecClientBase
-from onyx.server.features.build.sandbox.acp.base import ACPSession
-from onyx.server.features.build.sandbox.base import SSEKeepalive as SSEKeepalive
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -38,18 +33,6 @@ DEFAULT_CLIENT_INFO = {
     "title": "Onyx Sandbox Agent Client (K8s Exec)",
     "version": "1.0.0",
 }
-
-
-# Re-exported for back-compat with external imports.
-__all__ = [
-    "ACP_PROTOCOL_VERSION",
-    "ACPClientState",
-    "ACPEvent",
-    "ACPExecClient",
-    "ACPSession",
-    "DEFAULT_CLIENT_INFO",
-    "SSEKeepalive",
-]
 
 
 class ACPExecClient(ACPExecClientBase):

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
@@ -75,9 +75,6 @@ class ACPExecClient(ACPExecClientBase):
         return f"pod={self._pod_name}"
 
     def _open_transport(self, cwd: str) -> None:
-        if self._ws_client is not None:
-            raise RuntimeError("Client already started. Call stop() first.")
-
         k8s = self._get_k8s_client()
 
         # Set XDG_DATA_HOME so opencode stores session data on the shared

--- a/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py
@@ -1,64 +1,38 @@
 """ACP client that communicates via kubectl exec into the sandbox pod.
 
-This client runs `opencode acp` directly in the sandbox pod via kubernetes exec,
-using stdin/stdout for JSON-RPC communication. This bypasses the HTTP server
-and uses the native ACP subprocess protocol.
+This client runs ``opencode acp`` directly in the sandbox pod via kubernetes
+exec, using stdin/stdout for JSON-RPC communication. The protocol code lives
+on :class:`ACPExecClientBase`; this subclass owns the kubernetes-exec
+transport.
 
 Each message creates an ephemeral client (start → resume_or_create_session →
 send_message → stop) to prevent concurrent processes from corrupting
-opencode's flat file session storage.
-
-Usage:
-    client = ACPExecClient(
-        pod_name="sandbox-abc123",
-        namespace="onyx-sandboxes",
-    )
-    client.start(cwd="/workspace")
-    session_id = client.resume_or_create_session(cwd="/workspace/sessions/abc")
-    for event in client.send_message("What files are here?", session_id=session_id):
-        print(event)
-    client.stop()
+opencode's flat-file session storage.
 """
+
+from __future__ import annotations
 
 import json
 import shlex
-import threading
-import time
-from collections.abc import Generator
-from dataclasses import dataclass
-from dataclasses import field
-from queue import Empty
-from queue import Queue
 from typing import Any
-from typing import cast
+from typing import ClassVar
 
-from acp.schema import AgentMessageChunk
-from acp.schema import AgentPlanUpdate
-from acp.schema import AgentThoughtChunk
-from acp.schema import CurrentModeUpdate
-from acp.schema import Error
-from acp.schema import PromptResponse
-from acp.schema import ToolCallProgress
-from acp.schema import ToolCallStart
 from kubernetes import client
 from kubernetes import config
 from kubernetes.stream import stream as k8s_stream
 from kubernetes.stream.ws_client import WSClient
-from pydantic import BaseModel
-from pydantic import ValidationError
 
-from onyx.server.features.build.api.packet_logger import get_packet_logger
-from onyx.server.features.build.configs import ACP_MESSAGE_TIMEOUT
-from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
+from onyx.server.features.build.sandbox.acp.base import ACP_PROTOCOL_VERSION
+from onyx.server.features.build.sandbox.acp.base import ACPClientState
+from onyx.server.features.build.sandbox.acp.base import ACPEvent as ACPEvent
+from onyx.server.features.build.sandbox.acp.base import ACPExecClientBase
+from onyx.server.features.build.sandbox.acp.base import ACPSession
 from onyx.server.features.build.sandbox.base import SSEKeepalive as SSEKeepalive
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# ACP Protocol version
-ACP_PROTOCOL_VERSION = 1
 
-# Default client info
 DEFAULT_CLIENT_INFO = {
     "name": "onyx-sandbox-k8s-exec",
     "title": "Onyx Sandbox Agent Client (K8s Exec)",
@@ -66,50 +40,22 @@ DEFAULT_CLIENT_INFO = {
 }
 
 
-# ``SSEKeepalive`` is imported from ``sandbox.base`` so every backend yields
-# the same class; isinstance checks in ``session/manager.py`` need to match
-# across K8s and Docker. Local re-export kept for back-compat with external
-# imports of the K8s symbol.
-
-# Union type for all possible events from send_message
-ACPEvent = (
-    AgentMessageChunk
-    | AgentThoughtChunk
-    | ToolCallStart
-    | ToolCallProgress
-    | AgentPlanUpdate
-    | CurrentModeUpdate
-    | PromptResponse
-    | Error
-    | SSEKeepalive
-)
+# Re-exported for back-compat with external imports.
+__all__ = [
+    "ACP_PROTOCOL_VERSION",
+    "ACPClientState",
+    "ACPEvent",
+    "ACPExecClient",
+    "ACPSession",
+    "DEFAULT_CLIENT_INFO",
+    "SSEKeepalive",
+]
 
 
-@dataclass
-class ACPSession:
-    """Represents an active ACP session."""
+class ACPExecClient(ACPExecClientBase):
+    """ACP client that communicates via the kubernetes exec WebSocket."""
 
-    session_id: str
-    cwd: str
-
-
-@dataclass
-class ACPClientState:
-    """Internal state for the ACP client."""
-
-    initialized: bool = False
-    sessions: dict[str, ACPSession] = field(default_factory=dict)
-    next_request_id: int = 0
-    agent_capabilities: dict[str, Any] = field(default_factory=dict)
-    agent_info: dict[str, Any] = field(default_factory=dict)
-
-
-class ACPExecClient:
-    """ACP client that communicates via kubectl exec.
-
-    Runs `opencode acp` in the sandbox pod and communicates via stdin/stdout
-    through the kubernetes exec stream.
-    """
+    transport_name: ClassVar[str] = "k8s"
 
     def __init__(
         self,
@@ -119,32 +65,17 @@ class ACPExecClient:
         client_info: dict[str, Any] | None = None,
         client_capabilities: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize the exec-based ACP client.
-
-        Args:
-            pod_name: Name of the sandbox pod
-            namespace: Kubernetes namespace
-            container: Container name within the pod
-            client_info: Client identification info
-            client_capabilities: Client capabilities to advertise
-        """
+        super().__init__(
+            client_info=client_info or DEFAULT_CLIENT_INFO,
+            client_capabilities=client_capabilities,
+        )
         self._pod_name = pod_name
         self._namespace = namespace
         self._container = container
-        self._client_info = client_info or DEFAULT_CLIENT_INFO
-        self._client_capabilities = client_capabilities or {
-            "fs": {"readTextFile": True, "writeTextFile": True},
-            "terminal": True,
-        }
-        self._state = ACPClientState()
         self._ws_client: WSClient | None = None
-        self._response_queue: Queue[dict[str, Any]] = Queue()
-        self._reader_thread: threading.Thread | None = None
-        self._stop_reader = threading.Event()
         self._k8s_client: client.CoreV1Api | None = None
 
     def _get_k8s_client(self) -> client.CoreV1Api:
-        """Get or create kubernetes client."""
         if self._k8s_client is None:
             try:
                 config.load_incluster_config()
@@ -153,28 +84,22 @@ class ACPExecClient:
             self._k8s_client = client.CoreV1Api()
         return self._k8s_client
 
-    def start(self, cwd: str = "/workspace", timeout: float = 30.0) -> None:
-        """Start the agent process via exec and initialize the ACP connection.
+    # ------------------------------------------------------------------
+    # Transport hooks
+    # ------------------------------------------------------------------
 
-        Only performs the ACP `initialize` handshake. Sessions are created
-        separately via `resume_or_create_session()`.
+    def _log_target(self) -> str:
+        return f"pod={self._pod_name}"
 
-        Args:
-            cwd: Working directory for the `opencode acp` process
-            timeout: Timeout for initialization
-
-        Raises:
-            RuntimeError: If startup fails
-        """
+    def _open_transport(self, cwd: str) -> None:
         if self._ws_client is not None:
             raise RuntimeError("Client already started. Call stop() first.")
 
         k8s = self._get_k8s_client()
 
-        # Start opencode acp via exec.
         # Set XDG_DATA_HOME so opencode stores session data on the shared
-        # workspace volume instead of the container-local ~/.local/share/
-        # filesystem.
+        # workspace volume rather than the container-local
+        # ~/.local/share/ filesystem.
         data_dir = shlex.quote(f"{cwd}/.opencode-data")
         safe_cwd = shlex.quote(cwd)
         exec_command = [
@@ -183,103 +108,21 @@ class ACPExecClient:
             f"XDG_DATA_HOME={data_dir} exec opencode acp --cwd {safe_cwd}",
         ]
 
-        logger.info("[ACP] Starting client: pod=%s cwd=%s", self._pod_name, cwd)
-
-        try:
-            self._ws_client = k8s_stream(
-                k8s.connect_get_namespaced_pod_exec,
-                name=self._pod_name,
-                namespace=self._namespace,
-                container=self._container,
-                command=exec_command,
-                stdin=True,
-                stdout=True,
-                stderr=True,
-                tty=False,
-                _preload_content=False,
-                _request_timeout=900,  # 15 minute timeout for long-running sessions
-            )
-
-            # Start reader thread
-            self._stop_reader.clear()
-            self._reader_thread = threading.Thread(
-                target=self._read_responses, daemon=True
-            )
-            self._reader_thread.start()
-
-            # Give process a moment to start
-            time.sleep(0.5)
-
-            # Initialize ACP connection (no session creation)
-            self._initialize(timeout=timeout)
-
-            logger.info("[ACP] Client started: pod=%s", self._pod_name)
-        except Exception as e:
-            logger.error(
-                "[ACP] Client start failed: pod=%s error=%s", self._pod_name, e
-            )
-            self.stop()
-            raise RuntimeError(f"Failed to start ACP exec client: {e}") from e
-
-    def _read_responses(self) -> None:
-        """Background thread to read responses from the exec stream."""
-        buffer = ""
-        packet_logger = get_packet_logger()
-
-        while not self._stop_reader.is_set():
-            if self._ws_client is None:
-                break
-
-            try:
-                if self._ws_client.is_open():
-                    self._ws_client.update(timeout=0.1)
-
-                    # Read stderr - log any agent errors
-                    stderr_data = self._ws_client.read_stderr(timeout=0.01)
-                    if stderr_data:
-                        logger.warning(
-                            "[ACP] stderr pod=%s: %s",
-                            self._pod_name,
-                            stderr_data.strip()[:500],
-                        )
-
-                    # Read stdout
-                    data = self._ws_client.read_stdout(timeout=0.1)
-                    if data:
-                        buffer += data
-
-                        while "\n" in buffer:
-                            line, buffer = buffer.split("\n", 1)
-                            line = line.strip()
-                            if line:
-                                try:
-                                    message = json.loads(line)
-                                    packet_logger.log_jsonrpc_raw_message(
-                                        "IN", message, context="k8s"
-                                    )
-                                    self._response_queue.put(message)
-                                except json.JSONDecodeError:
-                                    logger.warning(
-                                        "[ACP] Invalid JSON from agent: %s", line[:100]
-                                    )
-
-                else:
-                    logger.warning("[ACP] WebSocket closed: pod=%s", self._pod_name)
-                    break
-
-            except Exception as e:
-                if not self._stop_reader.is_set():
-                    logger.warning("[ACP] Reader error: %s, pod=%s", e, self._pod_name)
-                break
-
-    def stop(self) -> None:
-        """Stop the exec session and clean up."""
-        session_ids = list(self._state.sessions.keys())
-        logger.info(
-            "[ACP] Stopping client: pod=%s sessions=%s", self._pod_name, session_ids
+        self._ws_client = k8s_stream(
+            k8s.connect_get_namespaced_pod_exec,
+            name=self._pod_name,
+            namespace=self._namespace,
+            container=self._container,
+            command=exec_command,
+            stdin=True,
+            stdout=True,
+            stderr=True,
+            tty=False,
+            _preload_content=False,
+            _request_timeout=900,  # 15 min — long-running session
         )
-        self._stop_reader.set()
 
+    def _close_transport(self) -> None:
         if self._ws_client is not None:
             try:
                 self._ws_client.close()
@@ -287,471 +130,78 @@ class ACPExecClient:
                 pass
             self._ws_client = None
 
-        if self._reader_thread is not None:
-            self._reader_thread.join(timeout=2.0)
-            self._reader_thread = None
+    def _is_transport_open(self) -> bool:
+        return self._ws_client is not None and self._ws_client.is_open()
 
-        self._state = ACPClientState()
-
-    def _get_next_id(self) -> int:
-        """Get the next request ID."""
-        request_id = self._state.next_request_id
-        self._state.next_request_id += 1
-        return request_id
-
-    def _send_request(self, method: str, params: dict[str, Any] | None = None) -> int:
-        """Send a JSON-RPC request."""
-        if self._ws_client is None or not self._ws_client.is_open():
+    def _write_line(self, line: str) -> None:
+        ws = self._ws_client
+        if ws is None or not ws.is_open():
             raise RuntimeError("Exec session not open")
+        ws.write_stdin(line)
 
-        request_id = self._get_next_id()
-        request: dict[str, Any] = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "method": method,
-        }
-        if params is not None:
-            request["params"] = params
+    def _read_responses_loop(self) -> None:
+        buffer = ""
 
-        # Log the outgoing request
-        packet_logger = get_packet_logger()
-        packet_logger.log_jsonrpc_request(method, request_id, params, context="k8s")
-
-        message = json.dumps(request) + "\n"
-        self._ws_client.write_stdin(message)
-
-        return request_id
-
-    def _send_notification(
-        self, method: str, params: dict[str, Any] | None = None
-    ) -> None:
-        """Send a JSON-RPC notification (no response expected)."""
-        if self._ws_client is None or not self._ws_client.is_open():
-            return
-
-        notification: dict[str, Any] = {
-            "jsonrpc": "2.0",
-            "method": method,
-        }
-        if params is not None:
-            notification["params"] = params
-
-        # Log the outgoing notification
-        packet_logger = get_packet_logger()
-        packet_logger.log_jsonrpc_request(method, None, params, context="k8s")
-
-        message = json.dumps(notification) + "\n"
-        self._ws_client.write_stdin(message)
-
-    def _wait_for_response(
-        self, request_id: int, timeout: float = 30.0
-    ) -> dict[str, Any]:
-        """Wait for a response to a specific request."""
-        start_time = time.time()
-
-        while True:
-            remaining = timeout - (time.time() - start_time)
-            if remaining <= 0:
-                raise RuntimeError(
-                    f"Timeout waiting for response to request {request_id}"
-                )
+        while not self._stop_reader.is_set():
+            ws = self._ws_client
+            if ws is None:
+                break
 
             try:
-                message = self._response_queue.get(timeout=min(remaining, 1.0))
+                if ws.is_open():
+                    ws.update(timeout=0.1)
 
-                if message.get("id") == request_id:
-                    if "error" in message:
-                        error = message["error"]
-                        raise RuntimeError(
-                            f"ACP error {error.get('code')}: {error.get('message')}"
+                    stderr_data = ws.read_stderr(timeout=0.01)
+                    if stderr_data:
+                        logger.warning(
+                            "%s stderr %s: %s",
+                            self._log_prefix,
+                            self._log_target(),
+                            stderr_data.strip()[:500],
                         )
-                    return message.get("result", {})
 
-                # Put back messages that aren't our response
-                self._response_queue.put(message)
-
-            except Empty:
-                continue
-
-    def _initialize(self, timeout: float = 30.0) -> dict[str, Any]:
-        """Initialize the ACP connection."""
-        params = {
-            "protocolVersion": ACP_PROTOCOL_VERSION,
-            "clientCapabilities": self._client_capabilities,
-            "clientInfo": self._client_info,
-        }
-
-        request_id = self._send_request("initialize", params)
-        result = self._wait_for_response(request_id, timeout)
-
-        self._state.initialized = True
-        self._state.agent_capabilities = result.get("agentCapabilities", {})
-        self._state.agent_info = result.get("agentInfo", {})
-
-        return result
-
-    def _create_session(self, cwd: str, timeout: float = 30.0) -> str:
-        """Create a new ACP session."""
-        params = {
-            "cwd": cwd,
-            "mcpServers": [],
-        }
-
-        request_id = self._send_request("session/new", params)
-        result = self._wait_for_response(request_id, timeout)
-
-        session_id = result.get("sessionId")
-        if not session_id:
-            raise RuntimeError("No session ID returned from session/new")
-
-        self._state.sessions[session_id] = ACPSession(session_id=session_id, cwd=cwd)
-        logger.info("[ACP] Created session: acp_session=%s cwd=%s", session_id, cwd)
-
-        return session_id
-
-    def _list_sessions(self, cwd: str, timeout: float = 10.0) -> list[dict[str, Any]]:
-        """List available ACP sessions, filtered by working directory.
-
-        Returns:
-            List of session info dicts with keys like 'sessionId', 'cwd', 'title'.
-            Empty list if session/list is not supported or fails.
-        """
-        try:
-            request_id = self._send_request("session/list", {"cwd": cwd})
-            result = self._wait_for_response(request_id, timeout)
-            sessions = result.get("sessions", [])
-            logger.info(
-                "[ACP] session/list: %s sessions for cwd=%s", len(sessions), cwd
-            )
-            return sessions
-        except Exception as e:
-            logger.info("[ACP] session/list unavailable: %s", e)
-            return []
-
-    def _resume_session(self, session_id: str, cwd: str, timeout: float = 30.0) -> str:
-        """Resume an existing ACP session.
-
-        Args:
-            session_id: The ACP session ID to resume
-            cwd: Working directory for the session
-            timeout: Timeout for the resume request
-
-        Returns:
-            The session ID
-
-        Raises:
-            RuntimeError: If resume fails
-        """
-        params = {
-            "sessionId": session_id,
-            "cwd": cwd,
-            "mcpServers": [],
-        }
-
-        request_id = self._send_request("session/resume", params)
-        result = self._wait_for_response(request_id, timeout)
-
-        # The response should contain the session ID
-        resumed_id = result.get("sessionId", session_id)
-        self._state.sessions[resumed_id] = ACPSession(session_id=resumed_id, cwd=cwd)
-
-        logger.info("[ACP] Resumed session: acp_session=%s cwd=%s", resumed_id, cwd)
-        return resumed_id
-
-    def _try_resume_existing_session(self, cwd: str, timeout: float) -> str | None:
-        """Try to find and resume an existing session for this workspace.
-
-        When multiple API server replicas connect to the same sandbox pod,
-        a previous replica may have already created an ACP session for this
-        workspace. This method discovers and resumes that session so the
-        agent retains conversation context.
-
-        Args:
-            cwd: Working directory to search for sessions
-            timeout: Timeout for ACP requests
-
-        Returns:
-            The resumed session ID, or None if no session could be resumed
-        """
-        # List sessions for this workspace directory
-        sessions = self._list_sessions(cwd, timeout=min(timeout, 10.0))
-        if not sessions:
-            return None
-
-        # Pick the most recent session (first in list, assuming sorted)
-        target = sessions[0]
-        target_id = target.get("sessionId")
-        if not target_id:
-            logger.warning("[ACP] session/list returned session without sessionId")
-            return None
-
-        logger.info(
-            "[ACP] Resuming existing session: acp_session=%s (found %s)",
-            target_id,
-            len(sessions),
-        )
-
-        try:
-            return self._resume_session(target_id, cwd, timeout)
-        except Exception as e:
-            logger.warning(
-                "[ACP] session/resume failed for %s: %s, falling back to session/new",
-                target_id,
-                e,
-            )
-            return None
-
-    def resume_or_create_session(self, cwd: str, timeout: float = 30.0) -> str:
-        """Resume a session from opencode's on-disk storage, or create a new one.
-
-        With ephemeral clients (one process per message), this always hits disk.
-        Tries resume first to preserve conversation context, falls back to new.
-
-        Args:
-            cwd: Working directory for the session
-            timeout: Timeout for ACP requests
-
-        Returns:
-            The ACP session ID
-        """
-        if not self._state.initialized:
-            raise RuntimeError("Client not initialized. Call start() first.")
-
-        # Try to resume from opencode's persisted storage
-        resumed_id = self._try_resume_existing_session(cwd, timeout)
-        if resumed_id:
-            return resumed_id
-
-        # Create a new session
-        return self._create_session(cwd=cwd, timeout=timeout)
-
-    def send_message(
-        self,
-        message: str,
-        session_id: str,
-        timeout: float = ACP_MESSAGE_TIMEOUT,
-    ) -> Generator[ACPEvent, None, None]:
-        """Send a message to a specific session and stream response events.
-
-        Args:
-            message: The message content to send
-            session_id: The ACP session ID to send the message to
-            timeout: Maximum time to wait for complete response (defaults to ACP_MESSAGE_TIMEOUT env var)
-
-        Yields:
-            Typed ACP schema event objects
-        """
-        if session_id not in self._state.sessions:
-            raise RuntimeError(
-                f"Unknown session {session_id}. Known sessions: {list(self._state.sessions.keys())}"
-            )
-        packet_logger = get_packet_logger()
-
-        logger.info(
-            "[ACP] Sending prompt: acp_session=%s pod=%s queue_backlog=%s",
-            session_id,
-            self._pod_name,
-            self._response_queue.qsize(),
-        )
-
-        prompt_content = [{"type": "text", "text": message}]
-        params = {
-            "sessionId": session_id,
-            "prompt": prompt_content,
-        }
-
-        request_id = self._send_request("session/prompt", params)
-        start_time = time.time()
-        last_event_time = time.time()
-        events_yielded = 0
-        keepalive_count = 0
-        completion_reason = "unknown"
-
-        while True:
-            remaining = timeout - (time.time() - start_time)
-            if remaining <= 0:
-                completion_reason = "timeout"
-                logger.warning(
-                    "[ACP] Prompt timeout: acp_session=%s events=%s, sending session/cancel",
-                    session_id,
-                    events_yielded,
-                )
-                try:
-                    self.cancel(session_id=session_id)
-                except Exception as cancel_err:
-                    logger.warning(
-                        "[ACP] session/cancel failed on timeout: %s", cancel_err
-                    )
-                yield Error(code=-1, message="Timeout waiting for response")
-                break
-
-            try:
-                message_data = self._response_queue.get(timeout=min(remaining, 1.0))
-                last_event_time = time.time()
-            except Empty:
-                # Send SSE keepalive if idle
-                idle_time = time.time() - last_event_time
-                if idle_time >= SSE_KEEPALIVE_INTERVAL:
-                    keepalive_count += 1
-                    yield SSEKeepalive()
-                    last_event_time = time.time()
-                continue
-
-            # Check for JSON-RPC response to our prompt request.
-            msg_id = message_data.get("id")
-            is_response = "method" not in message_data and (
-                msg_id == request_id
-                or (msg_id is not None and str(msg_id) == str(request_id))
-            )
-            if is_response:
-                completion_reason = "jsonrpc_response"
-                if "error" in message_data:
-                    error_data = message_data["error"]
-                    completion_reason = "jsonrpc_error"
-                    logger.warning("[ACP] Prompt error: %s", error_data)
-                    packet_logger.log_jsonrpc_response(
-                        request_id, error=error_data, context="k8s"
-                    )
-                    yield Error(
-                        code=error_data.get("code", -1),
-                        message=error_data.get("message", "Unknown error"),
-                    )
+                    data = ws.read_stdout(timeout=0.1)
+                    if data:
+                        buffer += data
+                        while "\n" in buffer:
+                            line, buffer = buffer.split("\n", 1)
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                message = json.loads(line)
+                            except json.JSONDecodeError:
+                                logger.warning(
+                                    "%s Invalid JSON from agent: %s",
+                                    self._log_prefix,
+                                    line[:100],
+                                )
+                                continue
+                            self._enqueue_message(message)
                 else:
-                    result = message_data.get("result", {})
-                    packet_logger.log_jsonrpc_response(
-                        request_id, result=result, context="k8s"
-                    )
-                    try:
-                        prompt_response = PromptResponse.model_validate(result)
-                        events_yielded += 1
-                        yield prompt_response
-                    except ValidationError as e:
-                        logger.error("[ACP] PromptResponse validation failed: %s", e)
-
-                elapsed_ms = (time.time() - start_time) * 1000
-                logger.info(
-                    "[ACP] Prompt complete: reason=%s acp_session=%s events=%s elapsed=%sms",
-                    completion_reason,
-                    session_id,
-                    events_yielded,
-                    format(elapsed_ms, ".0f"),
-                )
-                break
-
-            # Handle notifications (session/update)
-            if message_data.get("method") == "session/update":
-                params_data = message_data.get("params", {})
-                update = params_data.get("update", {})
-
-                prompt_complete = False
-                for event in self._process_session_update(update):
-                    events_yielded += 1
-                    yield event
-                    if isinstance(event, PromptResponse):
-                        prompt_complete = True
-                        break
-
-                if prompt_complete:
-                    completion_reason = "prompt_response_via_notification"
-                    elapsed_ms = (time.time() - start_time) * 1000
-                    logger.info(
-                        "[ACP] Prompt complete: reason=%s acp_session=%s events=%s elapsed=%sms",
-                        completion_reason,
-                        session_id,
-                        events_yielded,
-                        format(elapsed_ms, ".0f"),
+                    logger.warning(
+                        "%s WebSocket closed: %s",
+                        self._log_prefix,
+                        self._log_target(),
                     )
                     break
 
-            # Handle requests from agent - send error response
-            elif "method" in message_data and "id" in message_data:
-                logger.debug(
-                    "[ACP] Unsupported agent request: method=%s", message_data["method"]
-                )
-                self._send_error_response(
-                    message_data["id"],
-                    -32601,
-                    f"Method not supported: {message_data['method']}",
-                )
+            except Exception as e:
+                if not self._stop_reader.is_set():
+                    logger.warning(
+                        "%s Reader error: %s, %s",
+                        self._log_prefix,
+                        e,
+                        self._log_target(),
+                    )
+                break
 
-            else:
-                logger.warning(
-                    "[ACP] Unhandled message: id=%s method=%s keys=%s",
-                    message_data.get("id"),
-                    message_data.get("method"),
-                    list(message_data.keys()),
-                )
-
-    def _process_session_update(
-        self, update: dict[str, Any]
-    ) -> Generator[ACPEvent, None, None]:
-        """Process a session/update notification and yield typed ACP schema objects."""
-        update_type = update.get("sessionUpdate")
-        if not isinstance(update_type, str):
-            return
-
-        # Map update types to their ACP schema classes.
-        # Note: prompt_response is included because ACP sometimes sends it as a
-        # notification WITHOUT a corresponding JSON-RPC response. We accept
-        # either signal as turn completion (first one wins).
-        type_map: dict[str, type[BaseModel]] = {
-            "agent_message_chunk": AgentMessageChunk,
-            "agent_thought_chunk": AgentThoughtChunk,
-            "tool_call": ToolCallStart,
-            "tool_call_update": ToolCallProgress,
-            "plan": AgentPlanUpdate,
-            "current_mode_update": CurrentModeUpdate,
-            "prompt_response": PromptResponse,
-        }
-
-        model_class = type_map.get(update_type)
-        if model_class is not None:
-            try:
-                yield cast(ACPEvent, model_class.model_validate(update))
-            except ValidationError as e:
-                logger.warning("[ACP] Validation error for %s: %s", update_type, e)
-        elif update_type not in (
-            "user_message_chunk",
-            "available_commands_update",
-            "session_info_update",
-            "usage_update",
-        ):
-            logger.debug("[ACP] Unknown update type: %s", update_type)
-
-    def _send_error_response(self, request_id: int, code: int, message: str) -> None:
-        """Send an error response to an agent request."""
-        if self._ws_client is None or not self._ws_client.is_open():
-            return
-
-        response = {
-            "jsonrpc": "2.0",
-            "id": request_id,
-            "error": {"code": code, "message": message},
-        }
-
-        self._ws_client.write_stdin(json.dumps(response) + "\n")
-
-    def cancel(self, session_id: str | None = None) -> None:
-        """Cancel the current operation on a session.
-
-        Args:
-            session_id: The ACP session ID to cancel. If None, cancels all sessions.
-        """
-        if session_id:
-            if session_id in self._state.sessions:
-                self._send_notification(
-                    "session/cancel",
-                    {"sessionId": session_id},
-                )
-        else:
-            for sid in self._state.sessions:
-                self._send_notification(
-                    "session/cancel",
-                    {"sessionId": sid},
-                )
+    # ------------------------------------------------------------------
+    # K8s-only operations
+    # ------------------------------------------------------------------
 
     def health_check(self, timeout: float = 5.0) -> bool:  # noqa: ARG002
-        """Check if we can exec into the pod."""
+        """Check if we can exec into the pod via a fresh ``echo ok`` command."""
         try:
             k8s = self._get_k8s_client()
             result = k8s_stream(
@@ -768,16 +218,3 @@ class ACPExecClient:
             return "ok" in result
         except Exception:
             return False
-
-    @property
-    def is_running(self) -> bool:
-        """Check if the exec session is running."""
-        return self._ws_client is not None and self._ws_client.is_open()
-
-    def __enter__(self) -> "ACPExecClient":
-        """Context manager entry."""
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Context manager exit - ensures cleanup."""
-        self.stop()

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -70,6 +70,7 @@ from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
 from onyx.server.features.build.configs import SANDBOX_S3_BUCKET
 from onyx.server.features.build.configs import SANDBOX_SERVICE_ACCOUNT_NAME
+from onyx.server.features.build.sandbox.acp.base import ACPEvent
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.kubernetes.docker.sandbox_daemon.models import (
     SnapshotCreateRequest,
@@ -79,9 +80,6 @@ from onyx.server.features.build.sandbox.kubernetes.docker.sandbox_daemon.models 
 )
 from onyx.server.features.build.sandbox.kubernetes.docker.sandbox_daemon.models import (
     SnapshotRestoreRequest,
-)
-from onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client import (
-    ACPEvent,
 )
 from onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client import (
     ACPExecClient,

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -36,9 +36,7 @@ from onyx.db.models import User
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import upsert_agent_plan
-from onyx.server.features.build.sandbox.kubernetes.internal.acp_exec_client import (
-    SSEKeepalive,
-)
+from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.session.manager import BuildStreamingState
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.craft.stubs import StubSandboxManager


### PR DESCRIPTION
## Description

Pure code motion (no behavior change). Extracts the ACP JSON-RPC protocol layer shared between the K8s and Docker exec clients into a new `ACPExecClientBase` so future protocol fixes land once instead of being duplicated.

Stacked on #11222 (docker-compose-2). The K8s exec client and Docker exec client were ~95% structurally identical — same JSON-RPC framing, same state machine, same `send_message` loop, same session lifecycle. Only the transport (kubernetes exec WebSocket vs multiplexed docker exec socket) differed.

**Layout**
- New: `backend/onyx/server/features/build/sandbox/acp/base.py` — `ACPExecClientBase(ABC)` with the shared protocol. Subclasses implement five hooks: `_open_transport`, `_close_transport`, `_is_transport_open`, `_write_line`, `_read_responses_loop` (plus `_log_target`).
- `kubernetes/internal/acp_exec_client.py`: **783 → 220 lines** (subclasses base, keeps the kubernetes-exec transport + the K8s-only `health_check`).
- `docker/internal/acp_exec_client.py`: **603 → 237 lines** (subclasses base, keeps the Docker multiplexed-frame transport + `_recv_exact`).
- **Net: ~1386 → ~1096 lines.**

**K8s production path is touched.** This is the larger of the two clients and serves real traffic. Verified via:
- ty + ruff clean on all three files
- All 120 sandbox unit tests pass (3/3 Docker ACP framing tests, 117/117 others)
- Code review: subclass methods are mechanical lifts; the shared `send_message` matches the K8s original byte-for-byte modulo the log-prefix substitution

**Visible behavior diff:** K8s log prefix changes from `[ACP]` → `[K8S-ACP]` so it's symmetric with Docker's `[DOCKER-ACP]`. Dashboards/log filters that match `[ACP]` will still match (prefix substring). No other observable changes.

## How Has This Been Tested?

- \`uv run pytest backend/tests/unit/onyx/server/features/build/sandbox/\` — 120 passed, 2 skipped
- \`uv run pytest backend/tests/unit/onyx/server/features/build/sandbox/test_docker_acp_exec_client.py -xv\` — all 3 framing/round-trip tests pass against the same fake socket harness as before
- \`uv run ty check backend/onyx/server/features/build/sandbox/\` — clean
- \`uv run ruff check\` / \`ruff format\` — clean

Manual K8s smoke is not feasible from this environment; relying on code review for the K8s subclass since it's a mechanical lift of the existing transport code.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [docker-compose-skills #11218](https://github.com/onyx-dot-app/onyx/pull/11218)
2. [docker-compose-2 #11222](https://github.com/onyx-dot-app/onyx/pull/11222)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated the ACP JSON-RPC protocol into a shared `ACPExecClientBase` used by both K8s and Docker clients. Behavior is unchanged; the only visible change is the K8s log prefix now `[K8S-ACP]`.

- **Refactors**
  - New `backend/onyx/server/features/build/sandbox/acp/base.py`: protocol, state, session lifecycle, send loop, event dispatch; subclasses must define `transport_name` (enforced via `__init_subclass__`).
  - K8s `ACPExecClient` and Docker `DockerACPExecClient` now only contain transport code; removed double-open guards (base `start()` handles this). Sizes: 783→220 (K8s), 603→237 (Docker), net ~1386→~1096 lines.
  - Imports simplified: dropped ACP symbol re-exports from K8s/Docker modules; callers now import `ACPEvent` from `onyx.server.features.build.sandbox.acp.base` and `SSEKeepalive` from `onyx.server.features.build.sandbox.base`.
  - Logging: K8s prefix `[ACP]` → `[K8S-ACP]` to match Docker’s `[DOCKER-ACP]`.

<sup>Written for commit c3f05ab85eb25961b14bd49d1541bdece60813c5. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

