### PR TITLE
fix(ci): use runs-on volume=100gb label (hdd= was silently ignored)

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -3,7 +3,6 @@ self-hosted-runner:
   labels:
     - extras=ecr-cache
     - extras=s3-cache
-    - hdd=256
     - runs-on
     - runner=1cpu-linux-arm64
     - runner=1cpu-linux-x64
@@ -18,6 +17,7 @@ self-hosted-runner:
     - ubuntu-slim # Currently in public preview
     - volume=40gb
     - volume=50gb
+    - volume=256gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -17,7 +17,7 @@ self-hosted-runner:
     - ubuntu-slim # Currently in public preview
     - volume=40gb
     - volume=50gb
-    - volume=256gb
+    - volume=100gb
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
-      - volume=256gb
+      - volume=100gb
       - ${{ format('run-id={0}-craft-k8s-tests', github.run_id) }}
       - extras=s3-cache
     timeout-minutes: 20

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on:
       - runs-on
       - runner=4cpu-linux-x64
-      - hdd=256
+      - volume=256gb
       - ${{ format('run-id={0}-craft-k8s-tests', github.run_id) }}
       - extras=s3-cache
     timeout-minutes: 20

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -22,7 +22,6 @@ jobs:
       [
         runs-on,
         runner=8cpu-linux-x64,
-        volume=256gb,
         "run-id=${{ github.run_id }}-helm-chart-check",
       ]
     timeout-minutes: 45

--- a/.github/workflows/pr-helm-chart-testing.yml
+++ b/.github/workflows/pr-helm-chart-testing.yml
@@ -22,7 +22,7 @@ jobs:
       [
         runs-on,
         runner=8cpu-linux-x64,
-        hdd=256,
+        volume=256gb,
         "run-id=${{ github.run_id }}-helm-chart-check",
       ]
     timeout-minutes: 45


### PR DESCRIPTION
## Description

The `hdd=256` label used by `pr-craft-k8s-tests.yml` and `pr-helm-chart-testing.yml` is not a valid runs-on label and has been silently ignored. runs-on v2.9+ uses `volume=Ngb` ([docs](https://runs-on.com/docs/v2/configuration/job-labels/)). Both workflows were booting runners with the AMI's default ~38 GB root partition instead of the intended 256 GB.

Evidence: every recent run prints `InstanceDisk1 /=/dev/nvme0n1p1 Free=21.38GiB Used=16.30GiB` in the runs-on banner, identical across both workflows.

This is the root cause of the consistent `Craft Kubernetes Sandbox Tests` failures on main. The kubelet log on a failing kind node shows ENOSPC during sandbox-image extraction:

```
ErrImagePull: ... write /var/lib/containerd/.../sklearn/cluster/_k_means_common.cpython-311-x86_64-linux-gnu.so:
  no space left on device
```

Changes:
- `.github/workflows/pr-craft-k8s-tests.yml` — `hdd=256` → `volume=100gb`. The original `hdd=256` intent was a guess; 256 GiB is very likely overkill.
- `.github/workflows/pr-helm-chart-testing.yml` — disk label **removed entirely**. The `hdd=256` here has been a no-op since runs-on v2.9, meaning this workflow has been running successfully on the default ~38 GB partition for ~a year. No reason to grow it now.
- `.github/actionlint.yml` — drop unused `hdd=256` allowlist entry; add `volume=100gb`.

## How Has This Been Tested?

- Verified via runs-on v2 docs that `volume=Ngb` is the documented label since v2.9 and `hdd=` is not.
- `actionlint` (pre-commit) passes with the new allowlist entry.
- CI on this PR will exercise both workflows on the new label.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)