### PR TITLE
chore(vespa): hardcode OpenSearch in factory, remove runtime flags

### DIFF
--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -30,13 +30,10 @@ from onyx.background.celery.celery_utils import make_probe_path
 from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_PREFIX
 from onyx.background.celery.tasks.vespa.document_sync import DOCUMENT_SYNC_TASKSET_KEY
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
-from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_sqlalchemy_engine
 from onyx.document_index.opensearch.client import wait_for_opensearch_with_timeout
-from onyx.document_index.vespa.shared_utils.utils import wait_for_vespa_with_timeout
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_delete import RedisConnectorDelete
@@ -613,24 +610,13 @@ def wait_for_document_index_or_shutdown() -> None:
     Raises WorkerShutdown if the timeout is reached.
     """
     if DISABLE_VECTOR_DB:
-        logger.info(
-            "DISABLE_VECTOR_DB is set — skipping Vespa/OpenSearch readiness check."
-        )
+        logger.info("DISABLE_VECTOR_DB is set — skipping OpenSearch readiness check.")
         return
 
-    if not ONYX_DISABLE_VESPA:
-        if not wait_for_vespa_with_timeout():
-            msg = (
-                "[Vespa] Readiness probe did not succeed within the timeout. Exiting..."
-            )
-            logger.error(msg)
-            raise WorkerShutdown(msg)
-
-    if ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
-        if not wait_for_opensearch_with_timeout():
-            msg = "[OpenSearch] Readiness probe did not succeed within the timeout. Exiting..."
-            logger.error(msg)
-            raise WorkerShutdown(msg)
+    if not wait_for_opensearch_with_timeout():
+        msg = "[OpenSearch] Readiness probe did not succeed within the timeout. Exiting..."
+        logger.error(msg)
+        raise WorkerShutdown(msg)
 
 
 # File for validating worker liveness

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -6,11 +6,8 @@ from celery.schedules import crontab
 
 from onyx.configs.app_configs import AUTO_LLM_CONFIG_URL
 from onyx.configs.app_configs import AUTO_LLM_UPDATE_INTERVAL_SECONDS
-from onyx.configs.app_configs import DISABLE_OPENSEARCH_MIGRATION_TASK
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.app_configs import ENTERPRISE_EDITION_ENABLED
-from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.configs.app_configs import SCHEDULED_EVAL_DATASET_NAMES
 from onyx.configs.constants import ONYX_CLOUD_CELERY_TASK_PREFIX
 from onyx.configs.constants import OnyxCeleryPriority
@@ -268,28 +265,6 @@ if SCHEDULED_EVAL_DATASET_NAMES:
             },
         }
     )
-
-# Add OpenSearch migration task if enabled.
-if (
-    ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
-    and not DISABLE_OPENSEARCH_MIGRATION_TASK
-    and not ONYX_DISABLE_VESPA
-):
-    beat_task_templates.append(
-        {
-            "name": "migrate-chunks-from-vespa-to-opensearch",
-            "task": OnyxCeleryTask.MIGRATE_CHUNKS_FROM_VESPA_TO_OPENSEARCH_TASK,
-            # Try to enqueue an invocation of this task with this frequency.
-            "schedule": timedelta(seconds=120),  # 2 minutes
-            "options": {
-                "priority": OnyxCeleryPriority.LOW,
-                # If the task was not dequeued in this time, revoke it.
-                "expires": BEAT_EXPIRES_DEFAULT,
-                "queue": OnyxCeleryQueues.OPENSEARCH_MIGRATION,
-            },
-        }
-    )
-
 
 # Beat task names that require a vector DB. Filtered out when DISABLE_VECTOR_DB.
 _VECTOR_DB_BEAT_TASK_NAMES: set[str] = {

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -348,28 +348,9 @@ OPENSEARCH_EXPLAIN_ENABLED = (
 # existing indices need reindexing after a change.
 OPENSEARCH_TEXT_ANALYZER = os.environ.get("OPENSEARCH_TEXT_ANALYZER") or "english"
 
-# This is the "base" config for now, the idea is that at least for our dev
-# environments we always want to be dual indexing into both OpenSearch and Vespa
-# to stress test the new codepaths. Only enable this if there is some instance
-# of OpenSearch running for the relevant Onyx instance.
-# NOTE: Now enabled on by default, unless the env indicates otherwise.
-ENABLE_OPENSEARCH_INDEXING_FOR_ONYX = (
-    os.environ.get("ENABLE_OPENSEARCH_INDEXING_FOR_ONYX", "true").lower() == "true"
-)
-# NOTE: This effectively does nothing anymore, admins can now toggle whether
-# retrieval is through OpenSearch. This value is only used as a final fallback
-# in case that doesn't work for whatever reason.
-# Given that the "base" config above is true, this enables whether we want to
-# retrieve from OpenSearch or Vespa. We want to be able to quickly toggle this
-# in the event we see issues with OpenSearch retrieval in our dev environments.
-ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX = (
-    ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
-    and os.environ.get("ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX", "").lower() == "true"
-)
 DISABLE_OPENSEARCH_MIGRATION_TASK = (
     os.environ.get("DISABLE_OPENSEARCH_MIGRATION_TASK", "").lower() == "true"
 )
-ONYX_DISABLE_VESPA = os.environ.get("ONYX_DISABLE_VESPA", "true").lower() == "true"
 # Whether we should check for and create an index if necessary every time we
 # instantiate an OpenSearchDocumentIndex on multitenant cloud. Defaults to True.
 VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT = (

--- a/backend/onyx/db/opensearch_migration.py
+++ b/backend/onyx/db/opensearch_migration.py
@@ -19,8 +19,6 @@ from onyx.background.celery.tasks.opensearch_migration.constants import (
 from onyx.background.celery.tasks.opensearch_migration.constants import (
     TOTAL_ALLOWABLE_DOC_MIGRATION_ATTEMPTS_BEFORE_PERMANENT_FAILURE,
 )
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX
-from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.db.enums import OpenSearchDocumentMigrationStatus
 from onyx.db.models import Document
 from onyx.db.models import OpenSearchDocumentMigrationRecord
@@ -404,24 +402,6 @@ def get_opensearch_migration_state(
         record.migration_completed_at,
         record.approx_chunk_count_in_vespa,
     )
-
-
-def get_opensearch_retrieval_state(
-    db_session: Session,
-) -> bool:
-    """Returns the state of the OpenSearch retrieval.
-
-    If the tenant migration record is not found, defaults to
-    ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX.
-
-    If ONYX_DISABLE_VESPA is True, always returns True.
-    """
-    if ONYX_DISABLE_VESPA:
-        return True
-    record = db_session.query(OpenSearchTenantMigrationRecord).first()
-    if record is None:
-        return ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX
-    return record.enable_opensearch_retrieval
 
 
 def set_enable_opensearch_retrieval_with_commit(

--- a/backend/onyx/document_index/factory.py
+++ b/backend/onyx/document_index/factory.py
@@ -2,10 +2,7 @@ import httpx
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
-from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.db.models import SearchSettings
-from onyx.db.opensearch_migration import get_opensearch_retrieval_state
 from onyx.document_index.disabled import DisabledDocumentIndex
 from onyx.document_index.interfaces_new import DocumentIndex
 from onyx.document_index.interfaces_new import TenantState
@@ -13,8 +10,6 @@ from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
 from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
-from onyx.document_index.vespa.vespa_document_index import VespaDocumentIndex
-from onyx.document_index.vespa.vespa_document_index import VespaIndexPair
 from onyx.indexing.models import IndexingSetting
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
@@ -55,49 +50,11 @@ def _build_opensearch_pair(
     )
 
 
-def _build_vespa_pair(
-    search_settings: SearchSettings,
-    secondary_search_settings: SearchSettings | None,
-    httpx_client: httpx.Client | None,
-) -> VespaIndexPair:
-    tenant_state = _build_tenant_state()
-    primary = VespaDocumentIndex(
-        index_name=search_settings.index_name,
-        tenant_state=tenant_state,
-        large_chunks_enabled=search_settings.large_chunks_enabled,
-        httpx_client=httpx_client,
-    )
-    if secondary_search_settings is None:
-        return VespaIndexPair(
-            primary=primary,
-            secondary=None,
-            secondary_index_name=None,
-            secondary_embedding_dim=None,
-            secondary_embedding_precision=None,
-        )
-    secondary_indexing_setting = IndexingSetting.from_db_model(
-        secondary_search_settings
-    )
-    secondary = VespaDocumentIndex(
-        index_name=secondary_search_settings.index_name,
-        tenant_state=tenant_state,
-        large_chunks_enabled=secondary_search_settings.large_chunks_enabled,
-        httpx_client=httpx_client,
-    )
-    return VespaIndexPair(
-        primary=primary,
-        secondary=secondary,
-        secondary_index_name=secondary_search_settings.index_name,
-        secondary_embedding_dim=secondary_indexing_setting.final_embedding_dim,
-        secondary_embedding_precision=secondary_indexing_setting.embedding_precision,
-    )
-
-
 def get_default_document_index(
     search_settings: SearchSettings,
     secondary_search_settings: SearchSettings | None,
-    db_session: Session,
-    httpx_client: httpx.Client | None = None,
+    db_session: Session,  # noqa: ARG001
+    httpx_client: httpx.Client | None = None,  # noqa: ARG001
 ) -> DocumentIndex:
     """Gets the default document index for retrieval.
 
