### PR TITLE
fix(craft): pre-register all build-mode LLM providers on session restore

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -51,6 +51,7 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.manager import UploadLimitExceededError
 from onyx.server.features.build.utils import sanitize_filename
@@ -450,12 +451,18 @@ def restore_session(
             )
             db_session.commit()
 
+            # Pre-register every build-mode provider so per-prompt model
+            # overrides can cross providers without re-provisioning the pod.
+            all_llm_configs = get_all_build_mode_llm_configs(
+                db_session, default=llm_config
+            )
             sandbox_manager.provision(
                 sandbox_id=sandbox.id,
                 user_id=user.id,
                 tenant_id=tenant_id,
                 llm_config=llm_config,
                 onyx_pat=onyx_pat,
+                all_llm_configs=all_llm_configs,
             )
 
             # Mark as RUNNING after successful provision

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -2356,7 +2356,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         with self._build_serve_client(sandbox_id) as client:
             return client.ensure_session(
                 None,
-                cwd=session_path,
+                directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
             )
 
@@ -2452,7 +2452,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             )
             resolved_session_id = client.ensure_session(
                 opencode_session_id,
-                cwd=session_path,
+                directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
             )
             if resolved_session_id != opencode_session_id:
@@ -2487,6 +2487,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                 for event in client.send_message(
                     resolved_session_id,
                     message,
+                    directory=session_path,
                     model_provider=agent_provider,
                     model_id=agent_model,
                 ):
@@ -2511,7 +2512,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                     events_count,
                 )
                 try:
-                    client.abort(resolved_session_id)
+                    client.abort(resolved_session_id, directory=session_path)
                 except Exception as abort_err:
                     logger.warning(
                         "[SANDBOX-SERVE] abort failed on GeneratorExit: %s",
@@ -2532,7 +2533,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                     e,
                 )
                 try:
-                    client.abort(resolved_session_id)
+                    client.abort(resolved_session_id, directory=session_path)
                 except Exception as abort_err:
                     logger.warning(
                         "[SANDBOX-SERVE] abort failed on Exception: %s",

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -775,21 +775,34 @@ class OpencodeServeClient:
         self,
         opencode_session_id: str | None,
         *,
-        cwd: str,
+        directory: str,
         title: str | None = None,
     ) -> str:
         """Return a valid opencode session id. Idempotent across replicas.
+
+        ``directory`` anchors the opencode Instance for this session.
+        Opencode-serve scopes its session store per-directory via the
+        ``?directory=`` query parameter on every route (the
+        ``Instance.provide`` middleware in ``server.ts``); the body field
+        is silently ignored. Without it, the session is created in the
+        server's launch cwd (``/workspace``) and every subsequent op must
+        also omit ``?directory=`` to find it — which silently breaks
+        per-session filesystem isolation.
 
         Tolerates a brief cold-pod window where the sandbox is K8s-Ready
         but opencode-serve hasn't bound :4096 yet — both connect failures
         and RemoteProtocolError ("server disconnected before sending a
         response") are retried with short backoff before bubbling up.
         """
+        directory_params = {"directory": directory}
         if opencode_session_id:
             # GET is idempotent — safe to retry on either ConnectError or
             # RemoteProtocolError.
             r = self._http_with_cold_pod_retry(
-                "GET", f"/session/{opencode_session_id}", idempotent=True
+                "GET",
+                f"/session/{opencode_session_id}",
+                params=directory_params,
+                idempotent=True,
             )
             if r.status_code == 200:
                 logger.info(
@@ -812,7 +825,7 @@ class OpencodeServeClient:
                 "[SESSION-LIFECYCLE] ensure_session: no caller-supplied id; creating"
             )
 
-        body: dict[str, Any] = {"directory": cwd}
+        body: dict[str, Any] = {}
         if title:
             body["title"] = title
         # POST /session is NOT idempotent — opencode mints a new session
@@ -821,7 +834,11 @@ class OpencodeServeClient:
         # RemoteProtocolError after a half-handled POST could leak an
         # orphan opencode session.
         r = self._http_with_cold_pod_retry(
-            "POST", "/session", json=body, idempotent=False
+            "POST",
+            "/session",
+            params=directory_params,
+            json=body,
+            idempotent=False,
         )
         _raise_for_status(r, "session create")
         data = r.json()
@@ -829,15 +846,18 @@ class OpencodeServeClient:
         if not isinstance(new_id, str):
             raise RuntimeError("opencode /session returned no id")
         logger.info(
-            "[SESSION-LIFECYCLE] ensure_session: POST /session -> id=%s (cwd=%s)",
+            "[SESSION-LIFECYCLE] ensure_session: POST /session -> id=%s (directory=%s)",
             new_id,
-            cwd,
+            directory,
         )
         return new_id
 
