### PR TITLE
refactor(external-apps): Improve design for built-in external app defns

### DIFF
--- a/backend/onyx/external_apps/providers/__init__.py
+++ b/backend/onyx/external_apps/providers/__init__.py
@@ -43,7 +43,7 @@ def get_provider_or_raise(app: ExternalApp) -> ExternalAppProvider:
     if provider is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"OAuth flow not configured for app '{app.skill.name}' "
+            f"No provider configured for app '{app.skill.name}' "
             f"(app_type={app.app_type}).",
         )
     return provider

--- a/backend/onyx/external_apps/providers/__init__.py
+++ b/backend/onyx/external_apps/providers/__init__.py
@@ -2,42 +2,43 @@ from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.providers.base import OAuth
+from onyx.external_apps.providers.base import ExternalAppProvider
 from onyx.external_apps.providers.base import OrgCredentialField
-from onyx.external_apps.providers.google_calendar import GoogleCalendarOAuth
-from onyx.external_apps.providers.linear import LinearOAuth
-from onyx.external_apps.providers.slack import SlackOAuth
+from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
+from onyx.external_apps.providers.linear import LinearProvider
+from onyx.external_apps.providers.slack import SlackProvider
 from onyx.server.features.build.api.models import BuiltInExternalAppDescriptor
 from onyx.server.features.build.api.models import OrgCredentialFieldDescriptor
 
-_PROVIDER_CLASSES: list[type[OAuth]] = [
-    SlackOAuth,
-    GoogleCalendarOAuth,
-    LinearOAuth,
+_PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
+    SlackProvider,
+    GoogleCalendarProvider,
+    LinearProvider,
 ]
 
 
-def _build_providers() -> dict[ExternalAppType, OAuth]:
-    providers: dict[ExternalAppType, OAuth] = {}
+def _build_providers() -> dict[ExternalAppType, ExternalAppProvider]:
+    providers: dict[ExternalAppType, ExternalAppProvider] = {}
     for cls in _PROVIDER_CLASSES:
-        if cls.app_type in providers:
-            existing = type(providers[cls.app_type]).__name__
+        app_type = cls.spec.app_type
+        if app_type in providers:
+            existing = type(providers[app_type]).__name__
             raise RuntimeError(
-                f"Duplicate OAuth provider registration for "
-                f"app_type={cls.app_type}: {existing} and {cls.__name__}."
+                f"Duplicate provider registration for "
+                f"app_type={app_type}: {existing} and {cls.__name__}."
             )
-        providers[cls.app_type] = cls()
+        providers[app_type] = cls()
     return providers
 
 
-PROVIDERS: dict[ExternalAppType, OAuth] = _build_providers()
+PROVIDERS: dict[ExternalAppType, ExternalAppProvider] = _build_providers()
 
 
-def get_provider_for_app(app: ExternalApp) -> OAuth | None:
+def get_provider_for_app(app: ExternalApp) -> ExternalAppProvider | None:
     return PROVIDERS.get(app.app_type)
 
 
