### PR TITLE
feat(billing): cache /proxy/billing-information per tenant in Redis

### DIFF
--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -27,6 +27,7 @@ from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
 from pydantic import BaseModel
+from pydantic import ValidationError
 from redis.exceptions import RedisError
 
 from ee.onyx.configs.app_configs import LICENSE_ENFORCEMENT_ENABLED
@@ -394,7 +395,15 @@ async def proxy_billing_information(
         )
 
     if cached is not None:
-        return BillingInformationResponse.model_validate_json(cached)
+        try:
+            return BillingInformationResponse.model_validate_json(cached)
+        except ValidationError as exc:
+            # Stale schema or partial write — fall through to live proxy.
+            logger.warning(
+                "Billing info cache deserialize failed for tenant %s: %s",
+                tenant_id,
+                exc,
+            )
 
     result = await forward_to_control_plane(
         "GET", "/billing-information", params={"tenant_id": tenant_id}

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -27,6 +27,7 @@ from fastapi import Depends
 from fastapi import Header
 from fastapi import HTTPException
 from pydantic import BaseModel
+from redis.exceptions import RedisError
 
 from ee.onyx.configs.app_configs import LICENSE_ENFORCEMENT_ENABLED
 from ee.onyx.server.billing.models import SeatUpdateRequest
@@ -37,6 +38,7 @@ from ee.onyx.utils.license import is_license_valid
 from ee.onyx.utils.license import verify_license_signature
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
 
 BILLING_INFO_CACHE_KEY = "proxy:billing-information:v1"
@@ -379,9 +381,18 @@ async def proxy_billing_information(
         raise HTTPException(status_code=401, detail="License missing tenant_id")
 
     tenant_id = license_payload.tenant_id
-    redis_client = get_redis_client(tenant_id=tenant_id)
+    redis_client: TenantRedisClient | None = None
+    cached: bytes | None = None
+    try:
+        redis_client = get_redis_client(tenant_id=tenant_id)
+        cached = redis_client.get(BILLING_INFO_CACHE_KEY)
+    except RedisError as exc:
+        logger.warning(
+            "Billing info cache read failed for tenant %s: %s",
+            tenant_id,
+            exc,
+        )
 
-    cached = redis_client.get(BILLING_INFO_CACHE_KEY)
     if cached is not None:
         return BillingInformationResponse.model_validate_json(cached)
 
@@ -392,11 +403,19 @@ async def proxy_billing_information(
     if "tenant_id" not in result:
         result["tenant_id"] = tenant_id
     billing_info = BillingInformationResponse(**result)
-    redis_client.setex(
-        BILLING_INFO_CACHE_KEY,
-        BILLING_INFO_CACHE_TTL_SEC,
-        billing_info.model_dump_json(),
-    )
+    if redis_client is not None:
+        try:
+            redis_client.setex(
+                BILLING_INFO_CACHE_KEY,
+                BILLING_INFO_CACHE_TTL_SEC,
+                billing_info.model_dump_json(),
+            )
+        except RedisError as exc:
+            logger.warning(
+                "Billing info cache write failed for tenant %s: %s",
+                tenant_id,
+                exc,
+            )
     return billing_info
 
 
@@ -464,6 +483,15 @@ async def proxy_seat_update(
             "new_seat_count": request_body.new_seat_count,
         },
     )
+    try:
+        redis_client = get_redis_client(tenant_id=tenant_id)
+        redis_client.delete(BILLING_INFO_CACHE_KEY)
+    except RedisError as exc:
+        logger.warning(
+            "Billing info cache invalidation failed for tenant %s: %s",
+            tenant_id,
+            exc,
+        )
 
     # Return license in response - self-hosted instance stores it via /api/license/claim
     return SeatUpdateResponse(

--- a/backend/ee/onyx/server/tenants/proxy.py
+++ b/backend/ee/onyx/server/tenants/proxy.py
@@ -36,7 +36,11 @@ from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.utils.license import is_license_valid
 from ee.onyx.utils.license import verify_license_signature
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
+from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger
+
+BILLING_INFO_CACHE_KEY = "proxy:billing-information:v1"
+BILLING_INFO_CACHE_TTL_SEC = 300
 
 logger = setup_logger()
 
@@ -363,6 +367,11 @@ async def proxy_billing_information(
     """Proxy billing information request to control plane.
 
     Auth: Valid (non-expired) license required.
+
+    Caches the response in Redis per tenant for BILLING_INFO_CACHE_TTL_SEC.
+    The frontend polls this endpoint on a tight loop, but Stripe-backed
+    billing state doesn't change second-to-second, so a short shared cache
+    eliminates almost all control-plane round trips.
     """
     # tenant_id is a required field in LicensePayload (Pydantic validates this),
     # but we check explicitly for defense in depth
@@ -370,6 +379,11 @@ async def proxy_billing_information(
         raise HTTPException(status_code=401, detail="License missing tenant_id")
 
     tenant_id = license_payload.tenant_id
+    redis_client = get_redis_client(tenant_id=tenant_id)
+
+    cached = redis_client.get(BILLING_INFO_CACHE_KEY)
+    if cached is not None:
+        return BillingInformationResponse.model_validate_json(cached)
 
     result = await forward_to_control_plane(
         "GET", "/billing-information", params={"tenant_id": tenant_id}
@@ -377,7 +391,13 @@ async def proxy_billing_information(
     # Add tenant_id from license if not in response (control plane may not include it)
     if "tenant_id" not in result:
         result["tenant_id"] = tenant_id
-    return BillingInformationResponse(**result)
+    billing_info = BillingInformationResponse(**result)
+    redis_client.setex(
+        BILLING_INFO_CACHE_KEY,
+        BILLING_INFO_CACHE_TTL_SEC,
+        billing_info.model_dump_json(),
+    )
+    return billing_info
 
 
 class LicenseFetchResponse(BaseModel):


### PR DESCRIPTION
## Description

**Bug:** Cloud data plane proxies every `/proxy/billing-information` call to the control plane (Stripe-backed). Prod shows ~74 RPS mean / 164 peak from internal pollers.

**Fix:** Cache the `BillingInformationResponse` in tenant-prefixed Redis with a 300s TTL. Cache reads/writes are wrapped in `try/except RedisError` so Redis downtime falls back to the live proxy. `/proxy/seats/update` invalidates the cache after a successful seat update so stale counts aren't served.

**Notes:**
- Stale window bounded at 5 min — acceptable for billing display.
- Webhook-driven invalidation (subscription updates from Stripe) is a follow-up.
- Cache key is versioned (`v1`) so schema changes to `BillingInformationResponse` can bump it safely.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check