### PR TITLE
fix(ci): set MODEL_SERVER_HOST in nightly LLM provider test runner

### DIFF
--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -129,6 +129,8 @@ runs:
             -e OPENSEARCH_HOST=opensearch \
             -e REDIS_HOST=cache \
             -e API_SERVER_HOST=api_server \
+            -e MODEL_SERVER_HOST=inference_model_server \
+            -e INDEXING_MODEL_SERVER_HOST=inference_model_server \
             -e TEST_WEB_HOSTNAME=test-runner \
             -e AWS_REGION_NAME=us-west-2 \
             -e NIGHTLY_LLM_PROVIDER="${NIGHTLY_LLM_PROVIDER}" \


### PR DESCRIPTION
## Description

The nightly LLM provider chat tests ([workflow](https://github.com/onyx-dot-app/onyx/actions/workflows/nightly-llm-provider-chat.yml)) have been failing for every provider in the matrix since Saturday 2026-05-23 — first failure was the run after PR #11300 (*chore(tests): use FastAPI TestClient for integration tests*) merged on Fri 2026-05-22.

Every test errors during collection with:

```
setup.py 285: No existing docs or connectors found. Checking GPU availability for multipass indexing.
gpu_utils.py 34: Error: Unable to fetch GPU status. Error: HTTPConnectionPool(host='localhost', port=9000)…
```

**Root cause.** PR #11300 added a session-scoped autouse `_test_client` fixture in `backend/tests/integration/conftest.py` that runs the FastAPI app in-process via `TestClient`. The `TestClient` context manager triggers the lifespan, which calls `setup_onyx()` → `update_default_multipass_indexing()` → `gpu_status_request(indexing=True)`. With neither `MODEL_SERVER_HOST` nor `INDEXING_MODEL_SERVER_HOST` set, `shared_configs.configs` defaults both to `localhost`. That PR updated `pr-integration-tests.yml` to inject those env vars into the test-runner container, but missed the parallel `.github/actions/run-nightly-provider-chat-test/action.yml`.

**Fix.** Inject `MODEL_SERVER_HOST` and `INDEXING_MODEL_SERVER_HOST` into the nightly action's `docker run`. The nightly action only starts `inference_model_server` (not `indexing_model_server`), so point both at the inference host.

**Audit of other docker-run pytest sites** (in case the same gap existed elsewhere):
- `pr-integration-tests.yml:438` / `:664` — already set both env vars (PR #11300 added them).
- `pr-integration-tests.yml:547` (onyx-lite) — runs with `DISABLE_VECTOR_DB=true`, which gates out `update_default_multipass_indexing` in `backend/onyx/setup.py:120-160`.
- `pr-database-tests.yml:93` — `tests/integration/tests/migrations/conftest.py` overrides `_test_client` to a no-op.
- `pr-craft-k8s-tests.yml` / `pr-external-dependency-unit-tests.yml` — run `tests/external_dependency_unit/...`, not the integration suite.

No other workflow has the same gap.

## How Has This Been Tested?

- Traced the failure from the [nightly run](https://github.com/onyx-dot-app/onyx/actions/runs/26398969437/job/77706482971) to PR #11300 and confirmed the env-var pattern in `pr-integration-tests.yml` lines 402–403 / 643–644.
- Will trigger the nightly workflow via `workflow_dispatch` once merged to confirm green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `MODEL_SERVER_HOST` and `INDEXING_MODEL_SERVER_HOST` in the nightly LLM provider chat test runner to point to `inference_model_server`, fixing setup failures where the app defaulted to localhost and crashed during GPU checks.

- **Bug Fixes**
  - Inject both env vars into `docker run` in `.github/actions/run-nightly-provider-chat-test/action.yml`.
  - Point both to the single inference server since the nightly job doesn’t start an indexing server.

<sup>Written for commit a894cd9b816ac9c29a76033167213ebd259ba84d. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

