### PR TITLE
Add Canvas connector setup for LTI courses

### DIFF
--- a/backend/onyx/configs/lti_configs.py
+++ b/backend/onyx/configs/lti_configs.py
@@ -19,6 +19,10 @@ LTI_AUTH_TOKEN_URL: str | None = os.environ.get("LTI_AUTH_TOKEN_URL")
 # JWKS endpoint on the LMS for verifying signed JWTs
 LTI_JWKS_URL: str | None = os.environ.get("LTI_JWKS_URL")
 
+# Canvas API/web base URL for connector setup. Optional because hosted Canvas
+# often exposes the real school URL in launch claims.
+LTI_CANVAS_BASE_URL: str | None = os.environ.get("LTI_CANVAS_BASE_URL")
+
 # Deployment ID from the LMS
 LTI_DEPLOYMENT_ID: str | None = os.environ.get("LTI_DEPLOYMENT_ID")
 

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from collections.abc import Sequence
 from datetime import datetime
 from datetime import timezone
 from typing import Any
@@ -306,6 +307,31 @@ _DOC_TYPE_DISPLAY_NAMES: dict[str, str] = {
 }
 
 
+def _normalize_canvas_course_ids(
+    course_ids: Sequence[int | str] | None,
+) -> list[int] | None:
+    if course_ids is None:
+        return None
+
+    normalized_course_ids: list[int] = []
+    seen_course_ids: set[int] = set()
+    for raw_course_id in course_ids:
+        try:
+            course_id = int(str(raw_course_id).strip())
+        except ValueError as e:
+            raise ValueError("Canvas course_ids must contain numeric course IDs") from e
+
+        if course_id <= 0:
+            raise ValueError("Canvas course_ids must contain positive course IDs")
+        if course_id in seen_course_ids:
+            continue
+
+        seen_course_ids.add(course_id)
+        normalized_course_ids.append(course_id)
+
+    return normalized_course_ids
+
+
 def _course_type_folder_id(course_id: int, doc_type: str) -> str:
     return f"canvas-type-course-{course_id}-{doc_type}"
 
