### PR TITLE
fix(web): set conservative SWR opts on useCCPairs

### DIFF
--- a/web/src/hooks/useCCPairs.ts
+++ b/web/src/hooks/useCCPairs.ts
@@ -11,7 +11,8 @@ import { SWR_KEYS } from "@/lib/swr-keys";
  * Retrieves all connector-credential pairs configured in the system. CC Pairs
  * represent connections between data sources (connectors) and their authentication
  * credentials, used for indexing content from various sources like Confluence,
- * Slack, Google Drive, etc. Uses SWR for caching and automatic revalidation.
+ * Slack, Google Drive, etc. Fetched once on mount and held for the session;
+ * call `refetch()` after a mutation to refresh.
  *
  * @returns Object containing:
  *   - ccPairs: Array of CCPairBasicInfo objects

--- a/web/src/hooks/useCCPairs.ts
+++ b/web/src/hooks/useCCPairs.ts
@@ -75,7 +75,7 @@ export default function useCCPairs(enabled: boolean = true) {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       revalidateIfStale: false,
-      dedupingInterval: 60_000,
+      dedupingInterval: 30_000,
     }
   );
 

--- a/web/src/hooks/useCCPairs.ts
+++ b/web/src/hooks/useCCPairs.ts
@@ -70,7 +70,13 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 export default function useCCPairs(enabled: boolean = true) {
   const { data, error, isLoading, mutate } = useSWR<CCPairBasicInfo[]>(
     enabled ? SWR_KEYS.connectorStatus : null,
-    errorHandlingFetcher
+    errorHandlingFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+      dedupingInterval: 60_000,
+    }
   );
 
   return {


### PR DESCRIPTION
## Description

**Bug:** `useCCPairs` is mounted in `SettingsProvider` (root provider tree) with zero SWR options, so it inherited the SWR defaults: `revalidateOnFocus: true`, `revalidateOnReconnect: true`, `dedupingInterval: 2000`. Every page mount, tab focus, and network reconnect refetched the connector list.

**Why:** Prod cluster shows ~25 RPS mean / 68 RPS peak against `/manage/connector-status`. Each call runs a parallel CC-pair + index-attempt DB scan.

**Fix:** Match the existing pattern used in `useCurrentUser` and `useAuthTypeMetadata`:
- `revalidateOnFocus: false`
- `revalidateOnReconnect: false`
- `revalidateIfStale: false`
- `dedupingInterval: 30_000`

Manual `mutate()` calls still revalidate immediately (dedup doesn't gate those).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check