### PR TITLE
chore(db): drop unused KG indexes + redundant chunk_stats.id index

### DIFF
--- a/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
+++ b/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
@@ -1,0 +1,131 @@
+"""drop_unused_kg_indexes
+
+Revision ID: c7bc8cc2921d
+Revises: b02d7b35e48b
+Create Date: 2026-05-26 13:00:00.000000
+
+Drop a set of unused database indexes from each tenant schema.
+
+Motivation
+----------
+The ``managed_services`` cluster's primary RDS instance hit the EXT4
+htree directory limit on its data volume because the multi-tenant
+deployment (>6,000 tenant schemas) creates the same set of indexes per
+schema, multiplying every redundant index by the tenant count. The
+Knowledge Graph (KG) feature is not in active use on
+``managed_services``: across 6,134 tenants we observed zero index
+scans on the KG indexes (``pg_stat_user_indexes.idx_scan = 0``) over a
+3+ day observation window. We are dropping their non-PK, non-unique
+indexes here.
+
+Also included: ``ix_chunk_stats_id``, a redundant b-tree on
+``chunk_stats.id`` that duplicates the primary key index.
+
+Out of scope: the underlying ``kg_*`` tables and their unique
+constraints (``uq_kg_*``) remain — only secondary indexes are dropped.
+If KG is re-enabled later, the corresponding ``CREATE INDEX``
+statements will need to be reintroduced via a follow-up migration.
+
+Manual cleanup already performed
+--------------------------------
+The DB-side ``DROP INDEX`` was run manually across all existing tenant
+schemas on 2026-05-26, before this migration shipped. This migration's
+job is to:
+
+  (a) catch any new tenants that received these indexes during
+      provisioning windows that overlapped the manual cleanup, and
+  (b) keep schema state matching the model definitions in this PR (so
+      that ``alembic upgrade head`` on a fresh tenant doesn't leave
+      orphan indexes that don't exist in ``models.py``).
+
+``IF EXISTS`` makes each DROP idempotent.
+
+Downgrade
+---------
+``downgrade()`` is intentionally a no-op. These indexes were determined
+to be unused and we don't want to restore them on rollback. If KG
+re-enablement is required, write a forward migration that recreates
+only the indexes that are actually needed for the new workload.
+"""
+
+from alembic import op
+import sqlalchemy as sa  # noqa: F401  (kept for alembic template consistency)
+
+
+# revision identifiers, used by Alembic.
+revision = "c7bc8cc2921d"
+down_revision = "b02d7b35e48b"
+branch_labels = None
+depends_on = None
+
+
+# 51 indexes dropped per tenant schema. Alembic runs with
+# schema_translate_map, so the unqualified index names below resolve to
+# the current tenant's schema for each invocation.
+INDEXES_TO_DROP = [
+    "idx_kg_entity_clustering_trigrams",
+    "idx_kg_entity_normalization_trigrams",
+    "ix_chunk_stats_id",
+    "ix_entity_extraction_staging_acl",
+    "ix_entity_extraction_staging_name_search",
+    "ix_entity_name_search",
+    "ix_entity_type_acl",
+    "ix_kg_entity_document_id",
+    "ix_kg_entity_entity_key",
+    "ix_kg_entity_entity_type_id_name",
+    "ix_kg_entity_extraction_staging_document_id",
+    "ix_kg_entity_extraction_staging_entity_key",
+    "ix_kg_entity_extraction_staging_entity_type_id_name",
+    "ix_kg_entity_extraction_staging_id_name",
+    "ix_kg_entity_extraction_staging_name",
+    "ix_kg_entity_extraction_staging_parent_key",
+    "ix_kg_entity_id_name",
+    "ix_kg_entity_name",
+    "ix_kg_entity_parent_key",
+    "ix_kg_entity_type_id_name",
+    "ix_kg_relationship_extraction_staging_id_name",
+    "ix_kg_relationship_extraction_staging_nodes",
+    "ix_kg_relationship_extraction_staging_relationship_type_id_name",
+    "ix_kg_relationship_extraction_staging_source_document",
+    "ix_kg_relationship_extraction_staging_source_node",
+    "ix_kg_relationship_extraction_staging_source_node_type",
+    "ix_kg_relationship_extraction_staging_target_node",
+    "ix_kg_relationship_extraction_staging_target_node_type",
+    "ix_kg_relationship_extraction_staging_type",
+    "ix_kg_relationship_id_name",
+    "ix_kg_relationship_nodes",
+    "ix_kg_relationship_relationship_type_id_name",
+    "ix_kg_relationship_source_document",
+    "ix_kg_relationship_source_node",
+    "ix_kg_relationship_source_node_type",
+    "ix_kg_relationship_target_node",
+    "ix_kg_relationship_target_node_type",
+    "ix_kg_relationship_type",
+    "ix_kg_relationship_type_extraction_staging_id_name",
+    "ix_kg_relationship_type_extraction_staging_name",
+    "ix_kg_relationship_type_extraction_staging_source_entit_11ac",
+    "ix_kg_relationship_type_extraction_staging_target_entit_6684",
+    "ix_kg_relationship_type_extraction_staging_type",
+    "ix_kg_relationship_type_id_name",
+    "ix_kg_relationship_type_name",
+    "ix_kg_relationship_type_source_entity_type_id_name",
+    "ix_kg_relationship_type_target_entity_type_id_name",
+    "ix_kg_relationship_type_type",
+    "ix_kg_term_id_term",
+    "ix_search_term_entities",
+    "ix_search_term_term",
+]
+
+
+def upgrade() -> None:
+    for index_name in INDEXES_TO_DROP:
+        op.execute(f"DROP INDEX IF EXISTS {index_name};")
+
+
+def downgrade() -> None:
+    # Intentional no-op. These indexes were determined unused (zero
+    # index scans across thousands of tenants over multiple days) and
+    # we do not restore them on rollback. If KG is re-enabled, write a
+    # forward migration that recreates only the indexes that the new
+    # workload actually needs.
+    pass