-def get_provider_or_raise(app: ExternalApp) -> OAuth:
+def get_provider_or_raise(app: ExternalApp) -> ExternalAppProvider:
     provider = get_provider_for_app(app)
     if provider is None:
         raise OnyxError(
@@ -48,18 +49,22 @@ def get_provider_or_raise(app: ExternalApp) -> OAuth:
     return provider
 
 
-def _descriptor_for(provider_cls: type[OAuth]) -> BuiltInExternalAppDescriptor:
+def _descriptor_for(
+    provider_cls: type[ExternalAppProvider],
+) -> BuiltInExternalAppDescriptor:
+    spec = provider_cls.spec
+    descriptor = spec.descriptor
     return BuiltInExternalAppDescriptor(
-        app_type=provider_cls.app_type,
-        name=provider_cls.app_name,
-        description=provider_cls.description,
-        upstream_url_patterns=list(provider_cls.upstream_url_patterns),
-        auth_template=dict(provider_cls.auth_template),
+        app_type=spec.app_type,
+        name=spec.app_name,
+        description=descriptor.description,
+        upstream_url_patterns=list(descriptor.upstream_url_patterns),
+        auth_template=dict(descriptor.auth_template),
         required_org_credential_fields=[
             _to_credential_field_descriptor(f)
-            for f in provider_cls.required_org_credential_fields
+            for f in descriptor.required_org_credential_fields
         ],
-        setup_instructions=provider_cls.setup_instructions,
+        setup_instructions=descriptor.setup_instructions,
     )
 
 
@@ -82,7 +87,7 @@ def fetch_available_built_in_apps() -> list[BuiltInExternalAppDescriptor]:
 
 def fetch_built_in_app(app_type: ExternalAppType) -> BuiltInExternalAppDescriptor:
     for cls in _PROVIDER_CLASSES:
-        if cls.app_type == app_type:
+        if cls.spec.app_type == app_type:
             return _descriptor_for(cls)
     raise OnyxError(
         OnyxErrorCode.NOT_FOUND,
@@ -91,10 +96,10 @@ def fetch_built_in_app(app_type: ExternalAppType) -> BuiltInExternalAppDescripto
 
 
 __all__ = [
-    "OAuth",
-    "SlackOAuth",
-    "GoogleCalendarOAuth",
-    "LinearOAuth",
+    "ExternalAppProvider",
+    "SlackProvider",
+    "GoogleCalendarProvider",
+    "LinearProvider",
     "PROVIDERS",
     "get_provider_for_app",
     "get_provider_or_raise",

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -1,5 +1,3 @@
-"""Abstract interfaces for OAuth providers."""
-
 from abc import ABC
 from abc import abstractmethod
 from typing import Any
@@ -23,31 +21,96 @@ class OrgCredentialField(BaseModel):
     secret: bool = False
 
 
-class OAuth(ABC):
-    """Initial-grant OAuth 2.0 flow + descriptor metadata for the
-    admin UI. The descriptor fields are surfaced via
-    `BuiltInExternalAppDescriptor` so the frontend can render the
-    Configure modal without knowing each provider's specifics."""
+class OAuthFlowSpec(BaseModel):
+    """Initial-grant OAuth 2.0 parameters for a provider. Consumed by the
+    External-App OAuth routes to build the authorize URL and exchange the
+    code for a token."""
 
-    # ── OAuth flow ──────────────────────────────────────────────────
-    app_type: ClassVar[ExternalAppType]
-    app_name: ClassVar[str]
-    authorize_url: ClassVar[str]
-    token_url: ClassVar[str]
-    scope: ClassVar[str]
-    # Slack uses `user_scope` instead of `scope` to request user-acting
-    # tokens; without this, Slack interprets the request as bot scopes.
-    scope_param: ClassVar[str]
-    extra_authorize_params: ClassVar[dict[str, str]] = {}
+    model_config = ConfigDict(frozen=True)
 
-    # ── Admin UI descriptor ─────────────────────────────────────────
-    # Subclasses must set these so the built-in-options endpoint can
-    # advertise them to the frontend.
-    description: ClassVar[str]
-    upstream_url_patterns: ClassVar[list[str]]
-    auth_template: ClassVar[dict[str, str]]
-    required_org_credential_fields: ClassVar[list[OrgCredentialField]]
-    setup_instructions: ClassVar[str]
+    authorize_url: str
+    token_url: str
+    scope: str
+    # The query param the `scope` value rides under. Slack uses `user_scope`
+    # to request user-acting tokens; without it Slack assumes bot scopes.
+    scope_param: str
+    extra_authorize_params: dict[str, str] = {}
+
+
+class AdminDescriptorSpec(BaseModel):
+    """Everything the admin Configure modal renders and the egress gateway
+    needs. Surfaced verbatim through ``BuiltInExternalAppDescriptor`` so the
+    frontend can render the modal without knowing any provider specifics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    description: str
+    upstream_url_patterns: list[str]
+    auth_template: dict[str, str]
+    required_org_credential_fields: list[OrgCredentialField]
+    setup_instructions: str
+
+
+class ProviderSpec(BaseModel):
+    """The base declarative definition every built-in provider must supply:
+    identity + the admin descriptor. Pydantic enforces that nothing is
+    missing. OAuth providers use the :class:`OAuthProviderSpec` subtype, which
+    additionally carries the flow."""
+
+    model_config = ConfigDict(frozen=True)
+
+    app_type: ExternalAppType
+    app_name: str
+    descriptor: AdminDescriptorSpec
+
+
+class OAuthProviderSpec(ProviderSpec):
+    """A :class:`ProviderSpec` for providers whose users authenticate via an
+    OAuth 2.0 flow. Paired with :class:`OAuthExternalAppProvider`."""
+
+    oauth: OAuthFlowSpec
+
+
+class ExternalAppProvider(ABC):
+    """Base contract for a built-in external-app provider.
+
+    Every provider MUST define ``spec`` (a :class:`ProviderSpec`), validated at
+    class-definition time. Providers that authenticate via OAuth subclass
+    :class:`OAuthExternalAppProvider` instead, which narrows ``spec`` to
+    :class:`OAuthProviderSpec` and adds the credential-extraction hook.
+
+    Abstract tiers in this hierarchy pass ``abstract=True`` so they're exempt
+    from the ``spec`` requirement; only concrete, registrable providers are
+    checked."""
+
+    spec: ClassVar[ProviderSpec]
+
+    # The spec subtype this tier requires. Overridden by OAuth providers.
+    _spec_type: ClassVar[type[ProviderSpec]] = ProviderSpec
+
+    def __init_subclass__(cls, *, abstract: bool = False, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if abstract:
+            return
+        spec = cls.__dict__.get("spec")
+        if not isinstance(spec, cls._spec_type):
+            raise TypeError(
+                f"{cls.__name__} must define `spec` as a "
+                f"{cls._spec_type.__name__} instance."
+            )
+
+
+class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
+    """A provider whose users authenticate via an OAuth 2.0 flow. Concrete
+    subclasses MUST supply an :class:`OAuthProviderSpec` (so ``spec.oauth`` is
+    always present) and implement :meth:`extract_credentials`."""
+
+    spec: ClassVar[OAuthProviderSpec]
+    _spec_type: ClassVar[type[ProviderSpec]] = OAuthProviderSpec
 
     @abstractmethod
-    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]: ...
+    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        """Map a successful token-exchange response to the credentials to
+        persist for the user (e.g. pull the user access token out of Slack's
+        nested ``authed_user``). Raise ``OnyxError`` if the expected token is
+        absent."""

--- a/backend/onyx/external_apps/providers/google_calendar.py
+++ b/backend/onyx/external_apps/providers/google_calendar.py
@@ -1,58 +1,67 @@
 from typing import Any
-from typing import ClassVar
 
 from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.providers.base import OAuth
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OrgCredentialField
 
 
-class GoogleCalendarOAuth(OAuth):
-    app_type = ExternalAppType.GOOGLE_CALENDAR
-    app_name = "Google Calendar"
-    authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"
-    token_url = "https://oauth2.googleapis.com/token"
-    scope = "https://www.googleapis.com/auth/calendar"
-    scope_param = "scope"
-    # access_type=offline issues a refresh_token; prompt=consent
-    # forces fresh consent so Google reissues it on re-auth.
-    extra_authorize_params: ClassVar[dict[str, str]] = {
-        "response_type": "code",
-        "access_type": "offline",
-        "prompt": "consent",
-    }
-
-    description = (
-        "Read and create events on your Google Calendar from inside Onyx Craft."
-    )
-    upstream_url_patterns = ["https://www\\.googleapis\\.com/calendar/.*"]
-    auth_template = {"Authorization": "Bearer {access_token}"}
-    required_org_credential_fields = [
-        OrgCredentialField(
-            key="client_id",
-            label="Client ID",
+class GoogleCalendarProvider(OAuthExternalAppProvider):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.GOOGLE_CALENDAR,
+        app_name="Google Calendar",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
+            token_url="https://oauth2.googleapis.com/token",
+            scope="https://www.googleapis.com/auth/calendar",
+            scope_param="scope",
+            # access_type=offline issues a refresh_token; prompt=consent
+            # forces fresh consent so Google reissues it on re-auth.
+            extra_authorize_params={
+                "response_type": "code",
+                "access_type": "offline",
+                "prompt": "consent",
+            },
+        ),
+        descriptor=AdminDescriptorSpec(
             description=(
-                "Found in Google Cloud Console → APIs & Services → "
-                "Credentials → OAuth 2.0 Client IDs."
+                "Read and create events on your Google Calendar from inside Onyx Craft."
+            ),
+            upstream_url_patterns=["https://www\\.googleapis\\.com/calendar/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found in Google Cloud Console → APIs & Services → "
+                        "Credentials → OAuth 2.0 Client IDs."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Found alongside the Client ID. Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "In Google Cloud Console: create a project (or pick one), "
+                "enable the Google Calendar API under APIs & Services → "
+                "Library, configure the OAuth consent screen (External for "
+                "personal Google accounts, Internal for Workspace), then under "
+                "APIs & Services → Credentials create an OAuth 2.0 Client ID of "
+                "type Web application. Add this Onyx instance's callback URL "
+                "(/craft/v1/apps/oauth/callback) to Authorized redirect URIs. "
+                "Then paste the Client ID and Client Secret below."
             ),
         ),
-        OrgCredentialField(
-            key="client_secret",
-            label="Client Secret",
-            description=("Found alongside the Client ID. Treat this like a password."),
-            secret=True,
-        ),
-    ]
-    setup_instructions = (
-        "In Google Cloud Console: create a project (or pick one), enable the "
-        "Google Calendar API under APIs & Services → Library, configure the "
-        "OAuth consent screen (External for personal Google accounts, "
-        "Internal for Workspace), then under APIs & Services → Credentials "
-        "create an OAuth 2.0 Client ID of type Web application. Add this "
-        "Onyx instance's callback URL (/craft/v1/apps/oauth/callback) to "
-        "Authorized redirect URIs. Then paste the Client ID and Client "
-        "Secret below."
     )
 
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/external_apps/providers/linear.py
+++ b/backend/onyx/external_apps/providers/linear.py
@@ -1,54 +1,65 @@
 from typing import Any
-from typing import ClassVar
 
 from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.providers.base import OAuth
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OrgCredentialField
 
 
-class LinearOAuth(OAuth):
-    app_type = ExternalAppType.LINEAR
-    app_name = "Linear"
-    authorize_url = "https://linear.app/oauth/authorize"
-    token_url = "https://api.linear.app/oauth/token"
-    scope = "read,write"
-    scope_param = "scope"
-    # actor=user is Linear's default but explicit — actor=application
-    # would mint an app-acting token instead of user-acting.
-    extra_authorize_params: ClassVar[dict[str, str]] = {
-        "response_type": "code",
-        "actor": "user",
-    }
-
-    description = (
-        "Read and create issues, projects, and comments in Linear on the user's behalf."
-    )
-    upstream_url_patterns = ["https://api\\.linear\\.app/.*"]
-    auth_template = {"Authorization": "Bearer {access_token}"}
-    required_org_credential_fields = [
-        OrgCredentialField(
-            key="client_id",
-            label="Client ID",
+class LinearProvider(OAuthExternalAppProvider):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.LINEAR,
+        app_name="Linear",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://linear.app/oauth/authorize",
+            token_url="https://api.linear.app/oauth/token",
+            scope="read,write",
+            scope_param="scope",
+            # actor=user is Linear's default but explicit — actor=application
+            # would mint an app-acting token instead of user-acting.
+            extra_authorize_params={
+                "response_type": "code",
+                "actor": "user",
+            },
+        ),
+        descriptor=AdminDescriptorSpec(
             description=(
-                "Found in Linear → Settings → API → OAuth applications → your app."
+                "Read and create issues, projects, and comments in Linear "
+                "on the user's behalf."
+            ),
+            upstream_url_patterns=["https://api\\.linear\\.app/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found in Linear → Settings → API → OAuth "
+                        "applications → your app."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Found alongside the Client ID. Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "In Linear: Settings → API → OAuth applications → New OAuth "
+                "application. Fill in name, developer email, and description. "
+                "Add this Onyx instance's callback URL "
+                "(/craft/v1/apps/oauth/callback) to Callback URLs. Save. Then "
+                "paste the Client ID and Client Secret below. The agent will "
+                "be granted read+write access to issues, projects, and comments."
             ),
         ),
-        OrgCredentialField(
-            key="client_secret",
-            label="Client Secret",
-            description=("Found alongside the Client ID. Treat this like a password."),
-            secret=True,
-        ),
-    ]
-    setup_instructions = (
-        "In Linear: Settings → API → OAuth applications → New OAuth "
-        "application. Fill in name, developer email, and description. Add "
-        "this Onyx instance's callback URL (/craft/v1/apps/oauth/callback) "
-        "to Callback URLs. Save. Then paste the Client ID and Client "
-        "Secret below. The agent will be granted read+write access to "
-        "issues, projects, and comments."
     )
 
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -1,61 +1,71 @@
 from typing import Any
-from typing import ClassVar
 
 from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.providers.base import OAuth
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
 from onyx.external_apps.providers.base import OrgCredentialField
 
 
-class SlackOAuth(OAuth):
-    app_type = ExternalAppType.SLACK
-    app_name = "Slack"
-    authorize_url = "https://slack.com/oauth/v2/authorize"
-    token_url = "https://slack.com/api/oauth.v2.access"
-    scope = ",".join(
-        [
-            "chat:write",
-            "channels:history",
-            "channels:read",
-            "groups:history",
-            "groups:read",
-            "im:history",
-            "im:read",
-            "users:read",
-        ]
-    )
-    scope_param = "user_scope"
-    extra_authorize_params: ClassVar[dict[str, str]] = {}
-
-    description = "Read your Slack messages and channels as context inside Onyx Craft."
-    upstream_url_patterns = ["https://slack\\.com/api/.*"]
-    auth_template = {"Authorization": "Bearer {access_token}"}
-    required_org_credential_fields = [
-        OrgCredentialField(
-            key="client_id",
-            label="Client ID",
+class SlackProvider(OAuthExternalAppProvider):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.SLACK,
+        app_name="Slack",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://slack.com/oauth/v2/authorize",
+            token_url="https://slack.com/api/oauth.v2.access",
+            scope=",".join(
+                [
+                    "chat:write",
+                    "channels:history",
+                    "channels:read",
+                    "groups:history",
+                    "groups:read",
+                    "im:history",
+                    "im:read",
+                    "users:read",
+                ]
+            ),
+            scope_param="user_scope",
+        ),
+        descriptor=AdminDescriptorSpec(
             description=(
-                "Found under your Slack app's Basic Information → App Credentials."
+                "Read your Slack messages and channels as context inside Onyx Craft."
+            ),
+            upstream_url_patterns=["https://slack\\.com/api/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found under your Slack app's Basic Information → "
+                        "App Credentials."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Found under your Slack app's Basic Information → "
+                        "App Credentials. Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "Create a Slack app at api.slack.com/apps. Under OAuth & "
+                "Permissions, add this Onyx instance's callback URL "
+                "(/craft/v1/apps/oauth/callback) to Redirect URLs, and add the "
+                "User Token Scopes you want the agent to use (e.g. chat:write, "
+                "channels:history, channels:read, im:history, users:read). No "
+                "bot user is required. Then paste the app's Client ID and "
+                "Client Secret below."
             ),
         ),
-        OrgCredentialField(
-            key="client_secret",
-            label="Client Secret",
-            description=(
-                "Found under your Slack app's Basic Information → "
-                "App Credentials. Treat this like a password."
-            ),
-            secret=True,
-        ),
-    ]
-    setup_instructions = (
-        "Create a Slack app at api.slack.com/apps. Under OAuth & Permissions, "
-        "add this Onyx instance's callback URL (/craft/v1/apps/oauth/callback) "
-        "to Redirect URLs, and add the User Token Scopes you want the agent "
-        "to use (e.g. chat:write, channels:history, channels:read, im:history, "
-        "users:read). No bot user is required. Then paste the app's Client ID "
-        "and Client Secret below."
     )
 
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -27,6 +27,7 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers import get_provider_or_raise
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.models import OAuthCallbackRequest
 from onyx.server.features.build.api.models import OAuthCallbackResponse
@@ -61,6 +62,18 @@ def _oauth_client_credentials(app: ExternalApp) -> tuple[str, str]:
 
 def _frontend_callback_url() -> str:
     return f"{WEB_DOMAIN}{_FRONTEND_CALLBACK_PATH}"
+
+
+def _oauth_provider_or_raise(app: ExternalApp) -> OAuthExternalAppProvider:
+    """Resolve the app's provider and assert it authenticates via OAuth, or
+    400. Only the OAuth subset of built-in providers can drive these routes."""
+    provider = get_provider_or_raise(app)
+    if not isinstance(provider, OAuthExternalAppProvider):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"App '{app.skill.name}' does not use an OAuth flow.",
+        )
+    return provider
 
 
 def _token_response_is_error(
@@ -99,7 +112,7 @@ def start_external_app_oauth(
             OnyxErrorCode.INVALID_INPUT,
             "This app is currently disabled by an admin.",
         )
-    provider = get_provider_or_raise(app)
+    provider = _oauth_provider_or_raise(app)
     client_id, _client_secret = _oauth_client_credentials(app)
 
     oauth_uuid = uuid.uuid4()
@@ -115,16 +128,17 @@ def start_external_app_oauth(
     )
 
     redirect_uri = _frontend_callback_url()
+    oauth = provider.spec.oauth
     params: dict[str, str] = {
         "client_id": client_id,
         "redirect_uri": redirect_uri,
-        provider.scope_param: provider.scope,
+        oauth.scope_param: oauth.scope,
         "state": state,
-        **provider.extra_authorize_params,
+        **oauth.extra_authorize_params,
     }
     # urlencode so URI-shaped scopes (Google) get `:` and `/`
     # percent-encoded.
-    authorize_url = f"{provider.authorize_url}?{urlencode(params)}"
+    authorize_url = f"{oauth.authorize_url}?{urlencode(params)}"
     return OAuthStartResponse(authorize_url=authorize_url)
 
 
@@ -167,13 +181,14 @@ def handle_external_app_oauth_callback(
             f"External app with id {record.external_app_id} no longer exists.",
         )
 
-    provider = get_provider_or_raise(app)
+    provider = _oauth_provider_or_raise(app)
+    oauth = provider.spec.oauth
     # Re-read in case the admin rotated creds between /start and /callback.
     client_id, client_secret = _oauth_client_credentials(app)
 
     try:
         response = requests.post(
-            provider.token_url,
+            oauth.token_url,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             data={
                 "grant_type": "authorization_code",

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -1,10 +1,3 @@
-"""OAuth flow routes for External Apps.
-
-Provider-agnostic — these routes look up the matching `OAuth`
-provider by `app.app_type` and delegate authorize-URL construction
-and response parsing to it.
-"""
-
 import base64
 import uuid
 from typing import Any


### PR DESCRIPTION
## Description
Improves the design of built-in external apps by utilizing better OOP principles, such that the attributes required on different providers are more strictly required.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored built-in external app providers to a stricter, declarative design using specs. This centralizes OAuth/admin metadata, enforces required fields at class definition, and simplifies the OAuth API.

- **Refactors**
  - Added `ProviderSpec`, `OAuthProviderSpec`, `AdminDescriptorSpec`, and `OAuthFlowSpec`.
  - Introduced `ExternalAppProvider` with class-level `spec` validation and `OAuthExternalAppProvider` that requires an `OAuthProviderSpec`.
  - Migrated providers to spec-based classes and renamed to `SlackProvider`, `GoogleCalendarProvider`, and `LinearProvider`.
  - Updated the provider registry and descriptors to read from `provider_cls.spec` (including `spec.descriptor`).
  - OAuth routes now require `OAuthExternalAppProvider` (via `_oauth_provider_or_raise`) and use `provider.spec.oauth` for URLs, scopes, and params; clear error when the app is not OAuth-based.

<sup>Written for commit f19a26e31014046366d3e74ddfe16529589b812c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11364?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

