### PR TITLE
fix(web): bump useCurrentUser dedupingInterval to 5 min

### DIFF
--- a/web/src/hooks/useCurrentUser.ts
+++ b/web/src/hooks/useCurrentUser.ts
@@ -12,12 +12,15 @@ import { SWR_KEYS } from "@/lib/swr-keys";
  *
  * - `revalidateOnFocus: false`      — tab switches won't trigger a refetch
  * - `revalidateOnReconnect: false`   — network recovery won't trigger a refetch
- * - `dedupingInterval: 60_000`       — duplicate requests within 1 min are deduped
+ * - `dedupingInterval: 300_000`      — duplicate requests within 5 min are deduped
  *
- * Callers that mutate user state (token refresh, profile update) call
- * `mutateUser()` to refetch immediately. Some logout / admin-role-change
- * paths still rely on the dedup window expiring; keep the window short
- * enough that those stale-UI windows match existing behavior.
+ * The 5 min window is safe because every path that changes user state
+ * busts the cache explicitly:
+ * - `logout()` in `@/lib/user` clears `SWR_KEYS.me` after a successful
+ *   sign-out so subsequent reads do not return the just-signed-out user.
+ * - `useTokenRefresh` calls `onRefreshFail` → `mutateUser()` on token
+ *   refresh failure.
+ * - `EditUserModal` calls `mutateUser()` after a self role change.
  *
  * @example
  * ```ts
@@ -39,7 +42,7 @@ export function useCurrentUser(): {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       revalidateIfStale: false,
-      dedupingInterval: 60_000,
+      dedupingInterval: 300_000,
     }
   );
 

--- a/web/src/hooks/useCurrentUser.ts
+++ b/web/src/hooks/useCurrentUser.ts
@@ -12,11 +12,12 @@ import { SWR_KEYS } from "@/lib/swr-keys";
  *
  * - `revalidateOnFocus: false`      — tab switches won't trigger a refetch
  * - `revalidateOnReconnect: false`   — network recovery won't trigger a refetch
- * - `dedupingInterval: 300_000`      — duplicate requests within 5 min are deduped
+ * - `dedupingInterval: 60_000`       — duplicate requests within 1 min are deduped
  *
- * Mutations that change the user (profile updates, token refresh, signout)
- * call `mutateUser()` explicitly, so the 5 min window does not hide
- * those state transitions.
+ * Callers that mutate user state (token refresh, profile update) call
+ * `mutateUser()` to refetch immediately. Some logout / admin-role-change
+ * paths still rely on the dedup window expiring; keep the window short
+ * enough that those stale-UI windows match existing behavior.
  *
  * @example
  * ```ts
@@ -38,7 +39,7 @@ export function useCurrentUser(): {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       revalidateIfStale: false,
-      dedupingInterval: 300_000,
+      dedupingInterval: 60_000,
     }
   );
 

--- a/web/src/hooks/useCurrentUser.ts
+++ b/web/src/hooks/useCurrentUser.ts
@@ -28,14 +28,14 @@ import { SWR_KEYS } from "@/lib/swr-keys";
  * ```
  */
 export function useCurrentUser(): {
-  /** The authenticated user, or `undefined` while loading. */
-  user: User | undefined;
+  /** The authenticated user, `null` when signed out, or `undefined` while loading. */
+  user: User | null | undefined;
   /** Imperatively revalidate / update the cached user. */
-  mutateUser: KeyedMutator<User>;
+  mutateUser: KeyedMutator<User | null>;
   /** The error thrown by the fetcher, if any. */
   userError: (Error & { status?: number }) | undefined;
 } {
-  const { data, mutate, error } = useSWR<User>(
+  const { data, mutate, error } = useSWR<User | null>(
     SWR_KEYS.me,
     errorHandlingFetcher,
     {

--- a/web/src/hooks/useCurrentUser.ts
+++ b/web/src/hooks/useCurrentUser.ts
@@ -6,15 +6,17 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 /**
  * Fetches the current authenticated user via SWR (`/api/me`).
  *
- * This hook is intentionally configured with conservative revalidation
- * settings to avoid hammering the backend on every focus/reconnect event:
+ * The hook is mounted in the root `UserProvider`, so every route mount
+ * across the app touches this key. Conservative revalidation keeps the
+ * fan-out manageable:
  *
  * - `revalidateOnFocus: false`      — tab switches won't trigger a refetch
  * - `revalidateOnReconnect: false`   — network recovery won't trigger a refetch
- * - `dedupingInterval: 30_000`       — duplicate requests within 30 s are deduped
+ * - `dedupingInterval: 300_000`      — duplicate requests within 5 min are deduped
  *
- * The returned `mutateUser` handle lets callers imperatively refetch (e.g.
- * after a token refresh) without changing the global SWR config.
+ * Mutations that change the user (profile updates, token refresh, signout)
+ * call `mutateUser()` explicitly, so the 5 min window does not hide
+ * those state transitions.
  *
  * @example
  * ```ts
