### PR TITLE
fix(lint): collapse sandbox_daemon import block (ruff isort)

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/sandbox_daemon/server.py
@@ -14,7 +14,6 @@ from fastapi import Header
 from fastapi import HTTPException
 from fastapi import Query
 from fastapi import Request
-
 from sandbox_daemon.extract import MAX_BUNDLE_BYTES
 from sandbox_daemon.extract import safe_extract_then_atomic_swap
 from sandbox_daemon.models import SnapshotCreateRequest


### PR DESCRIPTION
## Description

Removes an empty line between the `fastapi` imports and the `sandbox_daemon.*` imports
## How Has This Been Tested?

- `ruff check` clean on the file after the edit.
- CI on this PR will exercise the same `prek run --all-files` invocation that failed in the merge queue.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)