### PR TITLE
chore(tests): drop unnecessary `reset` fixtures from integration tests

### DIFF
--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -402,7 +402,6 @@ def test_search_returns_results(
 
 
 def test_search_raw(
-    reset: None,  # noqa: ARG001
     cli_binary: Path,
     pat_token: str,
     admin_user: DATestUser,
@@ -420,9 +419,6 @@ def test_search_raw(
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
 
-    # ``reset`` only wipes Postgres; OpenSearch is shared across tests, so docs
-    # seeded by prior tests may still match. Find the seeded doc by content
-    # rather than asserting on result count.
     data = json.loads(result.stdout)
     matches = [r for r in data["results"] if phrase in r["content"]]
     assert len(matches) == 1

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_api.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_api.py
@@ -10,17 +10,14 @@ from onyx.db.discord_bot import get_discord_service_api_key
 from onyx.db.discord_bot import get_or_create_discord_service_api_key
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from tests.integration.common_utils.managers.discord_bot import DiscordBotManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestUser
 
 
 class TestBotConfigEndpoints:
     """Tests for /manage/admin/discord-bot/config endpoints."""
 
-    def test_get_bot_config_not_configured(self, reset: None) -> None:  # noqa: ARG002
+    def test_get_bot_config_not_configured(self, admin_user: DATestUser) -> None:
         """GET /config returns configured=False when no config exists."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Ensure no config exists
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
@@ -29,10 +26,8 @@ class TestBotConfigEndpoints:
         assert config["configured"] is False
         assert "created_at" not in config or config.get("created_at") is None
 
-    def test_create_bot_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_create_bot_config(self, admin_user: DATestUser) -> None:
         """POST /config creates a new bot config."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Ensure no config exists
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
@@ -49,11 +44,9 @@ class TestBotConfigEndpoints:
 
     def test_create_bot_config_already_exists(
         self,
-        reset: None,  # noqa: ARG002
+        admin_user: DATestUser,
     ) -> None:
         """POST /config returns 409 if config already exists."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Ensure no config exists, then create one
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
         DiscordBotManager.create_bot_config(
@@ -73,10 +66,8 @@ class TestBotConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
-    def test_delete_bot_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_delete_bot_config(self, admin_user: DATestUser) -> None:
         """DELETE /config removes the bot config."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Ensure no config exists, then create one
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
         DiscordBotManager.create_bot_config(
@@ -92,10 +83,8 @@ class TestBotConfigEndpoints:
         config = DiscordBotManager.get_bot_config(admin_user)
         assert config["configured"] is False
 
-    def test_delete_bot_config_not_found(self, reset: None) -> None:  # noqa: ARG002
+    def test_delete_bot_config_not_found(self, admin_user: DATestUser) -> None:
         """DELETE /config returns 404 if no config exists."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Ensure no config exists
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
 
@@ -109,10 +98,8 @@ class TestBotConfigEndpoints:
 class TestGuildConfigEndpoints:
     """Tests for /manage/admin/discord-bot/guilds endpoints."""
 
-    def test_create_guild_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_create_guild_config(self, admin_user: DATestUser) -> None:
         """POST /guilds creates a new guild config with registration key."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guild = DiscordBotManager.create_guild(admin_user)
 
         assert guild.id is not None
@@ -122,10 +109,8 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_list_guilds(self, reset: None) -> None:  # noqa: ARG002
+    def test_list_guilds(self, admin_user: DATestUser) -> None:
         """GET /guilds returns all guild configs."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create some guilds
         guild1 = DiscordBotManager.create_guild(admin_user)
         guild2 = DiscordBotManager.create_guild(admin_user)
@@ -140,10 +125,8 @@ class TestGuildConfigEndpoints:
         DiscordBotManager.delete_guild_if_exists(guild1.id, admin_user)
         DiscordBotManager.delete_guild_if_exists(guild2.id, admin_user)
 
-    def test_get_guild_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_get_guild_config(self, admin_user: DATestUser) -> None:
         """GET /guilds/{config_id} returns the specific guild config."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guild = DiscordBotManager.create_guild(admin_user)
 
         fetched = DiscordBotManager.get_guild(guild.id, admin_user)
@@ -156,17 +139,13 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_get_guild_config_not_found(self, reset: None) -> None:  # noqa: ARG002
+    def test_get_guild_config_not_found(self, admin_user: DATestUser) -> None:
         """GET /guilds/{config_id} returns 404 for non-existent guild."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         result = DiscordBotManager.get_guild_or_none(999999, admin_user)
         assert result is None
 
-    def test_update_guild_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_update_guild_config(self, admin_user: DATestUser) -> None:
         """PATCH /guilds/{config_id} updates the guild config."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guild = DiscordBotManager.create_guild(admin_user)
 
         # Update enabled status
@@ -185,10 +164,8 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_delete_guild_config(self, reset: None) -> None:  # noqa: ARG002
+    def test_delete_guild_config(self, admin_user: DATestUser) -> None:
         """DELETE /guilds/{config_id} removes the guild config."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guild = DiscordBotManager.create_guild(admin_user)
 
         # Delete it
@@ -198,19 +175,15 @@ class TestGuildConfigEndpoints:
         # Verify it's gone
         assert DiscordBotManager.get_guild_or_none(guild.id, admin_user) is None
 
-    def test_delete_guild_config_not_found(self, reset: None) -> None:  # noqa: ARG002
+    def test_delete_guild_config_not_found(self, admin_user: DATestUser) -> None:
         """DELETE /guilds/{config_id} returns 404 for non-existent guild."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         with pytest.raises(requests.HTTPError) as exc_info:
             DiscordBotManager.delete_guild(999999, admin_user)
 
         assert exc_info.value.response.status_code == 404
 
-    def test_registration_key_format(self, reset: None) -> None:  # noqa: ARG002
+    def test_registration_key_format(self, admin_user: DATestUser) -> None:
         """Registration key has proper format with tenant encoded."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guild = DiscordBotManager.create_guild(admin_user)
 
         # Key should be: discord_{encoded_tenant}.{random}
@@ -226,10 +199,8 @@ class TestGuildConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_each_registration_key_is_unique(self, reset: None) -> None:  # noqa: ARG002
+    def test_each_registration_key_is_unique(self, admin_user: DATestUser) -> None:
         """Each created guild gets a unique registration key."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         guilds = [DiscordBotManager.create_guild(admin_user) for _ in range(5)]
         keys = [g.registration_key for g in guilds]
 
@@ -243,10 +214,8 @@ class TestGuildConfigEndpoints:
 class TestChannelConfigEndpoints:
     """Tests for /manage/admin/discord-bot/guilds/{id}/channels endpoints."""
 
-    def test_list_channels_empty(self, reset: None) -> None:  # noqa: ARG002
+    def test_list_channels_empty(self, admin_user: DATestUser) -> None:
         """GET /guilds/{id}/channels returns empty list when no channels exist."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=111111111,
@@ -260,10 +229,8 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_list_channels_with_data(self, reset: None) -> None:  # noqa: ARG002
+    def test_list_channels_with_data(self, admin_user: DATestUser) -> None:
         """GET /guilds/{id}/channels returns channel configs."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=222222222,
@@ -293,10 +260,8 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_enabled(self, reset: None) -> None:  # noqa: ARG002
+    def test_update_channel_enabled(self, admin_user: DATestUser) -> None:
         """PATCH /guilds/{id}/channels/{id} updates enabled status."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=333333333,
@@ -329,10 +294,8 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_thread_only_mode(self, reset: None) -> None:  # noqa: ARG002
+    def test_update_channel_thread_only_mode(self, admin_user: DATestUser) -> None:
         """PATCH /guilds/{id}/channels/{id} updates thread_only_mode."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=444444444,
@@ -362,11 +325,9 @@ class TestChannelConfigEndpoints:
 
     def test_update_channel_require_bot_invocation(
         self,
-        reset: None,  # noqa: ARG002
+        admin_user: DATestUser,
     ) -> None:
         """PATCH /guilds/{id}/channels/{id} updates require_bot_invocation."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=555555555,
@@ -394,10 +355,8 @@ class TestChannelConfigEndpoints:
         # Cleanup
         DiscordBotManager.delete_guild_if_exists(guild.id, admin_user)
 
-    def test_update_channel_not_found(self, reset: None) -> None:  # noqa: ARG002
+    def test_update_channel_not_found(self, admin_user: DATestUser) -> None:
         """PATCH /guilds/{id}/channels/{id} returns 404 for non-existent channel."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Create a registered guild (has guild_id set)
         guild = DiscordBotManager.create_registered_guild_in_db(
             guild_id=666666666,
@@ -423,11 +382,9 @@ class TestServiceApiKeyCleanup:
 
     def test_delete_bot_config_also_deletes_service_api_key(
         self,
-        reset: None,  # noqa: ARG002
+        admin_user: DATestUser,
     ) -> None:
         """DELETE /config also deletes the service API key (self-hosted flow)."""
-        admin_user: DATestUser = UserManager.create(name="admin_user")
-
         # Setup: create bot config via API
         DiscordBotManager.delete_bot_config_if_exists(admin_user)
         DiscordBotManager.create_bot_config(

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -13,7 +13,6 @@ from tests.integration.common_utils.vespa import vespa_fixture
 
 
 def test_multiple_document_sets_syncing_same_connnector(
-    reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
 ) -> None:
     # Creating an admin user (first user created is automatically an admin)
@@ -70,7 +69,6 @@ def test_multiple_document_sets_syncing_same_connnector(
 
 
 def test_removing_connector(
-    reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
 ) -> None:
     # Creating an admin user (first user created is automatically an admin)
@@ -164,7 +162,6 @@ def test_removing_connector(
 
 
 def test_renaming_document_set(
-    reset: None,  # noqa: ARG001
     vespa_client: vespa_fixture,
 ) -> None:
     admin_user: DATestUser = UserManager.create(name="admin_user")

--- a/backend/tests/integration/tests/document_set/test_syncing.py
+++ b/backend/tests/integration/tests/document_set/test_syncing.py
@@ -6,7 +6,6 @@ from tests.integration.common_utils.managers.api_key import APIKeyManager
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
-from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.common_utils.vespa import vespa_fixture
@@ -14,10 +13,8 @@ from tests.integration.common_utils.vespa import vespa_fixture
 
 def test_multiple_document_sets_syncing_same_connnector(
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
 ) -> None:
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
     # create api key
     api_key: DATestAPIKey = APIKeyManager.create(
         user_performing_action=admin_user,
@@ -70,10 +67,8 @@ def test_multiple_document_sets_syncing_same_connnector(
 
 def test_removing_connector(
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
 ) -> None:
-    # Creating an admin user (first user created is automatically an admin)
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
     # create api key
     api_key: DATestAPIKey = APIKeyManager.create(
         user_performing_action=admin_user,
@@ -163,9 +158,8 @@ def test_removing_connector(
 
 def test_renaming_document_set(
     vespa_client: vespa_fixture,
+    admin_user: DATestUser,
 ) -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_user")
-
     api_key: DATestAPIKey = APIKeyManager.create(
         user_performing_action=admin_user,
     )

--- a/backend/tests/integration/tests/mcp/test_mcp_client_no_auth_flow.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_client_no_auth_flow.py
@@ -84,7 +84,6 @@ def ensure_mcp_server_exists() -> None:
 
 def test_mcp_client_no_auth_flow(
     mcp_no_auth_server: None,  # noqa: ARG001
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     basic_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001

--- a/backend/tests/integration/tests/mcp/test_mcp_server_search.py
+++ b/backend/tests/integration/tests/mcp/test_mcp_server_search.py
@@ -97,7 +97,6 @@ def _auth_headers(user: DATestUser, name: str) -> dict[str, str]:
 
 
 def test_mcp_document_search_flow(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test the complete MCP search flow: initialization, resources, tools, and search."""
@@ -154,7 +153,6 @@ def test_mcp_document_search_flow(
     reason="User group permissions are Enterprise-only",
 )
 def test_mcp_search_respects_acl_filters(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test that search respects ACL filters - privileged users can access, others cannot."""
@@ -214,7 +212,6 @@ def test_mcp_search_respects_acl_filters(
 
 
 def test_mcp_search_filters_by_document_set(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Passing document_set_names should scope results to the named set."""

--- a/backend/tests/integration/tests/no_vectordb/conftest.py
+++ b/backend/tests/integration/tests/no_vectordb/conftest.py
@@ -11,8 +11,6 @@ import requests
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.constants import GENERAL_HEADERS
 from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
-from tests.integration.common_utils.reset import reset_file_store
-from tests.integration.common_utils.reset import reset_postgres
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -37,13 +35,6 @@ pytestmark = pytest.mark.skipif(
     not _server_has_vector_db_disabled(),
     reason="Server is running with vector DB enabled; skipping no-vectordb tests",
 )
-
-
-@pytest.fixture()
-def reset() -> None:
-    """Reset Postgres and the file store, but skip Vespa (not running)."""
-    reset_postgres()
-    reset_file_store()
 
 
 @pytest.fixture()

--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_chat.py
@@ -49,7 +49,6 @@ def _wait_for_file_processed(
 
 
 def test_chat_with_small_project_file(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -105,7 +104,6 @@ def test_chat_with_small_project_file(
 
 
 def test_persona_with_user_files_chat(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -206,7 +204,6 @@ def _base_persona_body(**overrides: object) -> dict:
 
 
 def test_persona_rejects_document_sets_without_vector_db(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Creating a persona with document_set_ids should fail with 400."""
@@ -221,7 +218,6 @@ def test_persona_rejects_document_sets_without_vector_db(
 
 
 def test_persona_rejects_document_ids_without_vector_db(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Creating a persona with document_ids should fail with 400."""

--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_endpoints.py
@@ -25,7 +25,6 @@ def _headers(user: DATestUser) -> dict[str, str]:
 
 
 def test_admin_search_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -37,7 +36,6 @@ def test_admin_search_returns_501(
 
 
 def test_document_size_info_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -49,7 +47,6 @@ def test_document_size_info_returns_501(
 
 
 def test_document_chunk_info_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -61,7 +58,6 @@ def test_document_chunk_info_returns_501(
 
 
 def test_set_new_search_settings_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -73,7 +69,6 @@ def test_set_new_search_settings_returns_501(
 
 
 def test_cancel_new_embedding_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -84,7 +79,6 @@ def test_cancel_new_embedding_returns_501(
 
 
 def test_connector_router_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """The entire /manage router is gated — any connector endpoint should 501."""
@@ -96,7 +90,6 @@ def test_connector_router_returns_501(
 
 
 def test_ingestion_post_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.post(
@@ -108,7 +101,6 @@ def test_ingestion_post_returns_501(
 
 
 def test_ingestion_delete_returns_501(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.delete(
@@ -124,7 +116,6 @@ def test_ingestion_delete_returns_501(
 
 
 def test_settings_endpoint_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -137,7 +128,6 @@ def test_settings_endpoint_works(
 
 
 def test_document_set_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -148,7 +138,6 @@ def test_document_set_list_works(
 
 
 def test_persona_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(
@@ -159,7 +148,6 @@ def test_persona_list_works(
 
 
 def test_tool_list_works(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     resp = requests.get(

--- a/backend/tests/integration/tests/no_vectordb/test_no_vectordb_file_lifecycle.py
+++ b/backend/tests/integration/tests/no_vectordb/test_no_vectordb_file_lifecycle.py
@@ -62,7 +62,6 @@ def _file_is_gone(file_id: UUID, user: DATestUser, timeout: int = 15) -> None:
 
 
 def test_file_upload_process_delete_lifecycle(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -123,7 +122,6 @@ def test_file_upload_process_delete_lifecycle(
 
 
 def test_delete_blocked_while_associated(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:

--- a/backend/tests/integration/tests/personalization/test_personalization_flow.py
+++ b/backend/tests/integration/tests/personalization/test_personalization_flow.py
@@ -28,7 +28,7 @@ def _patch_personalization(headers: dict, cookies: dict, payload: dict) -> None:
     response.raise_for_status()
 
 
-def test_personalization_round_trip(reset: None) -> None:  # noqa: ARG001
+def test_personalization_round_trip() -> None:
     user = UserManager.create()
     headers, cookies = _get_auth_headers(user)
 
@@ -75,7 +75,7 @@ def test_personalization_round_trip(reset: None) -> None:  # noqa: ARG001
     assert me_final["personalization"]["memories"] == []
 
 
-def test_enable_memory_tool_round_trip(reset: None) -> None:  # noqa: ARG001
+def test_enable_memory_tool_round_trip() -> None:
     user = UserManager.create()
     headers, cookies = _get_auth_headers(user)
 
@@ -94,9 +94,7 @@ def test_enable_memory_tool_round_trip(reset: None) -> None:  # noqa: ARG001
     assert me_reenabled["personalization"]["enable_memory_tool"] is True
 
 
-def test_enable_memory_tool_independent_of_use_memories(
-    reset: None,  # noqa: ARG001
-) -> None:
+def test_enable_memory_tool_independent_of_use_memories() -> None:
     user = UserManager.create()
     headers, cookies = _get_auth_headers(user)
 

--- a/backend/tests/integration/tests/personas/test_persona_creation.py
+++ b/backend/tests/integration/tests/personas/test_persona_creation.py
@@ -28,7 +28,6 @@ def _share_persona(
 
 
 def test_persona_create_update_share_delete(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:

--- a/backend/tests/integration/tests/personas/test_persona_pagination.py
+++ b/backend/tests/integration/tests/personas/test_persona_pagination.py
@@ -94,7 +94,6 @@ def test_persona_pagination_basic(
 
 
 def test_persona_pagination_ordering(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test ordering - display_priority ASC nulls last, then ID ASC."""
@@ -146,7 +145,6 @@ def test_persona_pagination_ordering(
 
 
 def test_persona_pagination_admin_endpoint(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test admin paginated endpoint returns PersonaSnapshot format."""
@@ -177,7 +175,6 @@ def test_persona_pagination_admin_endpoint(
 
 
 def test_persona_pagination_with_deleted(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """Test pagination with include_deleted parameter."""
@@ -280,7 +277,6 @@ def test_persona_pagination_count_accuracy(
 
 
 def test_persona_pagination_user_permissions(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:

--- a/backend/tests/integration/tests/reporting/test_usage_export_api.py
+++ b/backend/tests/integration/tests/reporting/test_usage_export_api.py
@@ -26,7 +26,6 @@ from tests.integration.common_utils.test_models import DATestUser
 class TestUsageExportAPI:
     def test_generate_usage_report(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Seed some chat history data for the report
@@ -84,7 +83,6 @@ class TestUsageExportAPI:
 
     def test_generate_usage_report_with_date_range(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Seed some chat history data
@@ -150,7 +148,6 @@ class TestUsageExportAPI:
 
     def test_generate_usage_report_invalid_dates(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Test with invalid date format
@@ -166,7 +163,6 @@ class TestUsageExportAPI:
 
     def test_fetch_usage_reports(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # First generate a report to ensure we have at least one
@@ -349,7 +345,6 @@ class TestUsageExportAPI:
 
     def test_read_nonexistent_report(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Try to download a report that doesn't exist
@@ -361,7 +356,6 @@ class TestUsageExportAPI:
 
     def test_non_admin_cannot_generate_report(
         self,
-        reset: None,  # noqa: ARG002
         basic_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Try to generate a report as non-admin
@@ -374,7 +368,6 @@ class TestUsageExportAPI:
 
     def test_non_admin_cannot_fetch_reports(
         self,
-        reset: None,  # noqa: ARG002
         basic_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Try to fetch reports as non-admin
@@ -386,7 +379,6 @@ class TestUsageExportAPI:
 
     def test_non_admin_cannot_download_report(
         self,
-        reset: None,  # noqa: ARG002
         basic_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Try to download a report as non-admin
@@ -398,7 +390,6 @@ class TestUsageExportAPI:
 
     def test_concurrent_report_generation(
         self,
-        reset: None,  # noqa: ARG002
         admin_user: DATestUser,  # noqa: ARG002
     ) -> None:
         # Seed some data

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -35,7 +35,6 @@ def _search(
 
 
 def test_basic_search_returns_results(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
@@ -58,7 +57,6 @@ def test_basic_search_returns_results(
 
 
 def test_document_set_filtering(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
@@ -97,7 +95,6 @@ def test_document_set_filtering(
     reason="User group permissions are Enterprise-only",
 )
 def test_acl_enforcement(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
@@ -138,7 +135,6 @@ def test_acl_enforcement(
 
 
 def test_persona_scoped_search(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
@@ -178,7 +174,6 @@ def test_persona_scoped_search(
 
 
 def test_invalid_persona_returns_404(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
@@ -186,9 +181,7 @@ def test_invalid_persona_returns_404(
     assert resp.status_code == 404
 
 
-def test_unauthenticated_returns_401(
-    reset: None,  # noqa: ARG001
-) -> None:
+def test_unauthenticated_returns_401() -> None:
     resp = requests.post(
         SEARCH_URL,
         json={"query": "test"},

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_stream.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_stream.py
@@ -61,7 +61,6 @@ def test_send_two_messages(basic_user: DATestUser) -> None:
 
 
 def test_send_message_simple_with_history(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     LLMProviderManager.create(user_performing_action=admin_user)
@@ -121,7 +120,6 @@ def test_send_message__basic_searches(
 
 
 def test_send_message_disconnect_and_cleanup(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     """

--- a/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
+++ b/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
@@ -15,9 +15,8 @@ from tests.integration.common_utils.test_models import DATestUserGroup
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group() -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_for_add_user")
-    user_to_add: DATestUser = UserManager.create(name="basic_user_to_add")
+def test_add_users_to_group(admin_user: DATestUser) -> None:
+    user_to_add: DATestUser = UserManager.create()
 
     user_group: DATestUserGroup = UserGroupManager.create(
         name="add-user-test-group",
@@ -50,9 +49,7 @@ def test_add_users_to_group() -> None:
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group_invalid_user() -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_for_add_user_invalid")
-
+def test_add_users_to_group_invalid_user(admin_user: DATestUser) -> None:
     user_group: DATestUserGroup = UserGroupManager.create(
         name="add-user-invalid-test-group",
         user_ids=[admin_user.id],

--- a/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
+++ b/backend/tests/integration/tests/usergroup/test_add_users_to_group.py
@@ -15,7 +15,7 @@ from tests.integration.common_utils.test_models import DATestUserGroup
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group(reset: None) -> None:  # noqa: ARG001
+def test_add_users_to_group() -> None:
     admin_user: DATestUser = UserManager.create(name="admin_for_add_user")
     user_to_add: DATestUser = UserManager.create(name="basic_user_to_add")
 
@@ -50,7 +50,7 @@ def test_add_users_to_group(reset: None) -> None:  # noqa: ARG001
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_add_users_to_group_invalid_user(reset: None) -> None:  # noqa: ARG001
+def test_add_users_to_group_invalid_user() -> None:
     admin_user: DATestUser = UserManager.create(name="admin_for_add_user_invalid")
 
     user_group: DATestUserGroup = UserGroupManager.create(

--- a/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
+++ b/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
@@ -17,9 +17,7 @@ from tests.integration.common_utils.test_models import DATestUser
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_user_gets_permissions_when_added_to_group(
-    reset: None,  # noqa: ARG001
-) -> None:
+def test_user_gets_permissions_when_added_to_group() -> None:
     admin_user: DATestUser = UserManager.create(name="admin_for_perm_test")
     basic_user: DATestUser = UserManager.create(name="basic_user_for_perm_test")
 
@@ -65,9 +63,7 @@ def test_user_gets_permissions_when_added_to_group(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_group_permission_change_propagates_to_all_members(
-    reset: None,  # noqa: ARG001
-) -> None:
+def test_group_permission_change_propagates_to_all_members() -> None:
     admin_user: DATestUser = UserManager.create(name="admin_propagate")
     user_a: DATestUser = UserManager.create(name="user_a_propagate")
     user_b: DATestUser = UserManager.create(name="user_b_propagate")

--- a/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
+++ b/backend/tests/integration/tests/usergroup/test_group_membership_updates_user_permissions.py
@@ -17,9 +17,8 @@ from tests.integration.common_utils.test_models import DATestUser
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_user_gets_permissions_when_added_to_group() -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_for_perm_test")
-    basic_user: DATestUser = UserManager.create(name="basic_user_for_perm_test")
+def test_user_gets_permissions_when_added_to_group(admin_user: DATestUser) -> None:
+    basic_user: DATestUser = UserManager.create()
 
     # basic_user starts with only "basic" from the default group
     initial_permissions = UserManager.get_permissions(basic_user)
@@ -63,10 +62,11 @@ def test_user_gets_permissions_when_added_to_group() -> None:
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="User group tests are enterprise only",
 )
-def test_group_permission_change_propagates_to_all_members() -> None:
-    admin_user: DATestUser = UserManager.create(name="admin_propagate")
-    user_a: DATestUser = UserManager.create(name="user_a_propagate")
-    user_b: DATestUser = UserManager.create(name="user_b_propagate")
+def test_group_permission_change_propagates_to_all_members(
+    admin_user: DATestUser,
+) -> None:
+    user_a: DATestUser = UserManager.create()
+    user_b: DATestUser = UserManager.create()
 
     group = UserGroupManager.create(
         name="propagate-test-group",

--- a/backend/tests/integration/tests/web_search/test_web_search_api.py
+++ b/backend/tests/integration/tests/web_search/test_web_search_api.py
@@ -276,7 +276,6 @@ def _activate_exa_provider(admin_user: DATestUser) -> int:
 @pytestmark_exa
 @pytest.mark.skip(reason="Temporarily disabled")
 def test_web_search_endpoints_with_exa(
-    reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
     provider_id = _activate_exa_provider(admin_user)


### PR DESCRIPTION
## Summary

Drops the per-test `reset` fixture (full Postgres downgrade/upgrade + FileStore wipe, ~10s) from **77 integration tests across 18 files** that don't actually depend on global state. Net: **18 files changed, 29 insertions, 140 deletions**.

### What was removed
| Area | Tests | Why it was safe |
|---|---|---|
| `no_vectordb/` (3 files) | 18 | All use uniquely-named projects/personas; the local `reset` override also deleted along with unused imports |
| `discord_bot/test_discord_bot_api.py` | 21 | Each test does its own `delete_*_if_exists` setup; bare `UserManager.create(name="admin_user")` swapped for the resilient `admin_user` fixture |
| `reporting/test_usage_export_api.py` | 9 | Relative-count assertions (`initial_count + N`) or pure HTTP-status checks |
| `search/test_search_api.py` | 6 | Content-keyed assertions (existing comment in the file noted reset doesn't isolate OpenSearch anyway) |
| `personas/` (3 files) | 5 | Relative/ID-scoped assertions on pagination, ordering, deletion |
| `mcp/` (2 files) | 4 | Unique resource names, no global-state assertions |
| `personalization/test_personalization_flow.py` | 3 | `UserManager.create()` already UUID-names users; state is per-user |
| `document_set/test_syncing.py` | 3 | `uuid4()`-named resources |
| `usergroup/` (2 files) | 4 | Unique-named users/groups verified by ID |
| `streaming_endpoints/test_chat_stream.py` | 2 | Session-scoped tests (kept `reset` on the one that asserts exact Vespa doc counts) |
| `cli/test_cli_commands.py` | 1 | `test_search_raw` — already used unique phrase content |
| `web_search/test_web_search_api.py` | 1 | Test is `@pytest.mark.skip`'d anyway |

### What was left intact
Tests that have legitimate global-state dependencies kept `reset`:
- First-user-is-admin registration flows (auth, seat limits, default group assignment)
- Singleton-state tests (search settings, KG config, anonymous-user toggle, default LLM provider)
- Exact-count assertions (user/persona/session pagination, exact Vespa doc counts, exact usage-report counts)
- Permissions tests with clean-role dependencies

A few REVIEW-flagged tests (e.g. `test_send_message__basic_searches`, `test_read_usage_report`, `test_persona_pagination_page_size_limits`) were also left untouched out of caution.

## Test plan
- [ ] CI runs the affected integration test directories and they pass
- [ ] Spot-check that timing improves on `no_vectordb` / `discord_bot` / `reporting` suites (most resets removed there)
- [ ] Confirm `discord_bot` tests still pass after swapping bare `UserManager.create` for `admin_user` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the per-test `reset` fixture from 77 integration tests to avoid the ~10s Postgres/FileStore reset per test and speed up CI. Tests now rely on UUID-scoped resources and stable fixtures; global-state-dependent tests keep `reset`.

- **Refactors**
  - Dropped `reset` from 18 files where tests don’t depend on global state.
  - Replaced `UserManager.create(name="admin_user")` with the `admin_user` fixture in Discord bot, `document_set/test_syncing.py`, and usergroup tests to remove first-user-is-admin coupling and fix 400/403 errors without `reset`.
  - Left `reset` intact for tests with real global-state or exact-count assertions (e.g., registration flows, singleton settings, Vespa doc counts).

<sup>Written for commit fe9503136bcb86a017b30749a37881402c9c0050. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

