### PR TITLE
fix(chat): cache failed plaintext extractions to stop S3 re-fetch storm (#11268) to release v3.2

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -366,10 +366,15 @@ def _get_or_extract_plaintext(
     except Exception:
         logger.exception(f"Error when reading file, id={file_id}")
 
-    # Cache miss — extract and store.
+    # Cache miss — extract and store.  We cache the result unconditionally
+    # (including the empty string) so that files we cannot extract text from
+    # (e.g. .zip, or any extension without a handler in extract_file_text)
+    # don't get re-fetched from object storage and re-attempted on every
+    # subsequent chat turn.  Transient extraction errors surface as raised
+    # exceptions, not empty returns, so they propagate without poisoning the
+    # cache.
     content_text = extract_fn()
-    if content_text:
-        store_plaintext(file_id, content_text)
+    store_plaintext(file_id, content_text)
     return content_text
 
 

--- a/backend/onyx/file_store/utils.py
+++ b/backend/onyx/file_store/utils.py
@@ -34,14 +34,13 @@ def store_plaintext(file_id: str, plaintext_content: str) -> bool:
 
     Args:
         file_id: The ID of the file (user_file or artifact_file)
-        plaintext_content: The plaintext content to store
+        plaintext_content: The plaintext content to store (may be the empty
+            string, which is still cached so that files we cannot extract
+            text from don't get re-attempted on every retrieval)
 
     Returns:
         bool: True if storage was successful, False otherwise
     """
-    if not plaintext_content:
-        return False
-
     plaintext_file_name = plaintext_file_name_for_id(file_id)
     try:
         file_store = get_default_file_store()
@@ -110,6 +109,15 @@ def load_user_file(file_id: UUID, db_session: Session) -> InMemoryChatFile:
     # check for plain text normalized version first, then use original file otherwise
     try:
         file_io = file_store.read_file(plaintext_file_name, mode="b")
+        plaintext_bytes = file_io.read()
+        # An empty plaintext entry is a "we tried and there is no text"
+        # sentinel written by `_get_or_extract_plaintext` / `store_plaintext`
+        # for unprocessable files (e.g. .zip).  Treat it as a cache miss
+        # here so downstream tools (code interpreter, file reader) still
+        # receive the original bytes instead of an empty file.
+        if not plaintext_bytes:
+            raise ValueError("plaintext cache entry is empty; falling back to original")
+
         # Metadata-only file types preserve their original type so
         # downstream injection paths can route them correctly.
         if chat_file_type.use_metadata_only():
@@ -127,7 +135,7 @@ def load_user_file(file_id: UUID, db_session: Session) -> InMemoryChatFile:
 
         chat_file = InMemoryChatFile(
             file_id=str(user_file.file_id),
-            content=file_io.read(),
+            content=plaintext_bytes,
             file_type=plaintext_chat_file_type,
             filename=user_file.name,
         )

--- a/backend/tests/unit/onyx/chat/test_chat_utils.py
+++ b/backend/tests/unit/onyx/chat/test_chat_utils.py
@@ -1,8 +1,11 @@
 """Tests for chat_utils.py, specifically get_custom_agent_prompt."""
 
+from io import BytesIO
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from onyx.chat.chat_utils import _build_tool_call_response_history_message
+from onyx.chat.chat_utils import _get_or_extract_plaintext
 from onyx.chat.chat_utils import get_custom_agent_prompt
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.prompts.chat_prompts import TOOL_CALL_RESPONSE_CROSS_MESSAGE
@@ -170,3 +173,65 @@ class TestBuildToolCallResponseHistoryMessage:
             tool_call_response='{"raw":"value"}',
         )
         assert message == TOOL_CALL_RESPONSE_CROSS_MESSAGE
+
+
+class TestGetOrExtractPlaintext:
+    """Tests for the plaintext extraction cache used by chat file loading."""
+
+    def test_cache_hit_skips_extraction(self) -> None:
+        file_store = MagicMock()
+        file_store.read_file.return_value = BytesIO(b"cached text")
+        extract_fn = MagicMock(return_value="should not be called")
+
+        with (
+            patch(
+                "onyx.chat.chat_utils.get_default_file_store",
+                return_value=file_store,
+            ),
+            patch("onyx.chat.chat_utils.store_plaintext") as store_plaintext,
+        ):
+            result = _get_or_extract_plaintext("file-1", extract_fn)
+
+        assert result == "cached text"
+        extract_fn.assert_not_called()
+        store_plaintext.assert_not_called()
+
+    def test_cache_miss_stores_extracted_text(self) -> None:
+        file_store = MagicMock()
+        file_store.read_file.side_effect = RuntimeError("not in store")
+        extract_fn = MagicMock(return_value="extracted text")
+
+        with (
+            patch(
+                "onyx.chat.chat_utils.get_default_file_store",
+                return_value=file_store,
+            ),
+            patch("onyx.chat.chat_utils.store_plaintext") as store_plaintext,
+        ):
+            result = _get_or_extract_plaintext("file-2", extract_fn)
+
+        assert result == "extracted text"
+        extract_fn.assert_called_once()
+        store_plaintext.assert_called_once_with("file-2", "extracted text")
+
+    def test_cache_miss_caches_empty_extraction(self) -> None:
+        """Files extract_file_text cannot process (e.g. .zip) return "".
+        We must still cache that result so we don't re-fetch the file from
+        object storage on every subsequent chat turn.
+        """
+        file_store = MagicMock()
+        file_store.read_file.side_effect = RuntimeError("not in store")
+        extract_fn = MagicMock(return_value="")
+
+        with (
+            patch(
+                "onyx.chat.chat_utils.get_default_file_store",
+                return_value=file_store,
+            ),
+            patch("onyx.chat.chat_utils.store_plaintext") as store_plaintext,
+        ):
+            result = _get_or_extract_plaintext("file-3", extract_fn)
+
+        assert result == ""
+        extract_fn.assert_called_once()
+        store_plaintext.assert_called_once_with("file-3", "")

--- a/backend/tests/unit/onyx/file_store/test_store_plaintext.py
+++ b/backend/tests/unit/onyx/file_store/test_store_plaintext.py
@@ -1,0 +1,132 @@
+"""Tests for store_plaintext caching behavior in file_store.utils."""
+
+from io import BytesIO
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from onyx.file_store.models import ChatFileType
+from onyx.file_store.utils import load_user_file
+from onyx.file_store.utils import store_plaintext
+
+_UTILS_MODULE = "onyx.file_store.utils"
+
+
+@patch(f"{_UTILS_MODULE}.get_default_file_store")
+def test_store_plaintext_persists_non_empty_content(
+    mock_get_file_store: MagicMock,
+) -> None:
+    file_store = MagicMock()
+    mock_get_file_store.return_value = file_store
+
+    assert store_plaintext("file-1", "hello world") is True
+
+    file_store.save_file.assert_called_once()
+    assert file_store.save_file.call_args.kwargs["file_id"] == "plaintext_file-1"
+
+
+@patch(f"{_UTILS_MODULE}.get_default_file_store")
+def test_store_plaintext_persists_empty_content(
+    mock_get_file_store: MagicMock,
+) -> None:
+    """Empty content must be cached too: it marks unprocessable files
+    (e.g. .zip) so subsequent chat turns don't re-fetch and re-attempt
+    extraction. See _get_or_extract_plaintext in onyx/chat/chat_utils.py.
+    """
+    file_store = MagicMock()
+    mock_get_file_store.return_value = file_store
+
+    assert store_plaintext("file-2", "") is True
+
+    file_store.save_file.assert_called_once()
+    assert file_store.save_file.call_args.kwargs["file_id"] == "plaintext_file-2"
+
+
+@patch(f"{_UTILS_MODULE}.get_default_file_store")
+def test_store_plaintext_returns_false_on_save_failure(
+    mock_get_file_store: MagicMock,
+) -> None:
+    file_store = MagicMock()
+    file_store.save_file.side_effect = RuntimeError("boom")
+    mock_get_file_store.return_value = file_store
+
+    assert store_plaintext("file-3", "data") is False
+
+
+def _build_load_user_file_mocks(
+    *,
+    plaintext_bytes: bytes,
+    original_bytes: bytes,
+    file_mime: str = "application/zip",
+) -> tuple[MagicMock, MagicMock, MagicMock]:
+    """Shared setup for load_user_file tests.
+
+    Returns (file_store, db_session, user_file) so individual tests can adjust
+    side effects.  The file_store is wired so the first read_file call returns
+    the plaintext bytes and the second returns the original bytes.
+    """
+    user_file_id = uuid4()
+    user_file = MagicMock()
+    user_file.id = user_file_id
+    user_file.file_id = f"original-{user_file_id}"
+    user_file.name = "thing.zip"
+
+    db_session = MagicMock()
+    db_session.query.return_value.filter.return_value.first.return_value = user_file
+
+    file_record = MagicMock()
+    file_record.file_type = file_mime
+    file_record.display_name = "thing.zip"
+
+    file_store = MagicMock()
+    file_store.read_file_record.return_value = file_record
+    file_store.read_file.side_effect = [
+        BytesIO(plaintext_bytes),
+        BytesIO(original_bytes),
+    ]
+
+    return file_store, db_session, user_file
+
+
+@patch(f"{_UTILS_MODULE}.get_default_file_store")
+def test_load_user_file_empty_plaintext_falls_back_to_original_bytes(
+    mock_get_file_store: MagicMock,
+) -> None:
+    """An empty plaintext cache entry (written for unprocessable files like
+    .zip) must NOT be returned to downstream tools.  load_user_file should
+    fall through to the original-bytes path so code interpreter and file
+    reader still receive the real file content.
+    """
+    # Use an image mime type so the fallback path's chat_file_type is
+    # distinguishable from PLAIN_TEXT (the type that would be set on the
+    # cache-hit branch).  This makes the regression observable in both
+    # `content` AND `file_type`.
+    file_store, db_session, user_file = _build_load_user_file_mocks(
+        plaintext_bytes=b"",
+        original_bytes=b"\x89PNG\r\n\x1a\n-fake-png",
+        file_mime="image/png",
+    )
+    mock_get_file_store.return_value = file_store
+
+    chat_file = load_user_file(user_file.id, db_session)
+
+    assert chat_file.content == b"\x89PNG\r\n\x1a\n-fake-png"
+    # Original chat file type is preserved on fallback.
+    assert chat_file.file_type == ChatFileType.IMAGE
+
+
+@patch(f"{_UTILS_MODULE}.get_default_file_store")
+def test_load_user_file_non_empty_plaintext_used_as_is(
+    mock_get_file_store: MagicMock,
+) -> None:
+    file_store, db_session, user_file = _build_load_user_file_mocks(
+        plaintext_bytes=b"extracted text",
+        original_bytes=b"should-not-be-read",
+        file_mime="application/pdf",
+    )
+    mock_get_file_store.return_value = file_store
+
+    chat_file = load_user_file(user_file.id, db_session)
+
+    assert chat_file.content == b"extracted text"
+    assert chat_file.file_type == ChatFileType.PLAIN_TEXT


### PR DESCRIPTION
Cherry-pick of commit 9cb5cc71b2484dc426921cc6d1cfa17b9f980b1e to release/v3.2 branch.

Original PR: #11268

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache plaintext extraction results, including empty extractions, to stop repeated S3 fetches on unprocessable files. When the cached plaintext is empty, file loading now falls back to original bytes so downstream tools still get the real file.

- **Bug Fixes**
  - `_get_or_extract_plaintext` stores extracted content unconditionally to cache misses, including empty strings.
  - `store_plaintext` now persists empty content; `load_user_file` treats empty plaintext as a cache miss and returns original bytes while preserving the original `ChatFileType`.
  - Added unit tests for cache hit/miss behavior, empty-result caching, and fallback to original content.

<sup>Written for commit 972862b4d6ea4bca415ae72d4a772cd5fcf4f7f8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11288?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

