### PR TITLE
feat(helm): fail-fast safeguard against 0.4.x → 0.5.x Vespa data loss

### DIFF
--- a/deployment/helm/MIGRATION.md
+++ b/deployment/helm/MIGRATION.md
@@ -37,10 +37,11 @@ time and fails fast with a clear message instead of silently breaking. See
 
 1. **Stand up an external Vespa cluster.** Vespa Cloud or a self-hosted
    deployment outside this chart, whichever fits your operational model.
-2. **Re-index** your documents into the new cluster (Vespa data does not
-   roundtrip directly between releases; the chunk schemas have changed
-   over time anyway). Onyx connectors will reindex as part of normal
-   operation once they can reach the new endpoint.
+2. **Re-index is automatic.** Vespa data does not roundtrip directly
+   between releases (chunk schemas have changed over time anyway). No
+   manual action here; Onyx connectors will reindex on their own once
+   the api-server can reach the new endpoint (after the upgrade in
+   step 5).
 3. **Update your values** to point Onyx at the external Vespa endpoint
    (the api-server respects `VESPA_HOST` / `VESPA_PORT` env vars; set
    them through your `configMap:` block).

--- a/deployment/helm/MIGRATION.md
+++ b/deployment/helm/MIGRATION.md
@@ -1,0 +1,86 @@
+# Chart migration guide
+
+Breaking changes between Onyx Helm chart versions and what to do about them.
+
+## chart 0.4.x → 0.5.x
+
+### What changed
+
+Chart 0.5.0 removed the bundled `charts/vespa/` subchart. Earlier chart
+versions installed Vespa as a `da-vespa` StatefulSet alongside the rest of
+Onyx; the api-server connected to it on `localhost:19071` (Vespa application
+deploy port) and the chart-managed PV held the indexed corpus.
+
+The 0.5.x line assumes you are running Vespa **outside** the chart — either
+managed Vespa, Vespa Cloud, or a separately-managed deployment in another
+namespace.
+
+### Why this matters
+
+A naive `helm upgrade` from 0.4.x to 0.5.x will delete the `da-vespa`
+StatefulSet (no template renders it anymore). The PV underneath the
+StatefulSet's PVC will be orphaned but the data inside is unreachable
+until you reattach it manually. Meanwhile the api-server will crash-loop
+trying to deploy its Vespa application package:
+
+```
+ConnectionRefusedError: [Errno 111] Connection refused
+HTTPConnection(host='localhost', port=19071): Failed to establish a new
+connection
+```
+
+The chart now ships a guard that detects this situation at install/upgrade
+time and fails fast with a clear message instead of silently breaking. See
+`templates/legacy-vespa-check.yaml`.
+
+### How to upgrade safely
+
+1. **Stand up an external Vespa cluster.** Vespa Cloud or a self-hosted
+   deployment outside this chart, whichever fits your operational model.
+2. **Re-index** your documents into the new cluster (Vespa data does not
+   roundtrip directly between releases; the chunk schemas have changed
+   over time anyway). Onyx connectors will reindex as part of normal
+   operation once they can reach the new endpoint.
+3. **Update your values** to point Onyx at the external Vespa endpoint
+   (the api-server respects `VESPA_HOST` / `VESPA_PORT` env vars; set
+   them through your `configMap:` block).
+4. **Delete the old StatefulSet** once you no longer need it. The PV
+   reclaim policy determines whether the underlying disk goes with it —
+   verify before you delete anything.
+5. **Run `helm upgrade`** with chart 0.5.x. If the old StatefulSet is
+   already gone the legacy check passes automatically.
+
+If you need to bypass the check (e.g. you've already migrated and only
+have a stale PV lingering), set in your values:
+
+```yaml
+legacyVespaCheck:
+  acknowledged: true
+```
+
+or disable the check entirely with `legacyVespaCheck.enabled: false`.
+
+### `celery-worker-scheduled-tasks` deployment
+
+Chart 0.5.x added a `celery-worker-scheduled-tasks` Deployment that runs
+the `onyx.background.celery.versioned_apps.scheduled_tasks` celery app.
+That app exists only in `onyxdotapp/onyx-backend` images cut after the
+"scheduled tasks v1" change. If you upgrade the chart without bumping the
+backend image, the deployment will crash-loop with:
+
+```
+Error: Unable to load celery application.
+The module onyx.background.celery.versioned_apps.scheduled_tasks was not
+found.
+```
+
+The deployment is already gated on its `replicaCount`. If your image is
+too old, disable it explicitly in your values:
+
+```yaml
+celery_worker_scheduled_tasks:
+  replicaCount: 0
+```
+
+The scheduled-tasks worker is only required if you use Onyx's craft /
+sandbox feature; otherwise it is safe to leave disabled.

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,6 +1,8 @@
 # Recent chart changes (0.5.0)
 