--- a/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
+++ b/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
@@ -14,11 +14,9 @@ catalog overhead in multi-tenant deployments.
 Out of scope: the ``kg_*`` tables themselves, their primary keys, and
 their unique constraints (``uq_*``) are unchanged.
 
-``upgrade()`` is idempotent — each ``DROP INDEX`` uses ``IF EXISTS``.
-
-``downgrade()`` is intentionally a no-op. If KG is reactivated, the
-needed indexes should be reintroduced via a forward migration tailored
-to the new workload rather than blindly restored.
+``upgrade()`` and ``downgrade()`` are both idempotent (``IF EXISTS`` on
+drop, ``IF NOT EXISTS`` on create). The two paths share a single source
+of truth (``INDEXES``) so they stay in sync.
 """
 
 import sqlalchemy as sa
@@ -31,67 +29,274 @@ branch_labels = None
 depends_on = None
 
 
-# Alembic runs per-tenant via SET search_path in env.py, so unqualified
-# index names below resolve to the current tenant's schema.
-INDEXES_TO_DROP = [
-    "idx_kg_entity_clustering_trigrams",
-    "idx_kg_entity_normalization_trigrams",
-    "ix_chunk_stats_id",
-    "ix_entity_extraction_staging_acl",
-    "ix_entity_extraction_staging_name_search",
-    "ix_entity_name_search",
-    "ix_entity_type_acl",
-    "ix_kg_entity_document_id",
-    "ix_kg_entity_entity_key",
-    "ix_kg_entity_entity_type_id_name",
-    "ix_kg_entity_extraction_staging_document_id",
-    "ix_kg_entity_extraction_staging_entity_key",
-    "ix_kg_entity_extraction_staging_entity_type_id_name",
-    "ix_kg_entity_extraction_staging_id_name",
-    "ix_kg_entity_extraction_staging_name",
-    "ix_kg_entity_extraction_staging_parent_key",
-    "ix_kg_entity_id_name",
-    "ix_kg_entity_name",
-    "ix_kg_entity_parent_key",
-    "ix_kg_entity_type_id_name",
-    "ix_kg_relationship_extraction_staging_id_name",
-    "ix_kg_relationship_extraction_staging_nodes",
-    "ix_kg_relationship_extraction_staging_relationship_type_id_name",
-    "ix_kg_relationship_extraction_staging_source_document",
-    "ix_kg_relationship_extraction_staging_source_node",
-    "ix_kg_relationship_extraction_staging_source_node_type",
-    "ix_kg_relationship_extraction_staging_target_node",
-    "ix_kg_relationship_extraction_staging_target_node_type",
-    "ix_kg_relationship_extraction_staging_type",
-    "ix_kg_relationship_id_name",
-    "ix_kg_relationship_nodes",
-    "ix_kg_relationship_relationship_type_id_name",
-    "ix_kg_relationship_source_document",
-    "ix_kg_relationship_source_node",
-    "ix_kg_relationship_source_node_type",
-    "ix_kg_relationship_target_node",
-    "ix_kg_relationship_target_node_type",
-    "ix_kg_relationship_type",
-    "ix_kg_relationship_type_extraction_staging_id_name",
-    "ix_kg_relationship_type_extraction_staging_name",
-    "ix_kg_relationship_type_extraction_staging_source_entit_11ac",
-    "ix_kg_relationship_type_extraction_staging_target_entit_6684",
-    "ix_kg_relationship_type_extraction_staging_type",
-    "ix_kg_relationship_type_id_name",
-    "ix_kg_relationship_type_name",
-    "ix_kg_relationship_type_source_entity_type_id_name",
-    "ix_kg_relationship_type_target_entity_type_id_name",
-    "ix_kg_relationship_type_type",
-    "ix_kg_term_id_term",
-    "ix_search_term_entities",
-    "ix_search_term_term",
+# (index_name, CREATE INDEX statement) for each index this migration
+# manages. Alembic runs per-tenant via SET search_path in env.py, so
+# unqualified names below resolve to the current tenant's schema.
+INDEXES: list[tuple[str, str]] = [
+    (
+        "idx_kg_entity_clustering_trigrams",
+        "CREATE INDEX IF NOT EXISTS idx_kg_entity_clustering_trigrams "
+        "ON kg_entity USING gin (name public.gin_trgm_ops)",
+    ),
+    (
+        "idx_kg_entity_normalization_trigrams",
+        "CREATE INDEX IF NOT EXISTS idx_kg_entity_normalization_trigrams "
+        "ON kg_entity USING gin (name_trigrams)",
+    ),
+    (
+        "ix_chunk_stats_id",
+        "CREATE INDEX IF NOT EXISTS ix_chunk_stats_id ON chunk_stats USING btree (id)",
+    ),
+    (
+        "ix_entity_extraction_staging_acl",
+        "CREATE INDEX IF NOT EXISTS ix_entity_extraction_staging_acl "
+        "ON kg_entity_extraction_staging USING btree (entity_type_id_name, acl)",
+    ),
+    (
+        "ix_entity_extraction_staging_name_search",
+        "CREATE INDEX IF NOT EXISTS ix_entity_extraction_staging_name_search "
+        "ON kg_entity_extraction_staging USING btree (name, entity_type_id_name)",
+    ),
+    (
+        "ix_entity_name_search",
+        "CREATE INDEX IF NOT EXISTS ix_entity_name_search "
+        "ON kg_entity USING btree (name, entity_type_id_name)",
+    ),
+    (
+        "ix_entity_type_acl",
+        "CREATE INDEX IF NOT EXISTS ix_entity_type_acl "
+        "ON kg_entity USING btree (entity_type_id_name, acl)",
+    ),
+    (
+        "ix_kg_entity_document_id",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_document_id "
+        "ON kg_entity USING btree (document_id)",
+    ),
+    (
+        "ix_kg_entity_entity_key",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_entity_key "
+        "ON kg_entity USING btree (entity_key)",
+    ),
+    (
+        "ix_kg_entity_entity_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_entity_type_id_name "
+        "ON kg_entity USING btree (entity_type_id_name)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_document_id",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_document_id "
+        "ON kg_entity_extraction_staging USING btree (document_id)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_entity_key",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_entity_key "
+        "ON kg_entity_extraction_staging USING btree (entity_key)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_entity_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_entity_type_id_name "
+        "ON kg_entity_extraction_staging USING btree (entity_type_id_name)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_id_name "
+        "ON kg_entity_extraction_staging USING btree (id_name)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_name "
+        "ON kg_entity_extraction_staging USING btree (name)",
+    ),
+    (
+        "ix_kg_entity_extraction_staging_parent_key",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_extraction_staging_parent_key "
+        "ON kg_entity_extraction_staging USING btree (parent_key)",
+    ),
+    (
+        "ix_kg_entity_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_id_name "
+        "ON kg_entity USING btree (id_name)",
+    ),
+    (
+        "ix_kg_entity_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_name ON kg_entity USING btree (name)",
+    ),
+    (
+        "ix_kg_entity_parent_key",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_parent_key "
+        "ON kg_entity USING btree (parent_key)",
+    ),
+    (
+        "ix_kg_entity_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_entity_type_id_name "
+        "ON kg_entity_type USING btree (id_name)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_id_name "
+        "ON kg_relationship_extraction_staging USING btree (id_name)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_nodes",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_nodes "
+        "ON kg_relationship_extraction_staging USING btree (source_node, target_node)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_relationship_type_id_name",
+        "CREATE INDEX IF NOT EXISTS "
+        "ix_kg_relationship_extraction_staging_relationship_type_id_name "
+        "ON kg_relationship_extraction_staging USING btree (relationship_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_source_document",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_source_document "
+        "ON kg_relationship_extraction_staging USING btree (source_document)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_source_node",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_source_node "
+        "ON kg_relationship_extraction_staging USING btree (source_node)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_source_node_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_source_node_type "
+        "ON kg_relationship_extraction_staging USING btree (source_node_type)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_target_node",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_target_node "
+        "ON kg_relationship_extraction_staging USING btree (target_node)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_target_node_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_target_node_type "
+        "ON kg_relationship_extraction_staging USING btree (target_node_type)",
+    ),
+    (
+        "ix_kg_relationship_extraction_staging_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_extraction_staging_type "
+        "ON kg_relationship_extraction_staging USING btree (type)",
+    ),
+    (
+        "ix_kg_relationship_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_id_name "
+        "ON kg_relationship USING btree (id_name)",
+    ),
+    (
+        "ix_kg_relationship_nodes",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_nodes "
+        "ON kg_relationship USING btree (source_node, target_node)",
+    ),
+    (
+        "ix_kg_relationship_relationship_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_relationship_type_id_name "
+        "ON kg_relationship USING btree (relationship_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_source_document",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_source_document "
+        "ON kg_relationship USING btree (source_document)",
+    ),
+    (
+        "ix_kg_relationship_source_node",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_source_node "
+        "ON kg_relationship USING btree (source_node)",
+    ),
+    (
+        "ix_kg_relationship_source_node_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_source_node_type "
+        "ON kg_relationship USING btree (source_node_type)",
+    ),
+    (
+        "ix_kg_relationship_target_node",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_target_node "
+        "ON kg_relationship USING btree (target_node)",
+    ),
+    (
+        "ix_kg_relationship_target_node_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_target_node_type "
+        "ON kg_relationship USING btree (target_node_type)",
+    ),
+    (
+        "ix_kg_relationship_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type "
+        "ON kg_relationship USING btree (type)",
+    ),
+    (
+        "ix_kg_relationship_type_extraction_staging_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_extraction_staging_id_name "
+        "ON kg_relationship_type_extraction_staging USING btree (id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_extraction_staging_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_extraction_staging_name "
+        "ON kg_relationship_type_extraction_staging USING btree (name)",
+    ),
+    (
+        "ix_kg_relationship_type_extraction_staging_source_entit_11ac",
+        "CREATE INDEX IF NOT EXISTS "
+        "ix_kg_relationship_type_extraction_staging_source_entit_11ac "
+        "ON kg_relationship_type_extraction_staging USING btree (source_entity_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_extraction_staging_target_entit_6684",
+        "CREATE INDEX IF NOT EXISTS "
+        "ix_kg_relationship_type_extraction_staging_target_entit_6684 "
+        "ON kg_relationship_type_extraction_staging USING btree (target_entity_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_extraction_staging_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_extraction_staging_type "
+        "ON kg_relationship_type_extraction_staging USING btree (type)",
+    ),
+    (
+        "ix_kg_relationship_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_id_name "
+        "ON kg_relationship_type USING btree (id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_name "
+        "ON kg_relationship_type USING btree (name)",
+    ),
+    (
+        "ix_kg_relationship_type_source_entity_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_source_entity_type_id_name "
+        "ON kg_relationship_type USING btree (source_entity_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_target_entity_type_id_name",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_target_entity_type_id_name "
+        "ON kg_relationship_type USING btree (target_entity_type_id_name)",
+    ),
+    (
+        "ix_kg_relationship_type_type",
+        "CREATE INDEX IF NOT EXISTS ix_kg_relationship_type_type "
+        "ON kg_relationship_type USING btree (type)",
+    ),
+    (
+        "ix_kg_term_id_term",
+        "CREATE INDEX IF NOT EXISTS ix_kg_term_id_term "
+        "ON kg_term USING btree (id_term)",
+    ),
+    (
+        "ix_search_term_entities",
+        "CREATE INDEX IF NOT EXISTS ix_search_term_entities "
+        "ON kg_term USING btree (entity_types)",
+    ),
+    (
+        "ix_search_term_term",
+        "CREATE INDEX IF NOT EXISTS ix_search_term_term "
+        "ON kg_term USING btree (id_term)",
+    ),
 ]
 
 
 def upgrade() -> None:
-    for index_name in INDEXES_TO_DROP:
-        op.execute(sa.text(f"DROP INDEX IF EXISTS {index_name};"))
+    for name, _create_sql in INDEXES:
+        op.execute(sa.text(f"DROP INDEX IF EXISTS {name};"))
 
 
 def downgrade() -> None:
-    pass
+    for _name, create_sql in INDEXES:
+        op.execute(sa.text(create_sql + ";"))

--- a/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
+++ b/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
@@ -4,53 +4,24 @@ Revision ID: c7bc8cc2921d
 Revises: b02d7b35e48b
 Create Date: 2026-05-26 13:00:00.000000
 
-Drop a set of unused database indexes from each tenant schema.
+Drop unused secondary indexes from KG tables and the redundant index
+on ``chunk_stats.id`` (already covered by its primary key).
 
-Motivation
-----------
-The ``managed_services`` cluster's primary RDS instance hit the EXT4
-htree directory limit on its data volume because the multi-tenant
-deployment (>6,000 tenant schemas) creates the same set of indexes per
-schema, multiplying every redundant index by the tenant count. The
-Knowledge Graph (KG) feature is not in active use on
-``managed_services``: across 6,134 tenants we observed zero index
-scans on the KG indexes (``pg_stat_user_indexes.idx_scan = 0``) over a
-3+ day observation window. We are dropping their non-PK, non-unique
-indexes here.
+These secondary indexes have no observed usage and are not used by
+current queries. Dropping them reduces per-tenant schema size and
+catalog overhead in multi-tenant deployments.
 
-Also included: ``ix_chunk_stats_id``, a redundant b-tree on
-``chunk_stats.id`` that duplicates the primary key index.
+Out of scope: the ``kg_*`` tables themselves, their primary keys, and
+their unique constraints (``uq_*``) are unchanged.
 
-Out of scope: the underlying ``kg_*`` tables and their unique
-constraints (``uq_kg_*``) remain — only secondary indexes are dropped.
-If KG is re-enabled later, the corresponding ``CREATE INDEX``
-statements will need to be reintroduced via a follow-up migration.
+``upgrade()`` is idempotent — each ``DROP INDEX`` uses ``IF EXISTS``.
 
-Manual cleanup already performed
---------------------------------
-The DB-side ``DROP INDEX`` was run manually across all existing tenant
-schemas on 2026-05-26, before this migration shipped. This migration's
-job is to:
-
-  (a) catch any new tenants that received these indexes during
-      provisioning windows that overlapped the manual cleanup, and
-  (b) keep schema state matching the model definitions in this PR (so
-      that ``alembic upgrade head`` on a fresh tenant doesn't leave
-      orphan indexes that don't exist in ``models.py``).
-
-``IF EXISTS`` makes each DROP idempotent.
-
-Downgrade
----------
-``downgrade()`` is intentionally a no-op. These indexes were determined
-to be unused and we don't want to restore them on rollback. If KG
-re-enablement is required, write a forward migration that recreates
-only the indexes that are actually needed for the new workload.
+``downgrade()`` is intentionally a no-op. If KG is reactivated, the
+needed indexes should be reintroduced via a forward migration tailored
+to the new workload rather than blindly restored.
 """
 
 from alembic import op
