### PR TITLE
feat(tracing): populate Langfuse user_id and release on traces

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -648,6 +648,7 @@ def run_llm_loop(
         metadata={
             "tenant_id": get_current_tenant_id(),
             "chat_session_id": chat_session_id,
+            "user_id": user_identity.user_id if user_identity else None,
         },
     ):
         # Fix some LiteLLM issues,

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -211,6 +211,7 @@ def run_deep_research_llm_loop(
         metadata={
             "tenant_id": get_current_tenant_id(),
             "chat_session_id": chat_session_id,
+            "user_id": user_identity.user_id if user_identity else None,
         },
     ):
         # Here for lazy load LiteLLM

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -457,6 +457,7 @@ def rename_chat_session(
         metadata={
             "tenant_id": get_current_tenant_id(),
             "chat_session_id": str(chat_session_id),
+            "user_id": str(user_id) if user_id else None,
         },
     ):
         new_name = generate_chat_session_name(chat_history=simple_chat_history, llm=llm)

--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -122,12 +122,15 @@ class LangfuseTracingProcessor(TracingProcessor):
                 name=trace.name,
             )
 
-            # Always update the trace-level properties to set the trace name
-            # session_id is optional but name should always be set
+            # Promote first-class Langfuse fields out of metadata so they
+            # populate the dedicated UI facets (Sessions, Users) rather than
+            # only the metadata JSON blob.
             session_id = metadata.get("chat_session_id")
+            user_id = metadata.get("user_id")
             langfuse_span.update_trace(
                 name=trace.name,
                 session_id=session_id if session_id else None,
+                user_id=str(user_id) if user_id else None,
                 metadata=metadata if metadata else None,
             )
 

--- a/backend/onyx/tracing/setup.py
+++ b/backend/onyx/tracing/setup.py
@@ -83,6 +83,7 @@ def _setup_langfuse() -> None:
 
     from langfuse import Langfuse
 
+    from onyx import __version__
     from onyx.tracing.framework import add_trace_processor
     from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
 
@@ -95,6 +96,7 @@ def _setup_langfuse() -> None:
         public_key=LANGFUSE_PUBLIC_KEY,
         secret_key=LANGFUSE_SECRET_KEY,
         host=LANGFUSE_HOST if LANGFUSE_HOST else None,
+        release=__version__,
     )
 
     add_trace_processor(LangfuseTracingProcessor(client=client))

--- a/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
@@ -1,0 +1,71 @@
+"""Unit tests for LangfuseTracingProcessor metadata handling."""
+
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import MagicMock
+
+from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
+
+
+def _make_trace(metadata: Mapping[str, Any]) -> MagicMock:
+    trace = MagicMock()
+    trace.trace_id = "trace-123"
+    trace.name = "run_llm_loop"
+    trace.export.return_value = {"metadata": metadata}
+    return trace
+
+
+def _make_client_with_observation() -> tuple[MagicMock, MagicMock]:
+    observation = MagicMock()
+    observation.trace_id = "lf-trace-1"
+    observation.id = "lf-span-1"
+    client = MagicMock()
+    client.start_observation.return_value = observation
+    return client, observation
+
+
+def test_on_trace_start_promotes_user_id_and_session_id() -> None:
+    """user_id and chat_session_id in metadata must be passed as first-class
+    fields on update_trace so Langfuse populates the Users and Sessions views.
+    """
+    client, observation = _make_client_with_observation()
+    processor = LangfuseTracingProcessor(client=client)
+
+    metadata = {
+        "tenant_id": "tenant-abc",
+        "chat_session_id": "session-xyz",
+        "user_id": "user-42",
+    }
+    processor.on_trace_start(_make_trace(metadata))
+
+    observation.update_trace.assert_called_once()
+    kwargs = observation.update_trace.call_args.kwargs
+    assert kwargs["user_id"] == "user-42"
+    assert kwargs["session_id"] == "session-xyz"
+    assert kwargs["name"] == "run_llm_loop"
+    assert kwargs["metadata"] == metadata
+
+
+def test_on_trace_start_user_id_missing_passes_none() -> None:
+    """Anonymous / unattributed traces still update successfully with user_id=None."""
+    client, observation = _make_client_with_observation()
+    processor = LangfuseTracingProcessor(client=client)
+
+    metadata = {"tenant_id": "tenant-abc", "chat_session_id": "session-xyz"}
+    processor.on_trace_start(_make_trace(metadata))
+
+    kwargs = observation.update_trace.call_args.kwargs
+    assert kwargs["user_id"] is None
+    assert kwargs["session_id"] == "session-xyz"
+
+
+def test_on_trace_start_coerces_non_string_user_id() -> None:
+    """User ids that arrive as ints (e.g. from User.id) are coerced to strings."""
+    client, observation = _make_client_with_observation()
+    processor = LangfuseTracingProcessor(client=client)
+
+    metadata = {"chat_session_id": "session-xyz", "user_id": 7}
+    processor.on_trace_start(_make_trace(metadata))
+
+    kwargs = observation.update_trace.call_args.kwargs
+    assert kwargs["user_id"] == "7"


### PR DESCRIPTION
## Description

The Langfuse **Users** view was empty for our customer because Onyx traces never had a top-level `user_id` set. `LangfuseTracingProcessor.on_trace_start` was only passing `name`, `session_id`, and `metadata` to `update_trace(...)` — Langfuse populates its Users facet exclusively from the dedicated `user_id` trace field, so even though `LLMUserIdentity.user_id` is already constructed in `chat/process_message.py` it never reached the UI.

This PR:

1. Promotes `user_id` from trace metadata to a first-class Langfuse field on `update_trace(...)` (matching the existing `chat_session_id` -> `session_id` pattern).
2. Threads the user identity through the three top-level trace sites that already have it in scope:
   - `run_llm_loop` (`backend/onyx/chat/llm_loop.py`) — from `user_identity.user_id`
   - `run_deep_research_llm_loop` (`backend/onyx/deep_research/dr_loop.py`) — from `user_identity.user_id`
   - `chat_session_naming` (`backend/onyx/server/query_and_chat/chat_backend.py`) — from `user.id`
3. Passes `__version__` as the Langfuse `release` so the Releases view and per-trace version filtering reflect the running Onyx build (same pattern already used for Sentry init).

The first-class `user_id` is forwarded as a string and coerced if it arrives as a non-string (e.g. an integer `User.id`).

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py` cover:
  - `user_id` and `chat_session_id` are promoted from metadata to the dedicated `update_trace(...)` fields (the bug fix).
  - When `user_id` is absent, `update_trace(...)` still succeeds with `user_id=None`.
  - Non-string user ids are coerced to strings.
- Existing `backend/tests/unit/onyx/tracing/test_tracing_setup.py` continues to pass.
- `pre-commit run` clean on the touched files (ty, ruff, black).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate Langfuse trace user_id and set release from __version__ to fix the empty Users view and enable release-based filtering across traces.

- **Bug Fixes**
  - Promote user_id from metadata to the top-level trace field so Users are populated.
  - Thread user_id through run_llm_loop, run_deep_research_llm_loop, and chat session naming.
  - Coerce non-string IDs to strings and allow user_id=None when missing.

- **New Features**
  - Send __version__ as Langfuse release to power the Releases view and per-trace filters.

<sup>Written for commit d914e22f1e774408d1d43111334b339b0b9e2e89. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11247?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