@@ -348,9 +374,13 @@ class CanvasConnector(
     def __init__(
         self,
         canvas_base_url: str,
+        course_ids: Sequence[int | str] | None = None,
+        lti_context_id: str | None = None,
         batch_size: int = INDEX_BATCH_SIZE,
     ) -> None:
         self.canvas_base_url = canvas_base_url.rstrip("/").removesuffix("/api/v1")
+        self.course_ids = _normalize_canvas_course_ids(course_ids)
+        self.lti_context_id = lti_context_id
         self.batch_size = batch_size
         self._canvas_client: CanvasApiClient | None = None
         self._course_permissions_cache: dict[int, ExternalAccess | None] = {}
@@ -1017,7 +1047,15 @@ class CanvasConnector(
                 bearer_token=access_token,
                 canvas_base_url=self.canvas_base_url,
             )
-            client.get("courses", params={"per_page": "1"})
+            if self.course_ids is None or len(self.course_ids) == 0:
+                client.get("courses", params={"per_page": "1"})
+            else:
+                for course_id in self.course_ids:
+                    course_payload, _ = client.get(f"courses/{course_id}")
+                    if isinstance(course_payload, dict):
+                        self._courses_by_id[course_id] = CanvasCourse.from_api(
+                            course_payload
+                        )
         except ValueError as e:
             raise ConnectorValidationError(f"Invalid Canvas base URL: {e}")
         except OnyxError as e:
@@ -1038,6 +1076,17 @@ class CanvasConnector(
 
         # First call: materialize the list of course IDs
         if not new_checkpoint.course_ids:
+            if self.course_ids is not None:
+                new_checkpoint.course_ids = list(self.course_ids)
+                new_checkpoint.current_course_index = 0
+                new_checkpoint.stage = "pages"
+                logger.info(
+                    "Found %d configured Canvas courses to process",
+                    len(new_checkpoint.course_ids),
+                )
+                new_checkpoint.has_more = len(new_checkpoint.course_ids) > 0
+                return new_checkpoint
+
             try:
                 courses = self._list_courses()
             except Exception as e:

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timezone
+from typing import Any
 from typing import cast
 
 from sqlalchemy import and_
@@ -7,6 +8,7 @@ from sqlalchemy import exists
 from sqlalchemy import func
 from sqlalchemy import select
 from sqlalchemy.orm import aliased
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DEFAULT_PRUNING_FREQ
@@ -67,6 +69,52 @@ def fetch_connectors(
         stmt = stmt.where(Connector.input_type.in_(input_types))
     results = db_session.scalars(stmt)
     return list(results.all())
+
+
+def _canvas_config_matches_lti_course(
+    connector_specific_config: dict[str, Any],
+    lti_context_id: str,
+) -> bool:
+    config_lti_context_id = connector_specific_config.get("lti_context_id")
+    if (
+        config_lti_context_id is not None
+        and str(config_lti_context_id) == lti_context_id
+    ):
+        return True
+
+    course_ids = connector_specific_config.get("course_ids")
+    if course_ids is None:
+        return False
+
+    if isinstance(course_ids, list):
+        return any(str(course_id) == lti_context_id for course_id in course_ids)
+
+    return str(course_ids) == lti_context_id
+
+
+def fetch_canvas_cc_pair_for_lti_course(
+    db_session: Session,
+    lti_context_id: str,
+) -> ConnectorCredentialPair | None:
+    stmt = (
+        select(ConnectorCredentialPair)
+        .join(Connector)
+        .options(joinedload(ConnectorCredentialPair.connector))
+        .where(Connector.source == DocumentSource.CANVAS)
+        .order_by(ConnectorCredentialPair.id.asc())
+    )
+
+    cc_pairs = db_session.scalars(stmt).unique().all()
+    for cc_pair in cc_pairs:
+        if cc_pair.connector is None:
+            continue
+        if _canvas_config_matches_lti_course(
+            connector_specific_config=cc_pair.connector.connector_specific_config or {},
+            lti_context_id=lti_context_id,
+        ):
+            return cc_pair
+
+    return None
 
 
 def connector_by_name_source_exists(

--- a/backend/onyx/server/lti/api.py
+++ b/backend/onyx/server/lti/api.py
@@ -13,48 +13,397 @@ through to the editor and picker views via URL params.
 import secrets
 import uuid
 from urllib.parse import urlencode
+from urllib.parse import urlparse
 
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Form
+from fastapi import Path
 from fastapi import Query
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
 from fastapi_users.authentication import Strategy
+from pydantic import BaseModel
+from pydantic import Field
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import auth_backend
 from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import get_user_manager
 from onyx.auth.users import UserManager
+from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.lti_configs import LTI_AUTH_LOGIN_URL
+from onyx.configs.lti_configs import LTI_AUTH_TOKEN_URL
+from onyx.configs.lti_configs import LTI_CANVAS_BASE_URL
 from onyx.configs.lti_configs import LTI_CLIENT_ID
 from onyx.configs.lti_configs import LTI_DEPLOYMENT_ID
 from onyx.configs.lti_configs import LTI_ISSUER
+from onyx.configs.lti_configs import LTI_JWKS_URL
+from onyx.connectors.canvas.client import CanvasApiClient
+from onyx.connectors.canvas.connector import CanvasCourse
+from onyx.connectors.models import InputType
+from onyx.db.connector import connector_by_name_source_exists
+from onyx.db.connector import create_connector
+from onyx.db.connector import fetch_canvas_cc_pair_for_lti_course
+from onyx.db.connector import mark_ccpair_with_indexing_trigger
+from onyx.db.connector_credential_pair import add_credential_to_connector
+from onyx.db.credentials import create_credential
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import AccessType
+from onyx.db.enums import IndexingMode
+from onyx.db.index_attempt import get_latest_index_attempt_for_cc_pair_id
 from onyx.db.models import User
 from onyx.db.persona import get_tutor_persona_snapshots_for_course
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.server.documents.models import ConnectorBase
+from onyx.server.documents.models import CredentialBase
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.lti.jwks import get_public_jwks
 from onyx.server.lti.utils import _extract_email_from_claims
 from onyx.server.lti.utils import extract_lti_context
 from onyx.server.lti.utils import find_canvas_course_node_id
 from onyx.server.lti.utils import find_tutor_personas_for_course
+from onyx.server.lti.utils import get_lti_launch_context
 from onyx.server.lti.utils import get_or_create_lti_course_project
+from onyx.server.lti.utils import lti_roles_include_instructor
+from onyx.server.lti.utils import LtiLaunchContext
+from onyx.server.lti.utils import store_lti_launch_context
 from onyx.server.lti.utils import store_lti_state
 from onyx.server.lti.utils import upsert_lti_user
 from onyx.server.lti.utils import validate_and_consume_state
 from onyx.server.lti.utils import validate_lti_jwt
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 
 logger = setup_logger()
 router = APIRouter(prefix="/auth/lti")
+_CHECK_FOR_INDEXING_EXPIRES_SECONDS = 15 * 60
+_LTI_LAUNCH_PRESENTATION_CLAIM = (
+    "https://purl.imsglobal.org/spec/lti/claim/launch_presentation"
+)
+_CANVAS_GLOBAL_LTI_HOSTS = {
+    "canvas.instructure.com",
+    "canvas.beta.instructure.com",
+    "canvas.test.instructure.com",
+    "sso.canvaslms.com",
+    "sso.beta.canvaslms.com",
+    "sso.test.canvaslms.com",
+}
+
+
+class LtiCanvasConnectorSetupRequest(BaseModel):
+    canvas_access_token: str = Field(min_length=1)
+
+
+class LtiCanvasConnectorSetupResponse(BaseModel):
+    cc_pair_id: int
+    connector_id: int
+    credential_id: int
+    created: bool
+
+
+def _origin_from_url(raw_url: str | None) -> str | None:
+    if not raw_url:
+        return None
+
+    parsed_url = urlparse(raw_url)
+    if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+        return None
+
+    return f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+
+def _is_canvas_global_lti_host(raw_url: str) -> bool:
+    parsed_url = urlparse(raw_url)
+    hostname = parsed_url.hostname
+    return hostname in _CANVAS_GLOBAL_LTI_HOSTS
+
+
+def _canvas_base_url_from_request_headers(request: Request) -> str | None:
+    return _origin_from_url(request.headers.get("origin")) or _origin_from_url(
+        request.headers.get("referer")
+    )
+
+
+def _launch_presentation_claim(claims: dict) -> dict[str, object]:
+    launch_presentation = claims.get(_LTI_LAUNCH_PRESENTATION_CLAIM)
+    return launch_presentation if isinstance(launch_presentation, dict) else {}
+
+
+def _canvas_base_url_from_lti_claims(claims: dict) -> str | None:
+    return_url = _launch_presentation_claim(claims).get("return_url")
+    return _origin_from_url(str(return_url)) if return_url else None
+
+
+def _canvas_course_id_from_url(raw_url: str | None) -> int | None:
+    if not raw_url:
+        return None
+
+    parsed_url = urlparse(raw_url)
+    path_parts = [part for part in parsed_url.path.split("/") if part]
+    for index, path_part in enumerate(path_parts[:-1]):
+        if path_part != "courses":
+            continue
+        course_id = path_parts[index + 1]
+        if course_id.isdigit():
+            return int(course_id)
+    return None
+
+
+def _canvas_course_id_from_lti_claims(claims: dict) -> int | None:
+    return_url = _launch_presentation_claim(claims).get("return_url")
+    return _canvas_course_id_from_url(str(return_url)) if return_url else None
+
+
+def _get_launch_context_for_course_or_raise(
+    user: User,
+    course_id: str,
+) -> LtiLaunchContext:
+    redis_client = get_raw_redis_client()
+    launch_context = get_lti_launch_context(redis_client, user.id)
+    if launch_context is None:
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "No active LTI launch context found for this session",
+        )
+    if launch_context.course_id != course_id:
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "LTI course context does not match this request",
+        )
+    return launch_context
+
+
+def _canvas_base_url_from_issuer(issuer: str | None) -> str:
+    if not issuer:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "LTI issuer is not available for this launch",
+        )
+
+    parsed_issuer = urlparse(issuer)
+    if not parsed_issuer.scheme or not parsed_issuer.netloc:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "LTI issuer is not a valid URL",
+        )
+    return f"{parsed_issuer.scheme}://{parsed_issuer.netloc}"
+
+
+def _canvas_token_settings_url(canvas_base_url: str) -> str:
+    return f"{canvas_base_url}/profile/settings"
+
+
+def _canvas_base_url_from_lti_config() -> str | None:
+    if LTI_CANVAS_BASE_URL:
+        return _origin_from_url(LTI_CANVAS_BASE_URL)
+
+    for configured_url in (LTI_AUTH_TOKEN_URL, LTI_JWKS_URL, LTI_AUTH_LOGIN_URL):
+        if not configured_url or _is_canvas_global_lti_host(configured_url):
+            continue
+        origin = _origin_from_url(configured_url)
+        if origin:
+            return origin
+
+    return None
+
+
+def _canvas_base_url_for_launch_context(launch_context: LtiLaunchContext) -> str:
+    if launch_context.canvas_base_url:
+        return launch_context.canvas_base_url
+    configured_canvas_base_url = _canvas_base_url_from_lti_config()
+    if configured_canvas_base_url:
+        return configured_canvas_base_url
+    return _canvas_base_url_from_issuer(launch_context.issuer or LTI_ISSUER)
+
+
+def _course_text_matches(left: str | None, right: str | None) -> bool:
+    if left is None or right is None:
+        return False
+    return left.strip().casefold() == right.strip().casefold()
+
+
+def _resolve_canvas_api_course(
+    canvas_client: CanvasApiClient,
+    launch_context: LtiLaunchContext,
+) -> CanvasCourse:
+    if launch_context.canvas_course_id is not None:
+        try:
+            course_payload, _ = canvas_client.get(
+                f"courses/{launch_context.canvas_course_id}"
+            )
+            if isinstance(course_payload, dict):
+                return CanvasCourse.from_api(course_payload)
+        except OnyxError as e:
+            if e.status_code in (401, 403, 404):
+                raise OnyxError(
+                    OnyxErrorCode.CREDENTIAL_INVALID,
+                    "Canvas token could not access the launched course",
+                ) from e
+            raise
+
+    lti_course_id = launch_context.course_id.strip()
+    if lti_course_id.isdigit():
+        try:
+            course_payload, _ = canvas_client.get(f"courses/{lti_course_id}")
+            if isinstance(course_payload, dict):
+                return CanvasCourse.from_api(course_payload)
+        except OnyxError as e:
+            if e.status_code not in (403, 404):
+                raise
+
+    matching_courses: list[CanvasCourse] = []
+    for page in canvas_client.paginate(
+        "courses", params={"per_page": "100", "state[]": "available"}
+    ):
+        for raw_course in page:
+            if not isinstance(raw_course, dict):
+                continue
+            course = CanvasCourse.from_api(raw_course)
+            title_matches = _course_text_matches(
+                course.name, launch_context.course_title
+            )
+            label_matches = _course_text_matches(
+                course.course_code, launch_context.course_label
+            )
+            if title_matches or label_matches:
+                matching_courses.append(course)
+
+    if len(matching_courses) == 1:
+        return matching_courses[0]
+
+    if len(matching_courses) > 1:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Canvas token matched multiple courses for this LTI launch",
+        )
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "Canvas token could not access the launched course",
+    )
+
+
+def _validate_canvas_token_and_resolve_course(
+    canvas_access_token: str,
+    canvas_base_url: str,
+    launch_context: LtiLaunchContext,
+) -> CanvasCourse:
+    try:
+        logger.info(
+            "Validating Canvas LTI connector token against %s for course context %s",
+            canvas_base_url,
+            launch_context.course_id,
+        )
+        canvas_client = CanvasApiClient(
+            bearer_token=canvas_access_token,
+            canvas_base_url=canvas_base_url,
+        )
+        canvas_client.get("users/self")
+        return _resolve_canvas_api_course(canvas_client, launch_context)
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
+    except OnyxError as e:
+        if e.status_code in (401, 403):
+            raise OnyxError(
+                OnyxErrorCode.CREDENTIAL_INVALID,
+                "Canvas token could not be validated for this course",
+            ) from e
+        raise
+
+
+def _build_canvas_connector_name(
+    launch_context: LtiLaunchContext,
+    db_session: Session,
+) -> str:
+    name_parts = ["Canvas"]
+    if launch_context.course_label:
+        name_parts.append(launch_context.course_label.strip())
+    if launch_context.course_title:
+        name_parts.append(launch_context.course_title.strip())
+    if len(name_parts) == 1:
+        name_parts.append(f"Course {launch_context.course_id}")
+
+    base_name = " - ".join(part for part in name_parts if part)
+    if not connector_by_name_source_exists(
+        base_name, DocumentSource.CANVAS, db_session
+    ):
+        return base_name
+
+    name_with_context = f"{base_name} ({launch_context.course_id})"
+    if not connector_by_name_source_exists(
+        name_with_context, DocumentSource.CANVAS, db_session
+    ):
+        return name_with_context
+
+    return f"{name_with_context} {uuid.uuid4().hex[:8]}"
+
+
+def _build_lti_course_connector_status(
+    *,
+    course_id: str,
+    launch_context: LtiLaunchContext,
+    db_session: Session,
+) -> dict[str, object]:
+    cc_pair = fetch_canvas_cc_pair_for_lti_course(
+        db_session=db_session,
+        lti_context_id=course_id,
+    )
+    status: dict[str, object] = {
+        "course_id": course_id,
+        "has_connector": cc_pair is not None,
+        "cc_pair_id": None,
+        "connector_id": None,
+        "credential_id": None,
+        "cc_pair_status": None,
+        "indexing_status": None,
+        "indexing_trigger": None,
+        "total_docs_indexed": 0,
+        "has_indexed_documents": False,
+        "last_successful_index_time": None,
+    }
+
+    if cc_pair is not None:
+        latest_attempt = get_latest_index_attempt_for_cc_pair_id(
+            db_session=db_session,
+            connector_credential_pair_id=cc_pair.id,
+            secondary_index=False,
+            only_finished=False,
+        )
+        total_docs_indexed = cc_pair.total_docs_indexed or 0
+        status.update(
+            {
+                "cc_pair_id": cc_pair.id,
+                "connector_id": cc_pair.connector_id,
+                "credential_id": cc_pair.credential_id,
+                "cc_pair_status": cc_pair.status,
+                "indexing_status": latest_attempt.status if latest_attempt else None,
+                "indexing_trigger": cc_pair.indexing_trigger,
+                "total_docs_indexed": total_docs_indexed,
+                "has_indexed_documents": total_docs_indexed > 0,
+                "last_successful_index_time": cc_pair.last_successful_index_time,
+            }
+        )
+
+    if lti_roles_include_instructor(launch_context.roles):
+        canvas_base_url = _canvas_base_url_for_launch_context(launch_context)
+        status["setup"] = {
+            "can_setup": cc_pair is None,
+            "canvas_token_url": _canvas_token_settings_url(canvas_base_url),
+            "course_label": launch_context.course_label,
+            "course_title": launch_context.course_title,
+        }
+
+    return status
 
 
 @router.get("/tutors-for-course")