-    def delete_session(self, opencode_session_id: str) -> None:
+    def delete_session(self, opencode_session_id: str, *, directory: str) -> None:
         try:
-            r = self._http.delete(f"/session/{opencode_session_id}")
+            r = self._http.delete(
+                f"/session/{opencode_session_id}",
+                params={"directory": directory},
+            )
             if r.status_code not in (200, 204, 404):
                 logger.warning(
                     "opencode-serve: delete_session(%s) → HTTP %s",
@@ -851,7 +871,9 @@ class OpencodeServeClient:
                 e,
             )
 
-    def list_messages(self, opencode_session_id: str) -> list[dict[str, Any]]:
+    def list_messages(
+        self, opencode_session_id: str, *, directory: str
+    ) -> list[dict[str, Any]]:
         """Snapshot the assistant message accumulator. Returns the parsed
         JSON list directly — callers introspect via dict access.
 
@@ -859,16 +881,23 @@ class OpencodeServeClient:
         streaming and only populated post-terminator. Use this only for
         the post-terminator fallback in the reconnect path.
         """
-        r = self._http.get(f"/session/{opencode_session_id}/message")
+        r = self._http.get(
+            f"/session/{opencode_session_id}/message",
+            params={"directory": directory},
+        )
         _raise_for_status(r, "session messages")
         data = r.json()
         if isinstance(data, list):
             return cast(list[dict[str, Any]], data)
         return []
 
-    def abort(self, opencode_session_id: str) -> None:
+    def abort(self, opencode_session_id: str, *, directory: str) -> None:
         try:
-            self._http.post(f"/session/{opencode_session_id}/abort", json={})
+            self._http.post(
+                f"/session/{opencode_session_id}/abort",
+                params={"directory": directory},
+                json={},
+            )
         except httpx.HTTPError as e:
             logger.warning(
                 "opencode-serve: abort(%s) failed: %s",
@@ -877,13 +906,14 @@ class OpencodeServeClient:
             )
 
     def get_message(
-        self, opencode_session_id: str, message_id: str
+        self, opencode_session_id: str, message_id: str, *, directory: str
     ) -> dict[str, Any] | None:
         """GET /session/{id}/message/{id}. None on any failure (never raises)."""
         try:
             r = self._http_with_cold_pod_retry(
                 "GET",
                 f"/session/{opencode_session_id}/message/{message_id}",
+                params={"directory": directory},
                 idempotent=True,
             )
         except httpx.HTTPError as e:
@@ -914,11 +944,17 @@ class OpencodeServeClient:
         opencode_session_id: str,
         message: str,
         *,
+        directory: str,
         model_provider: str | None = None,
         model_id: str | None = None,
         timeout: float = ACP_MESSAGE_TIMEOUT,
     ) -> Generator[ACPEvent, None, None]:
         """Stream one turn of ACPEvents via the shared per-pod bus.
+
+        ``directory`` must match the one passed to :meth:`ensure_session`
+        — opencode-serve scopes its Instance (and therefore the session
+        store) per ``?directory=`` query param; calling with a different
+        directory will 404 the session.
 
         ``GeneratorExit`` (browser disconnect) → POST ``/abort``.
         Wall-clock timeout → POST ``/abort`` and yield :class:`Error`.
@@ -932,7 +968,7 @@ class OpencodeServeClient:
         state = _TurnState(session_id=opencode_session_id)
 
         def fetch_message(mid: str) -> dict[str, Any] | None:
-            return self.get_message(opencode_session_id, mid)
+            return self.get_message(opencode_session_id, mid, directory=directory)
 
         sub = self._event_bus.subscribe(opencode_session_id)
         try:
@@ -951,7 +987,11 @@ class OpencodeServeClient:
 
             try:
                 self._post_prompt_async(
-                    opencode_session_id, message, model_provider, model_id
+                    opencode_session_id,
+                    message,
+                    model_provider,
+                    model_id,
+                    directory=directory,
                 )
             except httpx.HTTPStatusError as e:
                 yield Error.model_validate(
@@ -968,11 +1008,16 @@ class OpencodeServeClient:
                 return
 
             yield from self._consume_from_bus(
-                sub, timeout, opencode_session_id, state, fetch_message
+                sub,
+                timeout,
+                opencode_session_id,
+                state,
+                fetch_message,
+                directory=directory,
             )
 
         except GeneratorExit:
-            self.abort(opencode_session_id)
+            self.abort(opencode_session_id, directory=directory)
             raise
         finally:
             self._event_bus.unsubscribe(sub)
@@ -984,6 +1029,8 @@ class OpencodeServeClient:
         opencode_session_id: str,
         state: _TurnState,
         fetch_message: Callable[[str], dict[str, Any] | None],
+        *,
+        directory: str,
     ) -> Generator[ACPEvent, None, None]:
         """Drain the bus queue, translate, yield until a
         :class:`PromptResponse` is emitted. permission.asked → auto-allow."""
@@ -993,7 +1040,7 @@ class OpencodeServeClient:
         while True:
             remaining = timeout - (time.monotonic() - start)
             if remaining <= 0:
-                self.abort(opencode_session_id)
+                self.abort(opencode_session_id, directory=directory)
                 yield Error.model_validate(
                     {"code": -1, "message": "Timeout waiting for response"}
                 )
@@ -1030,7 +1077,7 @@ class OpencodeServeClient:
                 yield acp_event
 
             if raw.get("type") == "permission.asked":
-                self._handle_permission_ask(raw, state.session_id)
+                self._handle_permission_ask(raw, state.session_id, directory=directory)
 
             if terminated_locally:
                 return
@@ -1043,6 +1090,8 @@ class OpencodeServeClient:
         message: str,
         model_provider: str | None,
         model_id: str | None,
+        *,
+        directory: str,
     ) -> None:
         """POST /session/.../prompt_async.
 
