### PR TITLE
feat(connector): Index documents on github connector

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -1,10 +1,12 @@
 import copy
+import os
 from collections.abc import Callable
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from enum import Enum
+from io import BytesIO
 from typing import Any
 from typing import cast
 
@@ -47,6 +49,8 @@ from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
+from onyx.file_processing.extract_file_text import detect_encoding
+from onyx.file_processing.extract_file_text import is_text_file
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -58,6 +62,53 @@ _MAX_NUM_RATE_LIMIT_RETRIES = 5
 
 ONE_DAY = timedelta(days=1)
 SLIM_BATCH_SIZE = 100
+
+# Prose document extensions eligible for document indexing. Intentionally
+# limited to human-readable docs — source code as well as data/config/log
+# formats (.json, .csv, .tsv, .xml, .yml, .yaml, .sql, .log, .conf) are
+# excluded, as they are rarely useful to search as documents.
+GITHUB_INDEXABLE_FILE_EXTENSIONS = {
+    ".md",
+    ".mdx",
+    ".markdown",
+    ".rst",
+    ".txt",
+}
+# Path segments whose presence anywhere in a file's path excludes it.
+GITHUB_PATH_DENYLIST = {
+    ".git",
+    "node_modules",
+    "vendor",
+    "dist",
+    "build",
+    ".venv",
+    "__pycache__",
+}
+# Skip files larger than this (checked against the git tree size before fetching).
+GITHUB_MAX_FILE_SIZE_BYTES = 1_000_000
+# Number of files emitted per checkpoint batch in the FILES stage.
+FILE_BATCH_SIZE = 100
+
+
+def _is_indexable_path(path: str, size: int | None) -> bool:
+    """Pure predicate: should this repo file be indexed?
+
+    Filters on extension allowlist, max size, and a path-segment denylist.
+    """
+    if size is not None and size > GITHUB_MAX_FILE_SIZE_BYTES:
+        return False
+
+    _, extension = os.path.splitext(path)
+    if extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+        return False
+
+    segments = set(path.split("/"))
+    if segments & GITHUB_PATH_DENYLIST:
+        return False
+
+    return True
+
+
 # Cases
 # X (from start) standard run, no fallback to cursor-based pagination
 # X (from start) standard run errors, fallback to cursor-based pagination
@@ -397,10 +448,67 @@ def _convert_issue_to_document(
     )
 
 
+def _decode_file_content(raw: bytes) -> str | None:
+    """Decode raw file bytes to text, or None if the content looks binary."""
+    buf = BytesIO(raw)
+    if not is_text_file(buf):
+        return None
+    encoding = detect_encoding(buf)
+    try:
+        return raw.decode(encoding)
+    except (UnicodeDecodeError, LookupError):
+        return None
+
+
+def _convert_file_to_document(
+    repo: Repository.Repository,
+    path: str,
+    content_text: str,
+    repo_external_access: ExternalAccess | None,
+) -> Document:
+    repo_full_name = repo.full_name
+    parts = repo_full_name.split("/", 1)
+    owner_name = parts[0] if parts else ""
+    repo_name = parts[1] if len(parts) > 1 else repo_full_name
+
+    branch = repo.default_branch
+    html_url = f"{repo.html_url}/blob/{branch}/{path}"
+    _, extension = os.path.splitext(path)
+
+    updated_at = repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
+
+    doc_metadata = {
+        "repo": repo_full_name,
+        "hierarchy": {
+            "source_path": [owner_name, repo_name, "files", *path.split("/")],
+            "owner": owner_name,
+            "repo": repo_name,
+            "object_type": "file",
+        },
+    }
+    return Document(
+        id=html_url,
+        sections=[TextSection(link=html_url, text=content_text)],
+        source=DocumentSource.GITHUB,
+        external_access=repo_external_access,
+        semantic_identifier=path,
+        doc_updated_at=updated_at,
+        doc_metadata=doc_metadata,
+        metadata={
+            "object_type": "File",
+            "repo": repo_full_name,
+            "path": path,
+            "file_extension": extension.lower(),
+            "branch": branch,
+        },
+    )
+
+
 class GithubConnectorStage(Enum):
     START = "start"
     PRS = "prs"
     ISSUES = "issues"
+    FILES = "files"
 
 
 class GithubConnectorCheckpoint(ConnectorCheckpoint):
@@ -410,17 +518,23 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
     cached_repo_ids: list[int] | None = None
     cached_repo: SerializedRepository | None = None
 
+    # Resolved + filtered file paths for the current repo's FILES stage.
+    # Populated once when the stage begins, then paginated via curr_page.
+    file_paths: list[str] | None = None
+
     # Used for the fallback cursor-based pagination strategy
     num_retrieved: int
     cursor_url: str | None = None
 
     def reset(self) -> None:
         """
-        Resets curr_page, num_retrieved, and cursor_url to their initial values (0, 0, None)
+        Resets curr_page, num_retrieved, cursor_url, and file_paths to their
+        initial values (0, 0, None, None)
         """
         self.curr_page = 0
         self.num_retrieved = 0
         self.cursor_url = None
