### PR TITLE
fix: mcp oauth token handling

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -286,14 +286,14 @@ class OnyxTokenStorage(TokenStorage):
             }
             update_connection_config(config.id, db_session, config_data)
 
-        # The shared admin row is intentionally NOT written here: it is
-        # cross-user state (it serves as the OAuth `client_info` registry
-        # for every user of this MCP server, see `get_client_info`), and
-        # writing this user's tokens / Authorization header into it would
-        # leak them to every other user of the same server (GHSA-q62f-rv3h-f822).
-        # The Redis push below is what `process_oauth_callback` blocks on
-        # to know token exchange has completed; the admin config id is the
-        # only stable identifier shared between the two contexts.
+        # The shared admin row is intentionally NOT written here: it
+        # serves as the OAuth `client_info` registry shared across all
+        # users of this MCP server (see `get_client_info`). Per-user
+        # state (access tokens and resolved `Authorization` headers)
+        # belongs only on the per-user row. The Redis push below is
+        # what `process_oauth_callback` blocks on to know token exchange
+        # has completed; the admin config id is the only stable
+        # identifier shared between the two contexts.
         if self.alt_config_id:
             r = get_redis_client()
             r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
@@ -336,11 +336,9 @@ class OnyxTokenStorage(TokenStorage):
             # used by every user of this MCP server (see `get_client_info`).
             # When DCR runs we want to cache the discovered client_info there
             # so future users can re-use it — but ONLY the `client_info`
-            # field. The per-user `config_data` carries this user's
-            # `tokens` and resolved `Authorization` header by the time the
-            # SDK calls `set_client_info`, and writing the whole payload
-            # into the shared admin row would leak those secrets to every
-            # other user of the same server (GHSA-q62f-rv3h-f822).
+            # field. The per-user `config_data` carries per-user state
+            # (`tokens`, resolved `Authorization` header) which belongs
+            # only on the per-user row.
             if self.alt_config_id:
                 alt_config = get_connection_config_by_id(self.alt_config_id, db_session)
                 alt_config_data = extract_connection_data(alt_config)