@@ -108,44 +65,16 @@ def get_default_document_index(
     if DISABLE_VECTOR_DB:
         return DisabledDocumentIndex()
 
-    opensearch_retrieval_enabled = get_opensearch_retrieval_state(db_session)
-    if ONYX_DISABLE_VESPA and not opensearch_retrieval_enabled:
-        raise ValueError(
-            "Bug: ONYX_DISABLE_VESPA is set but opensearch_retrieval_enabled is not set."
-        )
-
-    if opensearch_retrieval_enabled:
-        return _build_opensearch_pair(search_settings, secondary_search_settings)
-    return _build_vespa_pair(search_settings, secondary_search_settings, httpx_client)
+    return _build_opensearch_pair(search_settings, secondary_search_settings)
 
 
 def get_all_document_indices(
     search_settings: SearchSettings,
     secondary_search_settings: SearchSettings | None,
-    httpx_client: httpx.Client | None = None,
+    httpx_client: httpx.Client | None = None,  # noqa: ARG001
 ) -> list[DocumentIndex]:
-    """Gets every document index that should be written to.
-
-    NOTE: Make sure the Vespa index object is returned first. In the rare event
-    that there is some conflict between indexing and the migration task, it is
-    assumed that the state of Vespa is more up-to-date than the state of
-    OpenSearch.
-    """
+    """Gets every document index that should be written to."""
     if DISABLE_VECTOR_DB:
         return [DisabledDocumentIndex()]
 
-    if ONYX_DISABLE_VESPA and not ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
-        raise ValueError(
-            "Bug: ONYX_DISABLE_VESPA is set but ENABLE_OPENSEARCH_INDEXING_FOR_ONYX is not set."
-        )
-
-    result: list[DocumentIndex] = []
-    if not ONYX_DISABLE_VESPA:
-        result.append(
-            _build_vespa_pair(search_settings, secondary_search_settings, httpx_client)
-        )
-    if ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
-        result.append(
-            _build_opensearch_pair(search_settings, secondary_search_settings)
-        )
-    return result
+    return [_build_opensearch_pair(search_settings, secondary_search_settings)]

--- a/backend/onyx/server/features/hierarchy/api.py
+++ b/backend/onyx/server/features/hierarchy/api.py
@@ -1,18 +1,15 @@
 from fastapi import APIRouter
 from fastapi import Depends
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.access.hierarchy_access import get_user_external_group_ids
 from onyx.auth.permissions import require_permission
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.constants import DocumentSource
 from onyx.db.document import get_accessible_documents_for_hierarchy_node_paginated
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.hierarchy import get_accessible_hierarchy_nodes_for_source
 from onyx.db.models import User
-from onyx.db.opensearch_migration import get_opensearch_retrieval_state
 from onyx.server.features.hierarchy.constants import DOCUMENT_PAGE_SIZE
 from onyx.server.features.hierarchy.constants import HIERARCHY_NODE_DOCUMENTS_PATH
 from onyx.server.features.hierarchy.constants import HIERARCHY_NODES_LIST_PATH
@@ -26,30 +23,7 @@ from onyx.server.features.hierarchy.models import HierarchyNodeDocumentsResponse
 from onyx.server.features.hierarchy.models import HierarchyNodesResponse
 from onyx.server.features.hierarchy.models import HierarchyNodeSummary
 
-OPENSEARCH_NOT_ENABLED_MESSAGE = "Per-source knowledge selection is coming soon in v3.0! OpenSearch indexing must be enabled to use this feature."
-
-MIGRATION_STATUS_MESSAGE = (
-    "Our records indicate that the transition to OpenSearch is still in progress. "
-    "OpenSearch retrieval is necessary to use this feature. "
-    "You can still use Document Sets, though! "
-    "If you would like to manually switch to OpenSearch, "
-    'Go to the "Document Index Migration" section in the Admin panel.'
-)
-
 router = APIRouter(prefix=HIERARCHY_NODES_PREFIX)
-
-
-def _require_opensearch(db_session: Session) -> None:
-    if not ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
-        raise HTTPException(
-            status_code=403,
-            detail=OPENSEARCH_NOT_ENABLED_MESSAGE,
-        )
-    if not get_opensearch_retrieval_state(db_session):
-        raise HTTPException(
-            status_code=403,
-            detail=MIGRATION_STATUS_MESSAGE,
-        )
 
 
 def _get_user_access_info(user: User, db_session: Session) -> tuple[str, list[str]]:
@@ -62,7 +36,6 @@ def list_accessible_hierarchy_nodes(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> HierarchyNodesResponse:
-    _require_opensearch(db_session)
     user_email, external_group_ids = _get_user_access_info(user, db_session)
     nodes = get_accessible_hierarchy_nodes_for_source(
         db_session=db_session,
@@ -89,7 +62,6 @@ def list_accessible_hierarchy_node_documents(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> HierarchyNodeDocumentsResponse:
-    _require_opensearch(db_session)
     user_email, external_group_ids = _get_user_access_info(user, db_session)
     cursor = documents_request.cursor
     sort_field = documents_request.sort_field

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -113,9 +113,6 @@ class Settings(BaseModel):
     seat_count: int | None = None
     used_seats: int | None = None
 
-    # OpenSearch migration
-    opensearch_indexing_enabled: bool = False
-
 
 class UserSettings(Settings):
     notifications: list[Notification]

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -2,7 +2,6 @@ from onyx.cache.factory import get_cache_backend
 from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
@@ -59,7 +58,6 @@ def load_settings() -> Settings:
         settings.user_knowledge_enabled = False
 
     settings.show_extra_connectors = SHOW_EXTRA_CONNECTORS
-    settings.opensearch_indexing_enabled = ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 
     # Resolve context-aware defaults for token threshold.
     # None = admin hasn't set a value yet → use context-aware default.

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -4,13 +4,9 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
-from onyx.configs.app_configs import MANAGED_VESPA
-from onyx.configs.app_configs import ONYX_DISABLE_VESPA
 from onyx.configs.app_configs import VESPA_NUM_ATTEMPTS_ON_STARTUP
 from onyx.configs.constants import KV_REINDEX_KEY
-from onyx.configs.embedding_configs import SUPPORTED_EMBEDDING_MODELS
 from onyx.configs.embedding_configs import SupportedEmbeddingModel
 from onyx.configs.model_configs import GEN_AI_API_KEY
 from onyx.configs.model_configs import GEN_AI_MODEL_VERSION
@@ -312,19 +308,15 @@ def update_default_multipass_indexing(db_session: Session) -> None:
 
 def setup_multitenant_onyx() -> None:
     if DISABLE_VECTOR_DB:
-        logger.notice("DISABLE_VECTOR_DB is set — skipping multitenant Vespa setup.")
+        logger.notice(
+            "DISABLE_VECTOR_DB is set — skipping multitenant OpenSearch setup."
+        )
         return
 
-    if ENABLE_OPENSEARCH_INDEXING_FOR_ONYX:
-        opensearch_client = OpenSearchClient()
-        if not wait_for_opensearch_with_timeout(client=opensearch_client):
-            raise RuntimeError("Failed to connect to OpenSearch.")
-        set_cluster_state(opensearch_client)
-
-    # For Managed Vespa, the schema is sent over via the Vespa Console manually.
-    # NOTE: Pretty sure this code is never hit in any production environment.
-    if not MANAGED_VESPA and not ONYX_DISABLE_VESPA:
-        setup_vespa_multitenant(SUPPORTED_EMBEDDING_MODELS)
+    opensearch_client = OpenSearchClient()
+    if not wait_for_opensearch_with_timeout(client=opensearch_client):
+        raise RuntimeError("Failed to connect to OpenSearch.")
+    set_cluster_state(opensearch_client)
 
 
 def setup_vespa_multitenant(supported_indices: list[SupportedEmbeddingModel]) -> bool:

--- a/backend/tests/external_dependency_unit/full_setup.py
+++ b/backend/tests/external_dependency_unit/full_setup.py
@@ -66,9 +66,6 @@ def ensure_full_deployment_setup(
         with get_session_with_current_tenant() as db_session:
             active = get_active_search_settings(db_session)
             if opensearch_available:
-                # We use this special bool here instead of just relying on
-                # ENABLE_OPENSEARCH_INDEXING_FOR_ONYX because not all testing
-                # infra is configured for OpenSearch.
                 document_indices = get_all_document_indices(
                     active.primary, active.secondary
                 )

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -65,9 +65,6 @@ export interface Settings {
   seat_count?: number | null;
   used_seats?: number | null;
 
-  // OpenSearch migration
-  opensearch_indexing_enabled?: boolean;
-
   // Vector DB availability flag - false when DISABLE_VECTOR_DB is set.
   // When false, connectors, RAG search, document sets, and related features
   // are unavailable.


### PR DESCRIPTION
## Description
  - Hardcode the document-index factory to OpenSearch — `get_default_document_index` and `get_all_document_indices` no longer branch on flags or DB state, and `_build_vespa_pair` is gone.
  - Remove the runtime backend-selection flags `ONYX_DISABLE_VESPA`, `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX`, and `ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX`, plus the `get_opensearch_retrieval_state` DB helper that read them.
  - Worker readiness probe (`app_base.py`) and multitenant setup (`setup.py`) no longer wait on Vespa — only OpenSearch.
  - Drop the Vespa→OpenSearch migration beat task registration and the `_require_opensearch` guard in the hierarchy API (both are now permanent no-ops).
  - Remove the now-meaningless `opensearch_indexing_enabled` field from the settings model, store, and TypeScript interface.
  - Vespa source files, the migration tooling itself, and `VESPA_*` env vars stay on disk — those are owned by later phases.

## How Has This Been Tested?
  - Existing `backend/tests/unit/onyx/document_index` and `backend/tests/external_dependency_unit/document_index` cover the abstract interface against OpenSearch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardcodes OpenSearch as the sole document index backend and removes Vespa runtime selection/migration toggles. Workers, APIs, and multitenant setup now only depend on OpenSearch.

- **Refactors**
  - Document index factory now returns only OpenSearch; removed Vespa pairing and retrieval-state branching.
  - Deleted env flags: `ONYX_DISABLE_VESPA`, `ENABLE_OPENSEARCH_INDEXING_FOR_ONYX`, `ENABLE_OPENSEARCH_RETRIEVAL_FOR_ONYX`; removed `get_opensearch_retrieval_state`.
  - Worker readiness and multitenant setup only wait on/configure OpenSearch.
  - Removed OpenSearch migration beat task and the hierarchy API gate that depended on migration state.
  - Dropped `opensearch_indexing_enabled` from settings models/store and `web/src/interfaces/settings.ts`.
  - Vespa sources and `VESPA_*` envs remain for later phases but are unused now.

- **Migration**
  - Ensure OpenSearch is available; Vespa is no longer used at runtime.
  - Remove deprecated env vars mentioned above; the OpenSearch migration beat task and its flag are no-ops.
  - Remove any client references to `opensearch_indexing_enabled`.

<sup>Written for commit a24618658e95da8bef3ee0176398d5699df1b0af. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11370?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

