### PR TITLE
fix: confluence pagination limit

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -304,6 +304,10 @@ class OnyxConfluence:
             data = response.json()
 
             results = data.get("results", [])
+            # Confluence DC silently caps the page size
+            # at the admin-configured maximum (often 25-500) when the requested
+            # limit exceeds it, while still leaving more spaces to fetch.
+            # we only exit when no results are returned.
             if not results:
                 return
 
@@ -312,8 +316,6 @@ class OnyxConfluence:
             if is_v2:
                 url = data.get("_links", {}).get("next", "")
             else:
-                if len(results) < limit:
-                    return
                 start += len(results)
                 url = self._build_spaces_url(is_v2, base_url, limit, space_keys, start)
 

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -292,7 +292,33 @@ class OnyxConfluence:
         limit: int,
         space_keys: list[str] | None,
     ) -> Iterator[dict[str, Any]]:
-        """Internal helper to paginate through spaces for a specific API endpoint."""
+        """Internal helper to paginate through spaces for a specific API endpoint.
+
+        Server/v1 termination rules (they interact):
+
+        1. Stop when ``_links.next`` is absent. Per Atlassian's docs this
+           is the canonical end-of-pagination signal. Do NOT stop just
+           because ``len(results) < limit``: ``/rest/api/space`` on
+           Server/DC has a fixed code-level page-size cap (currently
+           ``DefaultRestSpaceManager.MAX_SIZE = 50``; not exposed in the
+           admin UI) and silently caps responses to that value when the
+           requested ``limit`` exceeds it (#4129). A capped page is not
+           the end-of-list. Treating it as such caused permission sync
+           to miss every space past the cap and crash with "No external
+           access found for document ID".
+
+        2. Re-derive ``start`` from ``previous_start + len(results)``
+           instead of honoring the ``start`` Confluence embeds in
+           ``_links.next``. The embedded ``start`` under-counts when the
+           page is capped (#4129), and on DC 8.5.8 / 7.19.21 / 8.9.0
+           (CONFSERVER-95272 / -95312) ``start`` past the true total
+           still returns records instead of empty, so we cannot trust
+           the server's offset bookkeeping there either.
+
+        3. Empty ``results`` is kept as a defensive safety net for the
+           known Confluence bug where ``_links.next`` is set but
+           ``results`` is empty.
+        """
         start = 0
         url = self._build_spaces_url(
             is_v2, base_url, limit, space_keys, start if not is_v2 else None
@@ -304,17 +330,17 @@ class OnyxConfluence:
             data = response.json()
 
             results = data.get("results", [])
-            # Confluence DC silently caps the page size
-            # at the admin-configured maximum (often 25-500) when the requested
-            # limit exceeds it, while still leaving more spaces to fetch.
-            # we only exit when no results are returned.
             if not results:
                 return
 
             yield from results
 
+            next_link = data.get("_links", {}).get("next", "")
+            if not next_link:
+                return
+
             if is_v2:
-                url = data.get("_links", {}).get("next", "")
+                url = next_link
             else:
                 start += len(results)
                 url = self._build_spaces_url(is_v2, base_url, limit, space_keys, start)

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1032,9 +1032,10 @@ def test_retrieve_confluence_spaces_server_paginates_past_capped_page(
     turn breaks ``get_all_space_permissions`` and crashes
     ``generic_doc_sync`` with "No external access found for document ID".
 
-    Here we request limit=5000 but the server returns 3 spaces per page
-    (its real cap), with a real end-of-data signaled only by an empty
-    final page.
+    Here we request limit=5000 but the server caps responses at 3 per
+    page. The real end-of-data is signaled by ``_links.next`` being
+    absent on the last data-bearing page (the canonical Atlassian
+    contract).
     """
     requested_limit = 5000
     server_cap = 3
@@ -1058,11 +1059,22 @@ def test_retrieve_confluence_spaces_server_paginates_past_capped_page(
             start = int(path.split(start_token, 1)[1].split("&", 1)[0])
 
         keys_on_page = all_keys[start : start + server_cap]
+        has_more = (start + server_cap) < len(all_keys)
+        # Atlassian's canonical end-of-pagination signal: emit
+        # ``_links.next`` only when more data follows. The loop must
+        # terminate when this is absent -- NOT when
+        # ``len(results) < limit``.
+        links: dict[str, str] = {}
+        if has_more:
+            links["next"] = (
+                f"/rest/api/space?limit={requested_limit}&start={start + server_cap}"
+            )
         return _create_mock_response(
             200,
             {
                 "results": [{"key": k} for k in keys_on_page],
                 "size": len(keys_on_page),
+                "_links": links,
             },
             url=path,
         )
@@ -1076,12 +1088,61 @@ def test_retrieve_confluence_spaces_server_paginates_past_capped_page(
     )
 
     assert [s["key"] for s in returned] == all_keys
-    # The loop must keep paginating across capped pages until it gets an
-    # empty page from the server. With 8 keys and a 3-per-page server cap,
-    # that's pages at start=0/3/6 returning data, then start=8 returning
-    # empty -> 4 total calls.
-    assert len(mock_get_call_paths) == 4
+    # 8 keys / 3 per page = 3 data pages. The third response carries no
+    # ``_links.next``, so we must NOT make a fourth probe call.
+    assert len(mock_get_call_paths) == 3
     assert all(f"limit={requested_limit}" in p for p in mock_get_call_paths)
+
+
+def test_retrieve_confluence_spaces_server_stops_when_next_link_absent(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """
+    Regression test for CONFSERVER-95272 / CONFSERVER-95312 (DC 8.5.8,
+    7.19.21, 8.9.0): when ``start`` exceeds the true total,
+    ``rest/api/space`` keeps returning records instead of an empty page.
+    A loop that terminated only on empty ``results`` would run unbounded
+    on these versions.
+
+    We must honor ``_links.next`` absence as the canonical end signal.
+    This test simulates the bug -- every call returns a record -- and
+    confirms that absence of ``_links.next`` is enough to stop the
+    loop after a finite number of calls.
+    """
+    mock_get_call_paths: list[str] = []
+    page_counter = {"n": 0}
+
+    def get_side_effect(
+        path: str,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        path = path.strip("/")
+        mock_get_call_paths.append(path)
+        page_counter["n"] += 1
+        is_first_page = page_counter["n"] == 1
+        return _create_mock_response(
+            200,
+            {
+                "results": [{"key": f"SPACE{page_counter['n']}"}],
+                "size": 1,
+                "_links": (
+                    {"next": "/rest/api/space?limit=5000&start=1"}
+                    if is_first_page
+                    else {}
+                ),
+            },
+            url=path,
+        )
+
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    returned = list(confluence_server_client.retrieve_confluence_spaces(limit=5000))
+
+    assert [s["key"] for s in returned] == ["SPACE1", "SPACE2"]
+    assert len(mock_get_call_paths) == 2
 
 
 def test_jsonrpc_websudo_html_response_raises_validation_error(

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1020,6 +1020,70 @@ def test_paginate_url_504_halves_multiple_times(
     assert "limit=5" in mock_get_call_paths[3]
 
 
+def test_retrieve_confluence_spaces_server_paginates_past_capped_page(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """
+    Regression test for #4129: Confluence Server/DC silently caps
+    ``rest/api/space`` page size at the admin-configured maximum when the
+    requested ``limit`` is larger. The pagination loop must NOT terminate
+    just because ``len(results) < requested_limit`` -- doing so causes
+    spaces beyond the cap to be invisible to permission sync, which in
+    turn breaks ``get_all_space_permissions`` and crashes
+    ``generic_doc_sync`` with "No external access found for document ID".
+
+    Here we request limit=5000 but the server returns 3 spaces per page
+    (its real cap), with a real end-of-data signaled only by an empty
+    final page.
+    """
+    requested_limit = 5000
+    server_cap = 3
+    all_keys = ["AAA", "BBB", "CCC", "DDD", "EEE", "FFF", "GGG", "HHH"]
+
+    mock_get_call_paths: list[str] = []
+
+    def get_side_effect(
+        path: str,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        path = path.strip("/")
+        mock_get_call_paths.append(path)
+
+        # Honor whatever ``start`` the loop asks for; default 0 on the
+        # initial call (no start param).
+        start_token = "start="
+        start = 0
+        if start_token in path:
+            start = int(path.split(start_token, 1)[1].split("&", 1)[0])
+
+        keys_on_page = all_keys[start : start + server_cap]
+        return _create_mock_response(
+            200,
+            {
+                "results": [{"key": k} for k in keys_on_page],
+                "size": len(keys_on_page),
+            },
+            url=path,
+        )
+
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    returned = list(
+        confluence_server_client.retrieve_confluence_spaces(limit=requested_limit)
+    )
+
+    assert [s["key"] for s in returned] == all_keys
+    # The loop must keep paginating across capped pages until it gets an
+    # empty page from the server. With 8 keys and a 3-per-page server cap,
+    # that's pages at start=0/3/6 returning data, then start=8 returning
+    # empty -> 4 total calls.
+    assert len(mock_get_call_paths) == 4
+    assert all(f"limit={requested_limit}" in p for p in mock_get_call_paths)
+
+
 def test_jsonrpc_websudo_html_response_raises_validation_error(
     confluence_server_client: OnyxConfluence,
 ) -> None:


### PR DESCRIPTION
## Description

Confluence server silently ignores your pagination limit requests, which was causing us to miss spaces during our paginated request to that endpoint. We're switching over to _links.next existing which should be a correct condition across confluence versions.

## How Has This Been Tested?

Added unit test

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Confluence Server/DC space pagination by relying on `_links.next` instead of page size, ensuring we don’t miss spaces and preventing downstream permission sync failures.

- **Bug Fixes**
  - Stop pagination only when `_links.next` is absent; do not use `len(results) < limit`.
  - For v1 endpoints, compute `start` as previous `start + len(results)` instead of trusting server-provided offsets.
  - Added regression tests for capped page sizes and for endpoints that omit `_links.next`.

<sup>Written for commit 715e3741272dd2fb144ea1ac8f644b32c7e9ee36. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11284?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

