### PR TITLE
feat: persistent indexing

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -47,11 +47,13 @@ from onyx.background.indexing.index_attempt_utils import cleanup_index_attempts
 from onyx.background.indexing.index_attempt_utils import get_old_index_attempt_ids
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import MANAGED_VESPA
+from onyx.configs.app_configs import PERSISTENT_INDEXING
 from onyx.configs.app_configs import VESPA_CLOUD_CERT_PATH
 from onyx.configs.app_configs import VESPA_CLOUD_KEY_PATH
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_INDEXING_LOCK_TIMEOUT
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import NotificationType
 from onyx.configs.constants import OnyxCeleryPriority
@@ -108,6 +110,8 @@ from onyx.indexing.adapters.document_indexing_adapter import (
 )
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
+from onyx.indexing.persistent_indexing import build_generic_connector_failure
+from onyx.indexing.persistent_indexing import record_generic_failure
 from onyx.natural_language_processing.search_nlp_models import EmbeddingModel
 from onyx.natural_language_processing.search_nlp_models import warm_up_bi_encoder
 from onyx.redis.redis_connector import RedisConnector
@@ -1392,6 +1396,10 @@ def _check_failure_threshold(
     1. We have more than 3 failures AND
     2. Failures account for more than 10% of processed documents
     """
+    # Persistent indexing: never abort on failure volume.
+    if PERSISTENT_INDEXING:
+        return
+
     failure_ratio = total_failures / (document_count or 1)
 
     FAILURE_THRESHOLD = 3
@@ -1507,6 +1515,105 @@ def _check_chunk_usage_limit(tenant_id: str) -> None:
         )
 
 
+def _record_docprocessing_failure_persistent(
+    *,
+    exc: BaseException,
+    index_attempt_id: int,
+    cc_pair_id: int,
+    tenant_id: str,
+    batch_num: int,
+    documents: list[Document] | None,
+    cross_batch_db_lock: RedisLock | None,
+) -> None:
+    """Catch-all recovery for `_docprocessing_task` under PERSISTENT_INDEXING.
+
+    Records per-doc `DocumentFailure`s (when `documents` was loaded) or a single
+    `EntityFailure` (when the batch never made it past load), then marks the
+    batch complete with zero counts so `check_indexing_completion` can resolve
+    the attempt as `COMPLETED_WITH_ERRORS`.
+
+    Every step is wrapped so a follow-on error here does not re-raise out of
+    the Celery task — we have already swallowed the original exception."""
+    task_logger.info(
+        "PERSISTENT_INDEXING enabled; recording docprocessing failure for "
+        "attempt=%s batch=%s",
+        index_attempt_id,
+        batch_num,
+    )
+
+    # Source lookup is best-effort; only used for Sentry tagging.
+    source: DocumentSource = DocumentSource.NOT_APPLICABLE
+    try:
+        with get_session_with_current_tenant() as db_session:
+            cc_pair = get_connector_credential_pair_from_id(
+                db_session, cc_pair_id, eager_load_connector=True
+            )
+            if cc_pair is not None:
+                source = cc_pair.connector.source
+    except Exception:
+        task_logger.exception(
+            "Failed to look up source for cc_pair %s during persistent indexing "
+            "recovery; falling back to NOT_APPLICABLE",
+            cc_pair_id,
+        )
+
+    if documents:
+        for doc in documents:
+            record_generic_failure(
+                index_attempt_id=index_attempt_id,
+                cc_pair_id=cc_pair_id,
+                source=source,
+                tenant_id=tenant_id,
+                failure=build_generic_connector_failure(exc=exc, document=doc),
+            )
+    else:
+        record_generic_failure(
+            index_attempt_id=index_attempt_id,
+            cc_pair_id=cc_pair_id,
+            source=source,
+            tenant_id=tenant_id,
+            failure=build_generic_connector_failure(
+                exc=exc,
+                entity_id=(
+                    f"docprocessing:attempt_{index_attempt_id}:batch_{batch_num}"
+                ),
+            ),
+        )
+
+    # Mark the batch complete with zero counts so check_indexing_completion
+    # doesn't wait forever for this batch. Best-effort: if the lock or DB
+    # write fails we still return cleanly.
+    try:
+        if cross_batch_db_lock is not None:
+            with (
+                get_session_with_current_tenant() as db_session,
+                cross_batch_db_lock,
+            ):
+                IndexingCoordination.update_batch_completion_and_docs(
+                    db_session=db_session,
+                    index_attempt_id=index_attempt_id,
+                    total_docs_indexed=0,
+                    new_docs_indexed=0,
+                    total_chunks=0,
+                )
+        else:
+            with get_session_with_current_tenant() as db_session:
+                IndexingCoordination.update_batch_completion_and_docs(
+                    db_session=db_session,
+                    index_attempt_id=index_attempt_id,
+                    total_docs_indexed=0,
+                    new_docs_indexed=0,
+                    total_chunks=0,
+                )
+    except Exception:
+        task_logger.exception(
+            "Failed to mark batch %s complete during persistent indexing "
+            "recovery for attempt %s",
+            batch_num,
+            index_attempt_id,
+        )
+
+
 def _docprocessing_task(
     index_attempt_id: int,
     cc_pair_id: int,
@@ -1578,6 +1685,12 @@ def _docprocessing_task(
 
     # dummy lock to satisfy linter
     per_batch_lock: RedisLock | None = None
+
+    # Hoisted so the except block can safely reference them under
+    # PERSISTENT_INDEXING when the failure happens mid-try.
+    documents: list[Document] | None = None
+    cross_batch_db_lock: RedisLock | None = None
+
     try:
         # FIX: Monitor memory before loading documents to track problematic batches
         emit_process_memory(
@@ -1813,7 +1926,9 @@ def _docprocessing_task(
         # This helps prevent memory accumulation across multiple batches
         # NOTE: Thread-local event loops in embedding threads are cleaned up automatically
         # via the _cleanup_thread_local decorator in search_nlp_models.py
-        del documents
+        # NOTE: We assign None rather than `del` so the variable stays bound;
+        # the except block under PERSISTENT_INDEXING needs to safely inspect it.
+        documents = None
         gc.collect()
 
         # FIX: Log final memory usage to track problematic tenants/CC pairs
@@ -1852,12 +1967,24 @@ def _docprocessing_task(
             f"elapsed={elapsed_time:.2f}s"
         )
 
-    except Exception:
+    except Exception as e:
         task_logger.exception(
             f"Document batch processing failed: batch_num={batch_num} attempt={index_attempt_id} "
         )
 
-        raise
+        if not PERSISTENT_INDEXING:
+            raise
+
+        _record_docprocessing_failure_persistent(
+            exc=e,
+            index_attempt_id=index_attempt_id,
+            cc_pair_id=cc_pair_id,
+            tenant_id=tenant_id,
+            batch_num=batch_num,
+            documents=documents,
+            cross_batch_db_lock=cross_batch_db_lock,
+        )
+        return
     finally:
         if per_batch_lock and per_batch_lock.owned():
             per_batch_lock.release()

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -23,6 +23,7 @@ from onyx.configs.app_configs import INDEXING_TRACER_INTERVAL
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.app_configs import LEAVE_CONNECTOR_ACTIVE_ON_INITIALIZATION_FAILURE
 from onyx.configs.app_configs import MAX_FILE_SIZE_BYTES
+from onyx.configs.app_configs import PERSISTENT_INDEXING
 from onyx.configs.app_configs import POLL_CONNECTOR_OFFSET
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -68,6 +69,8 @@ from onyx.file_store.staging import build_raw_file_callback
 from onyx.file_store.staging import RawFileCallback
 from onyx.file_store.staging import reap_prior_attempt_staged_files
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.indexing.persistent_indexing import build_generic_connector_failure
+from onyx.indexing.persistent_indexing import record_generic_failure
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import cache_hierarchy_nodes_batch
 from onyx.redis.redis_hierarchy import ensure_source_node_exists
@@ -279,6 +282,10 @@ def _check_failure_threshold(
     1. We have more than 3 failures AND
     2. Failures account for more than 10% of processed documents
     """
+    # Persistent indexing: never abort on failure volume.
+    if PERSISTENT_INDEXING:
+        return
+
     failure_ratio = total_failures / (document_count or 1)
 
     FAILURE_THRESHOLD = 3
@@ -601,12 +608,14 @@ def connector_document_extraction(
             checkpoint=checkpoint,
         )
 
-    try:
-        batch_num = last_batch_num  # starts at 0 if no last batch
-        total_doc_batches_queued = 0
-        total_failures = 0
-        document_count = 0
+    # Initialize loop state before the try so the except block can reference
+    # batch_num when reporting/recording errors under PERSISTENT_INDEXING.
+    batch_num = last_batch_num  # starts at 0 if no last batch
+    total_doc_batches_queued = 0
+    total_failures = 0
+    document_count = 0
 
+    try:
         # Ensure the SOURCE-type root hierarchy node exists before processing.
         # This is the root of the hierarchy tree for this source - all other
         # hierarchy nodes should ultimately have this as an ancestor.
@@ -917,6 +926,39 @@ def connector_document_extraction(
                         index_attempt_id,
                     )
                     raise e
+
+                if PERSISTENT_INDEXING:
+                    # Persistent indexing: record this as a generic EntityFailure
+                    # and let check_indexing_completion resolve the attempt as
+                    # COMPLETED_WITH_ERRORS instead of marking it FAILED.
+                    logger.info(
+                        "PERSISTENT_INDEXING enabled; recording docfetching "
+                        "failure as ConnectorFailure for attempt %s",
+                        index_attempt_id,
+                    )
+                    failure = build_generic_connector_failure(
+                        exc=e,
+                        entity_id=(
+                            f"docfetching:{db_connector.source.value}"
+                            f":cc_pair_{cc_pair_id}:batch_{batch_num}"
+                        ),
+                    )
+                    record_generic_failure(
+                        index_attempt_id=index_attempt_id,
+                        cc_pair_id=cc_pair_id,
+                        source=db_connector.source,
+                        tenant_id=tenant_id,
+                        failure=failure,
+                    )
+                    # Set total_batches so check_indexing_completion can resolve
+                    # the attempt. Without this the attempt would hang in
+                    # IN_PROGRESS forever.
+                    IndexingCoordination.set_total_batches(
+                        db_session=db_session_temp,
+                        index_attempt_id=index_attempt_id,
+                        total_batches=batch_num,
+                    )
+                    return
 
                 mark_attempt_failed(
                     index_attempt_id,

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -952,13 +952,23 @@ def connector_document_extraction(
                     )
                     # Set total_batches so check_indexing_completion can resolve
                     # the attempt. Without this the attempt would hang in
-                    # IN_PROGRESS forever.
-                    IndexingCoordination.set_total_batches(
-                        db_session=db_session_temp,
-                        index_attempt_id=index_attempt_id,
-                        total_batches=batch_num,
-                    )
-                    return
+                    # IN_PROGRESS forever. If this DB write fails we have no
+                    # way to land COMPLETED_WITH_ERRORS cleanly — fall through
+                    # to mark_attempt_failed below as a safety net.
+                    try:
+                        IndexingCoordination.set_total_batches(
+                            db_session=db_session_temp,
+                            index_attempt_id=index_attempt_id,
+                            total_batches=batch_num,
+                        )
+                        return
+                    except Exception:
+                        logger.exception(
+                            "Failed to set total_batches during persistent "
+                            "indexing recovery for attempt %s; falling back "
+                            "to mark_attempt_failed",
+                            index_attempt_id,
+                        )
 
                 mark_attempt_failed(
                     index_attempt_id,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -891,6 +891,15 @@ ZENDESK_CONNECTOR_SKIP_ARTICLE_LABELS = os.environ.get(
 CONTINUE_ON_CONNECTOR_FAILURE = os.environ.get(
     "CONTINUE_ON_CONNECTOR_FAILURE", ""
 ).lower() not in ["false", ""]
+# When true, indexing tolerates ALL operational errors raised from inside the
+# connector / pipeline data path: anything that would otherwise crash an index
+# attempt is recorded as a ConnectorFailure (DocumentFailure when a doc id is
+# known, otherwise EntityFailure) and the attempt continues. Also disables
+# the >3-failures-AND->10%-ratio abort. Does NOT suppress mark_attempt_failed
+# triggered by the watchdog/heartbeat, usage-limit overflow, inconsistent
+# attempt state, or completion-monitor exceptions — those signal that the
+# worker itself or the tenant's quota is broken, not connector data errors.
+PERSISTENT_INDEXING = os.environ.get("PERSISTENT_INDEXING", "").lower() == "true"
 # When swapping to a new embedding model, a secondary index is created in the background, to conserve
 # resources, we pause updates on the primary index by default while the secondary index is created
 DISABLE_INDEX_UPDATE_ON_SWAP = (

--- a/backend/onyx/indexing/persistent_indexing.py
+++ b/backend/onyx/indexing/persistent_indexing.py
@@ -1,0 +1,108 @@
+"""Helpers for the PERSISTENT_INDEXING catch-all error path.
+
+These are used by the docfetching / docprocessing task entrypoints to convert
+unanticipated exceptions into ConnectorFailure records so the index attempt
+can finish as COMPLETED_WITH_ERRORS instead of FAILED. Use only as a
+last-resort catch-all; connectors should keep yielding their own targeted
+ConnectorFailure objects with proper context for known error conditions.
+"""
+
+import sentry_sdk
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import EntityFailure
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.index_attempt import create_index_attempt_error
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+GENERIC_FAILURE_SENTRY_FINGERPRINT_PREFIX = "persistent-indexing-generic-failure"
+
+
+def build_generic_connector_failure(
+    *,
+    exc: BaseException,
+    document: Document | None = None,
+    entity_id: str | None = None,
+) -> ConnectorFailure:
+    """Build a ConnectorFailure for an unanticipated exception in the indexing
+    pipeline. Exactly one of `document` or `entity_id` must be provided:
+    `DocumentFailure` when the doc id is known, otherwise `EntityFailure`."""
+    if (document is None) == (entity_id is None):
+        raise ValueError(
+            "build_generic_connector_failure requires exactly one of "
+            "`document` or `entity_id`"
+        )
+
+    if document is not None:
+        document_link: str | None = None
+        if document.sections:
+            document_link = document.sections[0].link
+        return ConnectorFailure(
+            failed_document=DocumentFailure(
+                document_id=document.id,
+                document_link=document_link,
+            ),
+            failure_message=str(exc),
+            exception=exc if isinstance(exc, Exception) else None,
+        )
+
+    assert entity_id is not None  # linter
+    return ConnectorFailure(
+        failed_entity=EntityFailure(entity_id=entity_id),
+        failure_message=str(exc),
+        exception=exc if isinstance(exc, Exception) else None,
+    )
+
+
+def record_generic_failure(
+    index_attempt_id: int,
+    cc_pair_id: int,
+    source: DocumentSource,
+    tenant_id: str,
+    failure: ConnectorFailure,
+) -> None:
+    """Tag Sentry, then persist the failure via `create_index_attempt_error`.
+
+    Swallows DB errors with `logger.exception` so the recovery path itself
+    can't kill the attempt."""
+    exc = failure.exception
+    if exc is not None:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tag("stage", "persistent_indexing_catch_all")
+            scope.set_tag("connector_source", source.value)
+            scope.set_tag("cc_pair_id", str(cc_pair_id))
+            scope.set_tag("index_attempt_id", str(index_attempt_id))
+            scope.set_tag("tenant_id", tenant_id)
+            if failure.failed_document:
+                scope.set_tag("doc_id", failure.failed_document.document_id)
+            if failure.failed_entity:
+                scope.set_tag("entity_id", failure.failed_entity.entity_id)
+            scope.fingerprint = [
+                GENERIC_FAILURE_SENTRY_FINGERPRINT_PREFIX,
+                source.value,
+                type(exc).__name__,
+            ]
+            sentry_sdk.capture_exception(exc)
+
+    try:
+        with get_session_with_current_tenant() as db_session:
+            create_index_attempt_error(
+                index_attempt_id,
+                cc_pair_id,
+                failure,
+                db_session,
+            )
+    except Exception:
+        # Recording failure must never itself kill the attempt; if the DB write
+        # fails we still want the task to return cleanly under PERSISTENT_INDEXING.
+        logger.exception(
+            "Failed to persist generic indexing failure: attempt=%s cc_pair=%s",
+            index_attempt_id,
+            cc_pair_id,
+        )

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -43,6 +43,7 @@ from onyx.db.enums import IndexModelStatus
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_index_attempt_errors
 from onyx.db.models import IndexAttempt
+from onyx.db.models import IndexAttemptError
 from onyx.db.models import SearchSettings
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
@@ -181,6 +182,10 @@ def _seed_attempt(db_session: Session) -> tuple[int, int, int]:
 def _teardown_attempt(
     db_session: Session, cc_pair_id: int, search_settings_id: int, attempt_id: int
 ) -> None:
+    # IndexAttemptError FKs index_attempt; drop child rows first.
+    db_session.query(IndexAttemptError).filter(
+        IndexAttemptError.index_attempt_id == attempt_id
+    ).delete(synchronize_session="fetch")
     db_session.query(IndexAttempt).filter(IndexAttempt.id == attempt_id).delete(
         synchronize_session="fetch"
     )

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -1,0 +1,437 @@
+"""External-dependency-unit tests for PERSISTENT_INDEXING.
+
+Exercises `run_docfetching_entrypoint` against a mock connector that either:
+  (a) yields docs/failures then raises an unhandled exception, or
+  (b) yields more `ConnectorFailure`s than the >3-failures-AND->10%-ratio
+      threshold would normally tolerate.
+
+In both cases, with PERSISTENT_INDEXING patched to True, the attempt must
+not be marked FAILED; instead a `ConnectorFailure` is recorded against
+the attempt and `check_indexing_completion` can later resolve it to
+COMPLETED_WITH_ERRORS. With PERSISTENT_INDEXING False (default), the
+attempt is marked FAILED as before.
+
+Runs against real Postgres + real file_store; the celery `send_task`
+is mocked because docprocessing is a separate pod and not under test.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.indexing.run_docfetching import run_docfetching_entrypoint
+from onyx.configs.constants import DocumentSource
+from onyx.connectors import factory as connector_factory
+from onyx.connectors.interfaces import CheckpointedConnector
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.models import ConnectorCheckpoint
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import EntityFailure
+from onyx.connectors.models import TextSection
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.index_attempt import get_index_attempt
+from onyx.db.index_attempt import get_index_attempt_errors
+from onyx.db.models import IndexAttempt
+from onyx.db.models import SearchSettings
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+# ---------------------------------------------------------------------------
+# Mock checkpointed connector with configurable failure behavior
+# ---------------------------------------------------------------------------
+
+
+class _MockCheckpoint(ConnectorCheckpoint):
+    """Minimal checkpoint type for the mock connector."""
+
+    pass
+
+
+# Module-level config so the connector instance (constructed by the factory
+# with empty kwargs) can pick up test-specific behavior.
+_MOCK_BEHAVIOR: dict[str, Any] = {
+    "docs": [],
+    "failures": [],
+    "raise_at_end": False,
+    "raise_message": "simulated unhandled connector error",
+}
+
+
+def _reset_mock_behavior() -> None:
+    _MOCK_BEHAVIOR["docs"] = []
+    _MOCK_BEHAVIOR["failures"] = []
+    _MOCK_BEHAVIOR["raise_at_end"] = False
+    _MOCK_BEHAVIOR["raise_message"] = "simulated unhandled connector error"
+
+
+class MockCheckpointedConnector(CheckpointedConnector[_MockCheckpoint]):
+    """Yields whatever's configured in `_MOCK_BEHAVIOR`, then optionally raises.
+
+    Empty-kwargs construction is required because the production factory
+    calls `connector_class(**connector_specific_config)` and the cc_pair
+    seeded in the test has an empty config.
+    """
+
+    def __init__(self, **_ignored: Any) -> None:
+        pass
+
+    def load_credentials(
+        self,
+        credentials: dict[str, Any],  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        return None
+
+    def build_dummy_checkpoint(self) -> _MockCheckpoint:
+        return _MockCheckpoint(has_more=True)
+
+    def validate_checkpoint_json(self, checkpoint_json: str) -> _MockCheckpoint:
+        return _MockCheckpoint.model_validate_json(checkpoint_json)
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,  # noqa: ARG002
+        end: SecondsSinceUnixEpoch,  # noqa: ARG002
+        checkpoint: _MockCheckpoint,  # noqa: ARG002
+    ) -> CheckpointOutput[_MockCheckpoint]:
+        for doc in _MOCK_BEHAVIOR["docs"]:
+            yield doc
+        for failure in _MOCK_BEHAVIOR["failures"]:
+            yield failure
+        if _MOCK_BEHAVIOR["raise_at_end"]:
+            raise RuntimeError(_MOCK_BEHAVIOR["raise_message"])
+        return _MockCheckpoint(has_more=False)
+
+    def retrieve_all_slim_documents(self) -> GenerateSlimDocumentOutput:
+        yield from []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_doc(doc_id: str) -> Document:
+    return Document(
+        id=doc_id,
+        source=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"sem-{doc_id}",
+        sections=[TextSection(text="payload", link=f"https://example.com/{doc_id}")],
+        metadata={},
+    )
+
+
+def _make_doc_failure(doc_id: str) -> ConnectorFailure:
+    return ConnectorFailure(
+        failed_document=DocumentFailure(document_id=doc_id),
+        failure_message=f"yielded failure for {doc_id}",
+    )
+
+
+def _seed_attempt(db_session: Session) -> tuple[int, int, int]:
+    """Create cc_pair + search_settings + index_attempt rows.
+
+    Returns (cc_pair_id, search_settings_id, index_attempt_id)."""
+    cc_pair = make_cc_pair(db_session)
+
+    search_settings = SearchSettings(
+        model_name="test-model",
+        model_dim=768,
+        normalize=True,
+        query_prefix="",
+        passage_prefix="",
+        status=IndexModelStatus.PRESENT,
+        index_name=f"test_index_{uuid4().hex[:8]}",
+        embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    db_session.add(search_settings)
+    db_session.commit()
+    db_session.refresh(search_settings)
+
+    index_attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=search_settings.id,
+        from_beginning=False,
+        status=IndexingStatus.NOT_STARTED,
+        celery_task_id=f"test-task-{uuid4().hex[:8]}",
+    )
+    db_session.add(index_attempt)
+    db_session.commit()
+    db_session.refresh(index_attempt)
+
+    return cc_pair.id, search_settings.id, index_attempt.id
+
+
+def _teardown_attempt(
+    db_session: Session, cc_pair_id: int, search_settings_id: int, attempt_id: int
+) -> None:
+    db_session.query(IndexAttempt).filter(IndexAttempt.id == attempt_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.query(SearchSettings).filter(
+        SearchSettings.id == search_settings_id
+    ).delete(synchronize_session="fetch")
+    db_session.commit()
+    from onyx.db.models import ConnectorCredentialPair
+
+    cc_pair = (
+        db_session.query(ConnectorCredentialPair)
+        .filter(ConnectorCredentialPair.id == cc_pair_id)
+        .one_or_none()
+    )
+    if cc_pair is not None:
+        cleanup_cc_pair(db_session, cc_pair)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def register_mock_connector(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Inject MockCheckpointedConnector into the production factory cache."""
+    _reset_mock_behavior()
+    monkeypatch.setitem(
+        connector_factory._connector_cache,
+        DocumentSource.MOCK_CONNECTOR,
+        MockCheckpointedConnector,
+    )
+    try:
+        yield
+    finally:
+        _reset_mock_behavior()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_unhandled_exception_default_marks_attempt_failed(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    register_mock_connector: None,  # noqa: ARG001
+) -> None:
+    """Baseline: PERSISTENT_INDEXING False (default). An unhandled exception
+    inside the connector generator marks the attempt FAILED."""
+    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
+
+    _MOCK_BEHAVIOR["docs"] = [_make_doc(f"doc-{uuid4().hex[:8]}")]
+    _MOCK_BEHAVIOR["raise_at_end"] = True
+
+    try:
+        mock_app = MagicMock()
+        with pytest.raises(RuntimeError, match="simulated unhandled connector error"):
+            run_docfetching_entrypoint(
+                app=mock_app,
+                index_attempt_id=attempt_id,
+                tenant_id=TEST_TENANT_ID,
+                connector_credential_pair_id=cc_pair_id,
+            )
+
+        db_session.expire_all()
+        attempt = get_index_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == IndexingStatus.FAILED
+
+        errors = get_index_attempt_errors(attempt_id, db_session)
+        # No persistent-mode catch-all recorded — only what the connector
+        # itself yielded (none here).
+        assert len(errors) == 0
+    finally:
+        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
+
+
+def test_unhandled_exception_persistent_mode_records_entity_failure(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    register_mock_connector: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With PERSISTENT_INDEXING True, an unhandled exception inside the
+    connector generator is converted into an EntityFailure and the attempt
+    is NOT marked FAILED — it stays IN_PROGRESS for the completion monitor
+    to resolve as COMPLETED_WITH_ERRORS once all queued batches finish."""
+    # Patch the captured constant at every site that reads it. (See app_configs
+    # — the value is captured at import time, so patching os.environ does not
+    # affect already-imported modules.)
+    monkeypatch.setattr(
+        "onyx.background.indexing.run_docfetching.PERSISTENT_INDEXING", True
+    )
+
+    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
+
+    _MOCK_BEHAVIOR["docs"] = [_make_doc(f"doc-{uuid4().hex[:8]}")]
+    _MOCK_BEHAVIOR["raise_at_end"] = True
+    _MOCK_BEHAVIOR["raise_message"] = "simulated_persistent_mode_kaboom"
+
+    try:
+        mock_app = MagicMock()
+        # No raise expected — persistent mode swallows the exception.
+        run_docfetching_entrypoint(
+            app=mock_app,
+            index_attempt_id=attempt_id,
+            tenant_id=TEST_TENANT_ID,
+            connector_credential_pair_id=cc_pair_id,
+        )
+
+        db_session.expire_all()
+        attempt = get_index_attempt(db_session, attempt_id)
+        assert attempt is not None
+        # Attempt is NOT FAILED; completion monitor will resolve it later.
+        assert attempt.status != IndexingStatus.FAILED, (
+            f"Expected attempt to not be FAILED under PERSISTENT_INDEXING; "
+            f"got {attempt.status}"
+        )
+
+        # Generic catch-all recorded exactly one EntityFailure.
+        errors = get_index_attempt_errors(attempt_id, db_session)
+        assert len(errors) == 1
+        err = errors[0]
+        assert err.entity_id is not None
+        assert err.document_id is None
+        # entity_id format: docfetching:{source}:cc_pair_{id}:batch_{n}
+        assert err.entity_id.startswith(
+            f"docfetching:{DocumentSource.MOCK_CONNECTOR.value}:cc_pair_{cc_pair_id}"
+        )
+        assert "simulated_persistent_mode_kaboom" in (err.failure_message or "")
+    finally:
+        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
+
+
+def test_threshold_disabled_in_persistent_mode(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    register_mock_connector: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With PERSISTENT_INDEXING True, the docfetching `_check_failure_threshold`
+    early-returns, so a flood of connector-yielded `ConnectorFailure`s
+    never aborts the attempt. Without the flag, the same flood would
+    raise from `_check_failure_threshold` and mark the attempt FAILED."""
+    monkeypatch.setattr(
+        "onyx.background.indexing.run_docfetching.PERSISTENT_INDEXING", True
+    )
+
+    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
+
+    # 10 yielded failures, no docs — would trip >3-failures-AND->10%-ratio.
+    _MOCK_BEHAVIOR["failures"] = [
+        _make_doc_failure(f"doc-{i}-{uuid4().hex[:8]}") for i in range(10)
+    ]
+
+    try:
+        mock_app = MagicMock()
+        # No raise expected — threshold guard early-returns.
+        run_docfetching_entrypoint(
+            app=mock_app,
+            index_attempt_id=attempt_id,
+            tenant_id=TEST_TENANT_ID,
+            connector_credential_pair_id=cc_pair_id,
+        )
+
+        db_session.expire_all()
+        attempt = get_index_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status != IndexingStatus.FAILED
+
+        # All 10 failures recorded.
+        errors = get_index_attempt_errors(attempt_id, db_session)
+        assert len(errors) == 10
+        # All are document failures (what the connector yielded).
+        for err in errors:
+            assert err.document_id is not None
+            assert err.entity_id is None
+    finally:
+        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
+
+
+def test_threshold_default_aborts_attempt(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    register_mock_connector: None,  # noqa: ARG001
+) -> None:
+    """Baseline: PERSISTENT_INDEXING False (default). A flood of
+    `ConnectorFailure`s trips the threshold and marks the attempt FAILED."""
+    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
+
+    _MOCK_BEHAVIOR["failures"] = [
+        _make_doc_failure(f"doc-{i}-{uuid4().hex[:8]}") for i in range(10)
+    ]
+
+    try:
+        mock_app = MagicMock()
+        with pytest.raises(Exception):
+            run_docfetching_entrypoint(
+                app=mock_app,
+                index_attempt_id=attempt_id,
+                tenant_id=TEST_TENANT_ID,
+                connector_credential_pair_id=cc_pair_id,
+            )
+
+        db_session.expire_all()
+        attempt = get_index_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == IndexingStatus.FAILED
+    finally:
+        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
+
+
+def test_persistent_mode_uses_entity_failure_when_no_doc_context(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+    register_mock_connector: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the connector raises immediately with no doc context, the
+    catch-all records an EntityFailure (not a DocumentFailure) since we
+    have no doc id to associate the error with."""
+    monkeypatch.setattr(
+        "onyx.background.indexing.run_docfetching.PERSISTENT_INDEXING", True
+    )
+
+    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
+
+    # No docs, no yielded failures, just immediate raise.
+    _MOCK_BEHAVIOR["raise_at_end"] = True
+
+    try:
+        mock_app = MagicMock()
+        run_docfetching_entrypoint(
+            app=mock_app,
+            index_attempt_id=attempt_id,
+            tenant_id=TEST_TENANT_ID,
+            connector_credential_pair_id=cc_pair_id,
+        )
+
+        db_session.expire_all()
+        errors = get_index_attempt_errors(attempt_id, db_session)
+        assert len(errors) == 1
+        err = errors[0]
+        assert isinstance(err.entity_id, str), (
+            f"Expected EntityFailure, got document_id={err.document_id}"
+        )
+        assert err.document_id is None
+    finally:
+        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
+
+
+# Suppress unused-import warnings for symbols referenced only by name in
+# docstrings / type comments above.
+_ = EntityFailure

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -35,6 +35,7 @@ from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import EntityFailure
+from onyx.connectors.models import InputType
 from onyx.connectors.models import TextSection
 from onyx.db.enums import EmbeddingPrecision
 from onyx.db.enums import IndexingStatus
@@ -143,6 +144,11 @@ def _seed_attempt(db_session: Session) -> tuple[int, int, int]:
 
     Returns (cc_pair_id, search_settings_id, index_attempt_id)."""
     cc_pair = make_cc_pair(db_session)
+    # `make_cc_pair` defaults the connector's input_type to LOAD_STATE, but our
+    # mock implements CheckpointedConnector — which the factory only accepts
+    # under POLL. Override before the entrypoint runs.
+    cc_pair.connector.input_type = InputType.POLL
+    db_session.commit()
 
     search_settings = SearchSettings(
         model_name="test-model",

--- a/backend/tests/unit/onyx/indexing/test_persistent_indexing_helpers.py
+++ b/backend/tests/unit/onyx/indexing/test_persistent_indexing_helpers.py
@@ -1,0 +1,157 @@
+"""Unit tests for the PERSISTENT_INDEXING catch-all helpers in
+`onyx.indexing.persistent_indexing`."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from onyx.indexing.persistent_indexing import build_generic_connector_failure
+from onyx.indexing.persistent_indexing import record_generic_failure
+
+
+def _make_doc(
+    doc_id: str = "doc-1", link: str | None = "https://example.com/doc-1"
+) -> Document:
+    return Document(
+        id=doc_id,
+        semantic_identifier="test",
+        source=DocumentSource.FILE,
+        sections=[TextSection(text="some text", link=link)],
+        metadata={},
+    )
+
+
+# -----------------------------------------------------------------------------
+# build_generic_connector_failure
+# -----------------------------------------------------------------------------
+
+
+def test_build_generic_connector_failure_from_document() -> None:
+    doc = _make_doc()
+    exc = RuntimeError("kaboom")
+
+    failure = build_generic_connector_failure(exc=exc, document=doc)
+
+    assert failure.failed_document is not None
+    assert failure.failed_entity is None
+    assert failure.failed_document.document_id == "doc-1"
+    assert failure.failed_document.document_link == "https://example.com/doc-1"
+    assert failure.failure_message == "kaboom"
+    assert failure.exception is exc
+
+
+def test_build_generic_connector_failure_document_without_sections() -> None:
+    # Document with no sections should still produce a valid failure with no link.
+    doc = Document(
+        id="doc-empty",
+        semantic_identifier="empty",
+        source=DocumentSource.FILE,
+        sections=[],
+        metadata={},
+    )
+
+    failure = build_generic_connector_failure(exc=ValueError("oops"), document=doc)
+
+    assert failure.failed_document is not None
+    assert failure.failed_document.document_id == "doc-empty"
+    assert failure.failed_document.document_link is None
+
+
+def test_build_generic_connector_failure_from_entity() -> None:
+    exc = RuntimeError("entity boom")
+    failure = build_generic_connector_failure(
+        exc=exc, entity_id="docfetching:slack:cc_pair_42:batch_3"
+    )
+
+    assert failure.failed_entity is not None
+    assert failure.failed_document is None
+    assert failure.failed_entity.entity_id == "docfetching:slack:cc_pair_42:batch_3"
+    assert failure.failure_message == "entity boom"
+    assert failure.exception is exc
+
+
+def test_build_generic_connector_failure_rejects_both_args() -> None:
+    with pytest.raises(ValueError):
+        build_generic_connector_failure(
+            exc=RuntimeError("x"),
+            document=_make_doc(),
+            entity_id="some-entity",
+        )
+
+
+def test_build_generic_connector_failure_rejects_neither_arg() -> None:
+    with pytest.raises(ValueError):
+        build_generic_connector_failure(exc=RuntimeError("x"))
+
+
+def test_build_generic_connector_failure_with_base_exception() -> None:
+    # BaseException (not Exception) — exception field should be None since
+    # the BaseModel field is typed `Exception | None`.
+    exc = KeyboardInterrupt()  # subclass of BaseException, not Exception
+    failure = build_generic_connector_failure(exc=exc, entity_id="x")
+
+    assert failure.failed_entity is not None
+    assert failure.exception is None
+
+
+# -----------------------------------------------------------------------------
+# record_generic_failure
+# -----------------------------------------------------------------------------
+
+
+def test_record_generic_failure_persists_via_create_index_attempt_error() -> None:
+    failure = build_generic_connector_failure(
+        exc=RuntimeError("write me"), entity_id="entity-1"
+    )
+
+    with (
+        patch(
+            "onyx.indexing.persistent_indexing.get_session_with_current_tenant"
+        ) as mock_session_ctx,
+        patch(
+            "onyx.indexing.persistent_indexing.create_index_attempt_error"
+        ) as mock_create,
+    ):
+        mock_session = MagicMock()
+        mock_session_ctx.return_value.__enter__.return_value = mock_session
+
+        record_generic_failure(
+            index_attempt_id=7,
+            cc_pair_id=11,
+            source=DocumentSource.SLACK,
+            tenant_id="tenant-a",
+            failure=failure,
+        )
+
+        mock_create.assert_called_once_with(7, 11, failure, mock_session)
+
+
+def test_record_generic_failure_swallows_db_errors() -> None:
+    failure = build_generic_connector_failure(
+        exc=RuntimeError("db down"), entity_id="entity-1"
+    )
+
+    with (
+        patch(
+            "onyx.indexing.persistent_indexing.get_session_with_current_tenant"
+        ) as mock_session_ctx,
+        patch(
+            "onyx.indexing.persistent_indexing.create_index_attempt_error",
+            side_effect=Exception("db exploded"),
+        ),
+    ):
+        mock_session = MagicMock()
+        mock_session_ctx.return_value.__enter__.return_value = mock_session
+
+        # Must not raise: the recovery path itself can't kill the attempt.
+        record_generic_failure(
+            index_attempt_id=7,
+            cc_pair_id=11,
+            source=DocumentSource.SLACK,
+            tenant_id="tenant-a",
+            failure=failure,
+        )


### PR DESCRIPTION
## Description

Add an env var to allow indexing to run without stopping when error thresholds are reached. the intent is to only abort index attempts due to infra-related issues like pods dying; application level failures will all be caught and surfaced to the user and the attempt will be continued.

## How Has This Been Tested?

added tests and manually tested

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent indexing mode behind `PERSISTENT_INDEXING` that converts unexpected pipeline exceptions into recorded failures and keeps indexing running, so attempts can complete with errors instead of failing early. Failure-volume aborts are disabled; infra/heartbeat/usage-limit issues still fail attempts.

- **New Features**
  - Introduces `PERSISTENT_INDEXING` to tolerate application-level errors; infra/heartbeat/usage-limit errors still fail attempts.
  - Docprocessing/docfetching catch unexpected exceptions, record a `ConnectorFailure` (document-level when known, else entity-level), and continue. Docprocessing marks the failed batch complete with zero counts; docfetching sets `total_batches` on failure so completion can resolve the attempt. Failure-threshold checks are bypassed under this mode.
  - Adds `onyx.indexing.persistent_indexing` helpers (`build_generic_connector_failure`, `record_generic_failure`) with Sentry tagging and safe DB writes (DB errors while recording are swallowed).

- **Migration**
  - Set `PERSISTENT_INDEXING=true` to enable. No other changes needed.

<sup>Written for commit e726aeeadde862f859f613719bfd12fadbe40916. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

