### PR TITLE
fix(craft): unblock sandbox push under telepresence and own .env.k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/*
 !/.vscode/env_template.txt
 !/.vscode/env.web_template.txt
+!/.vscode/.env.k8s.template
 !/.vscode/launch.json
 !/.vscode/tasks.json
 .zed

--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -1,0 +1,147 @@
+# =============================================================================
+# .env.k8s — env for the "API Server (k8s)" launch
+# =============================================================================
+#
+# Copy this file to .vscode/.env.k8s and fill in the <REPLACE THIS> values.
+# .env.k8s is gitignored so your secrets stay on your machine.
+#
+#   cp .vscode/.env.k8s.template .vscode/.env.k8s
+#
+# Why a separate file from .vscode/.env?
+#   - .env is loaded by the plain "API Server" launch (SANDBOX_BACKEND=local).
+#   - .env.k8s is loaded by the "API Server (k8s)" launch
+#     (SANDBOX_BACKEND=kubernetes, telepresence-intercepted).
+#   - vscode envFile takes a single path, so we don't share. **Mirror any
+#     values you have in .env into the matching section here** — log levels,
+#     LLM API keys, integrations.
+#
+# Why a static template?
+#   We used to have telepresence's intercept regenerate .env.k8s from the
+#   intercepted pod's env on every launch (via --env-file) and append a
+#   .env.k8s.local on top. That made it hard to reason about where any var
+#   came from. Now you own .env.k8s end-to-end. When the chart adds a new
+#   required var, update this template and devs pull the change explicitly.
+#
+# When you change .env.k8s, the next "API Server (k8s)" launch picks it up.
+
+
+# =============================================================================
+# 1. Dev flags + logging  (mirror from .env)
+# =============================================================================
+
+AUTH_TYPE=basic
+DEV_MODE=true
+REQUIRE_EMAIL_VERIFICATION=false
+LICENSE_ENFORCEMENT_ENABLED=false
+ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
+SKIP_WARM_UP=true
+
+LOG_LEVEL=DEBUG
+LOG_DANSWER_MODEL_INTERACTIONS=false
+DISABLE_LLM_DOC_RELEVANCE=false
+DEV_LOGGING_ENABLED=true
+
+PYTHONPATH=../backend
+PYTHONUNBUFFERED=1
+
+
+# =============================================================================
+# 2. LLM API keys  (mirror from .env — at minimum set GEN_AI_API_KEY)
+# =============================================================================
+
+GEN_AI_API_KEY=<REPLACE THIS>
+GEN_AI_MODEL_VERSION=gpt-4o
+FAST_GEN_AI_MODEL_VERSION=gpt-4o-mini
+
+# Optional — set if you actually use them
+# OPENAI_API_KEY=<REPLACE THIS>
+# ANTHROPIC_API_KEY=<REPLACE THIS>
+# GEMINI_API_KEY=<REPLACE THIS>
+
+
+# =============================================================================
+# 3. In-cluster services (kind cluster's pod DNS — leave as-is for kind)
+# =============================================================================
+
+INTERNAL_URL=http://onyx-api-service:8080
+DOMAIN=localhost
+WEB_DOMAIN=http://localhost:3000
+
+POSTGRES_HOST=onyx-pg-rw
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+REDIS_HOST=onyx
+REDIS_PASSWORD=password
+
+# Object store — kind's in-cluster minio
+S3_ENDPOINT_URL=http://onyx-minio:9000
+S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket
+S3_AWS_ACCESS_KEY_ID=minioadmin
+S3_AWS_SECRET_ACCESS_KEY=minioadmin
+
+# Inference / indexing
+MODEL_SERVER_HOST=onyx-inference-model-service
+INDEXING_MODEL_SERVER_HOST=onyx-indexing-model-service
+
+# Opensearch — admin password is random per cluster install and is
+# auto-injected on every "k8s: telepresence intercept api_server" preLaunchTask
+# run (reads the onyx-opensearch Secret and overwrites the line below).
+# Leave the placeholder as-is; it will be replaced before the api_server
+# launches. To fetch manually:
+#   kubectl -n onyx get secret onyx-opensearch -o jsonpath='{.data.opensearch_admin_password}' | base64 -d
+ONYX_DISABLE_VESPA=true
+ENABLE_OPENSEARCH_INDEXING_FOR_ONYX=true
+ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX=false
+OPENSEARCH_HOST=onyx-opensearch-master.onyx.svc.cluster.local
+OPENSEARCH_REST_API_PORT=9200
+OPENSEARCH_ADMIN_USERNAME=admin
+OPENSEARCH_ADMIN_PASSWORD=<AUTO_FROM_CLUSTER>
+
+
+# =============================================================================
+# 4. Sandbox / Craft  (REQUIRED)
+# =============================================================================
+
+# Flips the api_server from local Docker sandboxes to in-cluster pod
+# sandboxes. The vscode (k8s) launch profiles set this via their env: block
+# as a safety net, but anything reading .env.k8s directly needs it set here.
+SANDBOX_BACKEND=kubernetes
+
+ENABLE_CRAFT=true
+
+# Sandbox image — must be built locally and loaded into your kind cluster.
+# The :dev tag is the convention for in-progress work; build/load from this
+# repo's Dockerfile:
+#   docker build -t onyxdotapp/sandbox:dev \\
+#     -f backend/onyx/server/features/build/sandbox/kubernetes/docker/Dockerfile \\
+#     backend/onyx/server/features/build/sandbox/kubernetes/docker
+#   kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev
+
+# How sandboxes reach the api_server *from inside the cluster* (sandbox pods
+# always run in-cluster even in local dev; this is the URL they call back to).
+SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080
+
+SANDBOX_NAMESPACE=onyx-sandboxes
+
+# Ed25519 private key signing pushes to the sandbox push daemon. Must match
+# the public key the sandbox image expects. The dev value below is a
+# 32-byte all-zeros key — fine for kind. Rotate for any shared cluster.
+# Regenerate with the one-liner in deployment/helm/charts/onyx/values.yaml
+# near `sandboxPushSecret`.
+ONYX_SANDBOX_PUSH_PRIVATE_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+
+# =============================================================================
+# 5. Optional integrations  (uncomment if you actually use them)
+# =============================================================================
+
+# EXA_API_KEY=<REPLACE THIS>
+# LINEAR_CLIENT_ID=<REPLACE THIS>
+# LINEAR_CLIENT_SECRET=<REPLACE THIS>
+# BRAINTRUST_API_KEY=<REPLACE THIS>
+# POSTHOG_HOST=https://us.i.posthog.com
+# POSTHOG_API_KEY=<REPLACE THIS>
+
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -177,12 +177,12 @@
     },
     {
       "label": "k8s: telepresence intercept api_server",
-      "detail": "Idempotently connect + intercept api_server. Pins telepresence to kind-onyx-dev via --context without mutating your kubectl current-context. Writes cluster env to .vscode/.env.k8s. Wired as preLaunchTask on every (k8s) launch config.",
+      "detail": "Idempotently connect + intercept api_server. Pins telepresence to kind-onyx-dev via --context without mutating your kubectl current-context. Env comes from your own .vscode/.env.k8s (copy from .env.k8s.template). Auto-injects the cluster-random OPENSEARCH_ADMIN_PASSWORD from the onyx-opensearch Secret. Wired as preLaunchTask on every (k8s) launch config.",
       "type": "process",
       "command": "bash",
       "args": [
         "-c",
-        "set -e; kubectl config get-contexts -o name | grep -qx kind-onyx-dev || { echo 'error: kubectl context kind-onyx-dev not found; run deployment/helm/dev/k8s-up.sh first' >&2; exit 1; }; telepresence connect --context kind-onyx-dev -n onyx; telepresence leave onyx-api-server 2>/dev/null || true; telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false --env-file \"${workspaceFolder}/.vscode/.env.k8s\"; if [ -f \"${workspaceFolder}/.vscode/.env.k8s.local\" ]; then echo '' >> \"${workspaceFolder}/.vscode/.env.k8s\"; cat \"${workspaceFolder}/.vscode/.env.k8s.local\" >> \"${workspaceFolder}/.vscode/.env.k8s\"; fi"
+        "set -e; KUBE='kubectl --context kind-onyx-dev'; ENV_FILE=\"${workspaceFolder}/.vscode/.env.k8s\"; kubectl config get-contexts -o name | grep -qx kind-onyx-dev || { echo 'error: kubectl context kind-onyx-dev not found; run deployment/helm/dev/k8s-up.sh first' >&2; exit 1; }; [ -f \"$ENV_FILE\" ] || { echo 'error: .vscode/.env.k8s not found; copy .vscode/.env.k8s.template and fill in <REPLACE THIS> values (see docs/dev/local-kubernetes.md).' >&2; exit 1; }; OS_PW=$($KUBE -n onyx get secret onyx-opensearch -o jsonpath='{.data.opensearch_admin_password}' 2>/dev/null | base64 -d || true); [ -n \"$OS_PW\" ] || { echo 'error: could not read opensearch admin password from Secret onyx-opensearch/onyx; is the cluster up?' >&2; exit 1; }; TMP=$(mktemp); awk -v pw=\"$OS_PW\" 'BEGIN{f=0} /^OPENSEARCH_ADMIN_PASSWORD=/{print \"OPENSEARCH_ADMIN_PASSWORD=\" pw; f=1; next} {print} END{if(!f) print \"OPENSEARCH_ADMIN_PASSWORD=\" pw}' \"$ENV_FILE\" > \"$TMP\" && mv \"$TMP\" \"$ENV_FILE\"; telepresence connect --context kind-onyx-dev -n onyx; telepresence leave onyx-api-server 2>/dev/null || true; telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false"
       ],
       "presentation": {
         "reveal": "silent",

--- a/backend/ee/onyx/feature_flags/factory.py
+++ b/backend/ee/onyx/feature_flags/factory.py
@@ -1,5 +1,7 @@
 from ee.onyx.feature_flags.posthog_provider import PostHogFeatureFlagProvider
+from ee.onyx.utils.posthog_client import posthog
 from onyx.feature_flags.interface import FeatureFlagProvider
+from onyx.feature_flags.interface import NoOpFeatureFlagProvider
 
 
 def get_posthog_feature_flag_provider() -> FeatureFlagProvider:
@@ -9,7 +11,12 @@ def get_posthog_feature_flag_provider() -> FeatureFlagProvider:
     This is the EE implementation that gets loaded by the versioned
     implementation loader.
 
-    Returns:
-        PostHogFeatureFlagProvider: The PostHog-based feature flag provider
+    When the PostHog client isn't configured (no `POSTHOG_API_KEY` — the
+    standard local-dev state), return a NoOp provider so env-var-driven
+    flag fallbacks (e.g. `ENABLE_CRAFT`) take effect. A real PostHog
+    provider with no client would silently answer `False` for every flag,
+    which masks env-var intent.
     """
+    if posthog is None:
+        return NoOpFeatureFlagProvider()
     return PostHogFeatureFlagProvider()

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -18,6 +18,20 @@ spec:
           podSelector:
             matchLabels:
               app: api-server
+        {{- if .Values.sandboxPushPolicy.allowTelepresenceAmbassador }}
+        # Local-dev only (enabled via values-localdev.yaml): when an api_server
+        # is intercepted by telepresence, outbound traffic from the developer's
+        # laptop enters the cluster as the traffic-manager pod in the
+        # ambassador namespace, not as the api_server pod. Allowing this source
+        # restores push connectivity for local dev. Prod overlays leave the
+        # default (false) and only api_server pods can push.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ambassador
+          podSelector:
+            matchLabels:
+              app: traffic-manager
+        {{- end }}
       ports:
         - protocol: TCP
           port: 8731

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -88,6 +88,17 @@ auth:
     values:
       private_key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
+# ---- Sandbox push NetworkPolicy ----
+#
+# Allow telepresence's traffic-manager (in the `ambassador` namespace) as a
+# permitted ingress source for the per-sandbox push daemon. When an api_server
+# is intercepted, outbound traffic from a developer's laptop enters the cluster
+# as the traffic-manager pod, not the api_server pod, so the prod-strict
+# policy (api_server-only) blocks skills + user-library hydration. Local-dev
+# clusters opt in here; prod overlays leave this off.
+sandboxPushPolicy:
+  allowTelepresenceAmbassador: true
+
 # ---- App pods ----
 #
 # Scaled to 0 since you run these locally via telepresence intercept.

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1337,6 +1337,14 @@ auth:
     values:
       private_key: ""
 
+# NetworkPolicy for the per-sandbox push daemon (port 8731).
+# In prod the strict default is correct: only api_server pods can push.
+# Local-dev enables `allowTelepresenceAmbassador` via values-localdev.yaml so
+# that traffic intercepted from a developer's laptop (which enters the cluster
+# as the telepresence traffic-manager pod) is also permitted.
+sandboxPushPolicy:
+  allowTelepresenceAmbassador: false
+
 configMap:
   # WARNING: do NOT copy hostname keys from a docker-compose .env into this
   # block. The compose stack uses underscored service names (e.g. `api_server`,

--- a/deployment/helm/dev/k8s-up.sh
+++ b/deployment/helm/dev/k8s-up.sh
@@ -92,8 +92,16 @@ fi
 
 kubectl get namespace "$NAMESPACE" >/dev/null 2>&1 \
   || kubectl create namespace "$NAMESPACE"
+# The chart also templates the onyx-sandboxes namespace (see
+# templates/sandbox-namespace.yaml). We pre-create it here so the
+# sandbox-file-sync ServiceAccount can be created before helm install runs,
+# but we must stamp Helm ownership metadata or `helm install` refuses to
+# adopt the namespace.
 kubectl get namespace onyx-sandboxes >/dev/null 2>&1 \
   || kubectl create namespace onyx-sandboxes
+kubectl label   namespace onyx-sandboxes app.kubernetes.io/managed-by=Helm --overwrite >/dev/null
+kubectl annotate namespace onyx-sandboxes meta.helm.sh/release-name=onyx --overwrite >/dev/null
+kubectl annotate namespace onyx-sandboxes meta.helm.sh/release-namespace="$NAMESPACE" --overwrite >/dev/null
 kubectl -n onyx-sandboxes get serviceaccount sandbox-file-sync >/dev/null 2>&1 \
   || kubectl -n onyx-sandboxes create serviceaccount sandbox-file-sync
 kubectl label node --all onyx.app/workload=sandbox --overwrite >/dev/null 2>&1
@@ -137,12 +145,64 @@ fi
 echo "helm upgrade --install onyx ..."
 # ${PW_FLAG[@]+"${PW_FLAG[@]}"} expands to nothing when empty; bare
 # "${PW_FLAG[@]}" errors under `set -u` on subsequent runs.
-helm upgrade --install onyx "$CHART_DIR" \
-  -n "$NAMESPACE" \
-  -f "$VALUES_OVERLAY" \
-  ${PW_FLAG[@]+"${PW_FLAG[@]}"}
+#
+# On a fresh cluster the CNPG operator pod isn't ready when we submit the
+# postgres Cluster CR, so its mutating webhook returns "connection refused"
+# and helm install fails. The operator becomes ready within ~15s, and a
+# `helm upgrade --install` reconciles the failed release cleanly. Retry
+# transparently to keep the OOB experience one-shot.
+HELM_ATTEMPTS=3
+for attempt in $(seq 1 "$HELM_ATTEMPTS"); do
+  if helm upgrade --install onyx "$CHART_DIR" \
+      -n "$NAMESPACE" \
+      -f "$VALUES_OVERLAY" \
+      ${PW_FLAG[@]+"${PW_FLAG[@]}"}; then
+    break
+  fi
+  if [[ "$attempt" -lt "$HELM_ATTEMPTS" ]]; then
+    echo "helm install failed (attempt $attempt/$HELM_ATTEMPTS) — waiting 20s for operators to be ready, then retrying ..."
+    sleep 20
+  else
+    echo "helm install failed after $HELM_ATTEMPTS attempts" >&2
+    exit 1
+  fi
+done
 
-# ---- 3. next steps ----
+# ---- 3. telepresence traffic-manager (one-time per cluster) ----
+
+# The vscode (k8s) launch profiles intercept api_server via telepresence,
+# which requires a traffic-manager deployment in the cluster. This is
+# cluster-scoped and idempotent — re-running on a cluster that already has
+# it installed is a no-op.
+if command -v telepresence >/dev/null 2>&1; then
+  if ! kubectl -n ambassador get deployment traffic-manager >/dev/null 2>&1; then
+    echo "installing telepresence traffic-manager (one-time per cluster) ..."
+    # On a freshly-installed cluster the default 30s helm timeout inside
+    # telepresence is often too tight (CRD webhook bootstraps, image pulls).
+    # Retry transparently — same pattern as the chart install above.
+    TP_ATTEMPTS=3
+    for tp_attempt in $(seq 1 "$TP_ATTEMPTS"); do
+      if telepresence helm install \
+          --kubeconfig "${KUBECONFIG:-$HOME/.kube/config}" \
+          --context "kind-$CLUSTER_NAME" >/dev/null 2>&1; then
+        echo "  traffic-manager installed."
+        break
+      fi
+      if [[ "$tp_attempt" -lt "$TP_ATTEMPTS" ]]; then
+        echo "  install attempt $tp_attempt/$TP_ATTEMPTS timed out — waiting 20s and retrying ..."
+        sleep 20
+      else
+        echo "  traffic-manager install failed after $TP_ATTEMPTS attempts; run manually:" >&2
+        echo "    telepresence helm install --context kind-$CLUSTER_NAME" >&2
+      fi
+    done
+  fi
+else
+  echo "note: telepresence CLI not found; skipping traffic-manager install."
+  echo "  install with: brew install datawire/blackbird/telepresence-oss"
+fi
+
+# ---- 4. next steps ----
 
 cat <<EOF
 
@@ -155,18 +215,19 @@ next steps:
        kubectl -n $NAMESPACE get pods -w
 
   2. (optional) connect your host to cluster DNS so you can run api_server
-     locally and have it reach in-cluster services:
-       telepresence helm install        # one-time, installs traffic-manager
+     locally and have it reach in-cluster services. Traffic-manager was
+     installed above; just connect:
        telepresence connect -n $NAMESPACE
 
   3. for features that depend on api_server-source pod identity (e.g.
      NetworkPolicies, in-pod auth via injected env), intercept instead:
        telepresence intercept onyx-api-server \\
          --namespace $NAMESPACE \\
-         --port 8080:8080 \\
-         --env-file .vscode/.env.k8s
+         --port 8080:8080
 
   4. open vscode and run the "Run All Onyx Services" launch profile.
+     Before first run, copy .vscode/.env.k8s.template to .vscode/.env.k8s
+     and fill in the <REPLACE THIS> values.
 
 teardown:
   deployment/helm/dev/k8s-down.sh

--- a/docs/dev/local-kubernetes.md
+++ b/docs/dev/local-kubernetes.md
@@ -47,7 +47,11 @@ telepresence connect -n onyx
 
 ## One-time setup
 
-Bring up the cluster:
+Follow the four steps below in order. Skipping step 3 (the sandbox image)
+is the most common Craft setup failure — sandbox pods can't pull
+`onyxdotapp/sandbox:dev` from anywhere, so Build sessions hang.
+
+### 1. Bring up the cluster
 
 ```bash
 deployment/helm/dev/k8s-up.sh
@@ -55,7 +59,8 @@ deployment/helm/dev/k8s-up.sh
 
 Or run the **`k8s: cluster up`** vscode task. The script is idempotent and
 refuses to run unless your kubectl context is exactly `kind-onyx-dev` (the
-`onyx` namespace also exists in prod EKS).
+`onyx` namespace also exists in prod EKS). It also installs the
+telepresence traffic-manager once per cluster.
 
 Watch pods (vespa and CNPG-postgres take a minute or two on first boot):
 
@@ -63,16 +68,56 @@ Watch pods (vespa and CNPG-postgres take a minute or two on first boot):
 kubectl -n onyx get pods -w
 ```
 
-Install the in-cluster telepresence traffic-manager (once per cluster):
-
-```bash
-telepresence helm install
-```
-
 The chart pins images to the `:edge` tag in
 [`values-localdev.yaml`](/deployment/helm/charts/onyx/values-localdev.yaml)
 with `pullPolicy: Always`, so in-cluster pods track nightly builds off `main`
 rather than the released `:latest`.
+
+### 2. Copy `.env.k8s` from the template
+
+```bash
+cp .vscode/.env.k8s.template .vscode/.env.k8s
+```
+
+Then fill in `<REPLACE THIS>` values (at minimum `GEN_AI_API_KEY`). See
+[Set up your `.env.k8s`](#set-up-your-envk8s) below for the full workflow
+and what to mirror from `.vscode/.env`.
+
+### 3. Build and load the sandbox image
+
+**Required for Craft (`SANDBOX_BACKEND=kubernetes`).** The chart points
+sandbox pods at `onyxdotapp/sandbox:dev`, which is local-only — it isn't on
+any registry, so kind's `imagePullPolicy: IfNotPresent` will fail until
+you've built it and loaded it into the kind node:
+
+```bash
+docker build -t onyxdotapp/sandbox:dev \
+  backend/onyx/server/features/build/sandbox/kubernetes/docker
+kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
+```
+
+Rebuild + reload when you change anything under that directory. The image
+tag (`onyxdotapp/sandbox:dev`) must match `SANDBOX_CONTAINER_IMAGE` in your
+`.env.k8s` and the chart's `sandbox.image.*` values.
+
+Verify it's present in the kind node:
+
+```bash
+docker exec onyx-dev-control-plane crictl images | grep sandbox
+```
+
+### 4. Connect telepresence
+
+```bash
+telepresence connect -n onyx
+```
+
+This sets up the DNS bridge so your local api_server can resolve
+in-cluster services (`onyx-pg-rw`, `onyx-minio`, etc.). The vscode `(k8s)`
+launch profiles also run an `intercept` automatically — `connect` here is
+only needed if you're driving telepresence outside of vscode.
+
+---
 
 **Known issue: CNPG operator on Docker Desktop k8s.** CloudNativePG fails
 with `unable to setup PKI infrastructure: no operator deployment found`
@@ -246,19 +291,49 @@ For Craft development, the required vars (already in the template) are:
 
 ```
 ENABLE_CRAFT=true
+SANDBOX_BACKEND=kubernetes
 SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev
 SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080
 ONYX_SANDBOX_PUSH_PRIVATE_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 ```
 
-`sandbox:dev` must be built and loaded into kind before sandbox pods can
-start:
+The `onyxdotapp/sandbox:dev` image referenced here is **local-only**; build
+and load it per [step 3 of One-time setup](#3-build-and-load-the-sandbox-image)
+before launching the api_server.
+
+## Troubleshooting
+
+### Craft tab missing from the sidebar (and `/craft` 404s)
+
+The web doesn't read `ENABLE_CRAFT` directly. The sidebar (`AppSidebar.tsx`)
+and the `/craft` route guard (`app/craft/layout.tsx`) both check
+`combinedSettings.settings.onyx_craft_enabled`, which is computed by the
+backend in `is_onyx_craft_enabled(user)`
+(`backend/onyx/server/features/build/utils.py`) and returned from
+`GET /api/settings` (`backend/onyx/server/settings/api.py`).
+
+That backend check returns **`False`** when:
+
+1. **No user is authenticated** — the settings endpoint short-circuits to
+   `False` for anonymous requests, so the tab won't appear on the login page
+   or in incognito. Log in first.
+2. **The api_server you're hitting doesn't have `ENABLE_CRAFT=true`.** Most
+   common cause: running the plain `API Server` launch (loads `.vscode/.env`)
+   instead of the `(k8s)` launch (loads `.vscode/.env.k8s`). The `(k8s)`
+   compound and `Run All Onyx Services (k8s)` are the only profiles that
+   source `.env.k8s`.
+
+Confirm by hitting `/api/settings` while logged in and checking
+`onyx_craft_enabled`:
 
 ```bash
-cd backend/onyx/server/features/build/sandbox/kubernetes/docker
-docker build -t sandbox:dev .
-kind load docker-image sandbox:dev --name onyx-dev
+# from a logged-in browser session, copy the cookie and:
+curl -sS http://localhost:3000/api/settings -H "Cookie: <paste>" | jq .settings.onyx_craft_enabled
 ```
+
+If that returns `true` but the tab is still missing, hard-reload (the
+settings response is fetched server-side; stale Next.js cache can hide a
+just-flipped flag).
 
 ## References
 

--- a/docs/dev/local-kubernetes.md
+++ b/docs/dev/local-kubernetes.md
@@ -79,6 +79,18 @@ with `unable to setup PKI infrastructure: no operator deployment found`
 against Docker Desktop's bundled kubernetes. Use kind (the default in
 `k8s-up.sh`) or a deployed dev cluster (`st-dev`).
 
+**Recovery: `onyx-sandboxes` namespace exists without Helm ownership.** If a
+previous `k8s-up.sh` (or any manual `kubectl create namespace onyx-sandboxes`)
+created the sandbox namespace before the chart could, helm install bails out
+with `exists and cannot be imported into the current release`. Adopt the
+namespace, then re-run `k8s-up.sh`:
+
+```bash
+kubectl label   namespace onyx-sandboxes app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate namespace onyx-sandboxes meta.helm.sh/release-name=onyx --overwrite
+kubectl annotate namespace onyx-sandboxes meta.helm.sh/release-namespace=onyx --overwrite
+```
+
 ## Daily workflow
 
 ### vscode tasks
@@ -91,6 +103,39 @@ Run Task):
 - `k8s: resume cluster` — start it back up; kubelet reconciles pods.
 - `k8s: cluster down (full teardown)` — delete the kind cluster and all PVC data.
 - `k8s: telepresence connect`, `... intercept api_server`, `... quit`.
+
+### Set up your `.env.k8s`
+
+The K8s api_server launch loads env from `.vscode/.env.k8s`. You own this
+file end-to-end — the telepresence intercept no longer regenerates it.
+Copy from the tracked template:
+
+```bash
+cp .vscode/.env.k8s.template .vscode/.env.k8s
+```
+
+Then fill in `<REPLACE THIS>` values. **Mirror everything you have in
+`.vscode/.env` into this file** — the K8s launch does not read `.env`,
+only `.env.k8s`. If you set `GEN_AI_API_KEY` only in `.env`, it won't be
+present in K8s mode and you'll hit confusing missing-key errors. The
+template's section 1 lists the standard `.env` vars to copy.
+
+**You must also set `SANDBOX_BACKEND=kubernetes`** (included in the
+template). This is what flips the api_server from local Docker sandboxes
+to in-cluster pod sandboxes. The vscode `(k8s)` launch profiles set it via
+their `env:` block as a safety net, but anything that reads `.env.k8s`
+directly (CLI scripts, ad-hoc invocations, tests) needs the value to be
+in the file too.
+
+`OPENSEARCH_ADMIN_PASSWORD` is the one cluster-random value — leave it as
+`<AUTO_FROM_CLUSTER>` in your `.env.k8s`. The `k8s: telepresence intercept
+api_server` preLaunchTask reads the `onyx-opensearch` Secret and rewrites
+that one line before each launch, so the password stays in sync even
+across `k8s-up.sh` reinstalls (which rotate it).
+
+The preLaunchTask fails fast if `.env.k8s` doesn't exist or if the
+opensearch Secret can't be read (cluster down), so you'll know immediately
+if you missed a step.
 
 ### Run your local processes
 
@@ -118,8 +163,8 @@ Individual `Celery <name> (k8s)` configs are hidden from the picker
 (`presentation.hidden: true`); flip `hidden` to `false` in
 `.vscode/launch.json` to run a single worker.
 
-Every `(k8s)` profile sources `.vscode/.env.k8s` (written by
-`telepresence intercept --env-file`) and sets `SANDBOX_BACKEND=kubernetes`.
+Every `(k8s)` profile sources `.vscode/.env.k8s` (the file you copied from
+`.env.k8s.template`) and sets `SANDBOX_BACKEND=kubernetes`.
 
 Visit `http://localhost:3000` once running.
 
@@ -190,34 +235,20 @@ kubectl -n onyx delete pvc --all
 deployment/helm/dev/k8s-up.sh
 ```
 
-## `.env.k8s.local`
+## `.env.k8s`
 
-`.env.k8s` is regenerated each preLaunchTask run by `telepresence intercept
---env-file`; `.env.k8s.local` is then appended (last-wins). Neither is
-checked in.
+`.env.k8s` is dev-owned and gitignored. The `k8s: telepresence intercept
+api_server` task no longer writes it — copy it once from
+`.env.k8s.template` and edit the `<REPLACE THIS>` values. See
+[Set up your `.env.k8s`](#set-up-your-envk8s) above for the workflow.
 
-Start `.env.k8s.local` from your `.vscode/.env`, then **remove** any keys
-that should come from the cluster — overriding these breaks DNS or auth into
-cluster services:
-
-- `POSTGRES_*`, `REDIS_*`, `OPENSEARCH_*`, `VESPA_HOST`
-- `S3_*` (MinIO endpoint + creds)
-- `MODEL_SERVER_HOST`, `INDEXING_MODEL_SERVER_HOST`
-- `INTERNAL_URL`
-
-Also drop `SANDBOX_BACKEND=local`-only keys (`SANDBOX_BASE_PATH`,
-`OUTPUTS_TEMPLATE_PATH`, `VENV_TEMPLATE_PATH`,
-`PERSISTENT_DOCUMENT_STORAGE_PATH`).
-
-Keep personal vars: API keys (OPENAI, BRAINTRUST, EXA), log levels,
-password-rule relaxations, feature flags, OAuth client IDs.
-
-For Craft development, these are required:
+For Craft development, the required vars (already in the template) are:
 
 ```
 ENABLE_CRAFT=true
-SANDBOX_CONTAINER_IMAGE=sandbox:dev
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev
 SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080
+ONYX_SANDBOX_PUSH_PRIVATE_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 ```
 
 `sandbox:dev` must be built and loaded into kind before sandbox pods can


### PR DESCRIPTION
## Description

Local-dev fixes that make the K8s sandbox flow + Craft work out of the box.

**1. Own `.vscode/.env.k8s` end-to-end via a tracked template.**

- Adds `.vscode/.env.k8s.template` (whitelisted in `.gitignore`) — devs copy it to `.env.k8s` once and edit `<REPLACE THIS>` values.
- `k8s: telepresence intercept api_server` task no longer passes `--env-file`, so it doesn't clobber `.env.k8s` on every launch. The `.env.k8s.local` append step is gone too.
- Task fails fast if `.env.k8s` doesn't exist, with a pointer to the template.
- Eliminates the "where did this var come from?" confusion of "telepresence regenerates + .local appends" model.

**2. New `sandboxPushPolicy.allowTelepresenceAmbassador` chart flag.**

- `values.yaml` default `false` → prod policy unchanged (`onyx-sandbox-push` only allows `app: api-server` pods to push).
- `values-localdev.yaml` sets it `true` → adds the ambassador-namespace `traffic-manager` pod as a permitted source.

Why: kindnet v0.29+ enforces NetworkPolicies. Locally-intercepted api_server traffic enters the cluster *as* the telepresence traffic-manager pod, not as api_server. Without this flag, skills + user-library hydration POSTs to the per-sandbox push daemon are dropped by the policy, retried for ~190 s, then silently fail. The exception is caught in `_hydrate_skills` / `_hydrate_user_library`, so the session eventually becomes usable, but with no skills / no user library, after a 3-minute UI hang on every session create.

Local-dev devs already use `values-localdev.yaml` via `k8s-up.sh -f "$VALUES_OVERLAY"`, so the flag activates automatically on next `helm upgrade`. Prod stays exactly as before.

**3. Honor `ENABLE_CRAFT` in DEV_MODE when PostHog isn't keyed.**

`backend/onyx/feature_flags/factory.py` routes DEV_MODE/MULTI_TENANT through the EE PostHog provider, which returns `False` for every flag when `POSTHOG_API_KEY` isn't set — the standard local-dev state. That silently overrode `ENABLE_CRAFT=true` and hid the Craft tab in the sidebar (and 404'd `/craft`) for every dev hitting `Run All Onyx Services (k8s)`.

Fix in `backend/ee/onyx/feature_flags/factory.py`: return `NoOpFeatureFlagProvider` when the posthog client is `None`. `is_onyx_craft_enabled` then falls through to the env var as intended.

**4. Doc restructure for `docs/dev/local-kubernetes.md`.**

The `onyxdotapp/sandbox:dev` image build was buried at the bottom of the `.env.k8s` section as commentary on a config var — easy to miss, and skipping it leaves sandbox pods unable to start. Promoted to a numbered step in `## One-time setup`, fixed the snippet to match the actual image tag (`onyxdotapp/sandbox:dev`, not `sandbox:dev`), and added a `## Troubleshooting` section explaining why the Craft tab can be missing in the sidebar (the auth + launch-profile cases).

## How Has This Been Tested?

- Rendered the chart with both default values and the localdev overlay (`helm template ... --show-only templates/network-policy-sandbox-push.yaml`). Confirmed the ambassador `from:` clause appears only with the localdev overlay.
- Manually validated end-to-end on a kind cluster running kindnet v0.29: with the policy patched to include the ambassador namespace, host → pod IP 8731 succeeds via telepresence and the daemon logs the push. Before the patch, traffic-manager logs `context deadline exceeded` (verified).
- `k8s: telepresence intercept api_server` task verified to fail loudly with the new pre-flight check when `.env.k8s` is missing.
- Walked the full doc on a clean machine: `k8s-up.sh` → `.env.k8s` copy → `onyxdotapp/sandbox:dev` build + `kind load` → `telepresence connect`. Verified DNS + `/health` resolve through the cluster and `crictl images` shows the loaded sandbox image.
- Verified the feature-flag fix by tracing `get_default_feature_flag_provider()` with DEV_MODE=true, ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true, and no `POSTHOG_API_KEY`: returns `NoOpFeatureFlagProvider`, so `is_onyx_craft_enabled` honors `ENABLE_CRAFT=true`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
