### PR TITLE
fix: remove unnecessary license dependency from test

### DIFF
--- a/backend/onyx/utils/jsonriver/LICENSE
+++ b/backend/onyx/utils/jsonriver/LICENSE
@@ -1,0 +1,31 @@
+BSD 3-Clause License
+
+Copyright (c) 2023 Google LLC (original TypeScript implementation)
+Copyright (c) 2024 jsonriver-python contributors (Python port)
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/backend/tests/integration/tests/pruning/website/js/jquery.flexslider.js
+++ b/backend/tests/integration/tests/pruning/website/js/jquery.flexslider.js
@@ -1,445 +1,343 @@
 /*
- * jQuery FlexSlider v2.1
+ * jQuery FlexSlider v1.8
  * http://www.woothemes.com/flexslider/
  *
  * Copyright 2012 WooThemes
- * Free to use under the GPLv2 license.
- * http://www.gnu.org/licenses/gpl-2.0.html
+ * Free to use under the MIT license.
+ * http://www.opensource.org/licenses/mit-license.php
  *
- * Contributing author: Tyler Smith (@mbmufffin)
+ * Contributing Author: Tyler Smith
  */
 
 (function ($) {
   //FlexSlider: Object Instance
   $.flexslider = function (el, options) {
-    var slider = $(el),
-      vars = $.extend({}, $.flexslider.defaults, options),
-      namespace = vars.namespace,
-      touch =
-        "ontouchstart" in window ||
-        (window.DocumentTouch && document instanceof DocumentTouch),
-      eventType = touch ? "touchend" : "click",
-      vertical = vars.direction === "vertical",
-      reverse = vars.reverse,
-      carousel = vars.itemWidth > 0,
-      fade = vars.animation === "fade",
-      asNav = vars.asNavFor !== "",
-      methods = {};
+    var slider = $(el);
 
-    // Store a reference to the slider object
+    // slider DOM reference for use outside of the plugin
     $.data(el, "flexslider", slider);
 
-    // Privat slider methods
-    methods = {
-      init: function () {
-        slider.animating = false;
-        slider.currentSlide = vars.startAt;
-        slider.animatingTo = slider.currentSlide;
-        slider.atEnd =
-          slider.currentSlide === 0 || slider.currentSlide === slider.last;
-        slider.containerSelector = vars.selector.substr(
-          0,
-          vars.selector.search(" "),
+    slider.init = function () {
+      slider.vars = $.extend({}, $.flexslider.defaults, options);
+      $.data(el, "flexsliderInit", true);
+      slider.container = $(".slides", slider).eq(0);
+      slider.slides = $(".slides:first > li", slider);
+      slider.count = slider.slides.length;
+      slider.animating = false;
+      slider.currentSlide = slider.vars.slideToStart;
+      slider.animatingTo = slider.currentSlide;
+      slider.atEnd = slider.currentSlide == 0 ? true : false;
+      slider.eventType =
+        "ontouchstart" in document.documentElement ? "touchstart" : "click";
+      slider.cloneCount = 0;
+      slider.cloneOffset = 0;
+      slider.manualPause = false;
+      slider.vertical = slider.vars.slideDirection == "vertical";
+      slider.prop = slider.vertical ? "top" : "marginLeft";
+      slider.args = {};
+
+      //Test for webbkit CSS3 Animations
+      slider.transitions =
+        "webkitTransition" in document.body.style && slider.vars.useCSS;
+      if (slider.transitions) slider.prop = "-webkit-transform";
+
+      //Test for controlsContainer
+      if (slider.vars.controlsContainer != "") {
+        slider.controlsContainer = $(slider.vars.controlsContainer).eq(
+          $(".slides").index(slider.container),
         );
-        slider.slides = $(vars.selector, slider);
-        slider.container = $(slider.containerSelector, slider);
-        slider.count = slider.slides.length;
-        // SYNC:
-        slider.syncExists = $(vars.sync).length > 0;
-        // SLIDE:
-        if (vars.animation === "slide") vars.animation = "swing";
-        slider.prop = vertical ? "top" : "marginLeft";
-        slider.args = {};
-        // SLIDESHOW:
-        slider.manualPause = false;
-        // TOUCH/USECSS:
-        slider.transitions =
-          !vars.video &&
-          !fade &&
-          vars.useCSS &&
-          (function () {
-            var obj = document.createElement("div"),
-              props = [
-                "perspectiveProperty",
-                "WebkitPerspective",
-                "MozPerspective",
-                "OPerspective",
-                "msPerspective",
-              ];
-            for (var i in props) {
-              if (obj.style[props[i]] !== undefined) {
-                slider.pfx = props[i].replace("Perspective", "").toLowerCase();
-                slider.prop = "-" + slider.pfx + "-transform";
-                return true;
-              }
-            }
-            return false;
-          })();
-        // CONTROLSCONTAINER:
-        if (vars.controlsContainer !== "")
-          slider.controlsContainer =
-            $(vars.controlsContainer).length > 0 && $(vars.controlsContainer);
-        // MANUAL:
-        if (vars.manualControls !== "")
-          slider.manualControls =
-            $(vars.manualControls).length > 0 && $(vars.manualControls);
+        slider.containerExists = slider.controlsContainer.length > 0;
+      }
+      //Test for manualControls
+      if (slider.vars.manualControls != "") {
+        slider.manualControls = $(
+          slider.vars.manualControls,
+          slider.containerExists ? slider.controlsContainer : slider,
+        );
+        slider.manualExists = slider.manualControls.length > 0;
+      }
 
-        // RANDOMIZE:
-        if (vars.randomize) {
-          slider.slides.sort(function () {
-            return Math.round(Math.random()) - 0.5;
+      ///////////////////////////////////////////////////////////////////
+      // FlexSlider: Randomize Slides
+      if (slider.vars.randomize) {
+        slider.slides.sort(function () {
+          return Math.round(Math.random()) - 0.5;
+        });
+        slider.container.empty().append(slider.slides);
+      }
+      ///////////////////////////////////////////////////////////////////
+
+      ///////////////////////////////////////////////////////////////////
+      // FlexSlider: Slider Animation Initialize
+      if (slider.vars.animation.toLowerCase() == "slide") {
+        if (slider.transitions) {
+          slider.setTransition(0);
+        }
+        slider.css({ overflow: "hidden" });
+        if (slider.vars.animationLoop) {
+          slider.cloneCount = 2;
+          slider.cloneOffset = 1;
+          slider.container
+            .append(slider.slides.filter(":first").clone().addClass("clone"))
+            .prepend(slider.slides.filter(":last").clone().addClass("clone"));
+        }
+        //create newSlides to capture possible clones
+        slider.newSlides = $(".slides:first > li", slider);
+        var sliderOffset = -1 * (slider.currentSlide + slider.cloneOffset);
+        if (slider.vertical) {
+          slider.newSlides.css({
+            display: "block",
+            width: "100%",
+            float: "left",
           });
-          slider.container.empty().append(slider.slides);
+          slider.container
+            .height((slider.count + slider.cloneCount) * 200 + "%")
+            .css("position", "absolute")
+            .width("100%");
+          //Timeout function to give browser enough time to get proper height initially
+          setTimeout(function () {
+            slider
+              .css({ position: "relative" })
+              .height(slider.slides.filter(":first").height());
+            slider.args[slider.prop] = slider.transitions
+              ? "translate3d(0," + sliderOffset * slider.height() + "px,0)"
+              : sliderOffset * slider.height() + "px";
+            slider.container.css(slider.args);
+          }, 100);
+        } else {
+          slider.args[slider.prop] = slider.transitions
+            ? "translate3d(" + sliderOffset * slider.width() + "px,0,0)"
+            : sliderOffset * slider.width() + "px";
+          slider.container
+            .width((slider.count + slider.cloneCount) * 200 + "%")
+            .css(slider.args);
+          //Timeout function to give browser enough time to get proper width initially
+          setTimeout(function () {
+            slider.newSlides
+              .width(slider.width())
+              .css({ float: "left", display: "block" });
+          }, 100);
+        }
+      } else {
+        //Default to fade
+        //Not supporting fade CSS3 transitions right now
+        slider.transitions = false;
+        slider.slides
+          .css({ width: "100%", float: "left", marginRight: "-100%" })
+          .eq(slider.currentSlide)
+          .fadeIn(slider.vars.animationDuration);
+      }
+      ///////////////////////////////////////////////////////////////////
+
+      ///////////////////////////////////////////////////////////////////
+      // FlexSlider: Control Nav
+      if (slider.vars.controlNav) {
+        if (slider.manualExists) {
+          slider.controlNav = slider.manualControls;
+        } else {
+          var controlNavScaffold = $('<ol class="flex-control-nav"></ol>');
+          var j = 1;
+          for (var i = 0; i < slider.count; i++) {
+            controlNavScaffold.append("<li><a>" + j + "</a></li>");
+            j++;
+          }
+
+          if (slider.containerExists) {
+            $(slider.controlsContainer).append(controlNavScaffold);
+            slider.controlNav = $(
+              ".flex-control-nav li a",
+              slider.controlsContainer,
+            );
+          } else {
+            slider.append(controlNavScaffold);
+            slider.controlNav = $(".flex-control-nav li a", slider);
+          }
         }
 
-        slider.doMath();
+        slider.controlNav.eq(slider.currentSlide).addClass("active");
 
-        // ASNAV:
-        if (asNav) methods.asNav.setup();
-
-        // INIT
-        slider.setup("init");
-
-        // CONTROLNAV:
-        if (vars.controlNav) methods.controlNav.setup();
-
-        // DIRECTIONNAV:
-        if (vars.directionNav) methods.directionNav.setup();
-
-        // KEYBOARD:
-        if (
-          vars.keyboard &&
-          ($(slider.containerSelector).length === 1 || vars.multipleKeyboard)
-        ) {
-          $(document).bind("keyup", function (event) {
-            var keycode = event.keyCode;
-            if (!slider.animating && (keycode === 39 || keycode === 37)) {
-              var target =
-                keycode === 39
-                  ? slider.getTarget("next")
-                  : keycode === 37
-                    ? slider.getTarget("prev")
-                    : false;
-              slider.flexAnimate(target, vars.pauseOnAction);
-            }
-          });
-        }
-        // MOUSEWHEEL:
-        if (vars.mousewheel) {
-          slider.bind("mousewheel", function (event, delta, deltaX, deltaY) {
-            event.preventDefault();
-            var target =
-              delta < 0 ? slider.getTarget("next") : slider.getTarget("prev");
-            slider.flexAnimate(target, vars.pauseOnAction);
-          });
-        }
-
-        // PAUSEPLAY
-        if (vars.pausePlay) methods.pausePlay.setup();
-
-        // SLIDSESHOW
-        if (vars.slideshow) {
-          if (vars.pauseOnHover) {
-            slider.hover(
-              function () {
-                if (!slider.manualPlay && !slider.manualPause) slider.pause();
-              },
-              function () {
-                if (!slider.manualPause && !slider.manualPlay) slider.play();
-              },
+        slider.controlNav.bind(slider.eventType, function (event) {
+          event.preventDefault();
+          if (!$(this).hasClass("active")) {
+            slider.controlNav.index($(this)) > slider.currentSlide
+              ? (slider.direction = "next")
+              : (slider.direction = "prev");
+            slider.flexAnimate(
+              slider.controlNav.index($(this)),
+              slider.vars.pauseOnAction,
             );
           }
-          // initialize animation
-          vars.initDelay > 0
-            ? setTimeout(slider.play, vars.initDelay)
-            : slider.play();
+        });
+      }
+      ///////////////////////////////////////////////////////////////////
+
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider: Direction Nav
+      if (slider.vars.directionNav) {
+        var directionNavScaffold = $(
+          '<ul class="flex-direction-nav"><li><a class="prev" href="#">' +
+            slider.vars.prevText +
+            '</a></li><li><a class="next" href="#">' +
+            slider.vars.nextText +
+            "</a></li></ul>",
+        );
+
+        if (slider.containerExists) {
+          $(slider.controlsContainer).append(directionNavScaffold);
+          slider.directionNav = $(
+            ".flex-direction-nav li a",
+            slider.controlsContainer,
+          );
+        } else {
+          slider.append(directionNavScaffold);
+          slider.directionNav = $(".flex-direction-nav li a", slider);
         }
 
-        // TOUCH
-        if (touch && vars.touch) methods.touch();
+        //Set initial disable styles if necessary
+        if (!slider.vars.animationLoop) {
+          if (slider.currentSlide == 0) {
+            slider.directionNav.filter(".prev").addClass("disabled");
+          } else if (slider.currentSlide == slider.count - 1) {
+            slider.directionNav.filter(".next").addClass("disabled");
+          }
+        }
 
-        // FADE&&SMOOTHHEIGHT || SLIDE:
-        if (!fade || (fade && vars.smoothHeight))
-          $(window).bind("resize focus", methods.resize);
+        slider.directionNav.bind(slider.eventType, function (event) {
+          event.preventDefault();
+          var target = $(this).hasClass("next")
+            ? slider.getTarget("next")
+            : slider.getTarget("prev");
 
-        // API: start() Callback
-        setTimeout(function () {
-          vars.start(slider);
-        }, 200);
-      },
-      asNav: {
-        setup: function () {
-          slider.asNav = true;
-          slider.animatingTo = Math.floor(slider.currentSlide / slider.move);
-          slider.currentItem = slider.currentSlide;
-          slider.slides
-            .removeClass(namespace + "active-slide")
-            .eq(slider.currentItem)
-            .addClass(namespace + "active-slide");
-          slider.slides.click(function (e) {
-            e.preventDefault();
-            var $slide = $(this),
-              target = $slide.index();
-            if (
-              !$(vars.asNavFor).data("flexslider").animating &&
-              !$slide.hasClass("active")
-            ) {
-              slider.direction = slider.currentItem < target ? "next" : "prev";
-              slider.flexAnimate(target, vars.pauseOnAction, false, true, true);
-            }
-          });
-        },
-      },
-      controlNav: {
-        setup: function () {
-          if (!slider.manualControls) {
-            methods.controlNav.setupPaging();
+          if (slider.canAdvance(target)) {
+            slider.flexAnimate(target, slider.vars.pauseOnAction);
+          }
+        });
+      }
+      //////////////////////////////////////////////////////////////////
+
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider: Keyboard Nav
+      if (slider.vars.keyboardNav && $("ul.slides").length == 1) {
+        function keyboardMove(event) {
+          if (slider.animating) {
+            return;
+          } else if (event.keyCode != 39 && event.keyCode != 37) {
+            return;
           } else {
-            // MANUALCONTROLS:
-            methods.controlNav.setupManual();
-          }
-        },
-        setupPaging: function () {
-          var type =
-              vars.controlNav === "thumbnails"
-                ? "control-thumbs"
-                : "control-paging",
-            j = 1,
-            item;
+            if (event.keyCode == 39) {
+              var target = slider.getTarget("next");
+            } else if (event.keyCode == 37) {
+              var target = slider.getTarget("prev");
+            }
 
-          slider.controlNavScaffold = $(
-            '<ol class="' +
-              namespace +
-              "control-nav " +
-              namespace +
-              type +
-              '"></ol>',
-          );
-
-          if (slider.pagingCount > 1) {
-            for (var i = 0; i < slider.pagingCount; i++) {
-              item =
-                vars.controlNav === "thumbnails"
-                  ? '<img src="' +
-                    slider.slides.eq(i).attr("data-thumb") +
-                    '"/>'
-                  : "<a>" + j + "</a>";
-              slider.controlNavScaffold.append("<li>" + item + "</li>");
-              j++;
+            if (slider.canAdvance(target)) {
+              slider.flexAnimate(target, slider.vars.pauseOnAction);
             }
           }
+        }
+        $(document).bind("keyup", keyboardMove);
+      }
+      //////////////////////////////////////////////////////////////////
 
-          // CONTROLSCONTAINER:
-          slider.controlsContainer
-            ? $(slider.controlsContainer).append(slider.controlNavScaffold)
-            : slider.append(slider.controlNavScaffold);
-          methods.controlNav.set();
+      ///////////////////////////////////////////////////////////////////
+      // FlexSlider: Mousewheel interaction
+      if (slider.vars.mousewheel) {
+        slider.mousewheelEvent = /Firefox/i.test(navigator.userAgent)
+          ? "DOMMouseScroll"
+          : "mousewheel";
+        slider.bind(slider.mousewheelEvent, function (e) {
+          e.preventDefault();
+          e = e ? e : window.event;
+          var wheelData = e.detail
+              ? e.detail * -1
+              : e.originalEvent.wheelDelta / 40,
+            target =
+              wheelData < 0
+                ? slider.getTarget("next")
+                : slider.getTarget("prev");
 
-          methods.controlNav.active();
+          if (slider.canAdvance(target)) {
+            slider.flexAnimate(target, slider.vars.pauseOnAction);
+          }
+        });
+      }
+      ///////////////////////////////////////////////////////////////////
 
-          slider.controlNavScaffold.delegate(
-            "a, img",
-            eventType,
-            function (event) {
-              event.preventDefault();
-              var $this = $(this),
-                target = slider.controlNav.index($this);
-
-              if (!$this.hasClass(namespace + "active")) {
-                slider.direction =
-                  target > slider.currentSlide ? "next" : "prev";
-                slider.flexAnimate(target, vars.pauseOnAction);
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider: Slideshow Setup
+      if (slider.vars.slideshow) {
+        //pauseOnHover
+        if (slider.vars.pauseOnHover && slider.vars.slideshow) {
+          slider.hover(
+            function () {
+              slider.pause();
+            },
+            function () {
+              if (!slider.manualPause) {
+                slider.resume();
               }
             },
           );
-          // Prevent iOS click event bug
-          if (touch) {
-            slider.controlNavScaffold.delegate(
-              "a",
-              "click touchstart",
-              function (event) {
-                event.preventDefault();
-              },
-            );
-          }
-        },
-        setupManual: function () {
-          slider.controlNav = slider.manualControls;
-          methods.controlNav.active();
+        }
 
-          slider.controlNav.live(eventType, function (event) {
-            event.preventDefault();
-            var $this = $(this),
-              target = slider.controlNav.index($this);
+        //Initialize animation
+        slider.animatedSlides = setInterval(
+          slider.animateSlides,
+          slider.vars.slideshowSpeed,
+        );
+      }
+      //////////////////////////////////////////////////////////////////
 
-            if (!$this.hasClass(namespace + "active")) {
-              target > slider.currentSlide
-                ? (slider.direction = "next")
-                : (slider.direction = "prev");
-              slider.flexAnimate(target, vars.pauseOnAction);
-            }
-          });
-          // Prevent iOS click event bug
-          if (touch) {
-            slider.controlNav.live("click touchstart", function (event) {
-              event.preventDefault();
-            });
-          }
-        },
-        set: function () {
-          var selector = vars.controlNav === "thumbnails" ? "img" : "a";
-          slider.controlNav = $(
-            "." + namespace + "control-nav li " + selector,
-            slider.controlsContainer ? slider.controlsContainer : slider,
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider: Pause/Play
+      if (slider.vars.pausePlay) {
+        var pausePlayScaffold = $(
+          '<div class="flex-pauseplay"><span></span></div>',
+        );
+
+        if (slider.containerExists) {
+          slider.controlsContainer.append(pausePlayScaffold);
+          slider.pausePlay = $(
+            ".flex-pauseplay span",
+            slider.controlsContainer,
           );
-        },
-        active: function () {
-          slider.controlNav
-            .removeClass(namespace + "active")
-            .eq(slider.animatingTo)
-            .addClass(namespace + "active");
-        },
-        update: function (action, pos) {
-          if (slider.pagingCount > 1 && action === "add") {
-            slider.controlNavScaffold.append(
-              $("<li><a>" + slider.count + "</a></li>"),
-            );
-          } else if (slider.pagingCount === 1) {
-            slider.controlNavScaffold.find("li").remove();
-          } else {
-            slider.controlNav.eq(pos).closest("li").remove();
-          }
-          methods.controlNav.set();
-          slider.pagingCount > 1 &&
-          slider.pagingCount !== slider.controlNav.length
-            ? slider.update(pos, action)
-            : methods.controlNav.active();
-        },
-      },
-      directionNav: {
-        setup: function () {
-          var directionNavScaffold = $(
-            '<ul class="' +
-              namespace +
-              'direction-nav"><li><a class="' +
-              namespace +
-              'prev" href="#">' +
-              vars.prevText +
-              '</a></li><li><a class="' +
-              namespace +
-              'next" href="#">' +
-              vars.nextText +
-              "</a></li></ul>",
+        } else {
+          slider.append(pausePlayScaffold);
+          slider.pausePlay = $(".flex-pauseplay span", slider);
+        }
+
+        var pausePlayState = slider.vars.slideshow ? "pause" : "play";
+        slider.pausePlay
+          .addClass(pausePlayState)
+          .text(
+            pausePlayState == "pause"
+              ? slider.vars.pauseText
+              : slider.vars.playText,
           );
 
-          // CONTROLSCONTAINER:
-          if (slider.controlsContainer) {
-            $(slider.controlsContainer).append(directionNavScaffold);
-            slider.directionNav = $(
-              "." + namespace + "direction-nav li a",
-              slider.controlsContainer,
-            );
+        slider.pausePlay.bind(slider.eventType, function (event) {
+          event.preventDefault();
+          if ($(this).hasClass("pause")) {
+            slider.pause();
+            slider.manualPause = true;
           } else {
-            slider.append(directionNavScaffold);
-            slider.directionNav = $(
-              "." + namespace + "direction-nav li a",
-              slider,
-            );
+            slider.resume();
+            slider.manualPause = false;
           }
+        });
+      }
+      //////////////////////////////////////////////////////////////////
 
-          methods.directionNav.update();
-
-          slider.directionNav.bind(eventType, function (event) {
-            event.preventDefault();
-            var target = $(this).hasClass(namespace + "next")
-              ? slider.getTarget("next")
-              : slider.getTarget("prev");
-            slider.flexAnimate(target, vars.pauseOnAction);
-          });
-          // Prevent iOS click event bug
-          if (touch) {
-            slider.directionNav.bind("click touchstart", function (event) {
-              event.preventDefault();
-            });
-          }
-        },
-        update: function () {
-          var disabledClass = namespace + "disabled";
-          if (slider.pagingCount === 1) {
-            slider.directionNav.addClass(disabledClass);
-          } else if (!vars.animationLoop) {
-            if (slider.animatingTo === 0) {
-              slider.directionNav
-                .removeClass(disabledClass)
-                .filter("." + namespace + "prev")
-                .addClass(disabledClass);
-            } else if (slider.animatingTo === slider.last) {
-              slider.directionNav
-                .removeClass(disabledClass)
-                .filter("." + namespace + "next")
-                .addClass(disabledClass);
-            } else {
-              slider.directionNav.removeClass(disabledClass);
-            }
-          } else {
-            slider.directionNav.removeClass(disabledClass);
-          }
-        },
-      },
-      pausePlay: {
-        setup: function () {
-          var pausePlayScaffold = $(
-            '<div class="' + namespace + 'pauseplay"><a></a></div>',
-          );
-
-          // CONTROLSCONTAINER:
-          if (slider.controlsContainer) {
-            slider.controlsContainer.append(pausePlayScaffold);
-            slider.pausePlay = $(
-              "." + namespace + "pauseplay a",
-              slider.controlsContainer,
-            );
-          } else {
-            slider.append(pausePlayScaffold);
-            slider.pausePlay = $("." + namespace + "pauseplay a", slider);
-          }
-
-          methods.pausePlay.update(
-            vars.slideshow ? namespace + "pause" : namespace + "play",
-          );
-
-          slider.pausePlay.bind(eventType, function (event) {
-            event.preventDefault();
-            if ($(this).hasClass(namespace + "pause")) {
-              slider.manualPause = true;
-              slider.manualPlay = false;
-              slider.pause();
-            } else {
-              slider.manualPause = false;
-              slider.manualPlay = true;
-              slider.play();
-            }
-          });
-          // Prevent iOS click event bug
-          if (touch) {
-            slider.pausePlay.bind("click touchstart", function (event) {
-              event.preventDefault();
-            });
-          }
-        },
-        update: function (state) {
-          state === "play"
-            ? slider.pausePlay
-                .removeClass(namespace + "pause")
-                .addClass(namespace + "play")
-                .text(vars.playText)
-            : slider.pausePlay
-                .removeClass(namespace + "play")
-                .addClass(namespace + "pause")
-                .text(vars.pauseText);
-        },
-      },
-      touch: function () {
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider:Touch Swip Gestures
+      //Some brilliant concepts adapted from the following sources
+      //Source: TouchSwipe - http://www.netcu.de/jquery-touchwipe-iphone-ipad-library
+      //Source: SwipeJS - http://swipejs.com
+      if ("ontouchstart" in document.documentElement && slider.vars.touch) {
+        //For brevity, variables are named for x-axis scrolling
+        //The variables are then swapped if vertical sliding is applied
+        //This reduces redundant code...I think :)
+        //If debugging, recognize variables are named for horizontal scrolling
         var startX,
           startY,
           offset,
@@ -448,829 +346,395 @@
           startT,
           scrolling = false;
 
-        el.addEventListener("touchstart", onTouchStart, false);
+        slider.each(function () {
+          if ("ontouchstart" in document.documentElement) {
+            this.addEventListener("touchstart", onTouchStart, false);
+          }
+        });
+
         function onTouchStart(e) {
           if (slider.animating) {
             e.preventDefault();
-          } else if (e.touches.length === 1) {
+          } else if (e.touches.length == 1) {
             slider.pause();
-            // CAROUSEL:
-            cwidth = vertical ? slider.h : slider.w;
+            cwidth = slider.vertical ? slider.height() : slider.width();
             startT = Number(new Date());
-            // CAROUSEL:
-            offset =
-              carousel && reverse && slider.animatingTo === slider.last
-                ? 0
-                : carousel && reverse
-                  ? slider.limit -
-                    (slider.itemW + vars.itemMargin) *
-                      slider.move *
-                      slider.animatingTo
-                  : carousel && slider.currentSlide === slider.last
-                    ? slider.limit
-                    : carousel
-                      ? (slider.itemW + vars.itemMargin) *
-                        slider.move *
-                        slider.currentSlide
-                      : reverse
-                        ? (slider.last -
-                            slider.currentSlide +
-                            slider.cloneOffset) *
-                          cwidth
-                        : (slider.currentSlide + slider.cloneOffset) * cwidth;
-            startX = vertical ? e.touches[0].pageY : e.touches[0].pageX;
-            startY = vertical ? e.touches[0].pageX : e.touches[0].pageY;
+            offset = slider.vertical
+              ? (slider.currentSlide + slider.cloneOffset) * slider.height()
+              : (slider.currentSlide + slider.cloneOffset) * slider.width();
+            startX = slider.vertical ? e.touches[0].pageY : e.touches[0].pageX;
+            startY = slider.vertical ? e.touches[0].pageX : e.touches[0].pageY;
+            slider.setTransition(0);
 
-            el.addEventListener("touchmove", onTouchMove, false);
-            el.addEventListener("touchend", onTouchEnd, false);
+            this.addEventListener("touchmove", onTouchMove, false);
+            this.addEventListener("touchend", onTouchEnd, false);
           }
         }
 
         function onTouchMove(e) {
-          dx = vertical
+          dx = slider.vertical
             ? startX - e.touches[0].pageY
             : startX - e.touches[0].pageX;
-          scrolling = vertical
+          scrolling = slider.vertical
             ? Math.abs(dx) < Math.abs(e.touches[0].pageX - startY)
             : Math.abs(dx) < Math.abs(e.touches[0].pageY - startY);
 
-          if (!scrolling || Number(new Date()) - startT > 500) {
+          if (!scrolling) {
             e.preventDefault();
-            if (!fade && slider.transitions) {
-              if (!vars.animationLoop) {
+            if (slider.vars.animation == "slide" && slider.transitions) {
+              if (!slider.vars.animationLoop) {
                 dx =
                   dx /
-                  ((slider.currentSlide === 0 && dx < 0) ||
-                  (slider.currentSlide === slider.last && dx > 0)
+                  ((slider.currentSlide == 0 && dx < 0) ||
+                  (slider.currentSlide == slider.count - 1 && dx > 0)
                     ? Math.abs(dx) / cwidth + 2
                     : 1);
               }
-              slider.setProps(offset + dx, "setTouch");
+              slider.args[slider.prop] = slider.vertical
+                ? "translate3d(0," + (-offset - dx) + "px,0)"
+                : "translate3d(" + (-offset - dx) + "px,0,0)";
+              slider.container.css(slider.args);
             }
           }
         }
 
         function onTouchEnd(e) {
-          // finish the touch by undoing the touch session
-          el.removeEventListener("touchmove", onTouchMove, false);
-
+          slider.animating = false;
           if (
-            slider.animatingTo === slider.currentSlide &&
+            slider.animatingTo == slider.currentSlide &&
             !scrolling &&
-            !(dx === null)
+            !(dx == null)
           ) {
-            var updateDx = reverse ? -dx : dx,
-              target =
-                updateDx > 0
-                  ? slider.getTarget("next")
-                  : slider.getTarget("prev");
-
+            var target =
+              dx > 0 ? slider.getTarget("next") : slider.getTarget("prev");
             if (
-              slider.canAdvance(target) &&
-              ((Number(new Date()) - startT < 550 && Math.abs(updateDx) > 50) ||
-                Math.abs(updateDx) > cwidth / 2)
+              (slider.canAdvance(target) &&
+                Number(new Date()) - startT < 550 &&
+                Math.abs(dx) > 20) ||
+              Math.abs(dx) > cwidth / 2
             ) {
-              slider.flexAnimate(target, vars.pauseOnAction);
-            } else {
-              if (!fade)
-                slider.flexAnimate(
-                  slider.currentSlide,
-                  vars.pauseOnAction,
-                  true,
-                );
+              slider.flexAnimate(target, slider.vars.pauseOnAction);
+            } else if (slider.vars.animation !== "fade") {
+              slider.flexAnimate(
+                slider.currentSlide,
+                slider.vars.pauseOnAction,
+              );
             }
           }
-          el.removeEventListener("touchend", onTouchEnd, false);
+
+          //Finish the touch by undoing the touch session
+          this.removeEventListener("touchmove", onTouchMove, false);
+          this.removeEventListener("touchend", onTouchEnd, false);
           startX = null;
           startY = null;
           dx = null;
           offset = null;
         }
-      },
-      resize: function () {
-        if (!slider.animating && slider.is(":visible")) {
-          if (!carousel) slider.doMath();
+      }
+      //////////////////////////////////////////////////////////////////
 
-          if (fade) {
-            // SMOOTH HEIGHT:
-            methods.smoothHeight();
-          } else if (carousel) {
-            //CAROUSEL:
-            slider.slides.width(slider.computedW);
-            slider.update(slider.pagingCount);
-            slider.setProps();
-          } else if (vertical) {
-            //VERTICAL:
-            slider.viewport.height(slider.h);
-            slider.setProps(slider.h, "setTotal");
-          } else {
-            // SMOOTH HEIGHT:
-            if (vars.smoothHeight) methods.smoothHeight();
-            slider.newSlides.width(slider.computedW);
-            slider.setProps(slider.computedW, "setTotal");
-          }
-        }
-      },
-      smoothHeight: function (dur) {
-        if (!vertical || fade) {
-          var $obj = fade ? slider : slider.viewport;
-          dur
-            ? $obj.animate(
-                { height: slider.slides.eq(slider.animatingTo).height() },
-                dur,
-              )
-            : $obj.height(slider.slides.eq(slider.animatingTo).height());
-        }
-      },
-      sync: function (action) {
-        var $obj = $(vars.sync).data("flexslider"),
-          target = slider.animatingTo;
-
-        switch (action) {
-          case "animate":
-            $obj.flexAnimate(target, vars.pauseOnAction, false, true);
-            break;
-          case "play":
-            if (!$obj.playing && !$obj.asNav) {
-              $obj.play();
+      //////////////////////////////////////////////////////////////////
+      //FlexSlider: Resize Functions (If necessary)
+      if (slider.vars.animation.toLowerCase() == "slide") {
+        $(window).resize(function () {
+          if (!slider.animating && slider.is(":visible")) {
+            if (slider.vertical) {
+              slider.height(slider.slides.filter(":first").height());
+              slider.args[slider.prop] =
+                -1 *
+                  (slider.currentSlide + slider.cloneOffset) *
+                  slider.slides.filter(":first").height() +
+                "px";
+              if (slider.transitions) {
+                slider.setTransition(0);
+                slider.args[slider.prop] = slider.vertical
+                  ? "translate3d(0," + slider.args[slider.prop] + ",0)"
+                  : "translate3d(" + slider.args[slider.prop] + ",0,0)";
+              }
+              slider.container.css(slider.args);
+            } else {
+              slider.newSlides.width(slider.width());
+              slider.args[slider.prop] =
+                -1 *
+                  (slider.currentSlide + slider.cloneOffset) *
+                  slider.width() +
+                "px";
+              if (slider.transitions) {
+                slider.setTransition(0);
+                slider.args[slider.prop] = slider.vertical
+                  ? "translate3d(0," + slider.args[slider.prop] + ",0)"
+                  : "translate3d(" + slider.args[slider.prop] + ",0,0)";
+              }
+              slider.container.css(slider.args);
             }
-            break;
-          case "pause":
-            $obj.pause();
-            break;
-        }
-      },
+          }
+        });
+      }
+      //////////////////////////////////////////////////////////////////
+
+      //FlexSlider: start() Callback
+      slider.vars.start(slider);
     };
 
-    // public methods
-    slider.flexAnimate = function (target, pause, override, withSync, fromNav) {
-      if (asNav && slider.pagingCount === 1)
-        slider.direction = slider.currentItem < target ? "next" : "prev";
+    //FlexSlider: Animation Actions
+    slider.flexAnimate = function (target, pause) {
+      if (!slider.animating && slider.is(":visible")) {
+        //Animating flag
+        slider.animating = true;
 
-      if (
-        !slider.animating &&
-        (slider.canAdvance(target, fromNav) || override) &&
-        slider.is(":visible")
-      ) {
-        if (asNav && withSync) {
-          var master = $(vars.asNavFor).data("flexslider");
-          slider.atEnd = target === 0 || target === slider.count - 1;
-          master.flexAnimate(target, true, false, true, fromNav);
-          slider.direction = slider.currentItem < target ? "next" : "prev";
-          master.direction = slider.direction;
+        //FlexSlider: before() animation Callback
+        slider.animatingTo = target;
+        slider.vars.before(slider);
+
+        //Optional paramter to pause slider when making an anmiation call
+        if (pause) {
+          slider.pause();
+        }
+
+        //Update controlNav
+        if (slider.vars.controlNav) {
+          slider.controlNav.removeClass("active").eq(target).addClass("active");
+        }
+
+        //Is the slider at either end
+        slider.atEnd = target == 0 || target == slider.count - 1 ? true : false;
+        if (!slider.vars.animationLoop && slider.vars.directionNav) {
+          if (target == 0) {
+            slider.directionNav
+              .removeClass("disabled")
+              .filter(".prev")
+              .addClass("disabled");
+          } else if (target == slider.count - 1) {
+            slider.directionNav
+              .removeClass("disabled")
+              .filter(".next")
+              .addClass("disabled");
+          } else {
+            slider.directionNav.removeClass("disabled");
+          }
+        }
+
+        if (!slider.vars.animationLoop && target == slider.count - 1) {
+          slider.pause();
+          //FlexSlider: end() of cycle Callback
+          slider.vars.end(slider);
+        }
+
+        if (slider.vars.animation.toLowerCase() == "slide") {
+          var dimension = slider.vertical
+            ? slider.slides.filter(":first").height()
+            : slider.slides.filter(":first").width();
 
           if (
-            Math.ceil((target + 1) / slider.visible) - 1 !==
-              slider.currentSlide &&
-            target !== 0
+            slider.currentSlide == 0 &&
+            target == slider.count - 1 &&
+            slider.vars.animationLoop &&
+            slider.direction != "next"
           ) {
-            slider.currentItem = target;
-            slider.slides
-              .removeClass(namespace + "active-slide")
-              .eq(target)
-              .addClass(namespace + "active-slide");
-            target = Math.floor(target / slider.visible);
-          } else {
-            slider.currentItem = target;
-            slider.slides
-              .removeClass(namespace + "active-slide")
-              .eq(target)
-              .addClass(namespace + "active-slide");
-            return false;
-          }
-        }
-
-        slider.animating = true;
-        slider.animatingTo = target;
-        // API: before() animation Callback
-        vars.before(slider);
-
-        // SLIDESHOW:
-        if (pause) slider.pause();
-
-        // SYNC:
-        if (slider.syncExists && !fromNav) methods.sync("animate");
-
-        // CONTROLNAV
-        if (vars.controlNav) methods.controlNav.active();
-
-        // !CAROUSEL:
-        // CANDIDATE: slide active class (for add/remove slide)
-        if (!carousel)
-          slider.slides
-            .removeClass(namespace + "active-slide")
-            .eq(target)
-            .addClass(namespace + "active-slide");
-
-        // INFINITE LOOP:
-        // CANDIDATE: atEnd
-        slider.atEnd = target === 0 || target === slider.last;
-
-        // DIRECTIONNAV:
-        if (vars.directionNav) methods.directionNav.update();
-
-        if (target === slider.last) {
-          // API: end() of cycle Callback
-          vars.end(slider);
-          // SLIDESHOW && !INFINITE LOOP:
-          if (!vars.animationLoop) slider.pause();
-        }
-
-        // SLIDE:
-        if (!fade) {
-          var dimension = vertical
-              ? slider.slides.filter(":first").height()
-              : slider.computedW,
-            margin,
-            slideString,
-            calcNext;
-
-          // INFINITE LOOP / REVERSE:
-          if (carousel) {
-            margin =
-              vars.itemWidth > slider.w ? vars.itemMargin * 2 : vars.itemMargin;
-            calcNext =
-              (slider.itemW + margin) * slider.move * slider.animatingTo;
-            slideString =
-              calcNext > slider.limit && slider.visible !== 1
-                ? slider.limit
-                : calcNext;
+            slider.slideString = "0px";
           } else if (
-            slider.currentSlide === 0 &&
-            target === slider.count - 1 &&
-            vars.animationLoop &&
-            slider.direction !== "next"
+            slider.currentSlide == slider.count - 1 &&
+            target == 0 &&
+            slider.vars.animationLoop &&
+            slider.direction != "prev"
           ) {
-            slideString = reverse
-              ? (slider.count + slider.cloneOffset) * dimension
-              : 0;
-          } else if (
-            slider.currentSlide === slider.last &&
-            target === 0 &&
-            vars.animationLoop &&
-            slider.direction !== "prev"
-          ) {
-            slideString = reverse ? 0 : (slider.count + 1) * dimension;
+            slider.slideString = -1 * (slider.count + 1) * dimension + "px";
           } else {
-            slideString = reverse
-              ? (slider.count - 1 - target + slider.cloneOffset) * dimension
-              : (target + slider.cloneOffset) * dimension;
+            slider.slideString =
+              -1 * (target + slider.cloneOffset) * dimension + "px";
           }
-          slider.setProps(slideString, "", vars.animationSpeed);
+          slider.args[slider.prop] = slider.slideString;
+
           if (slider.transitions) {
-            if (!vars.animationLoop || !slider.atEnd) {
-              slider.animating = false;
-              slider.currentSlide = slider.animatingTo;
-            }
-            slider.container.unbind("webkitTransitionEnd transitionend");
-            slider.container.bind(
-              "webkitTransitionEnd transitionend",
-              function () {
+            slider.setTransition(slider.vars.animationDuration);
+            slider.args[slider.prop] = slider.vertical
+              ? "translate3d(0," + slider.slideString + ",0)"
+              : "translate3d(" + slider.slideString + ",0,0)";
+            slider.container
+              .css(slider.args)
+              .one("webkitTransitionEnd transitionend", function () {
                 slider.wrapup(dimension);
-              },
-            );
+              });
           } else {
             slider.container.animate(
               slider.args,
-              vars.animationSpeed,
-              vars.easing,
+              slider.vars.animationDuration,
               function () {
                 slider.wrapup(dimension);
               },
             );
           }
         } else {
-          // FADE:
-          if (!touch) {
-            slider.slides
-              .eq(slider.currentSlide)
-              .fadeOut(vars.animationSpeed, vars.easing);
-            slider.slides
-              .eq(target)
-              .fadeIn(vars.animationSpeed, vars.easing, slider.wrapup);
-          } else {
-            slider.slides
-              .eq(slider.currentSlide)
-              .css({ opacity: 0, zIndex: 1 });
-            slider.slides.eq(target).css({ opacity: 1, zIndex: 2 });
-
-            slider.slides.unbind("webkitTransitionEnd transitionend");
-            slider.slides
-              .eq(slider.currentSlide)
-              .bind("webkitTransitionEnd transitionend", function () {
-                // API: after() animation Callback
-                vars.after(slider);
-              });
-
-            slider.animating = false;
-            slider.currentSlide = slider.animatingTo;
-          }
+          //Default to Fade
+          slider.slides
+            .eq(slider.currentSlide)
+            .fadeOut(slider.vars.animationDuration);
+          slider.slides
+            .eq(target)
+            .fadeIn(slider.vars.animationDuration, function () {
+              slider.wrapup();
+            });
         }
-        // SMOOTH HEIGHT:
-        if (vars.smoothHeight) methods.smoothHeight(vars.animationSpeed);
       }
     };
+
+    //FlexSlider: Function to minify redundant animation actions
     slider.wrapup = function (dimension) {
-      // SLIDE:
-      if (!fade && !carousel) {
+      if (slider.vars.animation == "slide") {
+        //Jump the slider if necessary
         if (
-          slider.currentSlide === 0 &&
-          slider.animatingTo === slider.last &&
-          vars.animationLoop
+          slider.currentSlide == 0 &&
+          slider.animatingTo == slider.count - 1 &&
+          slider.vars.animationLoop
         ) {
-          slider.setProps(dimension, "jumpEnd");
+          slider.args[slider.prop] = -1 * slider.count * dimension + "px";
+          if (slider.transitions) {
+            slider.setTransition(0);
+            slider.args[slider.prop] = slider.vertical
+              ? "translate3d(0," + slider.args[slider.prop] + ",0)"
+              : "translate3d(" + slider.args[slider.prop] + ",0,0)";
+          }
+          slider.container.css(slider.args);
         } else if (
-          slider.currentSlide === slider.last &&
-          slider.animatingTo === 0 &&
-          vars.animationLoop
+          slider.currentSlide == slider.count - 1 &&
+          slider.animatingTo == 0 &&
+          slider.vars.animationLoop
         ) {
-          slider.setProps(dimension, "jumpStart");
+          slider.args[slider.prop] = -1 * dimension + "px";
+          if (slider.transitions) {
+            slider.setTransition(0);
+            slider.args[slider.prop] = slider.vertical
+              ? "translate3d(0," + slider.args[slider.prop] + ",0)"
+              : "translate3d(" + slider.args[slider.prop] + ",0,0)";
+          }
+          slider.container.css(slider.args);
         }
       }
       slider.animating = false;
       slider.currentSlide = slider.animatingTo;
-      // API: after() animation Callback
-      vars.after(slider);
+      //FlexSlider: after() animation Callback
+      slider.vars.after(slider);
     };
 
-    // SLIDESHOW:
+    //FlexSlider: Automatic Slideshow
     slider.animateSlides = function () {
-      if (!slider.animating) slider.flexAnimate(slider.getTarget("next"));
+      if (!slider.animating) {
+        slider.flexAnimate(slider.getTarget("next"));
+      }
     };
-    // SLIDESHOW:
+
+    //FlexSlider: Automatic Slideshow Pause
     slider.pause = function () {
       clearInterval(slider.animatedSlides);
-      slider.playing = false;
-      // PAUSEPLAY:
-      if (vars.pausePlay) methods.pausePlay.update("play");
-      // SYNC:
-      if (slider.syncExists) methods.sync("pause");
+      if (slider.vars.pausePlay) {
+        slider.pausePlay
+          .removeClass("pause")
+          .addClass("play")
+          .text(slider.vars.playText);
+      }
     };
-    // SLIDESHOW:
-    slider.play = function () {
+
+    //FlexSlider: Automatic Slideshow Start/Resume
+    slider.resume = function () {
       slider.animatedSlides = setInterval(
         slider.animateSlides,
-        vars.slideshowSpeed,
+        slider.vars.slideshowSpeed,
       );
-      slider.playing = true;
-      // PAUSEPLAY:
-      if (vars.pausePlay) methods.pausePlay.update("pause");
-      // SYNC:
-      if (slider.syncExists) methods.sync("play");
+      if (slider.vars.pausePlay) {
+        slider.pausePlay
+          .removeClass("play")
+          .addClass("pause")
+          .text(slider.vars.pauseText);
+      }
     };
-    slider.canAdvance = function (target, fromNav) {
-      // ASNAV:
-      var last = asNav ? slider.pagingCount - 1 : slider.last;
-      return fromNav
-        ? true
-        : asNav &&
-            slider.currentItem === slider.count - 1 &&
-            target === 0 &&
-            slider.direction === "prev"
-          ? true
-          : asNav &&
-              slider.currentItem === 0 &&
-              target === slider.pagingCount - 1 &&
-              slider.direction !== "next"
-            ? false
-            : target === slider.currentSlide && !asNav
-              ? false
-              : vars.animationLoop
-                ? true
-                : slider.atEnd &&
-                    slider.currentSlide === 0 &&
-                    target === last &&
-                    slider.direction !== "next"
-                  ? false
-                  : slider.atEnd &&
-                      slider.currentSlide === last &&
-                      target === 0 &&
-                      slider.direction === "next"
-                    ? false
-                    : true;
+
+    //FlexSlider: Helper function for non-looping sliders
+    slider.canAdvance = function (target) {
+      if (!slider.vars.animationLoop && slider.atEnd) {
+        if (
+          slider.currentSlide == 0 &&
+          target == slider.count - 1 &&
+          slider.direction != "next"
+        ) {
+          return false;
+        } else if (
+          slider.currentSlide == slider.count - 1 &&
+          target == 0 &&
+          slider.direction == "next"
+        ) {
+          return false;
+        } else {
+          return true;
+        }
+      } else {
+        return true;
+      }
     };
+
+    //FlexSlider: Helper function to determine animation target
     slider.getTarget = function (dir) {
       slider.direction = dir;
-      if (dir === "next") {
-        return slider.currentSlide === slider.last
+      if (dir == "next") {
+        return slider.currentSlide == slider.count - 1
           ? 0
           : slider.currentSlide + 1;
       } else {
-        return slider.currentSlide === 0
-          ? slider.last
+        return slider.currentSlide == 0
+          ? slider.count - 1
           : slider.currentSlide - 1;
       }
     };
 
-    // SLIDE:
-    slider.setProps = function (pos, special, dur) {
-      var target = (function () {
-        var posCheck = pos
-            ? pos
-            : (slider.itemW + vars.itemMargin) *
-              slider.move *
-              slider.animatingTo,
-          posCalc = (function () {
-            if (carousel) {
-              return special === "setTouch"
-                ? pos
-                : reverse && slider.animatingTo === slider.last
-                  ? 0
-                  : reverse
-                    ? slider.limit -
-                      (slider.itemW + vars.itemMargin) *
-                        slider.move *
-                        slider.animatingTo
-                    : slider.animatingTo === slider.last
-                      ? slider.limit
-                      : posCheck;
-            } else {
-              switch (special) {
-                case "setTotal":
-                  return reverse
-                    ? (slider.count -
-                        1 -
-                        slider.currentSlide +
-                        slider.cloneOffset) *
-                        pos
-                    : (slider.currentSlide + slider.cloneOffset) * pos;
-                case "setTouch":
-                  return reverse ? pos : pos;
-                case "jumpEnd":
-                  return reverse ? pos : slider.count * pos;
-                case "jumpStart":
-                  return reverse ? slider.count * pos : pos;
-                default:
-                  return pos;
-              }
-            }
-          })();
-        return posCalc * -1 + "px";
-      })();
-
-      if (slider.transitions) {
-        target = vertical
-          ? "translate3d(0," + target + ",0)"
-          : "translate3d(" + target + ",0,0)";
-        dur = dur !== undefined ? dur / 1000 + "s" : "0s";
-        slider.container.css("-" + slider.pfx + "-transition-duration", dur);
-      }
-
-      slider.args[slider.prop] = target;
-      if (slider.transitions || dur === undefined)
-        slider.container.css(slider.args);
-    };
-
-    slider.setup = function (type) {
-      // SLIDE:
-      if (!fade) {
-        var sliderOffset, arr;
-
-        if (type === "init") {
-          slider.viewport = $('<div class="' + namespace + 'viewport"></div>')
-            .css({ overflow: "hidden", position: "relative" })
-            .appendTo(slider)
-            .append(slider.container);
-          // INFINITE LOOP:
-          slider.cloneCount = 0;
-          slider.cloneOffset = 0;
-          // REVERSE:
-          if (reverse) {
-            arr = $.makeArray(slider.slides).reverse();
-            slider.slides = $(arr);
-            slider.container.empty().append(slider.slides);
-          }
-        }
-        // INFINITE LOOP && !CAROUSEL:
-        if (vars.animationLoop && !carousel) {
-          slider.cloneCount = 2;
-          slider.cloneOffset = 1;
-          // clear out old clones
-          if (type !== "init") slider.container.find(".clone").remove();
-          slider.container
-            .append(slider.slides.first().clone().addClass("clone"))
-            .prepend(slider.slides.last().clone().addClass("clone"));
-        }
-        slider.newSlides = $(vars.selector, slider);
-
-        sliderOffset = reverse
-          ? slider.count - 1 - slider.currentSlide + slider.cloneOffset
-          : slider.currentSlide + slider.cloneOffset;
-        // VERTICAL:
-        if (vertical && !carousel) {
-          slider.container
-            .height((slider.count + slider.cloneCount) * 200 + "%")
-            .css("position", "absolute")
-            .width("100%");
-          setTimeout(
-            function () {
-              slider.newSlides.css({ display: "block" });
-              slider.doMath();
-              slider.viewport.height(slider.h);
-              slider.setProps(sliderOffset * slider.h, "init");
-            },
-            type === "init" ? 100 : 0,
-          );
-        } else {
-          slider.container.width(
-            (slider.count + slider.cloneCount) * 200 + "%",
-          );
-          slider.setProps(sliderOffset * slider.computedW, "init");
-          setTimeout(
-            function () {
-              slider.doMath();
-              slider.newSlides.css({
-                width: slider.computedW,
-                float: "left",
-                display: "block",
-              });
-              // SMOOTH HEIGHT:
-              if (vars.smoothHeight) methods.smoothHeight();
-            },
-            type === "init" ? 100 : 0,
-          );
-        }
-      } else {
-        // FADE:
-        slider.slides.css({
-          width: "100%",
-          float: "left",
-          marginRight: "-100%",
-          position: "relative",
-        });
-        if (type === "init") {
-          if (!touch) {
-            slider.slides
-              .eq(slider.currentSlide)
-              .fadeIn(vars.animationSpeed, vars.easing);
-          } else {
-            slider.slides
-              .css({
-                opacity: 0,
-                display: "block",
-                webkitTransition:
-                  "opacity " + vars.animationSpeed / 1000 + "s ease",
-                zIndex: 1,
-              })
-              .eq(slider.currentSlide)
-              .css({ opacity: 1, zIndex: 2 });
-          }
-        }
-        // SMOOTH HEIGHT:
-        if (vars.smoothHeight) methods.smoothHeight();
-      }
-      // !CAROUSEL:
-      // CANDIDATE: active slide
-      if (!carousel)
-        slider.slides
-          .removeClass(namespace + "active-slide")
-          .eq(slider.currentSlide)
-          .addClass(namespace + "active-slide");
-    };
-
-    slider.doMath = function () {
-      var slide = slider.slides.first(),
-        slideMargin = vars.itemMargin,
-        minItems = vars.minItems,
-        maxItems = vars.maxItems;
-
-      slider.w = slider.width();
-      slider.h = slide.height();
-      slider.boxPadding = slide.outerWidth() - slide.width();
-
-      // CAROUSEL:
-      if (carousel) {
-        slider.itemT = vars.itemWidth + slideMargin;
-        slider.minW = minItems ? minItems * slider.itemT : slider.w;
-        slider.maxW = maxItems ? maxItems * slider.itemT : slider.w;
-        slider.itemW =
-          slider.minW > slider.w
-            ? (slider.w - slideMargin * minItems) / minItems
-            : slider.maxW < slider.w
-              ? (slider.w - slideMargin * maxItems) / maxItems
-              : vars.itemWidth > slider.w
-                ? slider.w
-                : vars.itemWidth;
-        slider.visible = Math.floor(slider.w / (slider.itemW + slideMargin));
-        slider.move =
-          vars.move > 0 && vars.move < slider.visible
-            ? vars.move
-            : slider.visible;
-        slider.pagingCount = Math.ceil(
-          (slider.count - slider.visible) / slider.move + 1,
-        );
-        slider.last = slider.pagingCount - 1;
-        slider.limit =
-          slider.pagingCount === 1
-            ? 0
-            : vars.itemWidth > slider.w
-              ? (slider.itemW + slideMargin * 2) * slider.count -
-                slider.w -
-                slideMargin
-              : (slider.itemW + slideMargin) * slider.count -
-                slider.w -
-                slideMargin;
-      } else {
-        slider.itemW = slider.w;
-        slider.pagingCount = slider.count;
-        slider.last = slider.count - 1;
-      }
-      slider.computedW = slider.itemW - slider.boxPadding;
-    };
-
-    slider.update = function (pos, action) {
-      slider.doMath();
-
-      // update currentSlide and slider.animatingTo if necessary
-      if (!carousel) {
-        if (pos < slider.currentSlide) {
-          slider.currentSlide += 1;
-        } else if (pos <= slider.currentSlide && pos !== 0) {
-          slider.currentSlide -= 1;
-        }
-        slider.animatingTo = slider.currentSlide;
-      }
-
-      // update controlNav
-      if (vars.controlNav && !slider.manualControls) {
-        if (
-          (action === "add" && !carousel) ||
-          slider.pagingCount > slider.controlNav.length
-        ) {
-          methods.controlNav.update("add");
-        } else if (
-          (action === "remove" && !carousel) ||
-          slider.pagingCount < slider.controlNav.length
-        ) {
-          if (carousel && slider.currentSlide > slider.last) {
-            slider.currentSlide -= 1;
-            slider.animatingTo -= 1;
-          }
-          methods.controlNav.update("remove", slider.last);
-        }
-      }
-      // update directionNav
-      if (vars.directionNav) methods.directionNav.update();
-    };
-
-    slider.addSlide = function (obj, pos) {
-      var $obj = $(obj);
-
-      slider.count += 1;
-      slider.last = slider.count - 1;
-
-      // append new slide
-      if (vertical && reverse) {
-        pos !== undefined
-          ? slider.slides.eq(slider.count - pos).after($obj)
-          : slider.container.prepend($obj);
-      } else {
-        pos !== undefined
-          ? slider.slides.eq(pos).before($obj)
-          : slider.container.append($obj);
-      }
-
-      // update currentSlide, animatingTo, controlNav, and directionNav
-      slider.update(pos, "add");
-
-      // update slider.slides
-      slider.slides = $(vars.selector + ":not(.clone)", slider);
-      // re-setup the slider to accomdate new slide
-      slider.setup();
-
-      //FlexSlider: added() Callback
-      vars.added(slider);
-    };
-    slider.removeSlide = function (obj) {
-      var pos = isNaN(obj) ? slider.slides.index($(obj)) : obj;
-
-      // update count
-      slider.count -= 1;
-      slider.last = slider.count - 1;
-
-      // remove slide
-      if (isNaN(obj)) {
-        $(obj, slider.slides).remove();
-      } else {
-        vertical && reverse
-          ? slider.slides.eq(slider.last).remove()
-          : slider.slides.eq(obj).remove();
-      }
-
-      // update currentSlide, animatingTo, controlNav, and directionNav
-      slider.doMath();
-      slider.update(pos, "remove");
-
-      // update slider.slides
-      slider.slides = $(vars.selector + ":not(.clone)", slider);
-      // re-setup the slider to accomdate new slide
-      slider.setup();
-
-      // FlexSlider: removed() Callback
-      vars.removed(slider);
+    //FlexSlider: Helper function to set CSS3 transitions
+    slider.setTransition = function (dur) {
+      slider.container.css({ "-webkit-transition-duration": dur / 1000 + "s" });
     };
 
     //FlexSlider: Initialize
-    methods.init();
+    slider.init();
   };
 
   //FlexSlider: Default Settings
   $.flexslider.defaults = {
-    namespace: "flex-", //{NEW} String: Prefix string attached to the class of every element generated by the plugin
-    selector: ".slides > li", //{NEW} Selector: Must match a simple pattern. '{container} > {slide}' -- Ignore pattern at your own peril
-    animation: "fade", //String: Select your animation type, "fade" or "slide"
-    easing: "swing", //{NEW} String: Determines the easing method used in jQuery transitions. jQuery easing plugin is supported!
-    direction: "horizontal", //String: Select the sliding direction, "horizontal" or "vertical"
-    reverse: false, //{NEW} Boolean: Reverse the animation direction
-    animationLoop: true, //Boolean: Should the animation loop? If false, directionNav will received "disable" classes at either end
-    smoothHeight: false, //{NEW} Boolean: Allow height of the slider to animate smoothly in horizontal mode
-    startAt: 0, //Integer: The slide that the slider should start on. Array notation (0 = first slide)
+    animation: "slide", //String: Select your animation type, "fade" or "slide"
+    slideDirection: "horizontal", //String: Select the sliding direction, "horizontal" or "vertical"
     slideshow: true, //Boolean: Animate slider automatically
     slideshowSpeed: 7000, //Integer: Set the speed of the slideshow cycling, in milliseconds
-    animationSpeed: 600, //Integer: Set the speed of animations, in milliseconds
-    initDelay: 0, //{NEW} Integer: Set an initialization delay, in milliseconds
-    randomize: false, //Boolean: Randomize slide order
-
-    // Usability features
-    pauseOnAction: true, //Boolean: Pause the slideshow when interacting with control elements, highly recommended.
-    pauseOnHover: false, //Boolean: Pause the slideshow when hovering over slider, then resume when no longer hovering
-    useCSS: true, //{NEW} Boolean: Slider will use CSS3 transitions if available
-    touch: true, //{NEW} Boolean: Allow touch swipe navigation of the slider on touch-enabled devices
-    video: false, //{NEW} Boolean: If using video in the slider, will prevent CSS3 3D Transforms to avoid graphical glitches
-
-    // Primary Controls
+    animationDuration: 600, //Integer: Set the speed of animations, in milliseconds
+    directionNav: false, //Boolean: Create navigation for previous/next navigation? (true/false)
     controlNav: true, //Boolean: Create navigation for paging control of each clide? Note: Leave true for manualControls usage
-    directionNav: true, //Boolean: Create navigation for previous/next navigation? (true/false)
+    keyboardNav: true, //Boolean: Allow slider navigating via keyboard left/right keys
+    mousewheel: false, //Boolean: Allow slider navigating via mousewheel
     prevText: "Previous", //String: Set the text for the "previous" directionNav item
     nextText: "Next", //String: Set the text for the "next" directionNav item
-
-    // Secondary Navigation
-    keyboard: true, //Boolean: Allow slider navigating via keyboard left/right keys
-    multipleKeyboard: false, //{NEW} Boolean: Allow keyboard navigation to affect multiple sliders. Default behavior cuts out keyboard navigation with more than one slider present.
-    mousewheel: false, //{UPDATED} Boolean: Requires jquery.mousewheel.js (https://github.com/brandonaaron/jquery-mousewheel) - Allows slider navigating via mousewheel
     pausePlay: false, //Boolean: Create pause/play dynamic element
     pauseText: "Pause", //String: Set the text for the "pause" pausePlay item
     playText: "Play", //String: Set the text for the "play" pausePlay item
-
-    // Special properties
-    controlsContainer: "", //{UPDATED} jQuery Object/Selector: Declare which container the navigation elements should be appended too. Default container is the FlexSlider element. Example use would be $(".flexslider-container"). Property is ignored if given element is not found.
-    manualControls: "", //{UPDATED} jQuery Object/Selector: Declare custom control navigation. Examples would be $(".flex-control-nav li") or "#tabs-nav li img", etc. The number of elements in your controlNav should match the number of slides/tabs.
-    sync: "", //{NEW} Selector: Mirror the actions performed on this slider with another slider. Use with care.
-    asNavFor: "", //{NEW} Selector: Internal property exposed for turning the slider into a thumbnail navigation for another slider
-
-    // Carousel Options
-    itemWidth: 0, //{NEW} Integer: Box-model width of individual carousel items, including horizontal borders and padding.
-    itemMargin: 0, //{NEW} Integer: Margin between carousel items.
-    minItems: 0, //{NEW} Integer: Minimum number of carousel items that should be visible. Items will resize fluidly when below this.
-    maxItems: 0, //{NEW} Integer: Maxmimum number of carousel items that should be visible. Items will resize fluidly when above this limit.
-    move: 0, //{NEW} Integer: Number of carousel items that should move on animation. If 0, slider will move all visible items.
-
-    // Callback API
+    randomize: false, //Boolean: Randomize slide order
+    slideToStart: 0, //Integer: The slide that the slider should start on. Array notation (0 = first slide)
+    animationLoop: true, //Boolean: Should the animation loop? If false, directionNav will received "disable" classes at either end
+    pauseOnAction: true, //Boolean: Pause the slideshow when interacting with control elements, highly recommended.
+    pauseOnHover: false, //Boolean: Pause the slideshow when hovering over slider, then resume when no longer hovering
+    useCSS: true, //Boolean: Override the use of CSS3 Translate3d animations
+    touch: true, //Boolean: Disable touchswipe events
+    controlsContainer: "", //Selector: Declare which container the navigation elements should be appended too. Default container is the flexSlider element. Example use would be ".flexslider-container", "#container", etc. If the given element is not found, the default action will be taken.
+    manualControls: "", //Selector: Declare custom control navigation. Example would be ".flex-control-nav li" or "#tabs-nav li img", etc. The number of elements in your controlNav should match the number of slides/tabs.
     start: function () {}, //Callback: function(slider) - Fires when the slider loads the first slide
     before: function () {}, //Callback: function(slider) - Fires asynchronously with each slider animation
     after: function () {}, //Callback: function(slider) - Fires after each slider animation completes
     end: function () {}, //Callback: function(slider) - Fires when the slider reaches the last slide (asynchronous)
-    added: function () {}, //{NEW} Callback: function(slider) - Fires after a slide is added
-    removed: function () {}, //{NEW} Callback: function(slider) - Fires after a slide is removed
   };
 
   //FlexSlider: Plugin Function
   $.fn.flexslider = function (options) {
-    if (options === undefined) options = {};
-
-    if (typeof options === "object") {
-      return this.each(function () {
-        var $this = $(this),
-          selector = options.selector ? options.selector : ".slides > li",
-          $slides = $this.find(selector);
-
-        if ($slides.length === 1) {
-          $slides.fadeIn(400);
-          if (options.start) options.start($this);
-        } else if ($this.data("flexslider") == undefined) {
-          new $.flexslider(this, options);
-        }
-      });
-    } else {
-      // Helper strings to quickly perform functions on the slider
-      var $slider = $(this).data("flexslider");
-      switch (options) {
-        case "play":
-          $slider.play();
-          break;
-        case "pause":
-          $slider.pause();
-          break;
-        case "next":
-          $slider.flexAnimate($slider.getTarget("next"), true);
-          break;
-        case "prev":
-        case "previous":
-          $slider.flexAnimate($slider.getTarget("prev"), true);
-          break;
-        default:
-          if (typeof options === "number") $slider.flexAnimate(options, true);
+    return this.each(function () {
+      var $slides = $(this).find(".slides > li");
+      if ($slides.length === 1) {
+        $slides.fadeIn(400);
+        if (options && options.start) options.start($(this));
+      } else if ($(this).data("flexsliderInit") != true) {
+        new $.flexslider(this, options);
       }
-    }
+    });
   };
 })(jQuery);


### PR DESCRIPTION
## Description
The test has a .js file dependency which is just used as static asset during the test but it is GPL licensed. It's not packaged with the software and there is no "license poisoning" but there is no particular reason why this file is needed for even the test so just swapping it with a more permissively licensed file.

Also added a separate LICENSE file for a JSON utility, not strictly required but is best practice.

## How Has This Been Tested?
If it passes CI it's good.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unnecessary GPL dependency in the pruning test by swapping FlexSlider to an MIT-licensed version. Also added a BSD-3-Clause LICENSE for `jsonriver`; no runtime changes.

- **Dependencies**
  - Replaced `backend/tests/integration/tests/pruning/website/js/jquery.flexslider.js` v2.1 (GPLv2) with v1.8 (MIT). Test asset only; not shipped.
  - Added `backend/onyx/utils/jsonriver/LICENSE` (BSD-3-Clause) to document third‑party terms.

<sup>Written for commit babfd51f67ad3fea56d170e48ebb1512681f6fd1. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



