### PR TITLE
fix(saml): honor RelayState in SAML callback for SP-initiated flows

### DIFF
--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from fastapi import Request
 from fastapi import Response
 from fastapi import status
+from fastapi.responses import RedirectResponse
 from fastapi_users import exceptions
 from fastapi_users.authentication import Strategy
 from onelogin.saml2.auth import OneLogin_Saml2_Auth
@@ -281,6 +282,26 @@ async def _process_saml_callback(
 
     response = await auth_backend.login(strategy, user)
     await user_manager.on_after_login(user, request, response)
+
+    # Honor RelayState if present. The OneLogin toolkit puts it under
+    # post_data (POST binding) or get_data (Redirect binding). Without
+    # this, the IdP-originated POST lands on a bare 204 response and the
+    # browser has no signal to navigate, leaving the user stranded on the
+    # IdP's "Redirecting, please wait." intermediate page.
+    relay_state_raw = (
+        req.get("post_data", {}).get("RelayState")
+        or req.get("get_data", {}).get("RelayState")
+    )
+    relay_state = _sanitize_relay_state(relay_state_raw)
+    if relay_state:
+        redirect = RedirectResponse(url=relay_state, status_code=303)
+        # Preserve Set-Cookie header(s) emitted by auth_backend.login so the
+        # session cookie survives the redirect.
+        for header_name, header_value in response.raw_headers:
+            if header_name.lower() == b"set-cookie":
+                redirect.raw_headers.append((header_name, header_value))
+        return redirect
+
     return response
 
 


### PR DESCRIPTION
## What
The SAML callback handler now honors the `RelayState` parameter, issuing a 303 redirect to the original destination (with the auth cookie attached) instead of returning a bare 204.

## Why
After IdP login, Onyx returned an HTTP 204 with the session cookie. This works for IdP-initiated flows driven by the React frontend, but in SP-initiated flows (e.g. Keycloak's standard POST binding) the browser POSTs the SAMLResponse directly to `/api/auth/saml/callback` with `RelayState` set to the target path. A 204 gives the browser no signal to navigate, so users were stranded on the IdP's "Redirecting, please wait." intermediate page instead of landing on their original destination.

## Testing
Running in production on our deployment. Auto-redirect after login verified against a Keycloak IdP using the SP-initiated POST binding — users now land on their intended destination instead of the IdP redirect page. The RelayState value is passed through the existing `_sanitize_relay_state` helper before use.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor SAML `RelayState` in the callback to auto-redirect users after SP-initiated login. Returns a 303 to the original destination and preserves auth cookies instead of a 204 that left users on the IdP page.

- **Bug Fixes**
  - Read `RelayState` from `req["post_data"]` or `req["get_data"]`, then sanitize via `_sanitize_relay_state`.
  - When present, return a 303 `RedirectResponse` and copy `Set-Cookie` headers from the login response so the session persists.
  - Fall back to the existing response when `RelayState` is missing. Supports POST and Redirect bindings (e.g., Keycloak).

<sup>Written for commit 8f90dfaa872b4797a1c84ffac4bd888a1d904305. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11229?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

