### PR TITLE
feat(docker): hot-reload api_server in dev compose

### DIFF
--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -1,5 +1,18 @@
 # Docker Compose Override for Development/Testing
-# This file exposes service ports for development and testing purposes
+#
+# This overlay:
+#   1. Exposes service ports so they can be hit directly from the host.
+#   2. Bind-mounts ./backend into /app on the api_server,
+#      inference_model_server, and indexing_model_server containers and
+#      switches their uvicorn invocations to --reload, so backend and
+#      model-server code changes hot-reload without an image rebuild.
+#
+# NOT covered by hot reload in this overlay:
+#   - The `background` (Celery / supervisord) service still bakes source
+#     into the image at build time. Code changes there require
+#     `docker compose up -d --build background`.
+#   - The `web_server` (Next.js) container runs the production build;
+#     web hot reload is out of scope here.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
@@ -7,6 +20,11 @@
 # Or set COMPOSE_FILE environment variable:
 #   export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 #   docker compose up -d --wait
+#
+# First-time note: if your existing onyx-backend / onyx-model-server
+# images predate the `watchfiles` dependency being added to the default
+# requirements, run a one-time `docker compose ... up -d --build` to
+# pick it up. After that, code changes do not require rebuilds.
 
 services:
   api_server:
@@ -17,6 +35,23 @@ services:
         limits:
           cpus: "${API_SERVER_CPU_LIMIT:-0}"
           memory: "${API_SERVER_MEM_LIMIT:-0}"
+    command: >
+      /bin/sh -c "alembic upgrade head &&
+      echo \"Starting Onyx Api Server (hot-reload)\" &&
+      uvicorn onyx.main:app --host 0.0.0.0 --port 8080
+      --reload
+      --reload-dir /app/onyx
+      --reload-dir /app/ee
+      --reload-dir /app/shared_configs"
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      - ../../backend:/app
+      # Mask the bind mount at the Playwright browser cache subpath so
+      # the Chromium install baked into the image during `docker build`
+      # is not shadowed by the host source tree (which does not contain
+      # browser binaries).
+      - playwright_browsers_cache:/app/.cache/ms-playwright
 
   # Uncomment the block below to enable the MCP server for Onyx.
   # mcp_server:
@@ -39,6 +74,44 @@ services:
   inference_model_server:
     ports:
       - "9000:9000"
+    command: >
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000
+        --reload
+        --reload-dir /app/model_server
+        --reload-dir /app/shared_configs
+        --reload-dir /app/onyx;
+      fi"
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      # The HuggingFace model cache named volume from the base compose
+      # file (model_cache_huggingface:/app/.cache/huggingface/) keeps
+      # masking that subpath on top of this bind mount.
+      - ../../backend:/app
+
+  indexing_model_server:
+    command: >
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000
+        --reload
+        --reload-dir /app/model_server
+        --reload-dir /app/shared_configs
+        --reload-dir /app/onyx;
+      fi"
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      # indexing_huggingface_model_cache:/app/.cache/huggingface/ from
+      # the base compose file masks the HF cache subpath on top of this
+      # bind mount.
+      - ../../backend:/app
 
   cache:
     ports:
@@ -53,3 +126,6 @@ services:
   code-interpreter:
     ports:
       - "8000:8000"
+
+volumes:
+  playwright_browsers_cache:

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -2,12 +2,13 @@
 #
 # This overlay:
 #   1. Exposes service ports so they can be hit directly from the host.
-#   2. Bind-mounts ./backend into /app on the api_server,
-#      inference_model_server, and indexing_model_server containers and
-#      switches their uvicorn invocations to --reload, so backend and
-#      model-server code changes hot-reload without an image rebuild.
+#   2. Bind-mounts ./backend into /app on the api_server container and
+#      switches uvicorn to --reload, so backend code changes hot-reload
+#      without an image rebuild.
 #
 # NOT covered by hot reload in this overlay:
+#   - The `inference_model_server` and `indexing_model_server` containers
+#     still bake source into the image at build time.
 #   - The `background` (Celery / supervisord) service still bakes source
 #     into the image at build time. Code changes there require
 #     `docker compose up -d --build background`.
@@ -21,10 +22,10 @@
 #   export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
 #   docker compose up -d --wait
 #
-# First-time note: if your existing onyx-backend / onyx-model-server
-# images predate the `watchfiles` dependency being added to the default
-# requirements, run a one-time `docker compose ... up -d --build` to
-# pick it up. After that, code changes do not require rebuilds.
+# First-time note: if your existing onyx-backend image predates the
+# `watchfiles` dependency being added to the default requirements, run
+# a one-time `docker compose ... up -d --build` to pick it up. After
+# that, code changes do not require rebuilds.
 
 services:
   api_server:
@@ -74,44 +75,6 @@ services:
   inference_model_server:
     ports:
       - "9000:9000"
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000
-        --reload
-        --reload-dir /app/model_server
-        --reload-dir /app/shared_configs
-        --reload-dir /app/onyx;
-      fi"
-    environment:
-      - PYTHONDONTWRITEBYTECODE=1
-    volumes:
-      # The HuggingFace model cache named volume from the base compose
-      # file (model_cache_huggingface:/app/.cache/huggingface/) keeps
-      # masking that subpath on top of this bind mount.
-      - ../../backend:/app
-
-  indexing_model_server:
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000
-        --reload
-        --reload-dir /app/model_server
-        --reload-dir /app/shared_configs
-        --reload-dir /app/onyx;
-      fi"
-    environment:
-      - PYTHONDONTWRITEBYTECODE=1
-    volumes:
-      # indexing_huggingface_model_cache:/app/.cache/huggingface/ from
-      # the base compose file masks the HF cache subpath on top of this
-      # bind mount.
-      - ../../backend:/app
 
   cache:
     ports:


### PR DESCRIPTION
## Summary

- Bind-mount `./backend` into `/app` on `api_server` in `docker-compose.dev.yml` and switch uvicorn to `--reload` (scoped via `--reload-dir` to `/app/onyx`, `/app/ee`, `/app/shared_configs`). Backend code changes now hot-reload without an image rebuild.
- Preserve the Playwright browser cache (`/app/.cache/ms-playwright`) baked into the api_server image via a new `playwright_browsers_cache` named volume layered on top of the bind mount.
- Set `PYTHONDONTWRITEBYTECODE=1` on api_server so the bind mount doesn't accumulate `__pycache__` directories on the host.

Out of scope for this iteration: `inference_model_server`, `indexing_model_server`, the Celery `background` service, and the Next.js `web_server` container all still require a rebuild on code change.

`watchfiles` is already in `backend/requirements/default.txt`, so no new dependency. Users with pre-existing local images may need a one-time `docker compose ... up -d --build` to pick up `watchfiles` — noted in the file header.

## Test plan

- [ ] `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --wait` brings api_server to healthy.
- [ ] Editing a file under `backend/onyx/` triggers `WatchFiles detected changes ... Reloading` in `docker compose logs -f api_server` and the new code path runs without a container restart.
- [ ] `docker compose exec api_server ls /app/.cache/ms-playwright` still lists the Chromium install (named-volume masking works).
- [ ] `background`, `inference_model_server`, and `indexing_model_server` continue to start normally; backend code edits do *not* hot-reload them (documented).
- [ ] After several reload cycles, no `__pycache__` directories appear in the host `backend/` checkout.
- [ ] `docker compose ... down` cleans up; the `playwright_browsers_cache` named volume persists for the next `up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)