### PR TITLE
fix(craft): improve scheduled run chat indicator

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -384,13 +384,9 @@ export default function BuildChatPanel({
           outputPanelOpen ? "w-1/2 pl-4" : "w-full"
         )}
       >
-        {/* Banner shown only when the session was started by a scheduled task. */}
-        <ScheduledRunBanner
-          sessionId={sessionId ?? existingSessionId ?? null}
-        />
         {/* Chat header */}
         <div className="flex flex-row items-center justify-between pl-4 pr-4 py-3 relative overflow-visible">
-          <div className="flex flex-row items-center gap-2 max-w-[75%]">
+          <div className="flex min-w-0 flex-row items-center gap-2 max-w-[75%]">
             {/* Mobile sidebar toggle - only show on mobile when sidebar is folded */}
             {isMobile && leftSidebarFolded && (
               <OpalButton
@@ -401,6 +397,9 @@ export default function BuildChatPanel({
               />
             )}
             <SandboxStatusIndicator />
+            <ScheduledRunBanner
+              sessionId={sessionId ?? existingSessionId ?? null}
+            />
           </div>
           {/* Output panel toggle - only show when panel is fully closed (after animation) */}
           {isOutputPanelFullyClosed && (

--- a/web/src/app/craft/components/ScheduledRunBanner.tsx
+++ b/web/src/app/craft/components/ScheduledRunBanner.tsx
@@ -52,7 +52,7 @@ export default function ScheduledRunBanner({
           "transition-[max-width,background-color]",
           "duration-[350ms] ease-out",
           "hover:max-w-[30rem] hover:bg-background-tint-01",
-          "focus:max-w-[30rem] focus:bg-background-tint-01",
+          "focus-visible:max-w-[30rem] focus-visible:bg-background-tint-01",
           "focus:outline-hidden focus-visible:ring-2",
           "focus-visible:ring-border-04"
         )}
@@ -69,7 +69,7 @@ export default function ScheduledRunBanner({
             className={cn(
               "col-start-1 row-start-1 flex h-5 items-center gap-1.5",
               "opacity-100 transition-opacity duration-200 ease-out",
-              "group-hover:opacity-0 group-focus:opacity-0"
+              "group-hover:opacity-0 group-focus-visible:opacity-0"
             )}
           >
             <SvgClock size={14} className="shrink-0 text-text-03" />
@@ -83,7 +83,7 @@ export default function ScheduledRunBanner({
             className={cn(
               "col-start-1 row-start-1 flex h-5 items-center gap-1.5",
               "opacity-0 transition-opacity duration-200 ease-out",
-              "group-hover:opacity-100 group-focus:opacity-100"
+              "group-hover:opacity-100 group-focus-visible:opacity-100"
             )}
           >
             <SvgExternalLink size={14} className="shrink-0 text-text-03" />
@@ -101,8 +101,9 @@ export default function ScheduledRunBanner({
             "transition-[max-width,opacity,margin-left]",
             "duration-[350ms] ease-out",
             "group-hover:ml-1.5 group-hover:max-w-[23rem]",
-            "group-hover:opacity-100 group-focus:ml-1.5",
-            "group-focus:max-w-[23rem] group-focus:opacity-100"
+            "group-hover:opacity-100 group-focus-visible:ml-1.5",
+            "group-focus-visible:max-w-[23rem]",
+            "group-focus-visible:opacity-100"
           )}
         >
           <div className="h-3 w-px shrink-0 bg-border-01" />

--- a/web/src/app/craft/components/ScheduledRunBanner.tsx
+++ b/web/src/app/craft/components/ScheduledRunBanner.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import useSWR from "swr";
 import { Text } from "@opal/components";
 import { SvgClock, SvgExternalLink } from "@opal/icons";
+import { cn } from "@opal/utils";
 import { taskDetailPath } from "@/app/craft/v1/tasks/constants";
 import { formatAbsolute } from "@/app/craft/v1/tasks/utils";
 import type { ScheduledRunContextResponse } from "@/app/craft/v1/tasks/interfaces";
@@ -44,7 +45,17 @@ export default function ScheduledRunBanner({
     >
       <Link
         href={taskDetailPath(data.task_id)}
-        className="group inline-flex min-w-0 max-w-[5.75rem] items-center overflow-hidden rounded-08 border border-border-01 bg-background-tint-00 px-2 py-1 transition-[max-width,background-color] duration-[350ms] ease-out hover:max-w-[30rem] hover:bg-background-tint-01 focus:max-w-[30rem] focus:bg-background-tint-01 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-border-04"
+        className={cn(
+          "group inline-flex min-w-0 max-w-[5.75rem] items-center",
+          "overflow-hidden rounded-08 border border-border-01",
+          "bg-background-tint-00 px-2 py-1",
+          "transition-[max-width,background-color]",
+          "duration-[350ms] ease-out",
+          "hover:max-w-[30rem] hover:bg-background-tint-01",
+          "focus:max-w-[30rem] focus:bg-background-tint-01",
+          "focus:outline-hidden focus-visible:ring-2",
+          "focus-visible:ring-border-04"
+        )}
         data-testid="back-to-task-button"
         title={`Scheduled task: ${data.task_name}. Started ${formatAbsolute(
           data.started_at
@@ -54,7 +65,13 @@ export default function ScheduledRunBanner({
         )}`}
       >
         <span className="grid shrink-0 translate-y-px items-center">
-          <span className="col-start-1 row-start-1 flex h-5 items-center gap-1.5 opacity-100 transition-opacity duration-200 ease-out group-hover:opacity-0 group-focus:opacity-0">
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex h-5 items-center gap-1.5",
+              "opacity-100 transition-opacity duration-200 ease-out",
+              "group-hover:opacity-0 group-focus:opacity-0"
+            )}
+          >
             <SvgClock size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
               <Text font="figure-small-label" color="text-03" nowrap>
@@ -62,7 +79,13 @@ export default function ScheduledRunBanner({
               </Text>
             </span>
           </span>
-          <span className="col-start-1 row-start-1 flex h-5 items-center gap-1.5 opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100 group-focus:opacity-100">
+          <span
+            className={cn(
+              "col-start-1 row-start-1 flex h-5 items-center gap-1.5",
+              "opacity-0 transition-opacity duration-200 ease-out",
+              "group-hover:opacity-100 group-focus:opacity-100"
+            )}
+          >
             <SvgExternalLink size={14} className="shrink-0 text-text-03" />
             <span className="flex h-5 shrink-0 items-center">
               <Text font="figure-small-label" color="text-03" nowrap>
@@ -71,7 +94,17 @@ export default function ScheduledRunBanner({
             </span>
           </span>
         </span>
-        <div className="ml-0 flex h-5 w-max max-w-0 translate-y-px items-center gap-1.5 overflow-hidden opacity-0 transition-[max-width,opacity,margin-left] duration-[350ms] ease-out group-hover:ml-1.5 group-hover:max-w-[23rem] group-hover:opacity-100 group-focus:ml-1.5 group-focus:max-w-[23rem] group-focus:opacity-100">
+        <div
+          className={cn(
+            "ml-0 flex h-5 w-max max-w-0 translate-y-px items-center",
+            "gap-1.5 overflow-hidden opacity-0",
+            "transition-[max-width,opacity,margin-left]",
+            "duration-[350ms] ease-out",
+            "group-hover:ml-1.5 group-hover:max-w-[23rem]",
+            "group-hover:opacity-100 group-focus:ml-1.5",
+            "group-focus:max-w-[23rem] group-focus:opacity-100"
+          )}
+        >
           <div className="h-3 w-px shrink-0 bg-border-01" />
           <span className="flex h-5 min-w-0 -translate-y-px items-center overflow-hidden">
             <Text font="main-ui-action" color="text-05" nowrap maxLines={1}>

--- a/web/src/app/craft/components/ScheduledRunBanner.tsx
+++ b/web/src/app/craft/components/ScheduledRunBanner.tsx
@@ -1,9 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import useSWR from "swr";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
-import { SvgArrowLeft, SvgClock } from "@opal/icons";
+import { Text } from "@opal/components";
+import { SvgClock, SvgExternalLink } from "@opal/icons";
 import { taskDetailPath } from "@/app/craft/v1/tasks/constants";
 import { formatAbsolute } from "@/app/craft/v1/tasks/utils";
 import type { ScheduledRunContextResponse } from "@/app/craft/v1/tasks/interfaces";
@@ -15,9 +15,9 @@ interface ScheduledRunBannerProps {
 }
 
 /**
- * Banner rendered above the transcript when the active session was created by
- * a scheduled task. When the session is interactive, this returns ``null``
- * (no DOM is inserted).
+ * Header metadata rendered when the active session was created by a scheduled
+ * task. When the session is interactive, this returns ``null`` (no DOM is
+ * inserted).
  *
  * Uses ``useSWR`` so the per-session lookup is deduped across the chat panel
  * and the parent layout.
@@ -39,25 +39,52 @@ export default function ScheduledRunBanner({
 
   return (
     <div
-      className="flex items-center gap-2 px-4 py-2 bg-status-info-01 border-b border-border-01"
+      className="inline-flex min-w-0 max-w-full"
       data-testid="scheduled-run-banner"
     >
-      <SvgClock size={16} className="text-status-info-05" />
-      <Text mainUiBody text05 className="flex-1 truncate">
-        This session was started by scheduled task{" "}
-        <span className="font-main-ui-action">{data.task_name}</span> at{" "}
-        {formatAbsolute(data.started_at)}.
-      </Text>
-      <Button
-        icon={SvgArrowLeft}
-        variant="default"
-        prominence="tertiary"
-        size="sm"
+      <Link
         href={taskDetailPath(data.task_id)}
+        className="group inline-flex min-w-0 max-w-[5.75rem] items-center overflow-hidden rounded-08 border border-border-01 bg-background-tint-00 px-2 py-1 transition-[max-width,background-color] duration-[350ms] ease-out hover:max-w-[30rem] hover:bg-background-tint-01 focus:max-w-[30rem] focus:bg-background-tint-01 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-border-04"
         data-testid="back-to-task-button"
+        title={`Scheduled task: ${data.task_name}. Started ${formatAbsolute(
+          data.started_at
+        )}.`}
+        aria-label={`View scheduled task ${data.task_name}, started ${formatAbsolute(
+          data.started_at
+        )}`}
       >
-        Back to task
-      </Button>
+        <span className="grid shrink-0 translate-y-px items-center">
+          <span className="col-start-1 row-start-1 flex h-5 items-center gap-1.5 opacity-100 transition-opacity duration-200 ease-out group-hover:opacity-0 group-focus:opacity-0">
+            <SvgClock size={14} className="shrink-0 text-text-03" />
+            <span className="flex h-5 shrink-0 items-center">
+              <Text font="figure-small-label" color="text-03" nowrap>
+                Scheduled
+              </Text>
+            </span>
+          </span>
+          <span className="col-start-1 row-start-1 flex h-5 items-center gap-1.5 opacity-0 transition-opacity duration-200 ease-out group-hover:opacity-100 group-focus:opacity-100">
+            <SvgExternalLink size={14} className="shrink-0 text-text-03" />
+            <span className="flex h-5 shrink-0 items-center">
+              <Text font="figure-small-label" color="text-03" nowrap>
+                View task
+              </Text>
+            </span>
+          </span>
+        </span>
+        <div className="ml-0 flex h-5 w-max max-w-0 translate-y-px items-center gap-1.5 overflow-hidden opacity-0 transition-[max-width,opacity,margin-left] duration-[350ms] ease-out group-hover:ml-1.5 group-hover:max-w-[23rem] group-hover:opacity-100 group-focus:ml-1.5 group-focus:max-w-[23rem] group-focus:opacity-100">
+          <div className="h-3 w-px shrink-0 bg-border-01" />
+          <span className="flex h-5 min-w-0 -translate-y-px items-center overflow-hidden">
+            <Text font="main-ui-action" color="text-05" nowrap maxLines={1}>
+              {data.task_name}
+            </Text>
+          </span>
+          <span className="hidden h-5 shrink-0 items-center xl:flex">
+            <Text font="secondary-body" color="text-03" nowrap>
+              {`Started ${formatAbsolute(data.started_at)}`}
+            </Text>
+          </span>
+        </div>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/d7d45d12-e4e8-4db1-9089-1e480a572000

Updates the scheduled-run indicator in Craft chat from a full-width banner to a compact header chip. The chip defaults to a clock icon with "Scheduled", expands on hover/focus, and links directly back to the scheduled task.

Also switches the indicator to Opal `Text` and keeps the scheduled-run metadata lookup behavior unchanged.

## How Has This Been Tested?

- `bun node_modules/oxfmt/bin/oxfmt --check src`
- `bun node_modules/oxlint/bin/oxlint`
- `bun run types:check`
- Pre-commit checks during commit, including `oxfmt`, `oxlint`, and TypeScript type check

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the full-width scheduled-run banner in Craft chat with a compact chip in the chat header. The chip expands on hover or focus-visible and links to the scheduled task, keeping context visible without taking space.

- **New Features**
  - Moved the indicator into the chat header next to the sandbox status; added `min-w-0` to avoid overflow.
  - Built as a `next/link` chip using `@opal/components` `Text`, `@opal/icons` (`SvgClock`, `SvgExternalLink`), and `@opal/utils` `cn`. Shows "Scheduled" by default; on hover/focus-visible switches to "View task", revealing task name (+ started time on xl). Adds focus-visible ring, `title`, and `aria-label`.

- **Refactors**
  - Consolidated classes with `cn` and replaced the button with a link; `useSWR` scheduled-run lookup is unchanged.

<sup>Written for commit 42c9ff90a63ee157e867f96360d519e8d2ae5382. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

