### PR TITLE
chore(ci): drop backend image build from integration tests

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7ab71eae-0432-42fc-a3e1-41704faf305d","pid":36,"procStart":"1431056","acquiredAt":1779410580204}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7ab71eae-0432-42fc-a3e1-41704faf305d","pid":36,"procStart":"1431056","acquiredAt":1779410580204}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -99,7 +99,8 @@ RUN BUN_INSTALL=/usr/local bun install -g @anthropic-ai/claude-code@${CLAUDE_COD
 
 # Install opencode CLI for Craft agent functionality. Bun runs it directly,
 # so we don't need a separate Node.js install.
-RUN BUN_INSTALL=/usr/local bun install -g opencode-ai
+ARG OPENCODE_VERSION=latest
+RUN BUN_INSTALL=/usr/local bun install -g opencode-ai@${OPENCODE_VERSION}
 
 # Configure zsh — source the repo-local zshrc so shell customization
 # doesn't require an image rebuild.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ripgrep \
   socat \
   sudo \
+  supervisor \
   unzip \
   wget \
   zsh \
@@ -79,6 +80,10 @@ WORKDIR /workspace
 # Install Claude Code
 ARG CLAUDE_CODE_VERSION=latest
 RUN BUN_INSTALL=/usr/local bun install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+
+# Install opencode CLI for Craft agent functionality. Bun runs it directly,
+# so we don't need a separate Node.js install.
+RUN BUN_INSTALL=/usr/local bun install -g opencode-ai
 
 # Configure zsh — source the repo-local zshrc so shell customization
 # doesn't require an image rebuild.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,18 +52,20 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
-# Playwright doesn't ship Chromium builds for Ubuntu 26.04 yet; tell it
-# to use the Ubuntu 24.04 build instead (binary-compatible glibc).
-# Pinned both at image-build (install-deps below) and at runtime
-# (run-with-backend.sh's `playwright install chromium`).
-ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64
-
 # Install the apt packages Playwright needs to run headless Chromium for
 # the web-search open_url tool. The browser binary itself is downloaded
 # at container start by run-with-backend.sh, so the version always
 # matches the lockfile's playwright-python.
+#
+# Playwright doesn't ship Chromium builds for Ubuntu 26.04 yet, so spoof
+# the host platform to the binary-compatible Ubuntu 24.04 build. Arch
+# is detected from dpkg so both arm64 CI runners and x64 dev machines
+# work; we don't bake the override into ENV because that would leak
+# into interactive dev shells where it might mask real problems.
 RUN apt-get update \
-  && uvx --quiet --from playwright playwright install-deps chromium \
+  && PW_ARCH=$(case $(dpkg --print-architecture) in amd64) echo x64;; arm64) echo arm64;; esac) \
+  && PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-${PW_ARCH} \
+       uvx --quiet --from playwright playwright install-deps chromium \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install Python 3.11 via uv into a stable, image-level path so venvs

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,6 +52,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
+# Playwright doesn't ship Chromium builds for Ubuntu 26.04 yet; tell it
+# to use the Ubuntu 24.04 build instead (binary-compatible glibc).
+# Pinned both at image-build (install-deps below) and at runtime
+# (run-with-backend.sh's `playwright install chromium`).
+ENV PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-arm64
+
 # Install the apt packages Playwright needs to run headless Chromium for
 # the web-search open_url tool. The browser binary itself is downloaded
 # at container start by run-with-backend.sh, so the version always

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,6 +52,14 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
+# Install the apt packages Playwright needs to run headless Chromium for
+# the web-search open_url tool. The browser binary itself is downloaded
+# at container start by run-with-backend.sh, so the version always
+# matches the lockfile's playwright-python.
+RUN apt-get update \
+  && uvx --quiet --from playwright playwright install-deps chromium \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Install Python 3.11 via uv into a stable, image-level path so venvs
 # created in bind-mounted workspaces survive across `docker run`s.
 # Ubuntu 26.04's system Python is 3.14, but onnxruntime only ships

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -430,6 +430,8 @@ jobs:
               -e MOCK_CONNECTOR_SERVER_PORT=8001 \
               -e ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=${{ matrix.edition == 'ee' && 'true' || 'false' }} \
               -e ENABLE_CRAFT=true \