-import sqlalchemy as sa  # noqa: F401  (kept for alembic template consistency)
-
 
 # revision identifiers, used by Alembic.
 revision = "c7bc8cc2921d"
@@ -59,9 +30,8 @@ branch_labels = None
 depends_on = None
 
 
-# 51 indexes dropped per tenant schema. Alembic runs with
-# schema_translate_map, so the unqualified index names below resolve to
-# the current tenant's schema for each invocation.
+# Alembic runs per-tenant via SET search_path in env.py, so unqualified
+# index names below resolve to the current tenant's schema.
 INDEXES_TO_DROP = [
     "idx_kg_entity_clustering_trigrams",
     "idx_kg_entity_normalization_trigrams",
@@ -123,9 +93,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Intentional no-op. These indexes were determined unused (zero
-    # index scans across thousands of tenants over multiple days) and
-    # we do not restore them on rollback. If KG is re-enabled, write a
-    # forward migration that recreates only the indexes that the new
-    # workload actually needs.
     pass

--- a/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
+++ b/backend/alembic/versions/c7bc8cc2921d_drop_unused_kg_indexes.py
@@ -21,6 +21,7 @@ needed indexes should be reintroduced via a forward migration tailored
 to the new workload rather than blindly restored.
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -89,7 +90,7 @@ INDEXES_TO_DROP = [
 
 def upgrade() -> None:
     for index_name in INDEXES_TO_DROP:
-        op.execute(f"DROP INDEX IF EXISTS {index_name};")
+        op.execute(sa.text(f"DROP INDEX IF EXISTS {index_name};"))
 
 
 def downgrade() -> None:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -1196,9 +1196,7 @@ class KGEntityType(Base):
     __tablename__ = "kg_entity_type"
 
     # Primary identifier
-    id_name: Mapped[str] = mapped_column(
-        String, primary_key=True, nullable=False, index=True
-    )
+    id_name: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
 
     description: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
 
@@ -1267,23 +1265,20 @@ class KGRelationshipType(Base):
         NullFilteredString,
         primary_key=True,
         nullable=False,
-        index=True,
     )
 
-    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     source_entity_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     target_entity_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     definition: Mapped[bool] = mapped_column(
@@ -1301,7 +1296,7 @@ class KGRelationshipType(Base):
         comment="Clustering information for this relationship type",
     )
 
-    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
@@ -1338,23 +1333,20 @@ class KGRelationshipTypeExtractionStaging(Base):
         NullFilteredString,
         primary_key=True,
         nullable=False,
-        index=True,
     )
 
-    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     source_entity_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     target_entity_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     definition: Mapped[bool] = mapped_column(
@@ -1372,7 +1364,7 @@ class KGRelationshipTypeExtractionStaging(Base):
         comment="Clustering information for this relationship type",
     )
 
-    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
@@ -1406,18 +1398,12 @@ class KGEntity(Base):
     __tablename__ = "kg_entity"
 
     # Primary identifier
-    id_name: Mapped[str] = mapped_column(
-        NullFilteredString, primary_key=True, index=True
-    )
+    id_name: Mapped[str] = mapped_column(NullFilteredString, primary_key=True)
 
     # Basic entity information
-    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
-    entity_key: Mapped[str] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
-    parent_key: Mapped[str | None] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
+    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
+    entity_key: Mapped[str] = mapped_column(NullFilteredString, nullable=True)
+    parent_key: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
 
     name_trigrams: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String(3)),
