### PR TITLE
ci(helm): serialize releases to avoid gh-pages push race

### DIFF
--- a/.github/workflows/helm-chart-releases.yml
+++ b/.github/workflows/helm-chart-releases.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: write-all
 
+concurrency:
+  group: helm-chart-releases
+  cancel-in-progress: false
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Summary
- Adds a workflow-level `concurrency` group to `.github/workflows/helm-chart-releases.yml` so only one Helm release runs at a time.
- `cancel-in-progress: false` keeps queued releases instead of dropping them.

## Why
The most recent failure of `Release Onyx Helm Charts` ([run 26305351288](https://github.com/onyx-dot-app/onyx/actions/runs/26305351288/job/77440616410)) died on a `gh-pages` push race:

```
! [rejected]        gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/onyx-dot-app/onyx'
```

Two near-simultaneous merges to `main` both kicked off the release job; the second push lost the race because `stefanprodan/helm-gh-pages` clones, packages, and pushes without rebasing. Serializing the job eliminates the race entirely.

## Test plan
- [ ] Merge and confirm subsequent releases continue to publish to `gh-pages`.
- [ ] Trigger two merges in quick succession (or wait for one to occur organically) and verify the second run queues rather than racing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize Helm chart releases by adding a workflow-level `concurrency` group so only one release job runs at a time, preventing `gh-pages` push races. Set `cancel-in-progress: false` to queue subsequent runs instead of canceling them.

<sup>Written for commit d55eafe79d3761605df6844cdc5941c86438d475. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11399?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

