### PR TITLE
perf(ci): skip project sync for ods check-lazy-imports hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,6 @@ repos:
         files: ^(pyproject\.toml|uv\.lock|backend/requirements/.*\.txt)$
       - id: uv-run
         name: Check lazy imports
-        # --no-project skips syncing the backend's full dep tree; the Go-based
-        # `ods check-lazy-imports` only needs the `ods` binary from onyx-devtools.
         args: ["--no-project", "--with=onyx-devtools", "ods", "check-lazy-imports"]
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,9 @@ repos:
         files: ^(pyproject\.toml|uv\.lock|backend/requirements/.*\.txt)$
       - id: uv-run
         name: Check lazy imports
-        args: ["--with=onyx-devtools", "ods", "check-lazy-imports"]
+        # --no-project skips syncing the backend's full dep tree; the Go-based
+        # `ods check-lazy-imports` only needs the `ods` binary from onyx-devtools.
+        args: ["--no-project", "--with=onyx-devtools", "ods", "check-lazy-imports"]
         pass_filenames: true
         files: ^backend/(?!\.venv/|scripts/).*\.py$
       - id: uv-run


### PR DESCRIPTION
## Summary
- `ods check-lazy-imports` is a Go scanner over Python source (`tools/ods/cmd/check_lazy_imports.go`); it only needs the `ods` binary shipped in the `onyx-devtools` wheel, not the backend's full dep tree.
- Added `--no-project` to the `uv-run` args so the hook runs in an ephemeral uv env containing only `onyx-devtools`, skipping the project sync that previously dominated hook setup time.
- No change to `pr-database-tests.yml` — it already installs only `default.txt` + `dev.txt`, and those requirement exports are built with `--no-default-groups` + an explicit group, so `model_server` deps are never pulled in.

Closes https://github.com/onyx-dot-app/onyx/actions/runs/26254256080/job/77272963657

## Test plan
- [ ] CI: `Quality Checks PR` (`quality-checks` job) runs prek and exercises the lazy-imports hook end-to-end.
- [ ] Locally: `pre-commit run --files backend/onyx/llm/factory.py` (or any backend `.py` covered by the `files:` filter) completes successfully and visibly avoids syncing the project venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the lazy-imports pre-commit hook by adding `--no-project` to `uv`, so `ods check-lazy-imports` runs in an ephemeral env with only `onyx-devtools` instead of syncing the full project. This cuts hook setup time in CI and local runs.

<sup>Written for commit 18511fbf1353381cee8402af3cfe417111101301. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11400?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