@@ -1054,10 +1103,16 @@ class OpencodeServeClient:
         body: dict[str, Any] = {"parts": [{"type": "text", "text": message}]}
         if model_provider and model_id:
             body["model"] = {"providerID": model_provider, "modelID": model_id}
-        r = self._http.post(f"/session/{opencode_session_id}/prompt_async", json=body)
+        r = self._http.post(
+            f"/session/{opencode_session_id}/prompt_async",
+            params={"directory": directory},
+            json=body,
+        )
         _raise_for_status(r, "prompt_async")
 
-    def _handle_permission_ask(self, evt: dict[str, Any], session_id: str) -> None:
+    def _handle_permission_ask(
+        self, evt: dict[str, Any], session_id: str, *, directory: str
+    ) -> None:
         """Auto-allow + telemetry per §Decisions #1.
 
         Production ``opencode.json`` should already cover every permission
@@ -1085,6 +1140,7 @@ class OpencodeServeClient:
         try:
             self._http.post(
                 f"/session/{session_id}/permissions/{perm_id}",
+                params={"directory": directory},
                 json={"response": "once"},
             )
         except httpx.HTTPError as e:

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -109,6 +109,35 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 
+def get_all_build_mode_llm_configs(
+    db_session: DBSession,
+    default: LLMProviderConfig,
+) -> list[LLMProviderConfig]:
+    """``default`` first, then every other ``build-mode-*`` provider with a
+    visible model. Used at sandbox provision time so every configured
+    provider is pre-registered in opencode.json and per-prompt model
+    overrides can cross providers without a pod restart.
+    """
+    configs: list[LLMProviderConfig] = [default]
+    seen_providers: set[str] = {default.provider}
+    for provider in fetch_all_build_mode_llm_providers(db_session):
+        if provider.provider in seen_providers:
+            continue
+        seen_providers.add(provider.provider)
+        visible_models = [m for m in provider.model_configurations if m.is_visible]
+        if not visible_models:
+            continue
+        configs.append(
+            LLMProviderConfig(
+                provider=provider.provider,
+                model_name=visible_models[0].name,
+                api_key=provider.api_key,
+                api_base=provider.api_base,
+            )
+        )
+    return configs
+
+
 class UploadLimitExceededError(ValueError):
     """Raised when file upload limits are exceeded."""
 
@@ -427,7 +456,9 @@ class SessionManager:
         provider pre-loaded so per-prompt model overrides can cross
         providers without a pod restart."""
         onyx_pat = ensure_sandbox_pat(self._db_session, sandbox, user)
