### PR TITLE
fix(opal): correct case in Button import path

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -10,7 +10,7 @@ export {
 export {
   Button,
   type ButtonProps,
-} from "@opal/components/buttons/button/components";
+} from "@opal/components/buttons/Button/components";
 
 /* SelectButton */
 export {


### PR DESCRIPTION
## Description

The directory `web/lib/opal/src/components/buttons/Button/` is Pascal-case, but `web/lib/opal/src/components/index.ts` imported it as lowercase `buttons/button/components`. macOS's case-insensitive filesystem silently resolved the mismatch; Linux is case-sensitive and errors with:

```
Module not found: Can't resolve '@opal/components/buttons/button/components'
```

This was discovered while building a fresh dev image for a Tilt + k3d local-cluster workflow on a Linux container. The same bug would surface in CI any time the registry layer cache miss forces a cold rebuild of the web image, since the bun install + opal prepare path-alias resolution would hit the same case mismatch.

Single-character change: lowercase `b` -> uppercase `B` in one import path.

## How Has This Been Tested?

- `grep -rn '"@opal/components/buttons/button[/"]' web/` returns no matches after the fix.
- The Pascal-case directory `web/lib/opal/src/components/buttons/Button/` is the canonical location (matches every other import site).
- Re-ran the Linux dev image build and Next.js compiles past this error.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Button export path case in `web/lib/opal/src/components/index.ts` to match the Pascal-case directory and prevent Linux/CI build failures. Updates import from `@opal/components/buttons/button/components` to `@opal/components/buttons/Button/components`.

<sup>Written for commit 6119b4de0179d1d7864ab9a54701da7c2b83dc24. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

