### PR TITLE
feat: add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -256,6 +256,7 @@ class DocumentSource(str, Enum):
     IMAP = "imap"
     BITBUCKET = "bitbucket"
     TESTRAIL = "testrail"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
 
     # Special case just for integration tests
     MOCK_CONNECTOR = "mock_connector"
@@ -730,4 +731,5 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.DRUPAL_WIKI: "Knowledge base pages and content",
     DocumentSource.IMAP: "Email messages and threads",
     DocumentSource.TESTRAIL: "Test cases and QA management",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira Service Management requests and customer tickets",
 }

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,456 @@
+"""Connector for Jira Service Management.
+
+JSM requests are stored as Jira issues in service desk projects.
+This connector discovers service desks via the JSM REST API and indexes
+their requests using the same Jira issue processing pipeline.
+"""
+
+import copy
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+from jira import JIRA
+from jira.resources import Issue
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import JIRA_CONNECTOR_LABELS_TO_SKIP
+from onyx.configs.app_configs import JIRA_SLIM_PAGE_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
+    is_atlassian_date_error,
+)
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.exceptions import UnexpectedValidationError
+from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.jira.connector import (
+    _JIRA_FULL_PAGE_SIZE,
+    _perform_jql_search,
+    make_checkpoint_callback,
+    process_jira_issue,
+)
+from onyx.connectors.jira.utils import (
+    best_effort_get_field_from_issue,
+    build_jira_client,
+    build_jira_url,
+    JIRA_CLOUD_API_VERSION,
+)
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
+from onyx.db.enums import HierarchyNodeType
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+ONE_HOUR = 3600
+
+_FIELD_PROJECT = "project"
+_FIELD_KEY = "key"
+
+
+def _is_cloud_client(jira_client: JIRA) -> bool:
+    return jira_client._options["rest_api_version"] == JIRA_CLOUD_API_VERSION
+
+
+def _discover_service_desk_projects(
+    jira_client: JIRA,
+) -> list[dict[str, Any]]:
+    """Discover service desk projects via the JSM REST API."""
+    service_desks: list[dict[str, Any]] = []
+    start = 0
+    limit = 50
+
+    while True:
+        path = jira_client._get_url("rest/servicedeskapi/servicedesk")
+        params: dict[str, Any] = {"start": start, "limit": limit}
+        try:
+            response = jira_client._session.get(path, params=params)
+            response.raise_for_status()
+            data = response.json()
+        except Exception as e:
+            logger.warning(
+                "Failed to fetch service desks via JSM API: %s. "
+                "Falling back to all-project discovery.",
+                e,
+            )
+            return []
+
+        service_desks.extend(data.get("values", []))
+        total = data.get("total", len(service_desks))
+        start += limit
+        if start >= total:
+            break
+
+    return service_desks
+
+
+def _discover_all_projects(
+    jira_client: JIRA,
+) -> list[dict[str, Any]]:
+    """Fallback: list all projects as service desk candidates."""
+    try:
+        return [
+            {"projectKey": p.key, "projectName": p.name, "id": str(p.id)}
+            for p in jira_client.projects()
+        ]
+    except Exception as e:
+        logger.error("Failed to list Jira projects: %s", e)
+        return []
+
+
+def _build_service_desk_jql(
+    project_keys: list[str],
+    start: SecondsSinceUnixEpoch,
+    end: SecondsSinceUnixEpoch,
+) -> str:
+    start_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M"
+    )
+    end_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M"
+    )
+    projects = ", ".join(f'"{p}"' for p in project_keys)
+    return (
+        f"project IN ({projects}) "
+        f"AND updated >= '{start_str}' AND updated <= '{end_str}'"
+    )
+
+
+class JiraServiceManagementCheckpoint(ConnectorCheckpoint):
+    all_issue_ids: list[list[str]] = []
+    ids_done: bool = False
+    cursor: str | None = None
+    offset: int | None = None
+    seen_hierarchy_node_ids: list[str] = []
+
+
+class JiraServiceManagementConnector(
+    CheckpointedConnectorWithPermSync[JiraServiceManagementCheckpoint],
+    SlimConnectorWithPermSync,
+):
+    def __init__(
+        self,
+        jira_base_url: str,
+        project_keys: list[str] | None = None,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        scoped_token: bool = False,
+    ) -> None:
+        self.batch_size = batch_size
+        self.jira_base = jira_base_url.rstrip("/")
+        self.project_keys = project_keys
+        self._comment_email_blacklist = comment_email_blacklist or []
+        self.labels_to_skip = set(labels_to_skip)
+        self.scoped_token = scoped_token
+        self._jira_client: JIRA | None = None
+        self._resolved_project_keys: list[str] | None = None
+
+    @property
+    def comment_email_blacklist(self) -> tuple:
+        return tuple(email.strip() for email in self._comment_email_blacklist)
+
+    @property
+    def jira_client(self) -> JIRA:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+        return self._jira_client
+
+    # ---- Project discovery ----
+
+    def _resolve_project_keys(self) -> list[str]:
+        if self._resolved_project_keys is not None:
+            return self._resolved_project_keys
+
+        if self.project_keys:
+            self._resolved_project_keys = self.project_keys
+        else:
+            desks = _discover_service_desk_projects(self.jira_client)
+            if desks:
+                self._resolved_project_keys = [sd["projectKey"] for sd in desks]
+            else:
+                projects = _discover_all_projects(self.jira_client)
+                self._resolved_project_keys = [p["projectKey"] for p in projects]
+
+        if not self._resolved_project_keys:
+            logger.warning("No service desk projects found.")
+        return self._resolved_project_keys
+
+    def _get_jql(
+        self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
+    ) -> str:
+        keys = self._resolve_project_keys()
+        if not keys:
+            return "issue = NULL"
+        return _build_service_desk_jql(keys, start, end)
+
+    # ---- Credentials ----
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._jira_client = build_jira_client(
+            credentials=credentials,
+            jira_base=self.jira_base,
+            scoped_token=self.scoped_token,
+        )
+        return None
+
+    # ---- Helpers ----
+
+    def _get_project_info(
+        self, issue: Issue
+    ) -> tuple[str | None, str | None]:
+        project = best_effort_get_field_from_issue(issue, _FIELD_PROJECT)
+        if project is None:
+            return None, None
+        return project.key, project.name
+
+    def _yield_project_hierarchy_node(
+        self,
+        project_key: str,
+        project_name: str | None,
+        seen_ids: set[str],
+    ) -> Generator[HierarchyNode, None, None]:
+        if project_key in seen_ids:
+            return
+        seen_ids.add(project_key)
+        yield HierarchyNode(
+            raw_node_id=project_key,
+            display_name=project_name or project_key,
+            link=f"{self.jira_base}/projects/{project_key}",
+            node_type=HierarchyNodeType.PROJECT,
+        )
+
+    def _document_from_issue(
+        self,
+        issue: Issue,
+        parent_hierarchy_raw_node_id: str | None = None,
+    ) -> Document | None:
+        doc = process_jira_issue(
+            jira_base_url=self.jira_base,
+            issue=issue,
+            comment_email_blacklist=self.comment_email_blacklist,
+            labels_to_skip=self.labels_to_skip,
+            parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        )
+        if doc is not None:
+            doc.source = DocumentSource.JIRA_SERVICE_MANAGEMENT
+        return doc
+
+    def _update_has_more(
+        self, checkpoint: JiraServiceManagementCheckpoint
+    ) -> None:
+        if _is_cloud_client(self.jira_client):
+            checkpoint.has_more = (
+                len(checkpoint.all_issue_ids) > 0 or not checkpoint.ids_done
+            )
+        else:
+            # v2 uses offset-based pagination; has_more is set by
+            # the caller comparing offset deltas against page size
+            pass
+
+    # ---- Checkpointed loading ----
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JiraServiceManagementCheckpoint,
+    ) -> CheckpointOutput[JiraServiceManagementCheckpoint]:
+        jql = self._get_jql(start, end)
+        try:
+            yield from self._load_from_checkpoint(jql, checkpoint, False)
+        except Exception as e:
+            if is_atlassian_date_error(e):
+                yield from self._load_from_checkpoint(
+                    self._get_jql(start - ONE_HOUR, end), checkpoint, False
+                )
+            else:
+                raise e
+
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JiraServiceManagementCheckpoint,
+    ) -> CheckpointOutput[JiraServiceManagementCheckpoint]:
+        jql = self._get_jql(start, end)
+        try:
+            yield from self._load_from_checkpoint(jql, checkpoint, True)
+        except Exception as e:
+            if is_atlassian_date_error(e):
+                yield from self._load_from_checkpoint(
+                    self._get_jql(start - ONE_HOUR, end), checkpoint, True
+                )
+            else:
+                raise e
+
+    def _load_from_checkpoint(
+        self,
+        jql: str,
+        checkpoint: JiraServiceManagementCheckpoint,
+        include_permissions: bool,
+    ) -> CheckpointOutput[JiraServiceManagementCheckpoint]:
+        starting_offset = checkpoint.offset or 0
+        current_offset = starting_offset
+        new_checkpoint = copy.deepcopy(checkpoint)
+        seen_hierarchy_node_ids = set(new_checkpoint.seen_hierarchy_node_ids)
+
+        ckpt_cb = make_checkpoint_callback(new_checkpoint)
+
+        for issue in _perform_jql_search(
+            jira_client=self.jira_client,
+            jql=jql,
+            start=current_offset,
+            max_results=_JIRA_FULL_PAGE_SIZE,
+            all_issue_ids=new_checkpoint.all_issue_ids,
+            checkpoint_callback=ckpt_cb,
+            nextPageToken=new_checkpoint.cursor,
+            ids_done=new_checkpoint.ids_done,
+        ):
+            issue_key = issue.key
+            try:
+                project_key, project_name = self._get_project_info(issue)
+                if project_key:
+                    yield from self._yield_project_hierarchy_node(
+                        project_key, project_name, seen_hierarchy_node_ids
+                    )
+
+                if doc := self._document_from_issue(
+                    issue, parent_hierarchy_raw_node_id=project_key
+                ):
+                    yield doc
+
+            except Exception as e:
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=issue_key,
+                        document_link=build_jira_url(self.jira_base, issue_key),
+                    ),
+                    failure_message=f"Failed to process JSM issue: {str(e)}",
+                    exception=e,
+                )
+
+            current_offset += 1
+
+        new_checkpoint.seen_hierarchy_node_ids = list(seen_hierarchy_node_ids)
+        self._update_has_more(new_checkpoint)
+        if not _is_cloud_client(self.jira_client):
+            new_checkpoint.offset = current_offset
+            new_checkpoint.has_more = (
+                current_offset - starting_offset == _JIRA_FULL_PAGE_SIZE
+            )
+        return new_checkpoint
+
+    # ---- Slim docs ----
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        one_day = timedelta(hours=24).total_seconds()
+        start = start or 0
+        end = end or (datetime.now().timestamp() + one_day)
+
+        jql = self._get_jql(start, end)
+        cp = self.build_dummy_checkpoint()
+        ckpt_cb = make_checkpoint_callback(cp)
+        prev_offset = 0
+        current_offset = 0
+        batch: list[SlimDocument | HierarchyNode] = []
+        seen_hids: set[str] = set()
+
+        while cp.has_more:
+            for issue in _perform_jql_search(
+                jira_client=self.jira_client,
+                jql=jql,
+                start=current_offset,
+                max_results=JIRA_SLIM_PAGE_SIZE,
+                all_issue_ids=cp.all_issue_ids,
+                checkpoint_callback=ckpt_cb,
+                nextPageToken=cp.cursor,
+                ids_done=cp.ids_done,
+            ):
+                project_key, _ = self._get_project_info(issue)
+                if not project_key:
+                    continue
+                for node in self._yield_project_hierarchy_node(
+                    project_key, None, seen_hids
+                ):
+                    batch.append(node)
+
+                key = best_effort_get_field_from_issue(issue, _FIELD_KEY)
+                batch.append(
+                    SlimDocument(
+                        id=build_jira_url(self.jira_base, key),
+                        parent_hierarchy_raw_node_id=project_key,
+                    )
+                )
+                current_offset += 1
+                if len(batch) >= JIRA_SLIM_PAGE_SIZE:
+                    yield batch
+                    batch = []
+
+            self._update_has_more(cp)
+            if not _is_cloud_client(self.jira_client):
+                cp.offset = current_offset
+                cp.has_more = current_offset - prev_offset == JIRA_SLIM_PAGE_SIZE
+                prev_offset = current_offset
+
+        if batch:
+            yield batch
+
+    # ---- Validation ----
+
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira Service Management")
+        try:
+            self.jira_client.projects()
+        except Exception as e:
+            self._handle_validation_error(e)
+
+    def _handle_validation_error(self, e: Exception) -> None:
+        status_code = getattr(e, "status_code", None)
+        logger.error("JSM API error during validation: %s", e)
+        if status_code == 401:
+            raise CredentialExpiredError(
+                "Jira credential appears to be expired or invalid (HTTP 401)."
+            )
+        elif status_code == 403:
+            raise InsufficientPermissionsError(
+                "Your Jira token does not have sufficient permissions (HTTP 403)."
+            )
+        elif status_code == 429:
+            raise ConnectorValidationError(
+                "Validation failed due to Jira rate-limits being exceeded."
+            )
+        raise UnexpectedValidationError(f"Unexpected Jira error during validation: {e}")
+
+    # ---- Checkpoint protocol ----
+
+    @override
+    def validate_checkpoint_json(
+        self, checkpoint_json: str
+    ) -> JiraServiceManagementCheckpoint:
+        return JiraServiceManagementCheckpoint.model_validate_json(checkpoint_json)
+
+    @override
+    def build_dummy_checkpoint(self) -> JiraServiceManagementCheckpoint:
+        return JiraServiceManagementCheckpoint(has_more=True)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -38,6 +38,7 @@ from onyx.connectors.jira.connector import (
     make_checkpoint_callback,
     process_jira_issue,
 )
