### PR TITLE
feat(craft): Built-in apps for slack, gcal, linear

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -128,10 +128,6 @@ def create_external_app(
       raises ``OnyxError(DUPLICATE_RESOURCE)``.
     - A ``CUSTOM`` app gets a custom (bundle-backed) skill row with a fresh
       slug, so multiple instances can coexist.
-
-    Deferred import: ``db.skill`` imports ``is_user_authenticated_for_app`` from
-    this module to filter listings, so the dependency only flows one way at
-    module-load time.
     """
     from onyx.db.skill import create_built_in_skill_row__no_commit
     from onyx.db.skill import create_skill__no_commit

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -5,15 +5,12 @@ from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
-from onyx.db.models import Skill
-from onyx.db.utils import is_unique_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
@@ -181,50 +178,6 @@ def create_external_app(
     return app
 
 
-def _rebind_skill_for_app_type__no_commit(
-    skill: Skill,
-    app_type: ExternalAppType,
-    db_session: Session,
-) -> None:
-    """Keep the linked skill's definition source in lockstep with the app's
-    provider type after an update. A built-in provider type binds the row to
-    that provider's built-in content (``built_in_skill_id`` + ``slug`` + NULL
-    bundle); ``CUSTOM`` reverts it to a custom (bundle-backed) row. No-op when
-    the row already matches.
-
-    Raises ``OnyxError(DUPLICATE_RESOURCE)`` if rebinding would collide with an
-    existing row for the same provider in this tenant.
-    """
-    target_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
-    if target_id is not None:
-        if skill.built_in_skill_id == target_id:
-            return
-        skill.built_in_skill_id = target_id
-        skill.slug = target_id
-        skill.bundle_file_id = None
-        skill.bundle_sha256 = None
-    else:
-        if skill.built_in_skill_id is None:
-            return
-        skill.built_in_skill_id = None
-        # Custom rows satisfy the XOR check constraint via a (currently empty)
-        # bundle rather than a built-in id.
-        skill.bundle_file_id = ""
-        skill.bundle_sha256 = ""
-
-    from onyx.db.skill import SKILL_SLUG_UNIQUE_CONSTRAINT
-
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{skill.slug}' already exists.",
-            ) from e
-        raise
-
-
 def update_external_app(
     db_session: Session,
     external_app_id: int,
@@ -240,13 +193,16 @@ def update_external_app(
     committing both atomically.
 
     Skill-side fields: name, description, enabled.
-    External-app-side fields: app_type, upstream_url_patterns,
-    auth_template, organization_credentials.
+    External-app-side fields: upstream_url_patterns, auth_template,
+    organization_credentials.
 
-    Slug, bundle, and sharing scope are out of scope here (each has its
-    own update path in ``onyx.db.skill``).
+    ``app_type`` is immutable — it's the discriminator the OAuth dispatch
+    layer keys off and what the backing skill's definition source is bound
+    to, so it's passed for validation only. Slug, bundle, and sharing scope
+    are out of scope here (each has its own update path in ``onyx.db.skill``).
 
-    Raises ``OnyxError(NOT_FOUND)`` if no row with `external_app_id` exists.
+    Raises ``OnyxError(NOT_FOUND)`` if no row with `external_app_id` exists,
+    or ``OnyxError(INVALID_INPUT)`` if `app_type` differs from the stored value.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -255,18 +211,22 @@ def update_external_app(
             f"External app with id {external_app_id} not found.",
         )
 
+    # app_type is immutable. Changing it would silently rebind the skill's
+    # definition source
+    if app.app_type != app_type:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"app_type is immutable; cannot change from "
+            f"'{app.app_type.value}' to '{app_type.value}'.",
+        )
+
     app.skill.name = name
     app.skill.description = description
     app.skill.enabled = enabled
 
-    app.app_type = app_type
     app.upstream_url_patterns = upstream_url_patterns
     app.auth_template = auth_template
     app.organization_credentials = organization_credentials
-
-    # Provider type drives which skill content is delivered, so keep the
-    # backing skill row's definition source aligned when app_type changes.
-    _rebind_skill_for_app_type__no_commit(app.skill, app_type, db_session)
 
     db_session.commit()
     return app

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -1,17 +1,22 @@
 import re
 from typing import Any
 from uuid import UUID
+from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
+from onyx.db.models import Skill
+from onyx.db.utils import is_unique_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -101,11 +106,9 @@ def get_user_credentials_by_app_id(
 
 def create_external_app(
     db_session: Session,
-    slug: str,
+    *,
     name: str,
     description: str,
-    bundle_file_id: str,
-    bundle_sha256: str,
     app_type: ExternalAppType,
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],
@@ -119,27 +122,53 @@ def create_external_app(
     (name/description) and lifecycle (enabled); the external_app row owns
     gateway state (auth_template, upstream patterns, org creds).
 
-    `create_skill` raises ``OnyxError(DUPLICATE_RESOURCE)`` on slug collision
-    (before anything is committed).
+    The skill row's *shape* is derived from ``app_type``:
+
+    - A built-in provider (``EXTERNAL_APP_BUILT_IN_SKILL_IDS``) gets a built-in
+      skill row (``built_in_skill_id`` set, ``slug`` == that id) so it delivers
+      its bundled on-disk content through the same path as a seeded built-in.
+      Slug uniqueness means one instance per provider per tenant — a duplicate
+      raises ``OnyxError(DUPLICATE_RESOURCE)``.
+    - A ``CUSTOM`` app gets a custom (bundle-backed) skill row with a fresh
+      slug, so multiple instances can coexist.
+
+    Deferred import: ``db.skill`` imports ``is_user_authenticated_for_app`` from
+    this module to filter listings, so the dependency only flows one way at
+    module-load time.
     """
-    # Deferred import: `db.skill` imports `is_user_authenticated_for_app`
-    # from this module to filter listings, so the dependency only flows
-    # one way at module-load time.
+    from onyx.db.skill import create_built_in_skill_row__no_commit
     from onyx.db.skill import create_skill__no_commit
 
