### PR TITLE
fix(skills): drop orphan manifest_metadata before built-in seed

### DIFF
--- a/backend/alembic/versions/7f5b159041be_skill_built_in_id_discriminator.py
+++ b/backend/alembic/versions/7f5b159041be_skill_built_in_id_discriminator.py
@@ -145,6 +145,13 @@ def _seed_built_in_skills() -> None:
 
 
 def upgrade() -> None:
+    # Older tenants ran an earlier version of b6d184cfdaf3_skills that created
+    # `manifest_metadata` NOT NULL; that migration was later edited to drop
+    # the column, but already-migrated tenants still carry it. The ORM no
+    # longer references it, so remove it before seeding to avoid NOT NULL
+    # violations on the upsert below.
+    op.execute("ALTER TABLE skill DROP COLUMN IF EXISTS manifest_metadata")
+
     op.add_column(
         "skill",
         sa.Column("built_in_skill_id", sa.String(), nullable=True),


### PR DESCRIPTION
## Description

**Bug:** alembic migration `7f5b159041be_skill_built_in_id_discriminator` fails on every existing tenant with `NotNullViolationError` on `skill.manifest_metadata`.

**Why:** `b6d184cfdaf3_skills` once created that column `NOT NULL` then was later edited to drop it. Already-migrated tenants still carry the column; the ORM no longer references it; the new seed `INSERT` omits it → NOT NULL trips.

**Fix:** `ALTER TABLE skill DROP COLUMN IF EXISTS manifest_metadata` at the top of `upgrade()`, before the seed. Idempotent — no-op for tenants that don't have the column.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check