### PR TITLE
feat(craft): Custom External Apps

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -105,6 +105,8 @@ def create_external_app(
     db_session: Session,
     name: str,
     description: str,
+    bundle_file_id: str,
+    bundle_sha256: str,
     app_type: ExternalAppType,
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -5,12 +5,15 @@ from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
+from onyx.db.models import Skill
+from onyx.db.utils import is_unique_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
@@ -105,8 +108,6 @@ def create_external_app(
     db_session: Session,
     name: str,
     description: str,
-    bundle_file_id: str,
-    bundle_sha256: str,
     app_type: ExternalAppType,
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],
@@ -175,6 +176,50 @@ def create_external_app(
     return app
 
 
+def _rebind_skill_for_app_type__no_commit(
+    skill: Skill,
+    app_type: ExternalAppType,
+    db_session: Session,
+) -> None:
+    """Keep the linked skill's definition source in lockstep with the app's
+    provider type after an update. A built-in provider type binds the row to
+    that provider's built-in content (``built_in_skill_id`` + ``slug`` + NULL
+    bundle); ``CUSTOM`` reverts it to a custom (bundle-backed) row. No-op when
+    the row already matches.
+
+    Raises ``OnyxError(DUPLICATE_RESOURCE)`` if rebinding would collide with an
+    existing row for the same provider in this tenant.
+    """
+    target_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
+    if target_id is not None:
+        if skill.built_in_skill_id == target_id:
+            return
+        skill.built_in_skill_id = target_id
+        skill.slug = target_id
+        skill.bundle_file_id = None
+        skill.bundle_sha256 = None
+    else:
+        if skill.built_in_skill_id is None:
+            return
+        skill.built_in_skill_id = None
+        # Custom rows satisfy the XOR check constraint via a (currently empty)
+        # bundle rather than a built-in id.
+        skill.bundle_file_id = ""
+        skill.bundle_sha256 = ""
+
+    from onyx.db.skill import SKILL_SLUG_UNIQUE_CONSTRAINT
+
+    try:
+        db_session.flush()
+    except IntegrityError as e:
+        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
+            raise OnyxError(
+                OnyxErrorCode.DUPLICATE_RESOURCE,
+                f"A skill with slug '{skill.slug}' already exists.",
+            ) from e
+        raise
+
+
 def update_external_app(
     db_session: Session,
     external_app_id: int,
@@ -224,6 +269,10 @@ def update_external_app(
     app.upstream_url_patterns = upstream_url_patterns
     app.auth_template = auth_template
     app.organization_credentials = organization_credentials
+
+    # Provider type drives which skill content is delivered, so keep the
+    # backing skill row's definition source aligned when app_type changes.
+    _rebind_skill_for_app_type__no_commit(app.skill, app_type, db_session)
 
     db_session.commit()
     return app

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -259,7 +259,7 @@ def update_external_app(
         )
 
     # app_type is immutable. Changing it would silently rebind the skill's
-    # definition source.
+    # definition source
     if app.app_type != app_type:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -45,6 +45,44 @@ def required_user_credential_keys(
     )
 
 
+def validate_auth_template(
+    auth_template: dict[str, Any],
+    organization_credentials: dict[str, Any],
+) -> None:
+    """Validate an external app's header credential template before persisting.
+
+    The egress proxy injects ``auth_template`` headers (with ``{placeholder}``
+    values filled from org + per-user credentials) into outbound requests. An
+    app may legitimately inject *no* headers — e.g. an allowlist-only app that
+    just grants the sandbox network access to its upstream patterns — so an
+    empty template (and empty organization credentials) is allowed. When headers
+    *are* provided, each must be a non-empty string name mapped to a non-empty
+    string value; organization-credential keys must likewise be non-empty
+    strings. Raises ``OnyxError(INVALID_INPUT)`` on any violation.
+
+    Note: only ``{name}`` tokens matching the credential-key grammar are treated
+    as placeholders (see ``_PLACEHOLDER_RE``); other braces are literal, so
+    there is nothing further to validate about placeholder legality here.
+    """
+    for key, value in auth_template.items():
+        if not isinstance(key, str) or not key.strip():
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "auth_template header names must be non-empty strings.",
+            )
+        if not isinstance(value, str) or not value.strip():
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"auth_template value for header '{key}' must be a non-empty string.",
+            )
+    for key in organization_credentials:
+        if not isinstance(key, str) or not key.strip():
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "organization_credentials keys must be non-empty strings.",
+            )
+
+
 def is_user_authenticated_for_app(
     app: ExternalApp,
     user_cred: ExternalAppUserCredential | None,
@@ -114,6 +152,7 @@ def create_external_app(
     enabled: bool = True,
     is_public: bool = False,
     author_user_id: UUID | None = None,
+    slug: str | None = None,
 ) -> ExternalApp:
     """Create the backing Skill row and the ExternalApp that references it,
     committing both atomically. The skill row owns display metadata
@@ -127,8 +166,10 @@ def create_external_app(
       its bundled on-disk content through the same path as a seeded built-in.
       Slug uniqueness means one instance per provider per tenant — a duplicate
       raises ``OnyxError(DUPLICATE_RESOURCE)``.
-    - A ``CUSTOM`` app gets a custom (bundle-backed) skill row with a fresh
-      slug, so multiple instances can coexist.
+    - A ``CUSTOM`` app gets a custom (bundle-backed) skill row. ``slug`` is the
+      uploaded bundle's filename-derived slug (see the custom-app create
+      endpoint); when omitted, a fresh ``custom-<uuid>`` slug is generated so
+      bundle-less callers still get a unique, collision-free row.
     """
     from onyx.db.skill import create_built_in_skill_row__no_commit
     from onyx.db.skill import create_skill__no_commit
@@ -145,12 +186,11 @@ def create_external_app(
             db_session=db_session,
         )
     else:
-        # CUSTOM: fresh slug so multiple instances don't collide. The bundle is
-        # intentionally empty for now — custom-app bundle rendering is a
-        # separate workstream.
-        slug = f"{app_type.value.lower()}-{uuid4().hex[:8]}"
+        # CUSTOM: use the bundle's filename-derived slug, falling back to a
+        # generated one when no bundle is supplied (e.g. the JSON upsert path).
+        custom_slug = slug or f"{app_type.value.lower()}-{uuid4().hex[:8]}"
         skill = create_skill__no_commit(
-            slug=slug,
+            slug=custom_slug,
             name=name,
             description=description,
             bundle_file_id=bundle_file_id,
@@ -185,18 +225,28 @@ def update_external_app(
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],
     organization_credentials: dict[str, Any],
-) -> ExternalApp:
+    new_bundle_file_id: str | None = None,
+    new_bundle_sha256: str | None = None,
+) -> tuple[ExternalApp, str | None]:
     """Replace mutable fields on the external app and its linked skill,
-    committing both atomically.
+    committing both atomically. Returns ``(app, old_bundle_file_id)``.
 
     Skill-side fields: name, description, enabled.
     External-app-side fields: upstream_url_patterns, auth_template,
     organization_credentials.
 
-    ``app_type`` is immutable — it's the discriminator the OAuth dispatch
-    layer keys off and what the backing skill's definition source is bound
-    to, so it's passed for validation only. Slug, bundle, and sharing scope
-    are out of scope here (each has its own update path in ``onyx.db.skill``).
+    ``app_type`` is immutable — it's the discriminator the OAuth dispatch layer
+    keys off and what the backing skill's definition source is bound to, so it's
+    passed for validation only. Passing a value that differs from the stored one
+    raises; this also blocks editing a built-in app through the custom-app path
+    (which passes ``CUSTOM``) and vice versa.
+
+    Bundle replacement (custom apps only): when ``new_bundle_file_id`` /
+    ``new_bundle_sha256`` are given the skill's bundle is swapped (slug
+    unchanged) and the *previous* ``bundle_file_id`` is returned so the caller
+    can delete that blob after the commit — never inline. When omitted the
+    existing bundle is kept and the returned old id is ``None``. Built-in
+    callers leave these unset and ignore the returned id.
 
     Raises ``OnyxError(NOT_FOUND)`` if no row with `external_app_id` exists,
     or ``OnyxError(INVALID_INPUT)`` if `app_type` differs from the stored value.
@@ -209,7 +259,7 @@ def update_external_app(
         )
 
     # app_type is immutable. Changing it would silently rebind the skill's
-    # definition source
+    # definition source.
     if app.app_type != app_type:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
@@ -221,12 +271,19 @@ def update_external_app(
     app.skill.description = description
     app.skill.enabled = enabled
 
+    old_bundle_file_id: str | None = None
+    if new_bundle_file_id is not None:
+        # Keep the slug; only the bundle bytes change.
+        old_bundle_file_id = app.skill.bundle_file_id
+        app.skill.bundle_file_id = new_bundle_file_id
+        app.skill.bundle_sha256 = new_bundle_sha256
+
     app.upstream_url_patterns = upstream_url_patterns
     app.auth_template = auth_template
     app.organization_credentials = organization_credentials
 
     db_session.commit()
-    return app
+    return app, old_bundle_file_id
 
 
 def delete_external_app(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -5,15 +5,12 @@ from uuid import uuid4
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
-from onyx.db.models import Skill
-from onyx.db.utils import is_unique_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS
@@ -176,50 +173,6 @@ def create_external_app(
     return app
 
 
-def _rebind_skill_for_app_type__no_commit(
-    skill: Skill,
-    app_type: ExternalAppType,
-    db_session: Session,
-) -> None:
-    """Keep the linked skill's definition source in lockstep with the app's
-    provider type after an update. A built-in provider type binds the row to
-    that provider's built-in content (``built_in_skill_id`` + ``slug`` + NULL
-    bundle); ``CUSTOM`` reverts it to a custom (bundle-backed) row. No-op when
-    the row already matches.
-
-    Raises ``OnyxError(DUPLICATE_RESOURCE)`` if rebinding would collide with an
-    existing row for the same provider in this tenant.
-    """
-    target_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
-    if target_id is not None:
-        if skill.built_in_skill_id == target_id:
-            return
-        skill.built_in_skill_id = target_id
-        skill.slug = target_id
-        skill.bundle_file_id = None
-        skill.bundle_sha256 = None
-    else:
-        if skill.built_in_skill_id is None:
-            return
-        skill.built_in_skill_id = None
-        # Custom rows satisfy the XOR check constraint via a (currently empty)
-        # bundle rather than a built-in id.
-        skill.bundle_file_id = ""
-        skill.bundle_sha256 = ""
-
-    from onyx.db.skill import SKILL_SLUG_UNIQUE_CONSTRAINT
-
-    try:
-        db_session.flush()
-    except IntegrityError as e:
-        if is_unique_violation(e, SKILL_SLUG_UNIQUE_CONSTRAINT):
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{skill.slug}' already exists.",
-            ) from e
-        raise
-
-
 def update_external_app(
     db_session: Session,
     external_app_id: int,
@@ -269,10 +222,6 @@ def update_external_app(
     app.upstream_url_patterns = upstream_url_patterns
     app.auth_template = auth_template
     app.organization_credentials = organization_credentials
-
-    # Provider type drives which skill content is delivered, so keep the
-    # backing skill row's definition source aligned when app_type changes.
-    _rebind_skill_for_app_type__no_commit(app.skill, app_type, db_session)
 
     db_session.commit()
     return app

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -33,13 +33,9 @@ def required_user_credential_keys(
     auth_template: dict[str, Any],
     organization_credentials: dict[str, Any],
 ) -> list[str]:
-    """Credential parameter names the user must supply, derived from
-    `{placeholder}` references in `auth_template` values minus what
-    `organization_credentials` pre-fills. Returned sorted.
-
-    Looks at template *values*, not keys — keys are header names,
-    placeholders inside the values are the credential parameter names.
-    """
+    """Sorted credential parameter names the user must supply: `{placeholder}`
+    references in `auth_template` values not pre-filled by
+    `organization_credentials`."""
     return sorted(
         _placeholders_in_template(auth_template) - organization_credentials.keys()
     )
@@ -49,20 +45,12 @@ def validate_auth_template(
     auth_template: dict[str, Any],
     organization_credentials: dict[str, Any],
 ) -> None:
-    """Validate an external app's header credential template before persisting.
+    """Validate an app's header credential template before persisting.
 
-    The egress proxy injects ``auth_template`` headers (with ``{placeholder}``
-    values filled from org + per-user credentials) into outbound requests. An
-    app may legitimately inject *no* headers — e.g. an allowlist-only app that
-    just grants the sandbox network access to its upstream patterns — so an
-    empty template (and empty organization credentials) is allowed. When headers
-    *are* provided, each must be a non-empty string name mapped to a non-empty
-    string value; organization-credential keys must likewise be non-empty
-    strings. Raises ``OnyxError(INVALID_INPUT)`` on any violation.
-
-    Note: only ``{name}`` tokens matching the credential-key grammar are treated
-    as placeholders (see ``_PLACEHOLDER_RE``); other braces are literal, so
-    there is nothing further to validate about placeholder legality here.
+    An empty template is allowed (e.g. an allowlist-only app that injects no
+    headers). When headers are present, each name and value must be a non-empty
+    string, as must every organization-credential key. Raises
+    ``OnyxError(INVALID_INPUT)`` on violation.
     """
     for key, value in auth_template.items():
         if not isinstance(key, str) or not key.strip():
