### PR TITLE
fix(install): default to latest GitHub release for configs and image tag

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -161,6 +161,35 @@ download_file() {
     fi
 }
 
+# Fetches the most recent published release tag from the Onyx GitHub repo.
+# Used to default the installer to a pinned, tested release (instead of the
+# rolling "edge" tag) and to pull compose/nginx files that match it.
+LATEST_RELEASE_TAG=""
+fetch_latest_release_tag() {
+    local api_url="https://api.github.com/repos/onyx-dot-app/onyx/releases/latest"
+    local response=""
+    if [[ "$DOWNLOADER" == "curl" ]]; then
+        response=$(curl -fsSL --retry 2 --retry-delay 1 \
+            --connect-timeout 5 --max-time 10 \
+            -H "Accept: application/vnd.github+json" \
+            "$api_url" 2>/dev/null) || return 1
+    else
+        response=$(wget -q --tries=2 --timeout=10 \
+            --header="Accept: application/vnd.github+json" \
+            -O- "$api_url" 2>/dev/null) || return 1
+    fi
+    local tag
+    tag=$(echo "$response" \
+        | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' \
+        | head -1 \
+        | sed -E 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
+    if [[ -z "$tag" ]]; then
+        return 1
+    fi
+    LATEST_RELEASE_TAG="$tag"
+    return 0
+}
+
 # --- Docker Compose detection ---
 # Sets COMPOSE_CMD to "docker compose" (plugin) or "docker-compose" (standalone).
 # Returns 0 if either is available, 1 otherwise. Safe to re-run after installing
@@ -422,6 +451,22 @@ if [[ -n "${WSL_DISTRO_NAME:-}" ]] || grep -qi microsoft /proc/version 2>/dev/nu
     IS_WSL=true
 fi
 
+# Resolve the git ref to pull deployment files from, and the default image tag
+# to suggest at the version prompt. Both default to the most recent GitHub
+# release so users land on a pinned, tested version. If the API is unreachable,
+# fall back to main / edge (the pre-existing defaults).
+RELEASE_REF="main"
+DEFAULT_IMAGE_TAG="edge"
+RELEASE_LOOKUP_FAILED=false
+if [[ "$USE_LOCAL_FILES" = false ]]; then
+    if fetch_latest_release_tag; then
+        RELEASE_REF="$LATEST_RELEASE_TAG"
+        DEFAULT_IMAGE_TAG="$LATEST_RELEASE_TAG"
+    else
+        RELEASE_LOOKUP_FAILED=true
+    fi
+fi
+
 # Dry-run: show plan and exit
 if [[ "$DRY_RUN" = true ]]; then
     print_info "Dry run mode — showing what would happen:"
@@ -430,6 +475,7 @@ if [[ "$DRY_RUN" = true ]]; then
     echo "  • Include Craft: ${INCLUDE_CRAFT}"
     echo "  • OS type: ${OSTYPE:-unknown} (WSL: ${IS_WSL})"
     echo "  • Downloader: ${DOWNLOADER}"
+    echo "  • Default image tag: ${DEFAULT_IMAGE_TAG} (config ref: ${RELEASE_REF})"
     echo ""
     print_success "Dry run complete (no changes made)"
     exit 0
@@ -524,6 +570,10 @@ echo "Welcome to Onyx Installation Script"
 echo "===================================="
 echo ""
 
+if [[ "$RELEASE_LOOKUP_FAILED" = true ]]; then
+    print_warning "Could not determine latest Onyx release — falling back to main / edge"
+fi
+
 # User acknowledgment section
 echo -e "${YELLOW}${BOLD}This script will:${NC}"
 echo "1. Download deployment files for Onyx into a new '${INSTALL_ROOT}' directory"
@@ -540,8 +590,9 @@ else
     echo ""
 fi
 
-# GitHub repo base URL - using main branch
-GITHUB_RAW_URL="https://raw.githubusercontent.com/onyx-dot-app/onyx/main/deployment/docker_compose"
+# GitHub repo base URL — pinned to the resolved release ref (latest release tag
+# if reachable, otherwise main).
+GITHUB_RAW_URL="https://raw.githubusercontent.com/onyx-dot-app/onyx/${RELEASE_REF}/deployment/docker_compose"
 
 # Check system requirements
 print_step "Verifying Docker installation"
@@ -733,7 +784,7 @@ mkdir -p "${INSTALL_ROOT}/data/nginx/local"
 print_success "Directory structure created"
 
 # Ensure all required configuration files are present
-NGINX_BASE_URL="https://raw.githubusercontent.com/onyx-dot-app/onyx/main/deployment/data/nginx"
+NGINX_BASE_URL="https://raw.githubusercontent.com/onyx-dot-app/onyx/${RELEASE_REF}/deployment/data/nginx"
 
 if [[ "$USE_LOCAL_FILES" = true ]]; then
     print_step "Verifying existing configuration files"
@@ -885,10 +936,10 @@ if [ -f "$ENV_FILE" ]; then
         else
             print_info "Update selected. Which tag would you like to deploy?"
             echo ""
-            echo "• Press Enter for edge (recommended)"
+            echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
             echo "• Type a specific tag (e.g., v0.1.0)"
             echo ""
-            prompt_or_default "Enter tag [default: edge]: " "edge"
+            prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
             VERSION="$REPLY"
             echo ""
 
@@ -933,10 +984,10 @@ else
     else
         print_info "Which tag would you like to deploy?"
         echo ""
-        echo "• Press Enter for edge (recommended)"
+        echo "• Press Enter for ${DEFAULT_IMAGE_TAG} (recommended)"
         echo "• Type a specific tag (e.g., v0.1.0)"
         echo ""
-        prompt_or_default "Enter tag [default: edge]: " "edge"
+        prompt_or_default "Enter tag [default: ${DEFAULT_IMAGE_TAG}]: " "${DEFAULT_IMAGE_TAG}"
         VERSION="$REPLY"
         echo ""
 
@@ -1127,33 +1178,43 @@ print_success "Using port $AVAILABLE_PORT for nginx"
 # Determine if we're using a floating tag (edge, latest) that should force pull.
 # Read IMAGE_TAG from .env file and remove any quotes or whitespace.
 CURRENT_IMAGE_TAG=$(grep "^IMAGE_TAG=" "$ENV_FILE" | head -1 | cut -d'=' -f2 | tr -d ' "'"'"'')
-if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ]; then
+
+if [ "$CURRENT_IMAGE_TAG" = "edge" ] || [ "$CURRENT_IMAGE_TAG" = "latest" ] || [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
     USE_LATEST=true
-    print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
+    # Floating tags track main, so configs should come from main.
+    CONFIG_REF="main"
+    if [[ "$CURRENT_IMAGE_TAG" == craft-* ]]; then
+        print_info "Using craft tag '$CURRENT_IMAGE_TAG' - will force pull and recreate containers"
+    else
+        print_info "Using '$CURRENT_IMAGE_TAG' tag - will force pull and recreate containers"
+    fi
 else
     USE_LATEST=false
+    # Pinned release tags use their own ref so configs match the images.
+    CONFIG_REF="$CURRENT_IMAGE_TAG"
 fi
 
-# For pinned version tags, re-download config files from that tag so the
-# compose file matches the images being pulled (the initial download used main).
-if [[ "$USE_LATEST" = false ]] && [[ "$USE_LOCAL_FILES" = false ]]; then
-    PINNED_BASE="https://raw.githubusercontent.com/onyx-dot-app/onyx/${CURRENT_IMAGE_TAG}/deployment"
-    print_info "Fetching config files matching tag ${CURRENT_IMAGE_TAG}..."
-    if download_file "${PINNED_BASE}/docker_compose/docker-compose.yml" "${INSTALL_ROOT}/deployment/docker-compose.yml" 2>/dev/null; then
-        download_file "${PINNED_BASE}/data/nginx/app.conf.template" "${INSTALL_ROOT}/data/nginx/app.conf.template" 2>/dev/null || true
-        download_file "${PINNED_BASE}/data/nginx/run-nginx.sh" "${INSTALL_ROOT}/data/nginx/run-nginx.sh" 2>/dev/null || true
+# The initial download pulled configs from RELEASE_REF (latest release, or main
+# on fallback). If the chosen image tag wants configs from a different ref,
+# re-fetch them so the compose file matches the images being pulled.
+if [[ "$CONFIG_REF" != "$RELEASE_REF" ]] && [[ "$USE_LOCAL_FILES" = false ]]; then
+    CONFIG_BASE="https://raw.githubusercontent.com/onyx-dot-app/onyx/${CONFIG_REF}/deployment"
+    print_info "Fetching config files matching ${CONFIG_REF}..."
+    if download_file "${CONFIG_BASE}/docker_compose/docker-compose.yml" "${INSTALL_ROOT}/deployment/docker-compose.yml" 2>/dev/null; then
+        download_file "${CONFIG_BASE}/data/nginx/app.conf.template" "${INSTALL_ROOT}/data/nginx/app.conf.template" 2>/dev/null || true
+        download_file "${CONFIG_BASE}/data/nginx/run-nginx.sh" "${INSTALL_ROOT}/data/nginx/run-nginx.sh" 2>/dev/null || true
         chmod +x "${INSTALL_ROOT}/data/nginx/run-nginx.sh"
         if [[ "$LITE_MODE" = true ]]; then
-            download_file "${PINNED_BASE}/docker_compose/${LITE_COMPOSE_FILE}" \
+            download_file "${CONFIG_BASE}/docker_compose/${LITE_COMPOSE_FILE}" \
                 "${INSTALL_ROOT}/deployment/${LITE_COMPOSE_FILE}" 2>/dev/null || true
         fi
         if [[ "$INCLUDE_CRAFT" = true ]]; then
-            download_file "${PINNED_BASE}/docker_compose/${CRAFT_COMPOSE_FILE}" \
+            download_file "${CONFIG_BASE}/docker_compose/${CRAFT_COMPOSE_FILE}" \
                 "${INSTALL_ROOT}/deployment/${CRAFT_COMPOSE_FILE}" 2>/dev/null || true
         fi
-        print_success "Config files updated to match ${CURRENT_IMAGE_TAG}"
+        print_success "Config files updated to match ${CONFIG_REF}"
     else
-        print_warning "Tag ${CURRENT_IMAGE_TAG} not found on GitHub — using main branch configs"
+        print_warning "Ref ${CONFIG_REF} not found on GitHub — keeping configs from ${RELEASE_REF}"
     fi
 fi
 
@@ -1162,7 +1223,11 @@ print_step "Pulling Docker images"
 print_info "This may take several minutes depending on your internet connection..."
 echo ""
 print_info "Downloading Docker images (this may take a while)..."
-(cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD $(compose_file_args) pull --quiet)
+# Pass IMAGE_TAG inline so the value the user picked at the prompt wins over
+# any `export IMAGE_TAG=...` inherited from the caller's shell. Compose's
+# substitution prefers shell env over .env, so without this an exported
+# IMAGE_TAG in the user's shellrc would silently swap the images being pulled.
+(cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD $(compose_file_args) pull --quiet)
 if [ $? -eq 0 ]; then
     print_success "Docker images downloaded successfully"
 else
@@ -1188,15 +1253,15 @@ echo ""
 UP_EXIT=0
 if [ "$USE_LATEST" = true ]; then
     print_info "Force pulling latest images and recreating containers..."
-    (cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD $(compose_file_args) up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD $(compose_file_args) up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 else
-    (cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD $(compose_file_args) up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD $(compose_file_args) up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 fi
 if [ $UP_EXIT -ne 0 ]; then
     print_error "Failed to start Onyx services"
     echo ""
     print_info "Current container status:"
-    (cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD $(compose_file_args) ps)
+    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD $(compose_file_args) ps)
     echo ""
     print_info "Check the logs of any unhealthy service:"
     echo "  (cd \"${INSTALL_ROOT}/deployment\" && $COMPOSE_CMD $(compose_file_args) logs <service>)"


### PR DESCRIPTION
## Summary
- `install.sh` now calls the GitHub releases API to discover the most recent published Onyx release tag.
- That tag becomes the git ref used to download `docker-compose.yml`, the lite/craft overlays, and the nginx templates, so the config files match the images that will actually be pulled.
- The version prompt's default switches from the rolling `edge` tag to the resolved release tag (so non-interactive / `--no-prompt` runs land on a tested version too).
- If the API is unreachable, falls back to the previous behavior (`main` for configs, `edge` for the image tag) with a warning.
- Floating tags (`edge`, `latest`, `craft-*`) still pull configs from `main`; pinned release tags pull configs from their own ref. A new `CONFIG_REF` variable drives the re-download so we only re-fetch when the chosen ref differs from the initial download ref.

Closes https://github.com/onyx-dot-app/onyx/issues/11227

## Test plan

<img width="1377" height="2085" alt="20260520_15h43m32s_grim" src="https://github.com/user-attachments/assets/411adab7-013e-49ef-920c-d32c3ae11903" />


- [ ] `bash -n install.sh` (syntax check) — done locally
- [ ] `./install.sh --dry-run` shows the resolved default tag + config ref
- [ ] `./install.sh --dry-run` with network blocked falls back to `main` / `edge`
- [ ] Fresh install in a clean dir: accept default → ends up on the latest release tag, configs come from that tag
- [ ] Fresh install, type `edge` at the prompt → configs re-fetched from `main`, images pull `edge`
- [ ] Fresh install, type a known pinned tag (e.g. previous release) → configs re-fetched from that tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the installer to the latest GitHub release for both the image tag and config downloads, and ensure Docker Compose uses the selected tag even if the shell has a conflicting `IMAGE_TAG`. Adds bounded API timeouts and offline `--local` behavior; falls back to `main`/`edge` with a warning.

- **New Features**
  - Resolve and display the latest release via the GitHub Releases API.
  - Use that tag for config URLs via `RELEASE_REF`; prompt defaults via `DEFAULT_IMAGE_TAG`.
  - Floating tags (`edge`, `latest`, `craft-*`) keep configs from `main`; pinned tags use their own ref.
  - Re-fetch configs when needed via `CONFIG_REF` so files match the selected tag; `--dry-run` shows the resolved defaults.

- **Bug Fixes**
  - Pass `IMAGE_TAG` inline to Compose (pull/up/ps) so the user’s choice overrides any shell export without leaking env vars.
  - Bound GitHub API timeouts, skip the release lookup in `--local`, and print the fallback warning after the banner.

<sup>Written for commit c0a189a5328b2b88e178118d8e7376ba7c00c879. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11250?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



