### PR TITLE
fix(tenants): block GATED_ACCESS tenants from cloud API

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -1,10 +1,16 @@
 """Constants for license enforcement and per-feature tier gating.
 
-Two related concerns live here, both consumed by the `tier_gate` middleware:
+Three related concerns live here:
 
-1. `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` — paths that bypass license
-   enforcement entirely (auth, billing, health checks, etc.).
-2. `PATH_PREFIX_MIN_TIER` — minimum tier required to access a given path
+1. `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` — paths that bypass the
+   self-hosted `license_enforcement` middleware (auth, billing, health,
+   etc.) when the license is expired/gated.
+2. `MULTI_TENANT_GATING_ALLOWED_PREFIXES` — paths that bypass the
+   multi-tenant cloud gate in `tenant_tracking` when a tenant's
+   subscription is inactive (`gated_tenants` Redis set). Cloud uses
+   subscriptions, not licenses, and has cloud-specific billing endpoints
+   (e.g. Stripe publishable key) that the resubscribe flow needs.
+3. `PATH_PREFIX_MIN_TIER` — minimum tier required to access a given path
    prefix. `Tier.BUSINESS` = Business+. `Tier.ENTERPRISE` = Enterprise only.
    Longest-prefix-wins, so a nested path can resolve to a stricter tier
    than its parent (e.g. `/admin/enterprise-settings/scim` is ENTERPRISE
@@ -54,6 +60,40 @@ LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/users",
         # Notifications - needed for UI to load properly
         "/notifications",
+    }
+)
+
+
+# Paths reachable by a tenant whose subscription is inactive (cloud only).
+# Strict resubscribe surface — anything not on this list returns 402. Kept
+# narrow on purpose; the self-hosted allowlist above has entries that do
+# not apply in cloud (seat-limit user management, `/license`, `/proxy`),
+# and the cloud-only Stripe endpoints don't exist in self-hosted. Add
+# entries here only if the resubscribe flow actually fails without them.
+#
+# Direct evidence of who calls what (web/src/components/errorPages/AccessRestrictedPage.tsx
+# and SettingsProvider):
+#   /api/tenants/stripe-publishable-key   — Stripe SDK init
+#   /api/tenants/create-subscription-session — Stripe checkout
+#   /api/tenants/create-customer-portal-session — Stripe portal (payment method update)
+#   /api/tenants/billing-information — current billing state for the UI
+#   /api/billing, /api/admin/billing — unified billing API
+#   /api/me — basic user info needed to render the gated page
+#   /api/settings — application_status flag the gated page reads
+#   /api/auth — login / logout while gated
+#   /health — load-balancer probes
+MULTI_TENANT_GATING_ALLOWED_PREFIXES: frozenset[str] = frozenset(
+    {
+        "/auth",
+        "/health",
+        "/me",
+        "/settings",
+        "/billing",
+        "/admin/billing",
+        "/tenants/billing-information",
+        "/tenants/create-customer-portal-session",
+        "/tenants/create-subscription-session",
+        "/tenants/stripe-publishable-key",
     }
 )
 

--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -1,16 +1,10 @@
 """Constants for license enforcement and per-feature tier gating.
 
-Three related concerns live here:
+Two related concerns live here, both consumed by the `tier_gate` middleware:
 
