### PR TITLE
fix: dispose all Postgres pools on api server shutdown

### DIFF
--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -92,6 +92,20 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     return _ASYNC_ENGINE
 
 
+async def reset_sqlalchemy_async_engine() -> None:
+    """Dispose the process-global async engine and drop the reference so a
+    subsequent ``get_sqlalchemy_async_engine()`` rebuilds it from scratch.
+
+    Must be awaited so asyncpg's pool can close its connections (rather than
+    leaking them when the worker exits — uvicorn ``--reload`` exercises this
+    path on every file change).
+    """
+    global _ASYNC_ENGINE
+    if _ASYNC_ENGINE is not None:
+        await _ASYNC_ENGINE.dispose()
+        _ASYNC_ENGINE = None
+
+
 async def get_async_session(
     tenant_id: str | None = None,
 ) -> AsyncGenerator[AsyncSession, None]:

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -366,6 +366,13 @@ class SqlEngine:
                 cls._engine = None
 
     @classmethod
+    def reset_readonly_engine(cls) -> None:
+        with cls._readonly_lock:
+            if cls._readonly_engine:
+                cls._readonly_engine.dispose()
+                cls._readonly_engine = None
+
+    @classmethod
     @contextmanager
     def scoped_engine(cls, **init_kwargs: Any) -> Generator[None, None, None]:
         """Context manager that initializes the engine and guarantees cleanup."""

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -59,6 +59,7 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
 from onyx.db.engine.async_sql_engine import get_sqlalchemy_async_engine
+from onyx.db.engine.async_sql_engine import reset_sqlalchemy_async_engine
 from onyx.db.engine.connection_warmup import warm_up_connections
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import SqlEngine
@@ -396,7 +397,23 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
         stop_periodic_poller()
 
-    SqlEngine.reset_engine()
+    # Dispose every Postgres connection pool we opened in startup. Order:
+    # async first (its disposal is awaitable and can block), then the two
+    # sync engines. Each dispose() is wrapped so one failure cannot leak the
+    # remaining pools — this path runs on every uvicorn ``--reload`` worker
+    # shutdown, and any leaked pool accumulates until PG hits max_connections.
+    try:
+        await reset_sqlalchemy_async_engine()
+    except Exception:
+        logger.exception("Failed to dispose async SQLAlchemy engine on shutdown")
+    try:
+        SqlEngine.reset_engine()
+    except Exception:
+        logger.exception("Failed to dispose sync SQLAlchemy engine on shutdown")
+    try:
+        SqlEngine.reset_readonly_engine()
+    except Exception:
+        logger.exception("Failed to dispose readonly SQLAlchemy engine on shutdown")
 
     if AUTH_RATE_LIMITING_ENABLED:
         await close_auth_limiter()

