### PR TITLE
docs(craft): document docker sandbox backend + check in feature plans

### DIFF
--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -19,13 +19,46 @@ The sandbox system provides isolated execution environments where OpenCode agent
    - Sandboxes run as directories on the local filesystem
    - No automatic cleanup or snapshots
    - Suitable for development and testing
+   - No isolation: the agent process shares the api_server's user / network / filesystem
 
 2. **Kubernetes Mode** (`SANDBOX_BACKEND=kubernetes`)
-   - Sandboxes run as Kubernetes pods
-   - Automatic snapshots to S3
+   - Sandboxes run as Kubernetes pods, one per user
+   - api_server talks to the Kubernetes API for pod lifecycle and `kubectl exec`
+   - Automatic snapshots to S3 via a sidecar container with IRSA credentials
    - Auto-cleanup of idle sandboxes
-   - Production-ready with resource isolation
+   - Production-ready with resource isolation, security context, and NetworkPolicies
+   - Used by Onyx's Helm chart / cloud deployment
    - For local-cluster development, see [docs/dev/local-kubernetes.md](/docs/dev/local-kubernetes.md).
+
+3. **Docker Mode** (`SANDBOX_BACKEND=docker`)
+   - Sandboxes run as Docker containers on the same host as the rest of the compose stack, one per user
+   - api_server mounts `/var/run/docker.sock` and talks to the Docker Engine API for container lifecycle and `docker exec`
+   - Snapshots tar-streamed through api_server-owned `FileStore` — agent containers never receive S3/MinIO credentials
+   - Auto-cleanup of idle sandboxes (background worker uses the same Docker socket)
+   - For self-hosted `docker compose` deployments enabled by `install.sh --include-craft`
+   - Sandboxes join only the dedicated `onyx_craft_sandbox` bridge — `postgres` / `redis` / `minio` / model servers are not reachable by compose DNS
+
+#### Kubernetes → Docker mapping
+
+The Docker backend is intentionally the closest single-VM analogue of the Kubernetes backend:
+
+| Kubernetes                            | Docker compose                                              |
+| ------------------------------------- | ----------------------------------------------------------- |
+| Sandbox pod (`sandbox-<id>`)          | Sandbox container (`sandbox-<id8>`)                         |
+| Pod `emptyDir` workspace volume       | Named volume mounted at `/workspace/sessions`               |
+| `kubectl exec` for setup/file ops/ACP | `docker exec` over the Docker Engine API                    |
+| Sidecar container for snapshots/IRSA  | api_server tar-streams via `docker exec` → `FileStore`      |
+| `Service` + DNS for Next.js preview   | Container IP on `onyx_craft_sandbox` bridge, proxied        |
+| `NetworkPolicy` for egress isolation  | Dedicated bridge network + host `DOCKER-USER` iptables rule |
+| Per-pod resource requests/limits      | `SANDBOX_DOCKER_CPU_LIMIT` / `SANDBOX_DOCKER_MEMORY_LIMIT`  |
+
+#### Docker mode trust boundary
+
+`api_server` and `background` mount the host Docker socket so they can drive sandbox containers. Anything that can talk to that socket is effectively root on the host — only enable Craft on hosts you fully control. Sandbox containers themselves run unprivileged: `--security-opt no-new-privileges`, `--cap-drop ALL`, `user=1000:1000`, no Docker socket, and a fixed env allowlist (`ONYX_PAT` + `ONYX_SERVER_URL`).
+
+`SANDBOX_API_SERVER_URL` must be the **public** HTTPS URL that the agent reaches Onyx through (same way any onyx-cli client would). Compose hostnames like `http://api_server:8080` do not resolve from inside the sandbox bridge.
+
+On EC2 the Docker bridge by default routes to `169.254.169.254` (IMDS), which can hand out IAM credentials. `install.sh --include-craft` installs a host-level `DOCKER-USER` iptables rule to drop sandbox→IMDS traffic when it has sudo/iptables access, and prints the manual command otherwise. There is no application-level fallback — fix this at the host firewall.
 
 ### Directory Structure
 
@@ -148,7 +181,8 @@ Configuration is generated dynamically in `templates/opencode_config.py`.
 
 - **`base.py`** - Abstract base class defining the sandbox interface
 - **`local/manager.py`** - Filesystem-based sandbox manager for local development
-- **`kubernetes/manager.py`** - Kubernetes-based sandbox manager for production
+- **`kubernetes/kubernetes_sandbox_manager.py`** - Kubernetes-based sandbox manager for Helm/cloud
+- **`docker/docker_sandbox_manager.py`** - Docker Engine-based sandbox manager for docker-compose
 
 ### Managers (Shared)
 
@@ -176,7 +210,7 @@ Configuration is generated dynamically in `templates/opencode_config.py`.
 
 ```bash
 # Sandbox backend mode
-SANDBOX_BACKEND=local|kubernetes           # Default: local
+SANDBOX_BACKEND=local|kubernetes|docker    # Default: local
 
 # Template paths (local mode)
 OUTPUTS_TEMPLATE_PATH=/templates/outputs   # Default: /templates/outputs
@@ -203,6 +237,35 @@ SANDBOX_S3_BUCKET=onyx-sandbox-files      # Default: onyx-sandbox-files
 
 # Service account
 SANDBOX_SERVICE_ACCOUNT_NAME=sandbox-file-sync  # Has S3 access via IRSA for snapshots
+```
+
+### Docker Settings
+
+```bash
+# Container image (defaults to a pinned tag in docker-compose.yml)
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.44
+
+# Public URL the sandbox agent uses to reach Onyx (HTTPS, externally resolvable —
+# compose hostnames like http://api_server:8080 will not resolve from inside the
+# sandbox bridge).
+SANDBOX_API_SERVER_URL=https://onyx.your-org.example
+
+# Host path of the Docker socket mounted into api_server/background
+SANDBOX_DOCKER_SOCKET=/var/run/docker.sock      # Default: /var/run/docker.sock
+
+# Dedicated bridge network. Pre-created by install.sh --include-craft (or run
+# `docker network create onyx_craft_sandbox` manually). Sandboxes join *only*
+# this network — compose services are not reachable by DNS from inside.
+SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox       # Default: onyx_craft_sandbox
+
+# Prefix for per-sandbox named volumes (mounted at /workspace/sessions).
+SANDBOX_DOCKER_VOLUME_PREFIX=onyx-sandbox       # Default: onyx-sandbox
+
+# Per-container resource limits. Defaults match K8s pod *requests* (1 CPU / 2Gi)
+# rather than limits, since single-VM compose deployments rarely have headroom
+# to over-commit every sandbox.
+SANDBOX_DOCKER_MEMORY_LIMIT=2g                  # Default: 2g
+SANDBOX_DOCKER_CPU_LIMIT=1.0                    # Default: 1.0
 ```
 
 ### Lifecycle Settings
@@ -250,6 +313,17 @@ curl -X POST http://localhost:3000/api/build/session/{session_id}/message \
 ```
 
 ## Troubleshooting
+
+### Sandbox Stuck in PROVISIONING (Docker)
+
+**Symptoms**: Sandbox status never changes from `PROVISIONING` in `docker compose` deployments
+
+**Solutions**:
+
+- Confirm `api_server` actually has the Docker socket: `docker compose exec api_server ls -l /var/run/docker.sock`
+- Confirm the dedicated bridge exists: `docker network inspect onyx_craft_sandbox` (created by `install.sh --include-craft`, or run `docker network create onyx_craft_sandbox` manually)
+- Check sandbox logs: `docker logs sandbox-<id8>`
+- Confirm `SANDBOX_API_SERVER_URL` is a publicly resolvable HTTPS URL (the agent cannot reach `http://api_server:8080` from inside the sandbox bridge)
 
 ### Sandbox Stuck in PROVISIONING (Kubernetes)
 
@@ -310,6 +384,9 @@ ln -s $(pwd)/backend/onyx/server/features/build/templates/outputs/web $HOME/.ony
 - **Init containers** have S3 access for file sync, but main sandbox container does NOT
 - **Network policies** can restrict sandbox egress traffic
 - **Resource limits** prevent resource exhaustion
+- **Docker containers** run with `--security-opt no-new-privileges`, `--cap-drop ALL`, `user=1000:1000`, no Docker socket, and a fixed env allowlist (`ONYX_PAT` + `ONYX_SERVER_URL`)
+- **Docker network isolation** is enforced by joining only the dedicated `onyx_craft_sandbox` bridge — compose's default network (postgres/redis/minio/model servers) is unreachable by DNS from inside a sandbox
+- **EC2 IMDS** must be blocked at the host firewall (`install.sh --include-craft` installs a `DOCKER-USER` iptables rule on EC2 when sudo is available) — there is no app-level fallback
 
 ### Credentials Management
 

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -6,17 +6,19 @@
 ################################################################################
 ## COMMONLY MODIFIED CONFIGURATIONS
 ################################################################################