@@ -36,7 +38,7 @@ export function useCurrentUser(): {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
       revalidateIfStale: false,
-      dedupingInterval: 30_000,
+      dedupingInterval: 300_000,
     }
   );
 

--- a/web/src/lib/user.ts
+++ b/web/src/lib/user.ts
@@ -1,4 +1,6 @@
+import { mutate } from "swr";
 import { User } from "@/lib/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export const checkUserIsNoAuthUser = (userId: string) => {
   return userId === "__no_auth_user__";
@@ -20,6 +22,11 @@ export const logout = async (): Promise<Response> => {
     method: "POST",
     credentials: "include",
   });
+  if (response.ok) {
+    // Drop the cached /api/me so any subsequent useCurrentUser read does not
+    // hand callers the just-signed-out user from the SWR dedup window.
+    await mutate(SWR_KEYS.me, null, { revalidate: false });
+  }
   return response;
 };
 

--- a/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/EditUserModal.tsx
@@ -17,6 +17,7 @@ import { UserRole, USER_ROLE_LABELS } from "@/lib/types";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import useGroups from "@/hooks/useGroups";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 import { addUserToGroup, removeUserFromGroup, setUserRole } from "./svc";
 import type { UserRow } from "./interfaces";
 import { cn } from "@opal/utils";
@@ -51,6 +52,7 @@ export default function EditUserModal({
   onMutate,
 }: EditUserModalProps) {
   const businessTier = useTierAtLeast(Tier.BUSINESS);
+  const { user: currentUser, mutateUser } = useCurrentUser();
   const { data: allGroups, isLoading: groupsLoading } = useGroups();
   const [searchTerm, setSearchTerm] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -143,6 +145,13 @@ export default function EditUserModal({
         selectedRole !== user.role
       ) {
         await setUserRole(user.email, selectedRole);
+        // If an admin demoted themselves (or flipped their own curator
+        // flag), the cached /api/me would otherwise hold the old role for
+        // the full useCurrentUser dedup window. Force a refetch so the
+        // sidebar and gating checks see the new role immediately.
+        if (currentUser && currentUser.id === user.id) {
+          await mutateUser();
+        }
       }
 
       onMutate();


### PR DESCRIPTION
## Description

**Bug:** `useCurrentUser` is mounted in the root `UserProvider`, so every route mount touches `/api/me`. Prod shows ~65 RPS combined across 200/403.

**Fix:** Bump SWR `dedupingInterval` to 300_000 (5 min). Drops `/api/me` to ~13 RPS.

**Invariant work to make 5 min safe:**
- `lib/user.ts` `logout()` now busts the `/api/me` cache after a successful sign-out (`mutate(SWR_KEYS.me, null, { revalidate: false })`). Covers all five logout callsites (`AccountPopover`, `NewTenantModal`, `NoLlmProvidersModal`, `NotAllowedModal`, `AppHealthBanner`) in one place.
- `EditUserModal.handleSave` calls `mutateUser()` after `setUserRole` if the edited user is the current user — sidebar and gating checks see the new role immediately.
- `useTokenRefresh` → `onRefreshFail` → `mutateUser()` was already wired.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check