--- a/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
+++ b/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
@@ -1,0 +1,162 @@
+"""Verify that all Postgres connection pools are disposed on app shutdown.
+
+Regression test for an observed leak under ``uvicorn --reload``: each worker
+restart spawned new pools without disposing the prior worker's pools, so
+Postgres held the orphaned connections until its server-side timeouts kicked
+them out. After a handful of reload cycles, ``max_connections`` was exhausted
+and the api server hung.
+
+These tests exercise each disposal function directly. A higher-level
+integration check would re-run the FastAPI lifespan, but the lifespan touches
+auth, telemetry, vespa, and the file store — far more scaffolding than the
+behavior we care about here, which is that ``dispose()`` is in fact called and
+the cached engine references are released.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+import onyx.db.engine.async_sql_engine as async_sql_engine
+from onyx.db.engine.async_sql_engine import reset_sqlalchemy_async_engine
+from onyx.db.engine.sql_engine import SqlEngine
+
+
+def test_reset_engine_disposes_and_clears_sync_engine() -> None:
+    fake_engine = MagicMock()
+    SqlEngine._engine = fake_engine
+    try:
+        SqlEngine.reset_engine()
+        fake_engine.dispose.assert_called_once_with()
+        assert SqlEngine._engine is None
+    finally:
+        SqlEngine._engine = None
+
+
+def test_reset_engine_is_a_noop_when_uninitialized() -> None:
+    # Make sure the test is starting from a clean slate.
+    SqlEngine._engine = None
+    SqlEngine.reset_engine()  # should not raise
+    assert SqlEngine._engine is None
+
+
+def test_reset_readonly_engine_disposes_and_clears() -> None:
+    fake_readonly = MagicMock()
+    SqlEngine._readonly_engine = fake_readonly
+    try:
+        SqlEngine.reset_readonly_engine()
+        fake_readonly.dispose.assert_called_once_with()
+        assert SqlEngine._readonly_engine is None
+    finally:
+        SqlEngine._readonly_engine = None
+
+
+def test_reset_readonly_engine_is_a_noop_when_uninitialized() -> None:
+    SqlEngine._readonly_engine = None
+    SqlEngine.reset_readonly_engine()  # should not raise
+    assert SqlEngine._readonly_engine is None
+
+
+@pytest.mark.asyncio
+async def test_reset_async_engine_disposes_and_clears() -> None:
+    fake_async = MagicMock()
+    fake_async.dispose = AsyncMock()
+    async_sql_engine._ASYNC_ENGINE = fake_async
+    try:
+        await reset_sqlalchemy_async_engine()
+        fake_async.dispose.assert_awaited_once_with()
+        assert async_sql_engine._ASYNC_ENGINE is None
+    finally:
+        async_sql_engine._ASYNC_ENGINE = None
+
+
+@pytest.mark.asyncio
+async def test_reset_async_engine_is_a_noop_when_uninitialized() -> None:
+    async_sql_engine._ASYNC_ENGINE = None
+    await reset_sqlalchemy_async_engine()  # should not raise
+    assert async_sql_engine._ASYNC_ENGINE is None
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_disposes_all_three_engines() -> None:
+    """End-to-end check: the FastAPI lifespan's shutdown phase must dispose
+    each engine. The lifespan touches a lot of other startup machinery; we
+    patch it out so this test is hermetic and only asserts the disposal calls.
+    """
+    from onyx import main as onyx_main
+
+    sync_engine = MagicMock()
+    readonly_engine = MagicMock()
+    async_engine_mock = MagicMock()
+    async_engine_mock.dispose = AsyncMock()
+
+    # Replace the engines with mocks and stub out every other startup side
+    # effect so we can reach the shutdown phase quickly.
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(SqlEngine, "set_app_name"))
+        stack.enter_context(patch.object(SqlEngine, "init_engine"))
+        stack.enter_context(patch.object(SqlEngine, "init_readonly_engine"))
+        stack.enter_context(
+            patch.object(SqlEngine, "get_engine", return_value=sync_engine)
+        )
+        stack.enter_context(
+            patch.object(SqlEngine, "get_readonly_engine", return_value=readonly_engine)
+        )
+        reset_sync = stack.enter_context(patch.object(SqlEngine, "reset_engine"))
+        reset_ro = stack.enter_context(patch.object(SqlEngine, "reset_readonly_engine"))
+        reset_async = stack.enter_context(
+            patch.object(onyx_main, "reset_sqlalchemy_async_engine", new=AsyncMock())
+        )
+        stack.enter_context(
+            patch.object(
+                onyx_main,
+                "get_sqlalchemy_async_engine",
+                return_value=async_engine_mock,
+            )
+        )
+        stack.enter_context(
+            patch.object(onyx_main, "setup_postgres_connection_pool_metrics")
+        )
+        stack.enter_context(patch.object(onyx_main, "validate_no_vector_db_settings"))
+        stack.enter_context(patch.object(onyx_main, "validate_cache_backend_settings"))
+        stack.enter_context(patch.object(onyx_main, "validate_registry"))
+        stack.enter_context(
+            patch.object(
+                onyx_main,
+                "fetch_versioned_implementation",
+                return_value=lambda: None,
+            )
+        )
+        stack.enter_context(patch.object(onyx_main, "setup_tracing"))
+        stack.enter_context(
+            patch.object(onyx_main, "warm_up_connections", new=AsyncMock())
+        )
+        stack.enter_context(patch.object(onyx_main, "get_session_with_current_tenant"))
+        stack.enter_context(patch.object(onyx_main, "setup_onyx"))
+        stack.enter_context(patch.object(onyx_main, "get_default_file_store"))
+        stack.enter_context(patch.object(onyx_main, "get_or_generate_uuid"))
+        stack.enter_context(patch.object(onyx_main, "optional_telemetry"))
+        stack.enter_context(patch.object(onyx_main, "MULTI_TENANT", False))
+        stack.enter_context(
+            patch.object(onyx_main, "AUTH_RATE_LIMITING_ENABLED", False)
+        )
+        stack.enter_context(patch.object(onyx_main, "DISABLE_VECTOR_DB", False))
+        stack.enter_context(patch.object(onyx_main, "OAUTH_CLIENT_ID", ""))
+        stack.enter_context(patch.object(onyx_main, "OAUTH_CLIENT_SECRET", ""))
+        stack.enter_context(patch.object(onyx_main, "SYSTEM_RECURSION_LIMIT", None))
+
+        async with onyx_main.lifespan(MagicMock()):
+            # Inside the lifespan body: startup ran, shutdown not yet.
+            reset_sync.assert_not_called()
+            reset_ro.assert_not_called()
+            reset_async.assert_not_called()
+
+        # After exiting the context manager: shutdown ran.
+        reset_async.assert_awaited_once_with()
+        reset_sync.assert_called_once_with()
+        reset_ro.assert_called_once_with()


### PR DESCRIPTION
## Description

When uvicorn runs with `--reload`, each file change triggers a worker reload. The old worker was exiting without draining its async SQLAlchemy engine or its readonly sync engine, so their pools' server-side connections accumulated. After a handful of reload cycles, Postgres hit `max_connections` and the api server hung (TCP-alive, HTTP-dead — sockets accepted but every handler blocked acquiring a connection that would never come).

Observed: 72+ orphaned connections across 5 Python PIDs after normal local-dev edits.

Only the primary sync engine (`SqlEngine._engine`) was being disposed in the lifespan shutdown. The async engine (`_ASYNC_ENGINE` module global in `async_sql_engine.py`) and the readonly sync engine (`SqlEngine._readonly_engine`) had no disposal path at all.

**Changes**

- `sql_engine.py`: add `SqlEngine.reset_readonly_engine()`, mirroring `reset_engine()` under `_readonly_lock`.
- `async_sql_engine.py`: add async `reset_sqlalchemy_async_engine()` that awaits `AsyncEngine.dispose()` and clears the module global so a subsequent `get_sqlalchemy_async_engine()` rebuilds.
- `main.py` lifespan shutdown: dispose all three pools (async first because it's awaitable and slowest, then the two sync engines). Each is wrapped in its own `try/except` so one bad pool can't leak the rest.

No raw asyncpg pool exists (asyncpg runs under SQLAlchemy's `AsyncEngine`). No per-tenant engine pools — multi-tenancy uses `schema_translate_map` on the shared engine, so all tenants drain together.

This works in both dev (`uvicorn --reload`, frequent worker lifecycles) and prod (gunicorn + uvicorn workers, SIGTERM on rolling deploys) because the FastAPI lifespan shutdown phase runs on graceful SIGTERM/SIGINT in both cases. No reload-specific hacks, no pool-size changes, no signal handler needed.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/onyx/db/engine/test_engine_disposal.py`:

- Each disposal function in isolation: calls `dispose()` once, clears the cached reference, is a no-op when uninitialized.
- An end-to-end test that drives the actual `lifespan(...)` async context manager (with the rest of startup mocked) and asserts all three reset functions are invoked on exit and not invoked during the body.

```
$ uv run pytest tests/unit/onyx/db/engine/test_engine_disposal.py
======================== 7 passed, 1 warning in 5.12s =========================
```

Pre-commit (ruff, ruff format, ty type check, lazy imports) clean.

The live `--reload` connection-count walk was not run on this worktree because its Postgres host is shared with the developer's already-running services and a second uvicorn would conflict with the count we're measuring. Recommended verification before merge: against a clean local Postgres, run 5 consecutive `--reload` cycles and confirm `lsof -nP -iTCP:5432 | awk '/Python/{print $2}' | sort | uniq -c` does not grow monotonically.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispose all Postgres connection pools on API server shutdown to stop leaks during `uvicorn --reload`. Prevents `max_connections` exhaustion and hanging requests.

- **Bug Fixes**
  - Added `SqlEngine.reset_readonly_engine()` to dispose the readonly sync engine.
  - Added async `reset_sqlalchemy_async_engine()` to await `AsyncEngine.dispose()` and clear the cache.
  - Updated `FastAPI` lifespan shutdown to dispose all pools (async first, then two sync), each wrapped in its own try/except.
  - Added unit tests covering each reset and the lifespan shutdown path.

<sup>Written for commit 1b5445f509139edcf918833521d7fce9138ac376. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

