### PR TITLE
feat: catch sharepoint errors

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -2278,21 +2278,28 @@ class SharepointConnector(
                         if len(doc_batch) >= SLIM_BATCH_SIZE:
                             yield doc_batch
                             doc_batch = []
-                except (ClientRequestException, HTTPError) as e:
-                    if not _is_per_site_graph_failure(e):
-                        raise
-                    # Slim sync can't yield ConnectorFailure; log-and-skip.
-                    logger.warning(
-                        "Skipping slim site pages for %s: Graph returned %s (%s)",
-                        site_descriptor.url,
-                        (
-                            e.response.status_code
-                            if e.response is not None
-                            else "no response"
-                        ),
-                        _graph_error_code(e.response),
-                        exc_info=True,
-                    )
+                except Exception as e:
+                    # Broadened from per-site Graph 4xx to any Exception.
+                    # Slim retrieval can't yield ConnectorFailure, so
+                    # log-and-skip to keep perm sync alive for other sites.
+                    if (
+                        isinstance(e, (ClientRequestException, HTTPError))
+                        and e.response is not None
+                    ):
+                        logger.warning(
+                            "Skipping slim site pages for %s: Graph returned %s (%s)",
+                            site_descriptor.url,
+                            e.response.status_code,
+                            _graph_error_code(e.response),
+                            exc_info=True,
+                        )
+                    else:
+                        logger.warning(
+                            "Skipping slim site pages for %s: %s",
+                            site_descriptor.url,
+                            e,
+                            exc_info=True,
+                        )
         yield doc_batch
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -2793,98 +2800,123 @@ class SharepointConnector(
                 )
 
             item_count = 0
-            for driveitem in driveitems:
-                item_count += 1
+            # Outer try catches BFS-generator failures mid-iteration;
+            # per-item errors are still caught by the inner try below.
+            try:
+                for driveitem in driveitems:
+                    item_count += 1
 
-                if self._is_driveitem_excluded(driveitem):
-                    logger.debug("Excluding by path denylist: %s", driveitem.web_url)
-                    continue
+                    if self._is_driveitem_excluded(driveitem):
+                        logger.debug(
+                            "Excluding by path denylist: %s", driveitem.web_url
+                        )
+                        continue
 
-                if driveitem.id and driveitem.id in checkpoint.seen_document_ids:
-                    logger.debug(
-                        "Skipping duplicate document %s (%s)",
-                        driveitem.id,
-                        driveitem.name,
-                    )
-                    continue
+                    if driveitem.id and driveitem.id in checkpoint.seen_document_ids:
+                        logger.debug(
+                            "Skipping duplicate document %s (%s)",
+                            driveitem.id,
+                            driveitem.name,
+                        )
+                        continue
 
-                driveitem_extension = get_file_ext(driveitem.name)
-                if driveitem_extension not in OnyxFileExtensions.ALL_ALLOWED_EXTENSIONS:
-                    logger.warning(
-                        "Skipping %s as it is not a supported file type",
-                        driveitem.web_url,
-                    )
-                    continue
+                    driveitem_extension = get_file_ext(driveitem.name)
+                    if (
+                        driveitem_extension
+                        not in OnyxFileExtensions.ALL_ALLOWED_EXTENSIONS
+                    ):
+                        logger.warning(
+                            "Skipping %s as it is not a supported file type",
+                            driveitem.web_url,
+                        )
+                        continue
 
-                should_yield_if_empty = (
-                    driveitem_extension in OnyxFileExtensions.IMAGE_EXTENSIONS
-                    or driveitem_extension == ".pdf"
-                )
-
-                folder_path = self._extract_folder_path_from_parent_reference(
-                    driveitem.parent_reference_path
-                )
-                if folder_path and drive_web_url:
-                    yield from self._yield_folder_hierarchy_nodes(
-                        site_descriptor.url,
-                        drive_web_url,
-                        current_drive_name,
-                        folder_path,
-                        checkpoint,
+                    should_yield_if_empty = (
+                        driveitem_extension in OnyxFileExtensions.IMAGE_EXTENSIONS
+                        or driveitem_extension == ".pdf"
                     )
 
-                parent_hierarchy_url: str | None = None
-                if drive_web_url:
-                    parent_hierarchy_url = self._get_parent_hierarchy_url(
-                        site_descriptor.url,
-                        drive_web_url,
-                        current_drive_name,
-                        driveitem,
+                    folder_path = self._extract_folder_path_from_parent_reference(
+                        driveitem.parent_reference_path
                     )
+                    if folder_path and drive_web_url:
+                        yield from self._yield_folder_hierarchy_nodes(
+                            site_descriptor.url,
+                            drive_web_url,
+                            current_drive_name,
+                            folder_path,
+                            checkpoint,
+                        )
 
-                try:
-                    ctx: ClientContext | None = None
-                    if include_permissions:
-                        ctx = self._create_rest_client_context(site_descriptor.url)
+                    parent_hierarchy_url: str | None = None
+                    if drive_web_url:
+                        parent_hierarchy_url = self._get_parent_hierarchy_url(
+                            site_descriptor.url,
+                            drive_web_url,
+                            current_drive_name,
+                            driveitem,
+                        )
 
-                    access_token = self._get_graph_access_token()
-                    doc_or_failure = _convert_driveitem_to_document_with_permissions(
-                        driveitem,
-                        current_drive_name,
-                        ctx,
-                        self.graph_client,
-                        include_permissions=include_permissions,
-                        parent_hierarchy_raw_node_id=parent_hierarchy_url,
-                        graph_api_base=self.graph_api_base,
-                        access_token=access_token,
-                        treat_sharing_link_as_public=self.treat_sharing_link_as_public,
-                        raw_file_callback=self.raw_file_callback,
-                    )
+                    try:
+                        ctx: ClientContext | None = None
+                        if include_permissions:
+                            ctx = self._create_rest_client_context(site_descriptor.url)
 
-                    if isinstance(doc_or_failure, Document):
-                        if doc_or_failure.sections:
-                            checkpoint.seen_document_ids.add(doc_or_failure.id)
+                        access_token = self._get_graph_access_token()
+                        doc_or_failure = _convert_driveitem_to_document_with_permissions(
+                            driveitem,
+                            current_drive_name,
+                            ctx,
+                            self.graph_client,
+                            include_permissions=include_permissions,
+                            parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                            graph_api_base=self.graph_api_base,
+                            access_token=access_token,
+                            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                            raw_file_callback=self.raw_file_callback,
+                        )
+
+                        if isinstance(doc_or_failure, Document):
+                            if doc_or_failure.sections:
+                                checkpoint.seen_document_ids.add(doc_or_failure.id)
+                                yield doc_or_failure
+                            elif should_yield_if_empty:
+                                doc_or_failure.sections = [
+                                    TextSection(link=driveitem.web_url, text="")
+                                ]
+                                checkpoint.seen_document_ids.add(doc_or_failure.id)
+                                yield doc_or_failure
+                            else:
+                                logger.warning(
+                                    "Skipping %s as it is empty and not a PDF or image",
+                                    driveitem.web_url,
+                                )
+                        elif isinstance(doc_or_failure, ConnectorFailure):
                             yield doc_or_failure
-                        elif should_yield_if_empty:
-                            doc_or_failure.sections = [
-                                TextSection(link=driveitem.web_url, text="")
-                            ]
-                            checkpoint.seen_document_ids.add(doc_or_failure.id)
-                            yield doc_or_failure
-                        else:
-                            logger.warning(
-                                "Skipping %s as it is empty and not a PDF or image",
-                                driveitem.web_url,
-                            )
-                    elif isinstance(doc_or_failure, ConnectorFailure):
-                        yield doc_or_failure
-                except Exception as e:
-                    logger.warning(
-                        "Failed to process driveitem %s: %s", driveitem.web_url, e
-                    )
-                    yield _create_document_failure(
-                        driveitem, f"Failed to process: {str(e)}", e
-                    )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to process driveitem %s: %s",
+                            driveitem.web_url,
+                            e,
+                        )
+                        yield _create_document_failure(
+                            driveitem, f"Failed to process: {str(e)}", e
+                        )
+            except Exception as e:
+                logger.exception(
+                    "Failed mid-iteration for drive '%s' in site '%s'",
+                    current_drive_name,
+                    site_descriptor.url,
+                )
+                yield _create_entity_failure(
+                    f"{site_descriptor.url}|{current_drive_name}|bfs_iter",
+                    f"Failed to iterate drive items after {item_count}: {e}",
+                    (start_dt, end_dt),
+                    e,
+                )
+                # Clear drive state to avoid resuming on the same broken drive.
+                self._clear_drive_checkpoint_state(checkpoint)
+                return checkpoint
 
             logger.info(
                 "Processed %s items in drive '%s'", item_count, current_drive_name
@@ -2930,45 +2962,88 @@ class SharepointConnector(
                     site_descriptor, start=start_dt, end=end_dt
                 )
                 for site_page in site_pages:
-                    logger.debug(
-                        "Processing site page: %s",
-                        site_page.get("webUrl", site_page.get("name", "Unknown")),
+                    page_id = site_page.get("id")
+                    page_label = site_page.get(
+                        "webUrl", site_page.get("name", "Unknown")
                     )
-                    client_ctx: ClientContext | None = None
-                    if include_permissions:
-                        client_ctx = self._create_rest_client_context(
-                            site_descriptor.url
+                    # Skip a single broken page instead of aborting the
+                    # rest of the site (perm-sync error, malformed field,
+                    # token refresh blip, etc.).
+                    try:
+                        logger.debug("Processing site page: %s", page_label)
+                        client_ctx: ClientContext | None = None
+                        if include_permissions:
+                            client_ctx = self._create_rest_client_context(
+                                site_descriptor.url
+                            )
+                        yield (
+                            _convert_sitepage_to_document(
+                                site_page,
+                                site_descriptor.drive_name,
+                                client_ctx,
+                                self.graph_client,
+                                include_permissions=include_permissions,
+                                # Site pages have the site as their parent
+                                parent_hierarchy_raw_node_id=site_descriptor.url,
+                                treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                            )
                         )
-                    yield (
-                        _convert_sitepage_to_document(
-                            site_page,
-                            site_descriptor.drive_name,
-                            client_ctx,
-                            self.graph_client,
-                            include_permissions=include_permissions,
-                            # Site pages have the site as their parent
-                            parent_hierarchy_raw_node_id=site_descriptor.url,
-                            treat_sharing_link_as_public=self.treat_sharing_link_as_public,
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to process site page '%s' in site %s: %s",
+                            page_label,
+                            site_descriptor.url,
+                            e,
+                            exc_info=True,
                         )
-                    )
+                        if page_id:
+                            page_link = (
+                                page_label if isinstance(page_label, str) else None
+                            )
+                            yield ConnectorFailure(
+                                failed_document=DocumentFailure(
+                                    document_id=page_id,
+                                    document_link=page_link,
+                                ),
+                                failure_message=(
+                                    f"SharePoint site page '{page_label}': {e}"
+                                ),
+                                exception=e,
+                            )
+                        else:
+                            yield _create_entity_failure(
+                                f"{site_descriptor.url}|site_page|{page_label}",
+                                f"Failed to process site page '{page_label}': {e}",
+                                (start_dt, end_dt),
+                                e,
+                            )
                 logger.info(
                     "Finished processing site pages for site: %s",
                     site_descriptor.url,
                 )
-            except (ClientRequestException, HTTPError) as e:
-                if not _is_per_site_graph_failure(e):
-                    raise
-                logger.warning(
-                    "Skipping site pages for %s: Graph returned %s (%s)",
-                    site_descriptor.url,
-                    (
-                        e.response.status_code
-                        if e.response is not None
-                        else "no response"
-                    ),
-                    _graph_error_code(e.response),
-                    exc_info=True,
-                )
+            except Exception as e:
+                # Broadened from per-site Graph 4xx to any Exception:
+                # _fetch_site_pages failures skip the site-pages stage
+                # instead of failing the attempt. Per-page errors are
+                # caught above.
+                if (
+                    isinstance(e, (ClientRequestException, HTTPError))
+                    and e.response is not None
+                ):
+                    logger.warning(
+                        "Skipping site pages for %s: Graph returned %s (%s)",
+                        site_descriptor.url,
+                        e.response.status_code,
+                        _graph_error_code(e.response),
+                        exc_info=True,
+                    )
+                else:
+                    logger.warning(
+                        "Skipping site pages for %s: %s",
+                        site_descriptor.url,
+                        e,
+                        exc_info=True,
+                    )
                 yield _create_entity_failure(
                     site_descriptor.url,
                     f"Failed to fetch site pages: {e}",

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_load_checkpoint_resilience.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_load_checkpoint_resilience.py
@@ -1,0 +1,469 @@
+"""Tests for resilience wrappers added to SharepointConnector._load_from_checkpoint.
+
+Covers three failure modes that previously aborted the whole attempt:
+- G1: BFS-mode generator (`_iter_drive_items_paged`) raising mid-iteration.
+- G2: `_fetch_site_pages` raising a non-Graph 4xx in Phase 5.
+- G3: A single site page failing to convert in Phase 5.
+
+All three now yield a ConnectorFailure (EntityFailure or DocumentFailure)
+and let the rest of the indexing run continue.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+import pytest
+
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import DocumentSource
+from onyx.connectors.models import EntityFailure
+from onyx.connectors.models import TextSection
+from onyx.connectors.sharepoint.connector import DriveItemData
+from onyx.connectors.sharepoint.connector import SharepointConnector
+from onyx.connectors.sharepoint.connector import SharepointConnectorCheckpoint
+from onyx.connectors.sharepoint.connector import SiteDescriptor
+
+SITE_URL = "https://example.sharepoint.com/sites/sample"
+DRIVE_WEB_URL = f"{SITE_URL}/Shared Documents"
+DRIVE_ID = "fake-drive-id"
+# Use a name that isn't in SHARED_DOCUMENTS_MAP so the assertions can use it verbatim.
+DRIVE_NAME = "Engineering"
+
+_EPOCH_START: float = 0.0
+_END_TS = datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors of test_delta_checkpointing.py; kept local so this file is
+# self-contained).
+# ---------------------------------------------------------------------------
+
+
+def _make_item(item_id: str, name: str = "doc.pdf") -> DriveItemData:
+    return DriveItemData(
+        id=item_id,
+        name=name,
+        web_url=f"{SITE_URL}/{name}",
+        parent_reference_path="/drives/d1/root:",
+        drive_id=DRIVE_ID,
+    )
+
+
+def _make_document(item: DriveItemData) -> Document:
+    return Document(
+        id=item.id,
+        source=DocumentSource.SHAREPOINT,
+        semantic_identifier=item.name,
+        metadata={},
+        sections=[TextSection(link=item.web_url, text="content")],
+    )
+
+
+def _consume_generator(
+    gen: Generator[Any, None, SharepointConnectorCheckpoint],
+) -> tuple[list[Any], SharepointConnectorCheckpoint]:
+    yielded: list[Any] = []
+    try:
+        while True:
+            yielded.append(next(gen))
+    except StopIteration as e:
+        return yielded, e.value
+
+
+def _docs_from(yielded: list[Any]) -> list[Document]:
+    return [y for y in yielded if isinstance(y, Document)]
+
+
+def _failures_from(yielded: list[Any]) -> list[ConnectorFailure]:
+    return [y for y in yielded if isinstance(y, ConnectorFailure)]
+
+
+def _setup_connector(monkeypatch: pytest.MonkeyPatch) -> SharepointConnector:
+    connector = SharepointConnector()
+    connector._graph_client = object()  # ty: ignore[invalid-assignment]
+    connector.include_site_pages = False
+
+    def fake_resolve_drive(
+        self: SharepointConnector,  # noqa: ARG001
+        site_descriptor: SiteDescriptor,  # noqa: ARG001
+        drive_name: str,  # noqa: ARG001
+    ) -> tuple[str, str | None]:
+        return (DRIVE_ID, DRIVE_WEB_URL)
+
+    def fake_get_access_token(self: SharepointConnector) -> str:  # noqa: ARG001
+        return "fake-access-token"
+
+    monkeypatch.setattr(SharepointConnector, "_resolve_drive", fake_resolve_drive)
+    monkeypatch.setattr(
+        SharepointConnector, "_get_graph_access_token", fake_get_access_token
+    )
+    return connector
+
+
+def _mock_convert(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_convert(
+        driveitem: DriveItemData,
+        drive_name: str,  # noqa: ARG001
+        ctx: Any = None,  # noqa: ARG001
+        graph_client: Any = None,  # noqa: ARG001
+        graph_api_base: str = "",  # noqa: ARG001
+        include_permissions: bool = False,  # noqa: ARG001
+        parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
+        access_token: str | None = None,  # noqa: ARG001
+        treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+        raw_file_callback: Any = None,  # noqa: ARG001
+    ) -> Document:
+        return _make_document(driveitem)
+
+    monkeypatch.setattr(
+        "onyx.connectors.sharepoint.connector._convert_driveitem_to_document_with_permissions",
+        fake_convert,
+    )
+
+
+def _build_phase3_checkpoint(
+    folder_path: str | None = None,
+) -> SharepointConnectorCheckpoint:
+    """Checkpoint ready to enter Phase 3 (site initialised, one drive queued)."""
+    cp = SharepointConnectorCheckpoint(has_more=True)
+    cp.cached_site_descriptors = deque()
+    cp.current_site_descriptor = SiteDescriptor(
+        url=SITE_URL, drive_name=None, folder_path=folder_path
+    )
+    cp.cached_drive_names = deque([DRIVE_NAME])
+    cp.process_site_pages = False
+    return cp
+
+
+def _build_phase5_checkpoint() -> SharepointConnectorCheckpoint:
+    """Checkpoint ready to enter Phase 5 directly (drives done, site pages flagged)."""
+    cp = SharepointConnectorCheckpoint(has_more=True)
+    cp.cached_site_descriptors = deque()
+    cp.current_site_descriptor = SiteDescriptor(
+        url=SITE_URL, drive_name=None, folder_path=None
+    )
+    cp.cached_drive_names = deque()
+    cp.process_site_pages = True
+    return cp
+
+
+# ---------------------------------------------------------------------------
+# G1 — BFS-mode generator failures mid-iteration
+# ---------------------------------------------------------------------------
+
+
+class TestBfsIterationFailure:
+    """When `_iter_drive_items_paged` (BFS path) raises after yielding some
+    items, items emitted before the raise are kept, an EntityFailure is
+    yielded for the drive, the drive checkpoint state is cleared, and the
+    generator returns cleanly instead of aborting the attempt."""
+
+    def test_bfs_generator_failure_yields_entity_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        connector = _setup_connector(monkeypatch)
+        _mock_convert(monkeypatch)
+
+        good_items = [_make_item("a"), _make_item("b")]
+
+        def fake_iter_paged(
+            self: SharepointConnector,  # noqa: ARG001
+            drive_id: str,  # noqa: ARG001
+            folder_path: str | None = None,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+            page_size: int = 200,  # noqa: ARG001
+        ) -> Generator[DriveItemData, None, None]:
+            yield from good_items
+            raise RuntimeError("graph 500 mid-page")
+
+        monkeypatch.setattr(
+            SharepointConnector, "_iter_drive_items_paged", fake_iter_paged
+        )
+
+        # folder_path forces BFS mode
+        checkpoint = _build_phase3_checkpoint(folder_path="Engineering/Docs")
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, final_cp = _consume_generator(gen)
+
+        docs = _docs_from(yielded)
+        failures = _failures_from(yielded)
+
+        assert [d.id for d in docs] == ["a", "b"]
+        assert len(failures) == 1
+        failed_entity = failures[0].failed_entity
+        assert failed_entity is not None
+        assert isinstance(failed_entity, EntityFailure)
+        assert failed_entity.entity_id == f"{SITE_URL}|{DRIVE_NAME}|bfs_iter"
+        assert "graph 500 mid-page" in failures[0].failure_message
+
+        # Drive state cleared so resume doesn't loop on the broken drive.
+        assert final_cp.current_drive_name is None
+        assert final_cp.current_drive_id is None
+        assert final_cp.current_drive_web_url is None
+        assert final_cp.current_drive_delta_next_link is None
+
+    def test_bfs_generator_failure_at_start_still_yields_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A raise before any item is yielded still produces an EntityFailure
+        rather than crashing the attempt."""
+        connector = _setup_connector(monkeypatch)
+        _mock_convert(monkeypatch)
+
+        def fake_iter_paged(
+            self: SharepointConnector,  # noqa: ARG001
+            drive_id: str,  # noqa: ARG001
+            folder_path: str | None = None,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+            page_size: int = 200,  # noqa: ARG001
+        ) -> Generator[DriveItemData, None, None]:
+            raise RuntimeError("connection reset")
+            yield  # pragma: no cover  # make this a generator
+
+        monkeypatch.setattr(
+            SharepointConnector, "_iter_drive_items_paged", fake_iter_paged
+        )
+
+        checkpoint = _build_phase3_checkpoint(folder_path="Engineering/Docs")
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, final_cp = _consume_generator(gen)
+
+        assert _docs_from(yielded) == []
+        failures = _failures_from(yielded)
+        assert len(failures) == 1
+        assert failures[0].failed_entity is not None
+        assert (
+            failures[0].failed_entity.entity_id == f"{SITE_URL}|{DRIVE_NAME}|bfs_iter"
+        )
+        assert final_cp.current_drive_name is None
+
+
+# ---------------------------------------------------------------------------
+# G2 + G3 — Phase 5 site-pages wrap
+# ---------------------------------------------------------------------------
+
+
+def _mock_convert_sitepage(
+    monkeypatch: pytest.MonkeyPatch,
+    side_effect: Any,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.connectors.sharepoint.connector._convert_sitepage_to_document",
+        side_effect,
+    )
+
+
+class TestSitePagesFetchFailure:
+    """G2: when `_fetch_site_pages` itself raises (not classified as a per-site
+    Graph 4xx), Phase 5 yields a single EntityFailure keyed on the site URL
+    and the generator returns cleanly."""
+
+    def test_runtime_error_in_fetch_yields_entity_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        connector = _setup_connector(monkeypatch)
+        connector.include_site_pages = True
+
+        def fake_fetch(
+            self: SharepointConnector,  # noqa: ARG001
+            site_descriptor: SiteDescriptor,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+        ) -> list[dict[str, Any]]:
+            raise RuntimeError("pages endpoint blew up")
+
+        monkeypatch.setattr(SharepointConnector, "_fetch_site_pages", fake_fetch)
+
+        checkpoint = _build_phase5_checkpoint()
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, _final_cp = _consume_generator(gen)
+
+        assert _docs_from(yielded) == []
+        failures = _failures_from(yielded)
+        assert len(failures) == 1
+        assert failures[0].failed_entity is not None
+        assert failures[0].failed_entity.entity_id == SITE_URL
+        assert "pages endpoint blew up" in failures[0].failure_message
+
+
+class TestSitePagesPerPageFailure:
+    """G3: when one page fails to convert, the others still come through and
+    the broken page is reported as a per-page ConnectorFailure."""
+
+    def test_one_bad_page_yields_document_failure_and_others_succeed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        connector = _setup_connector(monkeypatch)
+        connector.include_site_pages = True
+
+        good_page_1 = {
+            "id": "good-1",
+            "webUrl": f"{SITE_URL}/SitePages/Good1.aspx",
+            "title": "Good 1",
+        }
+        bad_page = {
+            "id": "bad-1",
+            "webUrl": f"{SITE_URL}/SitePages/Bad.aspx",
+            "title": "Bad",
+        }
+        good_page_2 = {
+            "id": "good-2",
+            "webUrl": f"{SITE_URL}/SitePages/Good2.aspx",
+            "title": "Good 2",
+        }
+
+        def fake_fetch(
+            self: SharepointConnector,  # noqa: ARG001
+            site_descriptor: SiteDescriptor,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+        ) -> list[dict[str, Any]]:
+            return [good_page_1, bad_page, good_page_2]
+
+        monkeypatch.setattr(SharepointConnector, "_fetch_site_pages", fake_fetch)
+
+        def fake_convert(
+            page: dict[str, Any],
+            drive_name: str | None,  # noqa: ARG001
+            client_ctx: Any,  # noqa: ARG001
+            graph_client: Any,  # noqa: ARG001
+            include_permissions: bool = False,  # noqa: ARG001
+            parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
+            treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+        ) -> Document:
+            if page["id"] == "bad-1":
+                raise ValueError("malformed canvasLayout")
+            return Document(
+                id=page["id"],
+                source=DocumentSource.SHAREPOINT,
+                semantic_identifier=page["title"],
+                metadata={},
+                sections=[TextSection(link=page["webUrl"], text="content")],
+            )
+
+        _mock_convert_sitepage(monkeypatch, fake_convert)
+
+        checkpoint = _build_phase5_checkpoint()
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, _final_cp = _consume_generator(gen)
+
+        docs = _docs_from(yielded)
+        failures = _failures_from(yielded)
+
+        assert [d.id for d in docs] == ["good-1", "good-2"]
+        assert len(failures) == 1
+        failed_doc = failures[0].failed_document
+        assert failed_doc is not None
+        assert isinstance(failed_doc, DocumentFailure)
+        assert failed_doc.document_id == "bad-1"
+        assert failed_doc.document_link == bad_page["webUrl"]
+        assert "malformed canvasLayout" in failures[0].failure_message
+
+    def test_bad_page_without_id_yields_entity_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A page that fails to convert AND has no id falls back to an
+        EntityFailure (we don't have anything to attach a DocumentFailure to)."""
+        connector = _setup_connector(monkeypatch)
+        connector.include_site_pages = True
+
+        idless_page = {"webUrl": f"{SITE_URL}/SitePages/Orphan.aspx"}
+
+        def fake_fetch(
+            self: SharepointConnector,  # noqa: ARG001
+            site_descriptor: SiteDescriptor,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+        ) -> list[dict[str, Any]]:
+            return [idless_page]
+
+        monkeypatch.setattr(SharepointConnector, "_fetch_site_pages", fake_fetch)
+
+        def fake_convert(
+            page: dict[str, Any],  # noqa: ARG001
+            drive_name: str | None,  # noqa: ARG001
+            client_ctx: Any,  # noqa: ARG001
+            graph_client: Any,  # noqa: ARG001
+            include_permissions: bool = False,  # noqa: ARG001
+            parent_hierarchy_raw_node_id: str | None = None,  # noqa: ARG001
+            treat_sharing_link_as_public: bool = False,  # noqa: ARG001
+        ) -> Document:
+            raise KeyError("id")
+
+        _mock_convert_sitepage(monkeypatch, fake_convert)
+
+        checkpoint = _build_phase5_checkpoint()
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, _final_cp = _consume_generator(gen)
+
+        assert _docs_from(yielded) == []
+        failures = _failures_from(yielded)
+        assert len(failures) == 1
+        assert failures[0].failed_entity is not None
+        assert (
+            failures[0].failed_entity.entity_id
+            == f"{SITE_URL}|site_page|{idless_page['webUrl']}"
+        )
+
+    def test_all_pages_fail_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Even when every page fails, the generator completes — one
+        ConnectorFailure per page, no crash."""
+        connector = _setup_connector(monkeypatch)
+        connector.include_site_pages = True
+
+        pages = [
+            {"id": "p1", "webUrl": f"{SITE_URL}/SitePages/A.aspx"},
+            {"id": "p2", "webUrl": f"{SITE_URL}/SitePages/B.aspx"},
+        ]
+
+        def fake_fetch(
+            self: SharepointConnector,  # noqa: ARG001
+            site_descriptor: SiteDescriptor,  # noqa: ARG001
+            start: datetime | None = None,  # noqa: ARG001
+            end: datetime | None = None,  # noqa: ARG001
+        ) -> list[dict[str, Any]]:
+            return pages
+
+        monkeypatch.setattr(SharepointConnector, "_fetch_site_pages", fake_fetch)
+
+        def fake_convert(*_args: Any, **_kwargs: Any) -> Document:
+            raise RuntimeError("conversion always fails")
+
+        _mock_convert_sitepage(monkeypatch, fake_convert)
+
+        checkpoint = _build_phase5_checkpoint()
+        gen = connector._load_from_checkpoint(
+            _EPOCH_START, _END_TS, checkpoint, include_permissions=False
+        )
+        yielded, _final_cp = _consume_generator(gen)
+
+        assert _docs_from(yielded) == []
+        failures = _failures_from(yielded)
+        assert len(failures) == 2
+        assert {
+            f.failed_document.document_id for f in failures if f.failed_document
+        } == {
+            "p1",
+            "p2",
+        }

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -125,6 +125,60 @@ def test_all_site_pages_fail_does_not_crash(
 
 
 # ---------------------------------------------------------------------------
+# _fetch_slim_documents_from_sharepoint — `_fetch_site_pages` raising
+# ---------------------------------------------------------------------------
+
+
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_site_pages")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector._fetch_driveitems")
+@patch("onyx.connectors.sharepoint.connector.SharepointConnector.fetch_sites")
+def test_fetch_site_pages_runtime_error_does_not_crash_slim_run(
+    mock_fetch_sites: MagicMock,
+    mock_fetch_driveitems: MagicMock,
+    mock_fetch_site_pages: MagicMock,
+) -> None:
+    """When `_fetch_site_pages` itself raises a non-Graph-4xx (e.g. a
+    RuntimeError, 500, JSON decode error), the broadened outer except still
+    log-and-skips so other sites can finish."""
+    from onyx.connectors.models import SlimDocument
+
+    connector = _make_connector()
+    connector.include_site_documents = False
+    connector.include_site_pages = True
+
+    bad_site = MagicMock()
+    bad_site.url = SITE_URL + "/Bad"
+    good_site = MagicMock()
+    good_site.url = SITE_URL + "/Good"
+    mock_fetch_sites.return_value = [bad_site, good_site]
+    mock_fetch_driveitems.return_value = iter([])
+
+    good_page = {"id": "g1", "webUrl": good_site.url + "/SitePages/Home.aspx"}
+
+    def _fetch_side_effect(
+        site_descriptor: object, *_args: object, **_kwargs: object
+    ) -> list[dict[str, str]]:
+        if getattr(site_descriptor, "url", None) == bad_site.url:
+            raise RuntimeError("pages endpoint blew up")
+        return [good_page]
+
+    mock_fetch_site_pages.side_effect = _fetch_side_effect
+
+    slim_results = [
+        doc
+        for batch in connector._fetch_slim_documents_from_sharepoint(
+            include_permissions=False
+        )
+        for doc in batch
+        if isinstance(doc, SlimDocument)
+    ]
+
+    # Good site's page survives; bad site is silently skipped (slim retrieval
+    # can't yield ConnectorFailure).
+    assert [d.id for d in slim_results] == ["g1"]
+
+
+# ---------------------------------------------------------------------------
 # retrieve_all_slim_docs — pruning path skips permission fetching
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

There were a few gaps in the sharepoint connector where we were not catching skippable errors and surfacing them as connectorfailures; this PR closes these gaps.

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves SharePoint connector resilience by catching common runtime/Graph errors during drive iteration and site page processing. The indexer now yields failure records and continues; slim sync logs and skips bad sites.

- **Bug Fixes**
  - Catch mid-iteration generator failures in BFS drive item traversal; emit an entity failure scoped to site/drive, clear drive checkpoint state, and continue.
  - Wrap per-item processing to yield a document failure on unexpected errors instead of aborting the run.
  - Broaden site pages handling: failures fetching pages yield an entity failure; a single bad page yields a document failure; pages without IDs fall back to an entity failure.
  - Slim sync: broadened catch around site pages retrieval to log-and-skip broken sites so other sites continue.

<sup>Written for commit 1bd56ef5a4af3930be8131a8b50651240d5d243f. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