@@ -74,6 +423,124 @@ def lti_tutors_for_course(
         user=user,
         lti_context_id=context_id,
         db_session=db_session,
+    )
+
+
+@router.get("/course/{course_id}/connector-status")
+def lti_course_connector_status(
+    course_id: str = Path(..., min_length=1),
+    user: User = Depends(current_chat_accessible_user),
+    db_session: Session = Depends(get_session),
+) -> dict[str, object]:
+    launch_context = _get_launch_context_for_course_or_raise(user, course_id)
+    return _build_lti_course_connector_status(
+        course_id=course_id,
+        launch_context=launch_context,
+        db_session=db_session,
+    )
+
+
+@router.post("/course/{course_id}/setup-connector")
+def setup_lti_course_canvas_connector(
+    setup_request: LtiCanvasConnectorSetupRequest,
+    course_id: str = Path(..., min_length=1),
+    user: User = Depends(current_chat_accessible_user),
+    db_session: Session = Depends(get_session),
+) -> LtiCanvasConnectorSetupResponse:
+    launch_context = _get_launch_context_for_course_or_raise(user, course_id)
+    if not lti_roles_include_instructor(launch_context.roles):
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "Only instructors can set up Canvas course content",
+        )
+
+    existing_cc_pair = fetch_canvas_cc_pair_for_lti_course(
+        db_session=db_session,
+        lti_context_id=course_id,
+    )
+    if existing_cc_pair is not None:
+        return LtiCanvasConnectorSetupResponse(
+            cc_pair_id=existing_cc_pair.id,
+            connector_id=existing_cc_pair.connector_id,
+            credential_id=existing_cc_pair.credential_id,
+            created=False,
+        )
+
+    canvas_base_url = _canvas_base_url_for_launch_context(launch_context)
+    canvas_course = _validate_canvas_token_and_resolve_course(
+        canvas_access_token=setup_request.canvas_access_token,
+        canvas_base_url=canvas_base_url,
+        launch_context=launch_context,
+    )
+    connector_name = _build_canvas_connector_name(
+        launch_context=launch_context,
+        db_session=db_session,
+    )
+
+    try:
+        connector_response = create_connector(
+            db_session=db_session,
+            connector_data=ConnectorBase(
+                name=connector_name,
+                source=DocumentSource.CANVAS,
+                input_type=InputType.POLL,
+                connector_specific_config={
+                    "canvas_base_url": canvas_base_url,
+                    "course_ids": [canvas_course.id],
+                    "lti_context_id": launch_context.course_id,
+                },
+            ),
+        )
+    except ValueError as e:
+        raise OnyxError(OnyxErrorCode.DUPLICATE_RESOURCE, str(e)) from e
+
+    connector_id = int(connector_response.id)
+    credential = create_credential(
+        credential_data=CredentialBase(
+            credential_json={
+                "canvas_access_token": setup_request.canvas_access_token,
+            },
+            admin_public=False,
+            source=DocumentSource.CANVAS,
+            name=f"{connector_name} credential",
+        ),
+        user=user,
+        db_session=db_session,
+    )
+
+    cc_pair_response = add_credential_to_connector(
+        db_session=db_session,
+        user=user,
+        connector_id=connector_id,
+        credential_id=credential.id,
+        cc_pair_name=connector_name,
+        access_type=AccessType.SYNC,
+        groups=[],
+    )
+    if not cc_pair_response.success or cc_pair_response.data is None:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            cc_pair_response.message,
+        )
+
+    cc_pair_id = int(cc_pair_response.data)
+    mark_ccpair_with_indexing_trigger(
+        cc_pair_id=cc_pair_id,
+        indexing_mode=IndexingMode.REINDEX,
+        db_session=db_session,
+    )
+    client_app.send_task(
+        OnyxCeleryTask.CHECK_FOR_INDEXING,
+        priority=OnyxCeleryPriority.HIGH,
+        kwargs={"tenant_id": get_current_tenant_id()},
+        expires=_CHECK_FOR_INDEXING_EXPIRES_SECONDS,
+    )
+
+    return LtiCanvasConnectorSetupResponse(
+        cc_pair_id=cc_pair_id,
+        connector_id=connector_id,
+        credential_id=credential.id,
+        created=True,
     )
 
 