@@ -1432,9 +1418,7 @@ class KGEntity(Base):
         comment="Attributes for this entity",
     )
 
-    document_id: Mapped[str | None] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
+    document_id: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
 
     alternative_names: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list
@@ -1445,7 +1429,6 @@ class KGEntity(Base):
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Relationship to KGEntityType
@@ -1483,12 +1466,6 @@ class KGEntity(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
-    __table_args__ = (
-        # Fixed column names in indexes
-        Index("ix_entity_type_acl", entity_type_id_name, acl),
-        Index("ix_entity_name_search", name, entity_type_id_name),
-    )
-
 
 class KGEntityExtractionStaging(Base):
     __tablename__ = "kg_entity_extraction_staging"
@@ -1498,11 +1475,10 @@ class KGEntityExtractionStaging(Base):
         NullFilteredString,
         primary_key=True,
         nullable=False,
-        index=True,
     )
 
     # Basic entity information
-    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    name: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     attributes: Mapped[dict] = mapped_column(
         postgresql.JSONB,
@@ -1512,9 +1488,7 @@ class KGEntityExtractionStaging(Base):
         comment="Attributes for this entity",
     )
 
-    document_id: Mapped[str | None] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
+    document_id: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
 
     alternative_names: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list
@@ -1525,7 +1499,6 @@ class KGEntityExtractionStaging(Base):
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Relationship to KGEntityType
@@ -1555,12 +1528,8 @@ class KGEntityExtractionStaging(Base):
     )
 
     # Parent Child Information
