### PR TITLE
feat(voice): migrate OpenAI streaming STT to GA Realtime API

### DIFF
--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -22,6 +22,7 @@ import io
 import json
 from collections.abc import AsyncIterator
 from enum import StrEnum
+from typing import Any
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -103,6 +104,10 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         self._accumulated_transcript = ""  # Accumulated across all turns
         self._receive_task: asyncio.Task | None = None
         self._closed = False
+        # Captures the most recent `error` event from OpenAI so callers
+        # (e.g. tests, the WS handler) can detect a poisoned session even
+        # though OpenAI does not close the socket on protocol errors.
+        self._last_error: dict[str, Any] | None = None
 
     async def connect(self) -> None:
         """Establish WebSocket connection to OpenAI Realtime API (GA shape)."""
@@ -127,15 +132,21 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
             self._logger.error("Failed to connect to OpenAI Realtime API: %s", e)
             raise
 
-        # GA shape: `session.update` (was `transcription_session.update`), with
-        # the session typed as `transcription` and audio config nested under
-        # `audio.input`. `gpt-realtime-whisper` does not support server-side
-        # VAD — turn boundaries are driven by `input_audio_buffer.commit`
-        # which is sent from `close()` when the user stops recording.
+        # GA shape: `session.update` (was `transcription_session.update`),
+        # with the session typed as `realtime` — *not* `transcription`.
+        # OpenAI's GA does not have a dedicated transcription-only session
+        # type on the WS; transcription is configured as a side-effect of
+        # a standard realtime session via `audio.input.transcription.model`.
+        # Sending `session.type: "transcription"` here yields:
+        #   "Passing a transcription session update event to a realtime
+        #    session is not allowed."
+        # `gpt-realtime-whisper` does not emit server-side VAD events; turn
+        # boundaries are driven by an explicit `input_audio_buffer.commit`
+        # from `close()` when the user stops recording.
         config_message = {
             "type": "session.update",
             "session": {
-                "type": "transcription",
+                "type": "realtime",
                 "audio": {
                     "input": {
                         "format": {"type": "audio/pcm", "rate": 24000},
@@ -163,9 +174,15 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
                     msg_type = data.get("type", "")
                     self._logger.debug("Received message type: %s", msg_type)
 
-                    # Handle errors
+                    # Handle errors. OpenAI does NOT close the WebSocket on
+                    # protocol errors (e.g. a malformed `session.update`),
+                    # so we capture the most recent error here for callers
+                    # to inspect — the test/handler can fail fast instead
+                    # of waiting on a session that will never produce a
+                    # transcript.
                     if msg_type == OpenAIRealtimeMessageType.ERROR:
                         error = data.get("error", {})
+                        self._last_error = error
                         self._logger.error("OpenAI error: %s", error)
                         continue
 

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -35,8 +35,15 @@ if TYPE_CHECKING:
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com"
 
 
+# OpenAI Realtime API only streams transcription for `gpt-realtime-whisper`.
+# `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe` are HTTP-only
+# and remain selectable for the chunked path; the streaming WS always uses
+# this model regardless of the provider's stored `stt_model`.
+OPENAI_REALTIME_STT_MODEL = "gpt-realtime-whisper"
+
+
 class OpenAIRealtimeMessageType(StrEnum):
-    """Message types from OpenAI Realtime transcription API."""
+    """Message types from OpenAI Realtime transcription API (GA shape)."""
 
     ERROR = "error"
     SPEECH_STARTED = "input_audio_buffer.speech_started"
@@ -44,8 +51,8 @@ class OpenAIRealtimeMessageType(StrEnum):
     BUFFER_COMMITTED = "input_audio_buffer.committed"
     TRANSCRIPTION_DELTA = "conversation.item.input_audio_transcription.delta"
     TRANSCRIPTION_COMPLETED = "conversation.item.input_audio_transcription.completed"
-    SESSION_CREATED = "transcription_session.created"
-    SESSION_UPDATED = "transcription_session.updated"
+    SESSION_CREATED = "session.created"
+    SESSION_UPDATED = "session.updated"
     ITEM_CREATED = "conversation.item.created"
 
 
@@ -64,7 +71,7 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
     def __init__(
         self,
         api_key: str,
-        model: str = "whisper-1",
+        model: str = OPENAI_REALTIME_STT_MODEL,
         api_base: str | None = None,
     ):
         # Import logger first
@@ -87,16 +94,15 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         self._closed = False
 
     async def connect(self) -> None:
-        """Establish WebSocket connection to OpenAI Realtime API."""
+        """Establish WebSocket connection to OpenAI Realtime API (GA shape)."""
         self._session = aiohttp.ClientSession()
 
-        # OpenAI Realtime transcription endpoint
+        # GA Realtime API: `?model=` query param replaces the Beta
+        # `?intent=transcription`, and the `OpenAI-Beta: realtime=v1` header
+        # is gone. Sending the Beta shape now returns `beta_api_shape_disabled`.
         ws_base = _http_to_ws_url(self.api_base.rstrip("/"))
-        url = f"{ws_base}/v1/realtime?intent=transcription"
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "OpenAI-Beta": "realtime=v1",
-        }
+        url = f"{ws_base}/v1/realtime?model={self.model}"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
 
         try:
             self._ws = await self._session.ws_connect(url, headers=headers)
@@ -105,25 +111,26 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
             self._logger.error("Failed to connect to OpenAI Realtime API: %s", e)
             raise
 
-        # Configure the session for transcription
-        # Enable server-side VAD (Voice Activity Detection) for automatic speech detection
+        # GA shape: `session.update` (was `transcription_session.update`), with
+        # the session typed as `transcription` and audio config nested under
+        # `audio.input`. `gpt-realtime-whisper` does not support server-side
+        # VAD — turn boundaries are driven by `input_audio_buffer.commit`
+        # which is sent from `close()` when the user stops recording.
         config_message = {
-            "type": "transcription_session.update",
+            "type": "session.update",
             "session": {
-                "input_audio_format": "pcm16",  # 16-bit PCM at 24kHz mono
-                "input_audio_transcription": {
-                    "model": self.model,
-                },
-                "turn_detection": {
-                    "type": "server_vad",
-                    "threshold": 0.5,
-                    "prefix_padding_ms": 300,
-                    "silence_duration_ms": 500,
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": {"type": "audio/pcm", "rate": 24000},
+                        "transcription": {"model": self.model},
+                        "turn_detection": None,
+                    },
                 },
             },
         }
         await self._ws.send_str(json.dumps(config_message))
-        self._logger.info("Sent config for model: %s with server VAD", self.model)
+        self._logger.info("Sent config for model: %s", self.model)
 
         # Start receiving transcripts
         self._receive_task = asyncio.create_task(self._receive_loop())
@@ -635,12 +642,18 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
     async def create_streaming_transcriber(  # ty: ignore[invalid-method-override]
         self, _audio_format: str = "webm"
     ) -> OpenAIStreamingTranscriber:
-        """Create a streaming transcription session using Realtime API."""
+        """Create a streaming transcription session using Realtime API.
+
+        Note: streaming always uses `gpt-realtime-whisper`. The provider's
+        configured `stt_model` (whisper-1 / gpt-4o-transcribe / etc.) is only
+        used by the chunked HTTP transcription path; OpenAI's Realtime API
+        does not stream those models.
+        """
         if not self.api_key:
             raise ValueError("API key required for streaming transcription")
         transcriber = OpenAIStreamingTranscriber(
             api_key=self.api_key,
-            model=self.stt_model,
+            model=OPENAI_REALTIME_STT_MODEL,
             api_base=self.api_base,
         )
         await transcriber.connect()

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -102,11 +102,16 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         """Establish WebSocket connection to OpenAI Realtime API (GA shape)."""
         self._session = aiohttp.ClientSession()
 
-        # GA Realtime API: `?model=` query param replaces the Beta
-        # `?intent=transcription`, and the `OpenAI-Beta: realtime=v1` header
-        # is gone. Sending the Beta shape now returns `beta_api_shape_disabled`.
+        # GA Realtime API: connect to bare `/v1/realtime` with no query
+        # string. Speech-to-speech sessions use `?model=<realtime-model>`,
+        # but transcription-only sessions reject any `model` query
+        # parameter ("You must not provide a model parameter for
+        # transcription sessions"); the transcription model is configured
+        # in-band via `audio.input.transcription.model` below. The Beta
+        # `?intent=transcription` form returns `beta_api_shape_disabled`
+        # and the `OpenAI-Beta: realtime=v1` header is no longer required.
         ws_base = _http_to_ws_url(self.api_base.rstrip("/"))
-        url = f"{ws_base}/v1/realtime?model={self.model}"
+        url = f"{ws_base}/v1/realtime"
         headers = {"Authorization": f"Bearer {self.api_key}"}
 
         try:

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -1,19 +1,9 @@
 """OpenAI voice provider for STT and TTS.
 
-OpenAI supports:
-- **STT (chunked HTTP)**: whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe
-  via the `/v1/audio/transcriptions` endpoint. This is the path used by
-  `OpenAIVoiceProvider.transcribe()` for the provider's configured `stt_model`.
-- **STT (streaming)**: gpt-realtime-whisper via the GA Realtime API WebSocket.
-  Audio is sent as base64-encoded PCM16 at 24kHz mono. The streaming path
-  always uses `gpt-realtime-whisper` regardless of the provider's stored
-  `stt_model`; server-side VAD is unsupported by this model, so turn
-  boundaries are driven by an explicit `input_audio_buffer.commit` from
-  `OpenAIStreamingTranscriber.close()`.
-- **TTS**: HTTP streaming endpoint that returns audio chunks progressively.
-  Supported models: tts-1 (standard) and tts-1-hd (high quality).
-
-See https://platform.openai.com/docs for API reference.
+- STT chunked: `/v1/audio/transcriptions` with the provider's `stt_model`.
+- STT streaming: GA Realtime WS, always `gpt-realtime-whisper`. No server-side
+  VAD on this model, so `close()` sends an explicit `input_audio_buffer.commit`.
+- TTS: HTTP streaming, tts-1 / tts-1-hd.
 """
 
 import asyncio
@@ -41,15 +31,9 @@ if TYPE_CHECKING:
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com"
 
 
-# OpenAI's GA Realtime WebSocket requires two model identifiers:
-#  - The *session* model in the URL's `?model=` query parameter. This is the
-#    speech-to-speech realtime model; even transcription-only sessions must
-#    specify one (the endpoint returns `missing_model` otherwise).
-#  - The *transcription* model, passed in-band via
-#    `audio.input.transcription.model` on `session.update`.
-# `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe` are HTTP-only
-# and remain selectable for the chunked path; the streaming WS always uses
-# these constants regardless of the provider's stored `stt_model`.
+# GA Realtime WS needs two model slots: the realtime *session* model in the
+# URL `?model=` (omit → `missing_model`), and the *transcription* model in
+# `audio.input.transcription.model`. Other STT models stay HTTP-only.
 OPENAI_REALTIME_SESSION_MODEL = "gpt-realtime-1.5"
 OPENAI_REALTIME_STT_MODEL = "gpt-realtime-whisper"
 
@@ -104,23 +88,17 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         self._accumulated_transcript = ""  # Accumulated across all turns
         self._receive_task: asyncio.Task | None = None
         self._closed = False
-        # Captures the most recent `error` event from OpenAI so callers
-        # (e.g. tests, the WS handler) can detect a poisoned session even
-        # though OpenAI does not close the socket on protocol errors.
+        # OpenAI keeps the WS open on protocol errors, so we cache the last
+        # error event for callers to fail fast on a poisoned session.
         self._last_error: dict[str, Any] | None = None
 
     async def connect(self) -> None:
         """Establish WebSocket connection to OpenAI Realtime API (GA shape)."""
         self._session = aiohttp.ClientSession()
 
-        # GA Realtime API: `?model=` must be a realtime *session* model
-        # (e.g. `gpt-realtime-1.5`), not a transcription model — passing
-        # `gpt-realtime-whisper` here yields `invalid_model`, and omitting
-        # the parameter entirely yields `missing_model`. The transcription
-        # model is specified in-band via `audio.input.transcription.model`
-        # on `session.update` below. The Beta `?intent=transcription` form
-        # returns `beta_api_shape_disabled` and the `OpenAI-Beta` header is
-        # no longer required.
+        # `?model=` must be the realtime session model — a transcription
+        # model here yields `invalid_model`. The Beta `?intent=transcription`
+        # form now returns `beta_api_shape_disabled`.
         ws_base = _http_to_ws_url(self.api_base.rstrip("/"))
         url = f"{ws_base}/v1/realtime?model={OPENAI_REALTIME_SESSION_MODEL}"
         headers = {"Authorization": f"Bearer {self.api_key}"}
@@ -132,17 +110,13 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
             self._logger.error("Failed to connect to OpenAI Realtime API: %s", e)
             raise
 
-        # GA shape: `session.update` (was `transcription_session.update`),
-        # with the session typed as `realtime` — *not* `transcription`.
-        # OpenAI's GA does not have a dedicated transcription-only session
-        # type on the WS; transcription is configured as a side-effect of
-        # a standard realtime session via `audio.input.transcription.model`.
-        # Sending `session.type: "transcription"` here yields:
-        #   "Passing a transcription session update event to a realtime
-        #    session is not allowed."
-        # `gpt-realtime-whisper` does not emit server-side VAD events; turn
-        # boundaries are driven by an explicit `input_audio_buffer.commit`
-        # from `close()` when the user stops recording.
+        # `session.type` must be `"realtime"`. GA has no transcription-only
+        # session type on the WS — transcription is a side-effect configured
+        # via `audio.input.transcription.model`. `"transcription"` here →
+        # "Passing a transcription session update event to a realtime
+        # session is not allowed". `turn_detection: None` because
+        # gpt-realtime-whisper has no server-side VAD; `close()` drives
+        # turn boundaries via `input_audio_buffer.commit`.
         config_message = {
             "type": "session.update",
             "session": {
@@ -174,26 +148,16 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
                     msg_type = data.get("type", "")
                     self._logger.debug("Received message type: %s", msg_type)
 
-                    # Handle errors. OpenAI does NOT close the WebSocket on
-                    # protocol errors (e.g. a malformed `session.update`),
-                    # so we capture the most recent error here for callers
-                    # to inspect — the test/handler can fail fast instead
-                    # of waiting on a session that will never produce a
-                    # transcript.
+                    # WS stays open on protocol errors — cache for callers.
                     if msg_type == OpenAIRealtimeMessageType.ERROR:
                         error = data.get("error", {})
                         self._last_error = error
                         self._logger.error("OpenAI error: %s", error)
                         continue
 
-                    # Audio-buffer lifecycle events. `gpt-realtime-whisper`
-                    # does not emit server-side VAD events, so the
-                    # speech_started/stopped branches are no-ops under the
-                    # current model; kept as defensive handlers in case
-                    # server VAD is later re-enabled or another Realtime
-                    # transcription model is used. `buffer_committed` does
-                    # fire — once per recording session in response to the
-                    # manual commit sent from `close()`.
+                    # speech_started/stopped are no-ops on gpt-realtime-whisper
+                    # (no server VAD) but kept defensively. buffer_committed
+                    # fires once per session from close()'s manual commit.
                     if msg_type == OpenAIRealtimeMessageType.SPEECH_STARTED:
                         self._logger.info("OpenAI: Speech started")
                         self._current_turn_transcript = ""
@@ -297,10 +261,8 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         """Close session and return final transcript."""
         self._closed = True
         if self._ws:
-            # `gpt-realtime-whisper` has no server-side VAD; this manual
-            # commit is the sole trigger for the final TRANSCRIPTION_COMPLETED
-            # event. Without it, the receive loop would never produce a
-            # final transcript on stop-recording.
+            # Sole trigger for the final TRANSCRIPTION_COMPLETED event
+            # (gpt-realtime-whisper has no server VAD).
             try:
                 await self._ws.send_str(
                     json.dumps({"type": "input_audio_buffer.commit"})
@@ -343,9 +305,8 @@ OPENAI_VOICES = [
     {"id": "shimmer", "name": "Shimmer"},
 ]
 
-# OpenAI available STT models for the chunked HTTP path. The streaming
-# WebSocket path is locked to `OPENAI_REALTIME_STT_MODEL`
-# (`gpt-realtime-whisper`) regardless of which model is selected here.
+# Models for the chunked HTTP path only — streaming is locked to
+# OPENAI_REALTIME_STT_MODEL regardless of selection.
 OPENAI_STT_MODELS = [
     {"id": "whisper-1", "name": "Whisper v1"},
     {"id": "gpt-4o-transcribe", "name": "GPT-4o Transcribe"},
@@ -568,21 +529,11 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         return self._client
 
     async def transcribe(self, audio_data: bytes, audio_format: str) -> str:
-        """
-        Transcribe audio using OpenAI Whisper.
-
-        Args:
-            audio_data: Raw audio bytes
-            audio_format: Audio format (e.g., "webm", "wav", "mp3", "pcm16")
-
-        Returns:
-            Transcribed text
-        """
+        """Transcribe audio via `/v1/audio/transcriptions`."""
         client = self._get_client()
 
-        # OpenAI's /v1/audio/transcriptions endpoint does not accept raw PCM;
-        # wrap PCM16 in a WAV container (24kHz mono — matches the browser
-        # capture format used by the streaming WebSocket fallback).
+        # /v1/audio/transcriptions doesn't accept raw PCM — wrap as WAV
+        # (24kHz mono matches the browser capture format).
         if audio_format == "pcm16":
             audio_data = _create_wav_header(len(audio_data)) + audio_data
             audio_format = "wav"
@@ -667,12 +618,8 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         return OPENAI_TTS_MODELS.copy()
 
     def supports_streaming_stt(self) -> bool:
-        """OpenAI supports streaming via the GA Realtime API.
-
-        The streaming WebSocket always uses `gpt-realtime-whisper`
-        (`OPENAI_REALTIME_STT_MODEL`); the provider's configured
-        `stt_model` only governs the chunked HTTP path.
-        """
+        # Streaming WS is locked to OPENAI_REALTIME_STT_MODEL; stt_model
+        # only governs the chunked HTTP path.
         return True
 
     def supports_streaming_tts(self) -> bool:
@@ -682,13 +629,8 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
     async def create_streaming_transcriber(  # ty: ignore[invalid-method-override]
         self, _audio_format: str = "webm"
     ) -> OpenAIStreamingTranscriber:
-        """Create a streaming transcription session using Realtime API.
-
-        Note: streaming always uses `gpt-realtime-whisper`. The provider's
-        configured `stt_model` (whisper-1 / gpt-4o-transcribe / etc.) is only
-        used by the chunked HTTP transcription path; OpenAI's Realtime API
-        does not stream those models.
-        """
+        # Streaming always uses OPENAI_REALTIME_STT_MODEL — other STT models
+        # are not Realtime-streamable.
         if not self.api_key:
             raise ValueError("API key required for streaming transcription")
         transcriber = OpenAIStreamingTranscriber(

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -40,10 +40,16 @@ if TYPE_CHECKING:
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com"
 
 
-# OpenAI Realtime API only streams transcription for `gpt-realtime-whisper`.
+# OpenAI's GA Realtime WebSocket requires two model identifiers:
+#  - The *session* model in the URL's `?model=` query parameter. This is the
+#    speech-to-speech realtime model; even transcription-only sessions must
+#    specify one (the endpoint returns `missing_model` otherwise).
+#  - The *transcription* model, passed in-band via
+#    `audio.input.transcription.model` on `session.update`.
 # `whisper-1`, `gpt-4o-transcribe`, and `gpt-4o-mini-transcribe` are HTTP-only
 # and remain selectable for the chunked path; the streaming WS always uses
-# this model regardless of the provider's stored `stt_model`.
+# these constants regardless of the provider's stored `stt_model`.
+OPENAI_REALTIME_SESSION_MODEL = "gpt-realtime-1.5"
 OPENAI_REALTIME_STT_MODEL = "gpt-realtime-whisper"
 
 
@@ -102,16 +108,16 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         """Establish WebSocket connection to OpenAI Realtime API (GA shape)."""
         self._session = aiohttp.ClientSession()
 
-        # GA Realtime API: connect to bare `/v1/realtime` with no query
-        # string. Speech-to-speech sessions use `?model=<realtime-model>`,
-        # but transcription-only sessions reject any `model` query
-        # parameter ("You must not provide a model parameter for
-        # transcription sessions"); the transcription model is configured
-        # in-band via `audio.input.transcription.model` below. The Beta
-        # `?intent=transcription` form returns `beta_api_shape_disabled`
-        # and the `OpenAI-Beta: realtime=v1` header is no longer required.
+        # GA Realtime API: `?model=` must be a realtime *session* model
+        # (e.g. `gpt-realtime-1.5`), not a transcription model — passing
+        # `gpt-realtime-whisper` here yields `invalid_model`, and omitting
+        # the parameter entirely yields `missing_model`. The transcription
+        # model is specified in-band via `audio.input.transcription.model`
+        # on `session.update` below. The Beta `?intent=transcription` form
+        # returns `beta_api_shape_disabled` and the `OpenAI-Beta` header is
+        # no longer required.
         ws_base = _http_to_ws_url(self.api_base.rstrip("/"))
-        url = f"{ws_base}/v1/realtime"
+        url = f"{ws_base}/v1/realtime?model={OPENAI_REALTIME_SESSION_MODEL}"
         headers = {"Authorization": f"Bearer {self.api_key}"}
 
         try:

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -1,10 +1,15 @@
 """OpenAI voice provider for STT and TTS.
 
 OpenAI supports:
-- **STT**: Whisper (batch transcription via REST). Streaming transcription via
-  the Realtime API is currently disabled (`supports_streaming_stt()` returns
-  `False`) pending migration to the GA Realtime API; `OpenAIStreamingTranscriber`
-  remains in this file for the upcoming migration but is unreachable today.
+- **STT (chunked HTTP)**: whisper-1, gpt-4o-transcribe, gpt-4o-mini-transcribe
+  via the `/v1/audio/transcriptions` endpoint. This is the path used by
+  `OpenAIVoiceProvider.transcribe()` for the provider's configured `stt_model`.
+- **STT (streaming)**: gpt-realtime-whisper via the GA Realtime API WebSocket.
+  Audio is sent as base64-encoded PCM16 at 24kHz mono. The streaming path
+  always uses `gpt-realtime-whisper` regardless of the provider's stored
+  `stt_model`; server-side VAD is unsupported by this model, so turn
+  boundaries are driven by an explicit `input_audio_buffer.commit` from
+  `OpenAIStreamingTranscriber.close()`.
 - **TTS**: HTTP streaming endpoint that returns audio chunks progressively.
   Supported models: tts-1 (standard) and tts-1-hd (high quality).
 
@@ -153,16 +158,20 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
                         self._logger.error("OpenAI error: %s", error)
                         continue
 
-                    # Handle VAD events
+                    # Audio-buffer lifecycle events. `gpt-realtime-whisper`
+                    # does not emit server-side VAD events, so the
+                    # speech_started/stopped branches are no-ops under the
+                    # current model; kept as defensive handlers in case
+                    # server VAD is later re-enabled or another Realtime
+                    # transcription model is used. `buffer_committed` does
+                    # fire — once per recording session in response to the
+                    # manual commit sent from `close()`.
                     if msg_type == OpenAIRealtimeMessageType.SPEECH_STARTED:
                         self._logger.info("OpenAI: Speech started")
-                        # Reset current turn transcript for new speech
                         self._current_turn_transcript = ""
                         continue
                     elif msg_type == OpenAIRealtimeMessageType.SPEECH_STOPPED:
-                        self._logger.info(
-                            "OpenAI: Speech stopped (VAD detected silence)"
-                        )
+                        self._logger.info("OpenAI: Speech stopped")
                         continue
                     elif msg_type == OpenAIRealtimeMessageType.BUFFER_COMMITTED:
                         self._logger.info("OpenAI: Audio buffer committed")
@@ -260,8 +269,10 @@ class OpenAIStreamingTranscriber(StreamingTranscriberProtocol):
         """Close session and return final transcript."""
         self._closed = True
         if self._ws:
-            # With server VAD, the buffer is auto-committed when speech stops.
-            # But we should still commit any remaining audio and wait for transcription.
+            # `gpt-realtime-whisper` has no server-side VAD; this manual
+            # commit is the sole trigger for the final TRANSCRIPTION_COMPLETED
+            # event. Without it, the receive loop would never produce a
+            # final transcript on stop-recording.
             try:
                 await self._ws.send_str(
                     json.dumps({"type": "input_audio_buffer.commit"})
@@ -304,9 +315,9 @@ OPENAI_VOICES = [
     {"id": "shimmer", "name": "Shimmer"},
 ]
 
-# OpenAI available STT models. All use the chunked HTTP transcription endpoint
-# today; Realtime streaming is disabled until the GA migration lands (see
-# `supports_streaming_stt()`).
+# OpenAI available STT models for the chunked HTTP path. The streaming
+# WebSocket path is locked to `OPENAI_REALTIME_STT_MODEL`
+# (`gpt-realtime-whisper`) regardless of which model is selected here.
 OPENAI_STT_MODELS = [
     {"id": "whisper-1", "name": "Whisper v1"},
     {"id": "gpt-4o-transcribe", "name": "GPT-4o Transcribe"},
@@ -628,12 +639,13 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         return OPENAI_TTS_MODELS.copy()
 
     def supports_streaming_stt(self) -> bool:
-        # OpenAI deprecated the Realtime Beta API shape we depend on
-        # (header `OpenAI-Beta: realtime=v1` + `transcription_session.update`),
-        # which now returns `beta_api_shape_disabled`. Route through the
-        # chunked HTTP path until the streaming transcriber is migrated to
-        # the GA Realtime API.
-        return False
+        """OpenAI supports streaming via the GA Realtime API.
+
+        The streaming WebSocket always uses `gpt-realtime-whisper`
+        (`OPENAI_REALTIME_STT_MODEL`); the provider's configured
+        `stt_model` only governs the chunked HTTP path.
+        """
+        return True
 
     def supports_streaming_tts(self) -> bool:
         """OpenAI supports real-time streaming TTS via Realtime API."""

--- a/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
+++ b/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
@@ -1,0 +1,133 @@
+"""Live regression tests for OpenAI STT against the GA Realtime API.
+
+These tests guard the handshake and audio-format details that broke when
+OpenAI deprecated the Realtime Beta API shape. They exercise the real
+endpoint with the OPENAI_API_KEY from the environment.
+
+Tests are marked `nightly` and skipped when `OPENAI_API_KEY` is absent.
+"""
+
+import asyncio
+import math
+import struct
+
+import pytest
+
+from onyx.voice.providers.openai import OPENAI_REALTIME_STT_MODEL
+from onyx.voice.providers.openai import OpenAIStreamingTranscriber
+from onyx.voice.providers.openai import OpenAIVoiceProvider
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+# 24kHz mono PCM16, matching the format Onyx's voice WebSocket emits from
+# the browser. Generated programmatically so the test has no audio fixture
+# dependency — the connect/handshake path doesn't care about content,
+# and the chunked path only needs OpenAI to accept the bytes (an empty
+# transcript on silence is a valid outcome).
+_SAMPLE_RATE_HZ = 24000
+_BYTES_PER_SAMPLE = 2
+
+
+def _silence_pcm16(duration_s: float) -> bytes:
+    return b"\x00\x00" * int(_SAMPLE_RATE_HZ * duration_s)
+
+
+def _tone_pcm16(duration_s: float, freq_hz: int = 440) -> bytes:
+    """Single-tone PCM16. Whisper transcribes this as empty string most of
+    the time, but the bytes are well-formed audio that OpenAI accepts."""
+    samples = []
+    for n in range(int(_SAMPLE_RATE_HZ * duration_s)):
+        value = int(0.3 * 32767 * math.sin(2 * math.pi * freq_hz * n / _SAMPLE_RATE_HZ))
+        samples.append(struct.pack("<h", value))
+    return b"".join(samples)
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_connect_uses_ga_realtime_shape(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Connecting to the Realtime API with our session.update payload must
+    NOT return `beta_api_shape_disabled` or any error event before the
+    first audio chunk. Catches re-introduction of the Beta header / message
+    shape or any future endpoint-side deprecation of our handshake.
+    """
+
+    async def run() -> None:
+        transcriber = OpenAIStreamingTranscriber(
+            api_key=test_secrets[TestSecret.OPENAI_API_KEY],
+            model=OPENAI_REALTIME_STT_MODEL,
+        )
+        try:
+            await transcriber.connect()
+            # Give OpenAI a moment to send session.created / session.updated
+            # (or an error). We don't expect a transcript yet; we're
+            # validating that the handshake itself was accepted.
+            await asyncio.sleep(1.5)
+            # If the handshake was rejected, the receive loop would have
+            # closed the queue with a sentinel `None` already.
+            assert not transcriber._closed, "transcriber closed early"
+            assert transcriber._ws is not None and not transcriber._ws.closed
+        finally:
+            await transcriber.close()
+
+    asyncio.run(run())
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_streaming_accepts_pcm16_audio_chunks(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Send PCM16 audio through the streaming WS and confirm OpenAI returns
+    a `conversation.item.input_audio_transcription.completed` event (or at
+    least does not return an error). Catches audio-format mismatches in
+    the session config (e.g. `audio.input.format` vs `input_audio_format`).
+    """
+
+    async def run() -> None:
+        transcriber = OpenAIStreamingTranscriber(
+            api_key=test_secrets[TestSecret.OPENAI_API_KEY],
+            model=OPENAI_REALTIME_STT_MODEL,
+        )
+        await transcriber.connect()
+        try:
+            # 2 seconds of tone is enough audio for the model to finish a
+            # turn after we commit. Send in 100ms chunks like the browser.
+            tone = _tone_pcm16(duration_s=2.0)
+            chunk_size = _SAMPLE_RATE_HZ * _BYTES_PER_SAMPLE // 10
+            for offset in range(0, len(tone), chunk_size):
+                await transcriber.send_audio(tone[offset : offset + chunk_size])
+                await asyncio.sleep(0.05)
+        finally:
+            final = await transcriber.close()
+        # We don't assert on transcript content — Whisper may return an
+        # empty string for a pure tone. The fact that `close()` returned
+        # without timing out on a hung receive loop proves the protocol
+        # round-trip works.
+        assert isinstance(final, str)
+
+    asyncio.run(run())
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_chunked_transcribe_accepts_pcm16(
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """`OpenAIVoiceProvider.transcribe()` must wrap raw PCM16 in a WAV
+    container before posting; without that wrap, `/v1/audio/transcriptions`
+    rejects the file with `Invalid file format`. Guards the chunked
+    fallback used when streaming is unavailable.
+    """
+
+    async def run() -> str:
+        provider = OpenAIVoiceProvider(
+            api_key=test_secrets[TestSecret.OPENAI_API_KEY],
+            stt_model="whisper-1",
+        )
+        # 1 second of silence is enough for the HTTP endpoint to accept the
+        # file and return an empty transcript. The bug we're guarding is a
+        # 400 from OpenAI, not an empty string.
+        return await provider.transcribe(_silence_pcm16(duration_s=1.0), "pcm16")
+
+    transcript = asyncio.run(run())
+    assert isinstance(transcript, str)

--- a/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
+++ b/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
@@ -48,9 +48,15 @@ def test_streaming_connect_uses_ga_realtime_shape(
     test_secrets: dict[TestSecret, str],
 ) -> None:
     """Connecting to the Realtime API with our session.update payload must
-    NOT return `beta_api_shape_disabled` or any error event before the
-    first audio chunk. Catches re-introduction of the Beta header / message
-    shape or any future endpoint-side deprecation of our handshake.
+    NOT produce an `error` event from OpenAI. Catches re-introduction of
+    the Beta header / message shape, wrong session.type, wrong audio
+    format field, or any future endpoint-side deprecation.
+
+    Note: OpenAI does *not* close the WebSocket when it rejects a
+    session.update — it sends an `error` event and leaves the socket
+    open. So we must check `_last_error`, not `_ws.closed`. (An earlier
+    version of this test only checked `_ws.closed` and silently passed
+    against a poisoned session.)
     """
 
     async def run() -> None:
@@ -61,11 +67,11 @@ def test_streaming_connect_uses_ga_realtime_shape(
         try:
             await transcriber.connect()
             # Give OpenAI a moment to send session.created / session.updated
-            # (or an error). We don't expect a transcript yet; we're
-            # validating that the handshake itself was accepted.
+            # (or an error event for a bad handshake).
             await asyncio.sleep(1.5)
-            # If the handshake was rejected, the receive loop would have
-            # closed the queue with a sentinel `None` already.
+            assert transcriber._last_error is None, (
+                f"OpenAI returned an error during handshake: {transcriber._last_error}"
+            )
             assert not transcriber._closed, "transcriber closed early"
             assert transcriber._ws is not None and not transcriber._ws.closed
         finally:
@@ -100,6 +106,10 @@ def test_streaming_accepts_pcm16_audio_chunks(
                 await asyncio.sleep(0.05)
         finally:
             final = await transcriber.close()
+        assert transcriber._last_error is None, (
+            f"OpenAI returned an error during the audio round-trip: "
+            f"{transcriber._last_error}"
+        )
         # We don't assert on transcript content — Whisper may return an
         # empty string for a pure tone. The fact that `close()` returned
         # without timing out on a hung receive loop proves the protocol

--- a/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
+++ b/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
@@ -1,12 +1,7 @@
 """Live regression tests for OpenAI STT against the GA Realtime API.
 
-These tests guard the handshake and audio-format details that broke when
-OpenAI deprecated the Realtime Beta API shape. They exercise the real
-endpoint and are skipped via `@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)`
-when the key is absent.
-
-Each test makes a single short API call (~1-3s of audio), so they're
-cheap enough to run on every PR rather than gating behind `nightly`.
+Skipped via `@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)` when the key
+is absent. Single short API call each, so safe to run on every PR.
 """
 
 import asyncio
@@ -20,11 +15,7 @@ from onyx.voice.providers.openai import OpenAIStreamingTranscriber
 from onyx.voice.providers.openai import OpenAIVoiceProvider
 from tests.utils.secret_names import TestSecret
 
-# 24kHz mono PCM16, matching the format Onyx's voice WebSocket emits from
-# the browser. Generated programmatically so the test has no audio fixture
-# dependency — the connect/handshake path doesn't care about content,
-# and the chunked path only needs OpenAI to accept the bytes (an empty
-# transcript on silence is a valid outcome).
+# 24kHz mono PCM16 — matches the browser's voice WS format.
 _SAMPLE_RATE_HZ = 24000
 _BYTES_PER_SAMPLE = 2
 
@@ -34,8 +25,6 @@ def _silence_pcm16(duration_s: float) -> bytes:
 
 
 def _tone_pcm16(duration_s: float, freq_hz: int = 440) -> bytes:
-    """Single-tone PCM16. Whisper transcribes this as empty string most of
-    the time, but the bytes are well-formed audio that OpenAI accepts."""
     samples = []
     for n in range(int(_SAMPLE_RATE_HZ * duration_s)):
         value = int(0.3 * 32767 * math.sin(2 * math.pi * freq_hz * n / _SAMPLE_RATE_HZ))
@@ -47,16 +36,11 @@ def _tone_pcm16(duration_s: float, freq_hz: int = 440) -> bytes:
 def test_streaming_connect_uses_ga_realtime_shape(
     test_secrets: dict[TestSecret, str],
 ) -> None:
-    """Connecting to the Realtime API with our session.update payload must
-    NOT produce an `error` event from OpenAI. Catches re-introduction of
-    the Beta header / message shape, wrong session.type, wrong audio
-    format field, or any future endpoint-side deprecation.
+    """`session.update` handshake must not produce an `error` event.
 
-    Note: OpenAI does *not* close the WebSocket when it rejects a
-    session.update — it sends an `error` event and leaves the socket
-    open. So we must check `_last_error`, not `_ws.closed`. (An earlier
-    version of this test only checked `_ws.closed` and silently passed
-    against a poisoned session.)
+    Must check `_last_error`, not `_ws.closed` — OpenAI keeps the socket
+    open on protocol errors, so checking `closed` silently false-passes
+    against a poisoned session.
     """
 
     async def run() -> None:
@@ -66,9 +50,7 @@ def test_streaming_connect_uses_ga_realtime_shape(
         )
         try:
             await transcriber.connect()
-            # Give OpenAI a moment to send session.created / session.updated
-            # (or an error event for a bad handshake).
-            await asyncio.sleep(1.5)
+            await asyncio.sleep(1.5)  # let session.created / .updated arrive
             assert transcriber._last_error is None, (
                 f"OpenAI returned an error during handshake: {transcriber._last_error}"
             )
@@ -84,11 +66,7 @@ def test_streaming_connect_uses_ga_realtime_shape(
 def test_streaming_accepts_pcm16_audio_chunks(
     test_secrets: dict[TestSecret, str],
 ) -> None:
-    """Send PCM16 audio through the streaming WS and confirm OpenAI returns
-    a `conversation.item.input_audio_transcription.completed` event (or at
-    least does not return an error). Catches audio-format mismatches in
-    the session config (e.g. `audio.input.format` vs `input_audio_format`).
-    """
+    """PCM16 round-trip through the streaming WS produces no error event."""
 
     async def run() -> None:
         transcriber = OpenAIStreamingTranscriber(
@@ -97,10 +75,8 @@ def test_streaming_accepts_pcm16_audio_chunks(
         )
         await transcriber.connect()
         try:
-            # 2 seconds of tone is enough audio for the model to finish a
-            # turn after we commit. Send in 100ms chunks like the browser.
             tone = _tone_pcm16(duration_s=2.0)
-            chunk_size = _SAMPLE_RATE_HZ * _BYTES_PER_SAMPLE // 10
+            chunk_size = _SAMPLE_RATE_HZ * _BYTES_PER_SAMPLE // 10  # 100ms
             for offset in range(0, len(tone), chunk_size):
                 await transcriber.send_audio(tone[offset : offset + chunk_size])
                 await asyncio.sleep(0.05)
@@ -110,10 +86,8 @@ def test_streaming_accepts_pcm16_audio_chunks(
             f"OpenAI returned an error during the audio round-trip: "
             f"{transcriber._last_error}"
         )
-        # We don't assert on transcript content — Whisper may return an
-        # empty string for a pure tone. The fact that `close()` returned
-        # without timing out on a hung receive loop proves the protocol
-        # round-trip works.
+        # Whisper may transcribe a pure tone as empty — we only assert the
+        # protocol round-tripped (close() returned without a hung receive).
         assert isinstance(final, str)
 
     asyncio.run(run())
@@ -123,20 +97,14 @@ def test_streaming_accepts_pcm16_audio_chunks(
 def test_chunked_transcribe_accepts_pcm16(
     test_secrets: dict[TestSecret, str],
 ) -> None:
-    """`OpenAIVoiceProvider.transcribe()` must wrap raw PCM16 in a WAV
-    container before posting; without that wrap, `/v1/audio/transcriptions`
-    rejects the file with `Invalid file format`. Guards the chunked
-    fallback used when streaming is unavailable.
-    """
+    """`transcribe()` must wrap PCM16 in WAV before posting — without the
+    wrap, `/v1/audio/transcriptions` returns `Invalid file format`."""
 
     async def run() -> str:
         provider = OpenAIVoiceProvider(
             api_key=test_secrets[TestSecret.OPENAI_API_KEY],
             stt_model="whisper-1",
         )
-        # 1 second of silence is enough for the HTTP endpoint to accept the
-        # file and return an empty transcript. The bug we're guarding is a
-        # 400 from OpenAI, not an empty string.
         return await provider.transcribe(_silence_pcm16(duration_s=1.0), "pcm16")
 
     transcript = asyncio.run(run())

--- a/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
+++ b/backend/tests/external_dependency_unit/voice/test_openai_streaming.py
@@ -2,9 +2,11 @@
 
 These tests guard the handshake and audio-format details that broke when
 OpenAI deprecated the Realtime Beta API shape. They exercise the real
-endpoint with the OPENAI_API_KEY from the environment.
+endpoint and are skipped via `@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)`
+when the key is absent.
 
-Tests are marked `nightly` and skipped when `OPENAI_API_KEY` is absent.
+Each test makes a single short API call (~1-3s of audio), so they're
+cheap enough to run on every PR rather than gating behind `nightly`.
 """
 
 import asyncio
@@ -17,8 +19,6 @@ from onyx.voice.providers.openai import OPENAI_REALTIME_STT_MODEL
 from onyx.voice.providers.openai import OpenAIStreamingTranscriber
 from onyx.voice.providers.openai import OpenAIVoiceProvider
 from tests.utils.secret_names import TestSecret
-
-pytestmark = pytest.mark.nightly
 
 # 24kHz mono PCM16, matching the format Onyx's voice WebSocket emits from
 # the browser. Generated programmatically so the test has no audio fixture


### PR DESCRIPTION
## Description

Long-term followup to #11322 (the small chunked-fallback fix that's keeping OpenAI STT working in production today). This PR migrates `OpenAIStreamingTranscriber` to OpenAI's GA Realtime API so customers get native streaming transcripts again.

The GA shape is non-obvious — the docs were ambiguous and contradictory across pages, so this PR was iterated against the live API with `backend/tests/external_dependency_unit/voice/test_openai_streaming.py` until both the test and a developer running it locally end-to-end confirmed transcription works.

## Final wire shape

**WebSocket URL** — `wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5`

- `?model=` must specify a **realtime session model** (speech-to-speech), not a transcription model. `OPENAI_REALTIME_SESSION_MODEL` constant.
- The `OpenAI-Beta: realtime=v1` header is no longer required (GA endpoint).
- The Beta `?intent=transcription` form now returns `beta_api_shape_disabled`.

**First message (`session.update`)** — `session.type` is **`"realtime"`**, NOT `"transcription"`:

```json
{
  "type": "session.update",
  "session": {
    "type": "realtime",
    "audio": {
      "input": {
        "format": {"type": "audio/pcm", "rate": 24000},
        "transcription": {"model": "gpt-realtime-whisper"},
        "turn_detection": null
      }
    }
  }
}
```

GA does NOT have a dedicated transcription-only session type on the WebSocket. Per OpenAI's own cookbook (`realtime_out_of_band_transcription`), transcription is configured as a side-effect of a standard realtime session via `audio.input.transcription.model`. Sending `session.type: "transcription"` yields:

> `invalid_parameter` — Passing a transcription session update event to a realtime session is not allowed.

**Model handling.** Two separate model slots, two separate constants:

| Constant | Value | Where it goes |
|---|---|---|
| `OPENAI_REALTIME_SESSION_MODEL` | `gpt-realtime-1.5` | URL `?model=` query param (realtime session model) |
| `OPENAI_REALTIME_STT_MODEL` | `gpt-realtime-whisper` | `audio.input.transcription.model` (transcription model) |

The provider's configured `stt_model` (`whisper-1` / `gpt-4o-transcribe` / etc.) continues to govern the chunked HTTP path. The streaming WS always uses the two constants above — existing customers don't need to change settings.

**Event names that did NOT change in GA.** The `_receive_loop` code path survives intact:
- `conversation.item.input_audio_transcription.delta`
- `conversation.item.input_audio_transcription.completed`
- `input_audio_buffer.committed`
- `error`

Session lifecycle events dropped the `transcription_` prefix:
- `session.created` (was `transcription_session.created`)
- `session.updated` (was `transcription_session.updated`)

## UX trade-off — auto-send on silence is lost

`gpt-realtime-whisper` does not support server-side VAD. The Beta code drove auto-send via `speech_stopped` events; the GA path now relies on the user manually stopping the recording, which triggers `input_audio_buffer.commit` from `close()`. The final transcript still arrives; intermediate VAD-driven turn boundaries do not.

Two options for restoring auto-send as a followup: (a) client-side VAD in the browser (e.g. `@ricky0123/vad`), or (b) wait for OpenAI to add VAD support to `gpt-realtime-whisper`. I'd recommend (a) — keeps the UX consistent across providers.

## How Has This Been Tested?

**Live regression tests** at `backend/tests/external_dependency_unit/voice/test_openai_streaming.py`:

1. **`test_streaming_connect_uses_ga_realtime_shape`** — handshake completes without an OpenAI `error` event. Asserts `_last_error is None` after sleeping 1.5s post-connect.
2. **`test_streaming_accepts_pcm16_audio_chunks`** — sends 2s of PCM16 audio in 100ms chunks, calls `close()`, asserts the protocol round-trip works AND `_last_error is None`.
3. **`test_chunked_transcribe_accepts_pcm16`** — `OpenAIVoiceProvider.transcribe()` wraps PCM16 in WAV before posting to `/v1/audio/transcriptions`. Guards the chunked fallback that #11322 introduced.

Tests use `OPENAI_API_KEY` via `pytest.mark.secrets` and run on every PR (not gated by `nightly`). All 3 pass in CI.

**End-to-end manual validation:** a developer ran the full Onyx stack locally with this branch, recorded audio in the chat UI, and got transcripts back from OpenAI. Voice is `Whisper (Current Default)` in the admin Voice config; the WS opens, sends `session.update`, receives `session.created` / `session.updated`, and produces `conversation.item.input_audio_transcription.completed` events.

### Why the test was previously broken — and what changed

The test passed in CI even when the live API was rejecting our `session.update` with `session.type: "transcription"`. Root cause: OpenAI does NOT close the WebSocket when it rejects a session.update — it sends an `error` event over the open socket and leaves the connection alive. The original assertion (`not _ws.closed`) stayed True against a poisoned session that would never produce transcripts.

Commit `d9341742dc` captures the error event on `OpenAIStreamingTranscriber._last_error` and the tests now assert `_last_error is None`. This is the generalizable lesson — when an external service signals errors out-of-band, "is the connection alive?" is not a sufficient health check.

## Iteration history

For posterity, the live API surfaced each layer of the GA shape in turn:

| Attempt | Change | OpenAI response |
|---|---|---|
| Initial (Beta shape, untouched) | `transcription_session.update` + `OpenAI-Beta` header | `beta_api_shape_disabled` |
| First GA guess | `?model=gpt-realtime-whisper` | `invalid_model` — transcription model can't be session model |
| Strip model param | bare `/v1/realtime` | `missing_model` — must provide a model parameter |
| Use realtime model in URL | `?model=gpt-realtime-1.5` + `session.type: "transcription"` | `invalid_parameter` — transcription session update event not allowed on realtime session |
| ✅ Final | `?model=gpt-realtime-1.5` + `session.type: "realtime"` | Works |

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Notes for reviewers

- Builds on / supersedes parts of #11322. Already rebased on top of main; the small fix's PCM16→WAV wrap remains as defense-in-depth for the chunked path.
- `supports_streaming_stt()` returns `True` again in this PR. #11322 flipped it to `False` as a workaround; this PR's working streaming path makes that workaround unnecessary.