@@ -157,7 +624,12 @@ async def lti_login(
 
     # Store in Redis for validation on callback
     redis = await get_async_redis_connection()
-    await store_lti_state(redis, state, nonce)
+    await store_lti_state(
+        redis,
+        state,
+        nonce,
+        canvas_base_url=_canvas_base_url_from_request_headers(request),
+    )
 
     # Build the redirect URL back to the LMS authorization endpoint
     redirect_uri = f"{WEB_DOMAIN}/auth/lti/launch"
@@ -195,10 +667,10 @@ async def lti_launch(
     """
     # Validate and consume the state (atomic -- prevents replay)
     redis = await get_async_redis_connection()
-    expected_nonce = await validate_and_consume_state(redis, state)
+    lti_state = await validate_and_consume_state(redis, state)
 
     # Validate the JWT
-    claims = await validate_lti_jwt(id_token, expected_nonce)
+    claims = await validate_lti_jwt(id_token, lti_state.nonce)
 
     # Verify deployment ID if present
     deployment_id = claims.get(
@@ -212,7 +684,10 @@ async def lti_launch(
 
     # Extract user info
     email = _extract_email_from_claims(claims)
-    lti_roles = claims.get("https://purl.imsglobal.org/spec/lti/claim/roles", [])
+    raw_lti_roles = claims.get("https://purl.imsglobal.org/spec/lti/claim/roles", [])
+    lti_roles = (
+        [str(role) for role in raw_lti_roles] if isinstance(raw_lti_roles, list) else []
+    )
 
     logger.info("LTI launch for user %s with roles %s", email, lti_roles)
 
@@ -230,6 +705,12 @@ async def lti_launch(
     context = extract_lti_context(claims)
     custom_claims = claims.get("https://purl.imsglobal.org/spec/lti/claim/custom", {})
     assistant_id = custom_claims.get("assistant_id")
+    canvas_base_url = (
+        _canvas_base_url_from_lti_claims(claims)
+        or _canvas_base_url_from_request_headers(request)
+        or lti_state.canvas_base_url
+    )
+    canvas_course_id = _canvas_course_id_from_lti_claims(claims)
 
     # Build redirect URL — send students to /tutor, not /app
     redirect_params: dict[str, str] = {}
@@ -241,6 +722,19 @@ async def lti_launch(
     course_title = context.get("course_title")
     if course_id:
         redirect_params["lti_context_id"] = course_id
+        await store_lti_launch_context(
+            redis=redis,
+            user_id=user.id,
+            launch_context=LtiLaunchContext(
+                course_id=course_id,
+                course_label=context.get("course_label"),
+                course_title=course_title,
+                roles=lti_roles,
+                issuer=str(claims.get("iss") or LTI_ISSUER or ""),
+                canvas_base_url=canvas_base_url,
+                canvas_course_id=canvas_course_id,
+            ),
+        )
 
     # Try to resolve the Canvas course's indexed hierarchy node so the editor
     # can scope its knowledge picker to just this course's contents. Optional:

--- a/backend/onyx/server/lti/api.py
+++ b/backend/onyx/server/lti/api.py
@@ -53,6 +53,7 @@ from onyx.db.connector import fetch_canvas_cc_pair_for_lti_course
 from onyx.db.connector import mark_ccpair_with_indexing_trigger
 from onyx.db.connector_credential_pair import add_credential_to_connector
 from onyx.db.credentials import create_credential
+from onyx.db.document import get_document_counts_for_cc_pairs
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccessType
 from onyx.db.enums import IndexingMode
@@ -64,6 +65,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_async_redis_connection
 from onyx.redis.redis_pool import get_raw_redis_client
 from onyx.server.documents.models import ConnectorBase
+from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.server.documents.models import CredentialBase
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.lti.jwks import get_public_jwks
@@ -379,7 +381,26 @@ def _build_lti_course_connector_status(
             secondary_index=False,
             only_finished=False,
         )
-        total_docs_indexed = cc_pair.total_docs_indexed or 0
+        indexed_document_counts = get_document_counts_for_cc_pairs(
+            db_session=db_session,
+            cc_pairs=[
+                ConnectorCredentialPairIdentifier(
+                    connector_id=cc_pair.connector_id,
+                    credential_id=cc_pair.credential_id,
+                )
+            ],
+        )
+        indexed_document_count = (
+            indexed_document_counts[0][2] if indexed_document_counts else 0
+        )
+        latest_attempt_docs_indexed = (
+            latest_attempt.total_docs_indexed if latest_attempt else 0
+        ) or 0
+        total_docs_indexed = max(
+            cc_pair.total_docs_indexed or 0,
+            latest_attempt_docs_indexed,
+            indexed_document_count,
+        )
         status.update(
             {
                 "cc_pair_id": cc_pair.id,
@@ -389,7 +410,7 @@ def _build_lti_course_connector_status(
                 "indexing_status": latest_attempt.status if latest_attempt else None,
                 "indexing_trigger": cc_pair.indexing_trigger,
                 "total_docs_indexed": total_docs_indexed,
-                "has_indexed_documents": total_docs_indexed > 0,
+                "has_indexed_documents": indexed_document_count > 0,
                 "last_successful_index_time": cc_pair.last_successful_index_time,
             }
         )

--- a/backend/onyx/server/lti/utils.py
+++ b/backend/onyx/server/lti/utils.py
@@ -8,7 +8,6 @@ is the runtime side of that contract.
 """
 
 import contextlib
-import json
 import secrets
 import string
 import time
@@ -19,7 +18,9 @@ import jwt as pyjwt
 from fastapi_users import exceptions
 from jwt import PyJWKSet
 from jwt.exceptions import InvalidTokenError
+from pydantic import BaseModel
 from redis import asyncio as aioredis
+from redis.client import Redis
 from sqlalchemy import select
 
 from onyx.auth.schemas import UserCreate
@@ -61,6 +62,8 @@ _LTI_INSTRUCTOR_ROLES = {
 
 # Redis key prefix for LTI OIDC state
 _LTI_STATE_PREFIX = "lti_state:"
+_LTI_LAUNCH_CONTEXT_PREFIX = "lti_launch_context:"
+_LTI_LAUNCH_CONTEXT_TTL_SECONDS = 24 * 60 * 60
 
 # In-memory JWKS cache
 _jwks_cache: dict[str, dict] = {}
@@ -68,22 +71,52 @@ _jwks_cache_time: float = 0.0
 _JWKS_CACHE_TTL = 3600  # 1 hour
 
 
+class LtiLaunchContext(BaseModel):
+    course_id: str
+    course_label: str | None = None
+    course_title: str | None = None
+    roles: list[str]
+    issuer: str | None = None
+    canvas_base_url: str | None = None
+    canvas_course_id: int | None = None
+
+
+class LtiStoredState(BaseModel):
+    nonce: str
+    created: int
+    canvas_base_url: str | None = None
+
+
+def lti_roles_include_instructor(roles: list[str]) -> bool:
+    role_set = set(roles)
+    return bool(role_set & (_LTI_INSTRUCTOR_ROLES | _LTI_ADMIN_ROLES))
+
+
+def _lti_launch_context_key(user_id: UUID) -> str:
+    return f"{_LTI_LAUNCH_CONTEXT_PREFIX}{user_id}"
+
+
 async def store_lti_state(
     redis: aioredis.Redis,
     state: str,
     nonce: str,
+    canvas_base_url: str | None = None,
 ) -> None:
     """Store OIDC state+nonce in Redis with a short TTL."""
     key = f"{_LTI_STATE_PREFIX}{state}"
-    data = json.dumps({"nonce": nonce, "created": int(time.time())})
+    data = LtiStoredState(
+        nonce=nonce,
+        created=int(time.time()),
+        canvas_base_url=canvas_base_url,
+    ).model_dump_json()
     await redis.set(key, data, ex=LTI_NONCE_TTL_SECONDS)
 
 
 async def validate_and_consume_state(
     redis: aioredis.Redis,
     state: str,
-) -> str:
-    """Retrieve and atomically delete the state from Redis. Returns the nonce."""
+) -> LtiStoredState:
+    """Retrieve and atomically delete the state from Redis."""
     key = f"{_LTI_STATE_PREFIX}{state}"
     raw = await redis.getdel(key)
     if raw is None:
@@ -91,8 +124,40 @@ async def validate_and_consume_state(
             OnyxErrorCode.UNAUTHENTICATED,
             "LTI state expired or not found (possible replay)",
         )
-    data = json.loads(raw)
-    return str(data["nonce"])
+    raw_state = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+    return LtiStoredState.model_validate_json(raw_state)
+
+
+async def store_lti_launch_context(
+    redis: aioredis.Redis,
+    user_id: UUID,
+    launch_context: LtiLaunchContext,
+) -> None:
+    await redis.set(
+        _lti_launch_context_key(user_id),
+        launch_context.model_dump_json(),
+        ex=_LTI_LAUNCH_CONTEXT_TTL_SECONDS,
+    )
+
+
+def get_lti_launch_context(
+    redis: Redis,
+    user_id: UUID,
+) -> LtiLaunchContext | None:
+    raw_context = redis.get(_lti_launch_context_key(user_id))
+    if raw_context is None:
+        return None
+
+    raw_context_str = (
+        raw_context.decode("utf-8")
+        if isinstance(raw_context, bytes)
+        else str(raw_context)
+    )
+    try:
+        return LtiLaunchContext.model_validate_json(raw_context_str)
+    except Exception:
+        logger.exception("Failed to parse cached LTI launch context")
+        return None
 
 
 async def _fetch_jwks() -> dict:

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -851,6 +851,34 @@ class TestLoadCredentials:
         assert result is None
         assert connector._canvas_client is not None
 
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_load_credentials_validates_configured_courses(
+        self, mock_requests: MagicMock
+    ) -> None:
+        mock_requests.get.return_value = _mock_response(json_data=_mock_course(2))
+        connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL, course_ids=["2"])
+
+        result = connector.load_credentials({"canvas_access_token": FAKE_TOKEN})
+
+        requested_url = mock_requests.get.call_args.args[0]
+        assert result is None
+        assert requested_url == f"{FAKE_BASE_URL}/api/v1/courses/2"
+        assert 2 in connector._courses_by_id
+
+    def test_rejects_non_numeric_course_id_filter(self) -> None:
+        with pytest.raises(ValueError, match="numeric course IDs"):
+            CanvasConnector(canvas_base_url=FAKE_BASE_URL, course_ids=["course-a"])
+
+    def test_accepts_lti_context_id_metadata(self) -> None:
+        connector = CanvasConnector(
+            canvas_base_url=FAKE_BASE_URL,
+            course_ids=["2"],
+            lti_context_id="opaque-lti-context",
+        )
+
+        assert connector.course_ids == [2]
+        assert connector.lti_context_id == "opaque-lti-context"
+
     def test_canvas_client_raises_without_credentials(self) -> None:
         connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL)
 
