### PR TITLE
chore(dev): use bun for Web Server launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -112,7 +112,7 @@
       "type": "node",
       "request": "launch",
       "cwd": "${workspaceRoot}/web",
-      "runtimeExecutable": "npm",
+      "runtimeExecutable": "bun",
       "envFile": "${workspaceFolder}/.vscode/.env.web",
       "runtimeArgs": [
         "run",


### PR DESCRIPTION
## Description

We migrated `web/` from npm to bun. Update the VS Code "Web Server" launch config to invoke `bun run dev` instead of `npm run dev`.

## How Has This Been Tested?

Launched the "Web Server" config in VS Code; dev server starts via bun.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the VS Code Web Server launch to `bun` to match the `web/` migration. The config now runs `bun run dev` instead of `npm run dev`.

<sup>Written for commit 57420b2523667f08b382b895cf811a6488d44de6. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11279?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

