### PR TITLE
fix(craft): improve scheduled tasks empty state

### DIFF
--- a/web/src/app/craft/v1/tasks/constants.ts
+++ b/web/src/app/craft/v1/tasks/constants.ts
@@ -19,5 +19,8 @@ export function buildSessionPath(sessionId: string): Route {
   return `/craft/v1?sessionId=${sessionId}` as Route;
 }
 
+// Default page size for the scheduled task list.
+export const TASKS_PAGE_SIZE = 50;
+
 // Default page size for run history.
 export const RUNS_PAGE_SIZE = 50;

--- a/web/src/app/craft/v1/tasks/constants.ts
+++ b/web/src/app/craft/v1/tasks/constants.ts
@@ -3,10 +3,6 @@
  */
 
 import type { Route } from "next";
-import type {
-  EditorMode,
-  EditorPayload,
-} from "@/app/craft/v1/tasks/interfaces";
 
 export const TASKS_PATH = "/craft/v1/tasks" as Route;
 export const NEW_TASK_PATH = `${TASKS_PATH}/new` as Route;
@@ -25,37 +21,3 @@ export function buildSessionPath(sessionId: string): Route {
 
 // Default page size for run history.
 export const RUNS_PAGE_SIZE = 50;
-
-// Starter prompts shown on the empty list state. Pulled from the V1 product
-// spec — see docs/craft/product/scheduled-tasks.md.
-export interface StarterPrompt {
-  title: string;
-  prompt: string;
-  mode: EditorMode;
-  payload: EditorPayload;
-  timezone?: string; // falls back to user's TZ if absent
-}
-
-export const STARTER_PROMPTS: StarterPrompt[] = [
-  {
-    title: "Hourly Linear board sync",
-    prompt:
-      "Check if any new work has happened on Craft in the last hour, and if so keep the Craft Linear board up to date.",
-    mode: "interval",
-    payload: { unit: "hours", every: 1 },
-  },
-  {
-    title: "Monday escalations digest",
-    prompt:
-      "Summarize last week's customer escalations and post the summary to #cs-leadership.",
-    mode: "daily_weekly",
-    // 1 = Monday (cron convention: 0=Sun..6=Sat)
-    payload: { time_of_day: "09:00", weekdays: [1] },
-  },
-  {
-    title: "Daily 5pm churn-risk report",
-    prompt: "Run our churn-risk report and email it to me.",
-    mode: "daily_weekly",
-    payload: { time_of_day: "17:00", weekdays: [1, 2, 3, 4, 5] },
-  },
-];

--- a/web/src/app/craft/v1/tasks/constants.ts
+++ b/web/src/app/craft/v1/tasks/constants.ts
@@ -20,7 +20,7 @@ export function buildSessionPath(sessionId: string): Route {
 }
 
 // Default page size for the scheduled task list.
-export const TASKS_PAGE_SIZE = 50;
+export const TASKS_PAGE_SIZE = 20;
 
 // Default page size for run history.
 export const RUNS_PAGE_SIZE = 50;

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -5,9 +5,10 @@ import useSWR from "swr";
 import { useRouter } from "next/navigation";
 import * as SettingsLayouts from "@/layouts/settings-layouts";
 import { Section } from "@/layouts/general-layouts";
-import Card from "@/refresh-components/cards/Card";
 import Text from "@/refresh-components/texts/Text";
 import { Button, Table, Tooltip, createTableColumns } from "@opal/components";
+import { IllustrationContent } from "@opal/layouts";
+import SvgNoResult from "@opal/illustrations/no-result";
 import { toast } from "@/hooks/useToast";
 import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
@@ -17,11 +18,7 @@ import {
   RunStatusBadge,
   TaskStatusBadge,
 } from "@/app/craft/v1/tasks/components/StatusBadge";
-import {
-  NEW_TASK_PATH,
-  STARTER_PROMPTS,
-  taskDetailPath,
-} from "@/app/craft/v1/tasks/constants";
+import { NEW_TASK_PATH, taskDetailPath } from "@/app/craft/v1/tasks/constants";
 import type {
   ScheduledTaskListItem,
   ScheduledTaskListResponse,
@@ -126,7 +123,7 @@ export default function ScheduledTasksListPage() {
     errorHandlingFetcher,
     { revalidateOnFocus: false }
   );
-  const tasks = data?.items;
+  const tasks = data?.items ?? [];
   const [pendingDelete, setPendingDelete] =
     useState<ScheduledTaskListItem | null>(null);
   const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
@@ -201,25 +198,21 @@ export default function ScheduledTasksListPage() {
               Try again
             </Button>
           </Section>
-        ) : !tasks || tasks.length === 0 ? (
-          <EmptyState
-            onSelectStarter={(prompt) => {
-              const params = new URLSearchParams({
-                starter: prompt.title,
-                prompt: prompt.prompt,
-                mode: prompt.mode,
-                payload: JSON.stringify(prompt.payload),
-              });
-              router.push(`${NEW_TASK_PATH}?${params.toString()}`);
-            }}
-          />
         ) : (
           <Table
             data={tasks}
             columns={columns}
             getRowId={(row) => row.id}
+            pageSize={Math.max(tasks.length, 1)}
             selectionBehavior="single-select"
             onRowClick={(row) => router.push(taskDetailPath(row.id))}
+            emptyState={
+              <IllustrationContent
+                illustration={SvgNoResult}
+                title="No scheduled tasks found"
+                description="No scheduled tasks have been created yet."
+              />
+            }
           />
         )}
       </SettingsLayouts.Body>
@@ -272,63 +265,5 @@ function TaskRowActions({ task, handlers }: TaskRowActionsProps) {
         />
       </Tooltip>
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Empty state
-// ---------------------------------------------------------------------------
-
-interface EmptyStateProps {
-  onSelectStarter: (prompt: (typeof STARTER_PROMPTS)[number]) => void;
-}
-
-function EmptyState({ onSelectStarter }: EmptyStateProps) {
-  return (
-    <Section gap={1}>
-      <div className="flex flex-col items-center text-center py-6 gap-2">
-        <SvgClock size={48} className="text-text-03" />
-        <Text headingH2 text05>
-          Hand Craft a recurring job
-        </Text>
-        <Text mainUiBody text03 className="max-w-xl">
-          Save a prompt + schedule and Craft will run it on a timer. Each fire
-          creates a fresh session you can open from this page.
-        </Text>
-        <div className="pt-2">
-          <Button
-            variant="default"
-            prominence="primary"
-            icon={SvgPlus}
-            href={NEW_TASK_PATH}
-          >
-            Create scheduled task
-          </Button>
-        </div>
-      </div>
-      <Text mainUiAction text05>
-        Or start from a template:
-      </Text>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-        {STARTER_PROMPTS.map((starter) => (
-          <button
-            key={starter.title}
-            type="button"
-            onClick={() => onSelectStarter(starter)}
-            className="text-left"
-            data-testid={`starter-${starter.title}`}
-          >
-            <Card>
-              <Text mainUiAction text05>
-                {starter.title}
-              </Text>
-              <Text secondaryBody text03>
-                {starter.prompt}
-              </Text>
-            </Card>
-          </button>
-        ))}
-      </div>
-    </Section>
   );
 }

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -18,7 +18,11 @@ import {
   RunStatusBadge,
   TaskStatusBadge,
 } from "@/app/craft/v1/tasks/components/StatusBadge";
-import { NEW_TASK_PATH, taskDetailPath } from "@/app/craft/v1/tasks/constants";
+import {
+  NEW_TASK_PATH,
+  TASKS_PAGE_SIZE,
+  taskDetailPath,
+} from "@/app/craft/v1/tasks/constants";
 import type {
   ScheduledTaskListItem,
   ScheduledTaskListResponse,
@@ -203,7 +207,9 @@ export default function ScheduledTasksListPage() {
             data={tasks}
             columns={columns}
             getRowId={(row) => row.id}
-            pageSize={Math.max(tasks.length, 1)}
+            pageSize={
+              tasks.length > 0 ? Math.min(tasks.length, TASKS_PAGE_SIZE) : 1
+            }
             selectionBehavior="single-select"
             onRowClick={(row) => router.push(taskDetailPath(row.id))}
             emptyState={


### PR DESCRIPTION
## Description

<img width="1110" height="605" alt="Screenshot 2026-05-25 at 1 03 45 PM" src="https://github.com/user-attachments/assets/49755f25-14a9-4296-9165-e5d7d5f56d8f" />

- Updates the scheduled tasks empty list to render through the Opal Table emptyState pattern used by the admin agents page.
- Replaces the custom starter-template empty state with IllustrationContent and SvgNoResult.
- Removes now-unused starter prompt constants.

## How Has This Been Tested?

- npm run lint -- src/app/craft/v1/tasks/page.tsx src/app/craft/v1/tasks/constants.ts
- npm run types:check
- Pre-commit hooks on commit: oxfmt, oxlint, TypeScript type check

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the scheduled tasks page to use the shared Opal Table empty state and removed the starter-template flow. Capped the table page size to 20 to improve performance and avoid awkward pagination.

- **Refactors**
  - Use `Table`’s `emptyState` with `IllustrationContent` and `SvgNoResult` from `@opal/components`, `@opal/layouts`, and `@opal/illustrations/no-result`.
  - Remove custom EmptyState and starter-template flow; delete related types/constants from `constants.ts`.
  - Default `tasks` to `[]`; set `TASKS_PAGE_SIZE` to 20 and fall back to 1 when the list is empty.

<sup>Written for commit 22b0d10f5e0d93a465a79e52b636e7575bd56b13. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11361?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



