### PR TITLE
Allow internal search tool to filter by source type

### DIFF
--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session
 
 from onyx.chat.emitter import Emitter
 from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import FederatedConnectorSource
 from onyx.context.search.federated.slack_search import slack_retrieval
 from onyx.context.search.models import BaseFilters
@@ -124,6 +125,7 @@ from shared_configs.configs import MODEL_SERVER_PORT
 logger = setup_logger()
 
 QUERIES_FIELD = "queries"
+SOURCE_TYPES_FIELD = "source_types"
 
 
 def deduplicate_queries(
@@ -148,6 +150,51 @@ def deduplicate_queries(
             # Keep the first occurrence (preserves original casing)
             query_map[query_lower] = (query, weight)
     return list(query_map.values())
+
+
+def _parse_llm_source_types(raw_source_types: Any) -> list[DocumentSource] | None:
+    if raw_source_types is None:
+        return None
+
+    if not isinstance(raw_source_types, list):
+        logger.warning("Ignoring non-list source_types from search tool call")
+        return None
+
+    source_types: list[DocumentSource] = []
+    for source_type in raw_source_types:
+        if not isinstance(source_type, str):
+            logger.warning("Ignoring non-string source_type from search tool call")
+            continue
+
+        try:
+            source_types.append(DocumentSource(source_type.lower()))
+        except ValueError:
+            logger.warning("Ignoring unknown source_type '%s'", source_type)
+
+    return list(dict.fromkeys(source_types)) or None
+
+
+def _with_llm_source_type_filter(
+    base_filters: BaseFilters | None,
+    llm_source_types: list[DocumentSource] | None,
+) -> BaseFilters | None:
+    if not llm_source_types:
+        return base_filters
+
+    if base_filters is None:
+        return BaseFilters(source_type=llm_source_types)
+
+    if not base_filters.source_type:
+        return base_filters.model_copy(update={"source_type": llm_source_types})
+
+    allowed_source_types = [
+        source for source in llm_source_types if source in base_filters.source_type
+    ]
+    if not allowed_source_types:
+        logger.warning("Ignoring source_types that do not overlap existing filters")
+        return base_filters
+
+    return base_filters.model_copy(update={"source_type": allowed_source_types})
 
 
 def _estimate_section_tokens(
@@ -425,6 +472,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         query: str,
         hybrid_alpha: float | None,
         num_hits: int,
+        user_selected_filters: BaseFilters | None,
         acl_filters: list[str] | None,
         embedding_model: EmbeddingModel,
         federated_retrieval_infos: list[FederatedRetrievalInfo],
@@ -451,9 +499,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 hybrid_alpha=hybrid_alpha,
                 # For projects, the search scope is the project and has no other limits
                 user_selected_filters=(
-                    self.user_selected_filters
-                    if self.project_id_filter is None
-                    else None
+                    user_selected_filters if self.project_id_filter is None else None
                 ),
                 bypass_acl=self.bypass_acl,
                 limit=num_hits,
@@ -522,6 +568,15 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                             "items": {"type": "string"},
                             "description": "List of search queries to execute, typically a single query.",
                         },
+                        SOURCE_TYPES_FIELD: {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional source filters such as 'jira', 'confluence', "
+                                "'github', or 'google_drive'. Use when the user clearly "
+                                "asks for information from a specific connected source."
+                            ),
+                        },
                     },
                     "required": [QUERIES_FIELD],
                 },
@@ -550,6 +605,11 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         query_expansion_elapsed = 0.0
         document_selection_elapsed = 0.0
         document_expansion_elapsed = 0.0
+        llm_source_types = _parse_llm_source_types(llm_kwargs.get(SOURCE_TYPES_FIELD))
+        effective_user_selected_filters = _with_llm_source_type_filter(
+            self.user_selected_filters,
+            llm_source_types,
+        )
 
         # Pre-fetch all DB data in a single short-lived session so that
         # parallel search workers need zero DB connections.
@@ -563,12 +623,12 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
 
             # Validate document-set access for user-supplied filters.
             if (
-                self.user_selected_filters
-                and self.user_selected_filters.document_set
+                effective_user_selected_filters
+                and effective_user_selected_filters.document_set
                 and not self.bypass_acl
                 and self.user
             ):