-1. `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` — paths that bypass the
-   self-hosted `license_enforcement` middleware (auth, billing, health,
-   etc.) when the license is expired/gated.
-2. `MULTI_TENANT_GATING_ALLOWED_PREFIXES` — paths that bypass the
-   multi-tenant cloud gate in `tenant_tracking` when a tenant's
-   subscription is inactive (`gated_tenants` Redis set). Cloud uses
-   subscriptions, not licenses, and has cloud-specific billing endpoints
-   (e.g. Stripe publishable key) that the resubscribe flow needs.
-3. `PATH_PREFIX_MIN_TIER` — minimum tier required to access a given path
+1. `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` — paths that bypass license
+   enforcement entirely (auth, billing, health checks, etc.).
+2. `PATH_PREFIX_MIN_TIER` — minimum tier required to access a given path
    prefix. `Tier.BUSINESS` = Business+. `Tier.ENTERPRISE` = Enterprise only.
    Longest-prefix-wins, so a nested path can resolve to a stricter tier
    than its parent (e.g. `/admin/enterprise-settings/scim` is ENTERPRISE
@@ -18,6 +12,9 @@ Three related concerns live here:
 
 Import these constants in both production code and tests to ensure
 consistency.
+
+Multi-tenant cloud gating lives in `multi_tenant_gating_config.py` and is
+deliberately separate — cloud uses subscriptions, not licenses.
 """
 
 from onyx.server.settings.models import Tier
@@ -60,40 +57,6 @@ LICENSE_ENFORCEMENT_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/users",
         # Notifications - needed for UI to load properly
         "/notifications",
-    }
-)
-
-
-# Paths reachable by a tenant whose subscription is inactive (cloud only).
-# Strict resubscribe surface — anything not on this list returns 402. Kept
-# narrow on purpose; the self-hosted allowlist above has entries that do
-# not apply in cloud (seat-limit user management, `/license`, `/proxy`),
-# and the cloud-only Stripe endpoints don't exist in self-hosted. Add
-# entries here only if the resubscribe flow actually fails without them.
-#
-# Direct evidence of who calls what (web/src/components/errorPages/AccessRestrictedPage.tsx
-# and SettingsProvider):
-#   /api/tenants/stripe-publishable-key   — Stripe SDK init
-#   /api/tenants/create-subscription-session — Stripe checkout
-#   /api/tenants/create-customer-portal-session — Stripe portal (payment method update)
-#   /api/tenants/billing-information — current billing state for the UI
-#   /api/billing, /api/admin/billing — unified billing API
-#   /api/me — basic user info needed to render the gated page
-#   /api/settings — application_status flag the gated page reads
-#   /api/auth — login / logout while gated
-#   /health — load-balancer probes
-MULTI_TENANT_GATING_ALLOWED_PREFIXES: frozenset[str] = frozenset(
-    {
-        "/auth",
-        "/health",
-        "/me",
-        "/settings",
-        "/billing",
-        "/admin/billing",
-        "/tenants/billing-information",
-        "/tenants/create-customer-portal-session",
-        "/tenants/create-subscription-session",
-        "/tenants/stripe-publishable-key",
     }
 )
 

--- a/backend/ee/onyx/configs/multi_tenant_gating_config.py
+++ b/backend/ee/onyx/configs/multi_tenant_gating_config.py
@@ -1,0 +1,41 @@
+"""Constants for multi-tenant cloud subscription gating.
+
+Cloud-only. Self-hosted licensing lives in `license_enforcement_config.py`
+and is unrelated — do NOT merge the two surfaces.
+
+Consumed by `tenant_tracking` middleware. When a tenant is in the
+`gated_tenants` Redis set (control-plane marks `application_status =
+GATED_ACCESS` on trial expiry / payment failure), every request whose
+path is NOT in the allowlist below returns 402 SUBSCRIPTION_INACTIVE.
+"""
+
+# Paths reachable by a tenant whose subscription is inactive. Strict —
+# anything not on this list returns 402. Direct evidence of who calls what
+# comes from `web/src/components/errorPages/AccessRestrictedPage.tsx` and
+# the `SettingsProvider` / `useSettings` hook:
+#
+#   /tenants/stripe-publishable-key      — Stripe SDK init
+#   /tenants/create-subscription-session — Stripe checkout
+#   /tenants/create-customer-portal-session — Stripe portal (payment method)
+#   /tenants/billing-information         — current billing state for the UI
+#   /billing, /admin/billing             — unified billing API
+#   /me                                  — basic user info for the gated page
+#   /settings                            — application_status flag the FE reads
+#   /auth                                — login / logout while gated
+#   /health                              — load-balancer probes
+#
+# Add entries only when the resubscribe flow actually fails without them.
+MULTI_TENANT_GATING_ALLOWED_PREFIXES: frozenset[str] = frozenset(
+    {
+        "/auth",
+        "/health",
+        "/me",
+        "/settings",
+        "/billing",
+        "/admin/billing",
+        "/tenants/billing-information",
+        "/tenants/create-customer-portal-session",
+        "/tenants/create-subscription-session",
+        "/tenants/stripe-publishable-key",
+    }
+)

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import Awaitable
 from collections.abc import Callable
@@ -17,6 +18,7 @@ from onyx.auth.utils import extract_tenant_from_auth_header
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import TENANT_ID_COOKIE_NAME
 from onyx.db.engine.sql_engine import is_valid_schema_name
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.redis.redis_pool import retrieve_auth_token_data_from_redis
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
@@ -43,20 +45,29 @@ def add_api_server_tenant_id_middleware(
 
             CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-            # Block GATED_ACCESS tenants on every non-allowlisted path.
-            # The frontend ProductGatingWrapper only stops UI rendering — direct
-            # API callers (bots with stored auth, PATs, scripts) bypass it and
-            # have historically continued burning the cloud LLM key after their
-            # trial expired or payment failed. Allowlist mirrors the self-hosted
-            # `license_enforcement` middleware so a gated tenant can still reach
-            # /auth, /billing, /me, etc. to resubscribe, plus the multi-tenant
-            # Stripe publishable key endpoint needed to render the checkout flow.
-            if MULTI_TENANT and not _is_path_allowed(request.url.path):
+            # Block tenants whose subscription has lapsed (`application_status =
+            # GATED_ACCESS` in the cloud control plane → `gated_tenants` Redis
+            # set) from reaching anything outside the resubscribe surface. The
+            # frontend ProductGatingWrapper only swaps UI; direct API callers
+            # (bots with stored auth, PATs, scripts) used to walk past it and
+            # keep burning the cloud LLM key. Skip the lookup for the default
+            # schema (unauthenticated requests) — it is never in the gated set
+            # and the round-trip is wasted. Allowlist reuses the self-hosted
+            # `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` list (auth, /billing, /me,
+            # /settings, /notifications, …) plus the multi-tenant Stripe
+            # publishable-key endpoint that the resubscribe flow needs.
+            if (
+                MULTI_TENANT
+                and tenant_id != POSTGRES_DEFAULT_SCHEMA
+                and not _is_path_allowed(request.url.path)
+            ):
                 try:
-                    gated = is_tenant_gated(tenant_id)
+                    # `is_tenant_gated` uses the sync Redis client; offload so
+                    # the SISMEMBER round-trip does not block the event loop.
+                    gated = await asyncio.to_thread(is_tenant_gated, tenant_id)
                 except Exception:
-                    # Fail open on Redis errors — don't lock paying users out
-                    # because of cache connectivity.
+                    # Fail open on Redis errors — don't lock paying tenants out
+                    # because of cache connectivity issues.
                     logger.warning(
                         "[tenant_tracking] is_tenant_gated check failed; allowing request"
                     )
@@ -68,13 +79,12 @@ def add_api_server_tenant_id_middleware(
                         tenant_id,
                         request.url.path,
                     )
+                    code, status = OnyxErrorCode.SUBSCRIPTION_INACTIVE.value
                     return JSONResponse(
-                        status_code=402,
+                        status_code=status,
                         content={
-                            "detail": {
-                                "error": "license_expired",
-                                "message": "Your subscription has expired. Please update your billing.",
-                            }
+                            "error_code": code,
+                            "detail": "Your subscription is inactive. Update your billing to restore access.",
                         },
                     )
 

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -10,7 +10,7 @@ from fastapi import Response
 from fastapi.responses import JSONResponse
 
 from ee.onyx.auth.users import decode_anonymous_user_jwt_token
-from ee.onyx.configs.license_enforcement_config import (
+from ee.onyx.configs.multi_tenant_gating_config import (
     MULTI_TENANT_GATING_ALLOWED_PREFIXES,
 )
 from ee.onyx.server.tenants.product_gating import is_tenant_gated

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 
 from ee.onyx.auth.users import decode_anonymous_user_jwt_token
 from ee.onyx.configs.license_enforcement_config import (
-    LICENSE_ENFORCEMENT_ALLOWED_PREFIXES,
+    MULTI_TENANT_GATING_ALLOWED_PREFIXES,
 )
 from ee.onyx.server.tenants.product_gating import is_tenant_gated
 from onyx.auth.utils import extract_tenant_from_auth_header
@@ -52,10 +52,9 @@ def add_api_server_tenant_id_middleware(
             # (bots with stored auth, PATs, scripts) used to walk past it and
             # keep burning the cloud LLM key. Skip the lookup for the default
             # schema (unauthenticated requests) — it is never in the gated set
-            # and the round-trip is wasted. Allowlist reuses the self-hosted
-            # `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` list (auth, /billing, /me,
-            # /settings, /notifications, …) plus the multi-tenant Stripe
-            # publishable-key endpoint that the resubscribe flow needs.
+            # and the round-trip is wasted. Allowlist is the cloud-only
+            # `MULTI_TENANT_GATING_ALLOWED_PREFIXES` (auth, /me, /settings,
+            # billing endpoints) — see that constant for the exact surface.
             if (
                 MULTI_TENANT
                 and tenant_id != POSTGRES_DEFAULT_SCHEMA
@@ -98,10 +97,9 @@ def add_api_server_tenant_id_middleware(
 def _is_path_allowed(path: str) -> bool:
     if path.startswith("/api/"):
         path = path[4:]
-    if any(path.startswith(prefix) for prefix in LICENSE_ENFORCEMENT_ALLOWED_PREFIXES):
-        return True
-    # Multi-tenant billing uses the tenants namespace instead of /admin/billing.
-    return path.startswith("/tenants/stripe-publishable-key")
+    return any(
+        path.startswith(prefix) for prefix in MULTI_TENANT_GATING_ALLOWED_PREFIXES
+    )
 
 
 async def _get_tenant_id_from_request(

--- a/backend/ee/onyx/server/middleware/tenant_tracking.py
+++ b/backend/ee/onyx/server/middleware/tenant_tracking.py
@@ -6,8 +6,13 @@ from fastapi import FastAPI
 from fastapi import HTTPException
 from fastapi import Request
 from fastapi import Response
+from fastapi.responses import JSONResponse
 
 from ee.onyx.auth.users import decode_anonymous_user_jwt_token
+from ee.onyx.configs.license_enforcement_config import (
+    LICENSE_ENFORCEMENT_ALLOWED_PREFIXES,
+)
+from ee.onyx.server.tenants.product_gating import is_tenant_gated
 from onyx.auth.utils import extract_tenant_from_auth_header
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import TENANT_ID_COOKIE_NAME
@@ -37,11 +42,56 @@ def add_api_server_tenant_id_middleware(
                 tenant_id = POSTGRES_DEFAULT_SCHEMA
 
             CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+
+            # Block GATED_ACCESS tenants on every non-allowlisted path.
+            # The frontend ProductGatingWrapper only stops UI rendering — direct
+            # API callers (bots with stored auth, PATs, scripts) bypass it and
+            # have historically continued burning the cloud LLM key after their
+            # trial expired or payment failed. Allowlist mirrors the self-hosted
+            # `license_enforcement` middleware so a gated tenant can still reach
+            # /auth, /billing, /me, etc. to resubscribe, plus the multi-tenant
+            # Stripe publishable key endpoint needed to render the checkout flow.
+            if MULTI_TENANT and not _is_path_allowed(request.url.path):
+                try:
+                    gated = is_tenant_gated(tenant_id)
+                except Exception:
+                    # Fail open on Redis errors — don't lock paying users out
+                    # because of cache connectivity.
+                    logger.warning(
+                        "[tenant_tracking] is_tenant_gated check failed; allowing request"
+                    )
+                    gated = False
+
+                if gated:
+                    logger.info(
+                        "[tenant_tracking] Blocking gated tenant: tenant=%s path=%s",
+                        tenant_id,
+                        request.url.path,
+                    )
+                    return JSONResponse(
+                        status_code=402,
+                        content={
+                            "detail": {
+                                "error": "license_expired",
+                                "message": "Your subscription has expired. Please update your billing.",
+                            }
+                        },
+                    )
+
             return await call_next(request)
 
         except Exception as e:
             logger.exception("Error in tenant ID middleware: %s", str(e))
             raise
+
+
+def _is_path_allowed(path: str) -> bool:
+    if path.startswith("/api/"):
+        path = path[4:]
+    if any(path.startswith(prefix) for prefix in LICENSE_ENFORCEMENT_ALLOWED_PREFIXES):
+        return True
+    # Multi-tenant billing uses the tenants namespace instead of /admin/billing.
+    return path.startswith("/tenants/stripe-publishable-key")
 
 
 async def _get_tenant_id_from_request(

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -70,6 +70,7 @@ class OnyxErrorCode(Enum):
     SEAT_LIMIT_EXCEEDED = ("SEAT_LIMIT_EXCEEDED", 402)
     TRIAL_INVITE_LIMIT_EXCEEDED = ("TRIAL_INVITE_LIMIT_EXCEEDED", 403)
     FEATURE_NOT_AVAILABLE = ("FEATURE_NOT_AVAILABLE", 402)
+    SUBSCRIPTION_INACTIVE = ("SUBSCRIPTION_INACTIVE", 402)
 
     # ------------------------------------------------------------------
     # Payload (413)


### PR DESCRIPTION
## Description

**Bug**: cloud `application_status=GATED_ACCESS` was only enforced by the React `ProductGatingWrapper`. Direct API callers (bots, scripts, PATs) bypassed the UI and kept burning the cloud LLM key after trial expiry / payment failure.

**Impact**: 22,627 tenants in the `gated_tenants` Redis set today. 713 of them sent messages in May 2026, burning ~87% of all May cloud-key tokens. Dominant cohort: 168 `@duck.com` bot signups, ~95% of the gated burn.

**Fix**: extend `add_api_server_tenant_id_middleware` to call `is_tenant_gated(tenant_id)` once tenant context is set. Return 402 on non-allowlisted paths. Allowlist reuses the self-hosted `LICENSE_ENFORCEMENT_ALLOWED_PREFIXES` plus `/tenants/stripe-publishable-key` (needed for resubscribe flow). Fails open on Redis errors.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check