-    entity_key: Mapped[str] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
-    parent_key: Mapped[str | None] = mapped_column(
-        NullFilteredString, nullable=True, index=True
-    )
+    entity_key: Mapped[str] = mapped_column(NullFilteredString, nullable=True)
+    parent_key: Mapped[str | None] = mapped_column(NullFilteredString, nullable=True)
 
     event_time: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True),
@@ -1573,12 +1542,6 @@ class KGEntityExtractionStaging(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
-    __table_args__ = (
-        # Fixed column names in indexes
-        Index("ix_entity_type_acl", entity_type_id_name, acl),
-        Index("ix_entity_name_search", name, entity_type_id_name),
-    )
-
 
 class KGRelationship(Base):
     __tablename__ = "kg_relationship"
@@ -1587,45 +1550,41 @@ class KGRelationship(Base):
     id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         nullable=False,
-        index=True,
     )
 
     source_document: Mapped[str | None] = mapped_column(
-        NullFilteredString, ForeignKey("document.id"), nullable=True, index=True
+        NullFilteredString, ForeignKey("document.id"), nullable=True
     )
 
     # Source and target nodes (foreign keys to Entity table)
     source_node: Mapped[str] = mapped_column(
-        NullFilteredString, ForeignKey("kg_entity.id_name"), nullable=False, index=True
+        NullFilteredString, ForeignKey("kg_entity.id_name"), nullable=False
     )
 
     target_node: Mapped[str] = mapped_column(
-        NullFilteredString, ForeignKey("kg_entity.id_name"), nullable=False, index=True
+        NullFilteredString, ForeignKey("kg_entity.id_name"), nullable=False
     )
 
     source_node_type: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     target_node_type: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Relationship type