@@ -88,10 +76,8 @@ def is_user_authenticated_for_app(
     user_cred: ExternalAppUserCredential | None,
 ) -> bool:
     """True iff the user has supplied every credential parameter the app's
-    ``auth_template`` references that the org has not pre-filled. An
-    app with no user-required keys (everything covered by
-    ``organization_credentials``) is considered authenticated for every
-    user, no credential row needed."""
+    ``auth_template`` requires that the org hasn't pre-filled. Apps with no
+    user-required keys need no credential row."""
     required = required_user_credential_keys(
         app.auth_template, app.organization_credentials
     )
@@ -129,10 +115,8 @@ def get_user_credentials_by_app_id(
     db_session: Session,
     user_id: UUID,
 ) -> dict[int, ExternalAppUserCredential]:
-    """Return mapping from external_app_id -> the user's credential row.
-
-    Apps the user has never configured are simply absent from the mapping.
-    """
+    """Map external_app_id -> the user's credential row. Apps the user never
+    configured are absent."""
     stmt = select(ExternalAppUserCredential).where(
         ExternalAppUserCredential.user_id == user_id
     )
@@ -155,21 +139,14 @@ def create_external_app(
     slug: str | None = None,
 ) -> ExternalApp:
     """Create the backing Skill row and the ExternalApp that references it,
-    committing both atomically. The skill row owns display metadata
-    (name/description) and lifecycle (enabled); the external_app row owns
-    gateway state (auth_template, upstream patterns, org creds).
+    committing atomically. The skill owns display metadata + lifecycle; the
+    external_app owns gateway state.
 
-    The skill row's *shape* is derived from ``app_type``:
-
-    - A built-in provider (``EXTERNAL_APP_BUILT_IN_SKILL_IDS``) gets a built-in
-      skill row (``built_in_skill_id`` set, ``slug`` == that id) so it delivers
-      its bundled on-disk content through the same path as a seeded built-in.
-      Slug uniqueness means one instance per provider per tenant — a duplicate
-      raises ``OnyxError(DUPLICATE_RESOURCE)``.
-    - A ``CUSTOM`` app gets a custom (bundle-backed) skill row. ``slug`` is the
-      uploaded bundle's filename-derived slug (see the custom-app create
-      endpoint); when omitted, a fresh ``custom-<uuid>`` slug is generated so
-      bundle-less callers still get a unique, collision-free row.
+    Built-in providers (``EXTERNAL_APP_BUILT_IN_SKILL_IDS``) get a built-in
+    skill row whose slug is the provider id, so slug uniqueness means one
+    instance per provider per tenant (duplicate raises ``DUPLICATE_RESOURCE``).
+    CUSTOM apps get a bundle-backed skill using ``slug``, or a generated
+    ``custom-<uuid>`` slug when omitted.
     """
     from onyx.db.skill import create_built_in_skill_row__no_commit
     from onyx.db.skill import create_skill__no_commit
@@ -229,27 +206,19 @@ def update_external_app(
     new_bundle_sha256: str | None = None,
 ) -> tuple[ExternalApp, str | None]:
     """Replace mutable fields on the external app and its linked skill,
-    committing both atomically. Returns ``(app, old_bundle_file_id)``.
+    committing atomically. Returns ``(app, old_bundle_file_id)``.
 
-    Skill-side fields: name, description, enabled.
-    External-app-side fields: upstream_url_patterns, auth_template,
-    organization_credentials.
+    ``app_type`` is immutable (it's the dispatch discriminator); passing a value
+    differing from the stored one raises, which also blocks cross-editing
+    built-in vs custom apps.
 
-    ``app_type`` is immutable — it's the discriminator the OAuth dispatch layer
-    keys off and what the backing skill's definition source is bound to, so it's
-    passed for validation only. Passing a value that differs from the stored one
-    raises; this also blocks editing a built-in app through the custom-app path
-    (which passes ``CUSTOM``) and vice versa.
+    For custom apps, passing ``new_bundle_file_id``/``new_bundle_sha256`` swaps
+    the bundle (slug unchanged) and returns the previous ``bundle_file_id`` so
+    the caller can delete that blob after commit; otherwise the old id is
+    ``None``.
 
-    Bundle replacement (custom apps only): when ``new_bundle_file_id`` /
-    ``new_bundle_sha256`` are given the skill's bundle is swapped (slug
-    unchanged) and the *previous* ``bundle_file_id`` is returned so the caller
-    can delete that blob after the commit — never inline. When omitted the
-    existing bundle is kept and the returned old id is ``None``. Built-in
-    callers leave these unset and ignore the returned id.
-
-    Raises ``OnyxError(NOT_FOUND)`` if no row with `external_app_id` exists,
-    or ``OnyxError(INVALID_INPUT)`` if `app_type` differs from the stored value.
+    Raises ``OnyxError(NOT_FOUND)`` if the app doesn't exist, or
+    ``INVALID_INPUT`` if ``app_type`` differs from the stored value.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -290,12 +259,10 @@ def delete_external_app(
     db_session: Session,
     external_app_id: int,
 ) -> str | None:
-    """Delete the linked Skill (FK ON DELETE CASCADE removes the
-    external_app row as well as user credentials) and commit. Returns the
-    skill's ``bundle_file_id`` so the caller can clean up FileStore *after*
-    the delete is committed.
-
-    Raises ``OnyxError(NOT_FOUND)`` if no row with `external_app_id` exists.
+    """Delete the linked Skill (cascade removes the external_app row and user
+    credentials) and commit. Returns the skill's ``bundle_file_id`` so the
+    caller can clean up FileStore after the commit. Raises
+    ``OnyxError(NOT_FOUND)`` if the app doesn't exist.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -316,13 +283,9 @@ def upsert_external_app_user_credential(
     user_id: UUID,
     user_credentials: dict[str, Any],
 ) -> ExternalAppUserCredential:
-    """Create or replace the calling user's credentials for the given external
-    app, and commit.
-
-    Atomic via ON CONFLICT against the unique (external_app_id, user_id)
-    constraint, so concurrent callers can't both insert a duplicate row.
-
-    Raises ``OnyxError(NOT_FOUND)`` if no app with `external_app_id` exists.
+    """Create or replace the calling user's credentials for the app, and commit.
+    Atomic via ON CONFLICT on (external_app_id, user_id). Raises
+    ``OnyxError(NOT_FOUND)`` if the app doesn't exist.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -1,5 +1,11 @@
+from typing import Any
+
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import File
+from fastapi import Form
+from fastapi import UploadFile
+from pydantic import TypeAdapter
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -14,6 +20,7 @@ from onyx.db.external_app import get_user_credentials_by_app_id
 from onyx.db.external_app import required_user_credential_keys
 from onyx.db.external_app import update_external_app
 from onyx.db.external_app import upsert_external_app_user_credential
+from onyx.db.external_app import validate_auth_template
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import User
@@ -22,15 +29,36 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers import fetch_available_built_in_apps
 from onyx.external_apps.providers import fetch_built_in_app
+from onyx.file_store.file_store import FileStore
+from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.api.models import BuiltInExternalAppDescriptor
 from onyx.server.features.build.api.models import ExternalAppAdminResponse
 from onyx.server.features.build.api.models import ExternalAppUserResponse
 from onyx.server.features.build.api.models import UpsertExternalAppRequest
 from onyx.server.features.build.api.models import UpsertUserCredentialsRequest
+from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
+from onyx.utils.logger import setup_logger
+from onyx.utils.pydantic_util import parse_json_form_field
+
+logger = setup_logger()
 
 router = APIRouter()
+
+# Adapters for the structured custom-app form fields, which arrive as JSON
+# strings (multipart can't carry native lists/objects).
+_STR_LIST_ADAPTER = TypeAdapter(list[str])
+_STR_DICT_ADAPTER: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
+
+
+def _delete_bundle_blob(file_store: FileStore, file_id: str) -> None:
+    try:
+        file_store.delete_file(file_id, error_on_missing=False)
+    except Exception:
+        logger.warning(
+            "Failed to delete orphaned bundle blob %s", file_id, exc_info=True
+        )
 
 
 def _to_admin_response(app: ExternalApp) -> ExternalAppAdminResponse:
@@ -89,9 +117,20 @@ def upsert_external_app(
     """Create a new external app, or update an existing one if `id` is set.
 
     If `id` is provided but no app with that id exists, returns 404.
+
+    This endpoint is for built-in providers only. Custom apps (bundle-backed)
+    are created and edited through ``/admin/apps/custom`` so their bundle can be
+    uploaded/replaced; sending ``app_type=CUSTOM`` here is rejected.
     """
+    if request.app_type == ExternalAppType.CUSTOM:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Custom apps must be managed via POST /admin/apps/custom.",
+        )
+
     if request.id is not None:
