### PR TITLE
fix(craft): remove public_global sharing scope

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -284,7 +284,6 @@ class SessionOrigin(str, PyEnum):
 class SharingScope(str, PyEnum):
     PRIVATE = "private"
     PUBLIC_ORG = "public_org"
-    PUBLIC_GLOBAL = "public_global"
 
 
 class ScheduledTaskStatus(str, PyEnum):

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -299,15 +299,12 @@ def _check_webapp_access(
 ) -> BuildSession:
     """Check if user can access a session's webapp.
 
-    - public_global: accessible by anyone (no auth required)
-    - public_org: accessible by any authenticated user
     - private: only accessible by the session owner
+    - public_org: accessible by any authenticated user
     """
     session = db_session.get(BuildSession, session_id)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
-    if session.sharing_scope == SharingScope.PUBLIC_GLOBAL:
-        return session
     if user is None:
         raise HTTPException(status_code=401, detail="Authentication required")
     if session.sharing_scope == SharingScope.PRIVATE and session.user_id != user.id:
@@ -329,8 +326,11 @@ def _offline_html_response() -> Response:
     return Response(content=html, status_code=503, media_type="text/html")
 
 
-# Public router for webapp proxy — no authentication required
-# (access controlled per-session via sharing_scope)
+# Router for the webapp proxy. The route is exempted from the global auth
+# middleware (see PUBLIC_ENDPOINT_SPECS in auth_check.py) so the handler can
+# return a friendly redirect to /auth/login for unauthenticated browsers
+# instead of a bare 401. Auth is enforced inside the handler via
+# _check_webapp_access; never wire a handler here that doesn't enforce it.
 public_build_router = APIRouter(prefix="/build")
 
 