-## Version of Onyx to deploy, default is latest (main built nightly)
-## For Craft support, use: IMAGE_TAG=craft-latest
+## Version of Onyx to deploy, default is latest (main built nightly).
+## For Craft, run install.sh with --include-craft instead of editing this file
+## — the installer forces the craft-tagged backend image and applies the
+## docker-compose.craft.yml overlay together.
 IMAGE_TAG=latest
 
 ## Onyx Craft Configuration
-## Craft enables AI-powered web app building within Onyx (disabled by default)
-## To enable Craft, uncomment the lines below (and comment out the above)
-## or use --include-craft with the install script
-## This adds Node.js 20 and opencode CLI to the image at build time
+## Craft enables AI-powered web app building within Onyx (disabled by default).
+## To enable Craft, re-run install.sh with --include-craft. Setting these
+## variables by hand without the craft compose overlay (which only the
+## installer writes) leaves api_server with SANDBOX_BACKEND=docker but no
+## Docker socket mount — sandboxes will fail to provision.
 # ENABLE_CRAFT=true
-# IMAGE_TAG=craft-latest
 #
 ## --- Craft sandbox backend (docker-compose only) ---
 ## docker-compose defaults SANDBOX_BACKEND to "docker" so api_server drives

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -868,33 +868,27 @@ if [ -f "$ENV_FILE" ]; then
     echo ""
 
     if [ "$REPLY" = "update" ]; then
-        print_info "Update selected. Which tag would you like to deploy?"
-        echo ""
-        echo "• Press Enter for edge (recommended)"
-        echo "• Type a specific tag (e.g., v0.1.0)"
-        echo ""
         if [ "$INCLUDE_CRAFT" = true ]; then
-            prompt_or_default "Enter tag [default: craft-latest]: " "craft-latest"
-            VERSION="$REPLY"
+            # --include-craft requires the craft-tagged backend image (Node.js
+            # + opencode CLI are only built into that image), so the tag is
+            # forced rather than prompted for.
+            VERSION="craft-latest"
+            print_info "Update selected. Using craft-latest (required by --include-craft)."
         else
+            print_info "Update selected. Which tag would you like to deploy?"
+            echo ""
+            echo "• Press Enter for edge (recommended)"
+            echo "• Type a specific tag (e.g., v0.1.0)"
+            echo ""
             prompt_or_default "Enter tag [default: edge]: " "edge"
             VERSION="$REPLY"
-        fi
-        echo ""
+            echo ""
 
-        if [ "$INCLUDE_CRAFT" = true ] && [ "$VERSION" = "craft-latest" ]; then
-            print_info "Selected: craft-latest (Craft enabled)"
-        elif [ "$VERSION" = "edge" ]; then
-            print_info "Selected: edge (latest nightly)"
-        else
-            print_info "Selected: $VERSION"
-        fi
-
-        # Reject craft image tags when running in lite mode
-        if [[ "$LITE_MODE" = true ]] && [[ "${VERSION:-}" == craft-* ]]; then
-            print_error "Cannot use a craft image tag (${VERSION}) with --lite."
-            print_info "Craft requires services (Vespa, Redis, background workers) that lite mode disables."
-            exit 1
+            if [ "$VERSION" = "edge" ]; then
+                print_info "Selected: edge (latest nightly)"
+            else
+                print_info "Selected: $VERSION"
+            fi
         fi
 
         # Update .env file with new version
@@ -907,22 +901,8 @@ if [ -f "$ENV_FILE" ]; then
             echo "IMAGE_TAG=$VERSION" >> "$ENV_FILE"
         fi
         print_success "Updated IMAGE_TAG to $VERSION in .env file"
-
-        # If using craft image, also enable ENABLE_CRAFT
-        if [[ "$VERSION" == craft-* ]]; then
-            sed -i.bak 's/^#* *ENABLE_CRAFT=.*/ENABLE_CRAFT=true/' "$ENV_FILE" 2>/dev/null || true
-            print_success "ENABLE_CRAFT set to true"
-        fi
         print_success "Configuration updated for upgrade"
     else
-        # Reject restarting a craft deployment in lite mode
-        EXISTING_TAG=$(grep "^IMAGE_TAG=" "$ENV_FILE" | head -1 | cut -d'=' -f2 | tr -d ' "'"'"'')
-        if [[ "$LITE_MODE" = true ]] && [[ "${EXISTING_TAG:-}" == craft-* ]]; then
-            print_error "Cannot restart a craft deployment (${EXISTING_TAG}) with --lite."
-            print_info "Craft requires services (Vespa, Redis, background workers) that lite mode disables."
-            exit 1
-        fi
-
         print_info "Keeping existing configuration..."
         print_success "Will restart with current settings"
     fi
@@ -937,30 +917,26 @@ else
     print_info "No existing .env file found. Setting up new deployment..."
     echo ""
 
-    # Ask for version
-    print_info "Which tag would you like to deploy?"
-    echo ""
+    # Ask for version (skipped when --include-craft forces the craft-tagged
+    # backend image, which is the only image that ships Node.js + opencode CLI).
     if [ "$INCLUDE_CRAFT" = true ]; then
-        echo "• Press Enter for craft-latest (recommended for Craft)"
-        echo "• Type a specific tag (e.g., craft-v1.0.0)"
-        echo ""
-        prompt_or_default "Enter tag [default: craft-latest]: " "craft-latest"
-        VERSION="$REPLY"
+        VERSION="craft-latest"
+        print_info "Using craft-latest (required by --include-craft)."
     else
+        print_info "Which tag would you like to deploy?"
+        echo ""
         echo "• Press Enter for edge (recommended)"
         echo "• Type a specific tag (e.g., v0.1.0)"
         echo ""
         prompt_or_default "Enter tag [default: edge]: " "edge"
         VERSION="$REPLY"
-    fi
-    echo ""
+        echo ""
 
-    if [ "$INCLUDE_CRAFT" = true ] && [ "$VERSION" = "craft-latest" ]; then
-        print_info "Selected: craft-latest (Craft enabled)"
-    elif [ "$VERSION" = "edge" ]; then
-        print_info "Selected: edge (latest nightly)"
-    else
-        print_info "Selected: $VERSION"
+        if [ "$VERSION" = "edge" ]; then
+            print_info "Selected: edge (latest nightly)"
+        else
+            print_info "Selected: $VERSION"
+        fi
     fi
 
     # Ask for authentication schema
@@ -992,13 +968,6 @@ else
     # Use basic auth by default
     AUTH_SCHEMA="basic"
 
-    # Reject craft image tags when running in lite mode (must check before writing .env)
-    if [[ "$LITE_MODE" = true ]] && [[ "${VERSION:-}" == craft-* ]]; then
-        print_error "Cannot use a craft image tag (${VERSION}) with --lite."
-        print_info "Craft requires services (Vespa, Redis, background workers) that lite mode disables."
-        exit 1
-    fi
-
     # Create .env file from template
     print_info "Creating .env file with your selections..."
     cp "$ENV_TEMPLATE" "$ENV_FILE"
@@ -1029,9 +998,9 @@ else
     USER_AUTH_SECRET=$(openssl rand -hex 32)
     sed -i.bak "s/^USER_AUTH_SECRET=.*/USER_AUTH_SECRET=\"$USER_AUTH_SECRET\"/" "$ENV_FILE" 2>/dev/null || true
 
-    # Configure Craft based on flag or if using a craft-* image tag
-    # By default, env.template has Craft commented out (disabled)
-    if [ "$INCLUDE_CRAFT" = true ] || [[ "$VERSION" == craft-* ]]; then
+    # Configure Craft based on --include-craft.
+    # By default, env.template has Craft commented out (disabled).
+    if [ "$INCLUDE_CRAFT" = true ]; then
         # Set ENABLE_CRAFT=true for runtime configuration (handles commented and uncommented lines)
         sed -i.bak 's/^#* *ENABLE_CRAFT=.*/ENABLE_CRAFT=true/' "$ENV_FILE" 2>/dev/null || true
         # Ensure SANDBOX_BACKEND=docker is written explicitly (docker-compose
@@ -1147,16 +1116,12 @@ fi
 export HOST_PORT=$AVAILABLE_PORT
 print_success "Using port $AVAILABLE_PORT for nginx"
 
-# Determine if we're using a floating tag (edge, latest, craft-*) that should force pull
-# Read IMAGE_TAG from .env file and remove any quotes or whitespace
+# Determine if we're using a floating tag (edge, latest) that should force pull.
+# Read IMAGE_TAG from .env file and remove any quotes or whitespace.
 CURRENT_IMAGE_TAG=$(grep "^IMAGE_TAG=" "$ENV_FILE" | head -1 | cut -d'=' -f2 | tr -d ' "'"'"'')