-    skill = create_skill__no_commit(
-        slug=slug,
-        name=name,
-        description=description,
-        bundle_file_id=bundle_file_id,
-        bundle_sha256=bundle_sha256,
-        is_public=is_public,
-        author_user_id=author_user_id,
-        db_session=db_session,
-    )
-    # `create_skill` hardcodes enabled=True; honour the caller's intent.
-    if not enabled:
-        skill.enabled = False
+    built_in_skill_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
+    if built_in_skill_id is not None:
+        skill = create_built_in_skill_row__no_commit(
+            built_in_skill_id=built_in_skill_id,
+            name=name,
+            description=description,
+            is_public=is_public,
+            enabled=enabled,
+            author_user_id=author_user_id,
+            db_session=db_session,
+        )
+    else:
+        # CUSTOM: fresh slug so multiple instances don't collide. The bundle is
+        # intentionally empty for now — custom-app bundle rendering is a
+        # separate workstream.
+        slug = f"{app_type.value.lower()}-{uuid4().hex[:8]}"
+        skill = create_skill__no_commit(
+            slug=slug,
+            name=name,
+            description=description,
+            bundle_file_id="",
+            bundle_sha256="",
+            is_public=is_public,
+            author_user_id=author_user_id,
+            db_session=db_session,
+        )
+        # `create_skill` hardcodes enabled=True; honour the caller's intent.
+        if not enabled:
+            skill.enabled = False
+
     app = ExternalApp(
         skill_id=skill.id,
         app_type=app_type,
@@ -150,6 +179,50 @@ def create_external_app(
     db_session.add(app)
     db_session.commit()
     return app
+
+
+def _rebind_skill_for_app_type__no_commit(
+    skill: Skill,
+    app_type: ExternalAppType,
+    db_session: Session,
+) -> None:
+    """Keep the linked skill's definition source in lockstep with the app's
+    provider type after an update. A built-in provider type binds the row to
+    that provider's built-in content (``built_in_skill_id`` + ``slug`` + NULL
+    bundle); ``CUSTOM`` reverts it to a custom (bundle-backed) row. No-op when
+    the row already matches.
+
+    Raises ``OnyxError(DUPLICATE_RESOURCE)`` if rebinding would collide with an
+    existing row for the same provider in this tenant.
+    """
+    target_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
+    if target_id is not None:
+        if skill.built_in_skill_id == target_id:
+            return
+        skill.built_in_skill_id = target_id
+        skill.slug = target_id
+        skill.bundle_file_id = None
+        skill.bundle_sha256 = None
+    else:
+        if skill.built_in_skill_id is None:
+            return
+        skill.built_in_skill_id = None
+        # Custom rows satisfy the XOR check constraint via a (currently empty)
+        # bundle rather than a built-in id.
+        skill.bundle_file_id = ""
+        skill.bundle_sha256 = ""
+
+    from onyx.db.skill import SKILL_SLUG_UNIQUE_CONSTRAINT
+
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{skill.slug}' already exists.",
+            ) from e
+        raise
 
 
 def update_external_app(
@@ -190,6 +263,10 @@ def update_external_app(
     app.upstream_url_patterns = upstream_url_patterns
     app.auth_template = auth_template
     app.organization_credentials = organization_credentials
+
+    # Provider type drives which skill content is delivered, so keep the
+    # backing skill row's definition source aligned when app_type changes.
+    _rebind_skill_for_app_type__no_commit(app.skill, app_type, db_session)
 
     db_session.commit()
     return app

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -103,9 +103,10 @@ def get_user_credentials_by_app_id(
 
 def create_external_app(
     db_session: Session,
-    *,
     name: str,
     description: str,
+    bundle_file_id: str,
+    bundle_sha256: str,
     app_type: ExternalAppType,
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],
@@ -152,8 +153,8 @@ def create_external_app(
             slug=slug,
             name=name,
             description=description,
-            bundle_file_id="",
-            bundle_sha256="",
+            bundle_file_id=bundle_file_id,
+            bundle_sha256=bundle_sha256,
             is_public=is_public,
             author_user_id=author_user_id,
             db_session=db_session,

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -210,6 +210,7 @@ def list_skills_for_sandbox_injection(
         .order_by(Skill.name)
     )
     stmt = _add_user_visibility_filter(stmt, user)
+    stmt = _exclude_unavailable_built_ins(stmt, db_session)
     return list(db_session.scalars(stmt))
 
 
@@ -259,6 +260,59 @@ def create_skill__no_commit(
             raise OnyxError(
                 OnyxErrorCode.DUPLICATE_RESOURCE,
                 f"A skill with slug '{slug}' already exists.",
+            ) from e
+        raise
+    return skill
+
+
+def create_built_in_skill_row__no_commit(
+    *,
+    built_in_skill_id: str,
+    name: str,
+    description: str,
+    is_public: bool,
+    enabled: bool,
+    author_user_id: UUID | None = None,
+    db_session: Session,
+) -> Skill:
+    """Create a built-in-style ``Skill`` row: ``built_in_skill_id`` set,
+    ``slug == built_in_skill_id`` (the stable on-disk dir name), bundle fields
+    NULL (per the XOR check constraint). Used for external-app providers, whose
+    rows are created on demand rather than seeded.
+
+    Because the slug is the (globally unique) built-in id, a tenant can hold at
+    most one row per provider — a second attempt raises
+    ``OnyxError(DUPLICATE_RESOURCE)``, which is the desired "connect Slack once"
+    behaviour.
+    """
+    existing = db_session.scalars(
+        select(Skill.id).where(Skill.slug == built_in_skill_id)
+    ).first()
+    if existing is not None:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"A skill with slug '{built_in_skill_id}' already exists.",
+        )
+
+    skill = Skill(
+        slug=built_in_skill_id,
+        name=name,
+        description=description,
+        built_in_skill_id=built_in_skill_id,
+        bundle_file_id=None,
+        bundle_sha256=None,
+        is_public=is_public,
+        author_user_id=author_user_id,
+        enabled=enabled,
+    )
+    db_session.add(skill)
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{built_in_skill_id}' already exists.",
             ) from e
         raise
     return skill

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -1,5 +1,3 @@
-import uuid
-
 from fastapi import APIRouter
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -99,20 +97,14 @@ def upsert_external_app(
             organization_credentials=request.organization_credentials,
         )
     else:
-        # Skill identity is server-derived: a fresh slug per instance
-        # so multiple connections of the same provider don't collide;
-        # default-public so every org user sees it once it's connected.
-        # The bundle is intentionally empty for now — we'll attach the
-        # provider's skill_bundles/<provider>/ blob when the rendering
-        # path lands.
-        slug = f"{request.app_type.value.lower()}-{uuid.uuid4().hex[:8]}"
+        # Skill identity is server-derived from app_type: built-in providers
+        # bind to their built-in skill content (and slug), CUSTOM apps get a
+        # fresh per-instance slug + empty bundle. Default-public so every org
+        # user sees it once it's connected (then gated per-user on credentials).
         app = create_external_app(
             db_session=db_session,
-            slug=slug,
             name=request.name,
             description=request.description,
-            bundle_file_id="",
-            bundle_sha256="",
             enabled=request.enabled,
             is_public=True,
             app_type=request.app_type,

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -111,6 +111,8 @@ def upsert_external_app(
             db_session=db_session,
             name=request.name,
             description=request.description,
+            bundle_file_id="",
+            bundle_sha256="",
             enabled=request.enabled,
             is_public=True,
             app_type=request.app_type,

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -8,6 +8,7 @@ from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
 from onyx.db.external_app import create_external_app
 from onyx.db.external_app import delete_external_app
+from onyx.db.external_app import get_external_app_by_id
 from onyx.db.external_app import get_external_apps
 from onyx.db.external_app import get_user_credentials_by_app_id
 from onyx.db.external_app import required_user_credential_keys
@@ -16,6 +17,9 @@ from onyx.db.external_app import upsert_external_app_user_credential
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import User
+from onyx.db.skill import affected_user_ids_for_skill
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers import fetch_available_built_in_apps
 from onyx.external_apps.providers import fetch_built_in_app
 from onyx.server.features.build.api.models import BuiltInExternalAppDescriptor
@@ -23,6 +27,8 @@ from onyx.server.features.build.api.models import ExternalAppAdminResponse
 from onyx.server.features.build.api.models import ExternalAppUserResponse
 from onyx.server.features.build.api.models import UpsertExternalAppRequest
 from onyx.server.features.build.api.models import UpsertUserCredentialsRequest
+from onyx.skills.push import push_skill_to_affected_sandboxes
+from onyx.skills.push import push_skills_for_users
 
 router = APIRouter()
 
@@ -113,6 +119,12 @@ def upsert_external_app(
             organization_credentials=request.organization_credentials,
         )
 
+    # Refresh already-running sandboxes so an enable/disable (or content/grant
+    # change) takes effect live, not just on the next sandbox. The rebuilt
+    # per-user fileset filters on enabled + credentials, so disabling removes
+    # the skill and a user who hasn't authenticated yet still sees nothing.
+    push_skill_to_affected_sandboxes(app.skill, db_session)
+
     return _to_admin_response(app)
 
 
@@ -152,7 +164,19 @@ def delete_external_app_admin(
 
     Returns 404 if no app with `external_app_id` exists.
     """
+    # Resolve affected users *before* the delete cascades the skill row away,
+    # then refresh their sandboxes so the skill is removed live.
+    app = get_external_app_by_id(db_session, external_app_id)
+    if app is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"External app with id {external_app_id} not found.",
+        )
+    affected = affected_user_ids_for_skill(app.skill, db_session)
+
     delete_external_app(db_session=db_session, external_app_id=external_app_id)
+
+    push_skills_for_users(affected, db_session)
 
 
 # =============================================================================
@@ -177,6 +201,11 @@ def upsert_user_credentials(
         user_id=user.id,
         user_credentials=request.user_credentials,
     )
+
+    # Authenticating flips this user's per-user gate from blocked to allowed,
+    # so refresh their running sandboxes now rather than waiting for the next
+    # one. Scoped to the calling user — credentials are per-user.
+    push_skills_for_users({user.id}, db_session)
 
 
 @router.get("/apps")

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: google-calendar
+description: Read and manage the connected user's Google Calendar via a light Calendar API wrapper.
+---
+
+# Google Calendar
+
+Call the Google Calendar API as the connected user via the bundled helper.
+
+## Usage
+
+    python .opencode/skills/google-calendar/gcal_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. `create-event` and
+`delete-event` are the only writes. `primary` is the user's default calendar.
+Use `--raw` to skip empty-field pruning; `python gcal_api.py <command> -h`
+shows its flags.
+
+### List calendars
+
+```
+python gcal_api.py calendars [--limit N]
+```
+
+### List events
+
+```
+python gcal_api.py events primary [--from ISO] [--to ISO] [--q TEXT] [--limit N]
+```
+
+### One event
+
+```
+python gcal_api.py event primary <event_id>
+```
+
+### Create an event (write)
+
+```
+python gcal_api.py create-event primary "Sync" 2026-06-01T10:00:00Z 2026-06-01T10:30:00Z \
+    [--description D] [--attendees a@x.com,b@x.com]
+```
+
+### Delete an event (destructive)
+
+```
+python gcal_api.py delete-event primary <event_id>
+```
+
+### Free/busy
+
+```
+python gcal_api.py freebusy 2026-06-01T00:00:00Z 2026-06-02T00:00:00Z primary
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "items": [...], "count": N,
+"truncated": bool}` (`truncated` means more results existed past `--limit`).
+Transport errors print to stderr and exit non-zero; Google's error JSON (with
+`code` and `message`) is included.
+
+## Notes
+
+- Times are RFC3339 (e.g. `2026-06-01T10:00:00Z`); `events` returns expanded
+  single instances ordered by start time.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/gcal_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/gcal_api.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Google Calendar wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. Output is JSON on stdout.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://www.googleapis.com/calendar/v3/"
+_PAGE_SIZE = 250
+_DEFAULT_LIMIT = 250
+_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE")
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays
+    small. Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _seg(value: str) -> str:
+    """URL-encode a single path segment (ids may contain @ or /)."""
+    return urllib.parse.quote(value, safe="")
+
+
+def _req(
+    method: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Calendar endpoint; return parsed JSON ({} on empty/204).
+    Raises on transport failure (handled by the caller)."""
+    url = _BASE + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        url += "?" + urllib.parse.urlencode(clean)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        url, data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _paginate(path: str, params: dict[str, Any], limit: int) -> dict[str, Any]:
+    """Walk a list endpoint (`items` + `nextPageToken`) up to `limit`."""
+    items: list[Any] = []
+    token: str | None = None
+    while True:
+        q = dict(params, maxResults=min(_PAGE_SIZE, limit - len(items)))
+        if token:
+            q["pageToken"] = token
+        resp = _req("GET", path, params=q)
+        items.extend(resp.get("items") or [])
+        token = resp.get("nextPageToken")
+        if len(items) >= limit:
+            return {
+                "ok": True,
+                "items": items[:limit],
+                "count": limit,
+                "truncated": bool(token),
+            }
+        if not token:
+            break
+    return {"ok": True, "items": items, "count": len(items), "truncated": False}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="gcal_api.py", description="Google Calendar.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_limit(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    with_limit(sub.add_parser("calendars", help="list the user's calendars"))
+
+    sp = sub.add_parser("events", help="list events in a calendar")
+    sp.add_argument("calendar_id")
+    sp.add_argument("--from", dest="time_min", help="RFC3339 lower bound")
+    sp.add_argument("--to", dest="time_max", help="RFC3339 upper bound")
+    sp.add_argument("--q", help="free-text query")
+    with_limit(sp)
+
+    sp = sub.add_parser("event", help="one event")
+    sp.add_argument("calendar_id")
+    sp.add_argument("event_id")
+
+    sp = sub.add_parser("create-event", help="create an event (write)")
+    sp.add_argument("calendar_id")
+    sp.add_argument("summary")
+    sp.add_argument("start_iso")
+    sp.add_argument("end_iso")
+    sp.add_argument("--description")
+    sp.add_argument("--attendees", help="comma-separated emails")
+
+    sp = sub.add_parser("delete-event", help="delete an event (write)")
+    sp.add_argument("calendar_id")
+    sp.add_argument("event_id")
+
+    sp = sub.add_parser("freebusy", help="busy intervals for calendars")
+    sp.add_argument("from_iso")
+    sp.add_argument("to_iso")
+    sp.add_argument("calendar_ids", nargs="+")
+
+    sp = sub.add_parser("call", help="raw Calendar request")
+    sp.add_argument("method", choices=_METHODS)
+    sp.add_argument("path", help="appended to calendar/v3/")
+    sp.add_argument("json_body", nargs="?")
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "calendars":
+        return _paginate("users/me/calendarList", {}, a.limit)
+
+    if a.cmd == "events":
+        return _paginate(
+            f"calendars/{_seg(a.calendar_id)}/events",
+            {
+                "singleEvents": "true",
+                "orderBy": "startTime",
+                "timeMin": a.time_min,
+                "timeMax": a.time_max,
+                "q": a.q,
+            },
+            a.limit,
+        )
+
+    if a.cmd == "event":
+        ev = _req(
+            "GET",
+            f"calendars/{_seg(a.calendar_id)}/events/{_seg(a.event_id)}",
+        )
+        return {"ok": True, "event": ev}
+
+    if a.cmd == "create-event":
+        body: dict[str, Any] = {
+            "summary": a.summary,
+            "start": {"dateTime": a.start_iso},
+            "end": {"dateTime": a.end_iso},
+        }
+        if a.description:
+            body["description"] = a.description
+        if a.attendees:
+            body["attendees"] = [
+                {"email": e.strip()} for e in a.attendees.split(",") if e.strip()
+            ]
+        ev = _req("POST", f"calendars/{_seg(a.calendar_id)}/events", body=body)
+        return {"ok": True, "event": ev}
+
+    if a.cmd == "delete-event":
+        _req(
+            "DELETE",
+            f"calendars/{_seg(a.calendar_id)}/events/{_seg(a.event_id)}",
+        )
+        return {"ok": True, "deleted": True}
+
+    if a.cmd == "freebusy":
+        resp = _req(
+            "POST",
+            "freeBusy",
+            body={
+                "timeMin": a.from_iso,
+                "timeMax": a.to_iso,
+                "items": [{"id": c} for c in a.calendar_ids],
+            },
+        )
+        return {"ok": True, "calendars": resp.get("calendars")}
+
+    # `call` raw escape hatch
+    body = None
+    if a.json_body:
+        body = json.loads(a.json_body)
+        if not isinstance(body, dict):
+            return {"ok": False, "error": "json_body_not_object"}
+    resp = _req(a.method, a.path.lstrip("/"), body=body)
+    return {"ok": True, "data": resp}
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except json.JSONDecodeError as e:
+        print(f"invalid json_body: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Google Calendar: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Google Calendar: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: linear
+description: Query and mutate Linear (issues, projects, teams) on the connected user's behalf via a light GraphQL wrapper.
+---
+
+# Linear
+
+Call Linear as the connected user via the bundled helper.
+
+## Usage
+
+    python .opencode/skills/linear/linear_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. `create-issue` and
+`comment` are the only writes. Use `--raw` to skip empty-field pruning;
+`python linear_api.py <command> -h` shows its flags.
+
+### The connected user
+
+```
+python linear_api.py me
+```
+
+### Teams
+
+```
+python linear_api.py teams [--limit N]
+```
+
+### Issues (filtered)
+
+```
+python linear_api.py issues [--team KEY] [--assignee me] [--state NAME] [--limit N]
+```
+
+### One issue (by id or identifier)
+
+```
+python linear_api.py issue ENG-123
+```
+
+### Search issues
+
+```
+python linear_api.py search "login bug" [--limit N]
+```
+
+### Projects
+
+```
+python linear_api.py projects [--limit N]
+```
+
+### Create an issue (write)
+
+```
+python linear_api.py create-issue <team_id> "Title" [--description D] [--assignee USER_ID]
+```
+
+### Comment on an issue (write)
+
+```
+python linear_api.py comment <issue_id> "Looking into this"
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "<key>": [...], "count": N,
+"truncated": bool}` (`truncated` means more results existed past `--limit`).
+Failures return `{"ok": false, "errors": [...]}` and exit non-zero — surface
+the error rather than retrying blindly.
+
+## Notes
+
+- `create-issue` needs a team id (from `teams`); `--assignee` takes a user id.
+- `call` lets you send any GraphQL — pass user input as variables, not by
+  string-formatting into the query.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/linear_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/linear_api.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Linear (GraphQL) wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. User input is passed as
+GraphQL *variables* (never string-formatted into the query), so there
+is no injection risk. Output is JSON on stdout.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+_ENDPOINT = "https://api.linear.app/graphql"
+_PAGE_SIZE = 100
+_DEFAULT_LIMIT = 100
+_IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
+
+_ISSUE_FIELDS = """
+  id identifier title url priority
+  state { name type }
+  assignee { name email }
+  team { key name }
+  updatedAt
+"""
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays
+    small. Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _gql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """POST a GraphQL request; return the parsed JSON. Raises on
+    transport failure (handled by the caller)."""
+    req = urllib.request.Request(  # noqa: S310 — fixed https endpoint
+        _ENDPOINT,
+        data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _unwrap(resp: dict[str, Any], key: str) -> dict[str, Any]:
+    """GraphQL error → uniform error envelope; else lift data[key]."""
+    if resp.get("errors"):
+        return {"ok": False, "errors": resp["errors"]}
+    return {"ok": True, key: (resp.get("data") or {}).get(key)}
+
+
+def _paginate(
+    query: str, variables: dict[str, Any], conn_key: str, limit: int
+) -> dict[str, Any]:
+    """Walk a GraphQL connection (`nodes` + `pageInfo`) up to `limit`."""
+    nodes: list[Any] = []
+    after: str | None = None
+    while True:
+        v = dict(variables, first=min(_PAGE_SIZE, limit - len(nodes)))
+        if after:
+            v["after"] = after
+        resp = _gql(query, v)
+        if resp.get("errors"):
+            return {"ok": False, "errors": resp["errors"]}
+        conn = ((resp.get("data") or {}).get(conn_key)) or {}
+        nodes.extend(conn.get("nodes") or [])
+        page = conn.get("pageInfo") or {}
+        after = page.get("endCursor")
+        if len(nodes) >= limit:
+            return {
+                "ok": True,
+                conn_key: nodes[:limit],
+                "count": limit,
+                "truncated": bool(page.get("hasNextPage")),
+            }
+        if not page.get("hasNextPage"):
+            break
+    return {"ok": True, conn_key: nodes, "count": len(nodes), "truncated": False}
+
+
+def _issue_filter(a: argparse.Namespace) -> dict[str, Any]:
+    f: dict[str, Any] = {}
+    if getattr(a, "team", None):
+        f["team"] = {"key": {"eq": a.team}}
+    if getattr(a, "assignee", None) == "me":
+        f["assignee"] = {"isMe": {"eq": True}}
+    elif getattr(a, "assignee", None):
+        f["assignee"] = {"id": {"eq": a.assignee}}
+    if getattr(a, "state", None):
+        f["state"] = {"name": {"eq": a.state}}
+    return f
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="linear_api.py", description="Linear GraphQL.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_limit(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    sub.add_parser("me", help="the connected user (viewer)")
+
+    with_limit(sub.add_parser("teams", help="list teams"))
+
+    sp = sub.add_parser("issues", help="list issues (filtered)")
+    sp.add_argument("--team", help="team key, e.g. ENG")
+    sp.add_argument("--assignee", help="'me' or a user id")
+    sp.add_argument("--state", help="workflow state name")
+    with_limit(sp)
+
+    sp = sub.add_parser("issue", help="one issue by id or IDENT-123")
+    sp.add_argument("ref")
+
+    sp = sub.add_parser("search", help="full-text issue search")
+    sp.add_argument("query")
+    with_limit(sp)
+
+    with_limit(sub.add_parser("projects", help="list projects"))
+
+    sp = sub.add_parser("create-issue", help="create an issue (write)")
+    sp.add_argument("team_id")
+    sp.add_argument("title")
+    sp.add_argument("--description")
+    sp.add_argument("--assignee", help="user id")
+
+    sp = sub.add_parser("comment", help="comment on an issue (write)")
+    sp.add_argument("issue_id")
+    sp.add_argument("body")
+
+    sp = sub.add_parser("call", help="raw GraphQL")
+    sp.add_argument("query")
+    sp.add_argument("variables", nargs="?")
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "me":
+        return _unwrap(_gql("query { viewer { id name email } }", {}), "viewer")
+
+    if a.cmd == "teams":
+        q = (
+            "query($first:Int,$after:String){ teams(first:$first,after:$after)"
+            "{ nodes { id key name } pageInfo { hasNextPage endCursor } } }"
+        )
+        return _paginate(q, {}, "teams", a.limit)
+
+    if a.cmd == "issues":
+        q = (
+            "query($first:Int,$after:String,$filter:IssueFilter){"
+            " issues(first:$first,after:$after,filter:$filter)"
+            f"{{ nodes {{ {_ISSUE_FIELDS} }} pageInfo {{ hasNextPage endCursor }} }} }}"
+        )
+        return _paginate(q, {"filter": _issue_filter(a)}, "issues", a.limit)
+
+    if a.cmd == "issue":
+        if _IDENT_RE.match(a.ref):
+            team, number = a.ref.split("-")
+            q = (
+                "query($k:String!,$n:Float!){ issues(first:1,filter:"
+                "{team:{key:{eq:$k}},number:{eq:$n}})"
+                f"{{ nodes {{ {_ISSUE_FIELDS} description }} }} }}"
+            )
+            resp = _gql(q, {"k": team.upper(), "n": float(number)})
+            if resp.get("errors"):
+                return {"ok": False, "errors": resp["errors"]}
+            nodes = ((resp.get("data") or {}).get("issues") or {}).get("nodes") or []
+            return {"ok": True, "issue": nodes[0] if nodes else None}
+        q = f"query($id:String!){{ issue(id:$id){{ {_ISSUE_FIELDS} description }} }}"
+        return _unwrap(_gql(q, {"id": a.ref}), "issue")
+
+    if a.cmd == "search":
+        q = (
+            "query($q:String!,$first:Int,$after:String){"
+            " issueSearch(query:$q,first:$first,after:$after)"
+            f"{{ nodes {{ {_ISSUE_FIELDS} }} pageInfo {{ hasNextPage endCursor }} }} }}"
+        )
+        return _paginate(q, {"q": a.query}, "issueSearch", a.limit)
+
+    if a.cmd == "projects":
+        q = (
+            "query($first:Int,$after:String){ projects(first:$first,after:$after)"
+            "{ nodes { id name state url } pageInfo { hasNextPage endCursor } } }"
+        )
+        return _paginate(q, {}, "projects", a.limit)
+
+    if a.cmd == "create-issue":
+        inp: dict[str, Any] = {"teamId": a.team_id, "title": a.title}
+        if a.description:
+            inp["description"] = a.description
+        if a.assignee:
+            inp["assigneeId"] = a.assignee
+        q = (
+            "mutation($input:IssueCreateInput!){ issueCreate(input:$input)"
+            "{ success issue { id identifier url } } }"
+        )
+        return _unwrap(_gql(q, {"input": inp}), "issueCreate")
+
+    if a.cmd == "comment":
+        q = (
+            "mutation($input:CommentCreateInput!){ commentCreate(input:$input)"
+            "{ success comment { id url } } }"
+        )
+        return _unwrap(
+            _gql(q, {"input": {"issueId": a.issue_id, "body": a.body}}),
+            "commentCreate",
+        )
+
+    # `call` raw escape hatch
+    variables: dict[str, Any] = {}
+    if a.variables:
+        parsed = json.loads(a.variables)
+        if not isinstance(parsed, dict):
+            return {"ok": False, "error": "variables_not_object"}
+        variables = parsed
+    resp = _gql(a.query, variables)
+    if resp.get("errors"):
+        return {"ok": False, "errors": resp["errors"]}
+    return {"ok": True, "data": resp.get("data")}
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except json.JSONDecodeError as e:
+        print(f"invalid variables: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Linear: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Linear: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: slack
+description: Read, search, and post Slack messages on the connected user's behalf via the Slack Web API.
+---
+
+# Slack
+
+Call the Slack Web API as the connected user via the bundled helper.
+
+## Usage
+
+    python .opencode/skills/slack/slack_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. `post` is the only write.
+Use `--raw` to skip empty-field pruning; `python slack_api.py <command> -h`
+shows its flags.
+
+### List channels
+
+```
+python slack_api.py channels [--limit N]
+```
+
+### Read channel messages
+
+```
+python slack_api.py history C0123456789 [--limit N]
+```
+
+### Read thread replies
+
+```
+python slack_api.py replies C0123456789 1700000000.000100
+```
+
+### List workspace users
+
+```
+python slack_api.py users [--limit N]
+```
+
+### Look up one user
+
+```
+python slack_api.py user U0123456789
+```
+
+### Search messages
+
+```
+python slack_api.py search "deploy failed" [--count N]
+```
+
+### Post a message (write)
+
+```
+python slack_api.py post C0123456789 "Hello from Onyx"
+```
+
+## Output
+
+JSON on stdout. Read commands return `{"ok": true, "<key>": [...], "count": N,
+"truncated": bool}` (`truncated` means more results existed past `--limit`).
+Failures pass Slack's response through verbatim: `{"ok": false, "error":
+"<code>"}` (e.g. `not_in_channel`, `missing_scope`) and exit non-zero — surface
+`error` rather than retrying blindly.
+
+## Notes
+
+- Channels/users are referenced by ID (e.g. `C…`, `U…`); resolve names via
+  `channels` / `users` first.
+- Scopes were chosen by the admin. You cannot widen them; on `missing_scope`,
+  tell the user which scope is needed.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/slack_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/slack_api.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Slack Web API wrapper for the Onyx Craft sandbox.
+
+Common Slack operations exposed as subcommands. Output is JSON on stdout.
+Slack signals failure with {"ok": false, "error": "..."} (still HTTP 200).
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+_BASE = "https://slack.com/api/"
+_METHOD_RE = re.compile(r"^[a-z][a-zA-Z0-9._]*$")
+_PAGE_SIZE = 200
+_DEFAULT_LIMIT = 200
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays
+    small. Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _call(method: str, body: dict[str, Any]) -> dict[str, Any]:
+    """POST to a Slack method; return the parsed JSON. Raises on
+    transport failure (handled by the caller)."""
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        _BASE + method,
+        data=json.dumps(body).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _paginate(
+    method: str, params: dict[str, Any], list_key: str, limit: int
+) -> dict[str, Any]:
+    """Cursor-paginate `method`, accumulating `list_key` up to `limit`.
+    On a Slack error the raw error object is returned unchanged."""
+    items: list[Any] = []
+    cursor = ""
+    truncated = False
+    while True:
+        body = dict(params, limit=min(_PAGE_SIZE, limit - len(items)))
+        if cursor:
+            body["cursor"] = cursor
+        resp = _call(method, body)
+        if not resp.get("ok"):
+            return resp
+        items.extend(resp.get(list_key, []))
+        cursor = (resp.get("response_metadata") or {}).get("next_cursor") or ""
+        if len(items) >= limit:
+            truncated = bool(cursor)
+            items = items[:limit]
+            break
+        if not cursor:
+            break
+    return {"ok": True, list_key: items, "count": len(items), "truncated": truncated}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="slack_api.py", description="Slack Web API.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_limit(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    with_limit(sub.add_parser("channels", help="list conversations"))
+
+    sp = sub.add_parser("history", help="recent messages in a channel")
+    sp.add_argument("channel")
+    with_limit(sp)
+
+    sp = sub.add_parser("replies", help="messages in a thread")
+    sp.add_argument("channel")
+    sp.add_argument("ts")
+    with_limit(sp)
+
+    with_limit(sub.add_parser("users", help="list workspace users"))
+
+    sp = sub.add_parser("user", help="look up one user")
+    sp.add_argument("user_id")
+
+    sp = sub.add_parser("search", help="search messages")
+    sp.add_argument("query")
+    sp.add_argument("--count", type=int, default=20)
+
+    sp = sub.add_parser("post", help="post a message (write)")
+    sp.add_argument("channel")
+    sp.add_argument("text")
+
+    sp = sub.add_parser("call", help="raw Slack method")
+    sp.add_argument("method")
+    sp.add_argument("json_args", nargs="?")
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "channels":
+        return _paginate(
+            "conversations.list",
+            {"types": "public_channel,private_channel", "exclude_archived": True},
+            "channels",
+            a.limit,
+        )
+
+    if a.cmd == "history":
+        return _paginate(
+            "conversations.history", {"channel": a.channel}, "messages", a.limit
+        )
+
+    if a.cmd == "replies":
+        return _paginate(
+            "conversations.replies",
+            {"channel": a.channel, "ts": a.ts},
+            "messages",
+            a.limit,
+        )
+
+    if a.cmd == "users":
+        return _paginate("users.list", {}, "members", a.limit)
+
+    if a.cmd == "user":
+        return _call("users.info", {"user": a.user_id})
+
+    if a.cmd == "search":
+        return _call("search.messages", {"query": a.query, "count": a.count})
+
+    if a.cmd == "post":
+        return _call("chat.postMessage", {"channel": a.channel, "text": a.text})
+
+    # `call` raw escape hatch
+    if not _METHOD_RE.match(a.method):
+        return {"ok": False, "error": "invalid_method_name"}
+    args: dict[str, Any] = {}
+    if a.json_args:
+        parsed = json.loads(a.json_args)
+        if not isinstance(parsed, dict):
+            return {"ok": False, "error": "json_args_not_object"}
+        args = parsed
+    return _call(a.method, args)
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except json.JSONDecodeError as e:
+        print(f"invalid json_args: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Slack: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Slack: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -1,32 +1,37 @@
-"""Codified built-in skill definitions (runtime behavior only).
+"""Codified built-in skill definitions.
 
-``BUILT_IN_SKILLS`` defines built-in behavior (``source_dir``,
-``has_template``, ``is_available``) for every built-in, regardless of how its
-``skill`` table *row* comes to exist:
+``_REGISTRY`` is the single source of truth: one provider per built-in skill,
+one of two kinds —
 
-- **Seeded built-ins** (``pptx``, ``image-generation``, ``company-search``):
-  their rows are owned by Alembic migrations — adding/changing one requires a
-  migration. Removing an entry leaves orphan rows: runtime skips them (with a
-  warning), but a retiring migration should delete them.
+- ``SeededBuiltInProvider``: a plain built-in skill whose ``skill`` rows are
+  owned by Alembic migrations.
+- ``ExternalAppBuiltInProvider``: a built-in skill backed by a connectable
+  ``ExternalAppType``; rows are created on demand when an admin connects the app
+  (``onyx.db.external_app.create_external_app``).
 
-- **External-app built-ins** (``slack``, ``google-calendar``, ``linear``):
-  *not* seeded. A row is created on demand when an admin connects the app
-  (``onyx.db.external_app.create_external_app``), with ``built_in_skill_id``
-  set so it renders through the exact same disk-backed path as a seeded
-  built-in. ``EXTERNAL_APP_BUILT_IN_SKILL_IDS`` maps each provider's
-  ``ExternalAppType`` to its built-in id (also the slug + on-disk dir). Per-user
-  availability is gated on credentials by the sandbox-injection query, not here.
+Both render through the identical disk-backed push path; the kind only governs
+how the ``skill`` row comes to exist and whether an ``app_type`` connects to it.
+Per-user availability of an external-app skill is gated on credentials by the
+sandbox-injection query, not here.
+
+Everything else is derived from the registry, which validates at import that no
+two providers share a ``skill_id`` or an ``app_type``. Adding a built-in skill
+or external app is a single ``_REGISTRY`` entry plus its on-disk
+``skills/<skill_id>/`` directory.
 """
 
 import re
 from collections.abc import Callable
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Final
+from typing import Literal
 
 from pydantic import BaseModel
 from pydantic import computed_field
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
@@ -42,15 +47,26 @@ def _always_available(_: Session) -> bool:
 
 
 class BuiltInSkillDefinition(BaseModel):
-    """``built_in_skill_id`` is the stable identifier — also the seeded
-    slug and on-disk directory name under SKILLS_TEMPLATE_PATH."""
+    """Runtime behavior for one built-in skill (the resolved view a provider
+    produces). ``built_in_skill_id`` is the stable identifier, seeded slug, and
+    on-disk directory name under ``SKILLS_TEMPLATE_PATH`` — which fully
+    determines ``source_dir`` and ``has_template``, so both are computed.
 
-    model_config = ConfigDict(frozen=True)
+    ``extra="forbid"`` makes a stray ``source_dir=`` (e.g. an old test trying to
+    inject one) fail loud rather than be silently dropped; redirect via
+    ``SKILLS_TEMPLATE_PATH`` instead.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     built_in_skill_id: str = Field(pattern=SKILL_SLUG_PATTERN)
-    source_dir: Path
     is_available: Callable[[Session], bool] = _always_available
     unavailable_reason: str | None = None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def source_dir(self) -> Path:
+        return Path(SKILLS_TEMPLATE_PATH) / self.built_in_skill_id
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -59,42 +75,114 @@ class BuiltInSkillDefinition(BaseModel):
         return (self.source_dir / "SKILL.md.template").exists()
 
 
-def _def(built_in_skill_id: str) -> BuiltInSkillDefinition:
-    return BuiltInSkillDefinition(
-        built_in_skill_id=built_in_skill_id,
-        source_dir=Path(SKILLS_TEMPLATE_PATH) / built_in_skill_id,
+class BuiltInProvider(BaseModel):
+    """Base registry entry. ``skill_id`` doubles as the slug and on-disk dir
+    name, validated here so a bad entry fails at import."""
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: str
+    skill_id: str = Field(pattern=SKILL_SLUG_PATTERN)
+    is_available: Callable[[Session], bool] = _always_available
+    unavailable_reason: str | None = None
+
+    def to_definition(self) -> BuiltInSkillDefinition:
+        # source_dir is derived by the definition from built_in_skill_id; the
+        # declaration deliberately stays disk-layout-agnostic.
+        return BuiltInSkillDefinition(
+            built_in_skill_id=self.skill_id,
+            is_available=self.is_available,
+            unavailable_reason=self.unavailable_reason,
+        )
+
+
+class SeededBuiltInProvider(BuiltInProvider):
+    """A plain built-in skill whose rows are seeded/managed by migrations."""
+
+    kind: Literal["seeded"] = "seeded"
+
+
+class ExternalAppBuiltInProvider(BuiltInProvider):
+    """A built-in skill backed by a connectable external app."""
+
+    kind: Literal["external_app"] = "external_app"
+    app_type: ExternalAppType
+
+    @model_validator(mode="after")
+    def _reject_custom(self) -> "ExternalAppBuiltInProvider":
+        # CUSTOM apps ship no bundled content — they stay bundle-backed rows.
+        if self.app_type == ExternalAppType.CUSTOM:
+            raise ValueError("CUSTOM apps have no bundled built-in skill content")
+        return self
+
+
+BuiltInProviderEntry = SeededBuiltInProvider | ExternalAppBuiltInProvider
+
+
+class BuiltInSkillRegistry:
+    """Owns the providers and the indices derived from them, failing at import
+    if two providers collide on a ``skill_id`` or an ``app_type``.
+
+    The derived maps are exposed as the same plain dicts the module re-exports:
+    consumers bind ``BUILT_IN_SKILLS`` at import and tests inject temp built-ins
+    via ``monkeypatch.setitem``, so the maps are intentionally mutable in place
+    rather than read-only proxies.
+    """
+
+    def __init__(self, providers: Iterable[BuiltInProviderEntry]) -> None:
+        provider_list = tuple(providers)
+        definitions: dict[str, BuiltInSkillDefinition] = {}
+        external_app_skill_ids: dict[ExternalAppType, str] = {}
+
+        for provider in provider_list:
+            if provider.skill_id in definitions:
+                raise ValueError(f"Duplicate built-in skill_id: {provider.skill_id!r}")
+            definitions[provider.skill_id] = provider.to_definition()
+
+            if isinstance(provider, ExternalAppBuiltInProvider):
+                existing = external_app_skill_ids.get(provider.app_type)
+                if existing is not None:
+                    raise ValueError(
+                        f"Duplicate built-in external app for {provider.app_type}: "
+                        f"{existing!r} and {provider.skill_id!r}"
+                    )
+                external_app_skill_ids[provider.app_type] = provider.skill_id
+
+        self._definitions = definitions
+        self._external_app_skill_ids = external_app_skill_ids
+
+    @property
+    def definitions_by_skill_id(self) -> dict[str, BuiltInSkillDefinition]:
+        return self._definitions
+
+    @property
+    def external_app_skill_ids(self) -> dict[ExternalAppType, str]:
+        return self._external_app_skill_ids
+
+
+# Single source of truth.
+_REGISTRY: Final = BuiltInSkillRegistry(
+    providers=(
+        SeededBuiltInProvider(skill_id="pptx"),
+        SeededBuiltInProvider(skill_id="image-generation"),
+        SeededBuiltInProvider(skill_id="company-search"),
+        ExternalAppBuiltInProvider(skill_id="slack", app_type=ExternalAppType.SLACK),
+        ExternalAppBuiltInProvider(skill_id="linear", app_type=ExternalAppType.LINEAR),
+        ExternalAppBuiltInProvider(
+            skill_id="google-calendar", app_type=ExternalAppType.GOOGLE_CALENDAR
+        ),
     )
+)
 
+# Derived exports. ``Final`` pins the binding; the dicts stay mutable so tests
+# can inject temp built-ins via ``monkeypatch.setitem``.
+BUILT_IN_SKILLS: Final[dict[str, BuiltInSkillDefinition]] = (
+    _REGISTRY.definitions_by_skill_id
+)
+EXTERNAL_APP_BUILT_IN_SKILL_IDS: Final[dict[ExternalAppType, str]] = (
+    _REGISTRY.external_app_skill_ids
+)
 
-# Named handles so callers avoid bare slug literals (e.g. push.py dispatch).
-PPTX = _def("pptx")
-IMAGE_GENERATION = _def("image-generation")
-COMPANY_SEARCH = _def("company-search")
-
-# External-app providers that ship built-in skill content. Rows are created on
-# demand by ``create_external_app`` (never seeded), so these definitions exist
-# purely so the push path can render their on-disk content like any built-in.
-GOOGLE_CALENDAR = _def("google-calendar")
-SLACK = _def("slack")
-LINEAR = _def("linear")
-
-BUILT_IN_SKILLS: dict[str, BuiltInSkillDefinition] = {
-    d.built_in_skill_id: d
-    for d in (
-        PPTX,
-        IMAGE_GENERATION,
-        COMPANY_SEARCH,
-        GOOGLE_CALENDAR,
-        SLACK,
-        LINEAR,
-    )
-}
-
-# Maps an external-app provider's ``ExternalAppType`` to its built-in skill id
-# (== slug == on-disk dir). Only providers that ship bundled skill content
-# appear here; ``CUSTOM`` apps have none and stay custom (bundle-backed) rows.
-EXTERNAL_APP_BUILT_IN_SKILL_IDS: dict[ExternalAppType, str] = {
-    ExternalAppType.GOOGLE_CALENDAR: GOOGLE_CALENDAR.built_in_skill_id,
-    ExternalAppType.SLACK: SLACK.built_in_skill_id,
-    ExternalAppType.LINEAR: LINEAR.built_in_skill_id,
-}
+# Named handles so callers avoid bare slug literals.
+COMPANY_SEARCH: Final[BuiltInSkillDefinition] = BUILT_IN_SKILLS["company-search"]
+SLACK: Final[BuiltInSkillDefinition] = BUILT_IN_SKILLS["slack"]

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -1,11 +1,21 @@
 """Codified built-in skill definitions (runtime behavior only).
 
 ``BUILT_IN_SKILLS`` defines built-in behavior (``source_dir``,
-``has_template``, ``is_available``). The ``skill`` table *rows* are owned
-by Alembic migrations — adding/changing a built-in requires a migration.
+``has_template``, ``is_available``) for every built-in, regardless of how its
+``skill`` table *row* comes to exist:
 
-Removing an entry leaves orphan rows: runtime skips them (with a warning),
-but a retiring migration should delete them.
+- **Seeded built-ins** (``pptx``, ``image-generation``, ``company-search``):
+  their rows are owned by Alembic migrations — adding/changing one requires a
+  migration. Removing an entry leaves orphan rows: runtime skips them (with a
+  warning), but a retiring migration should delete them.
+
+- **External-app built-ins** (``slack``, ``google-calendar``, ``linear``):
+  *not* seeded. A row is created on demand when an admin connects the app
+  (``onyx.db.external_app.create_external_app``), with ``built_in_skill_id``
+  set so it renders through the exact same disk-backed path as a seeded
+  built-in. ``EXTERNAL_APP_BUILT_IN_SKILL_IDS`` maps each provider's
+  ``ExternalAppType`` to its built-in id (also the slug + on-disk dir). Per-user
+  availability is gated on credentials by the sandbox-injection query, not here.
 """
 
 import re
@@ -19,6 +29,7 @@ from pydantic import ConfigDict
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import ExternalAppType
 from onyx.server.features.build.configs import SKILLS_TEMPLATE_PATH
 
 # Slug grammar shared with custom bundle slugs (bundle.py imports this).
@@ -60,6 +71,30 @@ PPTX = _def("pptx")
 IMAGE_GENERATION = _def("image-generation")
 COMPANY_SEARCH = _def("company-search")
 
+# External-app providers that ship built-in skill content. Rows are created on
+# demand by ``create_external_app`` (never seeded), so these definitions exist
+# purely so the push path can render their on-disk content like any built-in.
+GOOGLE_CALENDAR = _def("google-calendar")
+SLACK = _def("slack")
+LINEAR = _def("linear")
+
 BUILT_IN_SKILLS: dict[str, BuiltInSkillDefinition] = {
-    d.built_in_skill_id: d for d in (PPTX, IMAGE_GENERATION, COMPANY_SEARCH)
+    d.built_in_skill_id: d
+    for d in (
+        PPTX,
+        IMAGE_GENERATION,
+        COMPANY_SEARCH,
+        GOOGLE_CALENDAR,
+        SLACK,
+        LINEAR,
+    )
+}
+
+# Maps an external-app provider's ``ExternalAppType`` to its built-in skill id
+# (== slug == on-disk dir). Only providers that ship bundled skill content
+# appear here; ``CUSTOM`` apps have none and stay custom (bundle-backed) rows.
+EXTERNAL_APP_BUILT_IN_SKILL_IDS: dict[ExternalAppType, str] = {
+    ExternalAppType.GOOGLE_CALENDAR: GOOGLE_CALENDAR.built_in_skill_id,
+    ExternalAppType.SLACK: SLACK.built_in_skill_id,
+    ExternalAppType.LINEAR: LINEAR.built_in_skill_id,
 }

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
-from onyx.db.skill import list_skills_for_user
+from onyx.db.skill import list_skills_for_sandbox_injection
 from onyx.file_store.file_store import FileStore
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
@@ -105,7 +105,13 @@ def _assemble_fileset(
 
     Built-in rows are rendered from disk; custom rows are unpacked from
     their FileStore bundle. A row whose ``built_in_skill_id`` no longer
-    matches a codified definition is skipped with a warning."""
+    matches a codified definition is skipped with a warning.
+
+    External-app skills are *not* a special case here: a connected provider's
+    row carries its ``built_in_skill_id`` (e.g. ``slack``) like any other
+    built-in, so it renders straight from disk. Which external-app rows reach
+    this point is decided upstream by ``list_skills_for_sandbox_injection``
+    (enabled + per-user credential gate)."""
     files: FileSet = {}
     file_store = get_default_file_store()
 
@@ -129,14 +135,16 @@ def _assemble_fileset(
 
 
 def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
-    """Return a flat ``{path: bytes}`` map of every skill the user can see."""
-    skills = list_skills_for_user(user=user, db_session=db_session)
+    """Return a flat ``{path: bytes}`` map of every skill delivered into the
+    user's sandbox — regular skills they can see plus the external-app skills
+    they've connected and authenticated for."""
+    skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
     return _assemble_fileset(skills, user, db_session)
 
 
 def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, FileSet]:
     """Return (skills_section, fileset) sharing one set of DB reads."""
-    skills = list_skills_for_user(user=user, db_session=db_session)
+    skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
     section = build_skills_section_from_data(skills)
     files = _assemble_fileset(skills, user, db_session)
     return section, files

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -105,13 +105,7 @@ def _assemble_fileset(
 
     Built-in rows are rendered from disk; custom rows are unpacked from
     their FileStore bundle. A row whose ``built_in_skill_id`` no longer
-    matches a codified definition is skipped with a warning.
-
-    External-app skills are *not* a special case here: a connected provider's
-    row carries its ``built_in_skill_id`` (e.g. ``slack``) like any other
-    built-in, so it renders straight from disk. Which external-app rows reach
-    this point is decided upstream by ``list_skills_for_sandbox_injection``
-    (enabled + per-user credential gate)."""
+    matches a codified definition is skipped with a warning."""
     files: FileSet = {}
     file_store = get_default_file_store()
 
@@ -135,9 +129,7 @@ def _assemble_fileset(
 
 
 def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
-    """Return a flat ``{path: bytes}`` map of every skill delivered into the
-    user's sandbox — regular skills they can see plus the external-app skills
-    they've connected and authenticated for."""
+    """Return a flat ``{path: bytes}`` map of every skill the user can see."""
     skills = list_skills_for_sandbox_injection(user=user, db_session=db_session)
     return _assemble_fileset(skills, user, db_session)
 

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -30,6 +30,8 @@ from fastapi_users.password import PasswordHelper
 if TYPE_CHECKING:
     from kubernetes import client as k8s_client_module
 from redis import Redis
+from sqlalchemy import select
+from sqlalchemy.orm import class_mapper
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import FileOrigin
@@ -39,6 +41,8 @@ from onyx.db.enums import AccountType
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import BuildSession
+from onyx.db.models import ExternalApp
+from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import Sandbox
 from onyx.db.models import Skill
 from onyx.db.models import Skill__UserGroup
@@ -67,6 +71,97 @@ _DEV_PUSH_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 @pytest.fixture(autouse=True)
 def _sandbox_push_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ONYX_SANDBOX_PUSH_PRIVATE_KEY", _DEV_PUSH_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Skill-table isolation
+# ---------------------------------------------------------------------------
+#
+# These tests run against the shared ``public`` schema (``TEST_TENANT_ID ==
+# "public"``) — the very schema a self-hosted / local dev deployment uses. The
+# fixtures and helpers below commit ``Skill`` / ``ExternalApp`` rows directly
+# and nothing rolled them back, so every committed row leaked into the
+# developer's live craft skill list (and into the next test's view of the
+# table). Tests also delete/mutate the migration-seeded built-in rows
+# (``pptx``, ``image-generation``, ``company-search``), corrupting them for the
+# live app.
+#
+# The ``_test_helpers`` contract states "the surrounding test owns transaction
+# boundaries"; this autouse fixture is that boundary for the skill tables. It
+# snapshots their committed state before each test and restores it afterward,
+# so a run leaves these tables exactly as it found them (the canonical
+# built-ins on a freshly-migrated DB).
+
+# Parent -> child order (FKs all point child -> parent). Restore/insert in this
+# order; delete in reverse so FK constraints stay satisfied.
+_SKILL_ISOLATION_MODELS: tuple[type[Any], ...] = (
+    Skill,
+    Skill__UserGroup,
+    ExternalApp,
+    ExternalAppUserCredential,
+)
+
+
+def _skill_table_column_keys(model: type[Any]) -> list[str]:
+    return [attr.key for attr in class_mapper(model).column_attrs]
+
+
+def _skill_table_pk_keys(model: type[Any]) -> list[str]:
+    return [col.key for col in class_mapper(model).primary_key]
+
+
+def _snapshot_skill_tables(
+    session: Session,
+) -> dict[type[Any], list[dict[str, Any]]]:
+    snapshot: dict[type[Any], list[dict[str, Any]]] = {}
+    for model in _SKILL_ISOLATION_MODELS:
+        keys = _skill_table_column_keys(model)
+        snapshot[model] = [
+            {key: getattr(row, key) for key in keys}
+            for row in session.execute(select(model)).scalars().all()
+        ]
+    return snapshot
+
+
+def _restore_skill_tables(
+    session: Session, snapshot: dict[type[Any], list[dict[str, Any]]]
+) -> None:
+    # Delete rows created during the test (children first so FKs stay valid).
+    for model in reversed(_SKILL_ISOLATION_MODELS):
+        pk_keys = _skill_table_pk_keys(model)
+        baseline_pks = {tuple(row[key] for key in pk_keys) for row in snapshot[model]}
+        for row in session.execute(select(model)).scalars().all():
+            if tuple(getattr(row, key) for key in pk_keys) not in baseline_pks:
+                session.delete(row)
+        session.flush()
+
+    # Re-insert baseline rows the test deleted and restore any it mutated
+    # (parents first). ``merge`` keys on PK: insert when absent, update when
+    # present.
+    for model in _SKILL_ISOLATION_MODELS:
+        for row in snapshot[model]:
+            session.merge(model(**row))
+        session.flush()
+
+    session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_skill_tables(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[None, None, None]:
+    """Restore the skill tables to their pre-test state (see note above).
+
+    Shares the test's ``db_session`` so there is a single transaction holder —
+    no second connection that could block on row locks the test still holds.
+    """
+    snapshot = _snapshot_skill_tables(db_session)
+    yield
+    # Drop any uncommitted state a failing/early-exiting test left open before
+    # reconciling against the committed baseline.
+    db_session.rollback()
+    _restore_skill_tables(db_session, snapshot)
 
 
 @pytest.fixture(scope="function")

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -80,7 +80,6 @@ class TestAvailabilityGate:
             gated_id,
             BuiltInSkillDefinition(
                 built_in_skill_id=original.built_in_skill_id,
-                source_dir=original.source_dir,
                 is_available=lambda _: False,
                 unavailable_reason="dependency missing in test",
             ),
@@ -121,7 +120,6 @@ class TestAvailabilityGate:
             gated_id,
             BuiltInSkillDefinition(
                 built_in_skill_id=original.built_in_skill_id,
-                source_dir=original.source_dir,
                 is_available=lambda _: False,
             ),
         )

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -1,0 +1,111 @@
+"""Ext-dep tests for external-app skill content delivery via
+``build_skills_fileset_for_user``.
+
+External-app providers are *built-in skills* created on demand: their ``Skill``
+row carries a ``built_in_skill_id`` (e.g. ``slack``) so it renders through the
+exact same disk-backed path as a seeded built-in — there is no external-app
+special case in the push pipeline. These tests verify that an authenticated,
+enabled provider delivers its on-disk content under its stable directory, and
+that the gate (``list_skills_for_sandbox_injection``: enabled + per-user
+credential completeness) keeps content out otherwise.
+
+Uses the real Slack provider directory on disk so the wiring
+(``built_in_skill_id -> source dir``) is exercised end to end. The DB-layer
+gate itself is covered separately by ``test_external_app_skill_visibility``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.skills.built_in import SLACK
+from onyx.skills.push import build_skills_fileset_for_user
+from tests.external_dependency_unit.craft._test_helpers import make_external_app
+from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft._test_helpers import make_user_credential
+from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+
+# Slack ships on-disk skill content; require a single user-supplied key.
+_AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}
+_FULL_CREDS = {"token": "xoxp-test"}
+_SLACK_ID = SLACK.built_in_skill_id  # == slug == on-disk dir ("slack")
+
+
+def _slack_skill(db_session: Session, *, enabled: bool = True) -> Skill:
+    """A built-in Slack skill row (slug == built_in_skill_id), mirroring what
+    ``create_external_app`` makes for a connected Slack app. ``reset_*`` keeps
+    it independent of the migration-seeded built-in rows."""
+    return reset_built_in_skill_row(
+        db_session,
+        built_in_skill_id=_SLACK_ID,
+        is_public=True,
+        enabled=enabled,
+    )
+
+
+def _has_slack_content(files: dict[str, bytes]) -> bool:
+    return f"{_SLACK_ID}/SKILL.md" in files
+
+
+def test_authenticated_provider_delivers_content_under_stable_dir(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    skill = _slack_skill(db_session)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+    )
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+    db_session.commit()
+
+    files = build_skills_fileset_for_user(user, db_session)
+
+    # Renders from disk under the stable provider dir, like any built-in.
+    assert f"{_SLACK_ID}/SKILL.md" in files
+    assert f"{_SLACK_ID}/slack_api.py" in files
+
+
+def test_unauthenticated_provider_delivers_nothing(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    skill = _slack_skill(db_session)
+    make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+    )  # no user credential row
+    db_session.commit()
+
+    files = build_skills_fileset_for_user(user, db_session)
+
+    assert not _has_slack_content(files)
+
+
+def test_disabled_provider_delivers_nothing_even_when_authenticated(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    skill = _slack_skill(db_session, enabled=False)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+    )
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+    db_session.commit()
+
+    files = build_skills_fileset_for_user(user, db_session)
+
+    assert not _has_slack_content(files)

--- a/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
@@ -1,0 +1,141 @@
+"""The external-apps API must refresh already-running sandboxes on mutation,
+the same way the skills admin API does — otherwise a sandbox created *before*
+an app is connected (or before a user authenticates) never receives the skill.
+
+These tests call the endpoint functions directly with the push helpers
+monkeypatched, asserting each mutation triggers the right push:
+
+- user fills credentials  -> push scoped to the calling user
+- admin create/enable     -> push to all affected sandboxes
+- admin delete            -> push to users affected *before* the cascade
+
+The push helpers themselves are exercised by ``test_skill_push``; here we only
+pin the wiring so it can't silently regress.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import UUID
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+import onyx.server.features.build.api.external_apps_api as api
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.server.features.build.api.models import UpsertExternalAppRequest
+from onyx.server.features.build.api.models import UpsertUserCredentialsRequest
+from tests.external_dependency_unit.craft._test_helpers import make_external_app
+from tests.external_dependency_unit.craft._test_helpers import make_user
+from tests.external_dependency_unit.craft._test_helpers import reset_built_in_skill_row
+
+_AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def _clean_slack_rows(db_session: Session) -> Generator[None, None, None]:
+    """Remove any ``slack`` skill row (cascading its external_app) before and
+    after each test, so the slug-unique ``create_external_app`` path doesn't
+    collide with a row left by another test."""
+    db_session.execute(delete(Skill).where(Skill.slug == "slack"))
+    db_session.commit()
+    yield
+    db_session.execute(delete(Skill).where(Skill.slug == "slack"))
+    db_session.commit()
+
+
+def _slack_app(db_session: Session) -> ExternalApp:
+    skill = reset_built_in_skill_row(
+        db_session, built_in_skill_id="slack", is_public=True
+    )
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+    )
+    db_session.commit()
+    return app
+
+
+def test_credential_upsert_pushes_to_calling_user_only(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = make_user(db_session)
+    app = _slack_app(db_session)
+
+    calls: list[set[UUID]] = []
+    monkeypatch.setattr(
+        api, "push_skills_for_users", lambda user_ids, _db: calls.append(set(user_ids))
+    )
+
+    api.upsert_user_credentials(
+        external_app_id=app.id,
+        request=UpsertUserCredentialsRequest(user_credentials={"token": "t"}),
+        user=user,
+        db_session=db_session,
+    )
+
+    assert calls == [{user.id}]
+
+
+def test_create_pushes_to_affected_sandboxes(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pushed: list[Skill] = []
+    monkeypatch.setattr(
+        api,
+        "push_skill_to_affected_sandboxes",
+        lambda skill, _db: pushed.append(skill),
+    )
+
+    api.upsert_external_app(
+        request=UpsertExternalAppRequest(
+            id=None,
+            name="Slack",
+            description="Slack",
+            enabled=True,
+            app_type=ExternalAppType.SLACK,
+            upstream_url_patterns=[],
+            auth_template=_AUTH_TEMPLATE,
+            organization_credentials={},
+        ),
+        _=test_user,
+        db_session=db_session,
+    )
+
+    assert len(pushed) == 1
+    assert pushed[0].built_in_skill_id == "slack"
+
+
+def test_delete_pushes_to_affected_users_before_cascade(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _slack_app(db_session)
+    app_id = app.id
+
+    calls: list[set[UUID]] = []
+    monkeypatch.setattr(
+        api, "push_skills_for_users", lambda user_ids, _db: calls.append(set(user_ids))
+    )
+
+    api.delete_external_app_admin(
+        external_app_id=app_id,
+        _=test_user,
+        db_session=db_session,
+    )
+
+    # Push fired exactly once (affected set resolved pre-delete; empty here
+    # since no running sandboxes exist in this test).
+    assert len(calls) == 1
+    assert api.get_external_app_by_id(db_session, app_id) is None

--- a/backend/tests/external_dependency_unit/craft/test_skill_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push.py
@@ -550,7 +550,8 @@ class TestSkillPush:
         # Build a synthetic built-in skill source tree with a mix of files
         # the exclusion rule should keep IN and files it must keep OUT.
         slug = f"excl-builtin-{uuid4().hex[:6]}"
-        source_dir = tmp_path / "builtin_src" / slug
+        skills_root = tmp_path / "builtin_src"
+        source_dir = skills_root / slug
         source_dir.mkdir(parents=True)
 
         # In: SKILL.md + a vanilla script.
@@ -566,13 +567,13 @@ class TestSkillPush:
         pycache.mkdir()
         (pycache / "foo.pyc").write_bytes(b"\x00\x01")
 
+        # source_dir is computed as SKILLS_TEMPLATE_PATH/<id>; redirect the root
+        # at our synthetic tree so the definition resolves to source_dir.
+        monkeypatch.setattr(built_in_module, "SKILLS_TEMPLATE_PATH", str(skills_root))
         monkeypatch.setitem(
             built_in_module.BUILT_IN_SKILLS,
             slug,
-            BuiltInSkillDefinition(
-                built_in_skill_id=slug,
-                source_dir=source_dir,
-            ),
+            BuiltInSkillDefinition(built_in_skill_id=slug),
         )
         make_built_in_skill_row(db_session, built_in_skill_id=slug)
 

--- a/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
@@ -25,62 +25,61 @@ from tests.external_dependency_unit.craft._test_helpers import reset_built_in_sk
 _FRONTMATTER = "---\nname: {slug}\ndescription: {slug}\n---\n"
 
 
+def _write_skill_dir(
+    skills_root: Path,
+    skill_id: str,
+    *,
+    template_body: str | None = None,
+    extra_files: dict[str, str] | None = None,
+) -> None:
+    """Write a built-in's on-disk content at ``skills_root/<skill_id>`` — the
+    same ``SKILLS_TEMPLATE_PATH/<built_in_skill_id>`` layout production uses, so
+    the definition's computed ``source_dir`` resolves here once the caller has
+    redirected ``SKILLS_TEMPLATE_PATH`` at ``skills_root``.
+    """
+    source_dir = skills_root / skill_id
+    source_dir.mkdir(parents=True)
+    if template_body is not None:
+        (source_dir / "SKILL.md.template").write_text(template_body, encoding="utf-8")
+    else:
+        (source_dir / "SKILL.md").write_text(
+            _FRONTMATTER.format(slug=skill_id), encoding="utf-8"
+        )
+    for rel, content in (extra_files or {}).items():
+        path = source_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
 def _register_built_in(
     monkeypatch: pytest.MonkeyPatch,
     db_session: Session,
+    skills_root: Path,
     *,
-    source_dir: Path,
+    extra_files: dict[str, str] | None = None,
+    template_body: str | None = None,
 ) -> str:
-    """Register a fresh built-in definition + Skill row for one test.
-
-    ``has_template`` is computed from ``source_dir`` (whether a
-    ``SKILL.md.template`` exists), so callers just write the right files.
-    Returns the synthetic ``built_in_skill_id`` (also used as slug).
+    """Register a fresh synthetic built-in (definition + Skill row) whose
+    content lives under ``skills_root/<id>``, redirecting ``SKILLS_TEMPLATE_PATH``
+    so its computed ``source_dir`` resolves there. Returns the synthetic
+    ``built_in_skill_id`` (also the slug and on-disk dir name).
     """
+    monkeypatch.setattr(built_in_module, "SKILLS_TEMPLATE_PATH", str(skills_root))
     built_in_skill_id = f"test-builtin-{uuid4().hex[:8]}"
-    definition = BuiltInSkillDefinition(
-        built_in_skill_id=built_in_skill_id,
-        source_dir=source_dir,
+    _write_skill_dir(
+        skills_root,
+        built_in_skill_id,
+        template_body=template_body,
+        extra_files=extra_files,
     )
-    monkeypatch.setitem(built_in_module.BUILT_IN_SKILLS, built_in_skill_id, definition)
+    monkeypatch.setitem(
+        built_in_module.BUILT_IN_SKILLS,
+        built_in_skill_id,
+        BuiltInSkillDefinition(built_in_skill_id=built_in_skill_id),
+    )
     make_built_in_skill_row(db_session, built_in_skill_id=built_in_skill_id)
     db_session.commit()
     return built_in_skill_id
-
-
-def _write_static_dir(
-    tmp_path: Path,
-    slug: str,
-    extra_files: dict[str, str] | None = None,
-) -> Path:
-    """Create a source dir under ``tmp_path`` with SKILL.md + optional siblings."""
-    source_dir = tmp_path / slug
-    source_dir.mkdir(parents=True)
-    (source_dir / "SKILL.md").write_text(
-        _FRONTMATTER.format(slug=slug), encoding="utf-8"
-    )
-    for rel, content in (extra_files or {}).items():
-        path = source_dir / rel
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
-    return source_dir
-
-
-def _write_template_dir(
-    tmp_path: Path,
-    slug: str,
-    *,
-    template_body: str,
-    extra_files: dict[str, str] | None = None,
-) -> Path:
-    source_dir = tmp_path / slug
-    source_dir.mkdir(parents=True)
-    (source_dir / "SKILL.md.template").write_text(template_body, encoding="utf-8")
-    for rel, content in (extra_files or {}).items():
-        path = source_dir / rel
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content, encoding="utf-8")
-    return source_dir
 
 
 class TestBuiltInFromDisk:
@@ -91,14 +90,16 @@ class TestBuiltInFromDisk:
         test_user: User,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        source = _write_static_dir(
-            tmp_path, "pptx", {"scripts/preview.py": "print('hi')"}
+        slug = _register_built_in(
+            monkeypatch,
+            db_session,
+            tmp_path,
+            extra_files={"scripts/preview.py": "print('hi')"},
         )
-        slug = _register_built_in(monkeypatch, db_session, source_dir=source)
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
-        assert b"name: pptx" in files[f"{slug}/SKILL.md"]
+        assert f"name: {slug}".encode() in files[f"{slug}/SKILL.md"]
         assert files[f"{slug}/scripts/preview.py"] == b"print('hi')"
 
     def test_excluded_dirs_and_dotfiles_are_skipped(
@@ -108,16 +109,16 @@ class TestBuiltInFromDisk:
         test_user: User,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        source = _write_static_dir(
+        slug = _register_built_in(
+            monkeypatch,
+            db_session,
             tmp_path,
-            "pptx",
-            {
+            extra_files={
                 "__pycache__/cached.pyc": "junk",
                 ".DS_Store": "junk",
                 "scripts/.hidden": "junk",
             },
         )
-        slug = _register_built_in(monkeypatch, db_session, source_dir=source)
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
@@ -144,20 +145,12 @@ class TestBuiltInTemplate:
             f"{_FRONTMATTER.format(slug='company-search')}"
             "Sources:\n{{AVAILABLE_SOURCES_SECTION}}\n"
         )
-        source = _write_template_dir(
-            tmp_path, "company-search", template_body=template_body
-        )
-        # Redirect the company-search definition at the tmp_path source
-        # and (re)create its row. reset_* is idempotent against the
-        # migration-seeded canonical row.
-        monkeypatch.setitem(
-            built_in_module.BUILT_IN_SKILLS,
-            "company-search",
-            BuiltInSkillDefinition(
-                built_in_skill_id="company-search",
-                source_dir=source,
-            ),
-        )
+        # Redirect SKILLS_TEMPLATE_PATH at tmp_path and write the template under
+        # company-search/ — the registry's existing definition computes its
+        # source_dir from there, so no definition swap is needed. reset_* is
+        # idempotent against the migration-seeded canonical row.
+        monkeypatch.setattr(built_in_module, "SKILLS_TEMPLATE_PATH", str(tmp_path))
+        _write_skill_dir(tmp_path, "company-search", template_body=template_body)
         reset_built_in_skill_row(db_session, built_in_skill_id="company-search")
         db_session.commit()
         make_cc_pair(db_session, DocumentSource.SLACK)
@@ -179,19 +172,12 @@ class TestBuiltInTemplate:
             f"{_FRONTMATTER.format(slug='company-search')}"
             "{{AVAILABLE_SOURCES_SECTION}}\n"
         )
-        source = _write_template_dir(
+        monkeypatch.setattr(built_in_module, "SKILLS_TEMPLATE_PATH", str(tmp_path))
+        _write_skill_dir(
             tmp_path,
             "company-search",
             template_body=template_body,
             extra_files={"scripts/search.py": "print('search')"},
-        )
-        monkeypatch.setitem(
-            built_in_module.BUILT_IN_SKILLS,
-            "company-search",
-            BuiltInSkillDefinition(
-                built_in_skill_id="company-search",
-                source_dir=source,
-            ),
         )
         reset_built_in_skill_row(db_session, built_in_skill_id="company-search")
         db_session.commit()

--- a/backend/tests/integration/tests/external_apps/test_external_apps.py
+++ b/backend/tests/integration/tests/external_apps/test_external_apps.py
@@ -520,16 +520,17 @@ def test_partial_credentials_keep_app_unauthenticated_full_org_template_is_immed
 # =============================================================================
 
 
-def test_app_type_round_trips_and_defaults_to_custom(
+def test_app_type_defaults_to_custom_and_is_immutable_on_update(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
-    """`app_type` is the discriminator the OAuth dispatch layer keys off,
-    so it must survive an upsert round-trip. The default flow (the
-    manager's `create()` with no override) produces a CUSTOM app, and an
-    explicit built-in value (SLACK here) round-trips on both create and
-    update — proving admins can switch an existing row's provider
-    binding without recreating it."""
+    """`app_type` is the discriminator the OAuth dispatch layer keys off and
+    what the backing skill's definition source is bound to, so it's fixed at
+    creation. The default flow (the manager's `create()` with no override)
+    produces a CUSTOM app, an explicit built-in value (SLACK) round-trips on
+    create, and an update that re-sends the *same* type succeeds — but an
+    update that tries to *change* the type is rejected with 400 rather than
+    silently rebinding the skill and orphaning credentials."""
     default_app = _create_test_app(admin_user, name="Default-type App")
     assert default_app.app_type == ExternalAppType.CUSTOM
 
@@ -538,15 +539,38 @@ def test_app_type_round_trips_and_defaults_to_custom(
     )
     assert slack_app.app_type == ExternalAppType.SLACK
 
-    updated = ExternalAppManager.update(
+    # Re-sending the unchanged app_type is a valid update (validation passes
+    # because old == new), and other fields still mutate.
+    unchanged = ExternalAppManager.update(
         user_performing_action=admin_user,
         app_id=slack_app.id,
-        name=slack_app.name,
+        name="Slack App (renamed)",
         description=slack_app.description,
         upstream_url_patterns=slack_app.upstream_url_patterns,
         auth_template=slack_app.auth_template,
         organization_credentials=slack_app.organization_credentials,
         enabled=slack_app.enabled,
-        app_type=ExternalAppType.LINEAR,
+        app_type=ExternalAppType.SLACK,
     )
-    assert updated.app_type == ExternalAppType.LINEAR
+    assert unchanged.app_type == ExternalAppType.SLACK
+    assert unchanged.name == "Slack App (renamed)"
+
+    # Changing app_type is forbidden.
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        ExternalAppManager.update(
+            user_performing_action=admin_user,
+            app_id=slack_app.id,
+            name=slack_app.name,
+            description=slack_app.description,
+            upstream_url_patterns=slack_app.upstream_url_patterns,
+            auth_template=slack_app.auth_template,
+            organization_credentials=slack_app.organization_credentials,
+            enabled=slack_app.enabled,
+            app_type=ExternalAppType.LINEAR,
+        )
+    assert exc.value.response.status_code == 400
+
+    # The stored type is unchanged after the rejected update.
+    apps = ExternalAppManager.list_admin(admin_user)
+    persisted = next(a for a in apps if a.id == slack_app.id)
+    assert persisted.app_type == ExternalAppType.SLACK

--- a/backend/tests/unit/onyx/skills/test_built_in_definition.py
+++ b/backend/tests/unit/onyx/skills/test_built_in_definition.py
@@ -9,8 +9,6 @@ and on-disk lookups."""
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -18,10 +16,7 @@ from onyx.skills.built_in import BuiltInSkillDefinition
 
 
 def _definition(slug: str) -> BuiltInSkillDefinition:
-    return BuiltInSkillDefinition(
-        built_in_skill_id=slug,
-        source_dir=Path("/tmp/does-not-matter"),
-    )
+    return BuiltInSkillDefinition(built_in_skill_id=slug)
 
 
 def test_valid_built_in_skill_id_constructs_cleanly() -> None:


### PR DESCRIPTION
## Description
Implements skills for slack, google calendar and linear. These are setup and configured via the external apps pathway.

## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds built-in Slack, Google Calendar, and Linear apps via the external apps flow. Connecting a provider creates a built-in skill bound to on-disk content; only enabled apps with complete user credentials ship, and running sandboxes refresh on admin and user changes.

- New Features
  - Unified built-in registry for seeded skills and external-app-backed skills; import-time checks prevent duplicate `skill_id`/`app_type` and `source_dir`/`has_template` are computed from disk.
  - Added built-in skill definitions for `slack`, `google-calendar`, and `linear`; provider → built-in id mapping via `EXTERNAL_APP_BUILT_IN_SKILL_IDS`.
  - `create_external_app` derives skill from `app_type`: built-ins create a single built-in skill row per tenant (slug == built-in id; duplicate → 409) via `create_built_in_skill_row__no_commit`; `CUSTOM` apps get a server-generated slug and an empty bundle.
  - `app_type` is immutable on update; resending the same type is allowed, changing it returns 400.
  - Sandbox content now uses `list_skills_for_sandbox_injection` so only enabled skills with complete per-user credentials are shipped; unavailable built-ins are filtered.
  - Admin create/update/delete and user credential upserts trigger live pushes (`push_skill_to_affected_sandboxes`, `push_skills_for_users`) so changes apply to running sandboxes.
  - Bundled helper CLIs and docs: `slack/slack_api.py`, `google-calendar/gcal_api.py`, `linear/linear_api.py` (auto-paginated reads with pruning; minimal writes).

- Tests
  - Autouse snapshot/restore for `Skill` and external-app tables prevents cross-test and local DB contamination.
  - Fileset tests verify provider content ships under stable dirs and gating (enabled + credentials) works.
  - Endpoint wiring tests assert pushes fire on admin create/delete and user credential upserts; integration tests confirm `app_type` defaults to `CUSTOM`, unchanged resubmits succeed, and type changes are rejected with 400.

<sup>Written for commit 9a82a22b39f92cd10a677325d761d61b29a27c9c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