+        self.file_paths = None
 
 
 def make_cursor_url_callback(
@@ -448,12 +562,14 @@ class GithubConnector(
         state_filter: str = "all",
         include_prs: bool = True,
         include_issues: bool = False,
+        include_files: bool = False,
     ) -> None:
         self.repo_owner = repo_owner
         self.repositories = repositories
         self.state_filter = state_filter
         self.include_prs = include_prs
         self.include_issues = include_issues
+        self.include_files = include_files
         self.github_client: Github | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -568,6 +684,57 @@ class GithubConnector(
         return lambda: repo.get_issues(
             state=self.state_filter, sort="updated", direction="desc"
         )
+
+    def _list_indexable_files(
+        self, repo: Repository.Repository, attempt_num: int = 0
+    ) -> list[str]:
+        """Resolve the repo's default-branch tree and return indexable file paths.
+
+        Returns paths sorted for stable checkpoint pagination.
+        """
+        if attempt_num > _MAX_NUM_RATE_LIMIT_RETRIES:
+            raise RuntimeError(
+                "Re-tried listing repo files too many times. "
+                "Something is going wrong with fetching objects from Github"
+            )
+        assert self.github_client is not None  # mypy
+        try:
+            git_tree = repo.get_git_tree(repo.default_branch, recursive=True)
+            if git_tree.raw_data.get("truncated"):
+                logger.error(
+                    "Git tree for repo %s was truncated by GitHub; "
+                    "some files will not be indexed",
+                    repo.full_name,
+                )
+            paths = [
+                element.path
+                for element in git_tree.tree
+                if element.type == "blob"
+                and _is_indexable_path(element.path, element.size)
+            ]
+            paths.sort()
+            return paths
+        except RateLimitExceededException:
+            sleep_after_rate_limit_exception(self.github_client)
+            return self._list_indexable_files(repo, attempt_num + 1)
+
+    def _fetch_file_content(
+        self, repo: Repository.Repository, path: str, attempt_num: int = 0
+    ) -> bytes:
+        if attempt_num > _MAX_NUM_RATE_LIMIT_RETRIES:
+            raise RuntimeError(
+                "Re-tried fetching file content too many times. "
+                "Something is going wrong with fetching objects from Github"
+            )
+        assert self.github_client is not None  # mypy
+        try:
+            content = repo.get_contents(path, ref=repo.default_branch)
+            if isinstance(content, list):
+                raise ValueError(f"Expected a file at {path}, got a directory")
+            return content.decoded_content
+        except RateLimitExceededException:
+            sleep_after_rate_limit_exception(self.github_client)
+            return self._fetch_file_content(repo, path, attempt_num + 1)
 
     def _fetch_from_github(
         self,
@@ -765,9 +932,89 @@ class GithubConnector(
                 return checkpoint
 
             # if we went past the start date during the loop or there are no more
-            # issues to get, we move on to the next repo
-            checkpoint.stage = GithubConnectorStage.PRS
+            # issues to get, we move on to indexing files
+            checkpoint.stage = GithubConnectorStage.FILES
             checkpoint.reset()
+
+        # Ensure the FILES stage is reached even when PRs/issues are disabled.
+        # Mirrors the unconditional ISSUES transition above; only reached once
+        # PRs and issues are fully drained (those blocks return early otherwise).
+        checkpoint.stage = GithubConnectorStage.FILES
+
+        if self.include_files and checkpoint.stage == GithubConnectorStage.FILES:
+            if checkpoint.file_paths is None:
+                pushed_at = (
+                    repo.pushed_at.replace(tzinfo=timezone.utc)
+                    if repo.pushed_at
+                    else None
+                )
+                if start is not None and pushed_at is not None and pushed_at < start:
+                    # Nothing changed in this repo since the last poll — skip.
+                    logger.info(
+                        "Skipping files for repo %s (pushed_at < start)", repo.name
+                    )
+                    checkpoint.file_paths = []
+                else:
+                    logger.info("Listing files for repo: %s", repo.name)
+                    checkpoint.file_paths = self._list_indexable_files(repo)
+                    logger.info(
+                        "Found %s indexable files for repo: %s",
+                        len(checkpoint.file_paths),
+                        repo.name,
+                    )
+
+            file_paths = checkpoint.file_paths
+            page = checkpoint.curr_page
+            batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
+            checkpoint.curr_page += 1
+
+            for path in batch:
+                html_url = f"{repo.html_url}/blob/{repo.default_branch}/{path}"
+                if is_slim:
+                    yield Document(
+                        id=html_url,
+                        sections=[],
+                        external_access=repo_external_access,
+                        source=DocumentSource.GITHUB,
+                        semantic_identifier="",
+                        metadata={},
+                    )
+                    continue
+                try:
+                    raw = self._fetch_file_content(repo, path)
+                    content_text = _decode_file_content(raw)
+                    if content_text is None:
+                        yield ConnectorFailure(
+                            failed_document=DocumentFailure(
+                                document_id=html_url,
+                                document_link=html_url,
+                            ),
+                            failure_message=(
+                                f"Skipping non-text/undecodable file: {path}"
+                            ),
+                        )
+                        continue
+                    yield _convert_file_to_document(
+                        repo, path, content_text, repo_external_access
+                    )
+                except Exception as e:
+                    error_msg = f"Error converting file {path} to document: {e}"
+                    logger.exception(error_msg)
+                    yield ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=html_url,
+                            document_link=html_url,
+                        ),
+                        failure_message=error_msg,
+                        exception=e,
+                    )
+                    continue
+
+            # More file batches remain for this repo — checkpoint and resume.
+            if (page + 1) * FILE_BATCH_SIZE < len(file_paths):
+                return checkpoint
+
+        # files complete (or disabled) -> fall through to next repo
 
         checkpoint.has_more = len(checkpoint.cached_repo_ids) > 0
         if checkpoint.cached_repo_ids:
@@ -902,6 +1149,12 @@ class GithubConnector(
         if not self.repo_owner:
             raise ConnectorValidationError(
                 "Invalid connector settings: 'repo_owner' must be provided."
+            )
+
+        if not (self.include_prs or self.include_issues or self.include_files):
+            raise ConnectorValidationError(
+                "Invalid connector settings: at least one of pull requests, "
+                "issues, or files must be selected for indexing."
             )
 
         try:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -475,6 +475,10 @@ def _convert_file_to_document(
     html_url = f"{repo.html_url}/blob/{branch}/{path}"
     _, extension = os.path.splitext(path)
 
+    # NOTE: GitHub's tree API does not expose per-file modification times without
+    # additional per-file commit-history calls. repo.pushed_at is the closest
+    # proxy available without extra API requests, but it reflects any push to
+    # any branch, so every file in the repo shares the same timestamp.
     updated_at = repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
 
     doc_metadata = {
@@ -731,6 +735,11 @@ class GithubConnector(
             content = repo.get_contents(path, ref=repo.default_branch)
             if isinstance(content, list):
                 raise ValueError(f"Expected a file at {path}, got a directory")
+            if content.decoded_content is None:
+                raise ValueError(
+                    f"Could not decode content for {path} "
+                    f"(encoding={content.encoding!r})"
+                )
             return content.decoded_content
         except RateLimitExceededException:
             sleep_after_rate_limit_exception(self.github_client)
@@ -861,7 +870,10 @@ class GithubConnector(
                 # save the checkpoint after changing stage; next run will continue from issues
                 return checkpoint
 
-        checkpoint.stage = GithubConnectorStage.ISSUES
+        # Advance into ISSUES only from PRS — never regress a later stage
+        # (e.g. a resumed FILES checkpoint) back to ISSUES.
+        if checkpoint.stage == GithubConnectorStage.PRS:
+            checkpoint.stage = GithubConnectorStage.ISSUES
 
         if self.include_issues and checkpoint.stage == GithubConnectorStage.ISSUES:
             logger.info("Fetching issues for repo: %s", repo.name)
@@ -936,10 +948,14 @@ class GithubConnector(
             checkpoint.stage = GithubConnectorStage.FILES
             checkpoint.reset()
 
-        # Ensure the FILES stage is reached even when PRs/issues are disabled.
-        # Mirrors the unconditional ISSUES transition above; only reached once
-        # PRs and issues are fully drained (those blocks return early otherwise).
-        checkpoint.stage = GithubConnectorStage.FILES
+        # Advance into FILES from PRS/ISSUES, but never regress a resumed FILES
+        # checkpoint (mid file-pagination) — that would null out file_paths and
+        # re-index from page 0.
+        if checkpoint.stage in (
+            GithubConnectorStage.PRS,
+            GithubConnectorStage.ISSUES,
+        ):
+            checkpoint.stage = GithubConnectorStage.FILES
 
         if self.include_files and checkpoint.stage == GithubConnectorStage.FILES:
             if checkpoint.file_paths is None:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -14,6 +14,7 @@ from github import Github
 from github import RateLimitExceededException
 from github import Repository
 from github.GithubException import GithubException
+from github.GithubException import UnknownObjectException
 from github.Issue import Issue
 from github.NamedUser import NamedUser
 from github.PaginatedList import PaginatedList
@@ -46,6 +47,7 @@ from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
@@ -74,6 +76,23 @@ GITHUB_INDEXABLE_FILE_EXTENSIONS = {
     ".rst",
     ".txt",
 }
+# Common documentation files that conventionally have no extension. Matched
+# case-insensitively against the file's basename (stem before any extension).
+GITHUB_INDEXABLE_FILENAMES = {
+    "readme",
+    "license",
+    "licence",
+    "changelog",
+    "contributing",
+    "authors",
+    "notice",
+    "copying",
+    "install",
+    "maintainers",
+    "codeowners",
+    "security",
+    "support",
+}
 # Path segments whose presence anywhere in a file's path excludes it.
 GITHUB_PATH_DENYLIST = {
     ".git",
@@ -93,20 +112,27 @@ FILE_BATCH_SIZE = 100
 def _is_indexable_path(path: str, size: int | None) -> bool:
     """Pure predicate: should this repo file be indexed?
 
-    Filters on extension allowlist, max size, and a path-segment denylist.
+    Filters on a max size and path-segment denylist, then matches either a
+    document extension (.md, .txt, ...) or a conventional extensionless
+    document basename (README, LICENSE, ...).
     """
     if size is not None and size > GITHUB_MAX_FILE_SIZE_BYTES:
-        return False
-
-    _, extension = os.path.splitext(path)
-    if extension.lower() not in GITHUB_INDEXABLE_FILE_EXTENSIONS:
         return False
 
     segments = set(path.split("/"))
     if segments & GITHUB_PATH_DENYLIST:
         return False
 
-    return True
+    basename = path.rsplit("/", 1)[-1]
+    _, extension = os.path.splitext(basename)
+    if extension.lower() in GITHUB_INDEXABLE_FILE_EXTENSIONS:
+        return True
+
+    # Extensionless docs like README / LICENSE (basename has no extension).
+    if not extension and basename.lower() in GITHUB_INDEXABLE_FILENAMES:
+        return True
+
+    return False
 
 
 # Cases
@@ -258,6 +284,16 @@ def _get_batch_rate_limited(
             github_client,
             attempt_num + 1,
         )
+    except UnknownObjectException:
+        # 404 on the listing endpoint means the collection is unavailable for
+        # this repo (e.g. pull requests or issues are disabled on a mirror).
+        # Treat it as empty so the connector skips the stage instead of crashing.
+        logger.warning(
+            "Got 404 listing objects (page %s); treating as empty. "
+            "The pull requests or issues feature is likely disabled for this repo.",
+            page_num,
+        )
+        return
     except GithubException as e:
         if not (
             e.status == 422
@@ -691,10 +727,12 @@ class GithubConnector(
 
     def _list_indexable_files(
         self, repo: Repository.Repository, attempt_num: int = 0
-    ) -> list[str]:
+    ) -> tuple[list[str], bool]:
         """Resolve the repo's default-branch tree and return indexable file paths.
 
-        Returns paths sorted for stable checkpoint pagination.
+        Returns (sorted paths, truncated) where `truncated` is True when GitHub
+        capped the recursive tree (>100k entries or >7MB), meaning some files
+        could not be enumerated and will be missing from the index.
         """
         if attempt_num > _MAX_NUM_RATE_LIMIT_RETRIES:
             raise RuntimeError(
@@ -704,7 +742,8 @@ class GithubConnector(
         assert self.github_client is not None  # mypy
         try:
             git_tree = repo.get_git_tree(repo.default_branch, recursive=True)
-            if git_tree.raw_data.get("truncated"):
+            truncated = bool(git_tree.raw_data.get("truncated"))
+            if truncated:
                 logger.error(
                     "Git tree for repo %s was truncated by GitHub; "
                     "some files will not be indexed",
@@ -717,7 +756,7 @@ class GithubConnector(
                 and _is_indexable_path(element.path, element.size)
             ]
             paths.sort()
-            return paths
+            return paths, truncated
         except RateLimitExceededException:
             sleep_after_rate_limit_exception(self.github_client)
             return self._list_indexable_files(repo, attempt_num + 1)
@@ -972,12 +1011,26 @@ class GithubConnector(
                     checkpoint.file_paths = []
                 else:
                     logger.info("Listing files for repo: %s", repo.name)
-                    checkpoint.file_paths = self._list_indexable_files(repo)
+                    paths, truncated = self._list_indexable_files(repo)
+                    checkpoint.file_paths = paths
                     logger.info(
                         "Found %s indexable files for repo: %s",
-                        len(checkpoint.file_paths),
+                        len(paths),
                         repo.name,
                     )
+                    # Surface truncation as a failure so the incomplete index is
+                    # visible in the connector UI, not just buried in logs.
+                    if truncated and not is_slim:
+                        yield ConnectorFailure(
+                            failed_entity=EntityFailure(
+                                entity_id=f"{repo.full_name}:files",
+                            ),
+                            failure_message=(
+                                f"GitHub truncated the file tree for "
+                                f"{repo.full_name}; some files could not be "
+                                f"enumerated and were not indexed."
+                            ),
+                        )
 
             file_paths = checkpoint.file_paths
             page = checkpoint.curr_page

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -51,7 +51,7 @@ from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
-from onyx.file_processing.extract_file_text import detect_encoding
+from onyx.file_processing.extract_file_text import file_io_to_text
 from onyx.file_processing.extract_file_text import is_text_file
 from onyx.utils.logger import setup_logger
 
@@ -489,11 +489,7 @@ def _decode_file_content(raw: bytes) -> str | None:
     buf = BytesIO(raw)
     if not is_text_file(buf):
         return None
-    encoding = detect_encoding(buf)
-    try:
-        return raw.decode(encoding)
-    except (UnicodeDecodeError, LookupError):
-        return None
+    return file_io_to_text(buf)
 
 
 def _convert_file_to_document(
@@ -784,6 +780,98 @@ class GithubConnector(
             sleep_after_rate_limit_exception(self.github_client)
             return self._fetch_file_content(repo, path, attempt_num + 1)
 
+    def _fetch_repo_files(
+        self,
+        repo: Repository.Repository,
+        checkpoint: GithubConnectorCheckpoint,
+        start: datetime | None,
+        is_slim: bool,
+        repo_external_access: ExternalAccess | None,
+    ) -> Generator[Document | ConnectorFailure, None, bool]:
+        """Emit one batch of indexable documents for `repo`, advancing the checkpoint.
+
+        On first entry for a repo (file_paths is None) it resolves and caches the
+        filtered file list, applying the pushed_at gate and surfacing tree
+        truncation as a failure. Returns True if more file batches remain (the
+        caller should return the checkpoint to resume), False once drained.
+        """
+        if checkpoint.file_paths is None:
+            pushed_at = (
+                repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
+            )
+            if start is not None and pushed_at is not None and pushed_at < start:
+                # Nothing changed in this repo since the last poll — skip.
+                logger.info("Skipping files for repo %s (pushed_at < start)", repo.name)
+                checkpoint.file_paths = []
+            else:
+                logger.info("Listing files for repo: %s", repo.name)
+                paths, truncated = self._list_indexable_files(repo)
+                checkpoint.file_paths = paths
+                logger.info(
+                    "Found %s indexable files for repo: %s", len(paths), repo.name
+                )
+                # Surface truncation as a failure so the incomplete index is
+                # visible in the connector UI, not just buried in logs.
+                if truncated and not is_slim:
+                    yield ConnectorFailure(
+                        failed_entity=EntityFailure(
+                            entity_id=f"{repo.full_name}:files",
+                        ),
+                        failure_message=(
+                            f"GitHub truncated the file tree for "
+                            f"{repo.full_name}; some files could not be "
+                            f"enumerated and were not indexed."
+                        ),
+                    )
+
+        file_paths = checkpoint.file_paths
+        page = checkpoint.curr_page
+        batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
+        checkpoint.curr_page += 1
+
+        for path in batch:
+            html_url = f"{repo.html_url}/blob/{repo.default_branch}/{path}"
+            if is_slim:
+                yield Document(
+                    id=html_url,
+                    sections=[],
+                    external_access=repo_external_access,
+                    source=DocumentSource.GITHUB,
+                    semantic_identifier="",
+                    metadata={},
+                )
+                continue
+            try:
+                raw = self._fetch_file_content(repo, path)
+                content_text = _decode_file_content(raw)
+                if content_text is None:
+                    yield ConnectorFailure(
+                        failed_document=DocumentFailure(
+                            document_id=html_url,
+                            document_link=html_url,
+                        ),
+                        failure_message=f"Skipping non-text/undecodable file: {path}",
+                    )
+                    continue
+                yield _convert_file_to_document(
+                    repo, path, content_text, repo_external_access
+                )
+            except Exception as e:
+                error_msg = f"Error converting file {path} to document: {e}"
+                logger.exception(error_msg)
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=html_url,
+                        document_link=html_url,
+                    ),
+                    failure_message=error_msg,
+                    exception=e,
+                )
+                continue
+
+        # True if more file batches remain for this repo.
+        return (page + 1) * FILE_BATCH_SIZE < len(file_paths)
+
     def _fetch_from_github(
         self,
         checkpoint: GithubConnectorCheckpoint,
@@ -997,90 +1085,11 @@ class GithubConnector(
             checkpoint.stage = GithubConnectorStage.FILES
 
         if self.include_files and checkpoint.stage == GithubConnectorStage.FILES:
-            if checkpoint.file_paths is None:
-                pushed_at = (
-                    repo.pushed_at.replace(tzinfo=timezone.utc)
-                    if repo.pushed_at
-                    else None
-                )
-                if start is not None and pushed_at is not None and pushed_at < start:
-                    # Nothing changed in this repo since the last poll — skip.
-                    logger.info(
-                        "Skipping files for repo %s (pushed_at < start)", repo.name
-                    )
-                    checkpoint.file_paths = []
-                else:
-                    logger.info("Listing files for repo: %s", repo.name)
-                    paths, truncated = self._list_indexable_files(repo)
-                    checkpoint.file_paths = paths
-                    logger.info(
-                        "Found %s indexable files for repo: %s",
-                        len(paths),
-                        repo.name,
-                    )
-                    # Surface truncation as a failure so the incomplete index is
-                    # visible in the connector UI, not just buried in logs.
-                    if truncated and not is_slim:
-                        yield ConnectorFailure(
-                            failed_entity=EntityFailure(
-                                entity_id=f"{repo.full_name}:files",
-                            ),
-                            failure_message=(
-                                f"GitHub truncated the file tree for "
-                                f"{repo.full_name}; some files could not be "
-                                f"enumerated and were not indexed."
-                            ),
-                        )
-
-            file_paths = checkpoint.file_paths
-            page = checkpoint.curr_page
-            batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
-            checkpoint.curr_page += 1
-
-            for path in batch:
-                html_url = f"{repo.html_url}/blob/{repo.default_branch}/{path}"
-                if is_slim:
-                    yield Document(
-                        id=html_url,
-                        sections=[],
-                        external_access=repo_external_access,
-                        source=DocumentSource.GITHUB,
-                        semantic_identifier="",
-                        metadata={},
-                    )
-                    continue
-                try:
-                    raw = self._fetch_file_content(repo, path)
-                    content_text = _decode_file_content(raw)
-                    if content_text is None:
-                        yield ConnectorFailure(
-                            failed_document=DocumentFailure(
-                                document_id=html_url,
-                                document_link=html_url,
-                            ),
-                            failure_message=(
-                                f"Skipping non-text/undecodable file: {path}"
-                            ),
-                        )
-                        continue
-                    yield _convert_file_to_document(
-                        repo, path, content_text, repo_external_access
-                    )
-                except Exception as e:
-                    error_msg = f"Error converting file {path} to document: {e}"
-                    logger.exception(error_msg)
-                    yield ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=html_url,
-                            document_link=html_url,
-                        ),
-                        failure_message=error_msg,
-                        exception=e,
-                    )
-                    continue
-
+            has_more_file_batches = yield from self._fetch_repo_files(
+                repo, checkpoint, start, is_slim, repo_external_access
+            )
             # More file batches remain for this repo — checkpoint and resume.
-            if (page + 1) * FILE_BATCH_SIZE < len(file_paths):
+            if has_more_file_batches:
                 return checkpoint
 
         # files complete (or disabled) -> fall through to next repo

--- a/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_checkpointing.py
@@ -902,8 +902,8 @@ def test_load_from_checkpoint_cursor_pagination_completion(
     assert cp4.cached_repo is not None
     assert cp4.cached_repo.id == mock_repo1.id  # Last processed repo
     assert (
-        cp4.stage == GithubConnectorStage.PRS
-    )  # Reset for a hypothetical next run/repo
+        cp4.stage == GithubConnectorStage.FILES
+    )  # FILES is the terminal stage of the pipeline
     assert cp4.curr_page == 0
     assert cp4.num_retrieved == 0
     assert cp4.cursor_url is None

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -195,6 +195,31 @@ def test_binary_file_yields_failure(
     assert isinstance(items[0], ConnectorFailure)
 
 
+def test_undecodable_content_yields_failure(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """decoded_content is None for non-base64 encodings (LFS, encoding='none').
+
+    This must surface as a ConnectorFailure, not an unhandled TypeError.
+    """
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo({"big.md": b"placeholder"})
+
+    none_content = MagicMock()
+    none_content.decoded_content = None
+    none_content.encoding = "none"
+    mock_repo.get_contents = MagicMock(return_value=none_content)
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    items = _all_items(outputs)
+    assert len(items) == 1
+    assert isinstance(items[0], ConnectorFailure)
+
+
 def test_pushed_at_gate_skips_file_stage(
     mock_github_client: MagicMock,
     create_mock_repo: Callable[..., MagicMock],
@@ -231,4 +256,38 @@ def test_files_paginated_across_checkpoints(
 
     docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
     assert len(docs) == 250
+    assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_files_paginated_with_issues_enabled_no_stage_regression(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """Resuming a multi-batch FILES checkpoint must not regress to ISSUES.
+
+    With include_issues=True, the unconditional stage transitions previously
+    overwrote a resumed FILES checkpoint back to ISSUES, nulling file_paths and
+    re-indexing files from page 0. Each file must be indexed exactly once.
+    """
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=False,
+        include_issues=True,
+        include_files=True,
+    )
+    connector.github_client = mock_github_client
+
+    files = {f"doc{i:03d}.md": f"content {i}".encode() for i in range(250)}
+    mock_repo = create_mock_repo(files)
+    mock_repo.get_issues.return_value.get_page.return_value = []  # no issues
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    ids = [d.id for d in docs]
+    assert len(ids) == 250
+    assert len(set(ids)) == 250  # no duplicates from re-indexing page 0
     assert outputs[-1].next_checkpoint.has_more is False

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from github import Github
+from github.GithubException import UnknownObjectException
 from github.RateLimit import RateLimit
 from github.Requester import Requester
 
@@ -45,6 +46,14 @@ from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_con
         (".git/config.md", 100, False),
         # size unknown is allowed (still extension-gated)
         ("README.md", None, True),
+        # extensionless conventional docs (case-insensitive)
+        ("README", 100, True),
+        ("LICENSE", 100, True),
+        ("docs/CHANGELOG", 100, True),
+        ("contributing", 100, True),
+        # extensionless but not a known doc filename
+        ("Makefile", 100, False),
+        ("Dockerfile", 100, False),
     ],
 )
 def test_is_indexable_path(path: str, size: int | None, expected: bool) -> None:
@@ -257,6 +266,85 @@ def test_files_paginated_across_checkpoints(
     docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
     assert len(docs) == 250
     assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_extensionless_docs_indexed(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo(
+        {
+            "README": b"top-level readme",
+            "LICENSE": b"MIT",
+            "Makefile": b"all:\n\tbuild",  # extensionless, not a doc -> excluded
+        }
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    ids = sorted(d.id for d in docs)
+    assert ids == [
+        "https://github.com/test-org/test-repo/blob/main/LICENSE",
+        "https://github.com/test-org/test-repo/blob/main/README",
+    ]
+
+
+def test_truncated_tree_yields_failure(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo({"README.md": b"# Hi"}, truncated=True)
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    items = _all_items(outputs)
+    failures = [i for i in items if isinstance(i, ConnectorFailure)]
+    docs = [i for i in items if isinstance(i, Document)]
+    # the enumerable file is still indexed, plus one truncation failure
+    assert len(docs) == 1
+    assert len(failures) == 1
+    assert failures[0].failed_entity is not None
+    assert "truncated" in failures[0].failure_message.lower()
+
+
+def test_prs_disabled_404_does_not_crash_files(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """A repo with PRs disabled (mirror) returns 404 on get_pulls.
+
+    This must skip the PRS stage rather than crash the whole connector, so
+    files still get indexed.
+    """
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=True,
+        include_issues=False,
+        include_files=True,
+    )
+    connector.github_client = mock_github_client
+
+    mock_repo = create_mock_repo({"README.md": b"# Hi"})
+    mock_repo.get_pulls.return_value.get_page.side_effect = UnknownObjectException(
+        404, {"message": "Not Found"}, {}
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    assert [d.id for d in docs] == [
+        "https://github.com/test-org/test-repo/blob/main/README.md"
+    ]
 
 
 def test_files_paginated_with_issues_enabled_no_stage_regression(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -1,0 +1,234 @@
+import time
+from collections.abc import Callable
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from github import Github
+from github.RateLimit import RateLimit
+from github.Requester import Requester
+
+from onyx.connectors.github.connector import _is_indexable_path
+from onyx.connectors.github.connector import GithubConnector
+from onyx.connectors.github.models import SerializedRepository
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
+
+
+@pytest.mark.parametrize(
+    "path,size,expected",
+    [
+        ("README.md", 100, True),
+        ("docs/guide.mdx", 100, True),
+        ("notes.txt", 100, True),
+        ("manual.rst", 100, True),
+        # disallowed extension (source code is intentionally excluded)
+        ("main.py", 100, False),
+        ("logo.png", 100, False),
+        # data / config / log formats are excluded (not "documents")
+        ("data.json", 100, False),
+        ("table.csv", 100, False),
+        ("table.tsv", 100, False),
+        ("config.yaml", 100, False),
+        ("config.yml", 100, False),
+        ("doc.xml", 100, False),
+        ("schema.sql", 100, False),
+        ("output.log", 100, False),
+        ("settings.conf", 100, False),
+        # oversized
+        ("BIG.md", 5_000_000, False),
+        # denylisted path segment
+        ("node_modules/pkg/README.md", 100, False),
+        (".git/config.md", 100, False),
+        # size unknown is allowed (still extension-gated)
+        ("README.md", None, True),
+    ],
+)
+def test_is_indexable_path(path: str, size: int | None, expected: bool) -> None:
+    assert _is_indexable_path(path, size) is expected
+
+
+@pytest.fixture
+def mock_github_client() -> MagicMock:
+    mock = MagicMock(spec=Github)
+    mock.get_repo = MagicMock()
+    mock.get_rate_limit = MagicMock(return_value=MagicMock(spec=RateLimit))
+    mock._requester = MagicMock(spec=Requester)
+    return mock
+
+
+def _tree_element(path: str, size: int, type_: str = "blob") -> MagicMock:
+    el = MagicMock()
+    el.path = path
+    el.size = size
+    el.type = type_
+    return el
+
+
+@pytest.fixture
+def create_mock_repo() -> Callable[..., MagicMock]:
+    def _create(
+        files: dict[str, bytes],
+        pushed_at: datetime | None = None,
+        truncated: bool = False,
+    ) -> MagicMock:
+        mock_repo = MagicMock()
+        mock_repo.name = "test-repo"
+        mock_repo.id = 1
+        mock_repo.full_name = "test-org/test-repo"
+        mock_repo.html_url = "https://github.com/test-org/test-repo"
+        mock_repo.default_branch = "main"
+        mock_repo.pushed_at = pushed_at or datetime(2023, 1, 1)
+        mock_repo.configure_mock(
+            raw_headers={"status": "200 OK"},
+            raw_data={"id": 1, "full_name": "test-org/test-repo"},
+        )
+
+        tree = MagicMock()
+        tree.tree = [_tree_element(p, len(c)) for p, c in files.items()]
+        tree.raw_data = {"truncated": truncated}
+        mock_repo.get_git_tree = MagicMock(return_value=tree)
+
+        def _get_contents(path: str, ref: str | None = None) -> MagicMock:
+            del ref  # accepted as a kwarg by the connector, unused in the mock
+            cf = MagicMock()
+            cf.decoded_content = files[path]
+            return cf
+
+        mock_repo.get_contents = MagicMock(side_effect=_get_contents)
+        return mock_repo
+
+    return _create
+
+
+def _build_connector(
+    mock_github_client: MagicMock, include_files: bool = True
+) -> GithubConnector:
+    connector = GithubConnector(
+        repo_owner="test-org",
+        repositories="test-repo",
+        include_prs=False,
+        include_issues=False,
+        include_files=include_files,
+    )
+    connector.github_client = mock_github_client
+    return connector
+
+
+def _all_items(outputs: list) -> list:
+    items: list = []
+    for o in outputs:
+        items.extend(o.items)
+    return items
+
+
+def test_files_not_indexed_when_disabled(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client, include_files=False)
+    mock_repo = create_mock_repo({"README.md": b"# Hello"})
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    assert _all_items(outputs) == []
+    mock_repo.get_git_tree.assert_not_called()
+
+
+def test_files_indexed_when_enabled(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo(
+        {
+            "README.md": b"# Hello world",
+            "docs/guide.md": b"a guide",
+            "src/main.py": b"print('hi')",  # excluded extension
+            "logo.png": b"\x89PNG\r\n",  # excluded extension
+        }
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    ids = sorted(d.id for d in docs)
+    assert ids == [
+        "https://github.com/test-org/test-repo/blob/main/README.md",
+        "https://github.com/test-org/test-repo/blob/main/docs/guide.md",
+    ]
+
+    readme = next(d for d in docs if d.id.endswith("README.md"))
+    assert readme.semantic_identifier == "README.md"
+    assert readme.sections[0].text == "# Hello world"
+    assert readme.doc_metadata is not None
+    assert readme.doc_metadata["hierarchy"]["source_path"] == [
+        "test-org",
+        "test-repo",
+        "files",
+        "README.md",
+    ]
+    assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_binary_file_yields_failure(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    # .md extension but undecodable binary content
+    mock_repo = create_mock_repo({"corrupt.md": b"\xff\xfe\x00\x01\x80\x81"})
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    items = _all_items(outputs)
+    assert len(items) == 1
+    assert isinstance(items[0], ConnectorFailure)
+
+
+def test_pushed_at_gate_skips_file_stage(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo(
+        {"README.md": b"# Hello"},
+        pushed_at=datetime(2020, 1, 1),
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    # poll window starts well after the repo's last push
+    start = datetime(2023, 1, 1, tzinfo=timezone.utc).timestamp()
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(
+            connector, start, time.time()
+        )
+
+    assert _all_items(outputs) == []
+    mock_repo.get_git_tree.assert_not_called()
+
+
+def test_files_paginated_across_checkpoints(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    files = {f"doc{i:03d}.md": f"content {i}".encode() for i in range(250)}
+    mock_repo = create_mock_repo(files)
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    assert len(docs) == 250
+    assert outputs[-1].next_checkpoint.has_more is False

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -243,6 +243,15 @@ export const connectorConfigs: Record<
         description: "Index issues from repositories",
         optional: true,
       },
+      {
+        type: "checkbox",
+        query: "Include documents?",
+        label: "Include Documents?",
+        name: "include_files",
+        description:
+          "Index text-based documents (markdown, text, etc.) from the default branch of repositories",
+        optional: true,
+      },
     ],
     advanced_values: [],
   },
@@ -1921,6 +1930,7 @@ export interface GithubConfig {
   repositories: string; // Comma-separated list of repository names
   include_prs: boolean;
   include_issues: boolean;
+  include_files: boolean;
 }
 
 export interface GitlabConfig {


### PR DESCRIPTION
## Description
Github repos can contain documents valuable for indexing. This change creates an additional toggle on the github connector that can allow for documents from repos to be indexed.

This is done by iterating through the repo and finding documents with the following extensions:
.md, .mdx, .markdown, .rst, .txt

## How Has This Been Tested?
Manually + some tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional document indexing to the GitHub connector. When enabled, we crawl the default branch and index text docs (.md, .mdx, .markdown, .rst, .txt) and common extensionless docs (README, LICENSE, etc.).

- **New Features**
  - New `include_files` setting and UI checkbox (“Include Documents?”) to index repository documents from the default branch.
  - Indexes only human-readable files; recognizes extensionless docs; skips denylisted paths, files >1MB, and non-text/undecodable content. Produces documents with blob links, file-based identifiers, and hierarchy metadata; surfaces truncated trees as failures.
  - Adds a FILES stage with checkpointed pagination (100 files per batch) and a `pushed_at` gate to skip unchanged repos. Validation now requires at least one of PRs, issues, or files to be enabled.

- **Bug Fixes**
  - Skip PRs/issues stages when GitHub returns 404 (feature disabled) instead of failing.
  - Prevent stage regression when resuming FILES pagination so each file is indexed exactly once.

<sup>Written for commit c566ebd8c5d78e02fe7015b69387f70bf2b07799. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11293?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