-If you are upgrading from an earlier 0.4.x release, note:
+If you are upgrading from an earlier 0.4.x release, **read [MIGRATION.md](../MIGRATION.md) first.** The 0.5.0 release dropped the bundled Vespa subchart; chart 0.5.6 ships a guard that fails `helm upgrade` if the legacy `da-vespa` StatefulSet is still in the namespace so you don't lose the indexed data silently.
+
+Other 0.5.0 changes:
 
 * **Redis** — the chart now bundles the `redis-operator` subchart alongside the
   `redis` subchart. The operator installs the CRD that the Redis CR binds to,

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,6 +1,6 @@
 # Recent chart changes (0.5.0)
 
-If you are upgrading from an earlier 0.4.x release, **read [MIGRATION.md](../MIGRATION.md) first.** The 0.5.0 release dropped the bundled Vespa subchart; chart 0.5.6 ships a guard that fails `helm upgrade` if the legacy `da-vespa` StatefulSet is still in the namespace so you don't lose the indexed data silently.
+If you are upgrading from an earlier 0.4.x release, **read [MIGRATION.md](./MIGRATION.md) first.** The 0.5.0 release dropped the bundled Vespa subchart; chart 0.5.6 ships a guard that fails `helm upgrade` if the legacy `da-vespa` StatefulSet is still in the namespace so you don't lose the indexed data silently.
 
 Other 0.5.0 changes:
 

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.5
+version: 0.5.6
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,13 +17,13 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: added
-      description: Optional External Secrets Operator support. Set
-        externalSecret.enabled=true to render an ExternalSecret CR that
-        materializes one shared Secret from an upstream secret manager (AWS
-        Secrets Manager, GCP Secret Manager, Vault, ...). Point each
-        auth.*.existingSecret at externalSecret.secretName, and use
-        extraEnvFromSecret to project loose env-var secrets via envFrom. Off
-        by default; rendered output is unchanged when disabled.
+      description: Safeguard against destructive upgrades from chart 0.4.x.
+        A pre-render check fails `helm upgrade` if the legacy `da-vespa`
+        StatefulSet is still present in the release namespace, so the
+        Vespa data volume is not silently deleted by the 0.5.0 subchart
+        removal. Override via legacyVespaCheck.acknowledged=true once
+        migrated to external Vespa, or legacyVespaCheck.enabled=false
+        to disable entirely. See deployment/helm/MIGRATION.md.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/legacy-vespa-check.yaml
+++ b/deployment/helm/charts/onyx/templates/legacy-vespa-check.yaml
@@ -12,10 +12,25 @@ check is a `lookup` against the live cluster, so it only fires during
 If the legacy StatefulSet has already been migrated away and only the
 PV is hanging around, set `legacyVespaCheck.acknowledged=true` to
 override the check.
+
+The hasKey guards below protect `helm upgrade --reuse-values` against a
+release whose previously-stored values predate the `legacyVespaCheck`
+key — direct nested access would nil-deref and silently bypass the
+entire fail-fast path. We treat absent values as the "safe default"
+(enabled, not acknowledged) so the protection is in force by default.
 */}}
-{{- if .Values.legacyVespaCheck.enabled }}
+{{- $cfg := default (dict) .Values.legacyVespaCheck }}
+{{- $checkEnabled := true }}
+{{- if hasKey $cfg "enabled" }}
+{{- $checkEnabled = $cfg.enabled }}
+{{- end }}
+{{- $checkAck := false }}
+{{- if hasKey $cfg "acknowledged" }}
+{{- $checkAck = $cfg.acknowledged }}
+{{- end }}
+{{- if $checkEnabled }}
 {{- $legacyVespa := lookup "apps/v1" "StatefulSet" .Release.Namespace "da-vespa" }}