-    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     # Add new relationship type reference
     relationship_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_relationship_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Add the SQLAlchemy relationship property
@@ -1655,10 +1614,6 @@ class KGRelationship(Base):
     __table_args__ = (
         # Composite primary key
         PrimaryKeyConstraint("id_name", "source_document"),
-        # Index for querying relationships by type
-        Index("ix_kg_relationship_type", type),
-        # Composite index for source/target queries
-        Index("ix_kg_relationship_nodes", source_node, target_node),
         # Ensure unique relationships between nodes of a specific type
         UniqueConstraint(
             "source_node",
@@ -1676,11 +1631,10 @@ class KGRelationshipExtractionStaging(Base):
     id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         nullable=False,
-        index=True,
     )
 
     source_document: Mapped[str | None] = mapped_column(
-        NullFilteredString, ForeignKey("document.id"), nullable=True, index=True
+        NullFilteredString, ForeignKey("document.id"), nullable=True
     )
 
     # Source and target nodes (foreign keys to Entity table)
@@ -1688,39 +1642,34 @@ class KGRelationshipExtractionStaging(Base):
         NullFilteredString,
         ForeignKey("kg_entity_extraction_staging.id_name"),
         nullable=False,
-        index=True,
     )
 
     target_node: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_extraction_staging.id_name"),
         nullable=False,
