### PR TITLE
fix(skills): fix skills table simplification

### DIFF
--- a/backend/alembic/versions/7f5b159041be_skill_built_in_id_discriminator.py
+++ b/backend/alembic/versions/7f5b159041be_skill_built_in_id_discriminator.py
@@ -145,12 +145,55 @@ def _seed_built_in_skills() -> None:
 
 
 def upgrade() -> None:
-    # Older tenants ran an earlier version of b6d184cfdaf3_skills that created
-    # `manifest_metadata` NOT NULL; that migration was later edited to drop
-    # the column, but already-migrated tenants still carry it. The ORM no
-    # longer references it, so remove it before seeding to avoid NOT NULL
-    # violations on the upsert below.
+    # --- Reconcile schema drift from the in-place rewrite of b6d184cfdaf3 ---
+    # b6d184cfdaf3_skills was edited after it had already run on long-lived
+    # deployments, so tenants disagree on the `skill` table shape depending on
+    # which version they ran. Normalize every lineage to the current (fresh-DB)
+    # shape before seeding so the ON CONFLICT (slug) upsert below has a valid
+    # arbiter and no stale NOT NULL columns block it.
+
+    # 1) `manifest_metadata` NOT NULL existed in the original revision and was
+    #    later removed. The ORM no longer references it; drop it so it can't
+    #    trigger a NOT NULL violation on the upsert.
     op.execute("ALTER TABLE skill DROP COLUMN IF EXISTS manifest_metadata")
+
+    # 2) Slug uniqueness. The original revision enforced it with a *partial*
+    #    unique index `ux_skill_slug (slug) WHERE deleted_at IS NULL` plus a
+    #    `deleted_at` soft-delete column. #11082 rewrote that to a plain *total*
+    #    UNIQUE constraint `uq_skill_slug` and dropped `deleted_at`. ON CONFLICT
+    #    (slug) requires a *total* unique constraint/index as its arbiter — a
+    #    partial index does not match and Postgres raises "no unique or
+    #    exclusion constraint matching the ON CONFLICT specification". Old
+    #    tenants still carry the partial index and lack the total constraint, so
+    #    converge them to the fresh-DB shape:
+    #
+    #    a. Drop the legacy partial index (fresh DBs never had it).
+    op.execute("DROP INDEX IF EXISTS ux_skill_slug")
+
+    #    b. Drop the legacy soft-delete column the rewritten model no longer
+    #       references (fresh DBs never had it). Skills V1 only just shipped, so
+    #       affected tenants hold no skill rows yet (the table is empty wherever
+    #       this migration hasn't committed) — hence no duplicate-slug cleanup
+    #       is needed before adding the total constraint below.
+    op.execute("ALTER TABLE skill DROP COLUMN IF EXISTS deleted_at")
+
+    #    c. Add the total UNIQUE constraint unless it already exists (fresh DBs
+    #       have it from the rewritten b6d184cfdaf3). Postgres has no
+    #       ADD CONSTRAINT IF NOT EXISTS, so guard explicitly.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'uq_skill_slug'
+                  AND conrelid = 'skill'::regclass
+            ) THEN
+                ALTER TABLE skill ADD CONSTRAINT uq_skill_slug UNIQUE (slug);
+            END IF;
+        END$$;
+        """
+    )
 
     op.add_column(
         "skill",


### PR DESCRIPTION
## Description
There is currently an issue on st-dev where we are failing to migration on `7f5b159041be_skill_built_in_id_discriminator.py`. This is due to modifications to `b6d184cfdaf3_skills.py` that took place.

St-dev initially upgraded with https://github.com/onyx-dot-app/onyx/pull/10996/changes#diff-24d0bbe3dfec046c19cf1cdd18c41ba06644a8c0243864d82bf2ff49cfcf94c7R1

That migration was later modified as per https://github.com/onyx-dot-app/onyx/pull/11082/changes#diff-24d0bbe3dfec046c19cf1cdd18c41ba06644a8c0243864d82bf2ff49cfcf94c7L34

St-dev did not get that latter modification. This has led to a crash since it has ran

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the skills migration to reconcile schema drift from the edited `b6d184cfdaf3_skills` revision. Prevents upgrade crashes by normalizing the `skill` table before seeding built-in skills.

- **Bug Fixes**
  - Drop `manifest_metadata` if present to avoid NOT NULL violations.
  - Drop legacy partial index `ux_skill_slug` and soft-delete column `deleted_at`.
  - Add total unique constraint `uq_skill_slug` on `slug` if missing.
  - Ensures ON CONFLICT(slug) upsert works during built-in skills seeding.

<sup>Written for commit 1426d964b104d2f1ba8b6f720d5b09b899fe3434. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

