### PR TITLE
fix(craft): strip viewer credentials in webapp proxy

### DIFF
--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -78,7 +78,7 @@ def get_rate_limit(
     return get_user_rate_limit_status(user, db_session)
 
 
-# Headers to skip when proxying.
+# Response headers to skip when proxying back from the sandbox.
 # Hop-by-hop headers must not be forwarded, and set-cookie is stripped to
 # prevent LLM-generated apps from setting cookies on the parent Onyx domain.
 EXCLUDED_HEADERS = {
@@ -88,6 +88,62 @@ EXCLUDED_HEADERS = {
     "connection",
     "set-cookie",
 }
+
+# Request headers stripped before forwarding to the sandbox. The sandbox runs
+# LLM-generated webapp code and must never receive the viewer's Onyx
+# credentials, CSRF tokens, or client-identity headers — otherwise a malicious
+# webapp can exfiltrate them (GHSA-v2mx-c9m8-5jrv / GHSA-j6q4-7ghr-53cv).
+#
+# The sandbox webapp is a frontend-only Next.js shell with no callbacks into
+# Onyx, so it does not depend on any of these for correct behavior. The proxy
+# is GET-only; if WebSocket upgrade is ever added, also strip
+# `sec-websocket-protocol`/`sec-websocket-extensions` (can carry bearer tokens).
+#
+# Entries must be lowercase — the filter compares against `key.lower()`.
+# Any header starting with `x-onyx-` is also stripped (see _is_header_excluded)
+# so future Onyx-internal headers don't silently leak.
+EXCLUDED_REQUEST_HEADERS = {
+    # End-to-end but unsafe to forward verbatim.
+    "host",
+    "content-length",
+    # Hop-by-hop (RFC 7230 §6.1).
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    # Credentials.
+    "cookie",
+    "authorization",
+    "x-api-key",
+    "x-auth-token",
+    # CSRF.
+    "x-csrf-token",
+    "x-xsrf-token",
+    # Client identity (RFC 7239 + common ingress/IDP conventions).
+    "forwarded",
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-port",
+    "x-forwarded-proto",
+    "x-forwarded-server",
+    "x-real-ip",
+    "x-client-ip",
+    "cf-connecting-ip",
+    "true-client-ip",
+    # IDP-injected identity (oauth2-proxy / similar).
+    "x-forwarded-user",
+    "x-forwarded-email",
+    "x-forwarded-preferred-username",
+}
+
+
+def _is_header_excluded(key: str) -> bool:
+    lowered = key.lower()
+    return lowered in EXCLUDED_REQUEST_HEADERS or lowered.startswith("x-onyx-")
 
 
 def _stream_response(response: httpx.Response) -> Iterator[bytes]:
@@ -243,17 +299,16 @@ def _proxy_request(
 
     logger.debug("Proxying request to: %s", target_url)
 
+    forwarded_headers = {
+        key: value
+        for key, value in request.headers.items()
+        if not _is_header_excluded(key)
+    }
+
     try:
         # Make the request to the target URL
         with httpx.Client(timeout=30.0, follow_redirects=True) as client:
-            response = client.get(
-                target_url,
-                headers={
-                    key: value
-                    for key, value in request.headers.items()
-                    if key.lower() not in ("host", "content-length")
-                },
-            )
+            response = client.get(target_url, headers=forwarded_headers)
 
             # Build response headers, excluding hop-by-hop headers
             response_headers = {

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -263,21 +263,55 @@ class TestProxyRequestWiring:
 
         monkeypatch.setattr(api.httpx, "Client", FakeClient)
 
-        # Send every deny-list entry as input, so dropping any entry from
-        # EXCLUDED_REQUEST_HEADERS surfaces here as a leak in `forwarded_headers`.
-        sensitive_headers: dict[str, str] = {
-            key: f"SHOULD-NOT-LEAK-{key}" for key in api.EXCLUDED_REQUEST_HEADERS
+        # Security spec: every header here must never reach the sandbox,
+        # regardless of how EXCLUDED_REQUEST_HEADERS evolves. Removing a key
+        # from the deny-list while leaving it here surfaces as a leak below.
+        # Mixed-case keys exercise the case-insensitive comparator.
+        sensitive_headers = {
+            "host": "app.onyx.local",
+            "content-length": "7",
+            "Connection": "keep-alive",
+            "Keep-Alive": "timeout=5",
+            "Proxy-Authenticate": "Basic",
+            "Proxy-Authorization": "Basic victim-proxy-token",
+            "TE": "trailers",
+            "Trailer": "Expires",
+            "Transfer-Encoding": "chunked",
+            "Upgrade": "websocket",
+            "Cookie": "fastapiusersauth=victim-session",
+            "Authorization": "Bearer victim-token",
+            "X-Api-Key": "victim-api-key",
+            "X-Auth-Token": "victim-auth-token",
+            "X-CSRF-Token": "csrf-token",
+            "X-XSRF-Token": "xsrf-token",
+            "Forwarded": "for=203.0.113.10;proto=https",
+            "X-Forwarded-For": "203.0.113.10",
+            "X-Forwarded-Host": "evil.example.com",
+            "X-Forwarded-Port": "443",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Server": "evil.example.com",
+            "X-Real-IP": "203.0.113.10",
+            "X-Client-IP": "203.0.113.10",
+            "CF-Connecting-IP": "203.0.113.10",
+            "True-Client-IP": "203.0.113.10",
+            "X-Forwarded-User": "victim@example.com",
+            "X-Forwarded-Email": "victim@example.com",
+            "X-Forwarded-Preferred-Username": "victim",
+            # x-onyx-* prefix matcher (not literal deny-list entries).
+            "X-Onyx-Authorization": "Bearer alt-victim-token",
+            "X-Onyx-Tenant-ID": "victim-tenant",
+            "X-Onyx-Request-ID": "abc-123",
+            "X-Onyx-Future-Header": "should-be-stripped-by-prefix",
         }
-        # Cover the `x-onyx-*` prefix matcher in `_is_header_excluded`. These
-        # keys are not in the literal deny-list set; the prefix is what strips
-        # them. Mixed-case here also exercises the case-insensitive comparator.
-        sensitive_headers["X-Onyx-Authorization"] = "Bearer alt-victim-token"
-        sensitive_headers["X-Onyx-Tenant-ID"] = "victim-tenant"
-        sensitive_headers["X-Onyx-Request-ID"] = "abc-123"
-        sensitive_headers["X-Onyx-Future-Header"] = "should-be-stripped-by-prefix"
-        # Promote one literal deny-list key to mixed-case to confirm the
-        # comparator lowercases before matching.
-        sensitive_headers["Cookie"] = sensitive_headers.pop("cookie")
+
+        # Completeness check: every literal deny-list entry is covered above.
+        # If a new entry is added to EXCLUDED_REQUEST_HEADERS without also
+        # being added here, this assertion fails and forces the test to grow.
+        covered = {key.lower() for key in sensitive_headers}
+        assert api.EXCLUDED_REQUEST_HEADERS <= covered, (
+            f"Deny-list entries missing from test input: "
+            f"{api.EXCLUDED_REQUEST_HEADERS - covered}"
+        )
 
         benign_headers = {"accept": "text/plain", "user-agent": "pytest"}
         request = cast(

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -263,34 +263,22 @@ class TestProxyRequestWiring:
 
         monkeypatch.setattr(api.httpx, "Client", FakeClient)
 
-        # Mix of lower- and mixed-case keys to exercise the case-insensitive
-        # filter (real Starlette Headers arrive lowercased, but defense-in-depth
-        # in the comparator should still work if that ever changes).
-        sensitive_headers = {
-            "host": "app.onyx.local",
-            "content-length": "7",
-            "Cookie": "fastapiusersauth=victim-session",
-            "Authorization": "Bearer victim-token",
-            "X-Onyx-Authorization": "Bearer alt-victim-token",
-            "X-Onyx-Tenant-ID": "victim-tenant",
-            "X-Onyx-Request-ID": "abc-123",
-            "X-Onyx-Future-Header": "should-be-stripped-by-prefix",
-            "x-api-key": "victim-api-key",
-            "x-auth-token": "victim-auth-token",
-            "proxy-authorization": "Basic victim-proxy-token",
-            "x-csrf-token": "csrf-token",
-            "x-xsrf-token": "xsrf-token",
-            "x-forwarded-for": "203.0.113.10",
-            "x-forwarded-host": "evil.example.com",
-            "x-forwarded-proto": "https",
-            "x-real-ip": "203.0.113.10",
-            "x-client-ip": "203.0.113.10",
-            "cf-connecting-ip": "203.0.113.10",
-            "true-client-ip": "203.0.113.10",
-            "x-forwarded-user": "victim@example.com",
-            "x-forwarded-email": "victim@example.com",
-            "forwarded": "for=203.0.113.10;proto=https",
+        # Send every deny-list entry as input, so dropping any entry from
+        # EXCLUDED_REQUEST_HEADERS surfaces here as a leak in `forwarded_headers`.
+        sensitive_headers: dict[str, str] = {
+            key: f"SHOULD-NOT-LEAK-{key}" for key in api.EXCLUDED_REQUEST_HEADERS
         }
+        # Cover the `x-onyx-*` prefix matcher in `_is_header_excluded`. These
+        # keys are not in the literal deny-list set; the prefix is what strips
+        # them. Mixed-case here also exercises the case-insensitive comparator.
+        sensitive_headers["X-Onyx-Authorization"] = "Bearer alt-victim-token"
+        sensitive_headers["X-Onyx-Tenant-ID"] = "victim-tenant"
+        sensitive_headers["X-Onyx-Request-ID"] = "abc-123"
+        sensitive_headers["X-Onyx-Future-Header"] = "should-be-stripped-by-prefix"
+        # Promote one literal deny-list key to mixed-case to confirm the
+        # comparator lowercases before matching.
+        sensitive_headers["Cookie"] = sensitive_headers.pop("cookie")
+
         benign_headers = {"accept": "text/plain", "user-agent": "pytest"}
         request = cast(
             Request,

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -236,6 +236,80 @@ class TestProxyRequestWiring:
             "<title>x</title>"
         )
 
+    def test_proxy_request_strips_sensitive_viewer_headers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Credential, CSRF, and forwarded-identity headers must not reach the sandbox."""
+        upstream = httpx.Response(
+            200, headers={"content-type": "text/plain"}, content=b"ok"
+        )
+        forwarded_headers: dict[str, str] = {}
+
+        monkeypatch.setattr(api, "_get_sandbox_url", lambda *_args: "http://sandbox")
+
+        class FakeClient:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            def __enter__(self) -> "FakeClient":
+                return self
+
+            def __exit__(self, *_args: object) -> Literal[False]:
+                return False
+
+            def get(self, _url: str, headers: dict[str, str]) -> httpx.Response:
+                forwarded_headers.update(headers)
+                return upstream
+
+        monkeypatch.setattr(api.httpx, "Client", FakeClient)
+
+        # Mix of lower- and mixed-case keys to exercise the case-insensitive
+        # filter (real Starlette Headers arrive lowercased, but defense-in-depth
+        # in the comparator should still work if that ever changes).
+        sensitive_headers = {
+            "host": "app.onyx.local",
+            "content-length": "7",
+            "Cookie": "fastapiusersauth=victim-session",
+            "Authorization": "Bearer victim-token",
+            "X-Onyx-Authorization": "Bearer alt-victim-token",
+            "X-Onyx-Tenant-ID": "victim-tenant",
+            "X-Onyx-Request-ID": "abc-123",
+            "X-Onyx-Future-Header": "should-be-stripped-by-prefix",
+            "x-api-key": "victim-api-key",
+            "x-auth-token": "victim-auth-token",
+            "proxy-authorization": "Basic victim-proxy-token",
+            "x-csrf-token": "csrf-token",
+            "x-xsrf-token": "xsrf-token",
+            "x-forwarded-for": "203.0.113.10",
+            "x-forwarded-host": "evil.example.com",
+            "x-forwarded-proto": "https",
+            "x-real-ip": "203.0.113.10",
+            "x-client-ip": "203.0.113.10",
+            "cf-connecting-ip": "203.0.113.10",
+            "true-client-ip": "203.0.113.10",
+            "x-forwarded-user": "victim@example.com",
+            "x-forwarded-email": "victim@example.com",
+            "forwarded": "for=203.0.113.10;proto=https",
+        }
+        benign_headers = {"accept": "text/plain", "user-agent": "pytest"}
+        request = cast(
+            Request,
+            SimpleNamespace(
+                headers={**sensitive_headers, **benign_headers},
+                query_params="",
+            ),
+        )
+
+        api._proxy_request(
+            "", request, UUID(SESSION_ID), cast(Session, SimpleNamespace())
+        )
+
+        lower = {key.lower(): value for key, value in forwarded_headers.items()}
+        # Exact match: no sensitive header survives, no extra header leaks
+        # through. If a new sensitive header is added to the request without a
+        # corresponding deny-list entry, this assertion will catch it.
+        assert lower == benign_headers
+
     def test_rewrites_absolute_link_header_font_preload_paths(self) -> None:
         headers = {
             "link": (


### PR DESCRIPTION
## Description

This PR adds a deny-list (`EXCLUDED_REQUEST_HEADERS`) of credential, CSRF, hop-by-hop, and forwarded-identity headers, plus a wildcard match for any header beginning with `x-onyx-` so future Onyx-internal headers are stripped by default. The sandbox webapp is a frontend-only Next.js shell with no callbacks into Onyx, so dropping these headers has no functional impact.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips viewer credentials and identity headers from the webapp proxy before forwarding to the sandbox Next.js server to prevent credential exfiltration (GHSA-v2mx-c9m8-5jrv / GHSA-j6q4-7ghr-53cv).

- **Bug Fixes**
  - Add `EXCLUDED_REQUEST_HEADERS` and `_is_header_excluded` to drop cookies, `Authorization`, `X-Api-Key`, CSRF tokens, hop-by-hop headers, `Forwarded`/`X-Forwarded-*`, IDP headers, any `x-onyx-*`, plus `Host` and `Content-Length`.
  - Forward only benign headers needed by Next.js (e.g., `Accept`, `User-Agent`).
  - Add `test_proxy_request_strips_sensitive_viewer_headers` with a hardcoded sensitive header set (mixed-case, includes `x-onyx-*`), a deny-list completeness check, and an exact, case-insensitive allowlist assertion on forwarded headers.

<sup>Written for commit ec6c60df49491dbe2246d08e8d567960ee75a423. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



