### PR TITLE
fix(sharepoint): handle HTTP 423 locked sites as per-site failures

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -283,7 +283,14 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # HTTP statuses we treat as transient and worth retrying.
 RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 
-PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({403, 404, 410})
+# `GET /sites/getAllSites` returns the tenant-wide directory of every site
+# collection, not just sites the app principal can read. Per-site content
+# access is gated separately, so some listed sites will always reject reads.
+# 403/404/410 cover "no permission / removed / gone"; 423 ("notAllowed")
+# covers admin-locked or M365-archived sites (e.g. `Set-SPOSiteArchiveState
+# -ArchiveState Archived`). All four are per-site conditions — skip the
+# site and continue the run rather than aborting the whole tenant index.
+PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({403, 404, 410, 423})
 
 
 def _is_per_site_graph_failure(e: ClientRequestException | HTTPError) -> bool:


### PR DESCRIPTION
## Description
  - An admin-locked or M365-archived SharePoint site (Graph returns `HTTP 423 notAllowed`) no longer aborts the entire tenant indexing run — the site is now recorded as a per-site failure and the connector continues to the next site.
  - Adds `423` to `PER_SITE_GRAPH_FAILURE_STATUSES` alongside the existing `403/404/410`, with a comment explaining why `getAllSites` surfaces sites the app can't read.

## How Has This Been Tested?
`backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py::TestIsPerSiteGraphFailure` automatically extend to cover the `423` case

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat SharePoint sites returning HTTP 423 (admin-locked or M365-archived) as per-site failures so tenant indexing continues. Adds 423 to `PER_SITE_GRAPH_FAILURE_STATUSES` and skips those sites instead of aborting the run.

<sup>Written for commit 49d9e533026381940e87053290a5444fab43bfa7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11266?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