-{{- if and $legacyVespa (not .Values.legacyVespaCheck.acknowledged) }}
-{{- fail (printf "\n\nERROR: legacy `da-vespa` StatefulSet detected in namespace %q.\n\nChart 0.5.0 removed the bundled Vespa subchart. Upgrading without first\nmigrating to external/managed Vespa will delete the StatefulSet and you\nwill lose access to the indexed data managed by it. The api-server will\nfail to start (connection refused on localhost:19071) until Vespa is\nreachable again.\n\nWhat to do:\n  1. Provision an external Vespa cluster (Vespa Cloud, self-hosted, etc.)\n  2. Re-index documents into the new cluster\n  3. Re-run `helm upgrade` once the legacy StatefulSet is deleted, OR\n     set `legacyVespaCheck.acknowledged=true` in your values to bypass\n     this check explicitly.\n\nSee deployment/helm/MIGRATION.md (chart 0.4.x → 0.5.x section) for details.\n" .Release.Namespace) }}
+{{- if and $legacyVespa (not $checkAck) }}
+{{- fail (printf "\n\nERROR: legacy `da-vespa` StatefulSet detected in namespace %q.\n\nChart 0.5.0 removed the bundled Vespa subchart. Upgrading without first\nmigrating to external/managed Vespa will delete the StatefulSet and you\nwill lose access to the indexed data managed by it. The api-server will\nfail to start (connection refused on localhost:19071) until it can reach\nan external Vespa endpoint.\n\nWhat to do:\n  1. Provision an external Vespa cluster (Vespa Cloud, self-hosted, etc.).\n  2. Update your values to point Onyx at the new endpoint — set\n     VESPA_HOST / VESPA_PORT under the `configMap:` block.\n  3. Delete the legacy `da-vespa` StatefulSet (check the PV reclaim\n     policy first; the data is gone once the PV is reclaimed).\n  4. Re-run `helm upgrade`. Onyx connectors will re-index into the new\n     cluster automatically once the api-server can reach it.\n\nOr set `legacyVespaCheck.acknowledged=true` to bypass this check\nexplicitly (only if the StatefulSet is already gone or is being kept\nintentionally).\n\nSee deployment/helm/MIGRATION.md (chart 0.4.x → 0.5.x section) for details.\n" .Release.Namespace) }}
 {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/legacy-vespa-check.yaml
+++ b/deployment/helm/charts/onyx/templates/legacy-vespa-check.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Detect upgrades from chart < 0.5.0, which bundled Vespa as a subchart.
+Chart 0.5.0 dropped that subchart, so a naive `helm upgrade` from 0.4.x
+would delete the `da-vespa` StatefulSet and orphan the Vespa data
+volume. The api-server would then crash-loop trying to deploy its Vespa
+application package against localhost:19071.
+
+Fail fast at install/upgrade time with a clear migration message. The
+check is a `lookup` against the live cluster, so it only fires during
+`helm install`/`helm upgrade` (not during local `helm template`).
+
+If the legacy StatefulSet has already been migrated away and only the
+PV is hanging around, set `legacyVespaCheck.acknowledged=true` to
+override the check.
+*/}}
+{{- if .Values.legacyVespaCheck.enabled }}
+{{- $legacyVespa := lookup "apps/v1" "StatefulSet" .Release.Namespace "da-vespa" }}
+{{- if and $legacyVespa (not .Values.legacyVespaCheck.acknowledged) }}
+{{- fail (printf "\n\nERROR: legacy `da-vespa` StatefulSet detected in namespace %q.\n\nChart 0.5.0 removed the bundled Vespa subchart. Upgrading without first\nmigrating to external/managed Vespa will delete the StatefulSet and you\nwill lose access to the indexed data managed by it. The api-server will\nfail to start (connection refused on localhost:19071) until Vespa is\nreachable again.\n\nWhat to do:\n  1. Provision an external Vespa cluster (Vespa Cloud, self-hosted, etc.)\n  2. Re-index documents into the new cluster\n  3. Re-run `helm upgrade` once the legacy StatefulSet is deleted, OR\n     set `legacyVespaCheck.acknowledged=true` in your values to bypass\n     this check explicitly.\n\nSee deployment/helm/MIGRATION.md (chart 0.4.x → 0.5.x section) for details.\n" .Release.Namespace) }}
+{{- end }}
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1189,6 +1189,17 @@ externalSecret:
 # Typically set to the same value as externalSecret.secretName.
 extraEnvFromSecret: ""
 
