### PR TITLE
chore(devtools): replace npm with bun in ods

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -222,7 +222,7 @@ ods backend model_server --port 9001
 
 ### `web` - Run Frontend Scripts
 
-Run npm scripts from `web/package.json` without manually changing directories.
+Run bun scripts from `web/package.json` without manually changing directories.
 
 ```shell
 ods web <script> [args...]
@@ -248,7 +248,7 @@ ods web test --watch
 
 Manage the Onyx devcontainer. Also available as `ods dc`.
 
-Requires the [devcontainer CLI](https://github.com/devcontainers/cli) (`npm install -g @devcontainers/cli`).
+Requires the [devcontainer CLI](https://github.com/devcontainers/cli) (`bun install -g @devcontainers/cli`).
 
 ```shell
 ods dev <subcommand>
@@ -276,7 +276,7 @@ ods dev up
 ods dev into
 
 # Run a command
-ods dev exec -- npm test
+ods dev exec -- bun test
 
 # Restart the container
 ods dev restart

--- a/tools/ods/cmd/dev_exec.go
+++ b/tools/ods/cmd/dev_exec.go
@@ -12,7 +12,7 @@ func newDevExecCommand() *cobra.Command {
 All arguments are treated as positional (flags like -it are passed through).
 
 Examples:
-  ods dev exec npm test
+  ods dev exec bun test
   ods dev exec -- ls -la
   ods dev exec -it echo hello`,
 		Args:               cobra.MinimumNArgs(1),

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -58,7 +58,7 @@ func devcontainerImage() string {
 // checkDevcontainerCLI ensures the devcontainer CLI is installed.
 func checkDevcontainerCLI() {
 	if _, err := exec.LookPath("devcontainer"); err != nil {
-		log.Fatal("devcontainer CLI is not installed. Install it with: npm install -g @devcontainers/cli")
+		log.Fatal("devcontainer CLI is not installed. Install it with: bun install -g @devcontainers/cli")
 	}
 }
 

--- a/tools/ods/cmd/trace.go
+++ b/tools/ods/cmd/trace.go
@@ -514,7 +514,7 @@ func parseTraceSelection(input string, max int) []int {
 }
 
 // openTraces opens the selected traces with playwright show-trace,
-// running npx from the web/ directory to use the project's Playwright version.
+// running bunx from the web/ directory to use the project's Playwright version.
 func openTraces(traces []traceInfo) {
 	tracePaths := make([]string, len(traces))
 	for i, t := range traces {
@@ -524,7 +524,7 @@ func openTraces(traces []traceInfo) {
 	args := append([]string{"playwright", "show-trace"}, tracePaths...)
 
 	log.Infof("Opening %d trace(s) with playwright show-trace...", len(traces))
-	cmd := exec.Command("npx", args...)
+	cmd := exec.Command("bunx", args...)
 
 	// Run from web/ to pick up the locally-installed Playwright version
 	if root, err := paths.GitRoot(); err == nil {
@@ -543,7 +543,7 @@ func openTraces(traces []traceInfo) {
 			log.Debugf("playwright exited with code %d", exitErr.ExitCode())
 			return
 		}
-		log.Errorf("playwright show-trace failed: %v\nMake sure Playwright is installed (npx playwright install)", err)
+		log.Errorf("playwright show-trace failed: %v\nMake sure Playwright is installed (bunx playwright install)", err)
 	}
 }
 

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -69,6 +69,7 @@ func runWebScript(args []string) {
 
 	bunArgs := []string{"run", scriptName}
 	if len(scriptArgs) > 0 {
+		// bun requires "--" to forward flags to the underlying script.
 		bunArgs = append(bunArgs, "--")
 		bunArgs = append(bunArgs, scriptArgs...)
 	}

--- a/tools/ods/cmd/web.go
+++ b/tools/ods/cmd/web.go
@@ -20,11 +20,11 @@ type webPackageJSON struct {
 	Scripts map[string]string `json:"scripts"`
 }
 
-// NewWebCommand creates a command that runs npm scripts from the web directory.
+// NewWebCommand creates a command that runs bun scripts from the web directory.
 func NewWebCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "web <script> [args...]",
-		Short: "Run web/package.json npm scripts",
+		Short: "Run web/package.json bun scripts",
 		Long:  webHelpDescription(),
 		Args: cobra.MinimumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -50,14 +50,14 @@ func runWebScript(args []string) {
 
 	nodeModules := filepath.Join(webDir, "node_modules")
 	if _, err := os.Stat(nodeModules); os.IsNotExist(err) {
-		log.Info("node_modules not found, running npm install --no-save...")
-		installCmd := exec.Command("npm", "install", "--no-save")
+		log.Info("node_modules not found, running bun install --frozen-lockfile...")
+		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
 		installCmd.Dir = webDir
 		installCmd.Stdout = os.Stdout
 		installCmd.Stderr = os.Stderr
 		installCmd.Stdin = os.Stdin
 		if err := installCmd.Run(); err != nil {
-			log.Fatalf("Failed to run npm install: %v", err)
+			log.Fatalf("Failed to run bun install: %v", err)
 		}
 	}
 
@@ -67,15 +67,14 @@ func runWebScript(args []string) {
 		scriptArgs = scriptArgs[1:]
 	}
 
-	npmArgs := []string{"run", scriptName}
+	bunArgs := []string{"run", scriptName}
 	if len(scriptArgs) > 0 {
-		// npm requires "--" to forward flags to the underlying script.
-		npmArgs = append(npmArgs, "--")
-		npmArgs = append(npmArgs, scriptArgs...)
+		bunArgs = append(bunArgs, "--")
+		bunArgs = append(bunArgs, scriptArgs...)
 	}
-	log.Debugf("Running in %s: npm %v", webDir, npmArgs)
+	log.Debugf("Running in %s: bun %v", webDir, bunArgs)
 
-	webCmd := exec.Command("npm", npmArgs...)
+	webCmd := exec.Command("bun", bunArgs...)
 	webCmd.Dir = webDir
 	webCmd.Stdout = os.Stdout
 	webCmd.Stderr = os.Stderr
@@ -90,7 +89,7 @@ func runWebScript(args []string) {
 				os.Exit(code)
 			}
 		}
-		log.Fatalf("Failed to run npm: %v", err)
+		log.Fatalf("Failed to run bun: %v", err)
 	}
 }
 
@@ -109,7 +108,7 @@ func webScriptNames() []string {
 }
 
 func webHelpDescription() string {
-	description := `Run npm scripts from web/package.json.
+	description := `Run bun scripts from web/package.json.
 
 Examples:
   ods web dev


### PR DESCRIPTION
## Summary
- Updates `ods web` to use `bun install --frozen-lockfile` and `bun run` (web/ migrated to bun, has `bun.lock`).
- Switches `ods trace` from `npx playwright show-trace` to `bunx playwright show-trace`.
- Updates `ods dev exec` example and the `devcontainer` CLI install hint to bun.
- `ods desktop` is intentionally untouched — `desktop/` still ships a `package-lock.json` and its README still uses npm.

## Test plan
- [ ] `go build ./...` in `tools/ods/` succeeds.
- [ ] `ods web dev` and `ods web lint` run via bun against a fresh `node_modules`.
- [ ] `ods trace --list` against a recent run still works (bunx playwright resolves from `web/`).
- [ ] `ods --help` / `ods web --help` text reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches ODS dev tools from `npm` to `bun` for the `web/` workspace to align with the frontend migration. Keeps `desktop/` on `npm`.

- **Refactors**
  - `ods web` runs `bun install --frozen-lockfile` and `bun run`.
  - `ods trace` uses `bunx playwright show-trace` and updates the error hint to `bunx playwright install`.
  - `ods dev exec` examples and the devcontainer CLI install hint now use `bun` (`bun install -g @devcontainers/cli`).
  - README and help text updated to reference `bun`; `ods desktop` unchanged.

<sup>Written for commit eb58164725188eff5919e3659065cccd25e02d75. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