-        app = update_external_app(
+        # Built-in apps have no bundle to swap; ignore the returned old-blob id.
+        app, _old = update_external_app(
             db_session=db_session,
             external_app_id=request.id,
             name=request.name,
@@ -127,6 +166,183 @@ def upsert_external_app(
     # the skill and a user who hasn't authenticated yet still sees nothing.
     push_skill_to_affected_sandboxes(app.skill, db_session)
 
+    return _to_admin_response(app)
+
+
+@router.post("/admin/apps/custom")
+def upsert_custom_external_app(
+    name: str = Form(...),
+    description: str = Form(""),
+    upstream_url_patterns: str = Form(...),
+    auth_template: str = Form(...),
+    organization_credentials: str = Form(...),
+    app_id: int | None = Form(None),
+    enabled: bool = Form(True),
+    bundle: UploadFile | None = File(None),
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> ExternalAppAdminResponse:
+    """Create or edit a CUSTOM external app (bundle-backed) + gateway config.
+
+    Multipart because of the bundle file; the structured fields ride as
+    JSON-encoded form strings. The display name is the form value (overriding
+    the bundle's SKILL.md name); description falls back to the bundle's when
+    left blank.
+
+    - **Create** (`app_id` omitted): a bundle is required. It goes through the
+      same ingest pathway as a custom skill (validate → store) and an
+      ``ExternalApp`` row is created alongside the backing skill. Default-public.
+    - **Edit** (`app_id` set): updates name/description/enabled + gateway config.
+      A bundle is optional — when supplied it *replaces* the existing one
+      (keeping the slug); when omitted the current bundle is kept.
+    """
+    parsed_patterns = parse_json_form_field(
+        upstream_url_patterns, _STR_LIST_ADAPTER, "upstream_url_patterns"
+    )
+    parsed_auth_template = parse_json_form_field(
+        auth_template, _STR_DICT_ADAPTER, "auth_template"
+    )
+    parsed_org_credentials = parse_json_form_field(
+        organization_credentials, _STR_DICT_ADAPTER, "organization_credentials"
+    )
+
+    if not name.strip():
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "name is required.")
+    if not parsed_patterns:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "At least one upstream URL pattern is required.",
+        )
+    validate_auth_template(parsed_auth_template, parsed_org_credentials)
+
+    file_store = get_default_file_store()
+
+    if app_id is None:
+        return _create_custom_app(
+            db_session=db_session,
+            file_store=file_store,
+            name=name.strip(),
+            description=description.strip(),
+            upstream_url_patterns=parsed_patterns,
+            auth_template=parsed_auth_template,
+            organization_credentials=parsed_org_credentials,
+            bundle=bundle,
+        )
+
+    return _edit_custom_app(
+        db_session=db_session,
+        file_store=file_store,
+        app_id=app_id,
+        name=name.strip(),
+        description=description.strip(),
+        enabled=enabled,
+        upstream_url_patterns=parsed_patterns,
+        auth_template=parsed_auth_template,
+        organization_credentials=parsed_org_credentials,
+        bundle=bundle,
+    )
+
+
+def _create_custom_app(
+    *,
+    db_session: Session,
+    file_store: FileStore,
+    name: str,
+    description: str,
+    upstream_url_patterns: list[str],
+    auth_template: dict[str, Any],
+    organization_credentials: dict[str, Any],
+    bundle: UploadFile | None,
+) -> ExternalAppAdminResponse:
+    if bundle is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "A bundle (.zip) is required when creating a custom app.",
+        )
+    ingested = ingest_skill_bundle(bundle.file.read(), bundle.filename, file_store)
+    try:
+        app = create_external_app(
+            db_session=db_session,
+            name=name,
+            description=description or ingested.description,
+            bundle_file_id=ingested.bundle_file_id,
+            bundle_sha256=ingested.bundle_sha256,
+            app_type=ExternalAppType.CUSTOM,
+            upstream_url_patterns=upstream_url_patterns,
+            auth_template=auth_template,
+            organization_credentials=organization_credentials,
+            is_public=True,
+            slug=ingested.slug,
+        )
+    except Exception:
+        _delete_bundle_blob(file_store, ingested.bundle_file_id)
+        raise
+
+    push_skill_to_affected_sandboxes(app.skill, db_session)
+    return _to_admin_response(app)
+
+
+def _edit_custom_app(
+    *,
+    db_session: Session,
+    file_store: FileStore,
+    app_id: int,
+    name: str,
+    description: str,
+    enabled: bool,
+    upstream_url_patterns: list[str],
+    auth_template: dict[str, Any],
+    organization_credentials: dict[str, Any],
+    bundle: UploadFile | None,
+) -> ExternalAppAdminResponse:
+    existing = get_external_app_by_id(db_session, app_id)
+    if existing is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"External app with id {app_id} not found.",
+        )
+
+    # Optionally replace the bundle, keeping the existing slug (stable identity).
+    new_bundle_file_id: str | None = None
+    new_bundle_sha256: str | None = None
+    final_description = description
+    if bundle is not None:
+        ingested = ingest_skill_bundle(
+            bundle.file.read(),
+            bundle.filename,
+            file_store,
+            slug=existing.skill.slug,
+        )
+        new_bundle_file_id = ingested.bundle_file_id
+        new_bundle_sha256 = ingested.bundle_sha256
+        if not final_description:
+            final_description = ingested.description
+
+    try:
+        app, old_bundle_file_id = update_external_app(
+            db_session=db_session,
+            external_app_id=app_id,
+            name=name,
+            description=final_description,
+            enabled=enabled,
+            app_type=ExternalAppType.CUSTOM,
+            upstream_url_patterns=upstream_url_patterns,
+            auth_template=auth_template,
+            organization_credentials=organization_credentials,
+            new_bundle_file_id=new_bundle_file_id,
+            new_bundle_sha256=new_bundle_sha256,
+        )
+    except Exception:
+        # Roll back the freshly-stored bundle blob if the update failed.
+        if new_bundle_file_id:
+            _delete_bundle_blob(file_store, new_bundle_file_id)
+        raise
+
+    # Drop the superseded bundle blob only after the swap committed.
+    if old_bundle_file_id:
+        _delete_bundle_blob(file_store, old_bundle_file_id)
+
+    push_skill_to_affected_sandboxes(app.skill, db_session)
     return _to_admin_response(app)
 
 

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -49,7 +49,7 @@ router = APIRouter()
 # Adapters for the structured custom-app form fields, which arrive as JSON
 # strings (multipart can't carry native lists/objects).
 _STR_LIST_ADAPTER = TypeAdapter(list[str])
-_STR_DICT_ADAPTER: TypeAdapter[dict[str, Any]] = TypeAdapter(dict[str, Any])
+_STR_DICT_ADAPTER: TypeAdapter[dict[str, str]] = TypeAdapter(dict[str, str])
 
 
 def _delete_bundle_blob(file_store: FileStore, file_id: str) -> None:
