### PR TITLE
fix(voice): unbreak OpenAI STT after Realtime Beta API deprecation

### DIFF
--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -525,12 +525,19 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
 
         Args:
             audio_data: Raw audio bytes
-            audio_format: Audio format (e.g., "webm", "wav", "mp3")
+            audio_format: Audio format (e.g., "webm", "wav", "mp3", "pcm16")
 
         Returns:
             Transcribed text
         """
         client = self._get_client()
+
+        # OpenAI's /v1/audio/transcriptions endpoint does not accept raw PCM;
+        # wrap PCM16 in a WAV container (24kHz mono — matches the browser
+        # capture format used by the streaming WebSocket fallback).
+        if audio_format == "pcm16":
+            audio_data = _create_wav_header(len(audio_data)) + audio_data
+            audio_format = "wav"
 
         # Create a file-like object from the audio bytes
         audio_file = io.BytesIO(audio_data)
@@ -612,8 +619,12 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         return OPENAI_TTS_MODELS.copy()
 
     def supports_streaming_stt(self) -> bool:
-        """OpenAI supports streaming via Realtime API for all STT models."""
-        return True
+        # OpenAI deprecated the Realtime Beta API shape we depend on
+        # (header `OpenAI-Beta: realtime=v1` + `transcription_session.update`),
+        # which now returns `beta_api_shape_disabled`. Route through the
+        # chunked HTTP path until the streaming transcriber is migrated to
+        # the GA Realtime API.
+        return False
 
     def supports_streaming_tts(self) -> bool:
         """OpenAI supports real-time streaming TTS via Realtime API."""

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -1,10 +1,10 @@
 """OpenAI voice provider for STT and TTS.
 
 OpenAI supports:
-- **STT**: Whisper (batch transcription via REST) and Realtime API (streaming
-  transcription via WebSocket with server-side VAD). Audio is sent as base64-encoded
-  PCM16 at 24kHz mono. The Realtime API returns transcript deltas and completed
-  transcription events per VAD-detected utterance.
+- **STT**: Whisper (batch transcription via REST). Streaming transcription via
+  the Realtime API is currently disabled (`supports_streaming_stt()` returns
+  `False`) pending migration to the GA Realtime API; `OpenAIStreamingTranscriber`
+  remains in this file for the upcoming migration but is unreachable today.
 - **TTS**: HTTP streaming endpoint that returns audio chunks progressively.
   Supported models: tts-1 (standard) and tts-1-hd (high quality).
 
@@ -297,7 +297,9 @@ OPENAI_VOICES = [
     {"id": "shimmer", "name": "Shimmer"},
 ]
 
-# OpenAI available STT models (all support streaming via Realtime API)
+# OpenAI available STT models. All use the chunked HTTP transcription endpoint
+# today; Realtime streaming is disabled until the GA migration lands (see
+# `supports_streaming_stt()`).
 OPENAI_STT_MODELS = [
     {"id": "whisper-1", "name": "Whisper v1"},
     {"id": "gpt-4o-transcribe", "name": "GPT-4o Transcribe"},


### PR DESCRIPTION
## Description

OpenAI deprecated the Realtime Beta API shape (`OpenAI-Beta: realtime=v1` header + `transcription_session.update` config) that `OpenAIStreamingTranscriber` depends on. As of recently, every WebSocket connection returns:

```
{'type': 'invalid_request_error', 'code': 'beta_api_shape_disabled',
 'message': 'The Realtime Beta API is no longer supported. Please use /v1/realtime for the GA API.'}
```

The streaming transcription died immediately, and the chunked fallback in `websocket_api.py` then posted raw PCM16 to `/v1/audio/transcriptions`, which only accepts container formats (flac/m4a/mp3/mp4/mpeg/mpga/oga/ogg/wav/webm). Both legs errored on every chunk — users saw blank transcripts on STT.

This change is the minimal stop-the-bleeding fix; the proper migration to OpenAI's GA Realtime API will follow in a separate PR on `main`.

**Two scoped changes in `backend/onyx/voice/providers/openai.py`:**

1. `OpenAIVoiceProvider.supports_streaming_stt()` returns `False` — routes OpenAI traffic through the chunked HTTP path until streaming is migrated to the GA Realtime API.
2. `OpenAIVoiceProvider.transcribe()` detects `audio_format == "pcm16"` and wraps the bytes in a WAV container (24kHz mono — matches the browser's capture format) before POSTing. Uses the existing `_create_wav_header` helper.

UX impact: STT no longer streams partial transcripts for OpenAI customers — the transcript appears on `end` instead of incrementally. Azure and ElevenLabs are untouched (they have their own `supports_streaming_stt()` / `transcribe()` implementations; Azure already handles `pcm16` in its own transcribe at L450).

Linear: ENG-XXXX

## How Has This Been Tested?

- Confirmed the failure mode in production logs on the `playlist-prod` cluster: `OpenAI error: ... 'beta_api_shape_disabled'` immediately followed by repeated `Invalid file format. Supported formats: ['flac', 'm4a', 'mp3', 'mp4', 'mpeg', 'mpga', 'oga', 'ogg', 'wav', 'webm']` on the chunked fallback path.
- `ruff check` / `ruff format` / `ty check` all pass.
- Manual STT validation against the affected cluster is pending image build.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI STT failures after the Realtime Beta API deprecation by disabling streaming and sending `pcm16` audio as WAV to the transcriptions endpoint. Also updates provider docs to reflect streaming is temporarily disabled. Linear: ENG-XXXX

- **Bug Fixes**
  - `supports_streaming_stt()` now returns `False` to route OpenAI STT through the chunked HTTP path.
  - When `audio_format` is `pcm16`, wrap bytes with a 24 kHz mono WAV header via `_create_wav_header` before POSTing to `/v1/audio/transcriptions`.

- **Refactors**
  - Updated the module docstring and the `OPENAI_STT_MODELS` comment to state streaming is disabled until the GA Realtime API migration.

<sup>Written for commit a4921727468ba2e93751175b09bab7bed6641aaa. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

