### PR TITLE
fix(metrics): populate llm_model column for single-model chats

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -656,12 +656,8 @@ def build_chat_turn(
             llm_provider_api_key=llm.config.api_key,
         )
         llms.append(llm)
-        model_display_names.append(_build_model_display_name(override))
+        model_display_names.append(_build_model_display_name(override, llm))
     token_counter = get_llm_token_counter(llms[0])
-
-    # not sure why we do this, but to maintain parity with previous code:
-    if not is_multi:
-        model_display_names = [""]
 
     # Verify that the user-specified files actually belong to the user
     verify_user_files(
@@ -895,6 +891,7 @@ def build_chat_turn(
             chat_session_id=chat_session.id,
             parent_message=user_message.id,
             message_type=MessageType.ASSISTANT,
+            model_display_name=model_display_names[0],
         )
         reserved_messages = [assistant_response]
         yield MessageResponseIDInfo(
@@ -1565,11 +1562,18 @@ def handle_stream_message_objects(
     )
 
 
-def _build_model_display_name(override: LLMOverride | None) -> str:
-    """Build a human-readable display name from an LLM override."""
-    if override is None:
-        return "unknown"
-    return override.display_name or override.model_version or "unknown"
+def _build_model_display_name(override: LLMOverride | None, llm: LLM) -> str:
+    """Build a human-readable display name for the LLM that will answer.
+
+    Falls back to the configured ``llm.config.model_name`` when no override is
+    set (default persona LLM) so the usage-metrics export always records the
+    actual model used, not an "unknown" sentinel or empty string.
+    """
+    if override is not None:
+        chosen = override.display_name or override.model_version
+        if chosen:
+            return chosen
+    return llm.config.model_name
 
 
 def handle_multi_model_stream(

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -616,6 +616,7 @@ def reserve_message_id(
     chat_session_id: UUID,
     parent_message: int,
     message_type: MessageType = MessageType.ASSISTANT,
+    model_display_name: str | None = None,
 ) -> ChatMessage:
     # Create an temporary holding chat message to the updated and saved at the end
     empty_message = ChatMessage(
@@ -625,6 +626,7 @@ def reserve_message_id(
         message="Response was terminated prior to completion, try regenerating.",
         token_count=15,
         message_type=message_type,
+        model_display_name=model_display_name,
     )
 
     # Add the empty message to the session


### PR DESCRIPTION
## Description

The `llm_model` column added to the usage-metrics CSV in #10648 is empty for nearly all rows. Users have reported the column is not populating.

**Root cause:** the single-model chat path (the overwhelming majority of traffic) never persisted `model_display_name` on the assistant `ChatMessage`:

- `process_message.build_chat_turn` built the per-LLM display name, then immediately overwrote it: `if not is_multi: model_display_names = [""]`. The original comment on that line was *"not sure why we do this, but to maintain parity with previous code"* — i.e. it was preserved from before the field even existed.
- `reserve_message_id` did not accept or write `model_display_name`, so the reserved placeholder `ChatMessage` was inserted with the field `NULL` and never updated when the LLM stream completed.

Only multi-model "compare" turns went through `reserve_multi_model_message_ids`, which already set the field — explaining the partial population observed in the wild.

**Fix:**
1. Drop the `[""]` reset so the real display name flows through to the single-model branch.
2. `_build_model_display_name(override, llm)` now falls back to `llm.config.model_name` when no override is set, so default-persona chats record the actual model used instead of an empty/`"unknown"` sentinel.
3. `reserve_message_id` accepts an optional `model_display_name` and writes it on the placeholder row, matching what `reserve_multi_model_message_ids` already did.

Historical rows are intentionally left `NULL` — backfilling reliably isn't possible.

**Why the original PR's tests missed this:** both tests added in #10648 set `model_display_name` via a side channel rather than going through the chat-send pipeline. `test_usage_export_pairing.py` writes the field directly via SQLAlchemy; `test_usage_export_api.py` relies on `chat_history_seeding.py` having been patched in the same PR to set `model_display_name = "pytest-model"` on every seeded assistant message. Neither exercises `reserve_message_id`, so the broken production write path was never covered. A follow-up that routes the integration test through the real persistence path (and drops the seeder hack) would close this gap.

## How Has This Been Tested?

- Static checks (ruff, ty, ripsecrets) pass via pre-commit on commit.
- Reviewed all callers of the changed functions: `reserve_message_id` has a single caller (the single-model branch updated here), and `_build_model_display_name` has a single caller (also updated). The new parameter is keyword-only with a `None` default, so it's backwards-compatible.
- Manual validation plan for the reviewer / before merge:
  1. Send a chat with the default persona LLM (no override) — exercises the new `llm.config.model_name` fallback.
  2. Send a chat with a persona-level LLM override — exercises the `override.display_name` path.
  3. Send a multi-model "compare" turn — confirms the unchanged multi-model path still works.
  4. `SELECT id, message_type, model_display_name FROM chat_message WHERE message_type = 'assistant' ORDER BY id DESC LIMIT 10;` — every new assistant row should have a value.
  5. Generate a usage-metrics export; the `llm_model` column should be populated on every assistant row.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty `llm_model` values in usage-metrics exports by persisting `model_display_name` for single-model chats. Exports now show the actual model for all new assistant messages.

- **Bug Fixes**
  - Kept the computed display name for single-model chats instead of resetting it to empty.
  - `_build_model_display_name` now falls back to `llm.config.model_name` when no override is set.
  - `reserve_message_id` accepts `model_display_name` and writes it on the placeholder row.
  - Historical rows remain `NULL`.

<sup>Written for commit 2bfb2a4711e5c2d63f7fa27bd4a08d804f0f190c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11309?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

