### PR TITLE
chore(ci): render sandbox namespace from helm chart in craft k8s lane

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -20,6 +20,8 @@ on:
       - ".github/actions/setup-python-and-install-dependencies/**"
       - "deployment/docker_compose/docker-compose.yml"
       - "deployment/docker_compose/docker-compose.dev.yml"
+      - "deployment/helm/charts/onyx/templates/sandbox-namespace.yaml"
+      - "deployment/helm/charts/onyx/values-ci.yaml"
 
 permissions:
   contents: read
@@ -149,21 +151,47 @@ jobs:
       - name: Label kind node for sandbox workload
         run: kubectl label node onyx-craft-ci-control-plane onyx.app/workload=sandbox
 
-      # Prod-equivalent of sandbox-namespace.yaml in the helm chart plus
-      # the ServiceAccount that's normally created out-of-band.
-      - name: Apply sandbox namespace + ServiceAccount
+      # `helm template` validates Chart.yaml dependencies up front, even
+      # for --show-only of a parent-chart template. Add the repos and
+      # build the deps so the render step doesn't error out.
+      - name: Build helm chart dependencies
         run: |
-          kubectl apply -f - <<'EOF'
-          apiVersion: v1
-          kind: Namespace
-          metadata:
-            name: onyx-sandboxes
-          ---
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add opensearch https://opensearch-project.github.io/helm-charts
+          helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
+          helm repo add ot-container-kit https://ot-container-kit.github.io/helm-charts
+          helm repo add minio https://charts.min.io/
+          helm repo add code-interpreter https://onyx-dot-app.github.io/python-sandbox/
+          helm repo update
+          helm dependency build deployment/helm/charts/onyx
+
+      # Render the sandbox namespace from the helm chart rather than
+      # inlining it here, so future chart edits (labels, annotations, new
+      # sandbox-scoped resources) flow into CI automatically. When you add
+      # a new chart component that the K8s sandbox tests depend on, add
+      # its template path to --show-only and apply it here.
+      - name: Render sandbox manifests from chart
+        run: |
+          mkdir -p /tmp/manifests
+          helm template onyx deployment/helm/charts/onyx \
+            -n onyx \
+            -f deployment/helm/charts/onyx/values-ci.yaml \
+            --show-only templates/sandbox-namespace.yaml \
+            > /tmp/manifests/sandbox.yaml
+          echo "--- rendered resources ---"
+          grep -E '^(kind|  name):' /tmp/manifests/sandbox.yaml || true
+
+      # sandbox-file-sync SA isn't in the chart — it's normally created
+      # out-of-band by the dev k8s-up.sh / cluster admin. Apply after the
+      # rendered manifests so the namespace exists first.
+      - name: Apply manifests + sandbox-file-sync SA
+        run: |
+          kubectl apply -f /tmp/manifests/sandbox.yaml
+          kubectl -n onyx-sandboxes apply -f - <<'EOF'
           apiVersion: v1
           kind: ServiceAccount
           metadata:
             name: sandbox-file-sync
-            namespace: onyx-sandboxes
           EOF
 
       - name: Create .env for Docker Compose

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -20,8 +20,11 @@ on:
       - ".github/actions/setup-python-and-install-dependencies/**"
       - "deployment/docker_compose/docker-compose.yml"
       - "deployment/docker_compose/docker-compose.dev.yml"