@@ -1233,6 +1261,24 @@ class TestCheckpoint:
 
 
 class TestLoadFromCheckpoint:
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_first_call_uses_configured_course_filter(
+        self, mock_requests: MagicMock
+    ) -> None:
+        """Configured course_ids should avoid materializing every visible course."""
+        mock_requests.get.return_value = _mock_response(json_data=_mock_course(2))
+        connector = CanvasConnector(canvas_base_url=FAKE_BASE_URL, course_ids=["2", 2])
+        connector.load_credentials({"canvas_access_token": FAKE_TOKEN})
+        cp = connector.build_dummy_checkpoint()
+
+        items, new_cp = _run_checkpoint(connector, cp)
+
+        assert items == []
+        assert new_cp.course_ids == [2]
+        assert new_cp.current_course_index == 0
+        assert new_cp.stage == "pages"
+        assert new_cp.has_more is True
+
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_first_call_materializes_courses(self, mock_requests: MagicMock) -> None:
         """First call should populate course_ids and yield no documents."""

--- a/backend/tests/unit/onyx/server/lti/test_lti_canvas_setup.py
+++ b/backend/tests/unit/onyx/server/lti/test_lti_canvas_setup.py
@@ -1,4 +1,6 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 
@@ -109,3 +111,41 @@ def test_resolve_canvas_api_course_rejects_inaccessible_canvas_course_id() -> No
         api._resolve_canvas_api_course(canvas_client, launch_context)
 
     assert exc_info.value.error_code == OnyxErrorCode.CREDENTIAL_INVALID
+
+
+@patch("onyx.server.lti.api.get_document_counts_for_cc_pairs")
+@patch("onyx.server.lti.api.get_latest_index_attempt_for_cc_pair_id")
+@patch("onyx.server.lti.api.fetch_canvas_cc_pair_for_lti_course")
+def test_lti_course_connector_status_uses_indexed_document_relationship(
+    mock_fetch_cc_pair: MagicMock,
+    mock_latest_attempt: MagicMock,
+    mock_document_counts: MagicMock,
+) -> None:
+    mock_fetch_cc_pair.return_value = SimpleNamespace(
+        id=10,
+        connector_id=20,
+        credential_id=30,
+        status="ACTIVE",
+        indexing_trigger=None,
+        total_docs_indexed=0,
+        last_successful_index_time=None,
+    )
+    mock_latest_attempt.return_value = SimpleNamespace(
+        status="success",
+        total_docs_indexed=0,
+    )
+    mock_document_counts.return_value = [(20, 30, 1)]
+    launch_context = LtiLaunchContext(
+        course_id="opaque-lti-context",
+        roles=[],
+    )
+
+    status = api._build_lti_course_connector_status(
+        course_id="opaque-lti-context",
+        launch_context=launch_context,
+        db_session=MagicMock(),
+    )
+
+    assert status["has_connector"] is True
+    assert status["has_indexed_documents"] is True
+    assert status["total_docs_indexed"] == 1