-        index=True,
     )
 
     source_node_type: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     target_node_type: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_entity_type.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Relationship type
-    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False, index=True)
+    type: Mapped[str] = mapped_column(NullFilteredString, nullable=False)
 
     # Add new relationship type reference
     relationship_type_id_name: Mapped[str] = mapped_column(
         NullFilteredString,
         ForeignKey("kg_relationship_type_extraction_staging.id_name"),
         nullable=False,
-        index=True,
     )
 
     # Add the SQLAlchemy relationship property
@@ -1755,10 +1704,6 @@ class KGRelationshipExtractionStaging(Base):
     __table_args__ = (
         # Composite primary key
         PrimaryKeyConstraint("id_name", "source_document"),
-        # Index for querying relationships by type
-        Index("ix_kg_relationship_type", type),
-        # Composite index for source/target queries
-        Index("ix_kg_relationship_nodes", source_node, target_node),
         # Ensure unique relationships between nodes of a specific type
         UniqueConstraint(
             "source_node",
@@ -1774,7 +1719,7 @@ class KGTerm(Base):
 
     # Make id_term the primary key
     id_term: Mapped[str] = mapped_column(
-        NullFilteredString, primary_key=True, nullable=False, index=True
+        NullFilteredString, primary_key=True, nullable=False
     )
 
     # List of entity types this term applies to
@@ -1792,13 +1737,6 @@ class KGTerm(Base):
         DateTime(timezone=True), server_default=func.now()
     )
 
-    __table_args__ = (
-        # Index for searching terms with specific entity types
-        Index("ix_search_term_entities", entity_types),
-        # Index for term lookups
-        Index("ix_search_term_term", id_term),
-    )
-
 
 class ChunkStats(Base):
     __tablename__ = "chunk_stats"
@@ -1812,7 +1750,6 @@ class ChunkStats(Base):
         default=lambda context: (
             f"{context.get_current_parameters()['document_id']}__{context.get_current_parameters()['chunk_in_doc_id']}"
         ),
-        index=True,
     )
 
     # Reference to parent document


