### PR TITLE
ci: allow Linear check ignorelist for jmelahman

### DIFF
--- a/.github/workflows/pr-linear-check.yml
+++ b/.github/workflows/pr-linear-check.yml
@@ -18,7 +18,17 @@ jobs:
       - name: Check PR body for Linear link or override
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IGNORED_AUTHORS: |
+            jmelahman
         run: |
+          normalized_author="$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')"
+          normalized_ignored="$(printf '%s\n' "${IGNORED_AUTHORS}" | tr '[:upper:]' '[:lower:]')"
+          if printf '%s\n' "${normalized_ignored}" | grep -Fxq "${normalized_author}"; then
+            echo "PR author ${PR_AUTHOR} is on the ignorelist. Check passed."
+            exit 0
+          fi
+
           # Looking for "https://linear.app" in the body
           if echo "$PR_BODY" | grep -qE "https://linear\.app"; then
             echo "Found a Linear link. Check passed."


### PR DESCRIPTION
## Summary
- Add an ignorelist to the PR Linear check workflow so PRs authored by listed GitHub users bypass the Linear-link / override-checkbox requirement.
- Seeded with `jmelahman` (same identity used in the cherry-pick allowlist).

## Test plan
- [ ] Open this PR without a Linear link or override checkbox and confirm the `linear-check` job passes.
- [ ] Verify the check still fails for PRs from authors not on the ignorelist when no Linear link / override is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an author ignorelist to the PR Linear check and seeds it with `jmelahman`, so PRs from listed users skip the Linear link/override requirement.

- **New Features**
  - Adds `IGNORED_AUTHORS` and case-insensitive exact match on `PR_AUTHOR`; prints a pass message and exits early for ignored authors while enforcing the check for others.

<sup>Written for commit db5d9d752bcdbfcebb6aa970fb1965e957c9da96. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11307?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