+              -e OUTPUTS_TEMPLATE_PATH=/workspace/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs \
+              -e VENV_TEMPLATE_PATH=/workspace/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv \
               -e ONYX_DEV_LICENSE \
               -e RUN_WITH_BACKEND_MODE=full \
               --entrypoint bash \

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -383,6 +383,7 @@ jobs:
 
             docker run --rm --network onyx_default \
               --name test-runner \
+              --env-file deployment/docker_compose/.env \
               -v ${{ github.workspace }}:/workspace \
               -w /workspace/backend \
               $CLI_VOLUME \
@@ -648,6 +649,10 @@ jobs:
             -e API_SERVER_HOST=127.0.0.1 \
             -e MODEL_SERVER_HOST=inference_model_server \
             -e INDEXING_MODEL_SERVER_HOST=indexing_model_server \
+            -e S3_ENDPOINT_URL=http://minio:9000 \
+            -e S3_AWS_ACCESS_KEY_ID=minioadmin \
+            -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
+            -e S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket \
             -e OPENAI_API_KEY=${OPENAI_API_KEY} \
             -e EXA_API_KEY=${EXA_API_KEY} \
             -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -654,6 +654,7 @@ jobs:
             -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
             -e S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket \
             -e OPENAI_API_KEY=${OPENAI_API_KEY} \
+            -e OPENAI_DEFAULT_API_KEY=${OPENAI_API_KEY} \
             -e EXA_API_KEY=${EXA_API_KEY} \
             -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
             -e SLACK_BOT_TOKEN_TEST_SPACE=${SLACK_BOT_TOKEN_TEST_SPACE} \
@@ -664,6 +665,8 @@ jobs:
             -e REQUIRE_EMAIL_VERIFICATION=false \
             -e DISABLE_TELEMETRY=true \
             -e DEV_MODE=true \
+            -e ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true \
+            -e LICENSE_ENFORCEMENT_ENABLED=false \
             -e RUN_WITH_BACKEND_MODE=full \
             --entrypoint bash \
             ${ECR_CACHE}:integration-test-devcontainer-${RUN_ID} \

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -70,11 +70,13 @@ jobs:
               - 'backend/**'
               - 'cli/**'
               - 'deployment/docker_compose/**'
+              - '.devcontainer/**'
               - 'docker-bake.hcl'
               - 'pyproject.toml'
               - 'uv.lock'
               - '.github/workflows/pr-integration-tests.yml'
               - '.github/actions/setup-test-license/**'
+              - '.github/actions/install-deps-and-generate-openapi-client/**'
 
   discover-test-dirs:
     # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
@@ -120,71 +122,6 @@ jobs:
           else
             echo 'editions=["ee","mit"]' >> $GITHUB_OUTPUT
           fi
