### PR TITLE
perf(tests): drop unnecessary reset fixture from no_vectordb tests

### DIFF
--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
@@ -25,7 +25,6 @@ def _headers(user: DATestUser) -> dict[str, str]:
 
 
 def test_admin_search_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -37,7 +36,6 @@ def test_admin_search_returns_501(
 
 
 def test_document_size_info_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -49,7 +47,6 @@ def test_document_size_info_returns_501(
 
 
 def test_document_chunk_info_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -61,7 +58,6 @@ def test_document_chunk_info_returns_501(
 
 
 def test_set_new_search_settings_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -73,7 +69,6 @@ def test_set_new_search_settings_returns_501(
 
 
 def test_cancel_new_embedding_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -84,7 +79,6 @@ def test_cancel_new_embedding_returns_501(
 
 
 def test_connector_router_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """The entire /manage router is gated — any connector endpoint should 501."""
@@ -96,7 +90,6 @@ def test_connector_router_returns_501(
 
 
 def test_ingestion_post_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -108,7 +101,6 @@ def test_ingestion_post_returns_501(
 
 
 def test_ingestion_delete_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.delete(
@@ -124,7 +116,6 @@ def test_ingestion_delete_returns_501(
 
 
 def test_settings_endpoint_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -137,7 +128,6 @@ def test_settings_endpoint_works(
 
 
 def test_document_set_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -148,7 +138,6 @@ def test_document_set_list_works(
 
 
 def test_persona_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -159,7 +148,6 @@ def test_persona_list_works(
 
 
 def test_tool_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(


### PR DESCRIPTION
## Summary
- `backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py` was taking ~15 min in CI because every one of its 12 tests pulled in the function-scoped `reset` fixture, which runs a full Postgres downgrade-to-base + upgrade-to-head + filestore wipe each time.
- These tests only assert HTTP status codes (501 for gated endpoints, 200 for non-gated) on read-only endpoints and never mutate state, so the reset is pure overhead. The `admin_user` fixture already handles the "user already exists" case.
- Dropping `reset` from all 12 tests should bring this file's runtime down by ~12×.

## Test plan
- [ ] CI: confirm `test_no_vectordb_endpoints.py` still passes
- [ ] CI: confirm total runtime for this file drops from ~15min to ~1min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the function-scoped `reset` fixture from 12 no-vectordb integration tests to eliminate costly DB/filestore resets and cut CI runtime from ~15 min to ~1 min.

- **Refactors**
  - Dropped `reset` from tests that only assert HTTP status codes on read-only endpoints; behavior unchanged.
  - `admin_user` handles existing-user cases, so a clean DB is not required.

<sup>Written for commit 4dde15f9652595c018c402c6d9591eedbdf5e6fc. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11256?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

