### PR TITLE
fix(images): deduplicate project images and add opt-in Azure cap

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -485,16 +485,6 @@ def construct_message_history(
                         forgotten_meta, token_counter
                     )
 
-    # Attach project images to the last user message
-    if context_files and context_files.image_files:
-        existing_images = last_user_message.image_files or []
-        last_user_message = ChatMessageSimple(
-            message=last_user_message.message,
-            token_count=last_user_message.token_count,
-            message_type=last_user_message.message_type,
-            image_files=existing_images + context_files.image_files,
-        )
-
     # Build the final message list according to README ordering:
     # [system], [history_before_last_user], [custom_agent], [context_files],
     # [forgotten_files], [last_user_message], [messages_after_last_user], [reminder]

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -16,6 +16,7 @@ from onyx.chat.emitter import Emitter
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import LlmStepResult
 from onyx.chat.tool_call_args_streaming import maybe_emit_argument_delta
+from onyx.configs.app_configs import ENABLE_AZURE_IMAGE_CAP
 from onyx.configs.app_configs import LOG_ONYX_MODEL_INTERACTIONS
 from onyx.configs.app_configs import PROMPT_CACHE_CHAT_HISTORY
 from onyx.configs.constants import MessageType
@@ -42,6 +43,7 @@ from onyx.llm.models import UserMessage
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.utils import model_needs_formatting_reenabled
 from onyx.prompts.chat_prompts import CODE_BLOCK_MARKDOWN
+from onyx.prompts.chat_prompts import IMAGE_DROP_REMINDER
 from onyx.prompts.constants import SYSTEM_REMINDER_TAG_CLOSE
 from onyx.prompts.constants import SYSTEM_REMINDER_TAG_OPEN
 from onyx.server.query_and_chat.placement import Placement
@@ -771,6 +773,59 @@ def _get_history_message_formatter(llm_config: LLMConfig) -> _HistoryMessageForm
     return _DEFAULT_HISTORY_MESSAGE_FORMATTER
 
 
