### PR TITLE
feat(craft): subagent (child opencode session) endpoints

### DIFF
--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -431,3 +431,15 @@ class BuiltInExternalAppDescriptor(BaseModel):
     auth_template: dict[str, str]
     required_org_credential_fields: list[OrgCredentialFieldDescriptor]
     setup_instructions: str
+
+
+class SubagentDescriptor(BaseModel):
+    """Child opencode session under a parent build session. Pod-ephemeral
+    — no ``BuildSession`` row of its own."""
+
+    opencode_session_id: str
+    parent_opencode_session_id: str
+
+
+class SubagentListResponse(BaseModel):
+    children: list[SubagentDescriptor]

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -10,6 +10,7 @@ from fastapi import File
 from fastapi import HTTPException
 from fastapi import Response
 from fastapi import UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import exists
 from sqlalchemy.orm import Session
@@ -54,6 +55,7 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.manager import UploadLimitExceededError
 from onyx.server.features.build.utils import sanitize_filename
@@ -1030,11 +1032,6 @@ def stream_subagent_events(
     opencode session — otherwise any fabricated id would register a
     long-lived empty-queue subscriber and leak until pod terminate.
     """
-    from fastapi.responses import StreamingResponse
-
-    from onyx.server.features.build.sandbox.base import SSEKeepalive
-    from onyx.server.features.build.session.manager import SessionManager
-
     build_session = get_build_session(session_id, user.id, db_session)
     if build_session is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "session")

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -1,5 +1,6 @@
 """API endpoints for Build Mode session management."""
 
+from collections.abc import Generator
 from datetime import datetime
 from uuid import UUID
 
@@ -38,6 +39,8 @@ from onyx.server.features.build.api.models import SessionResponse
 from onyx.server.features.build.api.models import SessionUpdateRequest
 from onyx.server.features.build.api.models import SetSessionSharingRequest
 from onyx.server.features.build.api.models import SetSessionSharingResponse
+from onyx.server.features.build.api.models import SubagentDescriptor
+from onyx.server.features.build.api.models import SubagentListResponse
 from onyx.server.features.build.api.models import SuggestionBubble
 from onyx.server.features.build.api.models import SuggestionTheme
 from onyx.server.features.build.api.models import UploadResponse
@@ -970,4 +973,107 @@ def get_session_scheduled_run_context(
         task_id=str(context["task_id"]),
         task_name=context["task_name"],
         started_at=context["started_at"],
+    )
+
+
+# =============================================================================
+# Subagent (child opencode session) endpoints
+# =============================================================================
+#
+# Child opencode sessions are pod-ephemeral — not persisted as
+# ``BuildSession`` rows. The bus tracks them in-memory; if the api_server
+# replica restarted recently the list may be empty until new children
+# are observed.
+
+
+@router.get("/{session_id}/subagents")
+def list_session_subagents(
+    session_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> SubagentListResponse:
+    build_session = get_build_session(session_id, user.id, db_session)
+    if build_session is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "session")
+    parent_opencode_id = build_session.opencode_session_id
+    if not parent_opencode_id:
+        return SubagentListResponse(children=[])
+
+    sandbox = get_sandbox_by_user_id(db_session, user.id)
+    if sandbox is None or not sandbox.status.is_active():
+        return SubagentListResponse(children=[])
+
+    sandbox_manager = get_sandbox_manager()
+    child_ids = sandbox_manager.list_subagents(sandbox.id, parent_opencode_id)
+    return SubagentListResponse(
+        children=[
+            SubagentDescriptor(
+                opencode_session_id=child_id,
+                parent_opencode_session_id=parent_opencode_id,
+            )
+            for child_id in child_ids
+        ]
+    )
+
+
+@router.get("/{session_id}/subagents/{child_opencode_id}/events")
+def stream_subagent_events(
+    session_id: UUID,
+    child_opencode_id: str,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> Response:
+    """SSE stream of one subagent's events. Caller closes the request
+    when done; no built-in terminator.
+
+    ``child_opencode_id`` must be a child of the build session's
+    opencode session — otherwise any fabricated id would register a
+    long-lived empty-queue subscriber and leak until pod terminate.
+    """
+    from fastapi.responses import StreamingResponse
+
+    from onyx.server.features.build.sandbox.base import SSEKeepalive
+    from onyx.server.features.build.session.manager import SessionManager
+
+    build_session = get_build_session(session_id, user.id, db_session)
+    if build_session is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "session")
+    parent_opencode_id = build_session.opencode_session_id
+    if not parent_opencode_id:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "session has no opencode session")
+    sandbox = get_sandbox_by_user_id(db_session, user.id)
+    if sandbox is None or not sandbox.status.is_active():
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "sandbox")
+
+    sandbox_manager = get_sandbox_manager()
+    sandbox_id = sandbox.id
+
+    children = sandbox_manager.list_subagents(sandbox_id, parent_opencode_id)
+    if child_opencode_id not in children:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "subagent not registered under this session",
+        )
+
+    def stream_generator() -> Generator[str, None, None]:
+        try:
+            for event in sandbox_manager.subscribe_to_opencode_session(
+                sandbox_id, child_opencode_id
+            ):
+                if isinstance(event, SSEKeepalive):
+                    yield ": keepalive\n\n"
+                    continue
+                event_type = SessionManager._get_event_type(event)
+                yield SessionManager._serialize_acp_event(event, event_type)
+        except GeneratorExit:
+            return
+
+    return StreamingResponse(
+        stream_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )


### PR DESCRIPTION
> Stacked on #11334

## Description

Thin API layer surfacing the child-session tracking already built into `PodEventBus`.

- **GET `/sessions/{id}/subagents`** — list child opencode session ids spawned under this build session (tracked by the per-pod `PodEventBus` from `session.created` events with `parentID`).
- **GET `/sessions/{id}/subagents/{child_opencode_id}/events`** — SSE stream of translated ACP events for one subagent. Authorizes by verifying the child is registered under the parent's opencode session; otherwise any arbitrary id would register a long-lived empty-queue subscriber and leak until pod terminate.

No frontend consumer yet — TUI-style subagent navigation UX (see `session-list.tsx:136`, `subagent-footer.tsx` in `sst/opencode`) is a follow-up.

## How Has This Been Tested?

- Endpoints register correctly under `/api/build/sessions/...`
- Live verification: hit `/subagents` against a session with 3 active subagents → returns all 3 with correct parent ids
- Authz: requesting `/events/<random_id>` returns 404 (`subagent not registered under this session`) instead of opening a leaked subscription

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add API endpoints to list subagents and stream events for a subagent within a build session. Uses per-pod tracking and prevents unauthorized or leaked SSE subscriptions.

- **New Features**
  - GET `/sessions/{id}/subagents` — returns `children` as `[{ opencode_session_id, parent_opencode_session_id }]`; empty if no parent opencode session or sandbox is inactive.
  - GET `/sessions/{id}/subagents/{child_opencode_id}/events` — SSE of translated ACP events for one subagent; validates the child belongs to the parent and returns 404 if session/sandbox is missing, no parent opencode session, or child not registered; includes keepalive events.

- **Refactors**
  - Move `StreamingResponse` and `SSEKeepalive` imports to module level for consistency with other streaming endpoints.

<sup>Written for commit 801ebcea6fba3e85cc89061ee17e58d439ffcff9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

