### PR TITLE
fix: persistent indexing docfetching raise

### DIFF
--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -69,8 +69,6 @@ from onyx.file_store.staging import build_raw_file_callback
 from onyx.file_store.staging import RawFileCallback
 from onyx.file_store.staging import reap_prior_attempt_staged_files
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
-from onyx.indexing.persistent_indexing import build_generic_connector_failure
-from onyx.indexing.persistent_indexing import record_generic_failure
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import cache_hierarchy_nodes_batch
 from onyx.redis.redis_hierarchy import ensure_source_node_exists
@@ -608,8 +606,6 @@ def connector_document_extraction(
             checkpoint=checkpoint,
         )
 
-    # Initialize loop state before the try so the except block can reference
-    # batch_num when reporting/recording errors under PERSISTENT_INDEXING.
     batch_num = last_batch_num  # starts at 0 if no last batch
     total_doc_batches_queued = 0
     total_failures = 0
@@ -927,49 +923,13 @@ def connector_document_extraction(
                     )
                     raise e
 
-                if PERSISTENT_INDEXING:
-                    # Persistent indexing: record this as a generic EntityFailure
-                    # and let check_indexing_completion resolve the attempt as
-                    # COMPLETED_WITH_ERRORS instead of marking it FAILED.
-                    logger.info(
-                        "PERSISTENT_INDEXING enabled; recording docfetching "
-                        "failure as ConnectorFailure for attempt %s",
-                        index_attempt_id,
-                    )
-                    failure = build_generic_connector_failure(
-                        exc=e,
-                        entity_id=(
-                            f"docfetching:{db_connector.source.value}"
-                            f":cc_pair_{cc_pair_id}:batch_{batch_num}"
-                        ),
-                    )
-                    record_generic_failure(
-                        index_attempt_id=index_attempt_id,
-                        cc_pair_id=cc_pair_id,
-                        source=db_connector.source,
-                        tenant_id=tenant_id,
-                        failure=failure,
-                    )
-                    # Set total_batches so check_indexing_completion can resolve
-                    # the attempt. Without this the attempt would hang in
-                    # IN_PROGRESS forever. If this DB write fails we have no
-                    # way to land COMPLETED_WITH_ERRORS cleanly — fall through
-                    # to mark_attempt_failed below as a safety net.
-                    try:
-                        IndexingCoordination.set_total_batches(
-                            db_session=db_session_temp,
-                            index_attempt_id=index_attempt_id,
-                            total_batches=batch_num,
-                        )
-                        return
-                    except Exception:
-                        logger.exception(
-                            "Failed to set total_batches during persistent "
-                            "indexing recovery for attempt %s; falling back "
-                            "to mark_attempt_failed",
-                            index_attempt_id,
-                        )
-
+                # PERSISTENT_INDEXING deliberately does NOT catch unhandled
+                # connector-generator exceptions: we can't isolate the failing
+                # entity from a black-box raise, and silently landing the
+                # attempt as COMPLETED_WITH_ERRORS would let the system advance
+                # past potentially-missed source data. Operators need a FAILED
+                # signal here to triage. Threshold disable + docprocessing
+                # per-batch recovery still apply.
                 mark_attempt_failed(
                     index_attempt_id,
                     db_session_temp,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -891,14 +891,19 @@ ZENDESK_CONNECTOR_SKIP_ARTICLE_LABELS = os.environ.get(
 CONTINUE_ON_CONNECTOR_FAILURE = os.environ.get(
     "CONTINUE_ON_CONNECTOR_FAILURE", ""
 ).lower() not in ["false", ""]
-# When true, indexing tolerates ALL operational errors raised from inside the
-# connector / pipeline data path: anything that would otherwise crash an index
-# attempt is recorded as a ConnectorFailure (DocumentFailure when a doc id is
-# known, otherwise EntityFailure) and the attempt continues. Also disables
-# the >3-failures-AND->10%-ratio abort. Does NOT suppress mark_attempt_failed
-# triggered by the watchdog/heartbeat, usage-limit overflow, inconsistent
-# attempt state, or completion-monitor exceptions — those signal that the
-# worker itself or the tenant's quota is broken, not connector data errors.
+# When true, indexing makes a best effort to keep going past errors that it
+# can bound:
+#   1. The >3-failures-AND->10%-ratio threshold abort is disabled, so a
+#      connector that yields many per-doc/entity `ConnectorFailure`s no longer
+#      aborts the attempt.
+#   2. Unhandled exceptions inside docprocessing (per-batch) are converted into
+#      `DocumentFailure`s for the docs in the batch (or an `EntityFailure` if
+#      the batch couldn't be loaded). The batch is marked complete so the
+#      attempt can resolve as COMPLETED_WITH_ERRORS.
+# Does NOT swallow unhandled exceptions raised from the connector generator
+# itself: those still mark the attempt FAILED, because we have no entity
+# context to isolate the failing item and silently advancing would risk
+# skipping source data. Operators must triage those by fixing the connector.
 PERSISTENT_INDEXING = os.environ.get("PERSISTENT_INDEXING", "").lower() == "true"
 # When swapping to a new embedding model, a secondary index is created in the background, to conserve
 # resources, we pause updates on the primary index by default while the secondary index is created

--- a/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
+++ b/backend/tests/external_dependency_unit/indexing/test_persistent_indexing.py
@@ -1,15 +1,15 @@
-"""External-dependency-unit tests for PERSISTENT_INDEXING.
+"""External-dependency-unit tests for PERSISTENT_INDEXING (docfetching side).
 
-Exercises `run_docfetching_entrypoint` against a mock connector that either:
-  (a) yields docs/failures then raises an unhandled exception, or
-  (b) yields more `ConnectorFailure`s than the >3-failures-AND->10%-ratio
-      threshold would normally tolerate.
+Exercises `run_docfetching_entrypoint` against a mock checkpointed connector.
+PERSISTENT_INDEXING's docfetching-side contract:
 
-In both cases, with PERSISTENT_INDEXING patched to True, the attempt must
-not be marked FAILED; instead a `ConnectorFailure` is recorded against
-the attempt and `check_indexing_completion` can later resolve it to
-COMPLETED_WITH_ERRORS. With PERSISTENT_INDEXING False (default), the
-attempt is marked FAILED as before.
+  - It DISABLES the >3-failures-AND->10%-ratio threshold abort, so a flood of
+    connector-yielded `ConnectorFailure`s no longer fails the attempt.
+  - It does NOT swallow unhandled exceptions raised from the connector
+    generator itself — those still mark the attempt FAILED (we can't isolate
+    the bad entity and silently advancing risks skipping source data).
+
+Per-batch docprocessing catch-all recovery is exercised separately.
 
 Runs against real Postgres + real file_store; the celery `send_task`
 is mocked because docprocessing is a separate pod and not under test.
@@ -34,7 +34,6 @@ from onyx.connectors.models import ConnectorCheckpoint
 from onyx.connectors.models import ConnectorFailure
 from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
-from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import InputType
 from onyx.connectors.models import TextSection
 from onyx.db.enums import EmbeddingPrecision
@@ -265,20 +264,17 @@ def test_unhandled_exception_default_marks_attempt_failed(
         _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
 
 
-def test_unhandled_exception_persistent_mode_records_entity_failure(
+def test_unhandled_exception_persistent_mode_still_marks_failed(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     initialize_file_store: None,  # noqa: ARG001
     register_mock_connector: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """With PERSISTENT_INDEXING True, an unhandled exception inside the
-    connector generator is converted into an EntityFailure and the attempt
-    is NOT marked FAILED — it stays IN_PROGRESS for the completion monitor
-    to resolve as COMPLETED_WITH_ERRORS once all queued batches finish."""
-    # Patch the captured constant at every site that reads it. (See app_configs
-    # — the value is captured at import time, so patching os.environ does not
-    # affect already-imported modules.)
+    """Even with PERSISTENT_INDEXING True, an unhandled exception inside the
+    connector generator still marks the attempt FAILED — there's no entity
+    context to isolate the failing item, so silently advancing would risk
+    skipping source data. Operators must triage by fixing the connector."""
     monkeypatch.setattr(
         "onyx.background.indexing.run_docfetching.PERSISTENT_INDEXING", True
     )
@@ -291,34 +287,22 @@ def test_unhandled_exception_persistent_mode_records_entity_failure(
 
     try:
         mock_app = MagicMock()
-        # No raise expected — persistent mode swallows the exception.
-        run_docfetching_entrypoint(
-            app=mock_app,
-            index_attempt_id=attempt_id,
-            tenant_id=TEST_TENANT_ID,
-            connector_credential_pair_id=cc_pair_id,
-        )
+        with pytest.raises(RuntimeError, match="simulated_persistent_mode_kaboom"):
+            run_docfetching_entrypoint(
+                app=mock_app,
+                index_attempt_id=attempt_id,
+                tenant_id=TEST_TENANT_ID,
+                connector_credential_pair_id=cc_pair_id,
+            )
 
         db_session.expire_all()
         attempt = get_index_attempt(db_session, attempt_id)
         assert attempt is not None
-        # Attempt is NOT FAILED; completion monitor will resolve it later.
-        assert attempt.status != IndexingStatus.FAILED, (
-            f"Expected attempt to not be FAILED under PERSISTENT_INDEXING; "
-            f"got {attempt.status}"
-        )
+        assert attempt.status == IndexingStatus.FAILED
 
-        # Generic catch-all recorded exactly one EntityFailure.
+        # No generic catch-all was triggered; no entity-level failure rows.
         errors = get_index_attempt_errors(attempt_id, db_session)
-        assert len(errors) == 1
-        err = errors[0]
-        assert err.entity_id is not None
-        assert err.document_id is None
-        # entity_id format: docfetching:{source}:cc_pair_{id}:batch_{n}
-        assert err.entity_id.startswith(
-            f"docfetching:{DocumentSource.MOCK_CONNECTOR.value}:cc_pair_{cc_pair_id}"
-        )
-        assert "simulated_persistent_mode_kaboom" in (err.failure_message or "")
+        assert len(errors) == 0
     finally:
         _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
 
@@ -401,48 +385,3 @@ def test_threshold_default_aborts_attempt(
         assert attempt.status == IndexingStatus.FAILED
     finally:
         _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
-
-
-def test_persistent_mode_uses_entity_failure_when_no_doc_context(
-    db_session: Session,
-    tenant_context: None,  # noqa: ARG001
-    initialize_file_store: None,  # noqa: ARG001
-    register_mock_connector: None,  # noqa: ARG001
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When the connector raises immediately with no doc context, the
-    catch-all records an EntityFailure (not a DocumentFailure) since we
-    have no doc id to associate the error with."""
-    monkeypatch.setattr(
-        "onyx.background.indexing.run_docfetching.PERSISTENT_INDEXING", True
-    )
-
-    cc_pair_id, search_settings_id, attempt_id = _seed_attempt(db_session)
-
-    # No docs, no yielded failures, just immediate raise.
-    _MOCK_BEHAVIOR["raise_at_end"] = True
-
-    try:
-        mock_app = MagicMock()
-        run_docfetching_entrypoint(
-            app=mock_app,
-            index_attempt_id=attempt_id,
-            tenant_id=TEST_TENANT_ID,
-            connector_credential_pair_id=cc_pair_id,
-        )
-
-        db_session.expire_all()
-        errors = get_index_attempt_errors(attempt_id, db_session)
-        assert len(errors) == 1
-        err = errors[0]
-        assert isinstance(err.entity_id, str), (
-            f"Expected EntityFailure, got document_id={err.document_id}"
-        )
-        assert err.document_id is None
-    finally:
-        _teardown_attempt(db_session, cc_pair_id, search_settings_id, attempt_id)
-
-
-# Suppress unused-import warnings for symbols referenced only by name in
-# docstrings / type comments above.
-_ = EntityFailure


### PR DESCRIPTION
## Description

Basically just reverting the catch-all at the docfetching level for persistent indexing. This was going to cause the index attempt to just be done when an arbitrary error was raised from within the connector. catching errors during docfetching can't treat errors as a black box; the connector won't be able to just skip over the problematic document without intervention within the connector code (follow up PRs)

## How Has This Been Tested?

modified tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the catch‑all in docfetching for `PERSISTENT_INDEXING` so unhandled exceptions from the connector generator now fail the index attempt instead of being recorded as a generic failure. Persistent indexing still disables the failure-threshold abort and keeps per‑batch docprocessing recovery.

- **Bug Fixes**
  - Removed the generic `ConnectorFailure` recording path in `run_docfetching` for generator-level exceptions; these now mark the attempt FAILED.
  - Clarified `PERSISTENT_INDEXING` semantics in `app_configs.py`: it disables the failure threshold and converts docprocessing batch errors, but does not swallow generator exceptions.
  - Updated tests to match the new behavior and dropped expectations for catch‑all entity failures during docfetching.

<sup>Written for commit 588f83c5e88217557e4b38864a826d5d817a1753. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11311?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

