### PR TITLE
fix(install): drop sg dependency, use sudo for docker commands

### DIFF
--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -214,10 +214,11 @@ detect_compose_cmd || true
 # in the "docker" group. Group membership doesn't apply to the current shell,
 # so when we add the user to the group mid-script we instead prefix subsequent
 # docker commands with sudo to finish this run. Future runs (after the user
-# logs out and back in) won't need it. DOCKER_SUDO is "" or "sudo".
-DOCKER_SUDO=""
+# logs out and back in) won't need it. DOCKER_SUDO is an array so that it
+# expands to no argument at all (rather than an empty string) when unset.
+DOCKER_SUDO=()
 refresh_docker_sudo() {
-    DOCKER_SUDO=""
+    DOCKER_SUDO=()
     if ! command -v docker &> /dev/null; then
         return
     fi
@@ -228,7 +229,7 @@ refresh_docker_sudo() {
         return
     fi
     if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
-        DOCKER_SUDO="sudo"
+        DOCKER_SUDO=(sudo)
     fi
 }
 refresh_docker_sudo
@@ -366,7 +367,8 @@ if [ "$SHUTDOWN_MODE" = true ]; then
 
             # Stop containers (without removing them)
             build_compose_file_args true
-            if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" stop); then
+            # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+            if (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="${HOST_PORT:-3000}" IMAGE_TAG="${IMAGE_TAG:-edge}" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" stop); then
                 print_success "Onyx containers stopped (paused)"
             else
                 print_error "Failed to stop containers"
@@ -419,7 +421,8 @@ if [ "$DELETE_DATA_MODE" = true ]; then
 
             # Stop and remove containers with volumes
             build_compose_file_args true
-            if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" down -v); then
+            # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+            if (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="${HOST_PORT:-3000}" IMAGE_TAG="${IMAGE_TAG:-edge}" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" down -v); then
                 print_success "Onyx containers and volumes removed"
             else
                 print_error "Failed to remove containers and volumes"
@@ -558,17 +561,21 @@ if command -v docker &> /dev/null \
     fi
 fi
 
-# On Linux, ensure docker commands can talk to the daemon. If the current user
-# isn't in the "docker" group, add them (so future shells are set up) and use
-# sudo for the rest of this run — the new group membership doesn't apply until
-# they log out and back in.
+# On Linux, ensure docker commands can talk to the daemon. If `docker info`
+# fails, fall back to sudo for the rest of this run. Add the user to the
+# "docker" group only when they aren't already a member — `docker info` also
+# fails when the daemon is stopped, and we don't want to silently mutate
+# group membership in that case. The downstream daemon check will exit with
+# a clearer message if the daemon really is down.
 refresh_docker_sudo
-if [[ -n "$DOCKER_SUDO" ]]; then
-    if ! getent group docker &> /dev/null; then
-        sudo groupadd docker
+if (( ${#DOCKER_SUDO[@]} > 0 )); then
+    if ! id -nG "$USER" | grep -qw docker; then
+        if ! getent group docker &> /dev/null; then
+            sudo groupadd docker
+        fi
+        print_info "Adding $USER to the docker group (effective on next login)..."
+        sudo usermod -aG docker "$USER"
     fi
-    print_info "Adding $USER to the docker group (effective on next login)..."
-    sudo usermod -aG docker "$USER"
     print_info "Using sudo for docker commands in this run."
 fi
 
@@ -678,7 +685,7 @@ version_compare() {
 }
 
 # Check Docker daemon
-if ! $DOCKER_SUDO docker info &> /dev/null; then
+if ! "${DOCKER_SUDO[@]}" docker info &> /dev/null; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         print_info "Docker daemon is not running. Starting Docker Desktop..."
         open -a Docker
@@ -919,7 +926,8 @@ ENV_TEMPLATE="${INSTALL_ROOT}/deployment/env.template"
 # Check if services are already running
 if [ -d "${INSTALL_ROOT}/deployment" ] && [ -f "${INSTALL_ROOT}/deployment/docker-compose.yml" ]; then
     build_compose_file_args true
-    RUNNING_CONTAINERS=$(cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps -q 2>/dev/null | wc -l)
+    # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+    RUNNING_CONTAINERS=$(cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps -q 2>/dev/null | wc -l)
     if [ "$RUNNING_CONTAINERS" -gt 0 ]; then
         print_error "Onyx services are currently running!"
         echo ""
@@ -1092,8 +1100,8 @@ else
         # Pre-create the dedicated sandbox bridge. docker-compose references
         # it as external=true so it must exist before `compose up`.
         SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
-        if ! $DOCKER_SUDO docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
-            if $DOCKER_SUDO docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
+        if ! "${DOCKER_SUDO[@]}" docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
+            if "${DOCKER_SUDO[@]}" docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
                 print_success "Created sandbox bridge network: $SANDBOX_NET"
             else
                 print_warning "Could not create sandbox network $SANDBOX_NET — create it manually:"
@@ -1254,7 +1262,8 @@ print_info "Downloading Docker images (this may take a while)..."
 # substitution prefers shell env over .env, so without this an exported
 # IMAGE_TAG in the user's shellrc would silently swap the images being pulled.
 build_compose_file_args
-if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" pull --quiet); then
+# shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+if (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" pull --quiet); then
     print_success "Docker images downloaded successfully"
 else
     print_error "Failed to download Docker images"
@@ -1279,18 +1288,21 @@ echo ""
 UP_EXIT=0
 if [ "$USE_LATEST" = true ]; then
     print_info "Force pulling latest images and recreating containers..."
-    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+    (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 else
-    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+    (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 fi
 if [ $UP_EXIT -ne 0 ]; then
     print_error "Failed to start Onyx services"
     echo ""
     print_info "Current container status:"
-    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
+    # shellcheck disable=SC2086 # COMPOSE_CMD is "docker compose" and needs word-splitting
+    (cd "${INSTALL_ROOT}/deployment" && "${DOCKER_SUDO[@]}" HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
     echo ""
     print_info "Check the logs of any unhealthy service:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO[*]:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
     echo ""
     print_info "If the issue persists, please contact: founders@onyx.app"
     exit 1
@@ -1308,7 +1320,7 @@ else
     echo -e "${YELLOW}${BOLD}   ⚠️  Onyx containers started  ⚠️${NC}"
     echo -e "${YELLOW}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     print_info "Services may still be initializing. Check status with:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO[*]:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
 fi
 echo ""
 print_info "Access Onyx at:"

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -209,6 +209,30 @@ detect_compose_cmd() {
 }
 detect_compose_cmd || true
 
+# --- Docker daemon access detection ---
+# On Linux, a non-root user can only talk to /var/run/docker.sock when they're
+# in the "docker" group. Group membership doesn't apply to the current shell,
+# so when we add the user to the group mid-script we instead prefix subsequent
+# docker commands with sudo to finish this run. Future runs (after the user
+# logs out and back in) won't need it. DOCKER_SUDO is "" or "sudo".
+DOCKER_SUDO=""
+refresh_docker_sudo() {
+    DOCKER_SUDO=""
+    if ! command -v docker &> /dev/null; then
+        return
+    fi
+    if [[ "$(id -u)" -eq 0 ]]; then
+        return
+    fi
+    if docker info &> /dev/null; then
+        return
+    fi
+    if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+        DOCKER_SUDO="sudo"
+    fi
+}
+refresh_docker_sudo
+
 # Ensures a required file is present. With --local, verifies the file exists on
 # disk. Otherwise, downloads it from the given URL. Returns 0 on success, 1 on
 # failure (caller should handle the exit).
@@ -342,7 +366,7 @@ if [ "$SHUTDOWN_MODE" = true ]; then
 
             # Stop containers (without removing them)
             build_compose_file_args true
-            if (cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" stop); then
+            if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" stop); then
                 print_success "Onyx containers stopped (paused)"
             else
                 print_error "Failed to stop containers"
@@ -395,7 +419,7 @@ if [ "$DELETE_DATA_MODE" = true ]; then
 
             # Stop and remove containers with volumes
             build_compose_file_args true
-            if (cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" down -v); then
+            if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" down -v); then
                 print_success "Onyx containers and volumes removed"
             else
                 print_error "Failed to remove containers and volumes"
@@ -534,25 +558,18 @@ if command -v docker &> /dev/null \
     fi
 fi
 
-# On Linux, ensure the current user can talk to the Docker daemon without
-# sudo.  If necessary, add them to the "docker" group and re-exec the
-# script under that group so the rest of the install proceeds normally.
-if command -v docker &> /dev/null \
-    && { [[ "$OSTYPE" == "linux-gnu"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; } \
-    && [[ "$(id -u)" -ne 0 ]] \
-    && ! docker info &> /dev/null; then
-    if [[ "${_ONYX_REEXEC:-}" = "1" ]]; then
-        print_error "Cannot connect to Docker after group re-exec."
-        print_info "Log out and back in, then run the script again."
-        exit 1
-    fi
+# On Linux, ensure docker commands can talk to the daemon. If the current user
+# isn't in the "docker" group, add them (so future shells are set up) and use
+# sudo for the rest of this run — the new group membership doesn't apply until
+# they log out and back in.
+refresh_docker_sudo
+if [[ -n "$DOCKER_SUDO" ]]; then
     if ! getent group docker &> /dev/null; then
         sudo groupadd docker
     fi
-    print_info "Adding $USER to the docker group..."
+    print_info "Adding $USER to the docker group (effective on next login)..."
     sudo usermod -aG docker "$USER"
-    print_info "Re-launching with docker group active..."
-    exec sg docker -c "_ONYX_REEXEC=1 bash $(printf '%q ' "$0" "$@")"
+    print_info "Using sudo for docker commands in this run."
 fi
 
 # ASCII Art Banner
@@ -661,7 +678,7 @@ version_compare() {
 }
 
 # Check Docker daemon
-if ! docker info &> /dev/null; then
+if ! $DOCKER_SUDO docker info &> /dev/null; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
         print_info "Docker daemon is not running. Starting Docker Desktop..."
         open -a Docker
@@ -902,7 +919,7 @@ ENV_TEMPLATE="${INSTALL_ROOT}/deployment/env.template"
 # Check if services are already running
 if [ -d "${INSTALL_ROOT}/deployment" ] && [ -f "${INSTALL_ROOT}/deployment/docker-compose.yml" ]; then
     build_compose_file_args true
-    RUNNING_CONTAINERS=$(cd "${INSTALL_ROOT}/deployment" && $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps -q 2>/dev/null | wc -l)
+    RUNNING_CONTAINERS=$(cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps -q 2>/dev/null | wc -l)
     if [ "$RUNNING_CONTAINERS" -gt 0 ]; then
         print_error "Onyx services are currently running!"
         echo ""
@@ -1075,8 +1092,8 @@ else
         # Pre-create the dedicated sandbox bridge. docker-compose references
         # it as external=true so it must exist before `compose up`.
         SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
-        if ! docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
-            if docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
+        if ! $DOCKER_SUDO docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
+            if $DOCKER_SUDO docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
                 print_success "Created sandbox bridge network: $SANDBOX_NET"
             else
                 print_warning "Could not create sandbox network $SANDBOX_NET — create it manually:"
@@ -1237,7 +1254,7 @@ print_info "Downloading Docker images (this may take a while)..."
 # substitution prefers shell env over .env, so without this an exported
 # IMAGE_TAG in the user's shellrc would silently swap the images being pulled.
 build_compose_file_args
-if (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" pull --quiet); then
+if (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" pull --quiet); then
     print_success "Docker images downloaded successfully"
 else
     print_error "Failed to download Docker images"
@@ -1262,18 +1279,18 @@ echo ""
 UP_EXIT=0
 if [ "$USE_LATEST" = true ]; then
     print_info "Force pulling latest images and recreating containers..."
-    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d --pull always --force-recreate "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 else
-    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
+    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" up -d "${UP_WAIT_ARGS[@]}") || UP_EXIT=$?
 fi
 if [ $UP_EXIT -ne 0 ]; then
     print_error "Failed to start Onyx services"
     echo ""
     print_info "Current container status:"
-    (cd "${INSTALL_ROOT}/deployment" && IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
+    (cd "${INSTALL_ROOT}/deployment" && $DOCKER_SUDO HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
     echo ""
     print_info "Check the logs of any unhealthy service:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
     echo ""
     print_info "If the issue persists, please contact: founders@onyx.app"
     exit 1
@@ -1291,7 +1308,7 @@ else
     echo -e "${YELLOW}${BOLD}   ⚠️  Onyx containers started  ⚠️${NC}"
     echo -e "${YELLOW}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     print_info "Services may still be initializing. Check status with:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
 fi
 echo ""
 print_info "Access Onyx at:"


### PR DESCRIPTION
## Summary

- The Linux install path called `exec sg docker -c "..."` to re-exec the script with the docker group active after adding the user. `sg` ships with the `login` package and is missing on some minimal Ubuntu images (slim containers, certain cloud images), so the install aborts with `exec: sg: not found`.
- Replaces the re-exec with a `DOCKER_SUDO` prefix: when the user can't talk to the daemon, add them to the docker group for future sessions and run the remaining `docker` / `docker compose` calls in this run through `sudo`. No dependency on `sg`, no re-launch.
- Threads `$DOCKER_SUDO` through every daemon-touching call site (shutdown `stop`, delete-data `down -v`, daemon check, running-containers `ps -q`, sandbox network inspect/create, `pull`, both `up` variants, diagnostic `ps`). Passes `HOST_PORT` inline alongside `IMAGE_TAG` on pull/up since `sudo` resets env. macOS paths are unaffected — `DOCKER_SUDO` stays empty on Darwin.

## Test plan

- [ ] Fresh Ubuntu image without `sg` available: `./install.sh` completes without "sg: not found".
- [ ] Linux user not in docker group: install adds them to the group, uses sudo for `pull` / `up`, and reports correct status.
- [ ] Linux user already in docker group: `DOCKER_SUDO` stays empty, no sudo prompts during docker calls.
- [ ] `./install.sh --shutdown` and `./install.sh --delete-data` work both before and after a fresh login.
- [ ] macOS install path still works (Docker Desktop wait loop unaffected).
- [ ] Root-user invocation (`sudo ./install.sh`) skips the group dance entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux installs that failed with “sg: not found” by dropping the `sg` re-exec and using a `DOCKER_SUDO` fallback. Detects daemon access, uses sudo for this session when needed, and still adds the user to the `docker` group for future sessions.

- **Bug Fixes**
  - Make `DOCKER_SUDO` an array (no empty-arg issues) and remove any re-exec.
  - Safer group handling: only add when not already in `docker`, and don’t change groups if the daemon is just stopped.
  - Apply `DOCKER_SUDO` across all Docker/Compose calls and checks: stop/down, `docker info`/`ps`, sandbox network inspect/create, pull, up, diagnostics.
  - Inline `HOST_PORT` and `IMAGE_TAG` for all sudo’d compose calls (including shutdown/delete-data). macOS unchanged; root skips group logic.

<sup>Written for commit f8975906ed425c0fa5639d1070c987756ba5ef25. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

