### PR TITLE
chore(deploy): replace bespoke nginx healthcheck in init-letsencrypt.sh

### DIFF
--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -328,6 +328,20 @@ services:
       - NGINX_PROXY_CONNECT_TIMEOUT=${NGINX_PROXY_CONNECT_TIMEOUT:-300}
       - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
       - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--quiet",
+          "--tries=1",
+          "--spider",
+          "http://127.0.0.1/nginx-health",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
   certbot:

--- a/deployment/docker_compose/init-letsencrypt.sh
+++ b/deployment/docker_compose/init-letsencrypt.sh
@@ -6,9 +6,6 @@ set -o allexport
 source .env.nginx
 set +o allexport
 
-# Function to determine correct docker compose command. Prefers the V2 plugin
-# (`docker compose`) since V1 (`docker-compose`) was EOL'd by Docker in 2023
-# and does not support the `--wait` / `--wait-timeout` flags used below.
 docker_compose_cmd() {
   if docker compose version >/dev/null 2>&1; then
     echo "docker compose"
@@ -20,15 +17,11 @@ docker_compose_cmd() {
   fi
 }
 
-# Assign appropriate Docker Compose command
 COMPOSE_CMD=$(docker_compose_cmd)
 
-# `--wait` / `--wait-timeout` are V2-only. Drop them on V1 so the script
-# still runs (without gating on the nginx healthcheck) on legacy hosts.
+# --wait/--wait-timeout are V2-only.
 WAIT_ARGS=(--wait --wait-timeout 300)
-if [[ "$COMPOSE_CMD" == "docker-compose" ]]; then
-  WAIT_ARGS=()
-fi
+[[ "$COMPOSE_CMD" == "docker-compose" ]] && WAIT_ARGS=()
 
 # Only add www to domain list if domain wasn't explicitly set as a subdomain
 if [[ ! $DOMAIN == www.* ]]; then

--- a/deployment/docker_compose/init-letsencrypt.sh
+++ b/deployment/docker_compose/init-letsencrypt.sh
@@ -6,20 +6,29 @@ set -o allexport
 source .env.nginx
 set +o allexport
 
-# Function to determine correct docker compose command
+# Function to determine correct docker compose command. Prefers the V2 plugin
+# (`docker compose`) since V1 (`docker-compose`) was EOL'd by Docker in 2023
+# and does not support the `--wait` / `--wait-timeout` flags used below.
 docker_compose_cmd() {
-  if command -v docker-compose >/dev/null 2>&1; then
-    echo "docker-compose"
-  elif command -v docker compose >/dev/null 2>&1; then
+  if docker compose version >/dev/null 2>&1; then
     echo "docker compose"
+  elif command -v docker-compose >/dev/null 2>&1; then
+    echo "docker-compose"
   else
-    echo 'Error: docker-compose or docker compose is not installed.' >&2
+    echo 'Error: docker compose (V2 plugin) or docker-compose is not installed.' >&2
     exit 1
   fi
 }
 
 # Assign appropriate Docker Compose command
 COMPOSE_CMD=$(docker_compose_cmd)
+
+# `--wait` / `--wait-timeout` are V2-only. Drop them on V1 so the script
+# still runs (without gating on the nginx healthcheck) on legacy hosts.
+WAIT_ARGS=(--wait --wait-timeout 300)
+if [[ "$COMPOSE_CMD" == "docker-compose" ]]; then
+  WAIT_ARGS=()
+fi
 
 # Only add www to domain list if domain wasn't explicitly set as a subdomain
 if [[ ! $DOMAIN == www.* ]]; then
@@ -61,7 +70,7 @@ echo
 
 
 echo "### Starting nginx ..."
-$COMPOSE_CMD -f docker-compose.prod.yml up --force-recreate -d --wait --wait-timeout 300 nginx
+$COMPOSE_CMD -f docker-compose.prod.yml up --force-recreate -d "${WAIT_ARGS[@]}" nginx
 echo
 
 echo "### Deleting dummy certificate for $domains ..."

--- a/deployment/docker_compose/init-letsencrypt.sh
+++ b/deployment/docker_compose/init-letsencrypt.sh
@@ -61,22 +61,8 @@ echo
 
 
 echo "### Starting nginx ..."
-$COMPOSE_CMD -f docker-compose.prod.yml up --force-recreate -d nginx
+$COMPOSE_CMD -f docker-compose.prod.yml up --force-recreate -d --wait --wait-timeout 300 nginx
 echo
-
-echo "Waiting for nginx to be ready, this may take a minute..."
-while true; do
-  # Use curl to send a request and capture the HTTP status code
-  status_code=$(curl -o /dev/null -s -w "%{http_code}\n" "http://localhost/api/health")
-  
-  # Check if the status code is 200
-  if [ "$status_code" -eq 200 ]; then
-    break  # Exit the loop
-  else
-    echo "Nginx is not ready yet, retrying in 5 seconds..."
-    sleep 5  # Sleep for 5 seconds before retrying
-  fi
-done
 
 echo "### Deleting dummy certificate for $domains ..."
 $COMPOSE_CMD -f docker-compose.prod.yml run  --name onyx --rm --entrypoint "\


### PR DESCRIPTION
## Summary
- Adds a `/nginx-health` healthcheck to the `nginx` service in `docker-compose.prod.yml`, mirroring the pattern already used in the base `docker-compose.yml`.
- Replaces the bespoke `curl http://localhost/api/health` polling loop in `init-letsencrypt.sh` with `docker compose up -d --wait --wait-timeout 300 nginx`.
- Follows the approach from c5a2b6864, which did the same for CI workflows.

Fixes #11352 — the old loop checked `/api/health` (which goes through nginx → api_server), so on a fresh EC2 deploy where only the nginx service is brought up by the script, the probe could never reach a healthy api_server and would loop forever. `/nginx-health` is served directly by nginx with no upstreams, which is what we actually want here (certbot only needs nginx up to serve the ACME webroot challenge).

## Test plan
- [ ] On a fresh EC2 host following https://docs.onyx.app/deployment/cloud/aws/ec2, run `./init-letsencrypt.sh` end-to-end and confirm it exits 0 and issues a cert.
- [ ] Verify `docker compose -f docker-compose.prod.yml ps` shows nginx as `healthy` after the wait completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the custom nginx readiness loop with Compose-native healthchecks and wait gating to make cert issuance reliable on fresh EC2 deploys. Adds an `/nginx-health` probe to `nginx` in `docker-compose.prod.yml`, updates `init-letsencrypt.sh` to prefer `docker compose` V2 with `--wait/--wait-timeout` (falling back to `docker-compose` without wait args), and trims non-functional comments. Fixes #11352.

<sup>Written for commit 754c6f41bbd7f189603d2c09db0613092f3db311. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11382?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