--- a/backend/tests/unit/onyx/server/lti/test_lti_canvas_setup.py
+++ b/backend/tests/unit/onyx/server/lti/test_lti_canvas_setup.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.lti import api
+from onyx.server.lti.utils import LtiLaunchContext
+
+
+def test_canvas_base_url_from_lti_claims_uses_launch_return_url() -> None:
+    claims = {
+        "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+            "return_url": "https://school.instructure.com/courses/123/external_content/success"
+        }
+    }
+
+    assert api._canvas_base_url_from_lti_claims(claims) == (
+        "https://school.instructure.com"
+    )
+
+
+def test_canvas_course_id_from_lti_claims_uses_launch_return_url() -> None:
+    claims = {
+        "https://purl.imsglobal.org/spec/lti/claim/launch_presentation": {
+            "return_url": "https://school.instructure.com/courses/123/external_content/success"
+        }
+    }
+
+    assert api._canvas_course_id_from_lti_claims(claims) == 123
+
+
+def test_canvas_base_url_for_launch_context_uses_local_lti_endpoint_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "LTI_CANVAS_BASE_URL", None)
+    monkeypatch.setattr(
+        api, "LTI_AUTH_TOKEN_URL", "http://canvas.docker/login/oauth2/token"
+    )
+    monkeypatch.setattr(
+        api,
+        "LTI_JWKS_URL",
+        "http://canvas.docker/api/lti/security/jwks",
+    )
+    monkeypatch.setattr(
+        api,
+        "LTI_AUTH_LOGIN_URL",
+        "http://canvas.docker/api/lti/authorize_redirect",
+    )
+    launch_context = LtiLaunchContext(
+        course_id="opaque-lti-context",
+        roles=[],
+        issuer="https://canvas.instructure.com",
+    )
+
+    assert api._canvas_base_url_for_launch_context(launch_context) == (
+        "http://canvas.docker"
+    )
+
+
+def test_canvas_base_url_for_launch_context_prefers_explicit_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "LTI_CANVAS_BASE_URL", "http://canvas.docker")
+    launch_context = LtiLaunchContext(
+        course_id="opaque-lti-context",
+        roles=[],
+        issuer="https://canvas.instructure.com",
+    )
+
+    assert api._canvas_base_url_for_launch_context(launch_context) == (
+        "http://canvas.docker"
+    )
+
+
+def test_resolve_canvas_api_course_uses_canvas_course_id() -> None:
+    canvas_client = MagicMock()
+    canvas_client.get.return_value = (
+        {"id": 123, "name": "Intro Biology", "course_code": "BIO101"},
+        None,
+    )
+    launch_context = LtiLaunchContext(
+        course_id="opaque-lti-context",
+        roles=[],
+        canvas_course_id=123,
+    )
+
+    course = api._resolve_canvas_api_course(canvas_client, launch_context)
+
+    assert course.id == 123
+    canvas_client.get.assert_called_once_with("courses/123")
+    canvas_client.paginate.assert_not_called()
+
+
+def test_resolve_canvas_api_course_rejects_inaccessible_canvas_course_id() -> None:
+    canvas_client = MagicMock()
+    canvas_client.get.side_effect = OnyxError(
+        OnyxErrorCode.BAD_GATEWAY,
+        "Not found",
+        status_code_override=404,
+    )
+    launch_context = LtiLaunchContext(
+        course_id="opaque-lti-context",
+        roles=[],
+        canvas_course_id=123,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        api._resolve_canvas_api_course(canvas_client, launch_context)
+
+    assert exc_info.value.error_code == OnyxErrorCode.CREDENTIAL_INVALID

--- a/web/src/app/tutor/create/page.tsx
+++ b/web/src/app/tutor/create/page.tsx
@@ -1,0 +1,5 @@
+import TutorEditorPage from "@/refresh-pages/admin/TutorPage/TutorEditorPage";
+
+export default function Page() {
+  return <TutorEditorPage />;
+}

--- a/web/src/app/tutor/edit/[id]/page.tsx
+++ b/web/src/app/tutor/edit/[id]/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { use, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { Route } from "next";
+import { useAgent } from "@/hooks/useAgents";
+import TutorEditorPage from "@/refresh-pages/admin/TutorPage/TutorEditorPage";
+
+export interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function Page(props: PageProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { id } = use(props.params);
+  const agentId = parseInt(id);
+  const fallbackUrl = searchParams?.toString()
+    ? `/tutor?${searchParams.toString()}`
+    : "/tutor";
+
+  const { agent, isLoading, refresh } = useAgent(
+    isNaN(agentId) ? null : agentId
+  );
+
+  useEffect(() => {
+    if (isNaN(agentId)) {
+      router.push(fallbackUrl as Route);
+    }
+  }, [agentId, fallbackUrl, router]);
+
+  useEffect(() => {
+    if (!isLoading && !agent) {
+      router.push(fallbackUrl as Route);
+    }
+  }, [isLoading, agent, fallbackUrl, router]);
+
+  if (isLoading || !agent) return null;
+
+  return <TutorEditorPage tutor={agent} refreshTutor={refresh} />;
+}

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -2055,6 +2055,8 @@ export interface ZulipConfig {
 
 export interface CanvasConfig {
   canvas_base_url: string;
+  course_ids?: number[];
+  lti_context_id?: string;
 }
 
 export interface CodaConfig {

--- a/web/src/refresh-pages/tutor/CanvasCourseSetupView.tsx
+++ b/web/src/refresh-pages/tutor/CanvasCourseSetupView.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@opal/components";
+import { IllustrationContent } from "@opal/layouts";
+import {
+  SvgArrowRight,
+  SvgBookOpen,
+  SvgCheckCircle,
+  SvgExternalLink,
+  SvgKey,
+} from "@opal/icons";
+import SvgNoResult from "@opal/illustrations/no-result";
+import InputTypeIn from "@/refresh-components/inputs/InputTypeIn";
+import SimpleLoader from "@/refresh-components/loaders/SimpleLoader";
+import Text from "@/refresh-components/texts/Text";
+
+interface LtiCourseConnectorSetup {
+  can_setup: boolean;
+  canvas_token_url: string | null;
+  course_label: string | null;
+  course_title: string | null;
+}
+
+export interface LtiCourseConnectorStatus {
+  course_id: string;
+  has_connector: boolean;
+  cc_pair_id: number | null;
+  connector_id: number | null;
+  credential_id: number | null;
+  cc_pair_status: string | null;
+  indexing_status: string | null;
+  indexing_trigger: string | null;
+  total_docs_indexed: number;
+  has_indexed_documents: boolean;
+  last_successful_index_time: string | null;
+  setup?: LtiCourseConnectorSetup;
+}
+
+interface CanvasCourseSetupViewProps {
+  courseId: string;
+  status: LtiCourseConnectorStatus;
+  onReady: () => void;
+}
+
+type SetupStep = "welcome" | "token" | "confirm";
+
+function getErrorDetail(payload: unknown): string {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    "detail" in payload &&
+    typeof payload.detail === "string"
+  ) {
+    return payload.detail;
+  }
+  return "Canvas could not be connected. Check the token and try again.";
+}
+
+async function fetchConnectorStatus(
+  courseId: string
+): Promise<LtiCourseConnectorStatus> {
+  const response = await fetch(
+    `/api/auth/lti/course/${encodeURIComponent(courseId)}/connector-status`
+  );
+  if (!response.ok) {
+    throw new Error("Unable to check Canvas connector status");
+  }
+  return response.json();
+}
+
+export function CanvasCoursePreparingView({
+  status,
+}: {
+  status: LtiCourseConnectorStatus;
+}) {
+  const title = "Course content is being prepared";
+  const description = status.has_connector
+    ? "Canvas content is indexing for this course. The tutor will be available once the first documents are ready."
+    : "Canvas content has not been connected for this course yet. The tutor will be available after setup starts.";
+
+  return (
+    <div className="h-full w-full flex items-center justify-center p-8">
+      <div className="flex flex-col items-center gap-4 text-center max-w-[28rem]">
+        <SimpleLoader className="h-6 w-6" />
+        <IllustrationContent
+          illustration={SvgNoResult}
+          title={title}
+          description={description}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function CanvasCourseSetupView({
+  courseId,
+  status,
+  onReady,
+}: CanvasCourseSetupViewProps) {
+  const [step, setStep] = useState<SetupStep>("welcome");
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const courseName = useMemo(() => {
+    return (
+      status.setup?.course_title ||
+      status.setup?.course_label ||
+      "this Canvas course"
+    );
+  }, [status.setup?.course_label, status.setup?.course_title]);
+
+  const pollForReady = useCallback(async () => {
+    const latestStatus = await fetchConnectorStatus(courseId);
+    if (latestStatus.has_indexed_documents) {
+      onReady();
+    }
+  }, [courseId, onReady]);
+
+  useEffect(() => {
+    if (step !== "confirm") return;
+
+    const interval = window.setInterval(() => {
+      pollForReady().catch(() => undefined);
+    }, 5000);
+
+    pollForReady().catch(() => undefined);
+    return () => window.clearInterval(interval);
+  }, [pollForReady, step]);
+
+  const submitToken = useCallback(async () => {
+    const trimmedToken = token.trim();
+    if (!trimmedToken) {
+      setError("Paste a Canvas access token to continue.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/api/auth/lti/course/${encodeURIComponent(courseId)}/setup-connector`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ canvas_access_token: trimmedToken }),
+        }
+      );
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(getErrorDetail(payload));
+      }
+      setStep("confirm");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : getErrorDetail(null));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [courseId, token]);
+
+  return (
+    <div className="h-full w-full overflow-auto bg-background-neutral-00">
+      <main className="min-h-full flex items-center justify-center px-4 py-8">
+        <section className="w-full max-w-[34rem] rounded-08 border border-border-01 bg-background-neutral-00 p-6 shadow-sm">
+          {step === "welcome" && (
+            <div className="flex flex-col gap-5">
+              <div className="flex flex-col gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-08 bg-background-neutral-03">
+                  <SvgBookOpen size={20} />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Text as="p" mainUiAction text05>
+                    Set up course content
+                  </Text>
+                  <Text as="p" secondaryBody text03>
+                    Connect Canvas content for {courseName}. Onyx will index
+                    pages, assignments, files, announcements, modules, quizzes,
+                    discussions, and the syllabus for this course only.
+                  </Text>
+                </div>
+              </div>
+              <Button
+                icon={SvgArrowRight}
+                onClick={() => setStep("token")}
+                width="full"
+              >
+                Continue
+              </Button>
+            </div>
+          )}
+
+          {step === "token" && (
+            <div className="flex flex-col gap-5">
+              <div className="flex flex-col gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-08 bg-background-neutral-03">
+                  <SvgKey size={20} />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Text as="p" mainUiAction text05>
+                    Connect Canvas
+                  </Text>
+                  <Text as="p" secondaryBody text03>
+                    Generate a Canvas access token, then paste it here. The
+                    token is checked against Canvas before indexing starts.
+                  </Text>
+                </div>
+              </div>
+
+              <ol className="flex flex-col gap-2 text-sm text-text-02 list-decimal pl-5">
+                <li>Open Canvas account settings in a new tab.</li>
+                <li>Create a new access token.</li>
+                <li>Paste the token into Onyx.</li>
+              </ol>
+
+              {status.setup?.canvas_token_url && (
+                <Button
+                  href={status.setup.canvas_token_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  icon={SvgExternalLink}
+                  prominence="secondary"
+                  width="full"
+                >
+                  Generate token in Canvas
+                </Button>
+              )}
+
+              <form
+                className="flex flex-col gap-3"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void submitToken();
+                }}
+              >
+                <InputTypeIn
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  type="password"
+                  placeholder="Canvas access token"
+                  autoComplete="off"
+                  showClearButton={false}
+                />
+                {error && (
+                  <Text as="p" secondaryBody text03 className="text-error">
+                    {error}
+                  </Text>
+                )}
+                <div className="flex flex-col-reverse sm:flex-row gap-2 sm:justify-end">
+                  <Button
+                    prominence="tertiary"
+                    onClick={() => setStep("welcome")}
+                    disabled={isSubmitting}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    type="submit"
+                    icon={SvgCheckCircle}
+                    disabled={isSubmitting}
+                  >
+                    {isSubmitting ? "Connecting" : "Start indexing"}
+                  </Button>
+                </div>
+              </form>
+            </div>
+          )}
+
+          {step === "confirm" && (
+            <div className="flex flex-col items-center gap-4 text-center py-3">
+              <SimpleLoader className="h-6 w-6" />
+              <IllustrationContent
+                illustration={SvgNoResult}
+                title="Indexing started"
+                description="Canvas content is being prepared for this course. The tutor will open when the first documents are ready."
+              />
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/web/src/refresh-pages/tutor/TutorChatPage.tsx
+++ b/web/src/refresh-pages/tutor/TutorChatPage.tsx
@@ -45,6 +45,15 @@ import { SvgChevronDown } from "@opal/icons";
 import Dropzone from "react-dropzone";
 import { cn } from "@/lib/utils";
 
+function BlankLtiStartupView() {
+  return (
+    <div
+      className="h-screen w-full bg-background-neutral-00"
+      aria-hidden="true"
+    />
+  );
+}
+
 export default function TutorChatPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -307,10 +316,13 @@ export default function TutorChatPage() {
   }, []);
 
   // Loading state
-  if (!isReady) return <OnyxInitializingLoader />;
+  if (!isReady) {
+    if (ltiContextId) return <BlankLtiStartupView />;
+    return <OnyxInitializingLoader />;
+  }
 
   if (ltiContextId && isLoadingCourseConnectorStatus) {
-    return <OnyxInitializingLoader />;
+    return <BlankLtiStartupView />;
   }
 
   if (ltiContextId && courseConnectorStatusError) {

--- a/web/src/refresh-pages/tutor/TutorChatPage.tsx
+++ b/web/src/refresh-pages/tutor/TutorChatPage.tsx
@@ -123,6 +123,8 @@ export default function TutorChatPage() {
     if (!courseTutors) return null;
     return new Set(courseTutors.map((t) => t.id));
   }, [courseTutors]);
+  const canManageCourseTutors =
+    isInstructor || Boolean(courseConnectorStatus?.setup);
 
   const {
     chatSessions,
@@ -360,6 +362,7 @@ export default function TutorChatPage() {
           ltiContextId={ltiContextId}
           projectId={projectId}
           ltiCanvasCourseNodeId={ltiCanvasCourseNodeId}
+          canManageTutors={canManageCourseTutors}
         />
       );
     }
@@ -399,7 +402,7 @@ export default function TutorChatPage() {
           onToggleHistory={toggleHistory}
           historyOpen={historyOpen}
           onManageTutors={
-            isInstructor && ltiContextId ? handleManageTutors : null
+            canManageCourseTutors && ltiContextId ? handleManageTutors : null
           }
         />
 

--- a/web/src/refresh-pages/tutor/TutorChatPage.tsx
+++ b/web/src/refresh-pages/tutor/TutorChatPage.tsx
@@ -35,6 +35,10 @@ import TutorHistoryPanel from "@/refresh-pages/tutor/TutorHistoryPanel";
 import TutorSuggestions from "@/refresh-pages/tutor/TutorSuggestions";
 import TutorNoAgent from "@/refresh-pages/tutor/TutorNoAgent";
 import TutorPickerView from "@/refresh-pages/tutor/TutorPickerView";
+import CanvasCourseSetupView, {
+  CanvasCoursePreparingView,
+  type LtiCourseConnectorStatus,
+} from "@/refresh-pages/tutor/CanvasCourseSetupView";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
 import { Button } from "@opal/components";
 import { SvgChevronDown } from "@opal/icons";
@@ -84,6 +88,27 @@ export default function TutorChatPage() {
   const { data: courseTutors } = useSWR<MinimalPersonaSnapshot[]>(
     courseTutorsSwrKey,
     errorHandlingFetcher
+  );
+  const courseConnectorStatusSwrKey = ltiContextId
+    ? `/api/auth/lti/course/${encodeURIComponent(
+        ltiContextId
+      )}/connector-status`
+    : null;
+  const {
+    data: courseConnectorStatus,
+    error: courseConnectorStatusError,
+    isLoading: isLoadingCourseConnectorStatus,
+    mutate: refreshCourseConnectorStatus,
+  } = useSWR<LtiCourseConnectorStatus>(
+    courseConnectorStatusSwrKey,
+    errorHandlingFetcher,
+    {
+      refreshInterval: (latestStatus) => {
+        if (!latestStatus) return 0;
+        if (!latestStatus.has_connector) return 5000;
+        return latestStatus.has_indexed_documents ? 0 : 5000;
+      },
+    }
   );
   const courseTutorIds = useMemo(() => {
     if (!courseTutors) return null;
@@ -184,6 +209,10 @@ export default function TutorChatPage() {
     scrollContainerRef.current?.scrollToBottom();
   }, []);
 
+  const handleCanvasConnectorReady = useCallback(() => {
+    void refreshCourseConnectorStatus();
+  }, [refreshCourseConnectorStatus]);
+
   // Derive course name from project (strip "[Canvas] " prefix)
   const courseName = useMemo(() => {
     if (!currentChatSession?.project_id) return null;
@@ -279,6 +308,36 @@ export default function TutorChatPage() {
 
   // Loading state
   if (!isReady) return <OnyxInitializingLoader />;
+
+  if (ltiContextId && isLoadingCourseConnectorStatus) {
+    return <OnyxInitializingLoader />;
+  }
+
+  if (ltiContextId && courseConnectorStatusError) {
+    return <TutorNoAgent />;
+  }
+
+  if (ltiContextId && courseConnectorStatus) {
+    if (
+      !courseConnectorStatus.has_connector &&
+      courseConnectorStatus.setup?.can_setup
+    ) {
+      return (
+        <CanvasCourseSetupView
+          courseId={ltiContextId}
+          status={courseConnectorStatus}
+          onReady={handleCanvasConnectorReady}
+        />
+      );
+    }
+
+    if (
+      !courseConnectorStatus.has_connector ||
+      !courseConnectorStatus.has_indexed_documents
+    ) {
+      return <CanvasCoursePreparingView status={courseConnectorStatus} />;
+    }
+  }
 
   // No agentId chosen yet — render the picker if we know the course context,
   // otherwise fall back to the legacy no-agent state.

--- a/web/src/refresh-pages/tutor/TutorPickerView.tsx
+++ b/web/src/refresh-pages/tutor/TutorPickerView.tsx
@@ -22,16 +22,18 @@ interface TutorPickerViewProps {
   ltiContextId: string;
   projectId: number | null;
   ltiCanvasCourseNodeId: string | null;
+  canManageTutors: boolean;
 }
 
 export default function TutorPickerView({
   ltiContextId,
   projectId,
   ltiCanvasCourseNodeId,
+  canManageTutors,
 }: TutorPickerViewProps) {
   const router = useRouter();
   const { isAdmin, isCurator } = useUser();
-  const isInstructor = isAdmin || isCurator;
+  const canManageCourseTutors = canManageTutors || isAdmin || isCurator;
 
   const swrKey = `/api/auth/lti/tutors-for-course?context_id=${encodeURIComponent(
     ltiContextId
@@ -99,7 +101,7 @@ export default function TutorPickerView({
   // Students with exactly one tutor skip the picker and jump straight in.
   // Instructors always see the picker so they can manage their tutors.
   const soleStudentTutorId =
-    !isInstructor && tutors.length === 1 ? tutors[0]!.id : null;
+    !canManageCourseTutors && tutors.length === 1 ? tutors[0]!.id : null;
   useEffect(() => {
     if (soleStudentTutorId === null) return;
     router.replace(buildTutorChatUrl(soleStudentTutorId) as Route);
@@ -127,7 +129,7 @@ export default function TutorPickerView({
 
   // 0 tutors: instructors get a CTA, students see the no-agent state.
   if (tutors.length === 0) {
-    if (!isInstructor) {
+    if (!canManageCourseTutors) {
       return <TutorNoAgent />;
     }
     return (
@@ -156,7 +158,7 @@ export default function TutorPickerView({
         title="Choose a tutor"
         description="Pick a virtual tutor to start a conversation. Multiple tutors may use different teaching styles."
         rightChildren={
-          isInstructor ? (
+          canManageCourseTutors ? (
             <Button
               icon={SvgPlus}
               onClick={() => router.push(buildCreateTutorUrl() as Route)}
@@ -172,7 +174,7 @@ export default function TutorPickerView({
             <TutorPickerCard
               key={tutor.id}
               tutor={tutor}
-              showInstructorActions={isInstructor}
+              showInstructorActions={canManageCourseTutors}
               onSelect={() => handleSelect(tutor.id)}
               onEdit={() => router.push(buildEditTutorUrl(tutor.id) as Route)}
             />

--- a/web/src/refresh-pages/tutor/TutorPickerView.tsx
+++ b/web/src/refresh-pages/tutor/TutorPickerView.tsx
@@ -74,7 +74,7 @@ export default function TutorPickerView({
           ltiCanvasCourseNodeId
         );
       }
-      return `/admin/tutor/edit/${agentId}?${params.toString()}`;
+      return `/tutor/edit/${agentId}?${params.toString()}`;
     },
     [ltiContextId, ltiCanvasCourseNodeId]
   );
@@ -88,7 +88,7 @@ export default function TutorPickerView({
         ltiCanvasCourseNodeId
       );
     }
-    return `/admin/tutor/create?${params.toString()}`;
+    return `/tutor/create?${params.toString()}`;
   }, [ltiContextId, ltiCanvasCourseNodeId]);
 
   const handleSelect = useCallback(


### PR DESCRIPTION
## Summary
- add course-scoped Canvas connector setup from LTI launches
- store launch context metadata and resolve local Canvas API base URLs for setup
- add embedded tutor setup/preparing UI and Canvas connector course filtering

## Tests
- ruff check for changed backend files
- compileall for changed backend modules
- targeted Canvas connector and LTI setup pytest coverage
- TypeScript type check and prettier via pre-commit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds course-scoped Canvas connector setup from LTI launches so instructors can connect a course with a token and start indexing; students see a preparing state until indexed documents are available. Also hides the startup loader during LTI boot/polling to avoid flicker.

- **New Features**
  - Store full LTI launch context in Redis (course id/label/title, roles, issuer, Canvas base URL, Canvas course id); resolve Canvas API origin from launch claims or headers, falling back to `LTI_CANVAS_BASE_URL`, LTI endpoint config, or issuer.
  - Endpoints for course setup: GET `/auth/lti/course/{course_id}/connector-status` and POST `/auth/lti/course/{course_id}/setup-connector`; status uses indexed document count and returns a Canvas token URL; CTAs restricted to instructors.
  - Validate a Canvas access token, resolve the launched course (by Canvas course id from the launch or by course id/title/label), create a Canvas connector/credential scoped to that course with `course_ids` and `lti_context_id`, mark for reindex, and enqueue a Celery check.
  - Canvas connector: supports and normalizes numeric `course_ids`, preloads configured course(s), uses them at checkpoint, and accepts `lti_context_id` metadata; rejects non‑numeric IDs.
  - DB: fetch an existing Canvas connector/credential pair by LTI course context to avoid duplicates.
  - UI: embedded setup and preparing views in Tutor for LTI courses; polls readiness via indexed document count; hides the initial loader during LTI startup/polling; shows setup/manage only to instructors; routes tutor create/edit to `/tutor/create` and `/tutor/edit/[id]`.
  - Types: `CanvasConfig` adds optional `course_ids` and `lti_context_id`.

<sup>Written for commit f49d59011f3879c95bbb5184ec6b4773d0645502. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