-      - "deployment/helm/charts/onyx/templates/sandbox-namespace.yaml"
-      - "deployment/helm/charts/onyx/values-ci.yaml"
+      # Watch the whole chart, not just the templates we render — shared
+      # inputs like _helpers.tpl, values.yaml, and Chart.yaml all feed
+      # into `helm template --show-only`, so a chart edit anywhere can
+      # break the render/apply flow.
+      - "deployment/helm/charts/onyx/**"
 
 permissions:
   contents: read

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -1,0 +1,36 @@
+# Values overlay for the Craft K8s CI lane (pr-craft-k8s-tests.yml).
+#
+# The CI workflow renders specific templates with `helm template --show-only`
+# and applies them to a kind cluster, so chart edits flow into the test lane
+# automatically. When you add a new chart component that the K8s sandbox tests
+# depend on, render it here and apply it in the workflow.
+
+configMap:
+  ENABLE_CRAFT: "true"
+  # Placeholder; the K8s sandbox tests don't call back to it. Required to
+  # satisfy the chart's fail() guard for ENABLE_CRAFT=true.
+  SANDBOX_API_SERVER_URL: "http://api.invalid"
+
+# Placeholder secret values so auth-secrets.yaml renders without erroring.
+# Postgres/Redis/MinIO actually run in docker-compose alongside the kind
+# cluster in this lane (see pr-craft-k8s-tests.yml), so the in-chart values
+# only need to satisfy the chart's pre-validate fail() guards.
+auth:
+  postgresql:
+    values:
+      username: "postgres"
+      password: "postgres"
+  redis:
+    values:
+      redis_password: "password"
+  objectstorage:
+    values:
+      s3_aws_access_key_id: "minioadmin"
+      s3_aws_secret_access_key: "minioadmin"
+  opensearch:
+    values:
+      opensearch_admin_password: "ci-test-not-used"
+  sandboxPushSecret:
+    enabled: true
+    values:
+      private_key: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="


### PR DESCRIPTION
## Description

Refactors the Craft K8s CI lane (`pr-craft-k8s-tests.yml`) to render the sandbox namespace from the helm chart via `helm template --show-only` instead of inlining a parallel copy of the YAML.

**Why:** keeps the CI lane aligned with the chart. When someone edits `templates/sandbox-namespace.yaml` (labels, annotations, new sandbox-scoped resources), the change flows into the test lane automatically. When someone adds a new chart component the K8s sandbox tests depend on, they extend `--show-only` here rather than maintaining a second inline copy.

What changed:
- New `deployment/helm/charts/onyx/values-ci.yaml` — minimal CI overlay (`ENABLE_CRAFT=true` + placeholder secret values to clear the chart's pre-validate `fail()` guards). Postgres/Redis/MinIO still run in docker-compose alongside the kind cluster in this lane, so secret values only need to satisfy the chart, not be real.
- `pr-craft-k8s-tests.yml`:
  - Added `helm dependency build` step (`helm template --show-only` validates Chart.yaml deps up front even when filtering).
  - Replaced inline `Apply sandbox namespace + ServiceAccount` heredoc with two steps: render from chart, then apply rendered manifest + the out-of-band `sandbox-file-sync` SA.
  - Added path triggers for `sandbox-namespace.yaml` and `values-ci.yaml`.

The `sandbox-file-sync` SA stays applied inline because it isn't in the chart — it's created out-of-band by `k8s-up.sh` / the cluster admin in real envs.

## How Has This Been Tested?

- Verified locally: `helm template onyx deployment/helm/charts/onyx -n onyx -f deployment/helm/charts/onyx/values-ci.yaml --show-only templates/sandbox-namespace.yaml` renders exactly one Namespace (`onyx-sandboxes` with chart labels) and nothing else.
- CI lane will exercise the full render → apply → test flow on this PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render the sandbox namespace from the Helm chart in the Craft K8s CI lane using `helm template --show-only`, removing duplicated inline YAML. This keeps the lane aligned with the chart so future edits flow into tests automatically.

- **Refactors**
  - Update `.github/workflows/pr-craft-k8s-tests.yml` to build chart deps, render `templates/sandbox-namespace.yaml` with `values-ci.yaml`, apply the manifest, then apply the out-of-band `sandbox-file-sync` SA; broaden path filter to watch `deployment/helm/charts/onyx/**`.
  - Add `deployment/helm/charts/onyx/values-ci.yaml`: minimal CI overlay (`ENABLE_CRAFT=true` + placeholder secrets) to satisfy chart guards; Postgres/Redis/MinIO still run via docker-compose.

<sup>Written for commit 635cccb8e86820ab094f27888ff0a21e18550440. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11259?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

