### PR TITLE
fix(discourse): include subcategories and omit empty auth headers

### DIFF
--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -39,7 +39,7 @@ class DiscoursePerms(BaseModel):
 def discourse_request(
     endpoint: str, perms: DiscoursePerms, params: dict | None = None
 ) -> Response:
-    headers = {}
+    headers: dict[str, str] = {}
     if perms.api_key.strip():
         headers["Api-Key"] = perms.api_key
     if perms.api_username.strip():
@@ -101,9 +101,7 @@ class DiscourseConnector(PollConnector):
 
             for subcategory in cat.get("subcategory_list", []):
                 subcategory_matches = (
-                    category_matches
-                    or not self.categories
-                    or subcategory["name"].lower() in self.categories
+                    category_matches or subcategory["name"].lower() in self.categories
                 )
                 if subcategory_matches:
                     self.category_id_map[subcategory["id"]] = {
@@ -169,6 +167,7 @@ class DiscourseConnector(PollConnector):
     ) -> list[int]:
         assert self.permissions is not None
         topic_ids = []
+        seen_topic_ids: set[int] = set()
 
         if not self.categories:
             latest_endpoint = urllib.parse.urljoin(
@@ -205,7 +204,12 @@ class DiscourseConnector(PollConnector):
             if (start and start > last_time_dt) or (end and end < last_time_dt):
                 continue
 
-            topic_ids.append(topic["id"])
+            topic_id = topic["id"]
+            if topic_id in seen_topic_ids:
+                continue
+
+            seen_topic_ids.add(topic_id)
+            topic_ids.append(topic_id)
 
         return topic_ids
 

--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -39,7 +39,11 @@ class DiscoursePerms(BaseModel):
 def discourse_request(
     endpoint: str, perms: DiscoursePerms, params: dict | None = None
 ) -> Response:
-    headers = {"Api-Key": perms.api_key, "Api-Username": perms.api_username}
+    headers = {}
+    if perms.api_key.strip():
+        headers["Api-Key"] = perms.api_key
+    if perms.api_username.strip():
+        headers["Api-Username"] = perms.api_username
 
     response = requests.get(
         endpoint, headers=headers, params=params, timeout=REQUEST_TIMEOUT_SECONDS
@@ -84,11 +88,28 @@ class DiscourseConnector(PollConnector):
             params={"include_subcategories": True},
         )
         categories = response.json()["category_list"]["categories"]
-        self.category_id_map = {
-            cat["id"]: {"name": cat["name"], "slug": cat["slug"]}
-            for cat in categories
-            if not self.categories or cat["name"].lower() in self.categories
-        }
+        self.category_id_map = {}
+        for cat in categories:
+            category_matches = (
+                not self.categories or cat["name"].lower() in self.categories
+            )
+            if category_matches:
+                self.category_id_map[cat["id"]] = {
+                    "name": cat["name"],
+                    "slug": cat["slug"],
+                }
+
+            for subcategory in cat.get("subcategory_list", []):
+                subcategory_matches = (
+                    category_matches
+                    or not self.categories
+                    or subcategory["name"].lower() in self.categories
+                )
+                if subcategory_matches:
+                    self.category_id_map[subcategory["id"]] = {
+                        "name": subcategory["name"],
+                        "slug": subcategory["slug"],
+                    }
         self.active_categories = set(self.category_id_map)
 
     def _get_doc_from_topic(self, topic_id: int) -> Document:

--- a/backend/tests/unit/onyx/connectors/discourse/test_discourse_connector.py
+++ b/backend/tests/unit/onyx/connectors/discourse/test_discourse_connector.py
@@ -1,0 +1,125 @@
+from unittest.mock import MagicMock
+
+from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
+from onyx.connectors.discourse.connector import discourse_request
+from onyx.connectors.discourse.connector import DiscourseConnector
+from onyx.connectors.discourse.connector import DiscoursePerms
+
+
+def test_discourse_request_omits_empty_auth_headers(monkeypatch) -> None:
+    response = MagicMock()
+    mock_get = MagicMock(return_value=response)
+    monkeypatch.setattr("onyx.connectors.discourse.connector.requests.get", mock_get)
+
+    discourse_request(
+        "https://forum.example.com/latest.json",
+        DiscoursePerms(api_key="", api_username=""),
+        params={"page": 1},
+    )
+
+    response.raise_for_status.assert_called_once()
+    mock_get.assert_called_once_with(
+        "https://forum.example.com/latest.json",
+        headers={},
+        params={"page": 1},
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+
+def test_discourse_request_only_sends_non_empty_auth_headers(monkeypatch) -> None:
+    response = MagicMock()
+    mock_get = MagicMock(return_value=response)
+    monkeypatch.setattr("onyx.connectors.discourse.connector.requests.get", mock_get)
+
+    discourse_request(
+        "https://forum.example.com/latest.json",
+        DiscoursePerms(api_key="discourse-key", api_username=""),
+    )
+
+    mock_get.assert_called_once_with(
+        "https://forum.example.com/latest.json",
+        headers={"Api-Key": "discourse-key"},
+        params=None,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
+
+def test_get_categories_map_includes_subcategories_when_parent_matches() -> None:
+    connector = DiscourseConnector(
+        base_url="https://forum.example.com",
+        categories=["Walt Disney World"],
+    )
+    connector.permissions = DiscoursePerms(api_key="", api_username="")
+
+    response = MagicMock()
+    response.json.return_value = {
+        "category_list": {
+            "categories": [
+                {
+                    "id": 1,
+                    "name": "Walt Disney World",
+                    "slug": "walt-disney-world",
+                    "subcategory_list": [
+                        {"id": 2, "name": "Dining", "slug": "dining"},
+                        {
+                            "id": 3,
+                            "name": "Accommodations",
+                            "slug": "accommodations",
+                        },
+                    ],
+                },
+                {
+                    "id": 4,
+                    "name": "Disneyland",
+                    "slug": "disneyland",
+                    "subcategory_list": [
+                        {
+                            "id": 5,
+                            "name": "Disneyland Dining",
+                            "slug": "disneyland-dining",
+                        }
+                    ],
+                },
+            ]
+        }
+    }
+    connector._make_request = MagicMock(return_value=response)  # type: ignore[method-assign]
+
+    connector._get_categories_map()
+
+    assert connector.category_id_map == {
+        1: {"name": "Walt Disney World", "slug": "walt-disney-world"},
+        2: {"name": "Dining", "slug": "dining"},
+        3: {"name": "Accommodations", "slug": "accommodations"},
+    }
+    assert connector.active_categories == {1, 2, 3}
+
+
+def test_get_categories_map_can_filter_directly_to_subcategory() -> None:
+    connector = DiscourseConnector(
+        base_url="https://forum.example.com",
+        categories=["Dining"],
+    )
+    connector.permissions = DiscoursePerms(api_key="", api_username="")
+
+    response = MagicMock()
+    response.json.return_value = {
+        "category_list": {
+            "categories": [
+                {
+                    "id": 1,
+                    "name": "Walt Disney World",
+                    "slug": "walt-disney-world",
+                    "subcategory_list": [
+                        {"id": 2, "name": "Dining", "slug": "dining"},
+                    ],
+                },
+            ]
+        }
+    }
+    connector._make_request = MagicMock(return_value=response)  # type: ignore[method-assign]
+
+    connector._get_categories_map()
+
+    assert connector.category_id_map == {2: {"name": "Dining", "slug": "dining"}}
+    assert connector.active_categories == {2}

--- a/backend/tests/unit/onyx/connectors/discourse/test_discourse_connector.py
+++ b/backend/tests/unit/onyx/connectors/discourse/test_discourse_connector.py
@@ -123,3 +123,39 @@ def test_get_categories_map_can_filter_directly_to_subcategory() -> None:
 
     assert connector.category_id_map == {2: {"name": "Dining", "slug": "dining"}}
     assert connector.active_categories == {2}
+
+
+def test_get_latest_topics_deduplicates_parent_and_subcategory_results() -> None:
+    connector = DiscourseConnector(
+        base_url="https://forum.example.com",
+        categories=["Walt Disney World"],
+    )
+    connector.permissions = DiscoursePerms(api_key="", api_username="")
+    connector.category_id_map = {
+        1: {"name": "Walt Disney World", "slug": "walt-disney-world"},
+        2: {"name": "Dining", "slug": "dining"},
+    }
+
+    parent_response = MagicMock()
+    parent_response.json.return_value = {
+        "topic_list": {
+            "topics": [
+                {"id": 10, "last_posted_at": "2026-05-25T00:00:00.000Z"},
+                {"id": 11, "last_posted_at": "2026-05-25T00:00:00.000Z"},
+            ]
+        }
+    }
+    subcategory_response = MagicMock()
+    subcategory_response.json.return_value = {
+        "topic_list": {
+            "topics": [
+                {"id": 10, "last_posted_at": "2026-05-25T00:00:00.000Z"},
+                {"id": 12, "last_posted_at": "2026-05-25T00:00:00.000Z"},
+            ]
+        }
+    }
+    connector._make_request = MagicMock(  # type: ignore[method-assign]
+        side_effect=[parent_response, subcategory_response]
+    )
+
+    assert connector._get_latest_topics(start=None, end=None, page=0) == [10, 11, 12]


### PR DESCRIPTION
Fixes #11149.\n\n## Summary\n- include Discourse subcategories when a matching parent category is configured\n- allow direct subcategory filters to populate the category map\n- omit empty Discourse auth headers so public forums can be accessed anonymously\n\n## Tests\n- .venv\\Scripts\\python.exe -m pytest backend\\tests\\unit\\onyx\\connectors\\discourse\\test_discourse_connector.py\n- .venv\\Scripts\\python.exe -m ruff check backend\\onyx\\connectors\\discourse\\connector.py backend\\tests\\unit\\onyx\\connectors\\discourse\\test_discourse_connector.py\n- .venv\\Scripts\\python.exe -m ruff format --check backend\\onyx\\connectors\\discourse\\connector.py backend\\tests\\unit\\onyx\\connectors\\discourse\\test_discourse_connector.py\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Discourse category mapping to include subcategories, support direct subcategory filters, and dedupe topics from parent/subcategory queries. Omit empty auth headers so public forums work; fixes #11149.

- **Bug Fixes**
  - Include subcategories when a matching parent is configured and dedupe topics across parent/subcategory results.
  - Allow direct subcategory filters; populate `category_id_map` and `active_categories`.
  - Skip sending empty `Api-Key` and `Api-Username` headers so public forums work without auth.

<sup>Written for commit bed6e19d867e772e99826bd2267f127b8a9333e7. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11377?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