-                requested = self.user_selected_filters.document_set
+                requested = effective_user_selected_filters.document_set
                 accessible = filter_document_set_names_by_user_access(
                     db_session=db_session,
                     document_set_names=requested,
@@ -603,9 +663,9 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 prefetch_source_types = None
             else:
                 prefetch_source_types = (
-                    list(self.user_selected_filters.source_type)
-                    if self.user_selected_filters
-                    and self.user_selected_filters.source_type
+                    list(effective_user_selected_filters.source_type)
+                    if effective_user_selected_filters
+                    and effective_user_selected_filters.source_type
                     else None
                 )
             federated_retrieval_infos = (
@@ -765,6 +825,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                         query,
                         None,
                         override_kwargs.num_hits,
+                        effective_user_selected_filters,
                         acl_filters,
                         embedding_model,
                         federated_retrieval_infos,
@@ -782,6 +843,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                         query,
                         KEYWORD_QUERY_HYBRID_ALPHA,
                         override_kwargs.num_hits,
+                        effective_user_selected_filters,
                         acl_filters,
                         embedding_model,
                         federated_retrieval_infos,

--- a/backend/tests/unit/onyx/tools/test_search_tool_source_filters.py
+++ b/backend/tests/unit/onyx/tools/test_search_tool_source_filters.py
@@ -1,0 +1,45 @@
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import BaseFilters
+from onyx.tools.tool_implementations.search.search_tool import _parse_llm_source_types
+from onyx.tools.tool_implementations.search.search_tool import (
+    _with_llm_source_type_filter,
+)
+
+
+def test_parse_llm_source_types_normalizes_known_sources() -> None:
+    assert _parse_llm_source_types(["JIRA", "confluence"]) == [
+        DocumentSource.JIRA,
+        DocumentSource.CONFLUENCE,
+    ]
+
+
+def test_parse_llm_source_types_ignores_unknown_sources() -> None:
+    assert _parse_llm_source_types(["jira", "not-a-source"]) == [DocumentSource.JIRA]
+
+
+def test_llm_source_filter_initializes_empty_filters() -> None:
+    filters = _with_llm_source_type_filter(None, [DocumentSource.JIRA])
+
+    assert filters == BaseFilters(source_type=[DocumentSource.JIRA])
+
+
+def test_llm_source_filter_preserves_existing_filters() -> None:
+    base_filters = BaseFilters(
+        source_type=[DocumentSource.JIRA, DocumentSource.CONFLUENCE],
+        document_set=["Engineering"],
+    )
+
+    filters = _with_llm_source_type_filter(base_filters, [DocumentSource.JIRA])
+
+    assert filters == BaseFilters(
+        source_type=[DocumentSource.JIRA],
+        document_set=["Engineering"],
+    )
+
+
+def test_llm_source_filter_keeps_existing_scope_on_disjoint_sources() -> None:
+    base_filters = BaseFilters(source_type=[DocumentSource.CONFLUENCE])
+
+    filters = _with_llm_source_type_filter(base_filters, [DocumentSource.JIRA])
+
+    assert filters == BaseFilters(source_type=[DocumentSource.CONFLUENCE])


### PR DESCRIPTION
## Summary
- expose optional `source_types` on the internal search tool schema
- parse/validate LLM-provided source names into `DocumentSource` values
- apply source filtering as a narrowing layer that intersects with existing user/admin filters when present
- add unit coverage for parsing, initialization, intersection, and disjoint existing scopes

## Why
Fixes #10781. When Jira and Confluence are both connected, short Jira tickets can be buried by longer Confluence pages in semantic search. Letting the model set an explicit source filter for clear intents like ticket IDs keeps the search scope aligned with the user request.

## Safety
If there is already a user/admin source filter, the LLM-provided source types only narrow that scope. Disjoint source requests keep the existing scope instead of expanding access or accidentally dropping the filter.

## Tests
- `$HOME/Library/Python/3.9/bin/uv run ruff format --check backend/onyx/tools/tool_implementations/search/search_tool.py backend/tests/unit/onyx/tools/test_search_tool_source_filters.py`
- `$HOME/Library/Python/3.9/bin/uv run ruff check backend/onyx/tools/tool_implementations/search/search_tool.py backend/tests/unit/onyx/tools/test_search_tool_source_filters.py`
- `$HOME/Library/Python/3.9/bin/uv run pytest backend/tests/unit/onyx/tools/test_search_tool_source_filters.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional source-type filtering to the internal search tool so queries can target sources like 'jira' or 'confluence'. This narrows results without widening access and helps surface short Jira tickets over long Confluence pages when appropriate.

- **New Features**
  - Exposes optional `source_types` array in the tool schema.
  - Parses and normalizes strings to `DocumentSource`; dedupes and ignores unknown/non-string inputs.
  - Intersects LLM-provided sources with existing user/admin filters; disjoint requests are ignored to avoid expanding scope.
  - Applies the effective filter across prefetching and search execution.
  - Adds unit tests for parsing, initialization, intersection, and disjoint cases.

<sup>Written for commit c6deec7e4e8aa0dea5cae10ff759748b307484b8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11378?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