-
-  build-backend-image:
-    needs: changes
-    if: needs.changes.outputs.integration == 'true'
-    runs-on:
-      [
-        runs-on,
-        runner=1cpu-linux-arm64,
-        "run-id=${{ github.run_id }}-build-backend-image",
-        "extras=ecr-cache",
-      ]
-    timeout-minutes: 45
-    steps:
-      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Format branch name for cache
-        id: format-branch
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ -n "${PR_NUMBER}" ]; then
-            CACHE_SUFFIX="${PR_NUMBER}"
-          else
-            # shellcheck disable=SC2001
-            CACHE_SUFFIX=$(echo "${REF_NAME}" | sed 's/[^A-Za-z0-9._-]/-/g')
-          fi
-          echo "cache-suffix=${CACHE_SUFFIX}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4
-
-      # needed for pulling Vespa, Redis, Postgres, and Minio images
-      # otherwise, we hit the "Unauthenticated users" limit
-      # https://docs.docker.com/docker-hub/usage/
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and push Backend Docker image
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # ratchet:docker/build-push-action@v7
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: true
-          tags: ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-backend-test-${{ github.run_id }}
-          # Bake Node.js, opencode, and sandbox templates into the image.
-          build-args: |
-            ENABLE_CRAFT=true
-          cache-from: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache-${{ github.event.pull_request.head.sha || github.sha }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache-${{ steps.format-branch.outputs.cache-suffix }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache
-            type=registry,ref=onyxdotapp/onyx-backend:latest
-          cache-to: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache-${{ github.event.pull_request.head.sha || github.sha }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache-${{ steps.format-branch.outputs.cache-suffix }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:backend-cache,mode=max
-          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   build-model-server-image:
     needs: changes
@@ -310,7 +247,6 @@ jobs:
     needs:
       [
         discover-test-dirs,
-        build-backend-image,
         build-model-server-image,
         build-devcontainer-image,
       ]
@@ -367,7 +303,6 @@ jobs:
           POSTGRES_USE_NULL_POOL=true
           REQUIRE_EMAIL_VERIFICATION=false
           DISABLE_TELEMETRY=true
-          ONYX_BACKEND_IMAGE=${ECR_CACHE}:integration-test-backend-test-${RUN_ID}
           ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:integration-test-model-server-test-${RUN_ID}
           INTEGRATION_TESTS_MODE=true
           MCP_SERVER_ENABLED=true
@@ -401,41 +336,9 @@ jobs:
             opensearch \
             cache \
             minio \
-            api_server \
             inference_model_server \
-            indexing_model_server \
-            background
+            indexing_model_server
         id: start_docker
-
-      - name: Verify background worker (supervisord)
-        run: |
-          # --wait above blocks on healthchecks, but the background container
-          # has no healthcheck — verify supervisord-managed Celery workers
-          # are actually up.
-          echo "Checking background worker health..."
-          if ! docker inspect --format='{{.State.Running}}' onyx-background-1 2>/dev/null | grep -q true; then
-            echo "ERROR: Background worker container is not running!"
-            docker logs onyx-background-1 2>&1 | tail -50
-            exit 1
-          fi
-
-          sleep 15  # supervisord startsecs
-
-          FAILED_PROCS=$(docker exec onyx-background-1 \
-            supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status 2>&1 \
-            | grep -E "FATAL|BACKOFF|STOPPED" \
-            | grep -v "slack_bot\|discord_bot\|watchdog" || true)
-          if [ -n "$FAILED_PROCS" ]; then
-            echo "ERROR: Critical background processes failed to start:"
-            echo "$FAILED_PROCS"
-            docker exec onyx-background-1 \
-              supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status
-            docker logs onyx-background-1 2>&1 | tail -80
-            exit 1
-          fi
-          echo "Background worker is healthy — all critical processes running."
-
-          echo "Finished waiting for services."
 
       - name: Start Mock Services
         if: matrix.test-dir.path == 'tests/indexing'
@@ -494,7 +397,7 @@ jobs:
               -e POSTGRES_USE_NULL_POOL=true \
               -e OPENSEARCH_HOST=opensearch \
               -e REDIS_HOST=cache \
-              -e API_SERVER_HOST=api_server \
+              -e API_SERVER_HOST=127.0.0.1 \
               -e S3_ENDPOINT_URL=http://minio:9000 \
               -e S3_AWS_ACCESS_KEY_ID=minioadmin \
               -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
@@ -526,17 +429,16 @@ jobs:
               -e ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=${{ matrix.edition == 'ee' && 'true' || 'false' }} \
               -e ENABLE_CRAFT=true \
               -e ONYX_DEV_LICENSE \
+              -e RUN_WITH_BACKEND_MODE=full \
+              --entrypoint bash \
               ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-devcontainer-${{ github.run_id }} \
-              uv run --no-sync pytest -v --tb=short -rs tests/integration/${{ matrix.test-dir.path }}
+              tests/integration/scripts/run-with-backend.sh -v --tb=short -rs tests/integration/${{ matrix.test-dir.path }}
 
       # ------------------------------------------------------------
-      # Always gather logs BEFORE "down":
-      - name: Dump API server logs
-        if: always()
-        run: |
-          cd deployment/docker_compose
-          docker compose logs --no-color api_server > $GITHUB_WORKSPACE/api_server.log || true
-
+      # Always gather logs BEFORE "down". The test-runner container's
+      # stdout (api_server + celery, routed via supervisord's
+      # log-redirect-handler) is captured directly in the workflow log
+      # for the "Run Integration Tests" step.
       - name: Dump all-container logs (optional)
         if: always()
         run: |
@@ -552,7 +454,7 @@ jobs:
       # ------------------------------------------------------------
 
   onyx-lite-tests:
-    needs: [build-backend-image, build-devcontainer-image]
+    needs: [build-devcontainer-image]
     permissions:
       id-token: write # Required for OIDC-based AWS credential exchange
       contents: read
@@ -584,9 +486,6 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Create .env file for Onyx Lite Docker Compose
-        env:
-          ECR_CACHE: ${{ env.RUNS_ON_ECR_CACHE }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           cat <<EOF > deployment/docker_compose/.env
           ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true
@@ -595,18 +494,18 @@ jobs:
           POSTGRES_USE_NULL_POOL=true
           REQUIRE_EMAIL_VERIFICATION=false
           DISABLE_TELEMETRY=true
-          ONYX_BACKEND_IMAGE=${ECR_CACHE}:integration-test-backend-test-${RUN_ID}
           INTEGRATION_TESTS_MODE=true
           EOF
 
-      # Start only the services needed for Onyx Lite (Postgres + API server)
+      # The api_server runs inside the test-runner container (started by
+      # tests/integration/scripts/run-with-backend.sh); only Postgres is
+      # needed from compose for Onyx Lite.
       - name: Start Docker containers (onyx-lite)
         run: |
           cd deployment/docker_compose
           docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml up -d \
             --wait --wait-timeout 300 \
-            relational_db \
-            api_server
+            relational_db
         id: start_docker_onyx_lite
 
       - name: Install Python deps and generate OpenAPI client
@@ -635,19 +534,14 @@ jobs:
               -e DB_READONLY_PASSWORD=password \
               -e POSTGRES_POOL_PRE_PING=true \
               -e POSTGRES_USE_NULL_POOL=true \
-              -e API_SERVER_HOST=api_server \
+              -e API_SERVER_HOST=127.0.0.1 \
               -e OPENAI_API_KEY=${OPENAI_API_KEY} \
               -e TEST_WEB_HOSTNAME=test-runner \
               -e ONYX_DEV_LICENSE \
+              -e RUN_WITH_BACKEND_MODE=api_only \
+              --entrypoint bash \
               ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-devcontainer-${{ github.run_id }} \
-              uv run --no-sync pytest -v --tb=short -rs tests/integration/tests/no_vectordb
-
-      - name: Dump API server logs (onyx-lite)
-        if: always()
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml \
-            logs --no-color api_server > $GITHUB_WORKSPACE/api_server_onyx_lite.log || true
+              tests/integration/scripts/run-with-backend.sh -v --tb=short -rs tests/integration/tests/no_vectordb
 
       - name: Dump all-container logs (onyx-lite)
         if: always()
@@ -670,8 +564,7 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml -f docker-compose.dev.yml down -v
 
   multitenant-tests:
-    needs:
-      [build-backend-image, build-model-server-image, build-devcontainer-image]
+    needs: [build-model-server-image, build-devcontainer-image]
     runs-on:
       [
         runs-on,
@@ -707,7 +600,6 @@ jobs:
           REQUIRE_EMAIL_VERIFICATION=false \
           DISABLE_TELEMETRY=true \
           OPENAI_DEFAULT_API_KEY=${OPENAI_API_KEY} \
-          ONYX_BACKEND_IMAGE=${ECR_CACHE}:integration-test-backend-test-${RUN_ID} \
           ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:integration-test-model-server-test-${RUN_ID} \
           DEV_MODE=true \
           docker compose -f docker-compose.multitenant-dev.yml up -d \
@@ -716,10 +608,8 @@ jobs:
             opensearch \
             cache \
             minio \
-            api_server \
             inference_model_server \
-            indexing_model_server \
-            background
+            indexing_model_server
         id: start_docker_multi_tenant
 
       - name: Install Python deps and generate OpenAPI client
@@ -747,7 +637,7 @@ jobs:
             -e POSTGRES_USE_NULL_POOL=true \
             -e OPENSEARCH_HOST=opensearch \
             -e REDIS_HOST=cache \
-            -e API_SERVER_HOST=api_server \
+            -e API_SERVER_HOST=127.0.0.1 \
             -e OPENAI_API_KEY=${OPENAI_API_KEY} \
             -e EXA_API_KEY=${EXA_API_KEY} \
             -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \
@@ -759,14 +649,10 @@ jobs:
             -e REQUIRE_EMAIL_VERIFICATION=false \
             -e DISABLE_TELEMETRY=true \
             -e DEV_MODE=true \
+            -e RUN_WITH_BACKEND_MODE=full \
+            --entrypoint bash \
             ${ECR_CACHE}:integration-test-devcontainer-${RUN_ID} \
-            uv run --no-sync pytest -v --tb=short -rs tests/integration/multitenant_tests
-
-      - name: Dump API server logs (multi-tenant)
-        if: always()
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.multitenant-dev.yml logs --no-color api_server > $GITHUB_WORKSPACE/api_server_multitenant.log || true
+            tests/integration/scripts/run-with-backend.sh -v --tb=short -rs tests/integration/multitenant_tests
 
       - name: Dump all-container logs (multi-tenant)
         if: always()

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -398,6 +398,8 @@ jobs:
               -e OPENSEARCH_HOST=opensearch \
               -e REDIS_HOST=cache \
               -e API_SERVER_HOST=127.0.0.1 \
+              -e MODEL_SERVER_HOST=inference_model_server \
+              -e INDEXING_MODEL_SERVER_HOST=indexing_model_server \
               -e S3_ENDPOINT_URL=http://minio:9000 \
               -e S3_AWS_ACCESS_KEY_ID=minioadmin \
               -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
@@ -535,6 +537,10 @@ jobs:
               -e POSTGRES_POOL_PRE_PING=true \
               -e POSTGRES_USE_NULL_POOL=true \
               -e API_SERVER_HOST=127.0.0.1 \
+              -e DISABLE_VECTOR_DB=true \
+              -e FILE_STORE_BACKEND=postgres \
+              -e CACHE_BACKEND=postgres \
+              -e AUTH_BACKEND=postgres \
               -e OPENAI_API_KEY=${OPENAI_API_KEY} \
               -e TEST_WEB_HOSTNAME=test-runner \
               -e ONYX_DEV_LICENSE \
@@ -638,6 +644,8 @@ jobs:
             -e OPENSEARCH_HOST=opensearch \
             -e REDIS_HOST=cache \
             -e API_SERVER_HOST=127.0.0.1 \
+            -e MODEL_SERVER_HOST=inference_model_server \
+            -e INDEXING_MODEL_SERVER_HOST=indexing_model_server \
             -e OPENAI_API_KEY=${OPENAI_API_KEY} \
             -e EXA_API_KEY=${EXA_API_KEY} \
             -e SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN} \

--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ plans/
 # Added context for LLMs
 .claude/CLAUDE.md
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .claude/worktrees/

--- a/backend/scripts/setup_craft_templates.sh
+++ b/backend/scripts/setup_craft_templates.sh
@@ -40,18 +40,25 @@ if [ ! -d "$VENV_TEMPLATE_PATH" ] && [ -f "$REQUIREMENTS_PATH" ]; then
     echo "  Python venv template created"
 fi
 
-# 2. Run npm install in web template
+# 2. Install web template deps (prefer npm in production; fall back to bun
+#    for environments like the CI devcontainer that ship bun instead of Node).
 if [ -d "$WEB_TEMPLATE_PATH" ]; then
-    if ! command -v npm >/dev/null 2>&1; then
-        echo "WARNING: npm is not available — skipping web template setup." >&2
+    if command -v npm >/dev/null 2>&1; then
+        WEB_INSTALL_CMD="npm install"
+    elif command -v bun >/dev/null 2>&1; then
+        WEB_INSTALL_CMD="bun install"
     else
+        WEB_INSTALL_CMD=""
+        echo "WARNING: neither npm nor bun available — skipping web template setup." >&2
+    fi
+    if [ -n "$WEB_INSTALL_CMD" ]; then
         # Always remove and reinstall to ensure correct architecture binaries
         if [ -d "${WEB_TEMPLATE_PATH}/node_modules" ]; then
             echo "  Removing existing node_modules..."
             rm -rf "${WEB_TEMPLATE_PATH}/node_modules"
         fi
-        echo "  Installing npm packages (this may take 1-2 minutes)..."
-        cd "$WEB_TEMPLATE_PATH" && npm install 2>&1 || { echo "ERROR: npm install failed" >&2; exit 1; }
+        echo "  Installing web template packages with '${WEB_INSTALL_CMD}' (this may take 1-2 minutes)..."
+        cd "$WEB_TEMPLATE_PATH" && $WEB_INSTALL_CMD 2>&1 || { echo "ERROR: ${WEB_INSTALL_CMD} failed" >&2; exit 1; }
         echo "  Web template dependencies installed"
     fi
 fi

--- a/backend/tests/integration/scripts/run-with-backend.sh
+++ b/backend/tests/integration/scripts/run-with-backend.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Boots the in-container backend (alembic migrations, optional Craft templates,
+# uvicorn api_server, and — in `full` mode — supervisord-managed celery workers)
+# before invoking pytest with whatever args were passed through.
+#
+# Modes (RUN_WITH_BACKEND_MODE):
+#   full     — integration / multitenant suites: uvicorn for api_server plus
+#              supervisord for the full celery worker set (the workers
+#              autostart from backend/supervisord.conf).
+#   api_only — onyx-lite suite: redis/celery aren't available, so we only
+#              start uvicorn.
+set -euo pipefail
+
+MODE="${RUN_WITH_BACKEND_MODE:-full}"
+BACKEND_DIR="/workspace/backend"
+SUPERVISORD_CONF="${BACKEND_DIR}/supervisord.conf"
+API_HEALTH_URL="http://127.0.0.1:8080/health"
+HEALTH_TIMEOUT_SECONDS="${API_SERVER_HEALTH_TIMEOUT_SECONDS:-600}"
+
+cd "$BACKEND_DIR"
+
+echo "==> Running alembic upgrade head"
+uv run --no-sync alembic upgrade head
+
+if [[ "${ENABLE_CRAFT:-false}" == "true" ]]; then
+    echo "==> Setting up Craft templates"
+    bash "${BACKEND_DIR}/scripts/setup_craft_templates.sh"
+fi
+
+SUPERVISORD_PID=""
+UVICORN_PID=""
+
+cleanup() {
+    local exit_code=$?
+    if [[ -n "$UVICORN_PID" ]] && kill -0 "$UVICORN_PID" 2>/dev/null; then
+        kill "$UVICORN_PID" 2>/dev/null || true
+        wait "$UVICORN_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$SUPERVISORD_PID" ]] && kill -0 "$SUPERVISORD_PID" 2>/dev/null; then
+        uv run --no-sync supervisorctl -c "$SUPERVISORD_CONF" shutdown >/dev/null 2>&1 || true
+        wait "$SUPERVISORD_PID" 2>/dev/null || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Starting uvicorn api_server"
+uv run --no-sync uvicorn onyx.main:app --host 0.0.0.0 --port 8080 \
+    > /var/log/api_server.log 2>&1 &
+UVICORN_PID=$!
+
+if [[ "$MODE" != "api_only" ]]; then
+    echo "==> Starting supervisord (celery workers)"
+    uv run --no-sync supervisord -c "$SUPERVISORD_CONF" &
+    SUPERVISORD_PID=$!
+
+    echo "==> Waiting for supervisord socket"
+    for _ in $(seq 1 30); do
+        [[ -S /tmp/supervisor.sock ]] && break
+        sleep 1
+    done
+    if [[ ! -S /tmp/supervisor.sock ]]; then
+        echo "ERROR: supervisord socket never appeared at /tmp/supervisor.sock" >&2
+        exit 1
+    fi
+fi
+
+echo "==> Waiting for api_server health (up to ${HEALTH_TIMEOUT_SECONDS}s)"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT_SECONDS ))
+until curl -fsS "$API_HEALTH_URL" >/dev/null 2>&1; do
+    if (( $(date +%s) >= deadline )); then
+        echo "ERROR: api_server did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s" >&2
+        echo "--- /var/log/api_server.log ---"
+        tail -n 200 /var/log/api_server.log 2>/dev/null || true
+        if [[ "$MODE" != "api_only" ]]; then
+            uv run --no-sync supervisorctl -c "$SUPERVISORD_CONF" status || true
+        fi
+        exit 1
+    fi
+    if ! kill -0 "$UVICORN_PID" 2>/dev/null; then
+        echo "ERROR: uvicorn exited before becoming healthy" >&2
+        echo "--- /var/log/api_server.log ---"
+        tail -n 200 /var/log/api_server.log 2>/dev/null || true
+        exit 1
+    fi
+    sleep 2
+done
+echo "==> api_server is healthy"
+
+if [[ "$MODE" != "api_only" ]]; then
+    # Mirror the previous remote supervisorctl healthcheck — fail if any
+    # critical worker is in FATAL/BACKOFF/STOPPED. slack_bot / discord_bot /
+    # watchdog are intentionally allowed to flap (no creds in CI).
+    echo "==> supervisorctl status"
+    STATUS_OUTPUT=$(uv run --no-sync supervisorctl -c "$SUPERVISORD_CONF" status || true)
+    echo "$STATUS_OUTPUT"
+    FAILED=$(echo "$STATUS_OUTPUT" \
+        | grep -E "FATAL|BACKOFF|STOPPED" \
+        | grep -v "slack_bot\|discord_bot\|watchdog" || true)
+    if [[ -n "$FAILED" ]]; then
+        echo "ERROR: critical background processes failed to start:" >&2
+        echo "$FAILED" >&2
+        exit 1
+    fi
+fi
+
+echo "==> Running pytest $*"
+uv run --no-sync pytest "$@"

--- a/backend/tests/integration/scripts/run-with-backend.sh
+++ b/backend/tests/integration/scripts/run-with-backend.sh
@@ -19,8 +19,13 @@ HEALTH_TIMEOUT_SECONDS="${API_SERVER_HEALTH_TIMEOUT_SECONDS:-600}"
 
 cd "$BACKEND_DIR"
 
-echo "==> Running alembic upgrade head"
-uv run --no-sync alembic upgrade head
+if [[ "${MULTI_TENANT:-false}" == "true" ]]; then
+    echo "==> Running alembic -n schema_private upgrade head"
+    uv run --no-sync alembic -n schema_private upgrade head
+else
+    echo "==> Running alembic upgrade head"
+    uv run --no-sync alembic upgrade head
+fi
 
 if [[ "${ENABLE_CRAFT:-false}" == "true" ]]; then
     echo "==> Setting up Craft templates"

--- a/backend/tests/integration/scripts/run-with-backend.sh
+++ b/backend/tests/integration/scripts/run-with-backend.sh
@@ -32,6 +32,14 @@ if [[ "${ENABLE_CRAFT:-false}" == "true" ]]; then
     bash "${BACKEND_DIR}/scripts/setup_craft_templates.sh"
 fi
 
+if [[ "$MODE" != "api_only" ]]; then
+    # The web_search tests exercise OnyxWebCrawler's Playwright fallback.
+    # The devcontainer image ships the apt deps; download the browser
+    # binary here so its version tracks the lockfile's playwright-python.
+    echo "==> Installing Playwright Chromium browser"
+    uv run --no-sync playwright install chromium
+fi
+
 SUPERVISORD_PID=""
 UVICORN_PID=""
 

--- a/backend/tests/integration/scripts/run-with-backend.sh
+++ b/backend/tests/integration/scripts/run-with-backend.sh
@@ -36,8 +36,12 @@ if [[ "$MODE" != "api_only" ]]; then
     # The web_search tests exercise OnyxWebCrawler's Playwright fallback.
     # The devcontainer image ships the apt deps; download the browser
     # binary here so its version tracks the lockfile's playwright-python.
-    echo "==> Installing Playwright Chromium browser"
-    uv run --no-sync playwright install chromium
+    # Playwright has no ubuntu26.04 Chromium build yet — pin to the
+    # binary-compatible 24.04 build, matching the host's arch.
+    PW_ARCH=$(case $(dpkg --print-architecture) in amd64) echo x64;; arm64) echo arm64;; esac)
+    echo "==> Installing Playwright Chromium browser (ubuntu24.04-${PW_ARCH})"
+    PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-${PW_ARCH} \
+        uv run --no-sync playwright install chromium
 fi
 
 SUPERVISORD_PID=""

--- a/backend/tests/integration/scripts/run-with-backend.sh
+++ b/backend/tests/integration/scripts/run-with-backend.sh
@@ -54,7 +54,12 @@ cleanup() {
         wait "$UVICORN_PID" 2>/dev/null || true
     fi
     if [[ -n "$SUPERVISORD_PID" ]] && kill -0 "$SUPERVISORD_PID" 2>/dev/null; then
+        # Belt-and-braces: supervisorctl shutdown is the clean path, but if the
+        # socket never came up (e.g. we hit `exit 1` from the socket-wait loop
+        # below) it'll fail silently and `wait` would block until the runner
+        # timeout. Send SIGTERM as a fallback so `wait` always returns.
         uv run --no-sync supervisorctl -c "$SUPERVISORD_CONF" shutdown >/dev/null 2>&1 || true
+        kill "$SUPERVISORD_PID" 2>/dev/null || true
         wait "$SUPERVISORD_PID" 2>/dev/null || true
     fi
     exit "$exit_code"


### PR DESCRIPTION
## Summary

- Embed api_server (uvicorn) and the celery worker set inside the test-runner container instead of running them as separate `docker-compose` services. This deletes the `build-backend-image` job and removes `ONYX_BACKEND_IMAGE` from the workflow entirely, shaving the full build-backend-image wall-clock off every PR.
- Adds `supervisor` and `opencode-ai` (via bun) to the devcontainer so it can host both the FastAPI server and the celery workers that the suite already exercises. Postgres / OpenSearch / Redis / Minio / model servers stay in compose unchanged.
- New `backend/tests/integration/scripts/run-with-backend.sh` is the docker entrypoint for all three test jobs: it runs `alembic upgrade head`, sets up Craft templates when `ENABLE_CRAFT=true`, starts supervisord (`full`) or direct uvicorn (`api_only` for onyx-lite, where redis/celery are unavailable), waits for `/health`, then `exec`s pytest with whatever args were passed.

Includes a small follow-up to `setup_craft_templates.sh` so it falls back to `bun install` when npm is not on PATH (the devcontainer ships bun, not Node).

The previous remote-supervisord healthcheck step is replaced by the equivalent local `supervisorctl status` inside the new script. `slack_bot` / `discord_bot` / `watchdog` are still allowed to flap (no creds in CI), matching the old behavior.

Plan: `plans/nifty-yawning-rainbow.md`.

## Test plan

- [ ] `integration-tests` matrix is green (in particular `tests/craft/*`, which exercises the Craft prerequisites inside the test runner).
- [ ] `onyx-lite-tests` is green via the `api_only` path (uvicorn only, no celery, no redis).
- [ ] `multitenant-tests` is green under the `full` path with `MULTI_TENANT=true` / `AUTH_TYPE=cloud`.
- [ ] Workflow graph no longer contains `build-backend-image`; `api_server` / `background` no longer appear in the docker-compose log artifacts.
- [ ] Wall-clock for the integration suite drops by the full duration of today's `build-backend-image` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the backend inside the test-runner devcontainer and drop the compose `api_server`/`background` services and backend image build. This simplifies CI and speeds up the integration suites.

- **Refactors**
  - Add `backend/tests/integration/scripts/run-with-backend.sh` to run migrations, optional Craft setup, install Playwright Chromium, start `uvicorn` (and `supervisor` in `full` mode), wait for `/health`, then exec pytest.
  - Add `supervisor`, `opencode-ai` (via `bun`, pinned via `OPENCODE_VERSION`), and Playwright Chromium deps to the devcontainer; Craft template setup falls back to `bun install` when `npm` isn’t present.
  - Replace the bespoke integration-test image with the devcontainer; CI bind-mounts the repo and runs the script via `--entrypoint bash`; remove the `build-backend-image` job and stop composing `api_server`/`background`.

- **Bug Fixes**
  - Set `API_SERVER_HOST=127.0.0.1` and pass `MODEL_SERVER_HOST`/`INDEXING_MODEL_SERVER_HOST`; for Onyx Lite, skip model server, Redis, S3, and MinIO and use Postgres-backed stores.
  - In `MULTI_TENANT=true`, run Alembic with the `schema_private` config and forward `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES`, `LICENSE_ENFORCEMENT_ENABLED`, and `OPENAI_DEFAULT_API_KEY` so tenant seeding runs and related tests pass.
  - Point Craft template paths to `/workspace/...`; make the Playwright platform override arch-aware and preinstall Chromium deps so it works on Ubuntu 26.04 and x64/arm64 hosts.
  - Ensure the `supervisord` cleanup can’t hang by sending SIGTERM after `supervisorctl shutdown` when the socket never appears.

<sup>Written for commit 1d4739d93c87dc69d9d0b3cd9c9b79e1d2a6c97e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