+# -- Safeguards against destructive upgrades from chart 0.4.x. Chart 0.5.0
+# removed the bundled Vespa subchart; the check below fails `helm upgrade`
+# if the legacy `da-vespa` StatefulSet is still in the namespace, so
+# the StatefulSet and its Vespa data volume are not silently deleted.
+# Set `acknowledged: true` once you've migrated to external Vespa, or
+# `enabled: false` to disable the check entirely.
+# See deployment/helm/MIGRATION.md.
+legacyVespaCheck:
+  enabled: true
+  acknowledged: false
+
 # -- Governs all Secrets created or used by this chart. Values set by this chart will be base64 encoded in the k8s cluster.
 auth:
   postgresql:


### PR DESCRIPTION
[ENG-4120](https://linear.app/onyx-app/issue/ENG-4120/helm-chart-optional-external-secrets-operator-support)

## Description

Chart 0.5.0 dropped the bundled `charts/vespa/` subchart, but nothing in the chart warned existing 0.4.x users that `helm upgrade` would silently delete their `da-vespa` StatefulSet. Adds a `lookup`-based pre-render check that fails the upgrade with a clear migration message if the legacy StatefulSet is still present.

The blast radius is narrow — the chart release that removed the Vespa subchart only published recently, so the population of users that haven't already moved to external Vespa but might hit `helm upgrade` against 0.5.x is small. But the failure mode is catastrophic (orphaned PV, api-server crash-loop on Vespa app-package deploy), and the check is cheap and silent for everyone who's already migrated, so the cost-benefit lands clearly in favor of shipping the guard.

Surfaced while rolling out the External Secrets cutover. The cutover needs chart ≥ 0.5.4 for the `externalSecret` template; bumping a customer from 0.4.48 → 0.5.5 deleted the `da-vespa` StatefulSet and the api-server immediately crash-looped:

```
ConnectionRefusedError: [Errno 111] Connection refused
HTTPConnection(host='localhost', port=19071): Failed to establish a new connection
```

We rolled the customer back cleanly. Without this guard, the next person to bump a 0.4.x cluster — internal or external — would hit the same trap with no warning.

**Files**

- `templates/legacy-vespa-check.yaml` — `lookup` for `da-vespa` StatefulSet in the release namespace at install/upgrade time. If found, calls `{{- fail }}` with an actionable message pointing at MIGRATION.md. Silent at local `helm template` (lookup needs a live cluster).
- `values.yaml` — new `legacyVespaCheck` block. `enabled: true` (default) runs the check; `acknowledged: true` bypasses it once the StatefulSet is gone.
- `deployment/helm/MIGRATION.md` (new) — 0.4.x → 0.5.x upgrade story: provision external Vespa, re-index (auto), values flip, StatefulSet cleanup. Also documents the `celery-worker-scheduled-tasks` crashloop on older backend images and the `replicaCount: 0` workaround.
- `Chart.yaml` — bumped to 0.5.6; `artifacthub.io/changes` annotation updated.
- `deployment/helm/README.md` — link to MIGRATION.md ahead of the existing 0.5.0 release notes.

## How Has This Been Tested?

- `helm lint .` passes.
- `helm template test . -f override.yaml` renders 5843 lines and emits no resource from the new template (lookup returns nil at template-time without a cluster, the `if` skips). No regression on the default render path.
- Logic-validated against an existing 0.5.x install where `da-vespa` does not exist — lookup returns nil → check passes → render proceeds normally.
- The fail-on-detection path can't be local-render-tested (lookup requires a cluster *and* the legacy resource), but the template follows the standard Helm `lookup` + `fail` idiom.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check