### PR TITLE
chore(dev): add k8s: alembic upgrade head vscode task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -202,6 +202,22 @@
         "panel": "dedicated"
       },
       "problemMatcher": []
+    },
+    {
+      "label": "k8s: alembic upgrade head",
+      "detail": "Run `alembic upgrade head` against the in-cluster Postgres (onyx-pg-rw). Idempotently connects telepresence to kind-onyx-dev so cluster DNS resolves, then loads DB env from .vscode/.env.k8s via python-dotenv.",
+      "type": "process",
+      "command": "bash",
+      "args": [
+        "-c",
+        "set -e; kubectl config get-contexts -o name | grep -qx kind-onyx-dev || { echo 'error: kubectl context kind-onyx-dev not found; run deployment/helm/dev/k8s-up.sh first' >&2; exit 1; }; ENV_FILE=\"${workspaceFolder}/.vscode/.env.k8s\"; [ -f \"$ENV_FILE\" ] || { echo 'error: .vscode/.env.k8s not found; copy .vscode/.env.k8s.template and fill in <REPLACE THIS> values (see docs/dev/local-kubernetes.md).' >&2; exit 1; }; [ -x \"${workspaceFolder}/.venv/bin/python\" ] || { echo 'error: ${workspaceFolder}/.venv/bin/python not found; run `uv sync` first.' >&2; exit 1; }; telepresence connect --context kind-onyx-dev -n onyx; cd \"${workspaceFolder}/backend\" && \"${workspaceFolder}/.venv/bin/python\" -m dotenv -f \"$ENV_FILE\" run -- alembic upgrade head"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
## Description

Adds a `k8s: alembic upgrade head` VS Code task so migrations against the in-cluster Postgres (kind-onyx-dev) are one click instead of a multi-step shell ritual.

The task:
- Verifies the `kind-onyx-dev` kubectl context exists and `.vscode/.env.k8s` is present (same preflight pattern as `k8s: telepresence intercept api_server`).
- Idempotently runs `telepresence connect --context kind-onyx-dev -n onyx` so the cluster DNS bridge is up and `onyx-pg-rw` resolves.
- Runs `alembic upgrade head` from `backend/` with env loaded from `.vscode/.env.k8s` via `python-dotenv` (same pattern used for tests in `CLAUDE.md`). `POSTGRES_HOST=onyx-pg-rw` etc. are already in `.env.k8s.template`, so no new env wiring is needed.

Pairs with a personal `kauh` shell alias (dotfiles, not in this PR) that mirrors `auh` for the local docker-compose flow.

## How Has This Been Tested?

- JSON parse check on `tasks.json`.
- Bash arg string was pattern-matched against the existing `k8s: telepresence intercept api_server` task (same context-pin + preflight idiom).
- Not yet run end-to-end through VS Code's task runner — verifying that is the main thing to confirm on review.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a VS Code task to run `alembic upgrade head` against the in-cluster Postgres in `kind-onyx-dev` with one click. It auto-connects `telepresence`, loads env from `.vscode/.env.k8s`, and runs the migration from `backend/`.

- **New Features**
  - Verifies `kind-onyx-dev` context, `.vscode/.env.k8s`, and `.venv/bin/python` exist before running.
  - Idempotently runs `telepresence connect --context kind-onyx-dev -n onyx` so `onyx-pg-rw` resolves.
  - Executes `alembic upgrade head` using `python-dotenv` to load DB env from `.vscode/.env.k8s`.

<sup>Written for commit 622d9d851af0fc37f121857c3005089c7099b017. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