-        all_llm_configs = self._get_all_llm_configs(default=llm_config)
+        all_llm_configs = get_all_build_mode_llm_configs(
+            self._db_session, default=llm_config
+        )
         sandbox_info = self._sandbox_manager.provision(
             sandbox_id=sandbox.id,
             user_id=user_id,
@@ -439,30 +470,6 @@ class SessionManager:
         update_sandbox_status__no_commit(
             self._db_session, sandbox.id, sandbox_info.status
         )
-
-    def _get_all_llm_configs(
-        self, default: LLMProviderConfig
-    ) -> list[LLMProviderConfig]:
-        """``default`` first, then every other ``build-mode-*`` provider
-        with a visible model."""
-        configs: list[LLMProviderConfig] = [default]
-        seen_providers: set[str] = {default.provider}
-        for provider in fetch_all_build_mode_llm_providers(self._db_session):
-            if provider.provider in seen_providers:
-                continue
-            seen_providers.add(provider.provider)
-            visible_models = [m for m in provider.model_configurations if m.is_visible]
-            if not visible_models:
-                continue
-            configs.append(
-                LLMProviderConfig(
-                    provider=provider.provider,
-                    model_name=visible_models[0].name,
-                    api_key=provider.api_key,
-                    api_base=provider.api_base,
-                )
-            )
-        return configs
 
     def ensure_sandbox_running(
         self,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_cold_pod_retry.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_cold_pod_retry.py
@@ -72,7 +72,7 @@ def test_ensure_session_retries_remoteprotocol_then_succeeds() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD)
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD)
     assert resolved == _STALE_ID
     assert call_count["n"] == 2
 
@@ -92,7 +92,7 @@ def test_ensure_session_retries_connecterror() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD)
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD)
     assert resolved == _STALE_ID
     assert call_count["n"] == 2
 
@@ -111,7 +111,7 @@ def test_ensure_session_exhausts_retries_and_raises() -> None:
     client = _make_client(transport, retries=2)  # 2 retries → 3 total attempts
 
     try:
-        client.ensure_session(_STALE_ID, cwd=_CWD)
+        client.ensure_session(_STALE_ID, directory=_CWD)
     except httpx.RemoteProtocolError:
         assert call_count["n"] == 3  # initial + 2 retries
         # Crucially: no POST /session ever fired.
@@ -136,7 +136,7 @@ def test_ensure_session_does_not_retry_on_http_error() -> None:
     client = _make_client(transport)
 
     try:
-        client.ensure_session(_STALE_ID, cwd=_CWD)
+        client.ensure_session(_STALE_ID, directory=_CWD)
     except httpx.HTTPStatusError as e:
         assert e.response.status_code == 500
         assert call_count["n"] == 1  # NO retries on 5xx
@@ -162,7 +162,7 @@ def test_ensure_session_retries_post_on_connecterror() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(None, cwd=_CWD)
+    resolved = client.ensure_session(None, directory=_CWD)
     assert resolved == _FRESH_ID
     assert call_count["n"] == 2
 
@@ -185,7 +185,7 @@ def test_ensure_session_does_not_retry_post_on_remoteprotocolerror() -> None:
     client = _make_client(transport)
 
     try:
-        client.ensure_session(None, cwd=_CWD)
+        client.ensure_session(None, directory=_CWD)
     except httpx.RemoteProtocolError:
         assert call_count["n"] == 1, (
             "POST /session must NOT retry on RemoteProtocolError"

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_session.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_session.py
@@ -22,6 +22,7 @@ HTTP-level contract so the higher-level test surface stays small.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
@@ -73,7 +74,7 @@ def test_ensure_session_reuses_valid_id_with_single_get() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD)
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD)
 
     assert resolved == _STALE_ID
     assert len(transport.requests) == 1
@@ -97,7 +98,9 @@ def test_ensure_session_creates_when_id_404s() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD, title="build-session-abc")
+    resolved = client.ensure_session(
+        _STALE_ID, directory=_CWD, title="build-session-abc"
+    )
 
     assert resolved == _FRESH_ID
     assert resolved != _STALE_ID  # MUST differ → triggers callback at caller
@@ -120,7 +123,7 @@ def test_ensure_session_creates_when_no_id_supplied() -> None:
     transport = _RecordingTransport(handler)
     client = _make_client(transport)
 
-    resolved = client.ensure_session(None, cwd=_CWD)
+    resolved = client.ensure_session(None, directory=_CWD)
 
     assert resolved == _FRESH_ID
     assert len(transport.requests) == 1
@@ -142,7 +145,7 @@ def test_ensure_session_raises_on_5xx_lookup() -> None:
     client = _make_client(transport)
 
     try:
-        client.ensure_session(_STALE_ID, cwd=_CWD)
+        client.ensure_session(_STALE_ID, directory=_CWD)
     except httpx.HTTPStatusError as e:
         assert e.response.status_code == 500
         # Exactly one request: we did NOT fall through to POST.
@@ -174,13 +177,46 @@ def test_ensure_session_callback_contract_triggers_on_id_mismatch() -> None:
         persisted_ids.append(new_id)
 
     # Mirror _send_message_via_serve's logic.
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD)
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD)
     if resolved != _STALE_ID:
         on_resolved(resolved)
 
     assert persisted_ids == [_FRESH_ID], (
         "callback must fire exactly once with the new id when stale"
     )
