### PR TITLE
docs: add Coolify deployment guide

### DIFF
--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -10,6 +10,8 @@ This README focuses on the easiest guided deployment which is via install.sh.
 
 **For more detailed guides, please refer to the documentation: https://docs.onyx.app/deployment/overview**
 
+If you are deploying with Coolify, see [Coolify setup](./coolify.md).
+
 ## install.sh script
 
 ```

--- a/deployment/docker_compose/coolify.md
+++ b/deployment/docker_compose/coolify.md
@@ -1,0 +1,33 @@
+# Onyx on Coolify
+
+Coolify can run Onyx from the existing Docker Compose stack.
+
+## Recommended setup
+
+- **Resource type:** Docker Compose
+- **Repository:** this repo
+- **Base directory:** `deployment/docker_compose`
+- **Compose file:** `docker-compose.prod-no-letsencrypt.yml`
+- **Public entrypoint:** the `nginx` service
+- **Persistent data:** keep the `../data` directory and the named Docker volumes created by the stack
+
+## Environment variables
+
+Copy the values from `env.template` into Coolify's environment editor.
+The minimum values you should set explicitly are:
+
+- `IMAGE_TAG=latest`
+- `USER_AUTH_SECRET=<random hex>`
+- `POSTGRES_USER=<your postgres user>`
+- `POSTGRES_PASSWORD=<your postgres password>`
+- `WEB_DOMAIN=https://your-domain.example`
+- `COMPOSE_PROFILES=s3-filestore`
+- `FILE_STORE_BACKEND=s3`
+
+If you want to use PostgreSQL for file storage instead of MinIO, set `FILE_STORE_BACKEND=postgres` and remove `s3-filestore` from `COMPOSE_PROFILES`.
+
+## Notes for Coolify
+
+- Coolify already provides TLS termination, so keep only one public ingress path.
+- If your Coolify deployment template insists on publishing host ports, remove the `ports:` block from the `nginx` service before applying the compose file.
+- If you want a smaller footprint, you can also use `docker-compose.onyx-lite.yml` as the base overlay and enable only the services you need.


### PR DESCRIPTION
## Summary\n- Add a Coolify-specific deployment guide for the existing Onyx Docker Compose stack\n- Link the new guide from the main deployment README\n- Call out the key env vars and Coolify ingress notes\n\n## Test Plan\n- Docs-only change\n- Verified with `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Coolify deployment guide for the Onyx Docker Compose stack and link it from the Docker Compose README. The guide covers recommended Coolify settings, required env vars, and ingress/TLS notes to make deployment straightforward.

<sup>Written for commit def838eaed0f74088141dcc36607279830265a6f. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