-if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ] || [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
+if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ]; then
     USE_LATEST=true
-    if [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
-        print_info "Using craft tag '$CURRENT_IMAGE_TAG' - will force pull and recreate containers"
-    else
-        print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
-    fi
+    print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
 else
     USE_LATEST=false
 fi

--- a/docs/craft/features/bun-node-modules-dedup.md
+++ b/docs/craft/features/bun-node-modules-dedup.md
@@ -1,0 +1,180 @@
+# Sandbox node_modules dedup via Bun
+
+## Context
+
+Each Craft session in a sandbox currently runs `npm install` against the
+Next.js template in `outputs/web/`. Measured cost per session on the
+`onyxdotapp/sandbox:v0.1.44` image:
+
+| | Per session |
+|---|---|
+| node_modules size on disk | ~836 MB |
+| `npm install` wall time | ~30 s |
+| node_modules file count | ~48,700 |
+
+The user-shared sandbox model means one Docker named volume (or one K8s
+emptyDir) holds N session workspaces. Disk usage scales linearly with N:
+
+| Sessions per sandbox | Volume size |
+|---|---|
+| 1 | ~715 MB |
+| 5 | ~3.5 GB |
+| 10 | ~7 GB |
+
+This is fine on K8s (emptyDir is ephemeral, cluster has space) but bites on
+docker-compose deployments where the host is typically a single small EC2.
+It's also wasted I/O: ~95% of the time the lockfile is identical across
+sessions, so we're reinstalling the same tree.
+
+## Issues to Address
+
+1. node_modules duplicated across every session in a sandbox.
+2. ~30 s of cold-start latency per session, dominated by `npm install`.
+3. Agent-driven `npm install <new-pkg>` mid-session must continue to work
+   and must not corrupt other sessions in the same sandbox.
+
+## Important Notes
+
+- Container images live on a shared registry; image size affects pull time
+  on every CI run and on every new EC2. Baking node_modules into the image
+  would add ~836 MB to a 675 MB image — meaningful penalty.
+- The Next.js template (`backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/`)
+  is shared by all session, and the `package.json` / lockfile in there is
+  the canonical version. Sessions never diverge from this lockfile unless
+  the agent explicitly modifies `package.json`.
+- The hot path is "session sets up → preview is reachable in under a few
+  seconds." Long npm-install wait blocks user-visible UX on every new
+  session.
+
+## Decision: Bun + Bun workspaces
+
+We replace `npm install` with `bun install` and structure
+`/workspace/sessions/` as a Bun workspace root. Key properties:
+
+- **Content-addressable global install cache**: Bun keeps tarballs in
+  `~/.bun/install/cache` and uses **hard-links** by default when populating
+  a project's `node_modules` (configurable via `--backend=hardlink`, which
+  is the default on Linux). So per-session disk overhead drops to inode
+  metadata — effectively zero.
+- **Workspace mode**: a top-level `package.json` at `/workspace/sessions/`
+  with `"workspaces": ["*/outputs/web"]` makes Bun resolve once, share a
+  single global node_modules under `/workspace/sessions/node_modules/`,
+  and *also* maintain per-session `node_modules/.bin` shadows. Sessions
+  read their deps from the hoisted store via the workspace resolution
+  algorithm.
+- **Speed**: `bun install` is typically 10–25× faster than `npm install`.
+  Cold session setup should drop from ~30 s to ~2–5 s.
+
+## Architecture
+
+```
+/workspace/sessions/
+├── package.json          # workspace root (baked into image OR written at provision)
+├── bun.lock              # shared lockfile (baked into image)
+├── node_modules/         # ONE hoisted tree per sandbox (Bun-managed)
+│   └── <flat deps>
+├── .shared/
+│   └── ... (already-used for snapshot bootstraps if any)
+└── <session_id>/
+    └── outputs/
+        └── web/
+            ├── package.json        # workspace member, references hoisted deps
+            └── node_modules/       # workspace-local symlinks/.bin entries
+```
+
+The setup script becomes:
+
+1. Copy template into `session/outputs/web/`.
+2. Ensure the workspace's `node_modules/` is populated. On first session,
+   `bun install --frozen-lockfile` at the workspace root. Subsequent
+   sessions: no-op (the hoisted tree is already there).
+3. Bun's `postinstall` ensures workspace members have their resolution
+   wired up.
+
+### Agent runs `bun install <new-pkg>` mid-session
+
+Bun's workspace install will add `<new-pkg>` to the *member's*
+`package.json` and the hoisted root `node_modules`. Other sessions in the
+same sandbox would see the new package's resolution but **wouldn't import
+it** (it's not in their `package.json`). The only risk is if the new
+package's version *upgrades* a transitive shared with another session's
+expectations; Bun handles this via the hoisted-vs-nested fallback in the
+workspace algorithm.
+
+If full isolation per session is required after all, we fall back to one
+of two patterns:
+1. Run `bun install` with `--no-save --linker=isolated` inside the
+   member (Bun supports an isolated-installs mode that mirrors pnpm's
+   per-project store). Each session gets its own dep tree backed by the
+   global cache.
+2. Keep workspaces off; do a normal `bun install` per session. Bun's
+   hardlink backend still gives us O(file count) inodes but ~0 disk per
+   session because all files are hardlinked from the global cache. This
+   is the simplest fallback and likely "good enough" without workspaces.
+
+## Implementation Strategy
+
+### PR A — Sandbox image switches from npm to bun
+
+- Update `backend/onyx/server/features/build/sandbox/kubernetes/docker/Dockerfile`:
+  - Install Bun (`curl -fsSL https://bun.sh/install | bash`).
+  - In the same RUN that copies the template, run `bun install --frozen-lockfile`
+    in the template's `outputs/web/` to populate Bun's cache. The cache is
+    ~50 MB of compressed tarballs (vs. ~836 MB of extracted node_modules)
+    so image growth is bounded.
+  - Bake `bun.lock` into the template.
+- Update both K8s and Docker manager setup scripts:
+  - Replace `cd outputs/web && npm install` with `cd outputs/web && bun install --frozen-lockfile`
+    (or, with workspaces, run once at the workspace root).
+- Update `_build_nextjs_start_script` so `dev` runs via `bun run dev`
+  (Bun runs Next.js fine; only the package-manager call changes).
+
+### PR B — Workspace hoisting (if disk savings from PR A are insufficient)
+
+- Add a top-level `package.json` at `/workspace/sessions/` defining `*/outputs/web`
+  as workspace members.
+- Modify setup script to write this top-level `package.json` at provision
+  time, then run `bun install` at the workspace root instead of per session.
+- Add lockfile-hash check: if the session's `package-lock.json` matches the
+  template's, skip per-session install entirely; if not, fall back to
+  isolated install just for that session.
+
+### PR C — Image-level dedup of Python venv
+
+Same problem exists for `/workspace/.venv` if sessions ever start mutating
+deps. Out of scope for this plan but worth tracking.
+
+## Tests
+
+- **External-dependency-unit**: spin up the new sandbox image against real
+  Docker; setup 3 sessions; assert:
+  - `du -sh /workspace/sessions/` is well under 1 GB.
+  - Each session can run `bun run dev` and serve the Next.js preview.
+  - Agent-driven `bun install lodash` in session A doesn't break session B.
+- **Benchmark**: time `setup_session_workspace` cold (first session) and
+  warm (2nd+ session in same sandbox). Target: < 5 s warm.
+- **Image size**: assert the new image is within ~100 MB of the current
+  image (allowed growth for Bun binary + Bun cache).
+
+## Open Questions
+
+1. Does Bun's `--linker=isolated` actually exist and work for our deps?
+   Bun has been moving fast in this space — needs verification before
+   committing to the workspace approach.
+2. Does Next.js dev mode have any sharp edges when started via `bun run dev`
+   vs `npm run dev`? Likely fine but worth confirming with the template's
+   exact version of Next.js (16.x).
+3. Do any of our template's deps have postinstall scripts that assume
+   `npm` specifically? We can audit via `grep -r postinstall package.json`
+   in the template.
+4. K8s parity: do we ship this only for Docker, or also flip K8s? The
+   per-session emptyDir cost is wasted I/O regardless; flipping K8s would
+   benefit cloud users too. Recommend: flip both, since the image is
+   shared.
+
+## Non-Goals
+
+- Switching the entire codebase to Bun — only the sandbox image.
+- Replacing Python venv setup. That's a separate workstream.
+- Backwards compatibility for sandbox image versions older than the bun
+  cutover. Forward-only.

--- a/docs/craft/features/docker-sandbox-backend.md
+++ b/docs/craft/features/docker-sandbox-backend.md
@@ -8,14 +8,11 @@ Decision update: Docker authority will live in `api_server`. The api server will
 
 Research checked:
 
-- `~/Documents/code/onyx/deployment/docker_compose/docker-compose.yml`
+- Existing `docker-compose.yml` + `install.sh` for Craft wiring:
   - `code-interpreter` already uses Docker-out-of-Docker by mounting `${DOCKER_SOCK_PATH:-/var/run/docker.sock}`.
   - docker-compose currently sets Craft template paths and `ENABLE_CRAFT`, but does not set `SANDBOX_BACKEND`; the code default is `local`.
-  - `--include-craft` in `install.sh` selects `craft-latest` and sets `ENABLE_CRAFT=true`, but does not provision an isolated Craft sandbox backend.
-- `~/Documents/code/cloud-deployment-yamls/danswer/`
-  - Cloud config sets `SANDBOX_BACKEND=kubernetes`, `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:latest`, `SANDBOX_S3_BUCKET`, and `SANDBOX_API_SERVER_URL`.
-  - Code interpreter is packaged as a separate K8s Deployment/Service, but Craft itself is not a separate service; api_server owns sandbox lifecycle through Kubernetes.
-- `~/Documents/code/onyx/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py`
+  - `--include-craft` selects `craft-latest` and sets `ENABLE_CRAFT=true`, but does not provision an isolated Craft sandbox backend.
+- `KubernetesSandboxManager` (`backend/onyx/server/features/build/sandbox/kubernetes/`):
   - K8s Craft provisions one sandbox pod per user.
   - Each pod contains a `sandbox` container for the agent and a `sidecar` container for push/snapshot HTTP on port `8731`.
   - api_server talks directly to Kubernetes for lifecycle and exec, and to the sidecar for signed push/snapshot operations.

--- a/docs/craft/features/docker-sandbox-backend.md
+++ b/docs/craft/features/docker-sandbox-backend.md
@@ -1,0 +1,441 @@
+# Onyx Craft on docker-compose - Direct Docker Backend Plan
+
+## Context
+
+Main goal: make Onyx Craft package cleanly for `docker compose` deployments with a containerized sandbox backend, while keeping the implementation as close as practical to the current Kubernetes Craft architecture.
+
+Decision update: Docker authority will live in `api_server`. The api server will mount the Docker socket and use a `DockerSandboxManager` directly, analogous to how `KubernetesSandboxManager` directly talks to the Kubernetes API today.
+
+Research checked:
+
+- `~/Documents/code/onyx/deployment/docker_compose/docker-compose.yml`
+  - `code-interpreter` already uses Docker-out-of-Docker by mounting `${DOCKER_SOCK_PATH:-/var/run/docker.sock}`.
+  - docker-compose currently sets Craft template paths and `ENABLE_CRAFT`, but does not set `SANDBOX_BACKEND`; the code default is `local`.
+  - `--include-craft` in `install.sh` selects `craft-latest` and sets `ENABLE_CRAFT=true`, but does not provision an isolated Craft sandbox backend.
+- `~/Documents/code/cloud-deployment-yamls/danswer/`
+  - Cloud config sets `SANDBOX_BACKEND=kubernetes`, `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:latest`, `SANDBOX_S3_BUCKET`, and `SANDBOX_API_SERVER_URL`.
+  - Code interpreter is packaged as a separate K8s Deployment/Service, but Craft itself is not a separate service; api_server owns sandbox lifecycle through Kubernetes.
+- `~/Documents/code/onyx/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py`
+  - K8s Craft provisions one sandbox pod per user.
+  - Each pod contains a `sandbox` container for the agent and a `sidecar` container for push/snapshot HTTP on port `8731`.
+  - api_server talks directly to Kubernetes for lifecycle and exec, and to the sidecar for signed push/snapshot operations.
+
+## Issues to Address
+
+1. Docker-compose Craft currently falls back to `local`, so the agent runs inside the api_server container/process boundary.
+2. Self-hosted docker-compose needs a containerized Craft backend without requiring Kubernetes.
+3. The Docker backend should mirror the K8s manager shape: api_server owns sandbox lifecycle through the platform control API.
+4. Craft sandboxes need per-user lifecycle, per-session workspaces, snapshot/restore, file push, ACP streaming, and Next.js preview.
+5. Agent containers must not receive Docker socket access or file-store credentials.
+6. EC2 IMDS exposure must be blocked or explicitly guarded. App code alone cannot safely claim this.
+7. Compose install must wire the feature through `--include-craft`.
+
+## Architecture
+
+Direct Docker manager in api_server:
+
+```text
+api_server
+  - SandboxBackend.DOCKER
+  - DockerSandboxManager
+  - mounts /var/run/docker.sock
+  |
+  | Docker Engine API
+  v
+sandbox-<id8>
+  - image: onyxdotapp/sandbox:<tag>
+  - one container per user/sandbox
+  - named volume mounted at /workspace/sessions
+  - no Docker socket
+  - no S3/MinIO credentials
+  - K8s-equivalent resource defaults for now
+```
+
+This is the closest docker-compose equivalent to Kubernetes:
+
+```text
+Kubernetes:
+  api_server -> Kubernetes API -> sandbox pod
+
+Docker compose:
+  api_server -> Docker Engine API -> sandbox container
+```
+
+The initial Docker implementation should use **one sandbox container per user**, not one container per session. This matches the K8s model, where one sandbox pod contains `/workspace/sessions/<session_id>` directories for multiple sessions.
+
+## Sidecar Decision
+
+For Docker V1, do not require a per-sandbox sidecar unless implementation proves it is materially simpler.
+
+Preferred V1:
+
+```text
+api_server -> Docker exec / Docker API -> sandbox container
+```
+
+Why:
+
+- Docker exec gives api_server a direct control path for ACP, setup, file ops, snapshots, and cleanup.
+- A single VM does not need the same in-pod HTTP control pattern that K8s uses to cross pod/filesystem boundaries.
+- Avoids doubling the number of sandbox containers.
+- Keeps Docker V1 smaller and easier to smoke test.
+
+Keep the design compatible with adding sidecars later:
+
+- Use labels and named volumes that could be shared with `sandbox-<id8>-sidecar`.
+- Keep push/snapshot code behind manager methods, not scattered through callers.
+- If Docker exec streaming becomes brittle, add an agent+sidecar pair in a follow-up.
+
+## Compose Wiring
+
+`api_server`:
+
+- Mounts `${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock` when Craft is enabled.
+- Sets `SANDBOX_BACKEND=docker`.
+- Sets `SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:<tag>`.
+- Keeps existing Craft template envs.
+- Keeps FileStore/S3/MinIO envs; snapshots are handled by api_server/FileStore, not by giving credentials to the sandbox.
+
+`background`:
+
+- Needs the same `SANDBOX_BACKEND=docker` config if celery tasks instantiate `get_sandbox_manager()` for idle cleanup/snapshotting.
+- If background must terminate/snapshot Docker sandboxes, it also needs Docker socket access.
+- Alternative: route all sandbox cleanup through api_server later, but V1 should keep parity with existing task ownership.
+
+`code-interpreter`:
+
+- Remains unchanged.
+
+`install.sh`:
+
+- `--include-craft` selects `craft-latest`, sets `ENABLE_CRAFT=true`, sets `SANDBOX_BACKEND=docker`, and ensures Docker socket env guidance exists.
+- It should warn clearly that api_server/background get Docker socket access, which is root-equivalent on the host.
+- On EC2, either install and verify host-level IMDS blocking or fail unless `CRAFT_ALLOW_UNBLOCKED_IMDS=true` is explicitly set.
+
+## Docker Resource Model
+
+Keep current K8s-style sandbox expectations for now:
+
+- one sandbox per user
+- multiple session workspaces under `/workspace/sessions`
+- resource defaults aligned with current K8s sandbox unless testing proves a single VM needs lower defaults
+
+Recommended envs for future tuning, even if defaults match K8s:
+
+- `SANDBOX_DOCKER_CPU_LIMIT`
+- `SANDBOX_DOCKER_MEMORY_LIMIT`
+- `SANDBOX_DOCKER_NETWORK`
+- `SANDBOX_DOCKER_VOLUME_PREFIX`
+- `SANDBOX_DOCKER_BLOCK_IMDS`
+
+## Network Model
+
+V1 should prioritize a clear separation between Onyx services and agent containers.
+
+Recommended Docker network shape:
+
+- Create/use a dedicated bridge network, e.g. `onyx_craft_sandbox`.
+- Sandbox containers join only that network.
+- api_server does not need to join that network if all control traffic uses Docker exec.
+- If Next.js preview is reached by IP/port, api_server must either:
+  - join the sandbox bridge network, or
+  - use Docker APIs to discover the sandbox container IP and proxy from the host namespace path available inside api_server.
+
+Important security note:
+
+- Docker bridge networking can route to EC2 IMDS (`169.254.169.254`) unless blocked at the host or Docker daemon/network layer.
+- Do not claim IMDS is fixed by application code.
+- If installing host `DOCKER-USER` rules, they must cover every Docker bridge that sandbox traffic can use, and verification must run from inside an actual sandbox container.
+
+## Snapshot and FileStore Strategy
+
+Use api_server-owned FileStore streaming for Docker V1:
+
+- `DockerSandboxManager.create_snapshot(...)`
+  - `docker exec` runs `tar` inside the sandbox container.
+  - api_server streams the tar bytes into `FileStore.save_file(...)`.
+  - sandbox container never receives S3/MinIO credentials.
+- `DockerSandboxManager.restore_snapshot(...)`
+  - api_server reads from FileStore.
+  - streams bytes into `tar -x` inside the sandbox container.
+
+Do not use `aws s3 cp` inside the sandbox agent for Docker V1. That would require storage credentials near the untrusted workload and would only support S3-like stores.
+
+The existing `SnapshotManager` needs stream helpers:
+
+- `create_snapshot_from_stream(stream, sandbox_id, tenant_id, size_hint=None)`
+- `restore_snapshot_to_stream(storage_path, write_stream)`
+
+## Implementation Strategy
+
+### PR 1 - Shared backend refactors
+
+- Add `SandboxBackend.DOCKER`.
+- Add Docker config envs.
+- Add `list_session_workspaces(sandbox_id) -> list[UUID]` to `SandboxManager`.
+- Move K8s `_list_session_directories` logic out of `sandbox/tasks/tasks.py` and onto `KubernetesSandboxManager`.
+- Add a local implementation that walks the local sandbox directory.
+- Generalize `cleanup_idle_sandboxes_task` so it works for K8s and Docker; local remains cleanup-disabled.
+- Add `SnapshotManager` stream helpers.
+
+### PR 2 - DockerSandboxManager
+
+New module:
+
+- `backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py`
+- `backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py`
+- `backend/onyx/server/features/build/sandbox/docker/internal/exec_helpers.py`
+
+Manager responsibilities:
+
+- connect to Docker via `docker.from_env()`
+- ensure sandbox network exists
+- ensure sandbox named volume exists
+- provision/reuse sandbox container idempotently
+- labels for discovery and cleanup:
+  - `onyx.app/component=craft-sandbox`
+  - `onyx.app/sandbox-id=<uuid>`
+  - `onyx.app/tenant-id=<tenant>`
+  - `onyx.app/user-id=<uuid>`
+- run container with:
+  - `--security-opt no-new-privileges`
+  - `--cap-drop ALL`
+  - `--user 1000:1000`
+  - no privileged mode
+  - no Docker socket mount
+  - no file-store credentials
+- implement workspace setup through exec scripts, reusing K8s/local setup behavior where practical
+- implement ACP using Docker exec socket transport
+- implement file ops through Docker exec
+- implement snapshots through tar streaming and FileStore
+- implement Next.js startup and preview URL handling
+- terminate container and volume cleanly
+
+### PR 3 - Compose and install packaging
+
+- Update `deployment/docker_compose/docker-compose.yml`:
+  - add Docker socket mount to `api_server` when Craft is enabled
+  - add Docker socket mount to `background` if idle cleanup runs there
+  - set `SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}` when Craft is enabled
+  - set `SANDBOX_CONTAINER_IMAGE`
+  - document the trust boundary inline
+- Update `deployment/docker_compose/env.template`:
+  - document `SANDBOX_BACKEND=docker`
+  - document Docker socket trust boundary
+  - document EC2 IMDS requirement/limitation
+  - document Docker resource envs
+- Update `deployment/docker_compose/install.sh`:
+  - `--include-craft` writes `SANDBOX_BACKEND=docker`
+  - warns that api_server/background get Docker socket access
+  - handles or guards EC2 IMDS
+
+### PR 4 - Docs and verification
+
+- Update Craft sandbox README with the three backends:
+  - `local`: dev only, no isolation
+  - `kubernetes`: Helm/cloud, api_server talks to K8s
+  - `docker`: docker-compose, api_server talks to Docker Engine
+- Document how Docker maps to K8s:
+  - K8s pod -> Docker container
+  - K8s emptyDir -> Docker named volume
+  - K8s exec -> Docker exec
+  - K8s service/preview -> Docker network/container IP or manager proxy
+
+## Tests
+
+Testing is a first-class part of this project. The Docker backend should not be merged as "manual smoke only"; it needs unit coverage for selection/refactor behavior and external-dependency-unit coverage against a real Docker daemon.
+
+### Unit tests
+
+Target location:
+
+- `backend/tests/unit/onyx/server/features/build/sandbox/`
+
+Tests to add/update:
+
+- `test_sandbox_backend_selection.py`
+  - monkeypatch `SANDBOX_BACKEND=SandboxBackend.DOCKER`
+  - reset the singleton manager
+  - assert `get_sandbox_manager()` returns `DockerSandboxManager`
+  - assert unknown backend still raises a useful error
+- `test_idle_cleanup_backend_abstraction.py`
+  - use a stub `SandboxManager`
+  - assert `cleanup_idle_sandboxes_task` calls `list_session_workspaces()` rather than the deleted K8s-only helper
+  - assert local backend still exits without cleanup
+  - assert snapshot failures for one session do not prevent later sessions from being attempted
+- `test_snapshot_manager_streams.py`
+  - fake `FileStore`
+  - `create_snapshot_from_stream(...)` saves bytes with `FileOrigin.SANDBOX_SNAPSHOT`
+  - `restore_snapshot_to_stream(...)` writes the stored bytes to the provided stream/writer
+  - validates storage path, display name, metadata, and size
+- `test_docker_manager_config.py`
+  - unit-test naming/label/network/volume helpers without Docker
+  - validate Docker resource env parsing
+  - validate env allowlist excludes S3/MinIO credentials from sandbox container env
+  - validate container create kwargs include `cap_drop`, `no-new-privileges`, `user=1000:1000`, memory/CPU settings, labels, and no Docker socket mount
+- `test_docker_acp_exec_client.py`
+  - mock Docker low-level exec socket
+  - assert JSON-RPC frames can be sent/received
+  - assert subprocess exit/closed socket is surfaced as a retryable or terminal error as appropriate
+
+### External-dependency-unit tests
+
+Target location:
+
+- `backend/tests/external_dependency_unit/craft/test_docker_sandbox.py`
+- or split by concern under `backend/tests/external_dependency_unit/craft/docker/`
+
+Skip policy:
+
+- Skip if Docker daemon is unavailable.
+- Skip unless `SANDBOX_BACKEND=docker` or an explicit test env like `RUN_DOCKER_SANDBOX_TESTS=true` is set.
+- Use unique test labels and prefixes so cleanup can remove only test-owned resources.
+
+Required fixtures:
+
+- Docker client fixture that verifies the daemon is reachable.
+- Unique sandbox ID/user ID/tenant ID per test.
+- Cleanup fixture that removes containers, volumes, and networks with test labels even after failures.
+- Minimal `LLMProviderConfig` fixture.
+- Fake or real FileStore fixture compatible with existing external dependency test patterns.
+
+Lifecycle tests:
+
+- `test_provision_creates_container_volume_and_network`
+  - call `provision()`
+  - assert one sandbox container exists
+  - assert named volume exists and is mounted at `/workspace/sessions`
+  - assert sandbox network exists and container is attached
+  - assert required labels are present
+- `test_provision_is_idempotent`
+  - call `provision()` twice
+  - assert the same container/volume are reused
+  - assert stopped container is restarted rather than duplicated
+- `test_terminate_removes_container_and_volume`
+  - provision, then terminate
+  - assert container and volume are gone
+  - assert repeated terminate is safe
+
+Workspace and file tests:
+
+- `test_setup_session_workspace_creates_expected_layout`
+  - provision and setup one session
+  - exec `find /workspace/sessions/<session_id>` or use manager read/list APIs
+  - assert `outputs`, `attachments`, `.opencode/skills`, `AGENTS.md`, and `opencode.json` exist
+- `test_file_operations_round_trip`
+  - upload file
+  - list directory
+  - read file
+  - delete file
+  - assert traversal attempts are rejected
+- `test_list_session_workspaces_filters_uuid_dirs`
+  - create valid and invalid directory names
+  - assert only UUID session directories are returned
+
+ACP and preview tests:
+
+- `test_acp_exec_smoke`
+  - start ACP through `DockerACPExecClient`
+  - run a minimal prompt or command path that does not require external LLM if possible
+  - otherwise mock only the LLM boundary while keeping Docker exec real
+- `test_nextjs_preview_path`
+  - setup a session with a Next.js port
+  - ensure Next.js starts
+  - assert manager preview URL/proxy reaches the expected HTML or health response
+  - assert only configured port range is allowed
+
+Snapshot tests:
+
+- `test_snapshot_round_trip`
+  - create files under `outputs` and `attachments`
+  - call `create_snapshot()`
+  - delete/recreate workspace
+  - call `restore_snapshot()`
+  - assert files are restored
+- `test_snapshot_does_not_include_generated_runtime_state`
+  - assert snapshot excludes venv, raw credentials, Docker socket mounts, and other non-user runtime state
+
+Security/isolation tests:
+
+- `test_sandbox_container_has_no_docker_socket_or_storage_env`
+  - inspect container mounts/env
+  - assert no `/var/run/docker.sock`
+  - assert no `S3_AWS_ACCESS_KEY_ID`, `S3_AWS_SECRET_ACCESS_KEY`, `MINIO_ROOT_PASSWORD`, or equivalent FileStore secrets
+- `test_sandbox_container_security_options`
+  - inspect container config
+  - assert non-root user, dropped caps, no privileged mode, no-new-privileges, expected resource limits
+- `test_network_isolation_from_compose_services`
+  - from inside sandbox, `curl` compose service names such as `api_server`, `relational_db`, `cache`, and `minio`
+  - assert they fail when the sandbox is only on the craft network
+  - assert public internet egress works if intended
+- `test_imds_blocking_when_enabled`
+  - only run on EC2 or when a test IMDS endpoint is configured
+  - assert `169.254.169.254` is unreachable from inside the sandbox when `SANDBOX_DOCKER_BLOCK_IMDS=true`
+
+Manual EC2 smoke:
+
+- Fresh EC2 with Docker installed and an IAM instance profile.
+- Run `curl -fsSL https://onyx.app/install_onyx.sh | bash -s -- --include-craft`.
+- Verify:
+  - `api_server` has Docker socket mount.
+  - creating a Craft session creates one sandbox container and one named volume.
+  - sandbox does not have Docker socket mount.
+  - sandbox cannot reach api_server/Postgres/Redis/MinIO/model services by compose DNS if network isolation is configured.
+  - sandbox can reach public internet if egress is intended.
+  - sandbox cannot retrieve IMDS credentials, or install fails with the documented guard.
+  - generated webapp preview loads through `/api/build/sessions/{id}/webapp`.
+  - idle cleanup snapshots and terminates the sandbox, and later restore works.
+
+## Open Decisions
+
+1. Sidecar: omit for Docker V1, but preserve labels/volume/network structure so an agent+sidecar pair can be added later.
+2. Background Docker socket: needed if celery cleanup owns Docker snapshot/termination. Confirm task ownership before wiring.
+3. Preview networking: decide whether api_server joins sandbox network or proxies via Docker-discovered IP path.
+4. IMDS: host-rule automation vs explicit EC2 guard. Recommendation: guard first unless host-rule automation can be deterministic and verified.
+
+## Updated PR Sequencing
+
+1. Shared backend refactors and stream snapshot helpers.
+2. `DockerSandboxManager` and Docker external-dependency tests.
+3. Compose/install/env/docs wiring under `--include-craft`.
+4. EC2 smoke and security hardening pass, especially IMDS and network isolation.
+
+## Non-Goals
+
+- No K8s network-policy fix in this workstream.
+- No migration story for existing local Craft sessions.
+- No new runner service.
+- No new code-interpreter changes.
+- No claim of EC2 credential safety without verified IMDS blocking or an explicit install-time guard.
+
+## Implementation Status (2026-05-20)
+
+### What landed
+
+| PR # | Title | Status |
+| --- | --- | --- |
+| #11218 (`1fce3ba78b`) | `feat(craft): backend-agnostic sandbox cleanup + snapshot stream helpers` | merged to `main` |
+| `d08a5ee078` | `feat(craft): docker-compose sandbox backend` (manager + compose/install/env wiring) | open on `docker-compose-2` (#11222) |
+| `d881a81a03` | `refactor(craft): simplify exec helpers and sandbox manager` | open in same stack |
+| `1465bd7a61` | `chore(craft): drop CRAFT_ALLOW_UNBLOCKED_IMDS opt-out` | open in same stack |
+| `e1d5bd22db` | `chore(craft): remove SANDBOX_DOCKER_BLOCK_IMDS` | open in same stack |
+| `d94321e924` | `refactor(craft): shared ACPExecClient base across K8s + Docker` | open on `docker-compose-3` (#11225) — tracked separately in [`shared-acp-exec-client.md`](./shared-acp-exec-client.md) |
+| `2c49919b10` | `docs(craft): document docker sandbox backend` | open on `docker-compose-2b` |
+
+PR 3 (compose/install/env wiring) shipped inside the same PR as PR 2 (`d08a5ee078`) rather than as a separate PR. PR 4 split into the IMDS-guard simplification commits (`1465bd7a61` + `e1d5bd22db`) and the docs commit (`2c49919b10`).
+
+### Divergences from the original plan
+
+- **`SANDBOX_DOCKER_BLOCK_IMDS` env was removed.** The plan listed it under "Docker Resource Model" as a runtime knob. In practice an app-level Docker bridge address block is unreliable (Docker manages user-defined network routing), so the env var was removed (`e1d5bd22db`). The only IMDS defense is the host-level `DOCKER-USER` iptables rule that `install.sh --include-craft` best-effort installs on EC2.
+- **`CRAFT_ALLOW_UNBLOCKED_IMDS` opt-out was dropped** (`1465bd7a61`). Install no longer hard-fails on EC2 when iptables is unavailable; it logs a clear warning with the manual command and continues. This matches the plan's "Open Decision 4 — Recommendation: guard first" but lands the guard as best-effort rather than blocking.
+- **Per-container resource defaults match K8s pod requests, not limits.** Plan said "match K8s sandbox unless testing proves a single VM needs lower defaults." Actual defaults are `1 CPU / 2 GiB`, matching K8s requests (not the K8s `2 CPU / 10 GiB` limits), because single-VM compose deployments cannot over-commit every sandbox.
+- **Background does mount the Docker socket** (Open Decision 2 resolved → yes). The idle-cleanup celery task owns snapshot+terminate, so `background` gets the same socket mount and `onyx_craft_sandbox` network attachment as `api_server`.
+- **api_server joins the sandbox bridge network** (Open Decision 3 resolved → joins, not proxies via discovered IP). Both `api_server` and `background` attach to `default` plus `onyx_craft_sandbox`, so the Next.js preview reaches sandboxes by container DNS / IP on the bridge.
+- **Sidecar still omitted** (Open Decision 1 resolved as planned). Docker V1 ships agent-only; labels and the named volume are structured so a sidecar can be added later without disturbing the layout.
+- **`SANDBOX_API_SERVER_URL` is required to be the *public* HTTPS URL**, not a compose hostname — documented in `env.template` and `sandbox/README.md`. The agent cannot resolve `api_server` by DNS from inside the sandbox bridge.
+- **Tests:** the external-dependency-unit Docker tests outlined in the plan landed alongside the manager. The plan-mode unit tests for `test_sandbox_backend_selection.py` / `test_idle_cleanup_backend_abstraction.py` / `test_snapshot_manager_streams.py` / `test_docker_manager_config.py` / `test_docker_acp_exec_client.py` were implemented as part of PR #11218 and `d08a5ee078`.
+
+### Still TODO
+
+- Manual EC2 smoke test on a fresh EC2 + IAM-role instance — verifying IMDS block, sandbox→compose-service unreachability, and snapshot/restore round-trip on real infra. The plan's `## Tests → Manual EC2 smoke` block remains the checklist.
+- Cherry-pick + merge of the `docker-compose-2` and `docker-compose-3` PR stack.

--- a/docs/craft/features/shared-acp-exec-client.md
+++ b/docs/craft/features/shared-acp-exec-client.md
@@ -1,0 +1,280 @@
+# Plan: Shared ACPExecClient base class for K8s + Docker
+
+## Context
+
+`backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py`
+(783 lines) and
+`backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py`
+(603 lines) are ~95% structurally identical. The ACP JSON-RPC protocol code,
+state management, `send_message` loop, session lifecycle, and event
+dispatch are byte-for-byte the same between them. The only real
+divergence is the transport: K8s uses the `kubernetes-client`
+WebSocket exec stream; Docker uses a raw multiplexed Docker exec socket.
+
+Today, every fix or behavior change to the ACP protocol layer has to be
+duplicated across two files. The current PR (docker-compose-2, #11222)
+already had to land an `SSEKeepalive`-move fix and a `_recv_exact`
+timeout fix; both would have been single-file changes against a shared
+base. Extracting the shared protocol code into an `ACPExecClientBase`
+abstract class reduces the long-term cost of every future ACP change
+and shrinks the codebase by ~700 lines.
+
+This is the natural follow-up to docker-compose-2 and lives on its own
+PR (`docker-compose-3`) so the K8s code motion is reviewed
+independently of the Docker functional work in the prior PR.
+
+## Issues to Address
+
+1. **Duplicated ACP protocol code across K8s and Docker exec clients.**
+   The protocol-level methods (`_send_request`, `_send_notification`,
+   `_wait_for_response`, `_initialize`, `_create_session`,
+   `_list_sessions`, `_resume_session`, `_try_resume_existing_session`,
+   `resume_or_create_session`, `send_message`,
+   `_process_session_update`, `cancel`, `__enter__`, `__exit__`) are
+   identical between the two clients except for transport details.
+
+2. **Duplicated state management.** Both clients independently define
+   `ACPSession`, `ACPClientState`, the `ACPEvent` union, the
+   `DEFAULT_CLIENT_INFO` dict, `ACP_PROTOCOL_VERSION`, and the
+   reader-thread + response-queue lifecycle.
+
+3. **Future drift risk.** When K8s and Docker fix the ACP packet-loss
+   issue logged in the previous PR (or any future protocol fix), it
+   would have to land in two files without a base class.
+
+## Important Notes
+
+- The base class lives in a neutral location so neither backend imports
+  the other: `backend/onyx/server/features/build/sandbox/acp/base.py`.
+  This is a new top-level subdirectory under `sandbox/`.
+- `SSEKeepalive` is already shared in `sandbox/base.py` from
+  docker-compose-2's earlier fix. Leave it there; the new
+  `ACPExecClientBase` imports it. (Don't move it again — both K8s and
+  Docker exec clients already re-export it for back-compat with any
+  external imports.)
+- The K8s subclass's `health_check()` method (runs `echo ok` via a
+  fresh exec) is K8s-specific and stays on the subclass. Docker has no
+  equivalent and doesn't need one.
+- `_get_k8s_client` (K8s-only) and `_recv_exact` / frame parser
+  (Docker-only) stay on their respective subclasses.
+- Pure code motion: no behavior change on either backend. Production
+  K8s ACP path must remain byte-for-byte equivalent to its current
+  behavior. Verify by reading the resulting K8s subclass + running the
+  existing unit tests.
+- The `logger` prefixes differ (`[ACP]` vs `[DOCKER-ACP]`) and the
+  `packet_logger` `context=` argument differs (`"k8s"` vs `"docker"`).
+  The base class takes a `log_prefix` and `log_context` (or wraps them
+  into a single `transport_name` field that derives both) to preserve
+  identical log output on each backend.
+
+## Implementation Strategy
+
+### New module: `backend/onyx/server/features/build/sandbox/acp/`
+
+Two files:
+
+- `__init__.py` (empty).
+- `base.py`:
+  - Module constants: `ACP_PROTOCOL_VERSION = 1`, `DEFAULT_CLIENT_INFO` (parametrize "name" via subclass override since K8s and Docker today report different client names — verify whether opencode actually uses these; if it ignores them, unify to a single value).
+  - Dataclasses: `ACPSession`, `ACPClientState`.
+  - `ACPEvent` type alias (the schema union).
+  - `ACPExecClientBase(ABC)` with the shared protocol implementation.
+
+### Abstract surface
+
+Five abstract methods (minimum needed to cover the transport divergence):
+
+```python
+class ACPExecClientBase(ABC):
+    transport_name: ClassVar[str]  # "k8s" or "docker" — drives log_prefix + packet_logger context
+
+    @abstractmethod
+    def _open_transport(self, cwd: str) -> None: ...
+
+    @abstractmethod
+    def _close_transport(self) -> None: ...
+
+    @abstractmethod
+    def _is_transport_open(self) -> bool: ...
+
+    @abstractmethod
+    def _write_line(self, line: str) -> None:
+        """Write one already-newline-terminated JSON-RPC line to the transport."""
+
+    @abstractmethod
+    def _read_responses_loop(self) -> None:
+        """Long-running reader. Pulls from the transport, parses JSON lines,
+        calls self._enqueue_message(msg) for each. Respects self._stop_reader."""
+```
+
+### Shared lifecycle (on the base)
+
+`start(cwd, timeout)`:
+1. Call `self._open_transport(cwd)` (subclass-specific).
+2. Clear `self._stop_reader`.
+3. Spawn reader thread targeting `self._read_responses_loop`.
+4. `time.sleep(0.5)` to let opencode boot.
+5. Call `self._initialize(timeout)`.
+6. On any exception, `self.stop()` then re-raise.
+
+`stop()`:
+1. Set `self._stop_reader`.
+2. Call `self._close_transport()`.
+3. Join reader thread (timeout=2s), null it out.
+4. Reset `self._state = ACPClientState()`.
+
+`_enqueue_message(msg)` (helper for subclass readers):
+- Log via `packet_logger.log_jsonrpc_raw_message("IN", msg, context=self.transport_name)`.
+- Put on `self._response_queue`.
+
+`__enter__` / `__exit__` shared.
+
+### Shared protocol methods (on the base)
+
+These move verbatim from either current implementation, with two
+mechanical substitutions:
+
+- `self._ws_client.write_stdin(...)` and `self._socket.sendall(...)`
+  → `self._write_line(...)`.
+- `self._ws_client.is_open()` and `self._socket is None` checks
+  → `self._is_transport_open()`.
+
+Methods:
+- `_get_next_id`
+- `_send_request`
+- `_send_notification`
+- `_wait_for_response`
+- `_initialize`
+- `_create_session`
+- `_list_sessions`
+- `_resume_session`
+- `_try_resume_existing_session`
+- `resume_or_create_session`
+- `send_message`
+- `_process_session_update`
+- `_send_error_response`
+- `cancel`
+- `is_running` (returns `self._is_transport_open()`)
+
+Log prefixes use `self.transport_name`: `[%s-ACP]` uppercased, so K8s
+sees `[K8S-ACP]` and Docker sees `[DOCKER-ACP]`. (Small visual change
+from `[ACP]` → `[K8S-ACP]` — worth flagging in the PR description.)
+
+### K8s subclass (in `kubernetes/internal/acp_exec_client.py`)
+
+Drops to ~150 lines. Keeps:
+- `__init__` taking `pod_name`, `namespace`, `container`,
+  `client_info`, `client_capabilities`. Calls `super().__init__(...)`.
+- `_get_k8s_client` (lazy K8s API client).
+- `_open_transport`: builds the `XDG_DATA_HOME=... exec opencode acp
+  --cwd ...` command, calls `k8s_stream(connect_get_namespaced_pod_exec, ...)`,
+  stores `self._ws_client`.
+- `_close_transport`: `self._ws_client.close()`, null it.
+- `_is_transport_open`: `self._ws_client is not None and
+  self._ws_client.is_open()`.
+- `_write_line`: `self._ws_client.write_stdin(line)`.
+- `_read_responses_loop`: the existing K8s reader (uses
+  `ws_client.update`/`read_stdout`/`read_stderr`), with the body of the
+  inner `try` block replaced by `self._enqueue_message(message)`.
+- `health_check` (K8s-only, kept).
+- `transport_name = "k8s"`.
+
+### Docker subclass (in `docker/internal/acp_exec_client.py`)
+
+Drops to ~120 lines. Keeps:
+- `__init__` taking `docker_client`, `container_name`, `user`,
+  `client_info`, `client_capabilities`. Calls `super().__init__(...)`.
+- `_open_transport`: `exec_create + exec_start(socket=True)` →
+  `_unwrap_socket` → set 0.5s socket timeout. Store `self._socket`.
+- `_close_transport`: shutdown(RDWR) + close, null the socket.
+- `_is_transport_open`: `self._socket is not None`.
+- `_write_line`: `self._socket.sendall(line.encode("utf-8"))` with the
+  existing `_socket_lock`.
+- `_read_responses_loop`: the existing Docker reader (frame parser via
+  `_recv_exact`), with the body replaced by `self._enqueue_message(message)`.
+- `_recv_exact` (kept — Docker-specific).
+- `transport_name = "docker"`.
+
+The currently-shared `_FRAME_HEADER_BYTES`, `_FRAME_STDOUT`, `_FRAME_STDERR`
+constants are already re-exported from `exec_helpers.py`; nothing to
+move.
+
+### Files to modify
+
+- **New**:
+  `backend/onyx/server/features/build/sandbox/acp/__init__.py`
+  `backend/onyx/server/features/build/sandbox/acp/base.py`
+- **Modified**:
+  `backend/onyx/server/features/build/sandbox/kubernetes/internal/acp_exec_client.py`
+  `backend/onyx/server/features/build/sandbox/docker/internal/acp_exec_client.py`
+- **Possibly affected** (verify imports still resolve):
+  `backend/onyx/server/features/build/session/manager.py` (imports
+  `SSEKeepalive` from `sandbox.base` — unchanged).
+  `backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py`
+  (imports `DockerACPExecClient`, `ACPEvent` — both still exported from
+  the same module).
+  `backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py`
+  (imports `ACPExecClient`, `ACPEvent` — both still exported).
+
+## Tests
+
+This is pure code motion — no new behavior to test. Verification is:
+
+- **Existing unit tests must still pass**, especially
+  `backend/tests/unit/onyx/server/features/build/sandbox/test_docker_acp_exec_client.py`
+  (which exercises Docker's `start` + initialize round-trip via a fake
+  framed socket and asserts `is_running` flips correctly on `stop`).
+- **K8s unit test sweep**: run anything under
+  `backend/tests/unit/onyx/server/features/build/sandbox/` to confirm
+  no K8s-specific assertions regress.
+- **Ty + ruff**: the codebase's pre-commit hooks must pass cleanly on
+  both subclasses and the base.
+- **Manual smoke (optional but recommended given K8s code motion)**:
+  run the Docker smoke script
+  `backend/scripts/manual_test_docker_sandbox.py` to confirm `start`,
+  `initialize`, and `stop` lifecycle still work end-to-end against a
+  real Docker daemon. We don't have an equivalent K8s smoke script —
+  rely on code review for the K8s side.
+
+No new tests required. If desired, a small unit test for the base
+class's `_send_request` / `_wait_for_response` against a fake
+transport could be added, but it would duplicate the framing test that
+`test_docker_acp_exec_client.py` already provides.
+
+## PR Mechanics
+
+- New branch stacked on `docker-compose-2` via
+  `ez create docker-compose-3 --from docker-compose-2`.
+- One commit: `refactor(craft): shared ACPExecClient base across K8s + Docker`.
+- PR title should call out: "no behavior change; pure code motion".
+- PR body should include the line-count delta (~1380 → ~870 across the
+  three files) and an explicit callout that the K8s production path
+  has been touched.
+
+## Implementation Status (2026-05-20)
+
+Landed as `d94321e924 refactor(craft): shared ACPExecClient base across K8s + Docker` on `docker-compose-3` (PR #11225, open).
+
+### Actual line counts (vs. estimated)
+
+| File | Plan estimate | Actual |
+| --- | --- | --- |
+| `sandbox/acp/base.py` (new) | — | 639 |
+| `kubernetes/internal/acp_exec_client.py` | ~150 | 220 |
+| `docker/internal/acp_exec_client.py` | ~120 | 237 |
+| **Total across 3 files** | **~870** | **1096** |
+| **Total before refactor (2 files)** | 1386 | 1386 |
+| **Net reduction** | ~510 | ~290 |
+
+The reduction was smaller than the plan estimated because more transport-adjacent helpers (frame parsing context, packet logging, reader-loop scaffolding) stayed on the subclasses than expected. Still a meaningful win — every future ACP protocol fix is now a one-file change.
+
+### Divergences from the plan
+
+- **Subclasses are larger than estimated.** Plan said ~150 (K8s) / ~120 (Docker); actual is 220 / 237. Reader loops and transport-open/close paths needed more subclass-specific scaffolding than the abstract surface anticipated.
+- **`SSEKeepalive` stayed in `sandbox/base.py`** as the plan required — no second migration.
+- **Log prefix change shipped.** `[ACP]` → `[K8S-ACP]` is live on the K8s path. Worth flagging in any review of K8s log diffs.
+- **No new tests added.** As planned, the refactor relies on existing `test_docker_acp_exec_client.py` + ty/ruff + manual Docker smoke. Manual K8s smoke was not run; review-only verification.
+
+### Still TODO
+
+- Merge of `docker-compose-3` (#11225) once `docker-compose-2` (#11222) lands.

--- a/web/src/app/craft/README.md
+++ b/web/src/app/craft/README.md
@@ -59,17 +59,14 @@ curl -fsSL https://raw.githubusercontent.com/onyx-dot-app/onyx/main/deployment/d
 
 This will:
 
-- Set `ENABLE_CRAFT=true` in the `.env` file
-- Set `IMAGE_TAG=craft-latest` to use Craft-enabled images
-- Run template setup on container startup
+- Set `ENABLE_CRAFT=true` and `SANDBOX_BACKEND=docker` in the `.env` file
+- Pin `IMAGE_TAG` to the Craft-enabled backend image (Node.js + opencode CLI baked in)
+- Download and layer in the `docker-compose.craft.yml` overlay so api_server / background can talk to the Docker socket
+- Create the dedicated `onyx_craft_sandbox` bridge network used to isolate sandbox containers
 
 ### Existing Deployments
 
-Enable Craft on an existing deployment:
-
-```bash
-ENABLE_CRAFT=true IMAGE_TAG=craft-latest docker compose up -d
-```
+Re-run the installer with `--include-craft` on top of an existing deployment — it patches the `.env`, pulls down the craft overlay, and recreates the relevant containers. Setting `ENABLE_CRAFT=true` by hand without re-running the installer leaves the Docker socket unmounted and sandboxes will fail to provision.
 
 ## How It Works
 


### PR DESCRIPTION
## Description

Docs-only follow-up to the docker-compose Craft work. Two commits:

1. **`docs(craft): document docker sandbox backend`** — updates `backend/onyx/server/features/build/sandbox/README.md` so it covers the new `docker` backend alongside `local` / `kubernetes`. Adds a K8s→Docker mapping table (pod → container, emptyDir → named volume, `kubectl exec` → `docker exec`, Service → bridge network, NetworkPolicy → host `DOCKER-USER` iptables), the trust-boundary + EC2 IMDS posture, a Docker env reference, Docker-mode troubleshooting steps, and Docker sandbox isolation security notes.

2. **`docs(craft): check in feature plans for docker sandbox stack`** — copies the planning docs behind the docker-compose Craft stack out of my private `~/.claude/plans/` and into `docs/craft/features/` alongside the existing feature docs:
   - `docker-sandbox-backend.md` (this stack's main plan, including a 2026-05-20 implementation-status section listing every commit/PR with divergences from the original plan)
   - `shared-acp-exec-client.md` (docker-compose-3's refactor plan, with actual line-count delta vs. estimate)
   - `bun-node-modules-dedup.md` (follow-up node_modules dedup plan)

## How Has This Been Tested?

Docs-only — pre-commit hooks ran clean on the README change. No runtime code touched.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Docker-based Craft sandbox backend and checks in feature plans, and fixes the installer so `--include-craft` is the only way to enable Craft with the compose overlay applied correctly. Adds Docker-mode guidance (K8s→Docker mapping, trust boundary, IMDS notes, env reference, troubleshooting) to the sandbox docs.

- **New Features**
  - Docker backend: `DockerSandboxManager`, Docker exec ACP client, snapshot streaming, unified `SSEKeepalive`, and configs (`SANDBOX_DOCKER_SOCKET`, `SANDBOX_DOCKER_NETWORK`). Includes unit tests and a manual smoke script.
  - Compose overlay + installer: moves socket/network wiring into `docker-compose.craft.yml`; `install.sh --include-craft` now applies the overlay, sets `ENABLE_CRAFT=true` and `SANDBOX_BACKEND=docker`, and forces `IMAGE_TAG=craft-latest`. `--include-craft` is the sole switch (craft-* tags alone no longer toggle Craft). Updates `env.template` and web Craft README to warn against manual toggles that skip the overlay.
  - Docs: expands sandbox README with Docker backend details (K8s→Docker mapping, trust boundary, EC2 IMDS host `DOCKER-USER` rule, and `SANDBOX_API_SERVER_URL` must be public), plus Docker-mode troubleshooting and security notes. Checks in feature plans: `docker-sandbox-backend.md`, `shared-acp-exec-client.md`, `bun-node-modules-dedup.md`.
  - Dependencies: adds `docker==7.1.0` and `types-docker`.

- **Migration**
  - To enable Craft on docker-compose: run `deployment/docker_compose/install.sh --include-craft`. Do not set `ENABLE_CRAFT` or craft-* tags by hand. Ensure `SANDBOX_API_SERVER_URL` is a publicly reachable HTTPS URL; the installer layers `docker-compose.craft.yml` and creates the `onyx_craft_sandbox` network.

<sup>Written for commit 6fe626a0f4d02640653f4e181755f46a51a4ba6b. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11232?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

