### PR TITLE
ci(craft): enable snapshot tests in ci

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -17,6 +17,8 @@ on:
       - "backend/onyx/server/features/build/sandbox/**"
       - "backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py"
       - "backend/tests/external_dependency_unit/craft/test_bun_node_modules_dedup.py"
+      - "backend/tests/external_dependency_unit/craft/test_snapshot_restore.py"
+      - "backend/tests/external_dependency_unit/craft/test_idle_cleanup.py"
       - ".github/workflows/pr-craft-k8s-tests.yml"
       - ".github/actions/setup-python-and-install-dependencies/**"
       - "deployment/docker_compose/docker-compose.yml"
@@ -290,7 +292,9 @@ jobs:
             --log-cli-level=INFO \
             --log-cli-format='%(asctime)s %(levelname)s %(name)s:%(funcName)s:%(lineno)d %(message)s' \
             backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py \
-            backend/tests/external_dependency_unit/craft/test_bun_node_modules_dedup.py
+            backend/tests/external_dependency_unit/craft/test_bun_node_modules_dedup.py \
+            backend/tests/external_dependency_unit/craft/test_snapshot_restore.py \
+            backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
 
       - name: Disk and docker status on failure
         if: failure()

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1666,18 +1666,15 @@ echo "Session cleanup complete"
         opencode_json_escaped = opencode_json.replace("'", "'\\''")
         agent_instructions_escaped = agent_instructions.replace("'", "'\\''")
 
+        # Snapshot tar only carries outputs/, attachments/, .opencode-data/ —
+        # re-link the managed-tree symlinks that setup_session_workspace creates.
         config_script = f"""
 set -e
-
-# Write agent instructions
-echo "Writing AGENTS.md"
+mkdir -p {session_path}/.opencode
+ln -sfn /workspace/managed/skills {session_path}/.opencode/skills
+ln -sfn /workspace/managed/user_library {session_path}/user_library
 printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
-
-# Write opencode config
-echo "Writing opencode.json"
 printf '%s' '{opencode_json_escaped}' > {session_path}/opencode.json
-
-echo "Session config regeneration complete"
 """
 
         logger.info("Regenerating session configuration files")

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
@@ -15,6 +15,7 @@ Per project memory: never run these locally — they touch the real cluster.
 from __future__ import annotations
 
 import io
+import os
 import tarfile
 from pathlib import Path
 from typing import Any
@@ -103,8 +104,24 @@ def _s3_client() -> Any:
 
     The K8s manager bypasses the FileStore for snapshots and uses AWS CLI
     in-pod, so the test verifies via boto3 directly against the same bucket.
+
+    In CI the in-pod sidecar talks to MinIO via the cluster-internal DNS
+    name (``AWS_ENDPOINT_URL`` env), but the test process runs on the host
+    and must use the host-accessible endpoint exposed by docker-compose
+    (``S3_ENDPOINT_URL``). Construct the client explicitly so it doesn't
+    inherit the in-cluster endpoint from ``AWS_ENDPOINT_URL``.
     """
-    return boto3.client("s3")
+    endpoint_url = os.environ.get("S3_ENDPOINT_URL")
+    access_key = os.environ.get("S3_AWS_ACCESS_KEY_ID")
+    secret_key = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
+    region = os.environ.get("AWS_REGION") or "us-east-1"
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+    )
 
 
 def _download_snapshot(storage_path: str, dest: Path) -> None:

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
@@ -219,11 +219,15 @@ def test_snapshot_excludes_managed_skills_agents_md_opencode_json(
 
     members = _list_archive_members(archive)
     # AGENTS.md, opencode.json live at the session root — they must not be
-    # captured. Likewise the .opencode/skills symlink (which targets
+    # captured. Match the session-root path only (the snapshot tars from the
+    # session dir, so the root would show up as ``AGENTS.md`` or
+    # ``./AGENTS.md``). The scaffolded Next.js project under outputs/web/
+    # ships its own AGENTS.md which is legitimate user code and must remain.
+    # Likewise the .opencode/skills symlink (which targets
     # /workspace/managed/skills) must not leak the managed tree.
     for forbidden in ("AGENTS.md", "opencode.json"):
-        assert not any(m.endswith(forbidden) for m in members), (
-            f"{forbidden} must not appear in snapshot. Members: {members}"
+        assert not any(m in (forbidden, f"./{forbidden}") for m in members), (
+            f"{forbidden} must not appear at snapshot root. Members: {members}"
         )
     assert not any("managed/skills" in m for m in members), (
         f"managed/skills/* must not appear in snapshot. Members: {members}"


### PR DESCRIPTION
## Description

Enables 14 dormant K8s-gated snapshot/cleanup tests in the `pr-craft-k8s-tests` lane (`test_snapshot_restore.py` × 8 + `test_idle_cleanup.py` × 6). These exercise `create_snapshot` / `restore_snapshot` via the sandbox sidecar's `aws s3 cp`; the sidecar S3 credentials are now plumbed through, so this is the first run.

Enabling the suite surfaced three issues, fixed here:

1. **`fix(craft): point snapshot test S3 client at host MinIO endpoint`** — `_s3_client()` in `test_snapshot_restore.py` called bare `boto3.client("s3")`, which inherited `AWS_ENDPOINT_URL=http://minio.onyx-sandboxes.svc.cluster.local:9000` (set for the in-pod sidecar). That DNS doesn't resolve from the runner host. Now constructs the client explicitly from `S3_ENDPOINT_URL` / `S3_AWS_*` (host-accessible MinIO on `localhost:9004`).
2. **`fix(craft): scope AGENTS.md/opencode.json exclusion to session root`** — `test_snapshot_excludes_managed_skills_agents_md_opencode_json` asserted `m.endswith("AGENTS.md")`, which matched the legitimate `outputs/web/AGENTS.md` from the Next.js scaffold the sandbox initializes. Tightened to the session-root path only (`AGENTS.md` or `./AGENTS.md`), matching the test's stated intent.
3. **`fix(craft): recreate managed-tree symlinks after K8s snapshot restore`** — real product bug. `cleanup_session_workspace` does `rm -rf` on the session dir, and the snapshot tar only carries `outputs/`, `attachments/`, `.opencode-data/`. After a restore the `.opencode/skills` and `user_library` symlinks were missing, so subsequent `push_to_sandbox` calls landed skill files in the managed tree without the session-side view resolving to them. `_regenerate_session_config` now re-links both, matching the docker backend.

## How Has This Been Tested?

`craft-k8s-tests` green on this PR (run [26256800180](https://github.com/onyx-dot-app/onyx/actions/runs/26256800180), 14m22s) — the full re-enabled suite runs end-to-end against the kind cluster.

Audited the other re-enabled tests (`test_kubernetes_sandbox.py`, `test_bun_node_modules_dedup.py`, `test_idle_cleanup.py`) for the same failure shapes (S3 endpoint inheritance, over-broad assertions, missing restore-side state). None had additional issues — the bun tests round-trip through `restore_snapshot` so they passively cover the symlink fix.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
