### PR TITLE
fix(docker): typo in the nginx conf name in no-letsencrypt compose file

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -300,7 +300,7 @@ services:
       && cp -a /nginx-templates/. /etc/nginx/conf.d/
       && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
       && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template.prod.no-letsencrypt"
+      && /tmp/run-nginx.sh app.conf.template.no-letsencrypt"
     env_file:
       - .env.nginx
     environment:


### PR DESCRIPTION
## Description

fix #11235 

## How Has This Been Tested?

In docker compose no letsencrypt environment
As soon as the ssl certs was generated it works well


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the no-letsencrypt Docker Compose to pass the correct Nginx template (`app.conf.template.no-letsencrypt`) to `run-nginx.sh`, so the service starts with the right config. Fixes #11235.

<sup>Written for commit de1c1d239cfb5dfccfce1b64b9a0c9a6ad740a67. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11236?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