@@ -1094,15 +1092,12 @@ def _db_mcp_server_to_api_mcp_server(
                 admin_credentials = {}
                 logger.warning("No client info found for server %s", db_server.name)
 
-    # Get auth template if this is a per-user API_TOKEN server.
-    #
-    # OAUTH per-user servers intentionally do NOT get an `auth_template`:
-    # OAuth uses the handshake URL (`/oauth/connect`) rather than a
-    # header template, so the frontend never consumes one for OAuth
-    # flows. Returning the admin row's headers for OAuth servers is the
-    # exposure path of GHSA-q62f-rv3h-f822 — the admin row is shared
-    # cross-user, so anything stamped onto its `headers` would leak to
-    # every authenticated caller of `/api/mcp/servers*`.
+    # The header template is only meaningful for per-user API_TOKEN
+    # servers, where it surfaces placeholder strings (e.g.
+    # `Bearer {API_KEY}`) for the user-side credential prompt. OAuth
+    # per-user servers do not get an `auth_template`: OAuth uses the
+    # handshake URL (`/oauth/connect`) rather than a header template,
+    # so the frontend never consumes one for OAuth flows.
     auth_template = None
     if (
         auth_performer == MCPAuthenticationPerformer.PER_USER

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -285,13 +285,19 @@ class OnyxTokenStorage(TokenStorage):
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
             update_connection_config(config.id, db_session, config_data)
-            if self.alt_config_id:
-                update_connection_config(self.alt_config_id, db_session, config_data)
 
-                # signal the oauth callback that token exchange is complete
-                r = get_redis_client()
-                r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
-                r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
+        # The shared admin row is intentionally NOT written here: it is
+        # cross-user state (it serves as the OAuth `client_info` registry
+        # for every user of this MCP server, see `get_client_info`), and
+        # writing this user's tokens / Authorization header into it would
+        # leak them to every other user of the same server (GHSA-q62f-rv3h-f822).
+        # The Redis push below is what `process_oauth_callback` blocks on
+        # to know token exchange has completed; the admin config id is the
+        # only stable identifier shared between the two contexts.
+        if self.alt_config_id:
+            r = get_redis_client()
+            r.rpush(key_tokens(str(self.alt_config_id)), tokens.model_dump_json())
+            r.expire(key_tokens(str(self.alt_config_id)), OAUTH_WAIT_SECONDS)
 
     async def get_client_info(self) -> OAuthClientInformationFull | None:
         with get_session_with_current_tenant() as db_session:
@@ -319,13 +325,29 @@ class OnyxTokenStorage(TokenStorage):
     async def set_client_info(  # ty: ignore[invalid-method-override]
         self, info: OAuthClientInformationFull
     ) -> None:
+        info_payload = info.model_dump(mode="json")
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
-            config_data[MCPOAuthKeys.CLIENT_INFO.value] = info.model_dump(mode="json")
+            config_data[MCPOAuthKeys.CLIENT_INFO.value] = info_payload
             update_connection_config(config.id, db_session, config_data)
+
+            # The shared admin row holds the OAuth `client_info` registry
+            # used by every user of this MCP server (see `get_client_info`).
+            # When DCR runs we want to cache the discovered client_info there
+            # so future users can re-use it — but ONLY the `client_info`
+            # field. The per-user `config_data` carries this user's
+            # `tokens` and resolved `Authorization` header by the time the
+            # SDK calls `set_client_info`, and writing the whole payload
+            # into the shared admin row would leak those secrets to every
+            # other user of the same server (GHSA-q62f-rv3h-f822).
             if self.alt_config_id:
-                update_connection_config(self.alt_config_id, db_session, config_data)
+                alt_config = get_connection_config_by_id(self.alt_config_id, db_session)
+                alt_config_data = extract_connection_data(alt_config)
+                alt_config_data[MCPOAuthKeys.CLIENT_INFO.value] = info_payload
+                update_connection_config(
+                    self.alt_config_id, db_session, alt_config_data
+                )
 
 
 def make_oauth_provider(
@@ -1072,9 +1094,20 @@ def _db_mcp_server_to_api_mcp_server(
                 admin_credentials = {}
                 logger.warning("No client info found for server %s", db_server.name)
 
-    # Get auth template if this is a per-user auth server
+    # Get auth template if this is a per-user API_TOKEN server.
+    #
+    # OAUTH per-user servers intentionally do NOT get an `auth_template`:
+    # OAuth uses the handshake URL (`/oauth/connect`) rather than a
+    # header template, so the frontend never consumes one for OAuth
+    # flows. Returning the admin row's headers for OAuth servers is the
+    # exposure path of GHSA-q62f-rv3h-f822 — the admin row is shared
+    # cross-user, so anything stamped onto its `headers` would leak to
+    # every authenticated caller of `/api/mcp/servers*`.
     auth_template = None
-    if auth_performer == MCPAuthenticationPerformer.PER_USER:
+    if (
+        auth_performer == MCPAuthenticationPerformer.PER_USER
+        and db_server.auth_type != MCPAuthenticationType.OAUTH
+    ):
         try:
             template_config = db_server.admin_connection_config
             if template_config:

--- a/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
@@ -1,0 +1,218 @@
+"""Invariants for the API model returned by the per-user MCP server
+listing endpoints (`GET /api/mcp/servers`,
+`GET /api/mcp/servers/persona/{id}`).
+
+The shared admin connection config row is cross-user state — it's the
+OAuth `client_info` registry used by every user of a given MCP server.
+Per-user state (access tokens, resolved `Authorization` headers) lives
+only on the per-user row. The `auth_template` field on the API model
+exists exclusively to support per-user API_TOKEN servers, where the
+admin defines a header template with placeholders (e.g.
+`Bearer {API_KEY}`) and the user fills the placeholders in their own
+credential modal. OAuth per-user servers use the OAuth handshake URL
+and never consume an `auth_template`, so the field must remain `None`
+for them regardless of caller role or the contents of the shared row.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import MCPTransport
+from onyx.server.features.mcp.api import _db_mcp_server_to_api_mcp_server
+
+
+def _make_connection_config(config: dict[str, Any]) -> MagicMock:
+    """Stand-in for `MCPConnectionConfig`; only needs a `.config`
+    attribute that `extract_connection_data` can read as a plain dict
+    (i.e. not wrapped in `SensitiveValue`)."""
+    cfg = MagicMock()
+    cfg.config = config
+    return cfg
+
+
+def _make_db_server(
+    *,
+    auth_type: MCPAuthenticationType,
+    auth_performer: MCPAuthenticationPerformer,
+    admin_config: MagicMock | None,
+) -> MagicMock:
+    server = MagicMock()
+    server.id = 1
+    server.name = "test-server"
+    server.description = "test"
+    server.server_url = "https://example.com/mcp"
+    server.owner = "owner@example.com"
+    server.transport = MCPTransport.STREAMABLE_HTTP
+    server.auth_type = auth_type
+    server.auth_performer = auth_performer
+    server.admin_connection_config = admin_config
+    server.admin_connection_config_id = 42 if admin_config is not None else None
+    server.status = MCPServerStatus.CONNECTED
+    server.last_refreshed_at = None
+    server.current_actions = []
+    return server
+
+
+def _make_user(*, email: str, role: UserRole) -> MagicMock:
+    user = MagicMock()
+    user.email = email
+    user.role = role
+    return user
+
+
+def _oauth_admin_config_with_runtime_headers() -> MagicMock:
+    """An OAuth admin connection config whose JSONB blob carries a
+    realistic mix of fields: the legitimate `client_info` registry
+    plus per-user-style fields (`headers`, `tokens`) that should never
+    be propagated to the listing API regardless of how they got there.
+    """
+    return _make_connection_config(
+        {
+            "headers": {
+                "Authorization": "Bearer xoxp-runtime-bearer-token",
+            },
+            "client_info": {
+                "client_id": "shared-oauth-client-id",
+                "client_secret": "shared-oauth-client-secret",
+                "redirect_uris": ["https://onyx.example.com/mcp/oauth/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "client_secret_post",
+            },
+            "tokens": {
+                "access_token": "xoxp-runtime-bearer-token",
+                "token_type": "Bearer",
+            },
+        }
+    )
+
+
+def _api_token_template_admin_config() -> MagicMock:
+    """Per-user API_TOKEN template: `headers` contains an `{API_KEY}`
+    placeholder string, not a real secret. This is the legitimate
+    `auth_template` payload the user-side credential modal renders."""
+    return _make_connection_config(
+        {
+            "headers": {
+                "Authorization": "Bearer {API_KEY}",
+            },
+            "required_fields": ["API_KEY"],
+        }
+    )
+
+
+class TestPerUserAuthTemplateInvariants:
+    def test_basic_user_oauth_server_listing_returns_no_auth_template(self) -> None:
+        db_server = _make_db_server(
+            auth_type=MCPAuthenticationType.OAUTH,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            admin_config=_oauth_admin_config_with_runtime_headers(),
+        )
+        basic_user = _make_user(email="user@example.com", role=UserRole.BASIC)
+
+        with patch(
+            "onyx.server.features.mcp.api.get_user_connection_config",
+            return_value=None,
+        ):
+            api_server = _db_mcp_server_to_api_mcp_server(
+                db_server,
+                MagicMock(),
+                request_user=basic_user,
+                include_auth_config=False,
+            )
+
+        assert api_server.auth_template is None
+        assert api_server.admin_credentials is None
+        assert api_server.user_credentials is None
+
+    def test_admin_user_oauth_server_listing_returns_no_auth_template(self) -> None:
+        """Admins on the listing endpoint share the same code path as
+        basic users; the OAuth invariant must apply regardless of role.
+        """
+        db_server = _make_db_server(
+            auth_type=MCPAuthenticationType.OAUTH,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            admin_config=_oauth_admin_config_with_runtime_headers(),
+        )
+        admin = _make_user(email="admin@example.com", role=UserRole.ADMIN)
+
+        with patch(
+            "onyx.server.features.mcp.api.get_user_connection_config",
+            return_value=None,
+        ):
+            api_server = _db_mcp_server_to_api_mcp_server(
+                db_server,
+                MagicMock(),
+                request_user=admin,
+                include_auth_config=False,
+            )
+
+        assert api_server.auth_template is None
+
+    def test_owner_admin_edit_oauth_server_returns_no_auth_template(self) -> None:
+        """The admin edit endpoint sets `include_auth_config=True` so
+        the owner sees masked admin credentials — but the OAuth-edit
+        flow consumes those via `admin_credentials.client_id` /
+        `client_secret`, not via `auth_template`. The header template
+        field must still be `None` for OAuth servers, and the masked
+        admin credentials must not surface any runtime header value.
+        """
+        db_server = _make_db_server(
+            auth_type=MCPAuthenticationType.OAUTH,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            admin_config=_oauth_admin_config_with_runtime_headers(),
+        )
+        owner = _make_user(email="owner@example.com", role=UserRole.ADMIN)
+
+        with patch(
+            "onyx.server.features.mcp.api.get_user_connection_config",
+            return_value=None,
+        ):
+            api_server = _db_mcp_server_to_api_mcp_server(
+                db_server,
+                MagicMock(),
+                request_user=owner,
+                include_auth_config=True,
+            )
+
+        assert api_server.auth_template is None
+        assert api_server.admin_credentials is not None
+        assert "Authorization" not in api_server.admin_credentials
+        assert all(
+            "xoxp-runtime-bearer-token" not in v
+            for v in api_server.admin_credentials.values()
+        )
+
+    def test_api_token_per_user_server_returns_placeholder_template(self) -> None:
+        """The legitimate `auth_template` use case: per-user API_TOKEN
+        servers must keep returning the placeholder header template so
+        the user-side credential modal knows which fields to prompt for.
+        """
+        db_server = _make_db_server(
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            admin_config=_api_token_template_admin_config(),
+        )
+        user = _make_user(email="user@example.com", role=UserRole.BASIC)
+
+        with patch(
+            "onyx.server.features.mcp.api.get_user_connection_config",
+            return_value=None,
+        ):
+            api_server = _db_mcp_server_to_api_mcp_server(
+                db_server,
+                MagicMock(),
+                request_user=user,
+                include_auth_config=False,
+            )
+
+        assert api_server.auth_template is not None
+        assert api_server.auth_template.headers == {
+            "Authorization": "Bearer {API_KEY}",
+        }
+        assert api_server.auth_template.required_fields == ["API_KEY"]


### PR DESCRIPTION
## Description

ensure invariants are maintained for OAuth MCP servers

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth MCP token handling by keeping per-user state on per-user rows and never returning header templates for OAuth servers. This prevents leaking runtime headers and aligns listing/edit APIs with the intended invariants.

- **Bug Fixes**
  - Store OAuth client_info on the shared admin row; keep tokens and Authorization headers only on per-user rows.
  - set_tokens: stop writing to the admin row; only update the per-user row and push a Redis signal using the admin config id.
  - set_client_info: copy only client_info to the admin row; do not propagate tokens/headers.
  - Per-user OAuth servers no longer return auth_template in listings or admin edit; per-user API_TOKEN servers still return the placeholder template.
  - Added unit tests covering these invariants.

<sup>Written for commit b06676a6a2ee128b76267980a6c835db83f431cc. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11238?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

