### PR TITLE
feat(api): cache /auth/type response in browsers

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -42,13 +42,12 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
         has_users = user_count > 0
 
     # Cache only after bootstrap; the first user flow depends on a live
-    # has_users flag so avoid serving a stale redirect. Set an explicit
-    # no-store in that case so an intermediate CDN with a default TTL
-    # doesn't pin has_users=false past the first signup.
-    if has_users:
-        response.headers["Cache-Control"] = "public, max-age=60"
-    else:
-        response.headers["Cache-Control"] = "no-store"
+    # has_users flag so avoid serving a stale redirect. no-store in that
+    # case prevents an intermediate CDN with a default TTL from pinning
+    # has_users=false past the first signup.
+    response.headers["Cache-Control"] = (
+        "public, max-age=60" if has_users else "no-store"
+    )
 
     return AuthTypeResponse(
         auth_type=AUTH_TYPE,

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -41,9 +41,10 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
         user_count = await get_user_count()
         has_users = user_count > 0
 
-    # Response only flips on auth-config change or first user signup, so a
-    # short browser cache is safe and cuts a hot pre-auth endpoint.
-    response.headers["Cache-Control"] = "public, max-age=60"
+    # Cache only after bootstrap; the first user flow depends on a live
+    # has_users flag so avoid serving a stale redirect.
+    if has_users:
+        response.headers["Cache-Control"] = "public, max-age=60"
 
     return AuthTypeResponse(
         auth_type=AUTH_TYPE,

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -42,9 +42,13 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
         has_users = user_count > 0
 
     # Cache only after bootstrap; the first user flow depends on a live
-    # has_users flag so avoid serving a stale redirect.
+    # has_users flag so avoid serving a stale redirect. Set an explicit
+    # no-store in that case so an intermediate CDN with a default TTL
+    # doesn't pin has_users=false past the first signup.
     if has_users:
         response.headers["Cache-Control"] = "public, max-age=60"
+    else:
+        response.headers["Cache-Control"] = "no-store"
 
     return AuthTypeResponse(
         auth_type=AUTH_TYPE,

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -4,6 +4,7 @@ import re
 import requests
 from fastapi import APIRouter
 from fastapi import HTTPException
+from fastapi import Response
 
 from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
@@ -31,7 +32,7 @@ async def healthcheck() -> StatusResponse:
 
 
 @router.get("/auth/type", tags=PUBLIC_API_TAGS)
-async def get_auth_type() -> AuthTypeResponse:
+async def get_auth_type(response: Response) -> AuthTypeResponse:
     # NOTE: This endpoint is critical for the multi-tenant flow and is hit before there is a tenant context
     # The reason is this is used during the login flow, but we don't know which tenant the user is supposed to be
     # associated with until they auth.
@@ -39,6 +40,10 @@ async def get_auth_type() -> AuthTypeResponse:
     if AUTH_TYPE != AuthType.CLOUD:
         user_count = await get_user_count()
         has_users = user_count > 0
+
+    # Response only flips on auth-config change or first user signup, so a
+    # short browser cache is safe and cuts a hot pre-auth endpoint.
+    response.headers["Cache-Control"] = "public, max-age=60"
 
     return AuthTypeResponse(
         auth_type=AUTH_TYPE,


### PR DESCRIPTION
## Description

**Bug:** `/auth/type` is hit on every page mount by `useAuthTypeMetadata` in the root provider tree. Prod shows ~65 RPS mean / 176 RPS peak against api-server for a response that essentially never changes.

**Fix:** Set `Cache-Control: public, max-age=60` so browsers cache the response. Guarded with `if has_users:` so the bootstrap (zero users) signup flow stays live.

**Notes:** Response is computed pre-tenant-context, so `public` is safe. In CLOUD mode the response is fully static.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check