### PR TITLE
fix: confluence pagination limit2

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -292,32 +292,12 @@ class OnyxConfluence:
         limit: int,
         space_keys: list[str] | None,
     ) -> Iterator[dict[str, Any]]:
-        """Internal helper to paginate through spaces for a specific API endpoint.
-
-        Server/v1 termination rules (they interact):
-
-        1. Stop when ``_links.next`` is absent. Per Atlassian's docs this
-           is the canonical end-of-pagination signal. Do NOT stop just
-           because ``len(results) < limit``: ``/rest/api/space`` on
-           Server/DC has a fixed code-level page-size cap (currently
-           ``DefaultRestSpaceManager.MAX_SIZE = 50``; not exposed in the
-           admin UI) and silently caps responses to that value when the
-           requested ``limit`` exceeds it (#4129). A capped page is not
-           the end-of-list. Treating it as such caused permission sync
-           to miss every space past the cap and crash with "No external
-           access found for document ID".
-
-        2. Re-derive ``start`` from ``previous_start + len(results)``
-           instead of honoring the ``start`` Confluence embeds in
-           ``_links.next``. The embedded ``start`` under-counts when the
-           page is capped (#4129), and on DC 8.5.8 / 7.19.21 / 8.9.0
-           (CONFSERVER-95272 / -95312) ``start`` past the true total
-           still returns records instead of empty, so we cannot trust
-           the server's offset bookkeeping there either.
-
-        3. Empty ``results`` is kept as a defensive safety net for the
-           known Confluence bug where ``_links.next`` is set but
-           ``results`` is empty.
+        """Paginate spaces. Server stops on missing ``_links.next``
+        (and empty ``results``, defensively). Don't stop on
+        ``len(results) < limit``: ``/rest/api/space`` on DC caps at
+        ``DefaultRestSpaceManager.MAX_SIZE`` (#4129). ``start`` is
+        re-derived locally; Confluence under-counts it on capped pages
+        and CONFSERVER-95272/-95312 returns records past the true end.
         """
         start = 0
         url = self._build_spaces_url(
@@ -772,53 +752,29 @@ class OnyxConfluence:
             # Yield the results individually.
             results = cast(list[dict[str, Any]], next_response.get("results", []))
 
-            # Note 1:
-            # Make sure we don't update the start by more than the amount
-            # of results we were able to retrieve. The Confluence API has a
-            # weird behavior where if you pass in a limit that is too large for
-            # the configured server, it will artificially limit the amount of
-            # results returned BUT will not apply this to the start parameter.
-            # This will cause us to miss results.
-            #
-            # Note 2:
-            # We specifically perform manual yielding (i.e., `for x in xs: yield x`) as opposed to using a `yield from xs`
-            # because we *have to call the `next_page_callback`* prior to yielding the last element!
-            #
-            # If we did:
-            #
-            # ```py
-            # yield from results
-            # if next_page_callback:
-            #   next_page_callback(url_suffix)
-            # ```
-            #
-            # then the logic would fail since the iterator would finish (and the calling scope would exit out of its driving
-            # loop) prior to the callback being called.
-
+            # #4129: DC silently caps page size and under-counts the
+            # ``start`` it embeds in ``_links.next``; re-derive it
+            # ourselves. Manual yielding (not ``yield from``) so we can
+            # fire ``next_page_callback`` before the last yield --
+            # otherwise the iterator may never resume.
             old_url_suffix = url_suffix
-            updated_start = get_start_param_from_url(old_url_suffix)
+            next_start = get_start_param_from_url(old_url_suffix) + len(results)
             url_suffix = cast(str, next_response.get("_links", {}).get("next", ""))
             if url_suffix and current_limit != limit:
                 url_suffix = update_param_in_path(
                     url_suffix, "limit", str(current_limit)
                 )
-            for i, result in enumerate(results):
-                updated_start += 1
-                if url_suffix and next_page_callback and i == len(results) - 1:
-                    # update the url if we're on the last result in the page
-                    if not self._is_cloud:
-                        # If confluence claims there are more results, we update the start param
-                        # based on how many results were returned and try again.
-                        url_suffix = update_param_in_path(
-                            url_suffix, "start", str(updated_start)
-                        )
-                    # notify the caller of the new url
-                    next_page_callback(url_suffix)
+            if url_suffix and not self._is_cloud and results:
+                url_suffix = update_param_in_path(url_suffix, "start", str(next_start))
 
-                elif force_offset_pagination and i == len(results) - 1:
-                    url_suffix = update_param_in_path(
-                        old_url_suffix, "start", str(updated_start)
-                    )
+            for i, result in enumerate(results):
+                if i == len(results) - 1:
+                    if url_suffix and next_page_callback:
+                        next_page_callback(url_suffix)
+                    elif force_offset_pagination:
+                        url_suffix = update_param_in_path(
+                            old_url_suffix, "start", str(next_start)
+                        )
 
                 yield result
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1094,6 +1094,70 @@ def test_retrieve_confluence_spaces_server_paginates_past_capped_page(
     assert all(f"limit={requested_limit}" in p for p in mock_get_call_paths)
 
 
+def test_paginate_url_server_re_derives_start_when_dc_under_counts(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """#4129: no-callback Server callers (paginated_cql_retrieval, slim
+    docs, etc.) must re-derive ``start`` when DC under-counts
+    ``_links.next.start``.
+    """
+    requested_limit = 10
+    server_cap = 3
+    all_ids = list(range(1, 9))
+    mock_get_call_paths: list[str] = []
+
+    def get_side_effect(
+        path: str,
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        path = path.strip("/")
+        mock_get_call_paths.append(path)
+
+        start = 0
+        if "start=" in path:
+            start = int(path.split("start=", 1)[1].split("&", 1)[0])
+
+        ids_on_page = all_ids[start : start + server_cap]
+        has_more = (start + server_cap) < len(all_ids)
+        # Simulate the bug: _links.next.start advances by requested_limit
+        # (10) rather than server_cap (3).
+        links: dict[str, str] = {}
+        if has_more:
+            links["next"] = (
+                f"/rest/api/content/search?cql=type=page"
+                f"&limit={requested_limit}&start={start + requested_limit}"
+            )
+        return _create_mock_response(
+            200,
+            {
+                "results": [{"id": i} for i in ids_on_page],
+                "_links": links,
+                "size": len(ids_on_page),
+            },
+            url=path,
+        )
+
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    returned = list(
+        confluence_server_client.paginated_cql_retrieval(
+            cql="type=page", limit=requested_limit
+        )
+    )
+
+    assert [r["id"] for r in returned] == all_ids
+    starts_seen = []
+    for path in mock_get_call_paths:
+        if "start=" in path:
+            starts_seen.append(int(path.split("start=", 1)[1].split("&", 1)[0]))
+        else:
+            starts_seen.append(0)
+    assert starts_seen == [0, 3, 6]
+
+
 def test_retrieve_confluence_spaces_server_stops_when_next_link_absent(
     confluence_server_client: OnyxConfluence,
 ) -> None:


### PR DESCRIPTION
## Description

We were previously not paginating properly for confluence server when a callback function wasn't passed in to the _paginate_url function, which specifically happens during perm sync. Similar to #11284, this would cause us to miss some results (and thus not give people access to everything they should be able to) for confluence server/data center.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Confluence Server/DC pagination so perm sync and CQL retrieval don’t miss results when the server caps page size or misreports offsets. We now paginate until `_links.next` is missing and compute offsets locally to cover DC quirks.

- **Bug Fixes**
  - Spaces: stop only when `_links.next` is absent; don’t stop on `len(results) < limit`; re-derive `start` to handle capped pages and DC bugs.
  - `_paginate_url`: compute next `start` from prior page + results, update `start` in Server `next` URLs up front, and call `next_page_callback` before the last yield; keep the requested `limit`.
  - Tests: added a no-callback Server/DC case where `_links.next.start` jumps by the requested limit; verify we still fetch all results, plus termination when `_links.next` is absent.

<sup>Written for commit a2509cad11cd7d068eed9a00d6c7061effd09dc8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11291?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

