### PR TITLE
fix: docfetching doc count

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -789,6 +789,7 @@ def connector_document_extraction(
 
                 batch_num += 1
                 total_doc_batches_queued += 1
+                document_count += len(doc_batch_cleaned)
 
                 logger.info(
                     "Queued document processing batch: batch_num=%s docs=%s attempt=%s",


### PR DESCRIPTION
## Description

fix dead variable that wasn't actually counting documents

## How Has This Been Tested?

n/a

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes document counting in doc fetching by incrementing `document_count` for each queued batch. Logs and metrics now reflect the real number of documents processed.

<sup>Written for commit f1593a3c7388ab62cf568b1a1099083806bcaf49. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

