### PR TITLE
feat(sharepoint): support /personal/ OneDrive for Business URLs

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1351,16 +1351,20 @@ class SharepointConnector(
             if base_url is None:
                 continue
 
+            # SharePoint site URLs come in three shapes: /sites/<name>,
+            # /teams/<name>, and /personal/<upn_with_underscores> for
+            # OneDrive for Business personal sites.
             lower_parts = [part.lower() for part in parts]
             site_type_index = None
-            for site_token in ("sites", "teams"):
+            for site_token in ("sites", "teams", "personal"):
                 if site_token in lower_parts:
                     site_type_index = lower_parts.index(site_token)
                     break
 
             if site_type_index is None or len(parts) <= site_type_index + 1:
                 logger.warning(
-                    "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name> or /teams/<name>)",
+                    "Site URL '%s' is not a valid Sharepoint URL "
+                    "(must contain /sites/<name>, /teams/<name>, or /personal/<upn>)",
                     url,
                 )
                 continue

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1104,13 +1104,22 @@ class SharepointConnector(
                 "Please check either 'Include Site Documents' or 'Include Site Pages' (or both)."
             )
 
-        # Ensure sites are sharepoint urls
+        # Ensure sites are sharepoint urls. We allow team sites (/sites/),
+        # team channels (/teams/), and OneDrive for Business personal sites
+        # (/personal/, served from `<tenant>-my.sharepoint.com`). Most SMB
+        # M365 tenants keep their content in personal OneDrive, so without
+        # /personal/ here we're locked out of the most common SMB shape.
         for site_url in self.sites:
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url
+                "/sites/" in site_url
+                or "/teams/" in site_url
+                or "/personal/" in site_url
             ):
                 raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
+                    "Site URLs must be full Sharepoint URLs "
+                    "(e.g. https://your-tenant.sharepoint.com/sites/your-site, "
+                    "https://your-tenant.sharepoint.com/teams/your-team, or "
+                    "https://your-tenant-my.sharepoint.com/personal/user_tenant_onmicrosoft_com)"
                 )
             try:
                 validate_outbound_http_url(site_url, https_only=True)
@@ -1211,7 +1220,9 @@ class SharepointConnector(
         """Extract the tenant domain from configured site URLs.
 
         Site URLs look like https://{tenant}.sharepoint.com/sites/... so the
-        tenant domain is the first label of the hostname.
+        tenant domain is the first label of the hostname. OneDrive personal
+        sites are served from https://{tenant}-my.sharepoint.com/personal/...
+        so we strip the `-my` suffix if present.
         """
         for site_url in self.sites:
             try:
@@ -1221,6 +1232,8 @@ class SharepointConnector(
             if not hostname:
                 continue
             tenant = hostname.split(".")[0]
+            if tenant.endswith("-my"):
+                tenant = tenant[: -len("-my")]
             if tenant:
                 return tenant
         logger.warning("No tenant domain found from %s sites", len(self.sites))


### PR DESCRIPTION
## What
The SharePoint connector now accepts and crawls OneDrive for Business personal site URLs (`<tenant>-my.sharepoint.com/personal/<upn>`), in addition to the existing `/sites/` and `/teams/` URLs.

## Why
The connector's URL validation only accepted paths containing `/sites/` or `/teams/`, silently rejecting `/personal/` OneDrive URLs. Even when validation was bypassed, the site-and-drive extractor didn't recognize the `personal` site token, so configured personal URLs were dropped and the connector fell back to auto-discovering team sites (which explicitly filter out `-my.sharepoint` hosts). The net effect: personal OneDrive was uncrawlable. For most SMB M365 tenants, that's where the bulk of content actually lives, not in team sites.

## Testing
Running in production on our deployment. The `/personal/` patch ingested 2838 documents from a real M365 tenant — covering both a personal OneDrive and a team site in the same run. The `-my` suffix is stripped from the host's first label so the REST API scope resolves to the correct tenant, and the downstream Graph calls (`sites.get_by_url`, `/drives`, `/root/children`) behave identically for personal sites (verified by direct Graph probe).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for OneDrive for Business personal site URLs (`https://<tenant>-my.sharepoint.com/personal/<upn>`) so the SharePoint connector can crawl personal OneDrive content. Also fixes tenant detection for `-my.sharepoint.com` hosts.

- **New Features**
  - URL validation and site parsing now recognize the `personal` token alongside `sites` and `teams`.
  - Tenant extraction strips the `-my` suffix from `<tenant>-my.sharepoint.com` to scope REST/Graph calls correctly.

<sup>Written for commit 949e4cf69131e7a3b628dd2f658ca00785c08d92. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11230?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

