### PR TITLE
test(playwright): add visual regression test for Maintenance page

### DIFF
--- a/web/tests/e2e/error-pages/maintenance_page.spec.ts
+++ b/web/tests/e2e/error-pages/maintenance_page.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+test.describe.configure({ mode: "parallel" });
+
+for (const theme of THEMES) {
+  test.describe(`Maintenance in Progress page (${theme} mode)`, () => {
+    test.beforeEach(async ({ page }) => {
+      await setThemeBeforeNavigation(page, theme);
+
+      // Force the SettingsProvider into its fatal-error branch by failing the
+      // core settings request with a non-auth status. When the web build has
+      // NEXT_PUBLIC_CLOUD_ENABLED=true, this renders the CloudError
+      // ("Maintenance in Progress") page.
+      await page.route("**/api/settings", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Simulated outage" }),
+        });
+      });
+      await page.route("**/api/enterprise-settings", async (route) => {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Simulated outage" }),
+        });
+      });
+    });
+
+    test("renders the Maintenance in Progress page", async ({ page }) => {
+      await page.goto("/app");
+
+      await expect(
+        page.getByText("Maintenance in Progress", { exact: true })
+      ).toBeVisible({ timeout: 15000 });
+      await expect(
+        page.getByText(
+          "Onyx is currently in a maintenance window. Please check back in a couple of minutes."
+        )
+      ).toBeVisible();
+
+      await expectScreenshot(page, {
+        name: `maintenance-page-${theme}`,
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `web/tests/e2e/error-pages/maintenance_page.spec.ts`, a visual regression test for the "Maintenance in Progress" page (`CloudErrorPage`).
- Intercepts `/api/settings` and `/api/enterprise-settings` with `500` responses so `SettingsProvider` falls into its fatal-error branch, then snapshots the page in light and dark themes.

## Notes
- The page only renders when the web build sets `NEXT_PUBLIC_CLOUD_ENABLED=true`. The playwright CI build (`pr-playwright-tests.yml`) currently doesn't pass that build arg — if we want this test to exercise `CloudError` (rather than the generic `ErrorPage`) in CI, the build step needs to be updated.

## Test plan
- [ ] `npx playwright test web/tests/e2e/error-pages/maintenance_page.spec.ts` locally against a cloud-enabled web build
- [ ] Re-run with `VISUAL_REGRESSION=true` and commit baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Playwright visual regression test for the Maintenance in Progress page. It forces settings API failures to trigger the fatal-error path and snapshots light and dark themes.

- Adds `web/tests/e2e/error-pages/maintenance_page.spec.ts` that intercepts `/api/settings` and `/api/enterprise-settings` with 500s, asserts copy, and captures screenshots.

- **Migration**
  - In CI, build the web app with `NEXT_PUBLIC_CLOUD_ENABLED=true` to exercise the cloud-specific page; otherwise the generic error page will render.

<sup>Written for commit 0ffea6e965ca88f98df3224ee74c4a67bd8ac343. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11383?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

