### PR TITLE
fix(icons): size unsized @opal/icons usages

### DIFF
--- a/web/src/app/admin/billing/LicenseActivationCard.tsx
+++ b/web/src/app/admin/billing/LicenseActivationCard.tsx
@@ -202,7 +202,7 @@ export default function LicenseActivationCard({
                 height="auto"
               >
                 <div className="billing-error-icon">
-                  <SvgXCircle />
+                  <SvgXCircle size={12} />
                 </div>
                 <Text secondaryBody text04>
                   {error}.{" "}

--- a/web/src/app/admin/bots/SlackBotTable.tsx
+++ b/web/src/app/admin/bots/SlackBotTable.tsx
@@ -84,7 +84,7 @@ export const SlackBotTable = ({ slackBots }: { slackBots: SlackBot[] }) => {
               >
                 <TableCell>
                   <div className="flex items-center">
-                    <SvgEdit className="mr-4" />
+                    <SvgEdit size={16} className="mr-4" />
                     {slackBot.name}
                   </div>
                 </TableCell>

--- a/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
+++ b/web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx
@@ -87,7 +87,10 @@ export default function SlackChannelConfigsTable({
                       <TableCell>
                         <div className="flex gap-x-2">
                           <div className="my-auto">
-                            <SvgEdit className="text-muted-foreground" />
+                            <SvgEdit
+                              size={16}
+                              className="text-muted-foreground"
+                            />
                           </div>
                           <div className="my-auto">
                             {"#" +

--- a/web/src/components/credentials/actions/ModifyCredential.tsx
+++ b/web/src/components/credentials/actions/ModifyCredential.tsx
@@ -133,7 +133,7 @@ function CredentialSelectionTable({
                         className="cursor-pointer my-auto"
                         aria-label="Edit credential"
                       >
-                        <SvgEdit />
+                        <SvgEdit size={16} />
                       </button>
                     )}
                   </td>


### PR DESCRIPTION
## Description

**Bug:** Several `@opal/icons` rendered at intrinsic SVG size (huge) — no `size` prop, no Tailwind `w-N h-N`, no CSS dim directly on the SVG.

**Cause:** PR #10474 migrated icons to `@opal/icons`. New icons set `width={size}/height={size}`; callers without a `size` (or sized className) fall back to the browser default (~300×150).

**Fix:** Pass explicit `size` matching the surrounding layout.

- `web/src/app/admin/bots/SlackBotTable.tsx` — `<SvgEdit>` next to bot name (`size=16`)
- `web/src/app/admin/bots/[bot-id]/SlackChannelConfigsTable.tsx` — channel-row edit hint (`size=16`)
- `web/src/components/credentials/actions/ModifyCredential.tsx` — "Edit credential" icon button (`size=16`)
- `web/src/app/admin/billing/LicenseActivationCard.tsx` — `SvgXCircle` inside the 0.75rem `.billing-error-icon` wrapper (CSS sizes the wrapper, not the SVG → `size=12`)

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check