@@ -347,7 +347,8 @@ def get_webapp(
 ) -> StreamingResponse | Response:
     """Proxy the webapp for a specific session (root and subpaths).
 
-    Accessible without authentication when sharing_scope is public_global.
+    Requires authentication; access is further gated by the session's
+    sharing_scope (private = owner only, public_org = any org member).
     Returns a friendly offline page when the sandbox is not running.
     """
     try:

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -168,31 +168,47 @@ def test_delete_session_returns_204_and_actually_deletes(
 
 def test_set_sharing_scope_changes_webapp_visibility(
     admin_user: DATestUser,
+    basic_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """PATCH to public_global flips the webapp from auth-required to anon-accessible.
+    """PATCH to public_org opens the webapp to other org members.
 
-    We don't assert a 200 from the unauthenticated webapp call — the local
-    sandbox typically has no Next.js dev server running, so the proxy hands
-    back the branded "offline" 503 page. What matters is that the auth gate
-    stops being applied: the unauthenticated call no longer redirects to
-    ``/auth/login`` (which is what private sessions do).
+    With the default ``private`` scope, only the session owner can hit the
+    webapp; another org user gets the auth-gate response (302/401/403/404).
+    Flipping the scope to ``public_org`` via the PATCH endpoint must
+    propagate to ``_check_webapp_access`` so the same other-user call now
+    reaches the proxy. We don't pin a 200 from that call — the local
+    sandbox has no Next.js dev server running and the proxy returns the
+    offline page (status 5xx HTML), which still proves the auth gate is
+    no longer applied.
     """
     body = _create_session(admin_user)
     session_id = body["id"]
     webapp_url = f"{API_SERVER_URL}/build/sessions/{session_id}/webapp"
 
-    # Private (default): unauthenticated call is redirected to /auth/login.
-    private_response = requests.get(webapp_url, allow_redirects=False)
-    assert private_response.status_code in (302, 401, 403)
+    # Private (default): an authenticated non-owner gets 404 (existence-hiding).
+    private_response = requests.get(
+        webapp_url,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        allow_redirects=False,
+    )
+    assert private_response.status_code == 404
 
     BuildSessionManager.set_sharing(
-        admin_user, uuid.UUID(session_id), SharingScope.PUBLIC_GLOBAL
+        admin_user, uuid.UUID(session_id), SharingScope.PUBLIC_ORG
     )
 
-    # Public global: no auth challenge — request reaches the proxy.
-    public_response = requests.get(webapp_url, allow_redirects=False)
-    assert public_response.status_code not in (302, 401, 403)
+    # public_org: same other org user reaches the proxy; with no upstream
+    # Next.js dev server, the proxy returns the branded offline HTML (5xx).
+    public_response = requests.get(
+        webapp_url,
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+        allow_redirects=False,
+    )
+    assert public_response.status_code in (200, 502, 503, 504)
+    assert "text/html" in public_response.headers.get("content-type", "").lower()
 
 
 def test_restore_session_returns_409_when_lock_held(

--- a/backend/tests/integration/tests/craft/test_webapp_proxy.py
+++ b/backend/tests/integration/tests/craft/test_webapp_proxy.py
@@ -67,6 +67,21 @@ def _unauth_get(
     )
 
 
+def _auth_get(
+    user: DATestUser,
+    session_id: UUID,
+    path: str = "",
+    allow_redirects: bool = False,
+) -> requests.Response:
+    """GET the proxy URL with ``user``'s auth headers/cookies."""
+    return requests.get(
+        _webapp_url(session_id, path),
+        headers=user.headers,
+        cookies=user.cookies,
+        allow_redirects=allow_redirects,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Auth / scope checks (the part of the proxy that doesn't need an upstream)
 # ---------------------------------------------------------------------------
@@ -153,20 +168,6 @@ def test_proxy_blocks_other_tenant_when_public_org(
         assert response.status_code == 401
 
 
-def test_proxy_allows_unauth_when_public_global(
-    admin_user: DATestUser,
-) -> None:
-    """``public_global`` → unauthenticated request passes the access check."""
-    session = _create_session(admin_user)
-    session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_GLOBAL)
-
-    response = _unauth_get(session_id, allow_redirects=False)
-
-    assert response.status_code != 401
-    assert "/auth/login" not in response.headers.get("location", "")
-
-
 # ---------------------------------------------------------------------------
 # Header stripping + offline page (no upstream required)
 # ---------------------------------------------------------------------------
@@ -183,9 +184,8 @@ def test_proxy_strips_set_cookie_header(admin_user: DATestUser) -> None:
     """
     session = _create_session(admin_user)
     session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_GLOBAL)
 
-    response = _unauth_get(session_id, allow_redirects=False)
+    response = _auth_get(admin_user, session_id, allow_redirects=False)
 
     # Lowercased header name lookup (requests does case-insensitive matching).
     assert "set-cookie" not in {k.lower() for k in response.headers}
@@ -208,9 +208,8 @@ def test_proxy_rewrites_nextjs_asset_paths_in_html(
     """
     session = _create_session(admin_user)
     session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_GLOBAL)
 
-    response = _unauth_get(session_id, allow_redirects=False)
+    response = _auth_get(admin_user, session_id, allow_redirects=False)
     assert "text/html" in response.headers.get("content-type", "").lower()
     # If a real upstream were live, any rewritten URL would carry the
     # session-scoped proxy prefix. The offline page contains no
@@ -237,14 +236,13 @@ def test_proxy_injects_hmr_shim_in_html_response(
     """
     session = _create_session(admin_user)
     session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_GLOBAL)
 
-    response = _unauth_get(session_id, allow_redirects=False)
+    response = _auth_get(admin_user, session_id, allow_redirects=False)
     # The injection logic only runs when the upstream returns text/html
     # and a 2xx — the offline page does not include the shim script tag
     # in any of its content. Verifies the shim is not accidentally
     # injected on the offline fallback (would expose the proxy base
-    # path to anonymous clients).
+    # path to authenticated clients).
     body = response.text
     assert "__WEBAPP_BASE__" not in body
 
@@ -264,9 +262,8 @@ def test_proxy_502_renders_branded_offline_page(
     """
     session = _create_session(admin_user)
     session_id = UUID(session["id"])
-    _set_scope(admin_user, session_id, SharingScope.PUBLIC_GLOBAL)
 
-    response = _unauth_get(session_id, allow_redirects=False)
+    response = _auth_get(admin_user, session_id, allow_redirects=False)
 
     assert response.status_code in (502, 503, 504)
     assert "text/html" in response.headers.get("content-type", "").lower()
@@ -342,13 +339,10 @@ def test_webapp_assets_isolated_across_sessions(
     session_a_id = UUID(session_a["id"])
     session_b_id = UUID(session_b["id"])
 
-    _set_scope(admin_user, session_a_id, SharingScope.PUBLIC_GLOBAL)
-    _set_scope(basic_user, session_b_id, SharingScope.PUBLIC_GLOBAL)
-
     asset_path = f"_next/static/{uuid4().hex}/leak.js"
 
-    response_a = _unauth_get(session_a_id, asset_path)
-    response_b = _unauth_get(session_b_id, asset_path)
+    response_a = _auth_get(admin_user, session_a_id, asset_path)
+    response_b = _auth_get(basic_user, session_b_id, asset_path)
 
     # Each session's proxy must respond from its own sandbox; the two
     # responses share a *structure* (both offline pages, no upstream)

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -2,7 +2,7 @@
 // Sharing Types
 // =============================================================================
 
-export type SharingScope = "private" | "public_org" | "public_global";
+export type SharingScope = "private" | "public_org";
 
 // =============================================================================
 // Session Error Constants


### PR DESCRIPTION
## Description

Removes the `public_global` Craft sharing scope, which was never surfaced in the Craft UI. Removing it from the backend enum so it can't be enabled at all.

Changes:
- `SharingScope.PUBLIC_GLOBAL` removed; `_check_webapp_access` now always requires an authenticated user
- Frontend `SharingScope` union narrowed to `"private" | "public_org"`
- Integration tests rewired from "unauth + public_global" to "auth + private" patterns; `test_set_sharing_scope_changes_webapp_visibility` rewritten to flip `private` → `public_org` and verify a non-owner org user gains access
- Webapp proxy route kept on `public_build_router` to preserve the friendly 401 → 302 redirect to `/auth/login` for unauthenticated browsers; comment updated to make the reasoning explicit

## How Has This Been Tested?

- Integration tests in `backend/tests/integration/tests/craft/test_webapp_proxy.py` cover the access matrix (private = owner only, public_org = any org member) and the offline-page fallback.
- `test_set_sharing_scope_changes_webapp_visibility` in `test_sessions_api.py` asserts the PATCH endpoint propagates to the access check.
- Two rounds of independent code review (no blockers in final pass).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check