### PR TITLE
chore(craft): bump default models to gpt-5.5

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -50,8 +50,8 @@ PYTHONUNBUFFERED=1
 # =============================================================================
 
 GEN_AI_API_KEY=<REPLACE THIS>
-GEN_AI_MODEL_VERSION=gpt-4o
-FAST_GEN_AI_MODEL_VERSION=gpt-4o-mini
+GEN_AI_MODEL_VERSION=gpt-5.5
+FAST_GEN_AI_MODEL_VERSION=gpt-5-mini
 
 # Optional — set if you actually use them
 # OPENAI_API_KEY=<REPLACE THIS>

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -236,7 +236,9 @@ export default function BuildOnboardingModal({
 
     const testResult = await testApiKeyHelper(
       currentProviderConfig.providerName,
-      payload
+      payload,
+      apiKey,
+      selectedModel
     );
 
     if (!testResult.ok) {

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -11,7 +11,7 @@ export interface BuildLlmSelection {
 // Priority order for smart default LLM selection
 const LLM_SELECTION_PRIORITY = [
   { provider: "anthropic", modelName: "claude-opus-4-7" },
-  { provider: "openai", modelName: "gpt-5.2" },
+  { provider: "openai", modelName: "gpt-5.5" },
   { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
 ] as const;
 
@@ -69,8 +69,9 @@ export const RECOMMENDED_BUILD_MODELS = {
   alternatives: [
     { provider: "anthropic", modelName: "claude-opus-4-6" },
     { provider: "anthropic", modelName: "claude-sonnet-4-6" },
-    { provider: "openai", modelName: "gpt-5.2" },
-    { provider: "openai", modelName: "gpt-5.1-codex" },
+    { provider: "openai", modelName: "gpt-5.5" },
+    { provider: "openai", modelName: "gpt-5.4" },
+    { provider: "openai", modelName: "gpt-5.3" },
     { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
   ],
 } as const;
@@ -162,8 +163,9 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     label: "OpenAI",
     providerName: "openai",
     models: [
-      { name: "gpt-5.2", label: "GPT-5.2", recommended: true },
-      { name: "gpt-5.1-codex", label: "GPT-5.1 Codex" },
+      { name: "gpt-5.5", label: "GPT-5.5", recommended: true },
+      { name: "gpt-5.4", label: "GPT-5.4" },
+      { name: "gpt-5.3", label: "GPT-5.3" },
     ],
     apiKeyPlaceholder: "sk-...",
     apiKeyUrl: "https://platform.openai.com/api-keys",


### PR DESCRIPTION
## Description

- Onboarding picker recommends gpt-5.5 / 5.4 / 5.3 (was gpt-5.2)
- `LLM_SELECTION_PRIORITY` default updated to match
- `.env.k8s.template` `GEN_AI_MODEL_VERSION` / `FAST` → gpt-5.5 / gpt-5-mini
- `BuildOnboardingModal` now passes `selectedModel` to `testApiKeyHelper`; without it the `/admin/llm/test` call sent `model:""` and Anthropic 400'd, which litellm wrapped as `APIConnectionError` so the UI showed a misleading "Failed to connect to API" toast on every model click

## How Has This Been Tested?

- Click each model in the Craft onboarding picker → test request now includes `model` in the body and succeeds with valid API key
- `npx tsc --noEmit -p .` clean

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump default OpenAI models to gpt-5.5 in onboarding and env templates, and update selection priority. Fix API key test to include the selected model to stop false “Failed to connect” toasts.

- **New Features**
  - Onboarding now recommends `gpt-5.5`, `gpt-5.4`, `gpt-5.3`; `LLM_SELECTION_PRIORITY` updated to prefer `gpt-5.5`.
  - `.env.k8s.template` defaults set to `GEN_AI_MODEL_VERSION=gpt-5.5` and `FAST_GEN_AI_MODEL_VERSION=gpt-5-mini`.

- **Bug Fixes**
  - `BuildOnboardingModal` passes `selectedModel` to `testApiKeyHelper`, so `/admin/llm/test` includes `model` and no longer triggers Anthropic 400s wrapped as `APIConnectionError`.

<sup>Written for commit 3dd0677d141136addf9492bccb794eb7e0cb53f5. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