@@ -212,6 +212,11 @@ def upsert_custom_external_app(
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "At least one upstream URL pattern is required.",
+        )
+    if any(not p.strip() for p in parsed_patterns):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "upstream_url_patterns must not contain empty entries.",
         )
     validate_auth_template(parsed_auth_template, parsed_org_credentials)
 

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -111,8 +111,6 @@ def upsert_external_app(
             db_session=db_session,
             name=request.name,
             description=request.description,
-            bundle_file_id="",
-            bundle_sha256="",
             enabled=request.enabled,
             is_public=True,
             app_type=request.app_type,

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -36,13 +36,11 @@ from onyx.server.features.build.api.models import ExternalAppAdminResponse
 from onyx.server.features.build.api.models import ExternalAppUserResponse
 from onyx.server.features.build.api.models import UpsertExternalAppRequest
 from onyx.server.features.build.api.models import UpsertUserCredentialsRequest
+from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
-from onyx.utils.logger import setup_logger
 from onyx.utils.pydantic_util import parse_json_form_field
-
-logger = setup_logger()
 
 router = APIRouter()
 
@@ -50,15 +48,6 @@ router = APIRouter()
 # strings (multipart can't carry native lists/objects).
 _STR_LIST_ADAPTER = TypeAdapter(list[str])
 _STR_DICT_ADAPTER: TypeAdapter[dict[str, str]] = TypeAdapter(dict[str, str])
-
-
-def _delete_bundle_blob(file_store: FileStore, file_id: str) -> None:
-    try:
-        file_store.delete_file(file_id, error_on_missing=False)
-    except Exception:
-        logger.warning(
-            "Failed to delete orphaned bundle blob %s", file_id, exc_info=True
-        )
 
 
 def _to_admin_response(app: ExternalApp) -> ExternalAppAdminResponse:
@@ -280,7 +269,7 @@ def _create_custom_app(
             slug=ingested.slug,
         )
     except Exception:
-        _delete_bundle_blob(file_store, ingested.bundle_file_id)
+        delete_bundle_blob(file_store, ingested.bundle_file_id)
         raise
 
     push_skill_to_affected_sandboxes(app.skill, db_session)
@@ -340,12 +329,12 @@ def _edit_custom_app(
     except Exception:
         # Roll back the freshly-stored bundle blob if the update failed.
         if new_bundle_file_id:
-            _delete_bundle_blob(file_store, new_bundle_file_id)
+            delete_bundle_blob(file_store, new_bundle_file_id)
         raise
 
     # Drop the superseded bundle blob only after the swap committed.
     if old_bundle_file_id:
-        _delete_bundle_blob(file_store, old_bundle_file_id)
+        delete_bundle_blob(file_store, old_bundle_file_id)
 
     push_skill_to_affected_sandboxes(app.skill, db_session)
     return _to_admin_response(app)

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -67,12 +67,9 @@ def _to_admin_response(app: ExternalApp) -> ExternalAppAdminResponse:
 def _to_user_response(
     app: ExternalApp, user_cred: ExternalAppUserCredential | None
 ) -> ExternalAppUserResponse:
-    """Compute the user-facing view of an app.
-
-    `credential_keys` = keys the auth_template references that the org has
-    not pre-filled. `credential_values` is the user's stored values for
-    those same keys (stale keys from prior templates are filtered out so
-    the frontend never renders a field that's no longer relevant).
+    """User-facing view of an app. ``credential_keys`` = auth_template keys the
+    org hasn't pre-filled; ``credential_values`` = the user's stored values for
+    those keys (stale keys filtered out).
     """
     required_keys = required_user_credential_keys(
         app.auth_template, app.organization_credentials
@@ -103,13 +100,9 @@ def upsert_external_app(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ExternalAppAdminResponse:
-    """Create a new external app, or update an existing one if `id` is set.
-
-    If `id` is provided but no app with that id exists, returns 404.
-
-    This endpoint is for built-in providers only. Custom apps (bundle-backed)
-    are created and edited through ``/admin/apps/custom`` so their bundle can be
-    uploaded/replaced; sending ``app_type=CUSTOM`` here is rejected.
+    """Create a new external app, or update the one with `id` if set (404 if
+    absent). Built-in providers only — custom apps use ``/admin/apps/custom``;
+    ``app_type=CUSTOM`` here is rejected.
     """
     if request.app_type == ExternalAppType.CUSTOM:
         raise OnyxError(
@@ -171,19 +164,16 @@ def upsert_custom_external_app(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ExternalAppAdminResponse:
-    """Create or edit a CUSTOM external app (bundle-backed) + gateway config.
+    """Create or edit a CUSTOM (bundle-backed) external app + gateway config.
 
-    Multipart because of the bundle file; the structured fields ride as
-    JSON-encoded form strings. The display name is the form value (overriding
-    the bundle's SKILL.md name); description falls back to the bundle's when
-    left blank.
+    Multipart (for the bundle); structured fields ride as JSON-encoded form
+    strings. Form ``name`` overrides the bundle's; blank ``description`` falls
+    back to the bundle's.
 
-    - **Create** (`app_id` omitted): a bundle is required. It goes through the
-      same ingest pathway as a custom skill (validate → store) and an
-      ``ExternalApp`` row is created alongside the backing skill. Default-public.
-    - **Edit** (`app_id` set): updates name/description/enabled + gateway config.
-      A bundle is optional — when supplied it *replaces* the existing one
-      (keeping the slug); when omitted the current bundle is kept.
+    - **Create** (`app_id` omitted): bundle required; ingested + persisted
+      alongside the backing skill. Default-public.
+    - **Edit** (`app_id` set): updates config; a supplied bundle replaces the
+      existing one (keeping the slug), otherwise the current bundle is kept.
     """
     parsed_patterns = parse_json_form_field(
         upstream_url_patterns, _STR_LIST_ADAPTER, "upstream_url_patterns"
@@ -375,9 +365,8 @@ def delete_external_app_admin(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    """Delete an external app. Cascades to all user-credential rows for the app.
-
-    Returns 404 if no app with `external_app_id` exists.
+    """Delete an external app, cascading to its user-credential rows. 404 if
+    absent.
     """
     # Resolve affected users *before* the delete cascades the skill row away,
     # then refresh their sandboxes so the skill is removed live.
@@ -428,12 +417,10 @@ def list_external_apps(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> list[ExternalAppUserResponse]:
-    """List enabled external apps with the calling user's credential state.
-
-    For each app, returns the credential keys the user must supply (auth
-    template keys not pre-filled by the org), the values the user has
-    already stored for those keys, and an `authenticated` flag. Org-level
-    credentials and the raw auth template are never exposed here.
+    """List enabled external apps with the calling user's credential state: the
+    keys the user must supply, the values already stored, and an
+    ``authenticated`` flag. Org credentials and the raw auth template aren't
+    exposed.
     """
     apps = get_external_apps(db_session=db_session)
     user_creds_by_app = get_user_credentials_by_app_id(

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -111,6 +111,8 @@ def upsert_external_app(
             db_session=db_session,
             name=request.name,
             description=request.description,
+            bundle_file_id="",
+            bundle_sha256="",
             enabled=request.enabled,
             is_public=True,
             app_type=request.app_type,

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -217,6 +217,7 @@ def upsert_custom_external_app(
             file_store=file_store,
             name=name.strip(),
             description=description.strip(),
+            enabled=enabled,
             upstream_url_patterns=parsed_patterns,
             auth_template=parsed_auth_template,
             organization_credentials=parsed_org_credentials,
@@ -243,6 +244,7 @@ def _create_custom_app(
     file_store: FileStore,
     name: str,
     description: str,
+    enabled: bool,
     upstream_url_patterns: list[str],
     auth_template: dict[str, Any],
     organization_credentials: dict[str, Any],
@@ -265,6 +267,7 @@ def _create_custom_app(
             upstream_url_patterns=upstream_url_patterns,
             auth_template=auth_template,
             organization_credentials=organization_credentials,
+            enabled=enabled,
             is_public=True,
             slug=ingested.slug,
         )

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -1,4 +1,3 @@
-import io
 import json
 from typing import Annotated
 from uuid import UUID
@@ -14,7 +13,6 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_curator_or_admin_user
-from onyx.configs.constants import FileOrigin
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Skill
 from onyx.db.models import User
@@ -39,9 +37,6 @@ from onyx.server.features.skill.models import GrantsReplace
 from onyx.server.features.skill.models import SkillPatchRequest
 from onyx.server.features.skill.models import SkillsList
 from onyx.skills.built_in import BUILT_IN_SKILLS
-from onyx.skills.bundle import compute_bundle_sha256
-from onyx.skills.bundle import parse_skill_md_metadata
-from onyx.skills.bundle import validate_custom_bundle
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
@@ -198,31 +193,23 @@ def replace_custom_skill_bundle(
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
     _ensure_custom(skill)
 
-    bundle_bytes = bundle.file.read()
-    validate_custom_bundle(bundle_bytes, slug=skill.slug)
-    name, description = parse_skill_md_metadata(bundle_bytes)
-    sha = compute_bundle_sha256(bundle_bytes)
-
     file_store = get_default_file_store()
-    new_file_id = file_store.save_file(
-        content=io.BytesIO(bundle_bytes),
-        display_name=f"{skill.slug}.zip",
-        file_origin=FileOrigin.SKILL_BUNDLE,
-        file_type="application/zip",
+    ingested = ingest_skill_bundle(
+        bundle.file.read(), bundle.filename, file_store, slug=skill.slug
     )
 
     try:
         updated, old_file_id = replace_skill_bundle(
             skill_id=skill_id,
-            new_bundle_file_id=new_file_id,
-            new_bundle_sha256=sha,
-            new_name=name,
-            new_description=description,
+            new_bundle_file_id=ingested.bundle_file_id,
+            new_bundle_sha256=ingested.bundle_sha256,
+            new_name=ingested.name,
+            new_description=ingested.description,
             db_session=db_session,
         )
         db_session.commit()
     except Exception:
-        delete_bundle_blob(file_store, new_file_id)
+        delete_bundle_blob(file_store, ingested.bundle_file_id)
         raise
 
     push_skill_to_affected_sandboxes(updated, db_session)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -42,8 +42,8 @@ from onyx.server.features.skill.models import SkillsList
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
-from onyx.skills.bundle import slug_from_filename
 from onyx.skills.bundle import validate_custom_bundle
+from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
 from onyx.utils.logger import setup_logger
@@ -123,28 +123,18 @@ def create_custom_skill(
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> CustomSkillResponse:
-    bundle_bytes = bundle.file.read()
-    slug = slug_from_filename(bundle.filename)
-    validate_custom_bundle(bundle_bytes, slug=slug)
-    name, description = parse_skill_md_metadata(bundle_bytes)
-    sha = compute_bundle_sha256(bundle_bytes)
     parsed_group_ids = _parse_group_ids(group_ids)
 
     file_store = get_default_file_store()
-    bundle_file_id = file_store.save_file(
-        content=io.BytesIO(bundle_bytes),
-        display_name=f"{slug}.zip",
-        file_origin=FileOrigin.SKILL_BUNDLE,
-        file_type="application/zip",
-    )
+    ingested = ingest_skill_bundle(bundle.file.read(), bundle.filename, file_store)
 
     try:
         skill = create_skill__no_commit(
-            slug=slug,
-            name=name,
-            description=description,
-            bundle_file_id=bundle_file_id,
-            bundle_sha256=sha,
+            slug=ingested.slug,
+            name=ingested.name,
+            description=ingested.description,
+            bundle_file_id=ingested.bundle_file_id,
+            bundle_sha256=ingested.bundle_sha256,
             is_public=is_public,
             author_user_id=user.id,
             db_session=db_session,
@@ -153,7 +143,7 @@ def create_custom_skill(
             replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
         db_session.commit()
     except Exception:
-        _delete_old_bundle(file_store, bundle_file_id)
+        _delete_old_bundle(file_store, ingested.bundle_file_id)
         raise
 
     push_skill_to_affected_sandboxes(skill, db_session)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -32,7 +32,6 @@ from onyx.db.skill import replace_skill_bundle
 from onyx.db.skill import replace_skill_grants
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.file_store.file_store import FileStore
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.skill.models import BuiltinSkillResponse
 from onyx.server.features.skill.models import CustomSkillResponse
@@ -43,6 +42,7 @@ from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
 from onyx.skills.bundle import validate_custom_bundle
+from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingest_skill_bundle
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
@@ -143,7 +143,7 @@ def create_custom_skill(
             replace_skill_grants(skill.id, parsed_group_ids, db_session=db_session)
         db_session.commit()
     except Exception:
-        _delete_old_bundle(file_store, ingested.bundle_file_id)
+        delete_bundle_blob(file_store, ingested.bundle_file_id)
         raise
 
     push_skill_to_affected_sandboxes(skill, db_session)
@@ -222,11 +222,11 @@ def replace_custom_skill_bundle(
         )
         db_session.commit()
     except Exception:
-        _delete_old_bundle(file_store, new_file_id)
+        delete_bundle_blob(file_store, new_file_id)
         raise
 
     push_skill_to_affected_sandboxes(updated, db_session)
-    _delete_old_bundle(file_store, old_file_id)
+    delete_bundle_blob(file_store, old_file_id)
     return CustomSkillResponse.from_model(
         updated, group_ids=get_group_ids_for_skill(skill_id, db_session)
     )
@@ -275,7 +275,7 @@ def delete_custom_skill(
 
     push_skills_for_users(affected, db_session)
     if old_file_id is not None:
-        _delete_old_bundle(get_default_file_store(), old_file_id)
+        delete_bundle_blob(get_default_file_store(), old_file_id)
 
 
 @user_router.get("")
@@ -333,10 +333,3 @@ def _parse_group_ids(raw: str) -> list[int]:
             "group_ids must be a JSON array of integers",
         )
     return parsed
-
-
-def _delete_old_bundle(file_store: FileStore, file_id: str) -> None:
-    try:
-        file_store.delete_file(file_id, error_on_missing=False)
-    except Exception:
-        logger.warning("Failed to delete old bundle blob %s", file_id, exc_info=True)

--- a/backend/onyx/skills/ingest.py
+++ b/backend/onyx/skills/ingest.py
@@ -16,6 +16,9 @@ from onyx.skills.bundle import compute_bundle_sha256
 from onyx.skills.bundle import parse_skill_md_metadata
 from onyx.skills.bundle import slug_from_filename
 from onyx.skills.bundle import validate_custom_bundle
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 class IngestedBundle(NamedTuple):
@@ -68,3 +71,11 @@ def ingest_skill_bundle(
         name=name,
         description=description,
     )
+
+
+def delete_bundle_blob(file_store: FileStore, file_id: str) -> None:
+    """Best-effort cleanup of a stored bundle blob we no longer reference."""
+    try:
+        file_store.delete_file(file_id, error_on_missing=False)
+    except Exception:
+        logger.warning("Failed to delete bundle blob %s", file_id, exc_info=True)

--- a/backend/onyx/skills/ingest.py
+++ b/backend/onyx/skills/ingest.py
@@ -1,12 +1,3 @@
-"""Shared ingest pathway for custom skill bundles.
-
-Both the custom-skill upload endpoint and the custom external-app create
-endpoint take the same uploaded ``.zip`` and run it through the same
-validate → parse → hash → store steps. This module is that single pathway;
-callers own the DB row they create from the result (a plain ``Skill`` or a
-``Skill`` + ``ExternalApp``) and the cleanup of the stored blob on failure.
-"""
-
 import io
 from typing import NamedTuple
 
@@ -36,21 +27,16 @@ def ingest_skill_bundle(
     *,
     slug: str | None = None,
 ) -> IngestedBundle:
-    """Validate, parse, and store a custom skill bundle.
+    """Validate, parse, hash, and store a custom skill bundle.
 
-    Derives the slug from the upload filename, validates the zip structure
-    (``SKILL.md`` present, no traversal/symlinks, size caps, slug not a reserved
-    built-in id), parses ``(name, description)`` from the ``SKILL.md``
-    frontmatter, hashes the raw bytes, and saves the blob to the file store.
+    Validates the zip structure, parses ``(name, description)`` from SKILL.md
+    frontmatter, hashes the bytes, and saves the blob.
 
-    Pass ``slug`` to keep an existing row's slug when *replacing* a bundle on an
-    update (the slug is the stable skill identity, not derived from the new
-    upload's filename). When omitted, the slug comes from ``filename`` — the
-    create path.
+    Pass ``slug`` to keep an existing row's slug when replacing a bundle on
+    update; when omitted the slug is derived from ``filename`` (create path).
 
-    Returns the slug, the stored ``bundle_file_id``, the sha256, and the parsed
-    ``(name, description)``. The caller owns DB row creation and is responsible
-    for deleting ``bundle_file_id`` if its transaction fails.
+    The caller owns DB row creation and must delete ``bundle_file_id`` if its
+    transaction fails.
     """
     if slug is None:
         slug = slug_from_filename(filename)

--- a/backend/onyx/skills/ingest.py
+++ b/backend/onyx/skills/ingest.py
@@ -1,0 +1,70 @@
+"""Shared ingest pathway for custom skill bundles.
+
+Both the custom-skill upload endpoint and the custom external-app create
+endpoint take the same uploaded ``.zip`` and run it through the same
+validate → parse → hash → store steps. This module is that single pathway;
+callers own the DB row they create from the result (a plain ``Skill`` or a
+``Skill`` + ``ExternalApp``) and the cleanup of the stored blob on failure.
+"""
+
+import io
+from typing import NamedTuple
+
+from onyx.configs.constants import FileOrigin
+from onyx.file_store.file_store import FileStore
+from onyx.skills.bundle import compute_bundle_sha256
+from onyx.skills.bundle import parse_skill_md_metadata
+from onyx.skills.bundle import slug_from_filename
+from onyx.skills.bundle import validate_custom_bundle
+
+
+class IngestedBundle(NamedTuple):
+    slug: str
+    bundle_file_id: str
+    bundle_sha256: str
+    name: str
+    description: str
+
+
+def ingest_skill_bundle(
+    bundle_bytes: bytes,
+    filename: str | None,
+    file_store: FileStore,
+    *,
+    slug: str | None = None,
+) -> IngestedBundle:
+    """Validate, parse, and store a custom skill bundle.
+
+    Derives the slug from the upload filename, validates the zip structure
+    (``SKILL.md`` present, no traversal/symlinks, size caps, slug not a reserved
+    built-in id), parses ``(name, description)`` from the ``SKILL.md``
+    frontmatter, hashes the raw bytes, and saves the blob to the file store.
+
+    Pass ``slug`` to keep an existing row's slug when *replacing* a bundle on an
+    update (the slug is the stable skill identity, not derived from the new
+    upload's filename). When omitted, the slug comes from ``filename`` — the
+    create path.
+
+    Returns the slug, the stored ``bundle_file_id``, the sha256, and the parsed
+    ``(name, description)``. The caller owns DB row creation and is responsible
+    for deleting ``bundle_file_id`` if its transaction fails.
+    """
+    if slug is None:
+        slug = slug_from_filename(filename)
+    validate_custom_bundle(bundle_bytes, slug=slug)
+    name, description = parse_skill_md_metadata(bundle_bytes)
+    sha = compute_bundle_sha256(bundle_bytes)
+
+    bundle_file_id = file_store.save_file(
+        content=io.BytesIO(bundle_bytes),
+        display_name=f"{slug}.zip",
+        file_origin=FileOrigin.SKILL_BUNDLE,
+        file_type="application/zip",
+    )
+    return IngestedBundle(
+        slug=slug,
+        bundle_file_id=bundle_file_id,
+        bundle_sha256=sha,
+        name=name,
+        description=description,
+    )

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -105,7 +105,13 @@ def _assemble_fileset(
 
     Built-in rows are rendered from disk; custom rows are unpacked from
     their FileStore bundle. A row whose ``built_in_skill_id`` no longer
-    matches a codified definition is skipped with a warning."""
+    matches a codified definition is skipped with a warning.
+
+    External-app skills are *not* a special case here: a connected provider's
+    row carries its ``built_in_skill_id`` (e.g. ``slack``) like any other
+    built-in, so it renders straight from disk. Which external-app rows reach
+    this point is decided upstream by ``list_skills_for_sandbox_injection``
+    (enabled + per-user credential gate)."""
     files: FileSet = {}
     file_store = get_default_file_store()
 

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -105,13 +105,7 @@ def _assemble_fileset(
 
     Built-in rows are rendered from disk; custom rows are unpacked from
     their FileStore bundle. A row whose ``built_in_skill_id`` no longer
-    matches a codified definition is skipped with a warning.
-
-    External-app skills are *not* a special case here: a connected provider's
-    row carries its ``built_in_skill_id`` (e.g. ``slack``) like any other
-    built-in, so it renders straight from disk. Which external-app rows reach
-    this point is decided upstream by ``list_skills_for_sandbox_injection``
-    (enabled + per-user credential gate)."""
+    matches a codified definition is skipped with a warning."""
     files: FileSet = {}
     file_store = get_default_file_store()
 

--- a/backend/onyx/utils/pydantic_util.py
+++ b/backend/onyx/utils/pydantic_util.py
@@ -22,13 +22,9 @@ def shallow_model_dump(model_instance: BaseModel) -> dict[str, Any]:
 
 
 def parse_json_form_field(raw: str, adapter: TypeAdapter[T], field_name: str) -> T:
-    """Parse a JSON-encoded multipart form field into a validated value.
-
-    Multipart endpoints carry structured fields (lists, objects) as JSON
-    strings. This validates ``raw`` against ``adapter`` (e.g. a module-level
-    ``TypeAdapter(list[str])``) and raises ``OnyxError(INVALID_INPUT)`` naming
-    the field on malformed input — covering both bad JSON and wrong shape —
-    rather than leaking a pydantic ``ValidationError`` to the client."""
+    """Parse a JSON-encoded multipart form field, validating against ``adapter``.
+    Raises ``OnyxError(INVALID_INPUT)`` naming the field on bad JSON or wrong
+    shape instead of leaking a pydantic ``ValidationError``."""
     try:
         return adapter.validate_json(raw)
     except ValidationError as e:

--- a/backend/onyx/utils/pydantic_util.py
+++ b/backend/onyx/utils/pydantic_util.py
@@ -1,6 +1,14 @@
 from typing import Any
+from typing import TypeVar
 
 from pydantic import BaseModel
+from pydantic import TypeAdapter
+from pydantic import ValidationError
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+T = TypeVar("T")
 
 
 def shallow_model_dump(model_instance: BaseModel) -> dict[str, Any]:
@@ -11,3 +19,20 @@ def shallow_model_dump(model_instance: BaseModel) -> dict[str, Any]:
         field_name: getattr(model_instance, field_name)
         for field_name in model_instance.__class__.model_fields
     }
+
+
+def parse_json_form_field(raw: str, adapter: TypeAdapter[T], field_name: str) -> T:
+    """Parse a JSON-encoded multipart form field into a validated value.
+
+    Multipart endpoints carry structured fields (lists, objects) as JSON
+    strings. This validates ``raw`` against ``adapter`` (e.g. a module-level
+    ``TypeAdapter(list[str])``) and raises ``OnyxError(INVALID_INPUT)`` naming
+    the field on malformed input — covering both bad JSON and wrong shape —
+    rather than leaking a pydantic ``ValidationError`` to the client."""
+    try:
+        return adapter.validate_json(raw)
+    except ValidationError as e:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"{field_name} is not valid JSON of the expected shape.",
+        ) from e

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -1,21 +1,3 @@
-"""The custom external-app endpoint (`POST /admin/apps/custom`) upserts a
-bundle-backed app: create runs an uploaded skill bundle through the shared
-ingest pathway and persists a custom ``Skill`` + ``ExternalApp``; edit updates
-the config and optionally replaces the bundle (keeping the slug).
-
-These call the endpoint function directly (push helper monkeypatched) against
-real Postgres + file store, asserting:
-
-- a happy upload persists both rows, form name overriding the bundle's name and
-  a blank description falling back to the bundle's;
-- a no-credentials (allowlist-only) app persists;
-- an edit updates config and swaps the bundle while keeping the slug;
-- a bundle without SKILL.md is rejected and nothing is persisted;
-- create without a bundle is rejected;
-- a failure after the blob is stored triggers blob cleanup;
-- the JSON `/admin/apps` endpoint rejects CUSTOM outright.
-"""
-
 from __future__ import annotations
 
 import io
@@ -76,8 +58,7 @@ def _create(
     auth_template: str = json.dumps(_AUTH_TEMPLATE),
     organization_credentials: str = json.dumps({"api_key": "sk-test"}),
 ) -> ExternalAppAdminResponse:
-    """Create a custom app with a valid default bundle. Tests that need a
-    specific bundle (missing SKILL.md, or none) call the endpoint directly."""
+    """Create a custom app with a valid default bundle."""
     return api.upsert_custom_external_app(
         name="My Form Name",
         description="",
@@ -94,12 +75,8 @@ def _create(
 
 @pytest.fixture(autouse=True, scope="module")
 def _ensure_bundle_store(initialize_file_store: None) -> None:  # noqa: ARG001
-    """Create the bundle blob store before any test runs.
-
-    The create/edit paths save the uploaded bundle to the file store via
-    ``ingest_skill_bundle``; without this the bucket may not exist and
-    ``save_file`` raises ``NoSuchBucket`` depending on test ordering.
-    """
+    """Create the bundle blob store before any test runs (create/edit save the
+    uploaded bundle via ``ingest_skill_bundle``)."""
 
 
 def test_create_persists_skill_and_app(

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -92,6 +92,16 @@ def _create(
     )
 
 
+@pytest.fixture(autouse=True, scope="module")
+def _ensure_bundle_store(initialize_file_store: None) -> None:  # noqa: ARG001
+    """Create the bundle blob store before any test runs.
+
+    The create/edit paths save the uploaded bundle to the file store via
+    ``ingest_skill_bundle``; without this the bucket may not exist and
+    ``save_file`` raises ``NoSuchBucket`` depending on test ordering.
+    """
+
+
 def test_create_persists_skill_and_app(
     db_session: Session,
     test_user: User,

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -253,7 +253,7 @@ def test_create_cleans_up_blob_on_failure(
 
     deleted: list[str] = []
     monkeypatch.setattr(
-        api, "_delete_bundle_blob", lambda _fs, file_id: deleted.append(file_id)
+        api, "delete_bundle_blob", lambda _fs, file_id: deleted.append(file_id)
     )
 
     slug = f"custom-test-{uuid4().hex[:8]}"

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -1,0 +1,286 @@
+"""The custom external-app endpoint (`POST /admin/apps/custom`) upserts a
+bundle-backed app: create runs an uploaded skill bundle through the shared
+ingest pathway and persists a custom ``Skill`` + ``ExternalApp``; edit updates
+the config and optionally replaces the bundle (keeping the slug).
+
+These call the endpoint function directly (push helper monkeypatched) against
+real Postgres + file store, asserting:
+
+- a happy upload persists both rows, form name overriding the bundle's name and
+  a blank description falling back to the bundle's;
+- a no-credentials (allowlist-only) app persists;
+- an edit updates config and swaps the bundle while keeping the slug;
+- a bundle without SKILL.md is rejected and nothing is persisted;
+- create without a bundle is rejected;
+- a failure after the blob is stored triggers blob cleanup;
+- the JSON `/admin/apps` endpoint rejects CUSTOM outright.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from uuid import uuid4
+
+import pytest
+from fastapi import UploadFile
+from sqlalchemy import delete
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import onyx.server.features.build.api.external_apps_api as api
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.api.models import ExternalAppAdminResponse
+from onyx.server.features.build.api.models import UpsertExternalAppRequest
+
+_AUTH_TEMPLATE = {"Authorization": "Bearer {api_key}"}
+_UPSTREAM = ["https://api.example.com/*"]
+
+
+def _noop(*_args: object, **_kwargs: object) -> None:
+    return None
+
+
+def _bundle_zip(*, with_skill_md: bool = True, marker: str = "v1") -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        if with_skill_md:
+            zf.writestr(
+                "SKILL.md",
+                "---\nname: Bundle Name\ndescription: Bundle description\n---\n\nDo things.\n",
+            )
+        zf.writestr("helper.py", f"print('{marker}')\n")
+    return buf.getvalue()
+
+
+def _upload(
+    filename: str, *, with_skill_md: bool = True, marker: str = "v1"
+) -> UploadFile:
+    return UploadFile(
+        file=io.BytesIO(_bundle_zip(with_skill_md=with_skill_md, marker=marker)),
+        filename=filename,
+    )
+
+
+def _create(
+    db_session: Session,
+    test_user: User,
+    slug: str,
+    *,
+    auth_template: str = json.dumps(_AUTH_TEMPLATE),
+    organization_credentials: str = json.dumps({"api_key": "sk-test"}),
+) -> ExternalAppAdminResponse:
+    """Create a custom app with a valid default bundle. Tests that need a
+    specific bundle (missing SKILL.md, or none) call the endpoint directly."""
+    return api.upsert_custom_external_app(
+        name="My Form Name",
+        description="",
+        upstream_url_patterns=json.dumps(_UPSTREAM),
+        auth_template=auth_template,
+        organization_credentials=organization_credentials,
+        app_id=None,
+        enabled=True,
+        bundle=_upload(f"{slug}.zip"),
+        _=test_user,
+        db_session=db_session,
+    )
+
+
+def test_create_persists_skill_and_app(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    resp = _create(db_session, test_user, slug)
+
+    # Form name overrides the bundle's SKILL.md name; blank description falls
+    # back to the bundle's parsed description.
+    assert resp.app_type == ExternalAppType.CUSTOM
+    assert resp.name == "My Form Name"
+    assert resp.description == "Bundle description"
+    assert resp.upstream_url_patterns == _UPSTREAM
+
+    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    assert skill is not None
+    assert skill.built_in_skill_id is None
+    assert skill.bundle_file_id  # bundle was stored
+    assert skill.name == "My Form Name"
+
+    app = db_session.scalar(select(ExternalApp).where(ExternalApp.skill_id == skill.id))
+    assert app is not None
+    assert app.auth_template == _AUTH_TEMPLATE
+    assert app.organization_credentials == {"api_key": "sk-test"}
+
+    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.commit()
+
+
+def test_create_with_no_credentials(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    resp = _create(
+        db_session,
+        test_user,
+        slug,
+        auth_template=json.dumps({}),
+        organization_credentials=json.dumps({}),
+    )
+
+    assert resp.auth_template == {}
+    assert resp.organization_credentials == {}
+    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is not None
+
+    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.commit()
+
+
+def test_edit_updates_config_and_replaces_bundle(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    created = _create(db_session, test_user, slug)
+    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    assert skill is not None
+    original_bundle_id = skill.bundle_file_id
+
+    # Edit: new name, new patterns, and a replacement bundle (different bytes).
+    edited = api.upsert_custom_external_app(
+        name="Renamed App",
+        description="A new description",
+        upstream_url_patterns=json.dumps(["https://api.example.com/v2/*"]),
+        auth_template=json.dumps(_AUTH_TEMPLATE),
+        organization_credentials=json.dumps({}),
+        app_id=created.id,
+        enabled=True,
+        bundle=_upload(f"{slug}.zip", marker="v2"),
+        _=test_user,
+        db_session=db_session,
+    )
+
+    assert edited.id == created.id
+    assert edited.name == "Renamed App"
+    assert edited.description == "A new description"
+    assert edited.upstream_url_patterns == ["https://api.example.com/v2/*"]
+    assert edited.organization_credentials == {}
+
+    db_session.expire_all()
+    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    assert skill is not None
+    # Slug is stable across a bundle swap, but the blob changed.
+    assert skill.name == "Renamed App"
+    assert skill.bundle_file_id
+    assert skill.bundle_file_id != original_bundle_id
+
+    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.commit()
+
+
+def test_create_rejects_bundle_without_skill_md(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    with pytest.raises(OnyxError):
+        api.upsert_custom_external_app(
+            name="No Skill",
+            description="",
+            upstream_url_patterns=json.dumps(_UPSTREAM),
+            auth_template=json.dumps(_AUTH_TEMPLATE),
+            organization_credentials=json.dumps({}),
+            app_id=None,
+            enabled=True,
+            bundle=_upload(f"{slug}.zip", with_skill_md=False),
+            _=test_user,
+            db_session=db_session,
+        )
+
+    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is None
+
+
+def test_create_requires_bundle(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    with pytest.raises(OnyxError):
+        api.upsert_custom_external_app(
+            name="No Bundle",
+            description="",
+            upstream_url_patterns=json.dumps(_UPSTREAM),
+            auth_template=json.dumps(_AUTH_TEMPLATE),
+            organization_credentials=json.dumps({}),
+            app_id=None,
+            enabled=True,
+            bundle=None,
+            _=test_user,
+            db_session=db_session,
+        )
+
+
+def test_create_cleans_up_blob_on_failure(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+
+    def _boom(*_args: object, **_kwargs: object) -> ExternalApp:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "forced failure")
+
+    monkeypatch.setattr(api, "create_external_app", _boom)
+
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        api, "_delete_bundle_blob", lambda _fs, file_id: deleted.append(file_id)
+    )
+
+    slug = f"custom-test-{uuid4().hex[:8]}"
+    with pytest.raises(OnyxError):
+        _create(db_session, test_user, slug)
+
+    # The bundle was stored during ingest, so the post-failure cleanup must run.
+    assert len(deleted) == 1
+
+
+def test_json_admin_apps_rejects_custom(
+    db_session: Session,
+    test_user: User,
+) -> None:
+    # The JSON /admin/apps endpoint is built-in only.
+    with pytest.raises(OnyxError):
+        api.upsert_external_app(
+            request=UpsertExternalAppRequest(
+                id=None,
+                name="Nope",
+                description="",
+                enabled=True,
+                app_type=ExternalAppType.CUSTOM,
+                upstream_url_patterns=_UPSTREAM,
+                auth_template=_AUTH_TEMPLATE,
+                organization_credentials={},
+            ),
+            _=test_user,
+            db_session=db_session,
+        )

--- a/backend/tests/integration/common_utils/managers/external_app.py
+++ b/backend/tests/integration/common_utils/managers/external_app.py
@@ -166,11 +166,16 @@ class ExternalAppManager:
                     "application/zip",
                 )
             }
+        # Drop the default JSON Content-Type so httpx can set the multipart
+        # boundary itself; leaving "application/json" in place makes the server
+        # try to JSON-parse the form body and report every field as missing.
+        headers = user_performing_action.headers.copy()
+        headers.pop("Content-Type", None)
         return client.post(
             f"{_BUILD_PREFIX}/admin/apps/custom",
             data=data,
             files=files,
-            headers=user_performing_action.headers,
+            headers=headers,
             cookies=user_performing_action.cookies,
         )
 

--- a/backend/tests/integration/common_utils/managers/external_app.py
+++ b/backend/tests/integration/common_utils/managers/external_app.py
@@ -17,11 +17,8 @@ _BUILD_PREFIX = f"{API_SERVER_URL}/build"
 
 
 def _minimal_bundle_zip() -> bytes:
-    """A valid skill bundle: a SKILL.md with frontmatter plus a helper file.
-
-    Custom apps are now bundle-backed, so creating one through the admin
-    endpoint requires uploading a .zip that passes ``ingest_skill_bundle``
-    (SKILL.md present, parseable frontmatter)."""
+    """A valid skill bundle (SKILL.md + helper file) for creating bundle-backed
+    custom apps through the admin endpoint."""
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr(
@@ -142,9 +139,8 @@ class ExternalAppManager:
         organization_credentials: dict[str, Any],
         enabled: bool,
     ) -> Any:
-        """POST the multipart custom-app endpoint. The structured fields ride as
-        JSON-encoded form strings; a bundle is required on create (``app_id``
-        omitted) and omitted on edit (the existing bundle is kept)."""
+        """POST the multipart custom-app endpoint. A bundle is required on create
+        (``app_id`` omitted) and omitted on edit."""
         data: dict[str, str] = {
             "name": name,
             "description": description,

--- a/backend/tests/integration/common_utils/managers/external_app.py
+++ b/backend/tests/integration/common_utils/managers/external_app.py
@@ -1,4 +1,8 @@
+import io
+import json
+import zipfile
 from typing import Any
+from uuid import uuid4
 
 from onyx.db.enums import ExternalAppType
 from onyx.server.features.build.api.models import ExternalAppAdminResponse
@@ -10,6 +14,22 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
 
 _BUILD_PREFIX = f"{API_SERVER_URL}/build"
+
+
+def _minimal_bundle_zip() -> bytes:
+    """A valid skill bundle: a SKILL.md with frontmatter plus a helper file.
+
+    Custom apps are now bundle-backed, so creating one through the admin
+    endpoint requires uploading a .zip that passes ``ingest_skill_bundle``
+    (SKILL.md present, parseable frontmatter)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "SKILL.md",
+            "---\nname: Bundle Name\ndescription: Bundle description\n---\n\nDo things.\n",
+        )
+        zf.writestr("helper.py", "print('hello')\n")
+    return buf.getvalue()
 
 
 class ExternalAppManager:
@@ -78,24 +98,81 @@ class ExternalAppManager:
         organization_credentials: dict[str, Any],
         enabled: bool,
     ) -> ExternalAppAdminResponse:
-        body = UpsertExternalAppRequest(
-            id=app_id,
-            name=name,
-            description=description,
-            app_type=app_type,
-            upstream_url_patterns=upstream_url_patterns,
-            auth_template=auth_template,
-            organization_credentials=organization_credentials,
-            enabled=enabled,
-        )
-        response = client.post(
-            f"{_BUILD_PREFIX}/admin/apps",
-            json=body.model_dump(mode="json"),
+        # Custom (bundle-backed) apps go through the multipart endpoint so a
+        # bundle can be uploaded; built-in providers use the JSON endpoint.
+        if app_type == ExternalAppType.CUSTOM:
+            response = ExternalAppManager._upsert_custom(
+                user_performing_action,
+                app_id,
+                name,
+                description,
+                upstream_url_patterns,
+                auth_template,
+                organization_credentials,
+                enabled,
+            )
+        else:
+            body = UpsertExternalAppRequest(
+                id=app_id,
+                name=name,
+                description=description,
+                app_type=app_type,
+                upstream_url_patterns=upstream_url_patterns,
+                auth_template=auth_template,
+                organization_credentials=organization_credentials,
+                enabled=enabled,
+            )
+            response = client.post(
+                f"{_BUILD_PREFIX}/admin/apps",
+                json=body.model_dump(mode="json"),
+                headers=user_performing_action.headers,
+                cookies=user_performing_action.cookies,
+            )
+        response.raise_for_status()
+        return ExternalAppAdminResponse.model_validate(response.json())
+
+    @staticmethod
+    def _upsert_custom(
+        user_performing_action: DATestUser,
+        app_id: int | None,
+        name: str,
+        description: str,
+        upstream_url_patterns: list[str],
+        auth_template: dict[str, Any],
+        organization_credentials: dict[str, Any],
+        enabled: bool,
+    ) -> Any:
+        """POST the multipart custom-app endpoint. The structured fields ride as
+        JSON-encoded form strings; a bundle is required on create (``app_id``
+        omitted) and omitted on edit (the existing bundle is kept)."""
+        data: dict[str, str] = {
+            "name": name,
+            "description": description,
+            "upstream_url_patterns": json.dumps(upstream_url_patterns),
+            "auth_template": json.dumps(auth_template),
+            "organization_credentials": json.dumps(organization_credentials),
+            "enabled": str(enabled).lower(),
+        }
+        files: dict[str, tuple[str, bytes, str]] | None = None
+        if app_id is not None:
+            data["app_id"] = str(app_id)
+        else:
+            # Unique filename → unique slug, so repeated creates within one test
+            # don't collide on the bundle-derived skill slug.
+            files = {
+                "bundle": (
+                    f"custom-{uuid4().hex[:8]}.zip",
+                    _minimal_bundle_zip(),
+                    "application/zip",
+                )
+            }
+        return client.post(
+            f"{_BUILD_PREFIX}/admin/apps/custom",
+            data=data,
+            files=files,
             headers=user_performing_action.headers,
             cookies=user_performing_action.cookies,
         )
-        response.raise_for_status()
-        return ExternalAppAdminResponse.model_validate(response.json())
 
     @staticmethod
     def list_admin(

--- a/backend/tests/integration/tests/external_apps/test_external_apps.py
+++ b/backend/tests/integration/tests/external_apps/test_external_apps.py
@@ -438,7 +438,7 @@ def test_update_or_delete_nonexistent_app_returns_404(
             app_id=missing_id,
             name="x",
             description="x",
-            upstream_url_patterns=[],
+            upstream_url_patterns=[r"^https://api\.example\.com/.*$"],
             auth_template={},
             organization_credentials={},
         )

--- a/backend/tests/unit/onyx/db/test_external_app_auth_template.py
+++ b/backend/tests/unit/onyx/db/test_external_app_auth_template.py
@@ -1,6 +1,4 @@
-"""Unit tests for `validate_auth_template` — the structural guard the
-custom external-app create endpoint runs before persisting an app's header
-credential template."""
+"""Unit tests for `validate_auth_template`."""
 
 from __future__ import annotations
 

--- a/backend/tests/unit/onyx/db/test_external_app_auth_template.py
+++ b/backend/tests/unit/onyx/db/test_external_app_auth_template.py
@@ -1,0 +1,54 @@
+"""Unit tests for `validate_auth_template` — the structural guard the
+custom external-app create endpoint runs before persisting an app's header
+credential template."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from onyx.db.external_app import validate_auth_template
+from onyx.error_handling.exceptions import OnyxError
+
+
+def test_valid_template_passes() -> None:
+    # No exception == valid.
+    validate_auth_template(
+        {"Authorization": "Bearer {api_key}"},
+        {"api_key": "sk-123"},
+    )
+
+
+def test_empty_org_credentials_allowed() -> None:
+    # A fully user-supplied credential app (org pre-fills nothing) is valid.
+    validate_auth_template({"Authorization": "Bearer {api_key}"}, {})
+
+
+def test_empty_template_and_credentials_allowed() -> None:
+    # An allowlist-only app injects no headers and pre-fills nothing.
+    validate_auth_template({}, {})
+
+
+@pytest.mark.parametrize(
+    "auth_template",
+    [
+        {"Authorization": ""},  # empty value
+        {"Authorization": "   "},  # whitespace-only value
+        {"": "Bearer x"},  # empty key
+        {"   ": "Bearer x"},  # whitespace-only key
+    ],
+)
+def test_malformed_template_rejected(auth_template: dict[str, Any]) -> None:
+    with pytest.raises(OnyxError):
+        validate_auth_template(auth_template, {})
+
+
+def test_non_string_value_rejected() -> None:
+    with pytest.raises(OnyxError):
+        validate_auth_template({"Authorization": 123}, {})
+
+
+def test_non_string_org_credential_key_rejected() -> None:
+    with pytest.raises(OnyxError):
+        validate_auth_template({"Authorization": "Bearer {api_key}"}, {"": "v"})

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -43,11 +43,75 @@ export async function upsertExternalApp(
   return res.json();
 }
 
-/** Toggle `enabled` without touching credentials. */
+interface UpsertCustomExternalAppInput {
+  /** Omit to create; set to edit an existing custom app. */
+  id?: number;
+  name: string;
+  description: string;
+  upstream_url_patterns: string[];
+  auth_template: Record<string, string>;
+  organization_credentials: Record<string, string>;
+  enabled: boolean;
+  /** Required on create; optional on edit (when set, replaces the bundle). */
+  bundle?: File;
+}
+
+/**
+ * Create or edit a CUSTOM external app. Custom apps go through this multipart
+ * endpoint (never the JSON `/admin/apps`) so their bundle can be uploaded or
+ * replaced. The structured fields are JSON-encoded form strings to match the
+ * backend's `POST /admin/apps/custom` handler.
+ */
+export async function upsertCustomExternalApp(
+  input: UpsertCustomExternalAppInput
+): Promise<ExternalAppAdminResponse> {
+  const form = new FormData();
+  if (input.id !== undefined) form.append("app_id", String(input.id));
+  form.append("name", input.name);
+  form.append("description", input.description);
+  form.append("enabled", String(input.enabled));
+  form.append(
+    "upstream_url_patterns",
+    JSON.stringify(input.upstream_url_patterns)
+  );
+  form.append("auth_template", JSON.stringify(input.auth_template));
+  form.append(
+    "organization_credentials",
+    JSON.stringify(input.organization_credentials)
+  );
+  if (input.bundle) form.append("bundle", input.bundle);
+
+  // No explicit Content-Type — the browser sets the multipart boundary.
+  const res = await fetch(`${BUILD_API_BASE}/admin/apps/custom`, {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(await readErrorDetail(res, "Save failed"));
+  }
+  return res.json();
+}
+
+/**
+ * Toggle `enabled` without touching credentials. Custom apps route through the
+ * custom endpoint (resending their current config, no bundle); built-in
+ * providers use the JSON endpoint.
+ */
 export async function setExternalAppEnabled(
   app: ExternalAppAdminResponse,
   enabled: boolean
 ): Promise<ExternalAppAdminResponse> {
+  if (app.app_type === "CUSTOM") {
+    return upsertCustomExternalApp({
+      id: app.id,
+      name: app.name,
+      description: app.description,
+      upstream_url_patterns: app.upstream_url_patterns,
+      auth_template: app.auth_template,
+      organization_credentials: app.organization_credentials,
+      enabled,
+    });
+  }
   return upsertExternalApp({
     id: app.id,
     name: app.name,

--- a/web/src/app/craft/v1/apps/UserCredentialsModal.tsx
+++ b/web/src/app/craft/v1/apps/UserCredentialsModal.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Modal from "@/refresh-components/Modal";
+import { Button, MessageCard, Text } from "@opal/components";
+import PasswordInputTypeIn from "@/refresh-components/inputs/PasswordInputTypeIn";
+import {
+  ExternalAppUserResponse,
+  getAppTypeLogo,
+} from "@/app/craft/v1/apps/registry";
+import { upsertUserCredentials } from "@/app/craft/services/externalAppsService";
+
+interface UserCredentialsModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Invoked after the credentials save so the caller can refresh. */
+  onSaved: () => void;
+  userApp: ExternalAppUserResponse;
+}
+
+/** Turn a credential key (`discord_token`, `apiKey`) into a readable label. */
+function humanizeKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Per-user credential entry for apps without an OAuth flow (custom apps).
+ * Renders one field per `credential_keys` the app still needs from the user,
+ * pre-filled with any value they've already stored, and persists them.
+ */
+export default function UserCredentialsModal({
+  open,
+  onClose,
+  onSaved,
+  userApp,
+}: UserCredentialsModalProps) {
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed each open so a prior attempt doesn't leak in.
+  useEffect(() => {
+    if (!open) return;
+    const initial: Record<string, string> = {};
+    for (const key of userApp.credential_keys) {
+      initial[key] = userApp.credential_values[key] ?? "";
+    }
+    setValues(initial);
+    setError(null);
+  }, [open, userApp]);
+
+  const canSave =
+    userApp.credential_keys.length > 0 &&
+    userApp.credential_keys.every((k) => (values[k] ?? "").trim().length > 0) &&
+    !isSaving;
+
+  async function save() {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await upsertUserCredentials(userApp.id, values);
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const Logo = getAppTypeLogo(userApp.app_type);
+
+  return (
+    <Modal open={open} onOpenChange={(o) => !o && onClose()}>
+      <Modal.Content width="md">
+        <Modal.Header
+          icon={Logo}
+          title={`Connect ${userApp.name}`}
+          description="Enter your credentials to authorize this app for your account."
+        />
+        <Modal.Body>
+          <div className="flex flex-col gap-4 w-full">
+            <div className="flex flex-col gap-3 w-full">
+              {userApp.credential_keys.map((key) => (
+                <div key={key} className="flex flex-col gap-1 w-full">
+                  <Text font="main-ui-action">{humanizeKey(key)}</Text>
+                  <PasswordInputTypeIn
+                    className="w-full"
+                    value={values[key] ?? ""}
+                    onChange={(e) =>
+                      setValues((prev) => ({ ...prev, [key]: e.target.value }))
+                    }
+                    placeholder={key}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {error && (
+              <MessageCard
+                variant="error"
+                title="Couldn't connect"
+                description={error}
+              />
+            )}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="flex justify-end gap-2 w-full">
+            <Button
+              prominence="secondary"
+              onClick={onClose}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button onClick={save} disabled={!canSave}>
+              {isSaving ? "Connecting…" : "Connect"}
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Modal from "@/refresh-components/Modal";
-import { Button, Text } from "@opal/components";
+import { Button, MessageCard, Text } from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
@@ -239,9 +239,11 @@ export default function CreateCustomAppModal({
             </div>
 
             {error && (
-              <Text font="secondary-body" color="text-03">
-                {error}
-              </Text>
+              <MessageCard
+                variant="error"
+                title="Couldn't save"
+                description={error}
+              />
             )}
           </div>
         </Modal.Body>

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Modal from "@/refresh-components/Modal";
+import { Button, Text } from "@opal/components";
+import { SvgUploadCloud } from "@opal/icons";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
+import InputKeyValue, {
+  KeyValue,
+} from "@/refresh-components/inputs/InputKeyValue";
+import { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+import { upsertCustomExternalApp } from "@/app/craft/services/externalAppsService";
+
+interface CreateCustomAppModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Invoked after a successful create/edit so callers can refresh their list. */
+  onSaved: () => void;
+  /** Null → create a new custom app; non-null → edit that app's config. */
+  existingApp: ExternalAppAdminResponse | null;
+}
+
+/** Collapse a key-value list into a record, dropping rows with an empty key. */
+function toRecord(items: KeyValue[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const { key, value } of items) {
+    const trimmedKey = key.trim();
+    if (trimmedKey) out[trimmedKey] = value;
+  }
+  return out;
+}
+
+/** Expand a record into editable rows, seeding one empty row when empty. */
+function toKeyValues(record: Record<string, string>): KeyValue[] {
+  const entries = Object.entries(record).map(([key, value]) => ({
+    key,
+    value,
+  }));
+  return entries.length > 0 ? entries : [{ key: "", value: "" }];
+}
+
+export default function CreateCustomAppModal({
+  open,
+  onClose,
+  onSaved,
+  existingApp,
+}: CreateCustomAppModalProps) {
+  const isEdit = existingApp !== null;
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [upstreamPatterns, setUpstreamPatterns] = useState<string[]>([]);
+  const [headers, setHeaders] = useState<KeyValue[]>([{ key: "", value: "" }]);
+  const [orgCredentials, setOrgCredentials] = useState<KeyValue[]>([
+    { key: "", value: "" },
+  ]);
+  const [file, setFile] = useState<File | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Re-seed every time the modal opens: from the existing app when editing,
+  // blank when creating. Prevents a prior attempt from leaking in.
+  useEffect(() => {
+    if (!open) return;
+    setName(existingApp?.name ?? "");
+    setDescription(existingApp?.description ?? "");
+    setUpstreamPatterns(existingApp?.upstream_url_patterns ?? []);
+    setHeaders(
+      existingApp
+        ? toKeyValues(existingApp.auth_template)
+        : [{ key: "", value: "" }]
+    );
+    setOrgCredentials(
+      existingApp
+        ? toKeyValues(existingApp.organization_credentials)
+        : [{ key: "", value: "" }]
+    );
+    setFile(null);
+    setError(null);
+  }, [open, existingApp]);
+
+  function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setFile(event.target.files?.[0] ?? null);
+  }
+
+  // Headers and organization credentials are both optional: an app may inject
+  // no credentials at all and simply allowlist its upstream patterns. Name and
+  // at least one upstream pattern are always required; a bundle is required
+  // only when creating (the bundle can't be replaced through this edit path).
+  const canSave =
+    name.trim().length > 0 &&
+    upstreamPatterns.length > 0 &&
+    (isEdit || file !== null) &&
+    !isSaving;
+
+  async function save() {
+    setIsSaving(true);
+    setError(null);
+    try {
+      // Custom apps always go through the custom endpoint. On edit a bundle is
+      // optional (replaces the existing one when present); enabled is toggled
+      // separately on the card, so preserve the existing value here.
+      await upsertCustomExternalApp({
+        id: existingApp?.id,
+        name: name.trim(),
+        description: description.trim(),
+        upstream_url_patterns: upstreamPatterns,
+        auth_template: toRecord(headers),
+        organization_credentials: toRecord(orgCredentials),
+        enabled: existingApp?.enabled ?? true,
+        bundle: file ?? undefined,
+      });
+      onSaved();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Modal open={open} onOpenChange={(o) => !o && onClose()}>
+      <Modal.Content width="lg" height="lg">
+        <Modal.Header
+          title={existingApp ? `Edit ${existingApp.name}` : "Create custom app"}
+          description={
+            isEdit
+              ? "Update this custom app's configuration, and optionally upload a new bundle to replace its files."
+              : "Define a custom external app: upload its skill bundle and configure how the egress proxy authenticates outbound requests."
+          }
+        />
+        <Modal.Body>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">Name</Text>
+              <InputTypeIn
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Custom App"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">Description</Text>
+              <InputTypeIn
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Optional — defaults to the bundle's SKILL.md description"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">Upstream URL patterns</Text>
+              <Text font="secondary-body" color="text-03">
+                Outbound URLs the proxy may inject credentials into. Type a
+                pattern and press Enter.
+              </Text>
+              <ListFieldInput
+                values={upstreamPatterns}
+                onChange={setUpstreamPatterns}
+                placeholder="https://api.example.com/*"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">Header credential pattern</Text>
+              <Text font="secondary-body" color="text-03">
+                {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
+              </Text>
+              <InputKeyValue
+                keyTitle="Header"
+                valueTitle="Value"
+                keyPlaceholder="Authorization"
+                valuePlaceholder="Bearer {api_key}"
+                items={headers}
+                onChange={setHeaders}
+                mode="line"
+                addButtonLabel="Add header"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">Organization credentials</Text>
+              <Text font="secondary-body" color="text-03">
+                Optional — values your org pre-fills for every user. Leave empty
+                for apps where each user supplies their own credentials.
+              </Text>
+              <InputKeyValue
+                keyTitle="Credential key"
+                valueTitle="Value"
+                keyPlaceholder="api_key"
+                valuePlaceholder="sk-…"
+                items={orgCredentials}
+                onChange={setOrgCredentials}
+                mode="line"
+                addButtonLabel="Add credential"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <Text font="main-ui-action">
+                {isEdit ? "Replace bundle (.zip)" : "Bundle (.zip)"}
+              </Text>
+              <Text font="secondary-body" color="text-03">
+                {isEdit
+                  ? "Optional — upload a new zip to replace the current bundle. Leave empty to keep it. The slug stays the same."
+                  : "A zip containing SKILL.md plus any other files. The filename becomes the app slug."}
+              </Text>
+              <div className="flex items-center gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".zip,application/zip"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                <Button
+                  icon={SvgUploadCloud}
+                  prominence="secondary"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {file
+                    ? "Change file"
+                    : isEdit
+                      ? "Choose new zip"
+                      : "Choose zip"}
+                </Button>
+                <Text font="main-ui-body" color="text-03">
+                  {file
+                    ? file.name
+                    : isEdit
+                      ? "Keeping current bundle"
+                      : "No file selected"}
+                </Text>
+              </div>
+            </div>
+
+            {error && (
+              <Text font="secondary-body" color="text-03">
+                {error}
+              </Text>
+            )}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="flex justify-end gap-2 w-full">
+            <Button
+              prominence="secondary"
+              onClick={onClose}
+              disabled={isSaving}
+            >
+              Cancel
+            </Button>
+            <Button onClick={save} disabled={!canSave}>
+              {isSaving
+                ? isEdit
+                  ? "Saving…"
+                  : "Creating…"
+                : isEdit
+                  ? "Save"
+                  : "Create"}
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/app/craft/v1/apps/admin/page.tsx
+++ b/web/src/app/craft/v1/apps/admin/page.tsx
@@ -15,6 +15,7 @@ import {
   getAppTypeLogo,
 } from "@/app/craft/v1/apps/registry";
 import ConfigureProviderModal from "@/app/craft/v1/apps/admin/ConfigureProviderModal";
+import CreateCustomAppModal from "@/app/craft/v1/apps/admin/CreateCustomAppModal";
 import {
   deleteExternalApp,
   setExternalAppEnabled,
@@ -41,6 +42,10 @@ export default function ExternalAppsAdminPage() {
   );
 
   const [modalState, setModalState] = useState<ModalState | null>(null);
+  // Custom-app create/edit modal. `existingApp: null` → create; non-null → edit.
+  const [customModal, setCustomModal] = useState<{
+    existingApp: ExternalAppAdminResponse | null;
+  } | null>(null);
 
   if (!isAdmin) {
     return (
@@ -95,6 +100,9 @@ export default function ExternalAppsAdminPage() {
                         onEdit={(descriptor) =>
                           setModalState({ descriptor, existingApp: app })
                         }
+                        onEditCustom={(customApp) =>
+                          setCustomModal({ existingApp: customApp })
+                        }
                         onChange={() => mutateApps()}
                       />
                     ))}
@@ -124,6 +132,9 @@ export default function ExternalAppsAdminPage() {
                     }
                   />
                 ))}
+                <CreateCustomAppCard
+                  onClick={() => setCustomModal({ existingApp: null })}
+                />
               </div>
             </section>
           </div>
@@ -138,6 +149,15 @@ export default function ExternalAppsAdminPage() {
             existingApp={modalState.existingApp}
           />
         )}
+
+        {customModal && (
+          <CreateCustomAppModal
+            open={customModal !== null}
+            onClose={() => setCustomModal(null)}
+            onSaved={() => mutateApps()}
+            existingApp={customModal.existingApp}
+          />
+        )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );
@@ -149,7 +169,10 @@ interface ConfiguredAppCardProps {
   app: ExternalAppAdminResponse;
   /** Null when the app's app_type no longer has a backend descriptor. */
   descriptor: BuiltInExternalAppDescriptor | null;
+  /** Edit a built-in provider instance (driven by its descriptor). */
   onEdit: (descriptor: BuiltInExternalAppDescriptor) => void;
+  /** Edit a custom app (no descriptor — config is on the row itself). */
+  onEditCustom: (app: ExternalAppAdminResponse) => void;
   onChange: () => void;
 }
 
@@ -157,6 +180,7 @@ function ConfiguredAppCard({
   app,
   descriptor,
   onEdit,
+  onEditCustom,
   onChange,
 }: ConfiguredAppCardProps) {
   const [isMutating, setIsMutating] = useState(false);
@@ -203,14 +227,24 @@ function ConfiguredAppCard({
           </Text>
         </div>
         <div className="flex items-center gap-2">
-          {descriptor && (
+          {app.app_type === "CUSTOM" ? (
             <Button
               prominence="secondary"
-              onClick={() => onEdit(descriptor)}
+              onClick={() => onEditCustom(app)}
               disabled={isMutating}
             >
               Edit
             </Button>
+          ) : (
+            descriptor && (
+              <Button
+                prominence="secondary"
+                onClick={() => onEdit(descriptor)}
+                disabled={isMutating}
+              >
+                Edit
+              </Button>
+            )
           )}
           <Button
             prominence="secondary"
@@ -254,6 +288,32 @@ function AvailableAppCard({ descriptor, onClick }: AvailableAppCardProps) {
         </div>
         <Button icon={SvgPlus} onClick={onClick}>
           Add
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+// ── Create-custom-app card ────────────────────────────────────────
+
+interface CreateCustomAppCardProps {
+  onClick: () => void;
+}
+
+function CreateCustomAppCard({ onClick }: CreateCustomAppCardProps) {
+  return (
+    <Card>
+      <div className="flex items-center gap-3 w-full">
+        <SvgPlug className="w-8 h-8" />
+        <div className="flex-1 flex flex-col gap-0.5">
+          <Text font="main-ui-action">Custom app</Text>
+          <Text font="secondary-body" color="text-03">
+            Bring your own integration: upload a skill bundle and configure its
+            credentials.
+          </Text>
+        </div>
+        <Button icon={SvgPlus} onClick={onClick}>
+          Create
         </Button>
       </div>
     </Card>

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -16,6 +16,7 @@ import {
   disconnectUserFromApp,
   startExternalAppOAuth,
 } from "@/app/craft/services/externalAppsService";
+import UserCredentialsModal from "@/app/craft/v1/apps/UserCredentialsModal";
 import { toast } from "@/hooks/useToast";
 
 export default function ExternalAppsUserPage() {
@@ -68,8 +69,15 @@ interface ProviderConnectRowProps {
 
 function ProviderConnectRow({ userApp, onChange }: ProviderConnectRowProps) {
   const [isStarting, setIsStarting] = useState(false);
+  const [credModalOpen, setCredModalOpen] = useState(false);
 
   async function connect() {
+    // Custom apps have no OAuth provider — collect the user's credentials
+    // directly via a popup instead of redirecting to an authorize URL.
+    if (userApp.app_type === "CUSTOM") {
+      setCredModalOpen(true);
+      return;
+    }
     setIsStarting(true);
     try {
       const { authorize_url } = await startExternalAppOAuth(userApp.id);
@@ -97,35 +105,50 @@ function ProviderConnectRow({ userApp, onChange }: ProviderConnectRowProps) {
   }
 
   const Logo = getAppTypeLogo(userApp.app_type);
+  const connectLabel =
+    userApp.app_type === "CUSTOM"
+      ? "Connect"
+      : isStarting
+        ? "Redirecting…"
+        : "Connect";
   return (
-    <Card>
-      <div className="flex items-center gap-3 w-full">
-        <Logo className="w-8 h-8" />
-        <div className="flex-1 flex flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <Text font="main-ui-action">{userApp.name}</Text>
-            {userApp.authenticated && (
-              <SvgCheckCircle className="w-4 h-4 text-status-success-05" />
-            )}
+    <>
+      <Card>
+        <div className="flex items-center gap-3 w-full">
+          <Logo className="w-8 h-8" />
+          <div className="flex-1 flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <Text font="main-ui-action">{userApp.name}</Text>
+              {userApp.authenticated && (
+                <SvgCheckCircle className="w-4 h-4 text-status-success-05" />
+              )}
+            </div>
+            <Text font="secondary-body" color="text-03">
+              {userApp.authenticated ? "Connected" : userApp.description}
+            </Text>
           </div>
-          <Text font="secondary-body" color="text-03">
-            {userApp.authenticated ? "Connected" : userApp.description}
-          </Text>
+          {userApp.authenticated ? (
+            <Button
+              prominence="secondary"
+              disabled={isStarting}
+              onClick={disconnect}
+            >
+              {isStarting ? "…" : "Disconnect"}
+            </Button>
+          ) : (
+            <Button disabled={isStarting} onClick={connect}>
+              {connectLabel}
+            </Button>
+          )}
         </div>
-        {userApp.authenticated ? (
-          <Button
-            prominence="secondary"
-            disabled={isStarting}
-            onClick={disconnect}
-          >
-            {isStarting ? "…" : "Disconnect"}
-          </Button>
-        ) : (
-          <Button disabled={isStarting} onClick={connect}>
-            {isStarting ? "Redirecting…" : "Connect"}
-          </Button>
-        )}
-      </div>
-    </Card>
+      </Card>
+
+      <UserCredentialsModal
+        open={credModalOpen}
+        onClose={() => setCredModalOpen(false)}
+        onSaved={onChange}
+        userApp={userApp}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Description
Allows admins to add custom external apps

UI nits will be fixed on final pass-over. Mainly focussing on functionality for now

<img width="1452" height="878" alt="Screenshot 2026-05-23 at 9 07 13 PM" src="https://github.com/user-attachments/assets/12cc189e-5e66-4e15-a3ed-0d5bacff30c5" />
<img width="959" height="965" alt="Screenshot 2026-05-23 at 9 07 17 PM" src="https://github.com/user-attachments/assets/6de60e88-cef5-4672-9bf8-c7df630cc798" />


## How Has This Been Tested?
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end support for Custom External Apps. Admins upload a bundle and gateway config; users connect by entering their own credentials (no OAuth).

- **New Features**
  - API: multipart `POST /admin/apps/custom` to create/edit custom apps (bundle required on create, optional on edit; URL patterns, header template, org creds). JSON `POST /admin/apps` rejects `CUSTOM`.
  - Validation: `parse_json_form_field` parses JSON form strings; `validate_auth_template` enforces non-empty string header names/values and allows empty templates/credentials; name and at least one upstream URL pattern are required.
  - Bundles: shared `ingest_skill_bundle` validates `SKILL.md`, derives slug from filename on create, keeps slug on replace, stores blobs, and uses `delete_bundle_blob` for cleanup on failure and after swaps; description falls back to the bundle’s when the form description is blank; pushes updated skills to affected sandboxes.
  - DB: `create_external_app` accepts a bundle-derived slug for custom apps; `update_external_app` can swap bundles and returns the old blob id for deletion; app type is immutable and validated on update.
  - UI: Admin Create/Edit modal and “Custom app” card; users connect via a credentials modal (no OAuth); enable/disable for custom apps routes through the multipart endpoint.
  - Services/Tests: `upsertCustomExternalApp` (multipart) added; integration manager posts to the custom endpoint for `CUSTOM`; tests cover create/edit, allowlist-only apps, missing `SKILL.md`, auth-template validation, blob cleanup, and rejecting `CUSTOM` on the JSON admin endpoint.

- **Migration**
  - Manage custom apps via `POST /admin/apps/custom`. The JSON `POST /admin/apps` rejects `CUSTOM`.

<sup>Written for commit 7ffdfab2e2e87e38602addccd701d1eb20aa38c2. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