+
+
+def test_ensure_session_passes_directory_as_query_string() -> None:
+    """opencode-serve scopes Instance (and the session store) per
+    ``?directory=`` query param — the body field is silently ignored
+    (it's not in ``Session.create.schema``). If we omit the query, every
+    session lands in the server's launch cwd (``/workspace``), defeating
+    per-session filesystem isolation. Lock the query-string contract on
+    both the GET-lookup and POST-create paths.
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "GET" and req.url.path == f"/session/{_STALE_ID}":
+            return httpx.Response(404)
+        if req.method == "POST" and req.url.path == "/session":
+            return httpx.Response(200, json={"id": _FRESH_ID})
+        raise AssertionError(f"unexpected {req.method} {req.url.path}")
+
+    transport = _RecordingTransport(handler)
+    client = _make_client(transport)
+
+    client.ensure_session(_STALE_ID, directory=_CWD)
+
+    assert len(transport.requests) == 2
+    get_req, post_req = transport.requests
+    # Both calls must carry ?directory=... — without it opencode falls
+    # back to process.cwd() and the session is anchored to /workspace.
+    assert get_req.url.params.get("directory") == _CWD
+    assert post_req.url.params.get("directory") == _CWD
+    # Body must NOT carry directory — opencode reads it from the query
+    # and the Session.create schema would silently drop it.
+    body = json.loads(post_req.content)
+    assert "directory" not in body
 
 
 def test_ensure_session_callback_does_not_fire_on_valid_id() -> None:
@@ -201,7 +237,7 @@ def test_ensure_session_callback_does_not_fire_on_valid_id() -> None:
     def on_resolved(new_id: str) -> None:
         persisted_ids.append(new_id)
 
-    resolved = client.ensure_session(_STALE_ID, cwd=_CWD)
+    resolved = client.ensure_session(_STALE_ID, directory=_CWD)
     if resolved != _STALE_ID:
         on_resolved(resolved)
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
@@ -36,6 +36,7 @@ from onyx.server.features.build.sandbox.opencode.serve_client import ClientTimeo
 from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
 
 _SESSION = "ses_test_123"
+_DIRECTORY = "/workspace/sessions/test-session"
 
 
 # ---------------------------------------------------------------------------
@@ -115,6 +116,7 @@ def _run_send_message(
         for evt in client.send_message(
             _SESSION,
             "hello",
+            directory=_DIRECTORY,
             model_provider=model_provider,
             model_id=model_id,
             timeout=timeout,
@@ -431,7 +433,9 @@ def test_send_message_yields_error_on_prompt_async_http_error(
 
     transport = httpx.MockTransport(handler)
     client = _make_client(bus, transport)
-    events: list[Any] = list(client.send_message(_SESSION, "hello", timeout=2.0))
+    events: list[Any] = list(
+        client.send_message(_SESSION, "hello", directory=_DIRECTORY, timeout=2.0)
+    )
     assert len(events) == 1
     assert isinstance(events[0], Error)
     assert events[0].code == 500
@@ -445,7 +449,9 @@ def test_send_message_yields_error_on_prompt_async_connection_error(
 
     transport = httpx.MockTransport(handler)
     client = _make_client(bus, transport)
-    events: list[Any] = list(client.send_message(_SESSION, "hi", timeout=2.0))
+    events: list[Any] = list(
+        client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=2.0)
+    )
     assert len(events) == 1
     assert isinstance(events[0], Error)
     assert events[0].code == -3
@@ -459,7 +465,9 @@ def test_send_message_errors_when_stream_ready_never_set(bus: PodEventBus) -> No
     bus.stream_ready.clear()
     transport = httpx.MockTransport(_ok_response)
     client = _make_client(bus, transport, connect_timeout=0.2)
-    events = list(client.send_message(_SESSION, "hi", timeout=2.0))
+    events = list(
+        client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=2.0)
+    )
     assert len(events) == 1
     assert isinstance(events[0], Error)
     assert events[0].code == -3
@@ -500,7 +508,9 @@ def test_send_message_wall_clock_timeout_aborts(bus: PodEventBus) -> None:
     transport = httpx.MockTransport(handler)
     client = _make_client(bus, transport)
     # Don't push any events — let the timeout elapse.
-    events = list(client.send_message(_SESSION, "hi", timeout=0.3))
+    events = list(
+        client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=0.3)
+    )
     assert any(isinstance(e, Error) and e.code == -1 for e in events)
     assert any("/abort" in p for p in aborts)
 
@@ -529,7 +539,7 @@ def test_send_message_aborts_on_generator_exit(bus: PodEventBus) -> None:
     # subscribe via the bus path the client uses, so let the client do
     # its own subscribe; we just dispatch into the bus, which will route
     # to that subscription.
-    gen = client.send_message(_SESSION, "hi", timeout=5.0)
+    gen = client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=5.0)
     bus._dispatch(
         {
             "type": "message.updated",
@@ -661,7 +671,7 @@ def test_send_message_unsubscribes_on_http_error(bus: PodEventBus) -> None:
 
     transport = httpx.MockTransport(handler)
     client = _make_client(bus, transport)
-    list(client.send_message(_SESSION, "hi", timeout=2.0))
+    list(client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=2.0))
     assert _SESSION not in bus._subscribers
 
 
@@ -676,7 +686,7 @@ def test_send_message_requires_event_bus() -> None:
         transport=transport,
     )
     with pytest.raises(RuntimeError, match="requires event_bus"):
-        list(client.send_message(_SESSION, "hi"))
+        list(client.send_message(_SESSION, "hi", directory=_DIRECTORY))
 
 
 # ---------------------------------------------------------------------------
@@ -700,4 +710,6 @@ def _gen_to_completion(
 
     threading.Thread(target=fire, daemon=True).start()
     started.set()
-    yield from client.send_message(_SESSION, "hi", timeout=timeout)
+    yield from client.send_message(
+        _SESSION, "hi", directory=_DIRECTORY, timeout=timeout
+    )

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -9,15 +9,19 @@ pre-registered when the pod was created.
 
 from __future__ import annotations
 
-import inspect
-from typing import Any
+from datetime import datetime
 from typing import cast
+from unittest.mock import MagicMock
 from unittest.mock import patch
+from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
-from onyx.server.features.build.api import sessions_api
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
+from onyx.db.models import User
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.manage.llm.models import LLMProviderView
@@ -200,35 +204,69 @@ class TestGetAllBuildModeLlmConfigs:
         assert configs[0] == _OPENAI_DEFAULT
 
 
-class TestProvisionCallsitesPassAllLlmConfigs:
-    """Both ``sandbox_manager.provision()`` callsites must pass
-    ``all_llm_configs`` — bypassing it causes the multi-provider
-    config to collapse to ``[default]`` and per-prompt overrides fail.
-    Guards against the regression that motivated this helper.
+class TestSessionManagerProvisionForwardsAllLlmConfigs:
+    """``SessionManager._provision_sandbox`` must forward the full
+    multi-provider list to ``sandbox_manager.provision()`` — passing only
+    the default collapses ``opencode.json`` and per-prompt model
+    overrides start failing with "Model not found" until pod restart.
     """
 