+from onyx.connectors.jira.access import get_project_permissions
 from onyx.connectors.jira.utils import (
     best_effort_get_field_from_issue,
     build_jira_client,
@@ -239,6 +240,8 @@ class JiraServiceManagementConnector(
         self,
         issue: Issue,
         parent_hierarchy_raw_node_id: str | None = None,
+        include_permissions: bool = False,
+        project_key: str | None = None,
     ) -> Document | None:
         doc = process_jira_issue(
             jira_base_url=self.jira_base,
@@ -249,6 +252,10 @@ class JiraServiceManagementConnector(
         )
         if doc is not None:
             doc.source = DocumentSource.JIRA_SERVICE_MANAGEMENT
+            if include_permissions and project_key:
+                doc.external_access = get_project_permissions(
+                    self.jira_client, project_key, add_prefix=True
+                )
         return doc
 
     def _update_has_more(
@@ -331,7 +338,10 @@ class JiraServiceManagementConnector(
                     )
 
                 if doc := self._document_from_issue(
-                    issue, parent_hierarchy_raw_node_id=project_key
+                    issue,
+                    parent_hierarchy_raw_node_id=project_key,
+                    include_permissions=include_permissions,
+                    project_key=project_key,
                 ):
                     yield doc
 

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -216,6 +216,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.testrail.connector",
         class_name="TestRailConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     # just for integration tests
     DocumentSource.MOCK_CONNECTOR: ConnectorMapping(
         module_path="onyx.connectors.mock_connector.connector",

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -745,6 +745,50 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext:
+      "Index service desk requests and customer tickets from Jira Service Management projects.",
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "list",
+        query:
+          "Enter project keys to restrict indexing (leave empty to auto-discover all service desks):",
+        label: "Project Keys",
+        name: "project_keys",
+        optional: true,
+        description:
+          "Specific Jira project keys to index (e.g., 'HELP', 'SUPPORT'). If empty, all service desk projects will be auto-discovered.",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -1964,6 +2008,12 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  project_keys?: string[];
+  comment_email_blacklist?: string[];
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -309,6 +309,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -239,6 +239,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira_service_management`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -594,6 +594,7 @@ export enum ValidSources {
   Imap = "imap",
   Bitbucket = "bitbucket",
   TestRail = "testrail",
+  JiraServiceManagement = "jira_service_management",
 
   // Craft-specific sources
   CraftFile = "craft_file",


### PR DESCRIPTION
Introduces a new connector for Jira Service Management that discovers service desk projects via the JSM REST API and indexes customer requests using the existing Jira issue processing pipeline.

Key changes:
- New DocumentSource: JIRA_SERVICE_MANAGEMENT
- JSM connector with service desk auto-discovery and project filtering
- Checkpointed + slim document support for incremental indexing
- Frontend config (form, credentials, source metadata)
- Registry mapping for lazy loading

## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Jira Service Management connector that auto-discovers service desk projects and indexes customer requests using the existing Jira issue pipeline. Includes incremental checkpoints, slim docs, permission sync, and UI configuration.

- **New Features**
  - Added `JIRA_SERVICE_MANAGEMENT` source and registry mapping; new connector supports auto-discovery or `project_keys`, checkpointed + slim indexing, and project hierarchy nodes (issues under their projects).
  - Frontend: config form, credentials template, docs and source metadata; supports `scoped_token` and `comment_email_blacklist`.

- **Bug Fixes**
  - Populate `external_access` on documents when permission sync is enabled.

<sup>Written for commit d71118a3f084f2f4a446cb1eee36d906f99936f7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11265?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



Closes #2281