### PR TITLE
feat(helm): gate scheduled-tasks worker on ENABLE_CRAFT

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.6
+version: 0.5.7
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,14 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Safeguard against destructive upgrades from chart 0.4.x.
-        A pre-render check fails `helm upgrade` if the legacy `da-vespa`
-        StatefulSet is still present in the release namespace, so the
-        Vespa data volume is not silently deleted by the 0.5.0 subchart
-        removal. Override via legacyVespaCheck.acknowledged=true once
-        migrated to external Vespa, or legacyVespaCheck.enabled=false
-        to disable entirely. See deployment/helm/MIGRATION.md.
+    - kind: changed
+      description: Gate the `celery-worker-scheduled-tasks` deployment (and
+        its metrics Service, HPA, KEDA ScaledObject, and ServiceMonitor) on
+        `configMap.ENABLE_CRAFT=true`. The worker only services Craft
+        scheduled-task fires, so it no longer spawns on installs where
+        Craft is disabled.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.vectorDB.enabled (.Values.celery_worker_scheduled_tasks.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") }}
+{{- if and .Values.vectorDB.enabled (.Values.celery_worker_scheduled_tasks.autoscaling.enabled) (ne (include "onyx.autoscaling.engine" .) "keda") (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-metrics-service.yaml
@@ -1,6 +1,6 @@
 {{- /* Metrics port must match the default in metrics_server.py (_DEFAULT_PORTS).
        Do NOT use PROMETHEUS_METRICS_PORT env var in Helm — each worker needs its own port. */ -}}
-{{- if gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0 }}
+{{- if and (gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0) (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-scaledobject.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.vectorDB.enabled (.Values.celery_worker_scheduled_tasks.autoscaling.enabled) (eq (include "onyx.autoscaling.engine" .) "keda") }}
+{{- if and .Values.vectorDB.enabled (.Values.celery_worker_scheduled_tasks.autoscaling.enabled) (eq (include "onyx.autoscaling.engine" .) "keda") (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.vectorDB.enabled (gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0) }}
+{{- if and .Values.vectorDB.enabled (gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0) (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-servicemonitors.yaml
@@ -149,7 +149,7 @@ spec:
       interval: 30s
       scrapeTimeout: 10s
 {{- end }}
-{{- if gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0 }}
+{{- if and (gt (int .Values.celery_worker_scheduled_tasks.replicaCount) 0) (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
## Description

The `celery-worker-scheduled-tasks` deployment only services Craft scheduled-task headless executor fires, but it was being rendered on every Helm install regardless of whether Craft was enabled. On clusters that don't have `configMap.ENABLE_CRAFT=true`, the pod still spawned and burned resources doing nothing useful.

This change gates the deployment (and its metrics Service, HPA, KEDA ScaledObject, and ServiceMonitor) on `configMap.ENABLE_CRAFT == "true"`, matching the gating pattern already used by `sandbox-namespace.yaml` and `network-policy-sandbox-push.yaml`.

Chart version bumped to `0.5.7`.

**Note for upgraders:** anyone previously running the scheduled-tasks worker without `ENABLE_CRAFT` set will see the deployment removed on upgrade. This is intentional — the worker had nothing to do on those installs.

## How Has This Been Tested?

Rendered the chart locally and confirmed gating works both ways:

- `helm template ... ` (no `ENABLE_CRAFT`) → 0 `scheduled-tasks` resources rendered
- `helm template ... --set configMap.ENABLE_CRAFT=true ...` → all 4 `scheduled-tasks` resources (Deployment, Service, ScaledObject, ServiceMonitor) rendered

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the `celery-worker-scheduled-tasks` Deployment (plus its metrics Service, HPA/KEDA ScaledObject, and ServiceMonitor) on `configMap.ENABLE_CRAFT=true` so it only runs when Craft is enabled. Bumps the chart to `0.5.7`.

- **Migration**
  - Upgrading without `ENABLE_CRAFT` will remove these resources; this is expected.
  - To enable the worker, set `--set configMap.ENABLE_CRAFT=true`.

<sup>Written for commit 7b86a9ba8e8fbd32a077295ca1d9f8ea34d407b1. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11270?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

