### PR TITLE
fix(ods): Auto-set DEVCONTAINER_REMOTE_USER=root on macOS

### DIFF
--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -175,18 +175,29 @@ func ensureRemoteUser() {
 		return
 	}
 
-	if runtime.GOOS == "linux" {
+	setRemoteUserRoot := func(reason string) {
+		log.Debugf("%s — setting DEVCONTAINER_REMOTE_USER=root", reason)
+		if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {
+			log.Warnf("Failed to set DEVCONTAINER_REMOTE_USER: %v", err)
+		}
+	}
+
+	switch runtime.GOOS {
+	case "linux":
 		sock := os.Getenv("DOCKER_SOCK")
 		xdg := os.Getenv("XDG_RUNTIME_DIR")
 		// Heuristic: rootless Docker on Linux typically places its socket
 		// under $XDG_RUNTIME_DIR. If DOCKER_SOCK was set to a custom path
 		// outside XDG_RUNTIME_DIR, set DEVCONTAINER_REMOTE_USER=root manually.
 		if xdg != "" && strings.HasPrefix(sock, xdg) {
-			log.Debug("Rootless Docker detected — setting DEVCONTAINER_REMOTE_USER=root")
-			if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {
-				log.Warnf("Failed to set DEVCONTAINER_REMOTE_USER: %v", err)
-			}
+			setRemoteUserRoot("Rootless Docker detected")
 		}
+	case "darwin":
+		// Docker Desktop on macOS bind-mounts host paths through the Linux
+		// VM as root-owned (no host-UID mapping like native Linux Docker),
+		// so init-dev-user.sh's WS_UID=0 branch always fires and rejects
+		// the non-root `dev` user.
+		setRemoteUserRoot("Docker Desktop on macOS")
 	}
 }
 

--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -193,10 +193,10 @@ func ensureRemoteUser() {
 			setRemoteUserRoot("Rootless Docker detected")
 		}
 	case "darwin":
-		// Docker Desktop on macOS bind-mounts host paths through the Linux
-		// VM as root-owned (no host-UID mapping like native Linux Docker),
-		// so init-dev-user.sh's WS_UID=0 branch always fires and rejects
-		// the non-root `dev` user.
+		// Docker Desktop on macOS bind-mounts host paths through the Linux VM
+		// as root-owned (no host-UID mapping like native Linux Docker), so
+		// init-dev-user.sh's WS_UID=0 branch always fires and rejects the
+		// non-root `dev` user.
 		setRemoteUserRoot("Docker Desktop on macOS")
 	}
 }


### PR DESCRIPTION
## Description

Even once the container starts on macOS (see #11327), the postStart hook
immediately fails:

```
error: rootless Docker detected but remoteUser is not root.
Set DEVCONTAINER_REMOTE_USER=root before starting the container,
or use 'ods dev up' which sets it automatically.
```

That message comes from `.devcontainer/init-dev-user.sh`, which bails
when the workspace bind-mount appears root-owned inside the container
(`WS_UID == 0`).

`ensureRemoteUser()` in `tools/ods/cmd/dev_up.go` already auto-sets
`DEVCONTAINER_REMOTE_USER=root` for this case on Linux rootless Docker,
but only when `runtime.GOOS == "linux"`. Docker Desktop on macOS uses
the same model — the file-sharing layer maps the macOS host user to
container root (analogous to Linux user-namespaces in rootless mode),
so workspace bind mounts appear UID 0 inside the container and writes
done as the in-container `dev` user can't round-trip back to the Mac.
Verified empirically:
`docker run --rm -v $(pwd):/ws alpine stat -c '%u:%g' /ws` → `0:0`.

The supported path on macOS is therefore the same as Linux rootless:
run as `root` inside the container. Root-in-container is the host user
on disk, so writes land with the right ownership.

Extend `ensureRemoteUser()` to also set `DEVCONTAINER_REMOTE_USER=root`
on `darwin`. The existing early-return on a pre-set env var is preserved,
so anyone running a non-standard Mac Docker setup that maps UIDs
differently (some OrbStack configs, custom Lima, etc.) can override
explicitly.

Also extracts the "set + log + handle setenv error" block into a small
local closure shared by both branches.

Note: stacking-wise this is independent of #<PR1> in code (different
function, no merge conflict), but on macOS you need both to actually
reach a working container — #<PR1> gets `docker run` to succeed, this
PR gets the postStart hook to succeed.

## How Has This Been Tested?

- `go build ./...` clean.
- With both this PR and #<PR1> applied locally, `ods dev up` completes
  on macOS / Docker Desktop:
  `{"outcome":"success","remoteUser":"root","remoteWorkspaceFolder":"/workspace"}`.
- Linux branch is unchanged behaviorally (same guard, routed through
  the new closure).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-sets `DEVCONTAINER_REMOTE_USER=root` on macOS (Docker Desktop) to prevent the postStart hook from failing, aligning behavior with Linux. Respects existing overrides and keeps Linux detection logic unchanged.

- **Bug Fixes**
  - On `darwin`, `ensureRemoteUser()` now sets `DEVCONTAINER_REMOTE_USER=root` to handle root-owned bind mounts from Docker Desktop.
  - Added a small shared setter with reasoned logging and error handling; Linux rootless-Docker path now uses it while preserving the early return when the env var is already set.

<sup>Written for commit 6c8ae45d83c0991d774acf2919052178f647b530. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11328?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
