### PR TITLE
fix(metrics): populate llm_model column for single-model chats (#11309) to release v3.2

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -705,12 +705,8 @@ def build_chat_turn(
             llm_provider_api_key=llm.config.api_key,
         )
         llms.append(llm)
-        model_display_names.append(_build_model_display_name(override))
+        model_display_names.append(_build_model_display_name(override, llm))
     token_counter = get_llm_token_counter(llms[0])
-
-    # not sure why we do this, but to maintain parity with previous code:
-    if not is_multi:
-        model_display_names = [""]
 
     # Verify that the user-specified files actually belong to the user
     verify_user_files(
@@ -938,6 +934,7 @@ def build_chat_turn(
             chat_session_id=chat_session.id,
             parent_message=user_message.id,
             message_type=MessageType.ASSISTANT,
+            model_display_name=model_display_names[0],
         )
         reserved_messages = [assistant_response]
         yield MessageResponseIDInfo(
@@ -1572,11 +1569,18 @@ def handle_stream_message_objects(
     )
 
 
-def _build_model_display_name(override: LLMOverride | None) -> str:
-    """Build a human-readable display name from an LLM override."""
-    if override is None:
-        return "unknown"
-    return override.display_name or override.model_version or "unknown"
+def _build_model_display_name(override: LLMOverride | None, llm: LLM) -> str:
+    """Build a human-readable display name for the LLM that will answer.
+
+    Falls back to the configured ``llm.config.model_name`` when no override is
+    set (default persona LLM) so the usage-metrics export always records the
+    actual model used, not an "unknown" sentinel or empty string.
+    """
+    if override is not None:
+        chosen = override.display_name or override.model_version
+        if chosen:
+            return chosen
+    return llm.config.model_name
 
 
 def handle_multi_model_stream(

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -609,6 +609,7 @@ def reserve_message_id(
     chat_session_id: UUID,
     parent_message: int,
     message_type: MessageType = MessageType.ASSISTANT,
+    model_display_name: str | None = None,
 ) -> ChatMessage:
     # Create an temporary holding chat message to the updated and saved at the end
     empty_message = ChatMessage(
@@ -618,6 +619,7 @@ def reserve_message_id(
         message="Response was terminated prior to completion, try regenerating.",
         token_count=15,
         message_type=message_type,
+        model_display_name=model_display_name,
     )
 
     # Add the empty message to the session


### PR DESCRIPTION
Cherry-pick of #11309 onto release/v3.2.

Same fix as v4.0 (see #11315) and v3.3 (#11316). Cherry-picked cleanly from commit d8bebe42e0fcad0041cb02cb747e902c22cba853 via three-way auto-merge — no manual conflict resolution.

## Description

The `llm_model` column added to the usage-metrics CSV in #10648 is empty for nearly all rows. Root cause: the single-model chat path never persisted `model_display_name`. See #11309 for the full writeup.

## How Has This Been Tested?

- Auto-merged cleanly against release/v3.2; resulting diff is identical to the main-branch fix (16 insertions / 10 deletions across `process_message.py` and `db/chat.py`).
- Verified `ChatMessage.model_display_name` column exists on release/v3.2 (`backend/onyx/db/models.py:2671`) so the new write is valid.
- Static checks pass via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix empty `llm_model` values in the usage-metrics CSV for single-model chats by recording the actual model on assistant messages. Backports this fix to v3.2.

- **Bug Fixes**
  - Persist `model_display_name` when reserving assistant messages in the single-model path.
  - Compute display name from the override when present, otherwise use `llm.config.model_name`; removed the logic that cleared names for single-model chats.
  - Added optional `model_display_name` to `reserve_message_id` to store the value without schema changes.

<sup>Written for commit 535b076c02fa36323248e71dd0571a294775c922. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

