### PR TITLE
Fix table text truncation

### DIFF
--- a/web/lib/opal/src/components/table/TableCell.tsx
+++ b/web/lib/opal/src/components/table/TableCell.tsx
@@ -24,7 +24,10 @@ export default function TableCell({
       {...props}
     >
       <div
-        className={cn("tbl-cell-inner", "flex items-center overflow-hidden")}
+        className={cn(
+          "tbl-cell-inner",
+          "flex min-w-0 w-full items-center overflow-hidden"
+        )}
         data-size={resolvedSize}
       >
         {children}

--- a/web/lib/opal/src/components/table/TableHead.tsx
+++ b/web/lib/opal/src/components/table/TableHead.tsx
@@ -87,7 +87,7 @@ export default function TableHead({
       data-size={resolvedSize}
       data-bottom-border={bottomBorder || undefined}
     >
-      <div className="flex items-center gap-1">
+      <div className="flex min-w-0 items-center gap-1">
         <div className="table-head-label">
           <Text
             font={isSmall ? "secondary-action" : "main-ui-action"}

--- a/web/lib/opal/src/components/table/styles.css
+++ b/web/lib/opal/src/components/table/styles.css
@@ -24,6 +24,18 @@
   @apply h-6 px-0.5;
 }
 
+.tbl-cell-inner > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.tbl-cell-inner > :where(p, span) {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ---- TableHead ---- */
 
 .table-head {
@@ -45,6 +57,10 @@
 }
 .table-head[data-size="md"] .table-head-label {
   @apply py-1;
+}
+
+.table-head-label {
+  @apply min-w-0 flex-1 overflow-hidden;
 }
 
 /* Sort button wrapper */

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -245,11 +245,11 @@
    --------------------------------------------------------------------------- */
 
 .opal-content-md {
-  @apply flex flex-col items-start;
+  @apply flex min-w-0 flex-col items-start;
 }
 
 .opal-content-md-header {
-  @apply flex flex-row items-center w-full;
+  @apply flex min-w-0 flex-row items-center w-full;
   gap: 0.125rem;
 }
 
@@ -275,7 +275,7 @@
    --------------------------------------------------------------------------- */
 
 .opal-content-md-title-row {
-  @apply flex items-center w-full;
+  @apply flex min-w-0 items-center w-full;
   gap: 0.25rem;
 }
 
@@ -327,7 +327,7 @@
    --------------------------------------------------------------------------- */
 
 .opal-content-md-description {
-  @apply text-left w-full;
+  @apply min-w-0 text-left w-full;
 }
 
 /* ===========================================================================

--- a/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentsTable.tsx
@@ -5,7 +5,7 @@ import { Table, createTableColumns } from "@opal/components";
 import { Content, IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
-import Text from "@/refresh-components/texts/Text";
+import Truncated from "@/refresh-components/texts/Truncated";
 import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
 import type { MinimalUserSnapshot } from "@/lib/types";
 import AgentAvatar from "@/refresh-components/avatars/AgentAvatar";
@@ -72,18 +72,18 @@ function buildColumns(onMutate: () => void) {
       header: "Name",
       weight: 25,
       cell: (value) => (
-        <Text as="span" mainUiBody text05>
+        <Truncated mainUiBody text05>
           {value}
-        </Text>
+        </Truncated>
       ),
     }),
     tc.column("description", {
       header: "Description",
       weight: 35,
       cell: (value) => (
-        <Text as="span" mainUiBody text03>
+        <Truncated mainUiBody text03>
           {value || "—"}
-        </Text>
+        </Truncated>
       ),
     }),
     tc.column("owner", {


### PR DESCRIPTION
## Description

Fixes ugly table overflow when long text appears in fixed-height rows.

- Makes Opal table cell contents shrink within their assigned column width.
- Applies single-line ellipsis behavior to direct text nodes in table cells.
- Lets Opal `ContentMd` shrink correctly inside table cells.
- Updates the admin agents table Name and Description columns to use the existing truncation helper with tooltip behavior.

## How Has This Been Tested?

- `git diff --check`
- Pre-commit during commit:
  - `oxfmt` passed
  - `oxlint` passed
  - `ripsecrets` passed
  - other non-frontend hooks skipped because no matching files were changed
- `typescript-check` was attempted, but failed resolving `tsgo` from npm (`GET https://registry.npmjs.org/tsgo - 404`) before it could check this change. The commit was created with only that hook skipped.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes long text overflow in Opal tables by constraining cell content and using single-line ellipsis to prevent layout breakage. Updates the Admin Agents table to use tooltip-based truncation for Name and Description.

- **Bug Fixes**
  - Constrain `TableCell` content (`min-w-0`, `w-full`), and apply ellipsis to direct `p`/`span` nodes.
  - Ensure table headers shrink (`min-w-0` on head wrapper and `.table-head-label`).
  - Let `ContentMd` shrink inside cells by adding `min-w-0` on key wrappers.
  - Replace `Text` with `Truncated` for Agents table Name/Description for clean truncation with tooltips.

<sup>Written for commit fa1c8a4e53047962aa793435e1c04107bf2ce982. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11360?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

