### PR TITLE
feat(wiki): skip document push hook during initial indexing

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1684,6 +1684,7 @@ def _docprocessing_task(
                 index_attempt.connector_credential_pair.connector.source.value
             )
             search_settings_id: int = index_attempt.search_settings.id
+            from_beginning: bool = index_attempt.from_beginning
 
         # Session is now closed; no connection held during embedding.
 
@@ -1723,6 +1724,7 @@ def _docprocessing_task(
             document_batch=documents,
             request_id=index_attempt_metadata.request_id,
             adapter=adapter,
+            from_beginning=from_beginning,
         )
 
         # Track chunk indexing usage for cloud usage limits

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -394,6 +394,7 @@ def index_doc_batch_with_handler(
     tenant_id: str,
     adapter: IndexingBatchAdapter,
     ignore_time_skip: bool = False,
+    from_beginning: bool = False,
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
 ) -> IndexingPipelineResult:
@@ -407,6 +408,7 @@ def index_doc_batch_with_handler(
             tenant_id=tenant_id,
             adapter=adapter,
             ignore_time_skip=ignore_time_skip,
+            from_beginning=from_beginning,
             enable_contextual_rag=enable_contextual_rag,
             llm=llm,
         )
@@ -1150,12 +1152,17 @@ def _maybe_push_documents(
     adapter: IndexingBatchAdapter,
     filtered_documents: list[Document],
     insertion_records: list[DocumentInsertionRecord],
+    from_beginning: bool = False,
 ) -> None:
     """Fire the DOCUMENT_PUSH hook for each successfully indexed public document.
 
     Single-tenant only — multi-tenant deployments would mix documents from
     different organizations into a shared external destination.
+    Does not fire during initial indexing (from_beginning=True).
     """
+    if from_beginning:
+        return
+
     if MULTI_TENANT:
         return
 
@@ -1223,6 +1230,7 @@ def index_doc_batch(
     enable_contextual_rag: bool = False,
     llm: LLM | None = None,
     ignore_time_skip: bool = False,
+    from_beginning: bool = False,
     filter_fnc: Callable[
         [list[Document]], tuple[list[Document], list[ConnectorFailure]]
     ] = filter_documents,
@@ -1450,6 +1458,7 @@ def index_doc_batch(
         adapter=adapter,
         filtered_documents=filtered_documents,
         insertion_records=primary_doc_idx_insertion_records,
+        from_beginning=from_beginning,
     )
 
     return IndexingPipelineResult(
@@ -1475,6 +1484,7 @@ def run_indexing_pipeline(
     adapter: IndexingBatchAdapter,
     chunker: Chunker | None = None,
     ignore_time_skip: bool = False,
+    from_beginning: bool = False,
 ) -> IndexingPipelineResult:
     """Builds a pipeline which takes in a list (batch) of docs and indexes them."""
     if db_session is not None:
@@ -1527,4 +1537,5 @@ def run_indexing_pipeline(
         enable_contextual_rag=enable_contextual_rag,
         llm=llm,
         ignore_time_skip=ignore_time_skip,
+        from_beginning=from_beginning,
     )

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -316,6 +316,23 @@ def _make_ctx() -> MagicMock:
     return ctx
 
 
+def test_document_push_skipped_when_from_beginning() -> None:
+    from onyx.indexing.indexing_pipeline import _maybe_push_documents
+
+    doc = _make_doc(doc_id="doc1")
+    with (
+        patch(_PATCH_MULTI_TENANT, False),
+        patch(_PATCH_EXECUTE_HOOK) as mock_hook,
+    ):
+        _maybe_push_documents(
+            _make_adapter(),
+            [doc],
+            _make_insertion_records(["doc1"]),
+            from_beginning=True,
+        )
+    mock_hook.assert_not_called()
+
+
 def test_document_push_skipped_in_multi_tenant_mode() -> None:
     from onyx.indexing.indexing_pipeline import _maybe_push_documents
 


### PR DESCRIPTION
## Description

Skip the `DOCUMENT_PUSH` hook when a connector is doing its initial index (`from_beginning=True`). The hook is intended for incremental updates — pushing every document during the first full crawl is noisy and unnecessary.
https://linear.app/onyx-app/issue/ENG-4118/agent-wiki
## How Has This Been Tested?

Manually verified the `from_beginning` flag is correctly read from the index attempt and threaded through `run_indexing_pipeline` → `index_doc_batch_with_handler` → `index_doc_batch` → `_maybe_push_documents`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip firing the `DOCUMENT_PUSH` hook during a connector’s initial indexing (`from_beginning=true`) to reduce noise; the hook now runs only for incremental updates (Linear ENG-4118).

- **Bug Fixes**
  - Threaded `from_beginning` from the index attempt through `index_doc_batch_with_handler` → `run_indexing_pipeline` → `_maybe_push_documents`.
  - Early return in `_maybe_push_documents` when `from_beginning=true`; added a unit test to verify; multi-tenant guard remains.

<sup>Written for commit aa2b1c528e6080abf51b606ed875e400ba488368. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11248?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