+# Azure OpenAI documents a 50-image limit per request; other Azure-hosted
+# models don't publish one. When ENABLE_AZURE_IMAGE_CAP=true is set, we cap
+# all Azure providers at 50 to avoid raw 400s from the gateway. Off by
+# default — no cap is applied to any provider.
+_AZURE_DEFAULT_IMAGE_CAP = 50
+
+
+def _is_azure_provider(model_provider: str) -> bool:
+    """True for any provider whose name starts with 'azure'."""
+    return model_provider.startswith("azure")
+
+
+def resolve_image_cap(model_provider: str) -> int | None:
+    """Return the per-request image-count cap, or None if no cap should be
+    enforced. Only Azure providers are capped, and only when
+    ENABLE_AZURE_IMAGE_CAP=true is set."""
+    if ENABLE_AZURE_IMAGE_CAP and _is_azure_provider(model_provider):
+        return _AZURE_DEFAULT_IMAGE_CAP
+    return None
+
+
+def _select_recent_image_indices(
+    history: list[ChatMessageSimple], cap: int
+) -> tuple[set[tuple[int, int]], int]:
+    """Pick which (msg_idx, img_idx) positions to keep when the request has
+    more images than the cap. Walks messages newest-to-oldest (recency wins
+    across turns) but walks images within each message in attachment order
+    (earlier positions preferred). This matters in mixed messages where
+    user-attached images appear first in image_files and project-context
+    images are appended at the end — when the cap bites, we prefer to keep
+    what the user explicitly attached over project-context fill.
+
+    Returns the keep-set and the count of images that would be dropped. Only
+    ChatFileType.IMAGE entries on USER messages count — that matches what
+    translate_history_to_llm_format actually emits, so cap slots aren't
+    wasted on images that would never reach the LLM."""
+    keep: set[tuple[int, int]] = set()
+    total = 0
+    kept = 0
+    for msg_idx in range(len(history) - 1, -1, -1):
+        msg = history[msg_idx]
+        if msg.message_type != MessageType.USER or not msg.image_files:
+            continue
+        for img_idx, img in enumerate(msg.image_files):
+            if img.file_type != ChatFileType.IMAGE:
+                continue
+            total += 1
+            if kept < cap:
+                keep.add((msg_idx, img_idx))
+                kept += 1
+    return keep, max(0, total - cap)
+
+
 def translate_history_to_llm_format(
     history: list[ChatMessageSimple],
     llm_config: LLMConfig,
@@ -787,6 +842,28 @@ def translate_history_to_llm_format(
     # may be less semantically meaningful, but it remains safe and order-preserving.
     last_cacheable_msg_idx = -1
     all_previous_msgs_cacheable = True
+
+    # Per-request image cap (provider-aware). When the cap is enforced and
+    # images are dropped, we emit a system-reminder UserMessage at the end of
+    # the translated request — the same pattern MessageType.USER_REMINDER uses.
+    image_cap = resolve_image_cap(llm_config.model_provider)
+    keep_image_indices: set[tuple[int, int]] | None = None
+    image_drop_notice: str | None = None
+    if image_cap is not None:
+        keep_image_indices, dropped_image_count = _select_recent_image_indices(
+            history, image_cap
+        )
+        if dropped_image_count > 0:
+            logger.warning(
+                "Image cap enforced: provider=%s model=%s cap=%d dropped=%d",
+                llm_config.model_provider,
+                llm_config.model_name,
+                image_cap,
+                dropped_image_count,
+            )
+            image_drop_notice = IMAGE_DROP_REMINDER.format(
+                dropped_count=dropped_image_count
+            )
 
     for idx, msg in enumerate(history):
         # if the message is being added to the history
@@ -821,34 +898,40 @@ def translate_history_to_llm_format(
                     )
                 ]
 
-                # Add image parts
-                for img_file in msg.image_files:
-                    if img_file.file_type == ChatFileType.IMAGE:
-                        try:
-                            image_type = get_image_type_from_bytes(img_file.content)
-                            base64_data = img_file.to_base64()
-                            image_url = f"data:{image_type};base64,{base64_data}"
+                # Add image parts (skipping any beyond the per-request cap)
+                for img_idx, img_file in enumerate(msg.image_files):
+                    if img_file.file_type != ChatFileType.IMAGE:
+                        continue
+                    if (
+                        keep_image_indices is not None
+                        and (idx, img_idx) not in keep_image_indices
+                    ):
+                        continue
+                    try:
+                        image_type = get_image_type_from_bytes(img_file.content)
+                        base64_data = img_file.to_base64()
+                        image_url = f"data:{image_type};base64,{base64_data}"
 
-                            content_parts.append(
-                                TextContentPart(
-                                    type="text",
-                                    text=f"[attached image — file_id: {img_file.file_id}]",
-                                )
+                        content_parts.append(
+                            TextContentPart(
+                                type="text",
+                                text=f"[attached image — file_id: {img_file.file_id}]",
                             )
-                            image_part = ImageContentPart(
-                                type="image_url",
-                                image_url=ImageUrlDetail(
-                                    url=image_url,
-                                    detail=None,
-                                ),
-                            )
-                            content_parts.append(image_part)
-                        except Exception as e:
-                            logger.warning(
-                                "Failed to process image file %s: %s. Skipping image.",
-                                img_file.file_id,
-                                e,
-                            )
+                        )
+                        image_part = ImageContentPart(
+                            type="image_url",
+                            image_url=ImageUrlDetail(
+                                url=image_url,
+                                detail=None,
+                            ),
+                        )
+                        content_parts.append(image_part)
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to process image file %s: %s. Skipping image.",
+                            img_file.file_id,
+                            e,
+                        )
                 user_msg = UserMessage(
                     role="user",
                     content=content_parts,
@@ -883,6 +966,17 @@ def translate_history_to_llm_format(
                 "Unknown message type %s in history. Skipping message.",
                 msg.message_type,
             )
+
+    # Surface the image-drop notice as a trailing system-reminder UserMessage
+    # — mirrors how MessageType.USER_REMINDER is wrapped (see USER_REMINDER
+    # branch above). Keeps operational metadata out of the user's content.
+    if image_drop_notice is not None:
+        wrapped = (
+            f"{SYSTEM_REMINDER_TAG_OPEN}\n"
+            f"{image_drop_notice}\n"
+            f"{SYSTEM_REMINDER_TAG_CLOSE}"
+        )
+        messages.append(UserMessage(role="user", content=wrapped))
 
     # Apply model-specific formatting when translating to LLM format (e.g. OpenAI
     # reasoning models need CODE_BLOCK_MARKDOWN prefix for correct markdown generation)

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1040,6 +1040,13 @@ LOG_ONYX_MODEL_INTERACTIONS = (
 PROMPT_CACHE_CHAT_HISTORY = (
     os.environ.get("PROMPT_CACHE_CHAT_HISTORY", "").lower() == "true"
 )
+
+# Opt-in cap on outgoing image-count for Azure providers (any model_provider
+# starting with "azure"). When enabled, requests are capped at 50 images each
+# (matching the documented Azure OpenAI ceiling) to avoid raw 400s from the
+# gateway. Off by default.
+ENABLE_AZURE_IMAGE_CAP = os.environ.get("ENABLE_AZURE_IMAGE_CAP", "").lower() == "true"
+
 # If set to `true` will enable additional logs about Vespa query performance
 # (time spent on finding the right docs + time spent fetching summaries from disk)
 LOG_VESPA_TIMING_INFORMATION = (

--- a/backend/onyx/prompts/chat_prompts.py
+++ b/backend/onyx/prompts/chat_prompts.py
@@ -74,6 +74,13 @@ If you reference or share these files, use the exact markdown format [filename](
 """.strip()
 
 
+# Wrapped in <system-reminder> tags by translate_history_to_llm_format when
+# the per-request image cap drops images from the outgoing request.
+IMAGE_DROP_REMINDER = """
+{dropped_count} earlier image(s) attached to this conversation were omitted to fit the model's per-request image limit.
+""".strip()
+
+
 # Specifically for OpenAI models, this prefix needs to be in place for the model to output markdown and correct styling
 CODE_BLOCK_MARKDOWN = "Formatting re-enabled. "
 

--- a/backend/tests/unit/onyx/chat/test_chat_utils.py
+++ b/backend/tests/unit/onyx/chat/test_chat_utils.py
@@ -1,13 +1,19 @@
 """Tests for chat_utils.py, specifically get_custom_agent_prompt."""
 
 from io import BytesIO
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from onyx.chat.chat_utils import _build_tool_call_response_history_message
 from onyx.chat.chat_utils import _get_or_extract_plaintext
+from onyx.chat.chat_utils import convert_chat_history
 from onyx.chat.chat_utils import get_custom_agent_prompt
+from onyx.chat.models import ChatLoadedFile
 from onyx.configs.constants import DEFAULT_PERSONA_ID
+from onyx.configs.constants import MessageType
+from onyx.db.models import ChatMessage
+from onyx.file_store.models import ChatFileType
 from onyx.prompts.chat_prompts import TOOL_CALL_RESPONSE_CROSS_MESSAGE
 
 
@@ -235,3 +241,71 @@ class TestGetOrExtractPlaintext:
         assert result == ""
         extract_fn.assert_called_once()
         store_plaintext.assert_called_once_with("file-3", "")
+
+
+class TestConvertChatHistory:
+    """Tests for convert_chat_history.
+
+    Regression coverage for the project-image duplication bug: project images
+    (passed via ``context_image_files``) must attach to the last USER message
+    exactly once, and only to the last USER message — even when earlier USER
+    messages exist in the history.
+    """
+
+    def _make_chat_message(
+        self,
+        message: str,
+        message_type: MessageType,
+        token_count: int = 5,
+    ) -> MagicMock:
+        msg = MagicMock()
+        msg.message = message
+        msg.message_type = message_type
+        msg.token_count = token_count
+        msg.files = None
+        msg.tool_calls = None
+        return msg
+
+    def test_attaches_project_images_to_last_user_message_only_once(
+        self,
+    ) -> None:
+        project_image = ChatLoadedFile(
+            file_id="project_image",
+            content=b"",
+            file_type=ChatFileType.IMAGE,
+            filename="project.png",
+            content_text=None,
+            token_count=50,
+        )
+
+        chat_history = [
+            self._make_chat_message("First question", MessageType.USER),
+            self._make_chat_message("First answer", MessageType.ASSISTANT),
+            self._make_chat_message("Second question", MessageType.USER),
+        ]
+
+        result = convert_chat_history(
+            chat_history=cast(list[ChatMessage], chat_history),
+            files=[],
+            context_image_files=[project_image],
+            additional_context=None,
+            token_counter=lambda s: len(s),
+            tool_id_to_name_map={},
+        )
+
+        user_messages = [
+            m for m in result.simple_messages if m.message_type == MessageType.USER
+        ]
+        assert len(user_messages) == 2
+
+        # First USER message must NOT carry the project image.
+        first_user = user_messages[0]
+        assert first_user.message == "First question"
+        assert first_user.image_files is None
+
+        # Last USER message carries the project image exactly once.
+        last_user = user_messages[-1]
+        assert last_user.message == "Second question"
+        assert last_user.image_files is not None
+        assert len(last_user.image_files) == 1
+        assert last_user.image_files[0].file_id == "project_image"

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -278,54 +278,41 @@ class TestConstructMessageHistory:
         assert result[4] == user_msg2  # Last user message
         assert result[5] == assistant_with_tool  # After last user message
 
-    def test_project_images_attached_to_last_user_message(self) -> None:
-        """Test that project images are attached to the last user message."""
-        system_prompt = create_message("System", MessageType.SYSTEM, 10)
-        user_msg1 = create_message("First", MessageType.USER, 5)
-        user_msg2 = create_message("Second", MessageType.USER, 5)
-
-        simple_chat_history = [user_msg1, user_msg2]
-        context_files = create_context_files(num_files=0, num_images=2)
-
-        result = construct_message_history(
-            system_prompt=system_prompt,
-            custom_agent_prompt=None,
-            simple_chat_history=simple_chat_history,
-            reminder_message=None,
-            context_files=context_files,
-            available_tokens=1000,
-        )
-
-        # Last message should have the project images
-        last_message = result[-1]
-        assert last_message.message == "Second"
-        assert last_message.image_files is not None
-        assert len(last_message.image_files) == 2
-        assert last_message.image_files[0].file_id == "image_0"
-        assert last_message.image_files[1].file_id == "image_1"
-
-    def test_project_images_preserve_existing_images(self) -> None:
-        """Test that project images are appended to existing images on the user message."""
+    def test_construct_message_history_does_not_duplicate_project_images(
+        self,
+    ) -> None:
+        """Project images are attached upstream in convert_chat_history; this
+        function must not re-attach them. Simulates the realistic state where
+        the last user message in simple_chat_history already carries the
+        project images, and asserts they appear exactly once."""
         system_prompt = create_message("System", MessageType.SYSTEM, 10)
 
-        # Create a user message with existing images
-        existing_image = ChatLoadedFile(
-            file_id="existing_image",
+        project_image = ChatLoadedFile(
+            file_id="project_image",
             content=b"",
             file_type=ChatFileType.IMAGE,
-            filename="existing.png",
+            filename="project.png",
             content_text=None,
             token_count=50,
         )
+        # Simulate convert_chat_history's output: the last user message already
+        # has the project image attached.
         user_msg = ChatMessageSimple(
-            message="Message with image",
+            message="What is in this image?",
             token_count=5,
             message_type=MessageType.USER,
-            image_files=[existing_image],
+            image_files=[project_image],
         )
 
         simple_chat_history = [user_msg]
-        context_files = create_context_files(num_files=0, num_images=1)
+        context_files = ExtractedContextFiles(
+            file_texts=[],
+            image_files=[project_image],
+            use_as_search_filter=False,
+            total_token_count=0,
+            file_metadata=[],
+            uncapped_token_count=0,
+        )
 
         result = construct_message_history(
             system_prompt=system_prompt,
@@ -336,12 +323,11 @@ class TestConstructMessageHistory:
             available_tokens=1000,
         )
 
-        # Last message should have both existing and project images
         last_message = result[-1]
+        assert last_message.message == "What is in this image?"
         assert last_message.image_files is not None
-        assert len(last_message.image_files) == 2
-        assert last_message.image_files[0].file_id == "existing_image"
-        assert last_message.image_files[1].file_id == "image_0"
+        assert len(last_message.image_files) == 1
+        assert last_message.image_files[0].file_id == "project_image"
 
     def test_truncation_from_top(self) -> None:
         """Test that history is truncated from the top when token budget is exceeded."""

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from onyx.chat import llm_step as llm_step_module
 from onyx.chat.llm_step import _extract_tool_call_kickoffs
 from onyx.chat.llm_step import _increment_turns
 from onyx.chat.llm_step import _parse_tool_args_to_dict
@@ -11,14 +12,22 @@ from onyx.chat.llm_step import _resolve_tool_arguments
 from onyx.chat.llm_step import _XmlToolCallContentFilter
 from onyx.chat.llm_step import extract_tool_calls_from_response_text
 from onyx.chat.llm_step import translate_history_to_llm_format
+from onyx.chat.models import ChatLoadedFile
 from onyx.chat.models import ChatMessageSimple
 from onyx.chat.models import ToolCallSimple
 from onyx.configs.constants import MessageType
+from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMConfig
 from onyx.llm.models import AssistantMessage
+from onyx.llm.models import TextContentPart
 from onyx.llm.models import ToolMessage
 from onyx.llm.models import UserMessage
+from onyx.llm.well_known_providers.constants import AZURE_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import OPENAI_PROVIDER_NAME
+from onyx.prompts.chat_prompts import IMAGE_DROP_REMINDER
+from onyx.prompts.constants import SYSTEM_REMINDER_TAG_CLOSE
+from onyx.prompts.constants import SYSTEM_REMINDER_TAG_OPEN
 from onyx.server.query_and_chat.placement import Placement
 from onyx.utils.postgres_sanitization import sanitize_string
 
@@ -581,3 +590,133 @@ class TestTranslateHistoryToLlmFormat:
                 ],
                 llm_config=self._llm_config(provider),
             )
+
+
+# Minimal valid PNG header bytes so get_image_type_from_bytes returns image/png
+# instead of raising — keeps the image-emission path running in tests.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _make_image(file_id: str) -> ChatLoadedFile:
+    return ChatLoadedFile(
+        file_id=file_id,
+        content=_PNG_BYTES,
+        file_type=ChatFileType.IMAGE,
+        filename=f"{file_id}.png",
+        content_text=None,
+        token_count=50,
+    )
+
+
+def _make_user_msg(
+    text: str, images: list[ChatLoadedFile] | None = None
+) -> ChatMessageSimple:
+    return ChatMessageSimple(
+        message=text,
+        token_count=5,
+        message_type=MessageType.USER,
+        image_files=images,
+    )
+
+
+def _make_llm_config(provider: str) -> LLMConfig:
+    return LLMConfig(
+        model_provider=provider,
+        model_name="test-model",
+        temperature=0,
+        max_input_tokens=8192,
+    )
+
+
+_ATTACHED_IMAGE_PREFIX = "[attached image — file_id: "
+_ATTACHED_IMAGE_SUFFIX = "]"
+
+
+def _attached_image_file_ids(user_msg: UserMessage) -> list[str]:
+    """Return file_ids in order, parsed from the per-image label text parts
+    emitted by translate_history_to_llm_format. Lets tests assert
+    `... == ["img0", "img1", ...]` instead of poking at substrings."""
+    if not isinstance(user_msg.content, list):
+        return []
+    return [
+        p.text[len(_ATTACHED_IMAGE_PREFIX) : -len(_ATTACHED_IMAGE_SUFFIX)]
+        for p in user_msg.content
+        if isinstance(p, TextContentPart) and p.text.startswith(_ATTACHED_IMAGE_PREFIX)
+    ]
+
+
+def _expected_image_drop_reminder(dropped_count: int) -> str:
+    """Build the exact wrapped reminder string a test should compare against."""
+    return (
+        f"{SYSTEM_REMINDER_TAG_OPEN}\n"
+        f"{IMAGE_DROP_REMINDER.format(dropped_count=dropped_count)}\n"
+        f"{SYSTEM_REMINDER_TAG_CLOSE}"
+    )
+
+
+class TestImageCap:
+    """End-to-end tests for the Azure-family image cap (translate_history_to_llm_format).
+
+    Three invariants worth pinning down — anything more is double coverage of
+    the same 30-line feature.
+    """
+
+    def test_disabled_by_default_passes_everything_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ENABLE_AZURE_IMAGE_CAP, even an Azure request with many
+        images flows untouched (no drops, no trailing reminder)."""
+        monkeypatch.setattr(llm_step_module, "ENABLE_AZURE_IMAGE_CAP", False)
+        history = [
+            _make_user_msg("hi", images=[_make_image(f"img{i}") for i in range(100)])
+        ]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(AZURE_PROVIDER_NAME)
+        )
+        assert isinstance(translated, list)
+        assert len(translated) == 1
+        assert isinstance(translated[0], UserMessage)
+        assert len(_attached_image_file_ids(translated[0])) == 100
+
+    def test_enabled_caps_azure_keeps_first_attachments_and_emits_reminder(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Azure + cap enabled + over-limit → first-N attachments survive
+        (user-attached preferred over later project-context fill), and a
+        trailing system-reminder UserMessage is emitted with the centralized
+        IMAGE_DROP_REMINDER prompt."""
+        monkeypatch.setattr(llm_step_module, "ENABLE_AZURE_IMAGE_CAP", True)
+        monkeypatch.setattr(llm_step_module, "_AZURE_DEFAULT_IMAGE_CAP", 3)
+        history = [
+            _make_user_msg(
+                "describe", images=[_make_image(f"img{i}") for i in range(5)]
+            )
+        ]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(AZURE_PROVIDER_NAME)
+        )
+        assert isinstance(translated, list)
+        assert len(translated) == 2
+        user_msg, reminder = translated
+        assert isinstance(user_msg, UserMessage)
+        assert _attached_image_file_ids(user_msg) == ["img0", "img1", "img2"]
+        assert isinstance(reminder, UserMessage)
+        assert reminder.content == _expected_image_drop_reminder(dropped_count=2)
+
+    def test_enabled_does_not_cap_non_azure_providers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The only way the Azure-prefix check could regress: a non-Azure
+        provider getting capped. Pin this down."""
+        monkeypatch.setattr(llm_step_module, "ENABLE_AZURE_IMAGE_CAP", True)
+        monkeypatch.setattr(llm_step_module, "_AZURE_DEFAULT_IMAGE_CAP", 3)
+        history = [
+            _make_user_msg("hi", images=[_make_image(f"img{i}") for i in range(5)])
+        ]
+        translated = translate_history_to_llm_format(
+            history=history, llm_config=_make_llm_config(OPENAI_PROVIDER_NAME)
+        )
+        assert isinstance(translated, list)
+        assert len(translated) == 1
+        assert isinstance(translated[0], UserMessage)
+        assert len(_attached_image_file_ids(translated[0])) == 5


### PR DESCRIPTION
## Description
  - Fix: project-attached images were being sent to the LLM twice per request when used in a chat under a Project, doubling image-token cost and surfacing the Azure 50-image-per-request ceiling at half the expected count. Each project image now reaches the model exactly once per turn.
  - Add: opt-in `ENABLE_AZURE_IMAGE_CAP` env var that caps outgoing requests at 50 images for Azure-family providers (matching the documented Azure OpenAI ceiling, [Microsoft Learn — Quotas and Limits (https://learn.microsoft.com/en-us/azure/foundry/openai/quotas-limits)). When engaged, the most recent attachments are kept, older ones are dropped, and a `<system-reminder>` notice is appended so the model can acknowledge missing context. Off by default; non-Azure providers are never capped.

## How Has This Been Tested?
  - New unit tests in `test_llm_step.py`, `test_chat_utils.py`, and updated tests in `test_llm_loop.py`. Run with `pytest
  backend/tests/unit/onyx/chat/`.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending project images twice and ensures each image is included once per turn. Adds an opt-in 50-image cap for Azure providers with a clear reminder when images are dropped.

- **Bug Fixes**
  - Project images are no longer duplicated; they appear exactly once on the last user message per turn.

- **New Features**
  - Opt-in Azure image cap: when `ENABLE_AZURE_IMAGE_CAP=true`, cap Azure-family providers to 50 images per request; keep the most recent images across turns and prefer earlier attachments within a message; non-Azure providers are never capped.
  - If images are dropped, append a trailing `<system-reminder>` user message so the model knows some context was omitted.

<sup>Written for commit feee087e60971f2badcbb6a01e266aa9f5fd9cdf. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11344?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