-    def test_session_manager_provision_passes_all_llm_configs(self) -> None:
-        source = _get_source(SessionManager._provision_sandbox)
-        assert "all_llm_configs=" in source, (
-            "_provision_sandbox must forward all_llm_configs to "
-            "sandbox_manager.provision()"
-        )
-        assert "get_all_build_mode_llm_configs" in source, (
-            "_provision_sandbox must build all_llm_configs via "
-            "get_all_build_mode_llm_configs"
+    def test_provision_passes_all_llm_configs(self) -> None:
+        sandbox_id = uuid4()
+        user_id = uuid4()
+        tenant_id = "tenant-x"
+
+        sandbox = MagicMock(spec=Sandbox)
+        sandbox.id = sandbox_id
+        user = MagicMock(spec=User)
+
+        sandbox_manager = MagicMock()
+        sandbox_manager.provision.return_value = SandboxInfo(
+            sandbox_id=sandbox_id,
+            directory_path="/workspace/sessions",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=datetime.now(),
         )
 
-    def test_restore_session_passes_all_llm_configs(self) -> None:
-        source = _get_source(sessions_api.restore_session)
-        assert "all_llm_configs=" in source, (
-            "restore_session must forward all_llm_configs when calling "
-            "sandbox_manager.provision() on a sleeping/terminated pod"
-        )
-        assert "get_all_build_mode_llm_configs" in source, (
-            "restore_session must build all_llm_configs via "
-            "get_all_build_mode_llm_configs"
-        )
+        manager = SessionManager.__new__(SessionManager)
+        manager._db_session = cast(Session, MagicMock())  # type: ignore[attr-defined]
+        manager._sandbox_manager = sandbox_manager  # type: ignore[attr-defined]
 
+        expected_configs = [
+            _OPENAI_DEFAULT,
+            LLMProviderConfig(
+                provider="anthropic",
+                model_name="claude-opus-4-7",
+                api_key="k-anthropic",
+                api_base=None,
+            ),
+        ]
 
-def _get_source(fn: Any) -> str:
-    return inspect.getsource(fn)
+        with (
+            patch(
+                "onyx.server.features.build.session.manager.ensure_sandbox_pat",
+                return_value="pat-token",
+            ),
+            patch(
+                "onyx.server.features.build.session.manager.get_all_build_mode_llm_configs",
+                return_value=expected_configs,
+            ) as mock_get_all_configs,
+            patch(
+                "onyx.server.features.build.session.manager.update_sandbox_status__no_commit"
+            ),
+        ):
+            manager._provision_sandbox(
+                sandbox=sandbox,
+                user=user,
+                user_id=user_id,
+                tenant_id=tenant_id,
+                llm_config=_OPENAI_DEFAULT,
+            )
+
+        mock_get_all_configs.assert_called_once()
+        sandbox_manager.provision.assert_called_once()
+        kwargs = sandbox_manager.provision.call_args.kwargs
+        assert kwargs["all_llm_configs"] == expected_configs
+        assert kwargs["llm_config"] == _OPENAI_DEFAULT
+        assert kwargs["sandbox_id"] == sandbox_id
+        assert kwargs["onyx_pat"] == "pat-token"

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -1,0 +1,234 @@
+"""Unit tests for ``get_all_build_mode_llm_configs``.
+
+Covers the sandbox-provisioning helper that builds the list of LLM
+providers baked into ``OPENCODE_CONFIG_CONTENT``. Bugs here surface as
+"Model not found: <provider>/<model>" errors at agent invocation time
+because per-prompt overrides can only target providers that were
+pre-registered when the pod was created.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from typing import cast
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from onyx.server.features.build.api import sessions_api
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
+from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.manage.llm.models import ModelConfigurationView
+
+
+def _model(name: str, is_visible: bool = True) -> ModelConfigurationView:
+    return ModelConfigurationView(
+        name=name,
+        is_visible=is_visible,
+        supports_image_input=False,
+    )
+
+
+def _provider(
+    *,
+    name: str,
+    provider: str,
+    models: list[ModelConfigurationView],
+    api_key: str | None = "k",
+    api_base: str | None = None,
+) -> LLMProviderView:
+    return LLMProviderView(
+        id=1,
+        name=name,
+        provider=provider,
+        api_key=api_key,
+        api_base=api_base,
+        model_configurations=models,
+    )
+
+
+_OPENAI_DEFAULT = LLMProviderConfig(
+    provider="openai",
+    model_name="gpt-4o",
+    api_key="k-openai",
+    api_base=None,
+)
+
+
+def _run(rows: list[LLMProviderView]) -> list[LLMProviderConfig]:
+    """Invoke under a patched ``fetch_all_build_mode_llm_providers``."""
+    with patch(
+        "onyx.server.features.build.session.manager.fetch_all_build_mode_llm_providers",
+        return_value=rows,
+    ):
+        # db_session is unused once the fetch is patched.
+        return get_all_build_mode_llm_configs(
+            db_session=cast(Session, None),
+            default=_OPENAI_DEFAULT,
+        )
+
+
+class TestGetAllBuildModeLlmConfigs:
+    def test_default_only_when_no_build_mode_rows(self) -> None:
+        configs = _run([])
+        assert configs == [_OPENAI_DEFAULT]
+
+    def test_includes_build_mode_provider_with_visible_model(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-7")],
+                    api_key="k-anthropic",
+                )
+            ]
+        )
+        assert [(c.provider, c.model_name) for c in configs] == [
+            ("openai", "gpt-4o"),
+            ("anthropic", "claude-opus-4-7"),
+        ]
+        assert configs[1].api_key == "k-anthropic"
+
+    def test_skips_build_mode_provider_with_no_visible_models(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[_model("claude-hidden", is_visible=False)],
+                )
+            ]
+        )
+        assert configs == [_OPENAI_DEFAULT]
+
+    def test_skips_build_mode_provider_with_empty_model_list(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[],
+                )
+            ]
+        )
+        assert configs == [_OPENAI_DEFAULT]
+
+    def test_picks_first_visible_model_when_multiple_visible(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[
+                        _model("claude-opus-4-6"),
+                        _model("claude-opus-4-7"),
+                        _model("claude-sonnet-4-6"),
+                    ],
+                )
+            ]
+        )
+        assert configs[1].model_name == "claude-opus-4-6"
+
+    def test_skips_hidden_models_when_picking_first(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[
+                        _model("claude-hidden-1", is_visible=False),
+                        _model("claude-opus-4-7"),
+                    ],
+                )
+            ]
+        )
+        assert configs[1].model_name == "claude-opus-4-7"
+
+    def test_dedupes_when_default_provider_also_in_build_mode_rows(self) -> None:
+        """If the default's provider type is also tagged as build-mode, we
+        keep the default (with its real config) and skip the duplicate."""
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-openai",
+                    provider="openai",
+                    models=[_model("gpt-4o-mini")],
+                    api_key="k-build-openai",
+                )
+            ]
+        )
+        assert configs == [_OPENAI_DEFAULT]
+        # The default's api_key wins; we never overwrite with the build-mode row's.
+        assert configs[0].api_key == "k-openai"
+
+    def test_multiple_distinct_build_mode_providers(self) -> None:
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-7")],
+                ),
+                _provider(
+                    name="build-mode-google",
+                    provider="google",
+                    models=[_model("gemini-2.5-pro")],
+                ),
+            ]
+        )
+        assert [(c.provider, c.model_name) for c in configs] == [
+            ("openai", "gpt-4o"),
+            ("anthropic", "claude-opus-4-7"),
+            ("google", "gemini-2.5-pro"),
+        ]
+
+    def test_default_provider_preserved_first(self) -> None:
+        """Default always stays at index 0 regardless of fetched-row order."""
+        configs = _run(
+            [
+                _provider(
+                    name="build-mode-anthropic",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-7")],
+                )
+            ]
+        )
+        assert configs[0] == _OPENAI_DEFAULT
+
+
+class TestProvisionCallsitesPassAllLlmConfigs:
+    """Both ``sandbox_manager.provision()`` callsites must pass
+    ``all_llm_configs`` — bypassing it causes the multi-provider
+    config to collapse to ``[default]`` and per-prompt overrides fail.
+    Guards against the regression that motivated this helper.
+    """
+
+    def test_session_manager_provision_passes_all_llm_configs(self) -> None:
+        source = _get_source(SessionManager._provision_sandbox)
+        assert "all_llm_configs=" in source, (
+            "_provision_sandbox must forward all_llm_configs to "
+            "sandbox_manager.provision()"
+        )
+        assert "get_all_build_mode_llm_configs" in source, (
+            "_provision_sandbox must build all_llm_configs via "
+            "get_all_build_mode_llm_configs"
+        )
+
+    def test_restore_session_passes_all_llm_configs(self) -> None:
+        source = _get_source(sessions_api.restore_session)
+        assert "all_llm_configs=" in source, (
+            "restore_session must forward all_llm_configs when calling "
+            "sandbox_manager.provision() on a sleeping/terminated pod"
+        )
+        assert "get_all_build_mode_llm_configs" in source, (
+            "restore_session must build all_llm_configs via "
+            "get_all_build_mode_llm_configs"
+        )
+
+
+def _get_source(fn: Any) -> str:
+    return inspect.getsource(fn)


### PR DESCRIPTION
## Description

`restore_session()` called `sandbox_manager.provision()` without `all_llm_configs`, so the multi-provider config in `opencode.json` collapsed to just the default. Per-prompt model overrides that crossed providers then failed with `Model not found: <provider>/<model>` until the pod was restarted.

- Lift `_get_all_llm_configs` out of `SessionManager` into a module-level `get_all_build_mode_llm_configs()` helper so both provision callsites share the same logic.
- Call it from `restore_session()` and forward the result as `all_llm_configs=` (the missing kwarg that caused the bug).
- Add unit tests covering the helper (dedupe, hidden-model filtering, multi-provider ordering) plus regression guards that both provision callsites still pass `all_llm_configs`.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py`
- pre-commit (ty, ruff, ruff format) via the commit hook

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes restored sessions registering only the default LLM provider and scopes opencode-serve sessions to the correct directory. All build-mode providers are pre-registered, and the session directory is passed via query string to prevent filesystem isolation leaks.

- **Bug Fixes**
  - Added `get_all_build_mode_llm_configs(db_session, default)` to build `all_llm_configs` (default first; dedupe providers; skip hidden/no-model).
  - `restore_session()` now forwards `all_llm_configs`; `SessionManager._provision_sandbox()` uses the same helper.
  - Thread `?directory=` through all opencode-serve routes (`ensure_session`, `send_message`, `list_messages`, `get_message`, `abort`, `delete_session`, permission replies); remove it from POST bodies; update Kubernetes manager to pass `directory=session_path`.
  - Replaced source inspection with a mock-based assertion that `provision()` receives `all_llm_configs`; added unit tests for the helper and the `?directory=` contract.

<sup>Written for commit e61afe14a905670b0996acd2ca9e57a91d2c2ca0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11396?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

