### PR TITLE
fix(voice): unbreak OpenAI STT after Realtime Beta API deprecation (#11322) to release v3.2

### DIFF
--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -1,10 +1,10 @@
 """OpenAI voice provider for STT and TTS.
 
 OpenAI supports:
-- **STT**: Whisper (batch transcription via REST) and Realtime API (streaming
-  transcription via WebSocket with server-side VAD). Audio is sent as base64-encoded
-  PCM16 at 24kHz mono. The Realtime API returns transcript deltas and completed
-  transcription events per VAD-detected utterance.
+- **STT**: Whisper (batch transcription via REST). Streaming transcription via
+  the Realtime API is currently disabled (`supports_streaming_stt()` returns
+  `False`) pending migration to the GA Realtime API; `OpenAIStreamingTranscriber`
+  remains in this file for the upcoming migration but is unreachable today.
 - **TTS**: HTTP streaming endpoint that returns audio chunks progressively.
   Supported models: tts-1 (standard) and tts-1-hd (high quality).
 
@@ -292,7 +292,9 @@ OPENAI_VOICES = [
     {"id": "shimmer", "name": "Shimmer"},
 ]
 
-# OpenAI available STT models (all support streaming via Realtime API)
+# OpenAI available STT models. All use the chunked HTTP transcription endpoint
+# today; Realtime streaming is disabled until the GA migration lands (see
+# `supports_streaming_stt()`).
 OPENAI_STT_MODELS = [
     {"id": "whisper-1", "name": "Whisper v1"},
     {"id": "gpt-4o-transcribe", "name": "GPT-4o Transcribe"},

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -520,12 +520,19 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
 
         Args:
             audio_data: Raw audio bytes
-            audio_format: Audio format (e.g., "webm", "wav", "mp3")
+            audio_format: Audio format (e.g., "webm", "wav", "mp3", "pcm16")
 
         Returns:
             Transcribed text
         """
         client = self._get_client()
+
+        # OpenAI's /v1/audio/transcriptions endpoint does not accept raw PCM;
+        # wrap PCM16 in a WAV container (24kHz mono — matches the browser
+        # capture format used by the streaming WebSocket fallback).
+        if audio_format == "pcm16":
+            audio_data = _create_wav_header(len(audio_data)) + audio_data
+            audio_format = "wav"
 
         # Create a file-like object from the audio bytes
         audio_file = io.BytesIO(audio_data)
@@ -595,8 +602,12 @@ class OpenAIVoiceProvider(VoiceProviderInterface):
         return OPENAI_TTS_MODELS.copy()
 
     def supports_streaming_stt(self) -> bool:
-        """OpenAI supports streaming via Realtime API for all STT models."""
-        return True
+        # OpenAI deprecated the Realtime Beta API shape we depend on
+        # (header `OpenAI-Beta: realtime=v1` + `transcription_session.update`),
+        # which now returns `beta_api_shape_disabled`. Route through the
+        # chunked HTTP path until the streaming transcriber is migrated to
+        # the GA Realtime API.
+        return False
 
     def supports_streaming_tts(self) -> bool:
         """OpenAI supports real-time streaming TTS via Realtime API."""


### PR DESCRIPTION
## Description

Cherry-pick of #11322 onto `release/v3.2`. Two commits, both auto-merged cleanly:

- `ee8b7514b0` — `fix(voice): unbreak OpenAI STT after Realtime Beta API deprecation`
- `7176e3b3ea` — `docs(voice): refresh OpenAI provider docs to reflect disabled streaming` (addresses Greptile review on the original)

OpenAI deprecated the Realtime Beta API shape that `OpenAIStreamingTranscriber` depends on; every WebSocket connection now returns `beta_api_shape_disabled`, the chunked fallback then posts raw PCM16 to `/v1/audio/transcriptions` which is rejected, and users see blank transcripts. The `playlist-prod` cluster (running `v3.2.11`) is currently affected.

Two scoped changes in `backend/onyx/voice/providers/openai.py`:
1. `supports_streaming_stt()` returns `False` — routes OpenAI STT through the chunked HTTP path until the GA Realtime migration lands.
2. `transcribe()` wraps PCM16 in a WAV container before posting (uses existing `_create_wav_header` helper).

UX impact: STT no longer streams partial transcripts on this release line — transcript appears on `end`. Azure and ElevenLabs are untouched.

The long-term GA Realtime API migration is tracked in #11323 and will only land on `main`.

## How Has This Been Tested?

- Tested on `main` via #11322; behaviour and code paths identical on `release/v3.2`.
- Cherry-pick auto-merged with no conflicts.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken OpenAI STT on v3.2 by disabling streaming and sending WAV-wrapped audio to the HTTP transcription endpoint. Users now get a single transcript at end instead of blank results.

- **Bug Fixes**
  - `supports_streaming_stt()` returns False to bypass the deprecated Realtime path and use chunked HTTP to `"/v1/audio/transcriptions"`.
  - Wrap raw PCM16 in a WAV container before POSTing so OpenAI accepts the upload.

<sup>Written for commit 7176e3b3ead2e31592df6bbf3222a96cb97b911e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11331?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