### PR DESCRIPTION
## Description

Removes `index=True` from 47 columns across the KG models (KGEntity, KGEntityType, KGEntityExtractionStaging, KGRelationship, KGRelationshipType, KGRelationshipTypeExtractionStaging, KGTerm) plus the redundant `index=True` on `ChunkStats.id` (already covered by its primary key). Removes 6 explicit `Index(...)` declarations in `__table_args__` for the same indexes. Adds an idempotent alembic migration `c7bc8cc2921d` that runs `DROP INDEX IF EXISTS` for the 51 corresponding indexes per-tenant.

### Why

KG indexes are unused: `pg_stat_user_indexes.idx_scan = 0` across every KG index on every tenant schema observed over a 3+ day window. The Knowledge Graph feature isn't in active use, so its secondary indexes are pure overhead — schema bloat, planner cost, and per-tenant file-count pressure in multi-tenant deployments.

This PR is one wave of a broader index cleanup. A prior wave (run separately) cleaned up 45 alembic-only "removed feature" indexes. Wave 3.A in this PR removes the unused KG indexes plus the PK-duplicate `ix_chunk_stats_id`.

### Migration semantics

- `upgrade()` iterates 51 names and calls `op.execute("DROP INDEX IF EXISTS <name>;")`. Alembic runs per-tenant via `SET search_path` in `env.py`, so unqualified names resolve to the current tenant's schema.
- Idempotent: `IF EXISTS` makes each DROP safe to re-run.
- `downgrade()` is intentionally a no-op. These indexes were determined unused; rollback should not recreate them. If KG is re-enabled later, recreation should happen via a forward migration tailored to the new workload.

### Trade-offs surfaced in review

A few dropped `*_document_id` / `*_source_document` indexes are still referenced by code paths that run regardless of whether KG has data:
- The `update_kg_entity_name_from_doc` PG trigger fires on every document upsert that touches `semantic_id` and does `UPDATE kg_entity WHERE document_id = NEW.id`.
- `delete_documents_complete__no_commit` (`backend/onyx/db/document.py`) unconditionally clears KG tables on every document deletion.

Cost is effectively zero on empty KG tables (cheap empty-table scan). Cost grows linearly if any tenant ever repopulates KG. If KG is re-enabled, the four `*_document_id` / `*_source_document` indexes can be reintroduced via a follow-up migration.

## How Has This Been Tested?

- `from onyx.db import models` imports cleanly.
- `alembic heads` returns a single head (`c7bc8cc2921d`) — no graph divergence.
- The 51-entry `INDEXES_TO_DROP` list was generated from live `pg_class` (every name corresponds to an index that actually exists in tenant schemas).
- The DB-side DROP was executed ahead of this PR shipping; the migration is the persistent codification (handles future tenant provisioning and brings model state into sync).
- No Python code outside `alembic/versions/` hardcodes any of the dropped index names (grep verified across `backend/` and `web/`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check