### PR TITLE
feat(craft): port DockerSandboxManager to opencode-serve transport

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -245,7 +245,7 @@ OPENCODE_SERVE_PORT = int(os.environ.get("OPENCODE_SERVE_PORT", "4096"))
 # password for opencode serve. Internal contract — the api_server writes
 # this name and opencode-serve reads it, so both ends must agree. Not
 # operator-tunable.
-OPENCODE_SERVER_PASSWORD_ENV = "OPENCODE_SERVER_PASSWORD"
+OPENCODE_SERVER_PASSWORD = "OPENCODE_SERVER_PASSWORD"
 
 # Username for HTTP Basic Auth against opencode serve. Opencode's serve
 # implementation hard-codes the username to "opencode" when only

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -241,14 +241,11 @@ AGENT_TRANSPORT = AgentTransport(
 # Match against the EXPOSE directive in the sandbox Dockerfile.
 OPENCODE_SERVE_PORT = int(os.environ.get("OPENCODE_SERVE_PORT", "4096"))
 
-# Name of the env var inside the sandbox container that holds the
-# per-pod HTTP Basic Auth password for opencode serve. The sandbox manager
-# is responsible for generating + provisioning the per-pod K8s Secret
-# (see docs/craft/opencode-serve-migration.md §Pod / image changes) and
-# mounting it under this name in the sandbox container's env.
-OPENCODE_SERVER_PASSWORD_ENV = os.environ.get(
-    "OPENCODE_SERVER_PASSWORD_ENV", "OPENCODE_SERVER_PASSWORD"
-)
+# Env var inside the sandbox container that holds the per-pod HTTP Basic
+# password for opencode serve. Internal contract — the api_server writes
+# this name and opencode-serve reads it, so both ends must agree. Not
+# operator-tunable.
+OPENCODE_SERVER_PASSWORD_ENV = "OPENCODE_SERVER_PASSWORD"
 
 # Username for HTTP Basic Auth against opencode serve. Opencode's serve
 # implementation hard-codes the username to "opencode" when only

--- a/backend/onyx/server/features/build/sandbox/acp/base.py
+++ b/backend/onyx/server/features/build/sandbox/acp/base.py
@@ -42,7 +42,7 @@ from pydantic import ValidationError
 from onyx.server.features.build.api.packet_logger import get_packet_logger
 from onyx.server.features.build.configs import ACP_MESSAGE_TIMEOUT
 from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
-from onyx.server.features.build.sandbox.base import SSEKeepalive
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -56,9 +56,10 @@ from onyx.server.features.build.sandbox.opencode.serve_client import (
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 
-# Re-export SSEKeepalive so existing ``from ...sandbox.base import
-# SSEKeepalive`` callers keep working after the move into sse.py.
-__all__ = ["SSEKeepalive"]
+# SSEKeepalive is imported at module level so ``from ...sandbox.base import
+# SSEKeepalive`` keeps working for callers (session/manager.py et al) after
+# the class moved into sse.py. No `__all__` — module-namespace imports
+# resolve by attribute lookup, not star-import filter.
 
 logger = setup_logger()
 
@@ -419,6 +420,7 @@ class SandboxManager(ABC):
             yield True
             return
 
+        self._init_serve_state()
         key = (sandbox_id, build_session_id)
         with self._prompt_locks_meta:
             lock = self._prompt_locks.get(key)
@@ -461,10 +463,10 @@ class SandboxManager(ABC):
         """
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return None
-        session_path = f"/workspace/sessions/{session_id}"
+        session_path = self._session_directory(session_id)
         logger.info(
             "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
-            "sandbox=%s cwd=%s (passing id=None, so client will POST /session)",
+            "sandbox=%s directory=%s (passing id=None, so client will POST /session)",
             session_id,
             sandbox_id,
             session_path,
@@ -485,6 +487,7 @@ class SandboxManager(ABC):
         under ACP (no shared event bus to track subagents)."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return []
+        self._init_serve_state()
         # Don't create a bus just to list — that spins up a reader thread
         # for a caller that didn't ask for events.
         with self._event_buses_lock:
@@ -553,10 +556,24 @@ class SandboxManager(ABC):
     # and `_read_opencode_password`); the rest of the serve transport is
     # backend-agnostic and lives here.
 
+    @staticmethod
+    def _session_directory(session_id: UUID) -> str:
+        """Absolute in-sandbox path for a session's workspace.
+
+        Single source of truth for the path layout — both managers mount
+        the same ``/workspace/sessions`` root inside the container/pod,
+        so the path is backend-agnostic.
+        """
+        return f"/workspace/sessions/{session_id}"
+
     def _init_serve_state(self) -> None:
-        """Initialize per-instance serve-transport state. Subclasses MUST
-        call this from their ``_initialize`` before any serve-path method
-        runs. Idempotent — guarded against double-init via attribute check.
+        """Initialize per-instance serve-transport state. Idempotent —
+        guarded against double-init via attribute check.
+
+        Called eagerly from each subclass ``_initialize`` (so the first
+        prompt doesn't pay init cost) AND lazily from every serve-state
+        accessor on the base class, so a subclass that forgets the eager
+        call still bootstraps on first use.
         """
         if getattr(self, "_serve_state_initialized", False):
             return
@@ -649,6 +666,7 @@ class SandboxManager(ABC):
         budget) with a fresh one — otherwise callers would keep getting
         ``BUS_CLOSED_SENTINEL`` until the api server restarted.
         """
+        self._init_serve_state()
         with self._event_buses_lock:
             bus = self._event_buses.get(sandbox_id)
             if bus is not None and not bus.closed:
@@ -720,7 +738,7 @@ class SandboxManager(ABC):
         a race.
         """
         packet_logger = get_packet_logger()
-        session_path = f"/workspace/sessions/{session_id}"
+        session_path = self._session_directory(session_id)
         client = self._build_serve_client(sandbox_id)
         try:
             logger.info(

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -488,11 +488,7 @@ class SandboxManager(ABC):
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return []
         self._init_serve_state()
-        # Don't create a bus just to list — that spins up a reader thread
-        # for a caller that didn't ask for events. Walk every existing
-        # per-directory bus belonging to this sandbox; the parent
-        # ``session.created`` event landed on whichever directory's bus
-        # was live when the spawn happened.
+        # Walk existing buses only — don't spin up a reader thread just to list.
         with self._event_buses_lock:
             buses = [
                 bus for (sid, _), bus in self._event_buses.items() if sid == sandbox_id
@@ -511,16 +507,9 @@ class SandboxManager(ABC):
         directory: str,
         keepalive_seconds: float = 15.0,
     ) -> Generator["ACPEvent", None, None]:
-        """Stream translated ACP events for an opencode session (parent
-        or child). Never terminates on its own; caller closes via
-        ``GeneratorExit``. Empty under ACP.
-
-        ``directory`` is the in-sandbox session path
-        (``/workspace/sessions/{build_session_id}``) — opencode-serve
-        scopes its session store per-directory, so the hydrate REST call
-        needs it. Without it, the delta-before-``message.updated`` race
-        falls back to the negative-cache path and drops in-flight
-        deltas for the current step on subagent streams.
+        """Stream translated ACP events for an opencode session. Caller closes
+        via ``GeneratorExit``. ``directory`` is required: opencode-serve scopes
+        its session store per-directory, so the hydrate REST call needs it.
         """
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return
@@ -555,47 +544,21 @@ class SandboxManager(ABC):
             bus.unsubscribe(sub)
             client.close()
 
-    # =====================================================================
-    # opencode serve transport — shared plumbing
-    # =====================================================================
-    #
-    # Subclasses provide the two backend-specific endpoints (`_serve_base_url`
-    # and `_read_opencode_password`); the rest of the serve transport is
-    # backend-agnostic and lives here.
-
     @staticmethod
     def _session_directory(session_id: UUID) -> str:
-        """Absolute in-sandbox path for a session's workspace.
-
-        Single source of truth for the path layout — both managers mount
-        the same ``/workspace/sessions`` root inside the container/pod,
-        so the path is backend-agnostic.
-        """
         return f"/workspace/sessions/{session_id}"
 
     def _init_serve_state(self) -> None:
-        """Initialize per-instance serve-transport state. Idempotent —
-        guarded against double-init via attribute check.
-
-        Called eagerly from each subclass ``_initialize`` (so the first
-        prompt doesn't pay init cost) AND lazily from every serve-state
-        accessor on the base class, so a subclass that forgets the eager
-        call still bootstraps on first use.
-        """
+        """Idempotent init for serve-transport state. Called eagerly from each
+        subclass ``_initialize`` and lazily from accessors as a safety net."""
         if getattr(self, "_serve_state_initialized", False):
             return
-        # One PodEventBus per (sandbox, directory). Opencode-serve's
-        # ``Instance.provide`` middleware scopes /event per ``?directory=``
-        # query param, so each session directory needs its own SSE stream.
+        # Per-(sandbox, directory): opencode-serve scopes /event by ?directory=.
         self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
-        # Tombstone set: blocks late ``subscribe`` from re-creating a bus
-        # for a sandbox whose terminate is in flight (leaks a reconnect
-        # loop otherwise). Cleared on re-provision.
+        # Tombstone: blocks late subscribe from racing a terminate.
         self._terminated_sandboxes: set[UUID] = set()
         self._event_buses_lock = threading.Lock()
-        # Per-(sandbox_id, build_session_id) locks that serialize concurrent
-        # send_message calls on a single build session. See prompt_slot for
-        # why we key on build_session_id rather than opencode_session_id.
+        # Key on build_session_id, not opencode_session_id — see prompt_slot.
         self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
         self._prompt_locks_meta: threading.Lock = threading.Lock()
         self._serve_state_initialized = True
@@ -611,12 +574,8 @@ class SandboxManager(ABC):
 
     @abstractmethod
     def _read_opencode_password(self, sandbox_id: UUID) -> str | None:
-        """Backend-specific lookup of the per-sandbox HTTP Basic password.
-
-        Returns ``None`` if the sandbox doesn't have one (e.g. legacy
-        provisioned before this code landed). Callers should fall back
-        to no-auth in that case.
-        """
+        """Per-sandbox HTTP Basic password. ``None`` for legacy sandboxes
+        provisioned before this code landed; caller falls back to no-auth."""
         ...
 
     def _wait_for_opencode_serve_ready(
@@ -624,18 +583,10 @@ class SandboxManager(ABC):
         sandbox_id: UUID,
         timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
     ) -> bool:
-        """Block until opencode-serve answers ``GET /doc`` with 200.
-
-        Backend readiness (k8s pod Ready / docker container running) only
-        proves the supervisor process is up. opencode-serve binds ``:4096``
-        a few hundred ms to a few seconds later, after it finishes config
-        parse and provider registry init. Returning RUNNING before that
-        means the first prompt's bus subscribe races a cold opencode —
-        connection refused or stale-auth 401 burns the bus's reconnect
-        budget and surfaces to the user as ``stream did not become ready``.
-
-        No-op under AGENT_TRANSPORT=acp.
-        """
+        """Block until opencode-serve answers ``GET /doc`` with 200. Backend
+        readiness only proves the supervisor is up; opencode binds :4096 a
+        few seconds later. Skipping this races the first prompt's bus
+        subscribe → "stream did not become ready"."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return True
 
@@ -668,17 +619,9 @@ class SandboxManager(ABC):
         return False
 
     def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
-        """Lazily build the per-(sandbox, directory) :class:`PodEventBus`.
-        Refuses to create one for a terminated sandbox.
-
-        Opencode-serve's ``Instance.provide`` middleware scopes /event per
-        ``?directory=`` query param, so each unique session directory on
-        a sandbox needs its own SSE stream.
-
-        Replaces a cached bus that has self-closed (exhausted its reconnect
-        budget) with a fresh one — otherwise callers would keep getting
-        ``BUS_CLOSED_SENTINEL`` until the api server restarted.
-        """
+        """Lazy per-(sandbox, directory) bus. Refuses to create for a terminated
+        sandbox. Replaces self-closed buses so callers don't wedge on
+        BUS_CLOSED_SENTINEL until restart."""
         self._init_serve_state()
         key = (sandbox_id, directory)
         with self._event_buses_lock:
@@ -746,17 +689,9 @@ class SandboxManager(ABC):
         *,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
     ) -> Generator["ACPEvent", None, None]:
-        """Stream ACP events by driving the in-sandbox ``opencode serve`` via
-        :class:`OpencodeServeClient`. See
-        ``docs/craft/opencode-serve-migration.md``.
-
-        ``opencode_session_id`` is the caller-persisted id from
-        ``BuildSession.opencode_session_id``. If ``None``, fall back to
-        creating one inline — but the session manager *should* preflight
-        via :meth:`ensure_opencode_session` and persist before calling
-        here, to avoid creating a fresh opencode session per turn under
-        a race.
-        """
+        """Stream ACP events via the in-sandbox ``opencode serve``. Callers
+        should preflight ``opencode_session_id`` with
+        :meth:`ensure_opencode_session` to avoid one orphan session per turn."""
         packet_logger = get_packet_logger()
         session_path = self._session_directory(session_id)
         client = self._build_serve_client(sandbox_id, session_path)
@@ -773,12 +708,8 @@ class SandboxManager(ABC):
                 title=f"build-session-{str(session_id)[:8]}",
             )
             if resolved_session_id != opencode_session_id:
-                # Caller's persisted id was stale (404) or missing. Notify
-                # the caller so they can persist the new id; without this,
-                # _ensure_opencode_session_id would reload the same stale
-                # id from the DB on every turn, 404 again, and orphan a
-                # fresh opencode session per turn (one assistant message
-                # per orphan → conversation loses all prior context).
+                # Notify caller so they persist the new id — without this we
+                # orphan one opencode session per turn (lose conversation context).
                 if opencode_session_id is not None:
                     logger.warning(
                         "[SANDBOX-SERVE] persisted opencode_session_id %s was "

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -14,9 +14,6 @@ Architecture Note (User-Shared Sandbox Model):
 - terminate() destroys the entire sandbox (all sessions)
 """
 
-import contextlib
-import os
-import queue
 import threading
 import time
 from abc import ABC
@@ -27,14 +24,8 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from uuid import UUID
 
-import httpx
-from acp.schema import PromptResponse
-
-from onyx.server.features.build.api.packet_logger import get_packet_logger
 from onyx.server.features.build.configs import AGENT_TRANSPORT
 from onyx.server.features.build.configs import AgentTransport
-from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
-from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.sandbox.models import FatalWriteError
@@ -46,20 +37,8 @@ from onyx.server.features.build.sandbox.models import PushResult
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
-from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
-from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
-from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
-from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
-from onyx.server.features.build.sandbox.opencode.serve_client import (
-    translate_opencode_event,
-)
-from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.features.build.sandbox.serve_transport import _ServeMixin
 from onyx.utils.logger import setup_logger
-
-# SSEKeepalive is imported at module level so ``from ...sandbox.base import
-# SSEKeepalive`` keeps working for callers (session/manager.py et al) after
-# the class moved into sse.py. No `__all__` — module-namespace imports
-# resolve by attribute lookup, not star-import filter.
 
 logger = setup_logger()
 
@@ -78,21 +57,8 @@ BUN_IMAGE_CACHE_DIR = "/home/sandbox/.bun/install/cache"
 # happens in the implementation modules
 ACPEvent = Any
 
-# Hostname of the api_server process — surfaces in serve-transport logs so
-# operators can tell which replica is driving a given prompt. Pod name in
-# K8s, container short-ID in Docker, "unknown" outside containers.
-_API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 
-# After the sandbox backend (pod/container) reports Ready, opencode-serve
-# still has to finish its own boot (config parse, provider registry init,
-# HTTP server bind on :4096). Empirically 1–3s warm, up to ~15s cold.
-# Budget 30s so a slow boot fails loudly here instead of as a downstream
-# "stream did not become ready".
-OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
-OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
-
-
-class SandboxManager(ABC):
+class SandboxManager(_ServeMixin, ABC):
     """Abstract interface for sandbox operations.
 
     Defines the contract for sandbox lifecycle management including:
@@ -117,6 +83,12 @@ class SandboxManager(ABC):
             │   └── attachments/
             └── $session_id_2/
                 └── ...
+
+    Serve-transport plumbing lives in :class:`_ServeMixin` (composed via
+    MRO). Subclasses get the event-bus cache, prompt slot, readiness probe,
+    and serve send-message loop for free; they only have to implement
+    :meth:`_load_serve_connection_info` (one read, cached forever) plus
+    the abstract methods declared below.
 
     IMPORTANT: Implementations must NOT interface with the database directly.
     All database operations should be handled by the caller.
@@ -171,6 +143,10 @@ class SandboxManager(ABC):
         Destroys the entire sandbox including all session workspaces.
         Use cleanup_session_workspace() to remove individual sessions.
 
+        Implementations MUST call ``self._close_all_sandbox_buses(sandbox_id)``
+        before destroying the container/pod so late subscribes can't race
+        a fresh bus against a deleted backend.
+
         Args:
             sandbox_id: The sandbox ID to terminate
         """
@@ -224,6 +200,11 @@ class SandboxManager(ABC):
 
         1. Stop the Next.js dev server if running on nextjs_port
         2. Remove the session directory: sessions/$session_id/
+
+        Implementations MUST call ``self._close_session_buses(sandbox_id,
+        session_id)`` so the per-session :class:`PodEventBus` and its
+        reader thread / httpx connection are released. Forgetting this
+        leaks one bus per deleted session until the api_server restarts.
 
         Does NOT terminate the sandbox - other sessions may still be using it.
 
@@ -345,7 +326,6 @@ class SandboxManager(ABC):
         """
         ...
 
-    @abstractmethod
     def send_message(
         self,
         sandbox_id: UUID,
@@ -359,6 +339,12 @@ class SandboxManager(ABC):
     ) -> Generator[ACPEvent, None, None]:
         """Stream typed ACP events for one user message.
 
+        Dispatches on ``AGENT_TRANSPORT``: under ``serve`` (default
+        post-migration) calls into :meth:`_send_message_via_serve` (shared
+        across backends, lives on :class:`_ServeMixin`); under ``acp``
+        (rollback) delegates to the backend-specific
+        :meth:`_send_message_via_acp`.
+
         Serve-only kwargs (ignored by ACP transport):
 
         - ``opencode_session_id``: persistent opencode-serve session id.
@@ -370,432 +356,37 @@ class SandboxManager(ABC):
         - ``on_opencode_session_resolved``: invoked synchronously, before
           the first event is yielded, with the resolved opencode session
           id whenever it differs from the caller-supplied
-          ``opencode_session_id`` (i.e. the persisted id 404'd and the
-          transport had to mint a new one, or the caller passed ``None``).
-          Callers persist the new id so subsequent turns don't 404 the
-          same stale id and orphan a fresh opencode session per turn.
+          ``opencode_session_id``. Callers persist the new id so
+          subsequent turns don't 404 the same stale id and orphan a fresh
+          opencode session per turn.
         """
-        ...
-
-    @contextlib.contextmanager
-    def prompt_slot(
-        self,
-        sandbox_id: UUID,
-        build_session_id: UUID,
-    ) -> Generator[bool, None, None]:
-        """Non-blocking try-acquire of a per-(sandbox, build_session) lock
-        that serializes concurrent ``send_message`` calls on a build session.
-
-        Yields ``True`` if the slot was acquired and the caller may proceed
-        with the turn (lock is released on context exit), or ``False`` if a
-        turn is already in flight on this build session and the caller
-        should abort without side effects (no user_message persistence, no
-        prompt POST).
-
-        Why this exists: opencode-serve's ``prompt_async`` is fire-and-
-        forget and not concurrent-safe — empirically, a second POST while
-        a turn is in flight is silently dropped (no 409, no queue), and
-        the second subscriber catches the *first* turn's terminator. Without
-        serialization at this layer the user sees an empty response and a
-        phantom user_message is persisted with no assistant reply.
-
-        Keying on ``build_session_id`` (rather than ``opencode_session_id``)
-        is deliberate:
-          1. It's stable across opencode session id rotations triggered by
-             the ``on_opencode_session_resolved`` callback — concurrent
-             requests landing in the middle of a 404-then-mint sequence
-             still contend on the same lock.
-          2. It blocks first-turn races: two simultaneous prompts on a
-             fresh build session (where ``opencode_session_id`` is NULL
-             for both) both contend before each calls POST /session, so
-             only one opencode session is ever created.
-          3. It bounds the lock dict size to one entry per build session
-             instead of one per (build_session × pod_restart_count).
-
-        Under ``AGENT_TRANSPORT=acp`` (rollback path) this is a no-op
-        (yields ``True``) — the per-message exec'd ``opencode acp``
-        subprocess model has no shared state to serialize.
-        """
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            yield True
-            return
-
-        self._init_serve_state()
-        key = (sandbox_id, build_session_id)
-        with self._prompt_locks_meta:
-            lock = self._prompt_locks.get(key)
-            if lock is None:
-                lock = threading.Lock()
-                self._prompt_locks[key] = lock
-
-        acquired = lock.acquire(blocking=False)
-        try:
-            if not acquired:
-                logger.warning(
-                    "[SANDBOX-SERVE] prompt_slot: refused — concurrent send_message "
-                    "on sandbox=%s build_session=%s",
-                    sandbox_id,
-                    build_session_id,
-                )
-            yield acquired
-        finally:
-            if acquired:
-                lock.release()
-
-    def ensure_opencode_session(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-    ) -> str | None:
-        """Return a stable opencode-serve session id for this build session.
-
-        Used only when ``AGENT_TRANSPORT=serve``. The caller (session
-        manager) persists the returned id on the ``BuildSession`` row so
-        subsequent ``send_message`` calls can hit the same opencode
-        session by id, eliminating the on-disk session/list heuristic
-        the ACP path uses.
-
-        Returns ``None`` under ACP — that transport has no notion of a
-        persistent session id and doesn't need this preflight.
-
-        Idempotent: calling twice for the same (sandbox, session) on serve
-        returns the same id (delegated to ``OpencodeServeClient.ensure_session``).
-        """
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return None
-        session_path = self._session_directory(session_id)
-        logger.info(
-            "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
-            "sandbox=%s directory=%s (passing id=None, so client will POST /session)",
-            session_id,
-            sandbox_id,
-            session_path,
-        )
-        with self._build_serve_client(sandbox_id, session_path) as client:
-            return client.ensure_session(
-                None,
-                directory=session_path,
-                title=f"build-session-{str(session_id)[:8]}",
-            )
-
-    def list_subagents(
-        self,
-        sandbox_id: UUID,
-        parent_opencode_session_id: str,
-    ) -> list[str]:
-        """Child opencode session ids spawned under the parent. Empty
-        under ACP (no shared event bus to track subagents)."""
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return []
-        self._init_serve_state()
-        # Walk existing buses only — don't spin up a reader thread just to list.
-        with self._event_buses_lock:
-            buses = [
-                bus for (sid, _), bus in self._event_buses.items() if sid == sandbox_id
-            ]
-        for bus in buses:
-            children = bus.list_children(parent_opencode_session_id)
-            if children:
-                return children
-        return []
-
-    def subscribe_to_opencode_session(
-        self,
-        sandbox_id: UUID,
-        opencode_session_id: str,
-        *,
-        directory: str,
-        keepalive_seconds: float = 15.0,
-    ) -> Generator["ACPEvent", None, None]:
-        """Stream translated ACP events for an opencode session. Caller closes
-        via ``GeneratorExit``. ``directory`` is required: opencode-serve scopes
-        its session store per-directory, so the hydrate REST call needs it.
-        """
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return
-        bus = self._get_or_create_event_bus(sandbox_id, directory)
-        state = _TurnState(session_id=opencode_session_id)
-        client = self._build_serve_client(sandbox_id, directory)
-
-        def fetch_message(mid: str) -> dict[str, Any] | None:
-            return client.get_message(opencode_session_id, mid, directory=directory)
-
-        sub = bus.subscribe(opencode_session_id)
-        try:
-            last_event = time.monotonic()
-            while True:
-                try:
-                    raw = sub.queue.get(timeout=1.0)
-                except queue.Empty:
-                    if time.monotonic() - last_event >= keepalive_seconds:
-                        yield SSEKeepalive()
-                        last_event = time.monotonic()
-                    continue
-                if raw is BUS_CLOSED_SENTINEL:
-                    return
-                last_event = time.monotonic()
-                if raw.get("type") == "server.connected":
-                    continue
-                for acp_event in translate_opencode_event(
-                    raw, state, fetch_message=fetch_message
-                ):
-                    yield acp_event
-        finally:
-            bus.unsubscribe(sub)
-            client.close()
-
-    @staticmethod
-    def _session_directory(session_id: UUID) -> str:
-        return f"/workspace/sessions/{session_id}"
-
-    def _init_serve_state(self) -> None:
-        """Idempotent init for serve-transport state. Called eagerly from each
-        subclass ``_initialize`` and lazily from accessors as a safety net."""
-        if getattr(self, "_serve_state_initialized", False):
-            return
-        # Per-(sandbox, directory): opencode-serve scopes /event by ?directory=.
-        self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
-        # Tombstone: blocks late subscribe from racing a terminate.
-        self._terminated_sandboxes: set[UUID] = set()
-        self._event_buses_lock = threading.Lock()
-        # Key on build_session_id, not opencode_session_id — see prompt_slot.
-        self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
-        self._prompt_locks_meta: threading.Lock = threading.Lock()
-        self._serve_state_initialized = True
-
-    @abstractmethod
-    def _serve_base_url(self, sandbox_id: UUID) -> str:
-        """Backend-specific base URL for this sandbox's opencode-serve.
-
-        K8s: per-pod ClusterIP service on the cluster DNS.
-        Docker: container name on the sandbox bridge network.
-        """
-        ...
-
-    @abstractmethod
-    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:
-        """Per-sandbox HTTP Basic password. ``None`` for legacy sandboxes
-        provisioned before this code landed; caller falls back to no-auth."""
-        ...
-
-    def _wait_for_opencode_serve_ready(
-        self,
-        sandbox_id: UUID,
-        timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
-    ) -> bool:
-        """Block until opencode-serve answers ``GET /doc`` with 200. Backend
-        readiness only proves the supervisor is up; opencode binds :4096 a
-        few seconds later. Skipping this races the first prompt's bus
-        subscribe → "stream did not become ready"."""
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return True
-
-        password = self._read_opencode_password(sandbox_id)
-        auth = httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
-        base_url = self._serve_base_url(sandbox_id)
-        deadline = time.time() + timeout
-        last_err: str | None = None
-        while time.time() < deadline:
-            try:
-                with httpx.Client(base_url=base_url, auth=auth, timeout=2.0) as client:
-                    r = client.get("/doc")
-                    if r.status_code == 200:
-                        logger.info(
-                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
-                            sandbox_id,
-                        )
-                        return True
-                    last_err = f"HTTP {r.status_code}"
-            except httpx.HTTPError as e:
-                last_err = f"{type(e).__name__}: {e}"
-            time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
-        logger.error(
-            "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
-            "after %.0fs (last error: %s)",
-            sandbox_id,
-            timeout,
-            last_err,
-        )
-        return False
-
-    def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
-        """Lazy per-(sandbox, directory) bus. Refuses to create for a terminated
-        sandbox. Replaces self-closed buses so callers don't wedge on
-        BUS_CLOSED_SENTINEL until restart."""
-        self._init_serve_state()
-        key = (sandbox_id, directory)
-        with self._event_buses_lock:
-            bus = self._event_buses.get(key)
-            if bus is not None and not bus.closed:
-                return bus
-            if bus is not None and bus.closed:
-                logger.warning(
-                    "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
-                    "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
-                    sandbox_id,
-                    directory,
-                )
-                self._event_buses.pop(key, None)
-            if sandbox_id in self._terminated_sandboxes:
-                raise RuntimeError(
-                    f"Sandbox {sandbox_id} has been terminated; refusing to "
-                    "create a new event bus against its (deleted) backend"
-                )
-            password = self._read_opencode_password(sandbox_id)
-            if password is None:
-                logger.warning(
-                    "[SANDBOX-SERVE] No opencode password for sandbox %s; "
-                    "bus will run without auth (likely a legacy sandbox, re-provision to fix)",
-                    sandbox_id,
-                )
-            auth = (
-                httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password)
-                if password
-                else None
-            )
-            bus = PodEventBus(
-                base_url=self._serve_base_url(sandbox_id),
-                auth=auth,
-                directory=directory,
-                event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
-            )
-            self._event_buses[key] = bus
-            logger.info(
-                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s dir=%s",
+        if AGENT_TRANSPORT == AgentTransport.SERVE:
+            yield from self._send_message_via_serve(
                 sandbox_id,
-                directory,
+                session_id,
+                message,
+                opencode_session_id,
+                agent_provider,
+                agent_model,
+                on_opencode_session_resolved=on_opencode_session_resolved,
             )
-            return bus
+            return
+        yield from self._send_message_via_acp(sandbox_id, session_id, message)
 
-    def _build_serve_client(
-        self, sandbox_id: UUID, directory: str
-    ) -> OpencodeServeClient:
-        password = self._read_opencode_password(sandbox_id)
-        bus = self._get_or_create_event_bus(sandbox_id, directory)
-        return OpencodeServeClient(
-            base_url=self._serve_base_url(sandbox_id),
-            password=password,
-            event_bus=bus,
-        )
-
-    def _send_message_via_serve(
+    @abstractmethod
+    def _send_message_via_acp(
         self,
         sandbox_id: UUID,
         session_id: UUID,
         message: str,
-        opencode_session_id: str | None,
-        agent_provider: str | None,
-        agent_model: str | None,
-        *,
-        on_opencode_session_resolved: Callable[[str], None] | None = None,
-    ) -> Generator["ACPEvent", None, None]:
-        """Stream ACP events via the in-sandbox ``opencode serve``. Callers
-        should preflight ``opencode_session_id`` with
-        :meth:`ensure_opencode_session` to avoid one orphan session per turn."""
-        packet_logger = get_packet_logger()
-        session_path = self._session_directory(session_id)
-        client = self._build_serve_client(sandbox_id, session_path)
-        try:
-            logger.info(
-                "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "
-                "caller-supplied opencode_session_id=%s",
-                session_id,
-                opencode_session_id,
-            )
-            resolved_session_id = client.ensure_session(
-                opencode_session_id,
-                directory=session_path,
-                title=f"build-session-{str(session_id)[:8]}",
-            )
-            if resolved_session_id != opencode_session_id:
-                # Notify caller so they persist the new id — without this we
-                # orphan one opencode session per turn (lose conversation context).
-                if opencode_session_id is not None:
-                    logger.warning(
-                        "[SANDBOX-SERVE] persisted opencode_session_id %s was "
-                        "invalid; replaced with %s for session=%s",
-                        opencode_session_id,
-                        resolved_session_id,
-                        session_id,
-                    )
-                if on_opencode_session_resolved is not None:
-                    on_opencode_session_resolved(resolved_session_id)
+    ) -> Generator[ACPEvent, None, None]:
+        """Rollback transport: exec ``opencode acp`` once per message.
 
-            logger.info(
-                "[SANDBOX-SERVE] Sending message: session=%s opencode_session=%s api_pod=%s",
-                session_id,
-                resolved_session_id,
-                _API_SERVER_HOSTNAME,
-            )
-            packet_logger.log_session_start(session_id, sandbox_id, message)
-
-            events_count = 0
-            got_prompt_response = False
-            try:
-                for event in client.send_message(
-                    resolved_session_id,
-                    message,
-                    directory=session_path,
-                    model_provider=agent_provider,
-                    model_id=agent_model,
-                ):
-                    events_count += 1
-                    if isinstance(event, PromptResponse):
-                        got_prompt_response = True
-                    yield event
-
-                logger.info(
-                    "[SANDBOX-SERVE] send_message completed: session=%s events=%s got_prompt_response=%s",
-                    session_id,
-                    events_count,
-                    got_prompt_response,
-                )
-                packet_logger.log_session_end(
-                    session_id, success=True, events_count=events_count
-                )
-            except GeneratorExit:
-                logger.warning(
-                    "[SANDBOX-SERVE] GeneratorExit: session=%s events=%s, sending abort",
-                    session_id,
-                    events_count,
-                )
-                try:
-                    client.abort(resolved_session_id, directory=session_path)
-                except Exception as abort_err:
-                    logger.warning(
-                        "[SANDBOX-SERVE] abort failed on GeneratorExit: %s",
-                        abort_err,
-                    )
-                packet_logger.log_session_end(
-                    session_id,
-                    success=False,
-                    error="GeneratorExit",
-                    events_count=events_count,
-                )
-                raise
-            except Exception as e:
-                logger.error(
-                    "[SANDBOX-SERVE] Exception: session=%s events=%s error=%s",
-                    session_id,
-                    events_count,
-                    e,
-                )
-                try:
-                    client.abort(resolved_session_id, directory=session_path)
-                except Exception as abort_err:
-                    logger.warning(
-                        "[SANDBOX-SERVE] abort failed on Exception: %s",
-                        abort_err,
-                    )
-                packet_logger.log_session_end(
-                    session_id,
-                    success=False,
-                    error=f"Exception: {e}",
-                    events_count=events_count,
-                )
-                raise
-        finally:
-            client.close()
+        Only reached when ``AGENT_TRANSPORT=acp``. Kept as the deprecated
+        leg of the serve migration; backends will drop their
+        implementations once the rollback window closes.
+        """
+        ...
 
     @abstractmethod
     def list_directory(

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -472,7 +472,7 @@ class SandboxManager(ABC):
         with self._build_serve_client(sandbox_id) as client:
             return client.ensure_session(
                 None,
-                cwd=session_path,
+                directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
             )
 
@@ -715,7 +715,7 @@ class SandboxManager(ABC):
             )
             resolved_session_id = client.ensure_session(
                 opencode_session_id,
-                cwd=session_path,
+                directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
             )
             if resolved_session_id != opencode_session_id:
@@ -750,6 +750,7 @@ class SandboxManager(ABC):
                 for event in client.send_message(
                     resolved_session_id,
                     message,
+                    directory=session_path,
                     model_provider=agent_provider,
                     model_id=agent_model,
                 ):
@@ -774,7 +775,7 @@ class SandboxManager(ABC):
                     events_count,
                 )
                 try:
-                    client.abort(resolved_session_id)
+                    client.abort(resolved_session_id, directory=session_path)
                 except Exception as abort_err:
                     logger.warning(
                         "[SANDBOX-SERVE] abort failed on GeneratorExit: %s",
@@ -795,7 +796,7 @@ class SandboxManager(ABC):
                     e,
                 )
                 try:
-                    client.abort(resolved_session_id)
+                    client.abort(resolved_session_id, directory=session_path)
                 except Exception as abort_err:
                     logger.warning(
                         "[SANDBOX-SERVE] abort failed on Exception: %s",

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -15,6 +15,8 @@ Architecture Note (User-Shared Sandbox Model):
 """
 
 import contextlib
+import os
+import queue
 import threading
 import time
 from abc import ABC
@@ -24,8 +26,17 @@ from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any
+from typing import TYPE_CHECKING
 from uuid import UUID
 
+import httpx
+from acp.schema import PromptResponse
+
+from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import AGENT_TRANSPORT
+from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
+from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.sandbox.models import FatalWriteError
@@ -38,6 +49,12 @@ from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
 from onyx.utils.logger import setup_logger
+
+if TYPE_CHECKING:
+    from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+    from onyx.server.features.build.sandbox.opencode.serve_client import (
+        OpencodeServeClient,
+    )
 
 logger = setup_logger()
 
@@ -55,6 +72,19 @@ BUN_IMAGE_CACHE_DIR = "/home/sandbox/.bun/install/cache"
 # Using Any here to avoid circular imports - the actual type checking
 # happens in the implementation modules
 ACPEvent = Any
+
+# Hostname of the api_server process — surfaces in serve-transport logs so
+# operators can tell which replica is driving a given prompt. Pod name in
+# K8s, container short-ID in Docker, "unknown" outside containers.
+_API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
+
+# After the sandbox backend (pod/container) reports Ready, opencode-serve
+# still has to finish its own boot (config parse, provider registry init,
+# HTTP server bind on :4096). Empirically 1–3s warm, up to ~15s cold.
+# Budget 30s so a slow boot fails loudly here instead of as a downstream
+# "stream did not become ready".
+OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
+OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
 
 
 @dataclass
@@ -359,8 +389,8 @@ class SandboxManager(ABC):
     @contextlib.contextmanager
     def prompt_slot(
         self,
-        sandbox_id: UUID,  # noqa: ARG002 — used by serve-transport subclasses
-        build_session_id: UUID,  # noqa: ARG002
+        sandbox_id: UUID,
+        build_session_id: UUID,
     ) -> Generator[bool, None, None]:
         """Non-blocking try-acquire of a per-(sandbox, build_session) lock
         that serializes concurrent ``send_message`` calls on a build session.
@@ -391,16 +421,39 @@ class SandboxManager(ABC):
           3. It bounds the lock dict size to one entry per build session
              instead of one per (build_session × pod_restart_count).
 
-        Default implementation is a no-op (yields ``True``) for transports
-        that don't multiplex a long-lived process (e.g. ACP, which exec's a
-        fresh opencode per turn).
+        Under ``AGENT_TRANSPORT=acp`` (rollback path) this is a no-op
+        (yields ``True``) — the per-message exec'd ``opencode acp``
+        subprocess model has no shared state to serialize.
         """
-        yield True
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            yield True
+            return
+
+        key = (sandbox_id, build_session_id)
+        with self._prompt_locks_meta:
+            lock = self._prompt_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._prompt_locks[key] = lock
+
+        acquired = lock.acquire(blocking=False)
+        try:
+            if not acquired:
+                logger.warning(
+                    "[SANDBOX-SERVE] prompt_slot: refused — concurrent send_message "
+                    "on sandbox=%s build_session=%s",
+                    sandbox_id,
+                    build_session_id,
+                )
+            yield acquired
+        finally:
+            if acquired:
+                lock.release()
 
     def ensure_opencode_session(
         self,
-        sandbox_id: UUID,  # noqa: ARG002 — used by serve-transport subclasses
-        session_id: UUID,  # noqa: ARG002
+        sandbox_id: UUID,
+        session_id: UUID,
     ) -> str | None:
         """Return a stable opencode-serve session id for this build session.
 
@@ -410,37 +463,377 @@ class SandboxManager(ABC):
         session by id, eliminating the on-disk session/list heuristic
         the ACP path uses.
 
-        Default implementation returns ``None`` — applies to the ACP
-        transport, which has no notion of a persistent session id and
-        doesn't need this preflight.
+        Returns ``None`` under ACP — that transport has no notion of a
+        persistent session id and doesn't need this preflight.
 
-        Implementations on the serve path MUST be idempotent: calling
-        twice for the same (sandbox, session) returns the same id.
+        Idempotent: calling twice for the same (sandbox, session) on serve
+        returns the same id (delegated to ``OpencodeServeClient.ensure_session``).
         """
-        return None
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return None
+        session_path = f"/workspace/sessions/{session_id}"
+        logger.info(
+            "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
+            "sandbox=%s cwd=%s (passing id=None, so client will POST /session)",
+            session_id,
+            sandbox_id,
+            session_path,
+        )
+        with self._build_serve_client(sandbox_id) as client:
+            return client.ensure_session(
+                None,
+                cwd=session_path,
+                title=f"build-session-{str(session_id)[:8]}",
+            )
 
     def list_subagents(
         self,
-        sandbox_id: UUID,  # noqa: ARG002 — used by serve-transport subclasses
-        parent_opencode_session_id: str,  # noqa: ARG002
+        sandbox_id: UUID,
+        parent_opencode_session_id: str,
     ) -> list[str]:
         """Child opencode session ids spawned under the parent. Empty
-        on transports that don't track subagents (e.g. docker/ACP)."""
-        return []
+        under ACP (no shared event bus to track subagents)."""
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return []
+        # Don't create a bus just to list — that spins up a reader thread
+        # for a caller that didn't ask for events.
+        with self._event_buses_lock:
+            bus = self._event_buses.get(sandbox_id)
+        if bus is None:
+            return []
+        return bus.list_children(parent_opencode_session_id)
 
     def subscribe_to_opencode_session(
         self,
-        sandbox_id: UUID,  # noqa: ARG002
-        opencode_session_id: str,  # noqa: ARG002
+        sandbox_id: UUID,
+        opencode_session_id: str,
         *,
-        directory: str,  # noqa: ARG002
-        keepalive_seconds: float = 15.0,  # noqa: ARG002
+        directory: str,
+        keepalive_seconds: float = 15.0,
     ) -> Generator["ACPEvent", None, None]:
-        """Stream events for an arbitrary opencode session without
-        sending a prompt. Yields keepalives while idle. Empty on
-        transports without a shared event bus."""
-        return
-        yield  # pragma: no cover — make this a generator
+        """Stream translated ACP events for an opencode session (parent
+        or child). Never terminates on its own; caller closes via
+        ``GeneratorExit``. Empty under ACP."""
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return
+        from onyx.server.features.build.sandbox.opencode.event_bus import (
+            BUS_CLOSED_SENTINEL,
+        )
+        from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
+        from onyx.server.features.build.sandbox.opencode.serve_client import (
+            translate_opencode_event,
+        )
+
+        bus = self._get_or_create_event_bus(sandbox_id)
+        state = _TurnState(session_id=opencode_session_id)
+        sub = bus.subscribe(opencode_session_id)
+        try:
+            last_event = time.monotonic()
+            while True:
+                try:
+                    raw = sub.queue.get(timeout=1.0)
+                except queue.Empty:
+                    if time.monotonic() - last_event >= keepalive_seconds:
+                        yield SSEKeepalive()
+                        last_event = time.monotonic()
+                    continue
+                if raw is BUS_CLOSED_SENTINEL:
+                    return
+                last_event = time.monotonic()
+                if raw.get("type") == "server.connected":
+                    continue
+                for acp_event in translate_opencode_event(raw, state):
+                    yield acp_event
+        finally:
+            bus.unsubscribe(sub)
+
+    # =====================================================================
+    # opencode serve transport — shared plumbing
+    # =====================================================================
+    #
+    # Subclasses provide the two backend-specific endpoints (`_serve_base_url`
+    # and `_read_opencode_password`); the rest of the serve transport is
+    # backend-agnostic and lives here.
+
+    def _init_serve_state(self) -> None:
+        """Initialize per-instance serve-transport state. Subclasses MUST
+        call this from their ``_initialize`` before any serve-path method
+        runs. Idempotent — guarded against double-init via attribute check.
+        """
+        if getattr(self, "_serve_state_initialized", False):
+            return
+        # One PodEventBus per sandbox, created lazily on first send_message.
+        self._event_buses: dict[UUID, "PodEventBus"] = {}
+        # Tombstone set: blocks late ``subscribe`` from re-creating a bus
+        # for a sandbox whose terminate is in flight (leaks a reconnect
+        # loop otherwise). Cleared on re-provision.
+        self._terminated_sandboxes: set[UUID] = set()
+        self._event_buses_lock = threading.Lock()
+        # Per-(sandbox_id, build_session_id) locks that serialize concurrent
+        # send_message calls on a single build session. See prompt_slot for
+        # why we key on build_session_id rather than opencode_session_id.
+        self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
+        self._prompt_locks_meta: threading.Lock = threading.Lock()
+        self._serve_state_initialized = True
+
+    @abstractmethod
+    def _serve_base_url(self, sandbox_id: UUID) -> str:
+        """Backend-specific base URL for this sandbox's opencode-serve.
+
+        K8s: per-pod ClusterIP service on the cluster DNS.
+        Docker: container name on the sandbox bridge network.
+        """
+        ...
+
+    @abstractmethod
+    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:
+        """Backend-specific lookup of the per-sandbox HTTP Basic password.
+
+        Returns ``None`` if the sandbox doesn't have one (e.g. legacy
+        provisioned before this code landed). Callers should fall back
+        to no-auth in that case.
+        """
+        ...
+
+    def _wait_for_opencode_serve_ready(
+        self,
+        sandbox_id: UUID,
+        timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Block until opencode-serve answers ``GET /doc`` with 200.
+
+        Backend readiness (k8s pod Ready / docker container running) only
+        proves the supervisor process is up. opencode-serve binds ``:4096``
+        a few hundred ms to a few seconds later, after it finishes config
+        parse and provider registry init. Returning RUNNING before that
+        means the first prompt's bus subscribe races a cold opencode —
+        connection refused or stale-auth 401 burns the bus's reconnect
+        budget and surfaces to the user as ``stream did not become ready``.
+
+        No-op under AGENT_TRANSPORT=acp.
+        """
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return True
+
+        password = self._read_opencode_password(sandbox_id)
+        auth = httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
+        base_url = self._serve_base_url(sandbox_id)
+        deadline = time.time() + timeout
+        last_err: str | None = None
+        while time.time() < deadline:
+            try:
+                with httpx.Client(base_url=base_url, auth=auth, timeout=2.0) as client:
+                    r = client.get("/doc")
+                    if r.status_code == 200:
+                        logger.info(
+                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
+                            sandbox_id,
+                        )
+                        return True
+                    last_err = f"HTTP {r.status_code}"
+            except httpx.HTTPError as e:
+                last_err = f"{type(e).__name__}: {e}"
+            time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
+        logger.error(
+            "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
+            "after %.0fs (last error: %s)",
+            sandbox_id,
+            timeout,
+            last_err,
+        )
+        return False
+
+    def _get_or_create_event_bus(self, sandbox_id: UUID) -> "PodEventBus":
+        """Lazily build the per-sandbox :class:`PodEventBus`. Refuses to
+        create one for a terminated sandbox (see ``_terminated_sandboxes``).
+
+        Replaces a cached bus that has self-closed (exhausted its reconnect
+        budget) with a fresh one — otherwise callers would keep getting
+        ``BUS_CLOSED_SENTINEL`` until the api server restarted.
+        """
+        with self._event_buses_lock:
+            bus = self._event_buses.get(sandbox_id)
+            if bus is not None and not bus.closed:
+                return bus
+            if bus is not None and bus.closed:
+                logger.warning(
+                    "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
+                    "sandbox %s (prior bus exhausted its reconnect budget)",
+                    sandbox_id,
+                )
+                self._event_buses.pop(sandbox_id, None)
+            if sandbox_id in self._terminated_sandboxes:
+                raise RuntimeError(
+                    f"Sandbox {sandbox_id} has been terminated; refusing to "
+                    "create a new event bus against its (deleted) backend"
+                )
+            from onyx.server.features.build.sandbox.opencode.event_bus import (
+                PodEventBus,
+            )
+
+            password = self._read_opencode_password(sandbox_id)
+            if password is None:
+                logger.warning(
+                    "[SANDBOX-SERVE] No opencode password for sandbox %s; "
+                    "bus will run without auth (likely a legacy sandbox, re-provision to fix)",
+                    sandbox_id,
+                )
+            auth = (
+                httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password)
+                if password
+                else None
+            )
+            bus = PodEventBus(
+                base_url=self._serve_base_url(sandbox_id),
+                auth=auth,
+                event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
+            )
+            self._event_buses[sandbox_id] = bus
+            logger.info(
+                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s", sandbox_id
+            )
+            return bus
+
+    def _build_serve_client(self, sandbox_id: UUID) -> "OpencodeServeClient":
+        from onyx.server.features.build.sandbox.opencode import OpencodeServeClient
+
+        password = self._read_opencode_password(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id)
+        return OpencodeServeClient(
+            base_url=self._serve_base_url(sandbox_id),
+            password=password,
+            event_bus=bus,
+        )
+
+    def _send_message_via_serve(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        message: str,
+        opencode_session_id: str | None,
+        agent_provider: str | None,
+        agent_model: str | None,
+        *,
+        on_opencode_session_resolved: Callable[[str], None] | None = None,
+    ) -> Generator["ACPEvent", None, None]:
+        """Stream ACP events by driving the in-sandbox ``opencode serve`` via
+        :class:`OpencodeServeClient`. See
+        ``docs/craft/opencode-serve-migration.md``.
+
+        ``opencode_session_id`` is the caller-persisted id from
+        ``BuildSession.opencode_session_id``. If ``None``, fall back to
+        creating one inline — but the session manager *should* preflight
+        via :meth:`ensure_opencode_session` and persist before calling
+        here, to avoid creating a fresh opencode session per turn under
+        a race.
+        """
+        packet_logger = get_packet_logger()
+        session_path = f"/workspace/sessions/{session_id}"
+        client = self._build_serve_client(sandbox_id)
+        try:
+            logger.info(
+                "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "
+                "caller-supplied opencode_session_id=%s",
+                session_id,
+                opencode_session_id,
+            )
+            resolved_session_id = client.ensure_session(
+                opencode_session_id,
+                cwd=session_path,
+                title=f"build-session-{str(session_id)[:8]}",
+            )
+            if resolved_session_id != opencode_session_id:
+                # Caller's persisted id was stale (404) or missing. Notify
+                # the caller so they can persist the new id; without this,
+                # _ensure_opencode_session_id would reload the same stale
+                # id from the DB on every turn, 404 again, and orphan a
+                # fresh opencode session per turn (one assistant message
+                # per orphan → conversation loses all prior context).
+                if opencode_session_id is not None:
+                    logger.warning(
+                        "[SANDBOX-SERVE] persisted opencode_session_id %s was "
+                        "invalid; replaced with %s for session=%s",
+                        opencode_session_id,
+                        resolved_session_id,
+                        session_id,
+                    )
+                if on_opencode_session_resolved is not None:
+                    on_opencode_session_resolved(resolved_session_id)
+
+            logger.info(
+                "[SANDBOX-SERVE] Sending message: session=%s opencode_session=%s api_pod=%s",
+                session_id,
+                resolved_session_id,
+                _API_SERVER_HOSTNAME,
+            )
+            packet_logger.log_session_start(session_id, sandbox_id, message)
+
+            events_count = 0
+            got_prompt_response = False
+            try:
+                for event in client.send_message(
+                    resolved_session_id,
+                    message,
+                    model_provider=agent_provider,
+                    model_id=agent_model,
+                ):
+                    events_count += 1
+                    if isinstance(event, PromptResponse):
+                        got_prompt_response = True
+                    yield event
+
+                logger.info(
+                    "[SANDBOX-SERVE] send_message completed: session=%s events=%s got_prompt_response=%s",
+                    session_id,
+                    events_count,
+                    got_prompt_response,
+                )
+                packet_logger.log_session_end(
+                    session_id, success=True, events_count=events_count
+                )
+            except GeneratorExit:
+                logger.warning(
+                    "[SANDBOX-SERVE] GeneratorExit: session=%s events=%s, sending abort",
+                    session_id,
+                    events_count,
+                )
+                try:
+                    client.abort(resolved_session_id)
+                except Exception as abort_err:
+                    logger.warning(
+                        "[SANDBOX-SERVE] abort failed on GeneratorExit: %s",
+                        abort_err,
+                    )
+                packet_logger.log_session_end(
+                    session_id,
+                    success=False,
+                    error="GeneratorExit",
+                    events_count=events_count,
+                )
+                raise
+            except Exception as e:
+                logger.error(
+                    "[SANDBOX-SERVE] Exception: session=%s events=%s error=%s",
+                    session_id,
+                    events_count,
+                    e,
+                )
+                try:
+                    client.abort(resolved_session_id)
+                except Exception as abort_err:
+                    logger.warning(
+                        "[SANDBOX-SERVE] abort failed on Exception: %s",
+                        abort_err,
+                    )
+                packet_logger.log_session_end(
+                    session_id,
+                    success=False,
+                    error=f"Exception: {e}",
+                    events_count=events_count,
+                )
+                raise
+        finally:
+            client.close()
 
     @abstractmethod
     def list_directory(

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -85,10 +85,8 @@ class SandboxManager(_ServeMixin, ABC):
                 └── ...
 
     Serve-transport plumbing lives in :class:`_ServeMixin` (composed via
-    MRO). Subclasses get the event-bus cache, prompt slot, readiness probe,
-    and serve send-message loop for free; they only have to implement
-    :meth:`_load_serve_connection_info` (one read, cached forever) plus
-    the abstract methods declared below.
+    MRO); subclasses implement :meth:`_load_serve_connection_info` plus
+    the abstract methods below.
 
     IMPORTANT: Implementations must NOT interface with the database directly.
     All database operations should be handled by the caller.
@@ -138,17 +136,12 @@ class SandboxManager(_ServeMixin, ABC):
 
     @abstractmethod
     def terminate(self, sandbox_id: UUID) -> None:
-        """Terminate a sandbox and clean up all resources.
-
-        Destroys the entire sandbox including all session workspaces.
-        Use cleanup_session_workspace() to remove individual sessions.
+        """Terminate a sandbox and clean up all resources. Destroys every
+        session workspace; for one session use ``cleanup_session_workspace``.
 
         Implementations MUST call ``self._close_all_sandbox_buses(sandbox_id)``
-        before destroying the container/pod so late subscribes can't race
-        a fresh bus against a deleted backend.
-
-        Args:
-            sandbox_id: The sandbox ID to terminate
+        before destroying the backend so late subscribes can't race a fresh
+        bus in.
         """
         ...
 
@@ -196,22 +189,13 @@ class SandboxManager(_ServeMixin, ABC):
         session_id: UUID,
         nextjs_port: int | None = None,
     ) -> None:
-        """Clean up a session workspace (on session delete).
-
-        1. Stop the Next.js dev server if running on nextjs_port
-        2. Remove the session directory: sessions/$session_id/
+        """Clean up a session workspace on session delete: stop the
+        Next.js dev server and remove ``sessions/$session_id/``. Does NOT
+        terminate the sandbox.
 
         Implementations MUST call ``self._close_session_buses(sandbox_id,
-        session_id)`` so the per-session :class:`PodEventBus` and its
-        reader thread / httpx connection are released. Forgetting this
-        leaks one bus per deleted session until the api_server restarts.
-
-        Does NOT terminate the sandbox - other sessions may still be using it.
-
-        Args:
-            sandbox_id: The sandbox ID
-            session_id: The session ID to clean up
-            nextjs_port: Optional port where Next.js server is running
+        session_id)`` — otherwise the per-session ``PodEventBus`` (reader
+        thread + httpx connection) leaks until api_server restarts.
         """
         ...
 
@@ -337,28 +321,19 @@ class SandboxManager(_ServeMixin, ABC):
         agent_model: str | None = None,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
     ) -> Generator[ACPEvent, None, None]:
-        """Stream typed ACP events for one user message.
+        """Stream typed ACP events for one user message. Dispatches on
+        ``AGENT_TRANSPORT`` — ``serve`` to ``_send_message_via_serve``,
+        ``acp`` (rollback) to ``_send_message_via_acp``.
 
-        Dispatches on ``AGENT_TRANSPORT``: under ``serve`` (default
-        post-migration) calls into :meth:`_send_message_via_serve` (shared
-        across backends, lives on :class:`_ServeMixin`); under ``acp``
-        (rollback) delegates to the backend-specific
-        :meth:`_send_message_via_acp`.
+        Serve-only kwargs (ignored by ACP):
 
-        Serve-only kwargs (ignored by ACP transport):
-
-        - ``opencode_session_id``: persistent opencode-serve session id.
-          Callers should pass ``BuildSession.opencode_session_id``; if
-          ``None`` the transport calls :meth:`ensure_opencode_session`.
-        - ``agent_provider`` / ``agent_model``: per-prompt model
-          override (``body["model"]``). Both must be set; either
-          ``None`` falls back to opencode's loaded default.
-        - ``on_opencode_session_resolved``: invoked synchronously, before
-          the first event is yielded, with the resolved opencode session
-          id whenever it differs from the caller-supplied
-          ``opencode_session_id``. Callers persist the new id so
-          subsequent turns don't 404 the same stale id and orphan a fresh
-          opencode session per turn.
+        - ``opencode_session_id``: persistent serve session id; pass
+          ``BuildSession.opencode_session_id`` or ``None`` to mint.
+        - ``agent_provider`` / ``agent_model``: per-prompt model override;
+          either ``None`` falls back to the loaded default.
+        - ``on_opencode_session_resolved``: invoked with the resolved id
+          when it differs from the caller's. Caller persists it so later
+          turns don't orphan a fresh session each time.
         """
         if AGENT_TRANSPORT == AgentTransport.SERVE:
             yield from self._send_message_via_serve(
@@ -380,12 +355,9 @@ class SandboxManager(_ServeMixin, ABC):
         session_id: UUID,
         message: str,
     ) -> Generator[ACPEvent, None, None]:
-        """Rollback transport: exec ``opencode acp`` once per message.
-
-        Only reached when ``AGENT_TRANSPORT=acp``. Kept as the deprecated
-        leg of the serve migration; backends will drop their
-        implementations once the rollback window closes.
-        """
+        """Rollback transport: exec ``opencode acp`` per message. Only
+        reached under ``AGENT_TRANSPORT=acp``; dropped once the rollback
+        window closes."""
         ...
 
     @abstractmethod

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -503,11 +503,24 @@ class SandboxManager(ABC):
     ) -> Generator["ACPEvent", None, None]:
         """Stream translated ACP events for an opencode session (parent
         or child). Never terminates on its own; caller closes via
-        ``GeneratorExit``. Empty under ACP."""
+        ``GeneratorExit``. Empty under ACP.
+
+        ``directory`` is the in-sandbox session path
+        (``/workspace/sessions/{build_session_id}``) — opencode-serve
+        scopes its session store per-directory, so the hydrate REST call
+        needs it. Without it, the delta-before-``message.updated`` race
+        falls back to the negative-cache path and drops in-flight
+        deltas for the current step on subagent streams.
+        """
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return
         bus = self._get_or_create_event_bus(sandbox_id)
         state = _TurnState(session_id=opencode_session_id)
+        client = self._build_serve_client(sandbox_id)
+
+        def fetch_message(mid: str) -> dict[str, Any] | None:
+            return client.get_message(opencode_session_id, mid, directory=directory)
+
         sub = bus.subscribe(opencode_session_id)
         try:
             last_event = time.monotonic()
@@ -524,10 +537,13 @@ class SandboxManager(ABC):
                 last_event = time.monotonic()
                 if raw.get("type") == "server.connected":
                     continue
-                for acp_event in translate_opencode_event(raw, state):
+                for acp_event in translate_opencode_event(
+                    raw, state, fetch_message=fetch_message
+                ):
                     yield acp_event
         finally:
             bus.unsubscribe(sub)
+            client.close()
 
     # =====================================================================
     # opencode serve transport — shared plumbing

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -471,7 +471,7 @@ class SandboxManager(ABC):
             sandbox_id,
             session_path,
         )
-        with self._build_serve_client(sandbox_id) as client:
+        with self._build_serve_client(sandbox_id, session_path) as client:
             return client.ensure_session(
                 None,
                 directory=session_path,
@@ -489,12 +489,19 @@ class SandboxManager(ABC):
             return []
         self._init_serve_state()
         # Don't create a bus just to list — that spins up a reader thread
-        # for a caller that didn't ask for events.
+        # for a caller that didn't ask for events. Walk every existing
+        # per-directory bus belonging to this sandbox; the parent
+        # ``session.created`` event landed on whichever directory's bus
+        # was live when the spawn happened.
         with self._event_buses_lock:
-            bus = self._event_buses.get(sandbox_id)
-        if bus is None:
-            return []
-        return bus.list_children(parent_opencode_session_id)
+            buses = [
+                bus for (sid, _), bus in self._event_buses.items() if sid == sandbox_id
+            ]
+        for bus in buses:
+            children = bus.list_children(parent_opencode_session_id)
+            if children:
+                return children
+        return []
 
     def subscribe_to_opencode_session(
         self,
@@ -517,9 +524,9 @@ class SandboxManager(ABC):
         """
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return
-        bus = self._get_or_create_event_bus(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
         state = _TurnState(session_id=opencode_session_id)
-        client = self._build_serve_client(sandbox_id)
+        client = self._build_serve_client(sandbox_id, directory)
 
         def fetch_message(mid: str) -> dict[str, Any] | None:
             return client.get_message(opencode_session_id, mid, directory=directory)
@@ -577,8 +584,10 @@ class SandboxManager(ABC):
         """
         if getattr(self, "_serve_state_initialized", False):
             return
-        # One PodEventBus per sandbox, created lazily on first send_message.
-        self._event_buses: dict[UUID, PodEventBus] = {}
+        # One PodEventBus per (sandbox, directory). Opencode-serve's
+        # ``Instance.provide`` middleware scopes /event per ``?directory=``
+        # query param, so each session directory needs its own SSE stream.
+        self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
         # Tombstone set: blocks late ``subscribe`` from re-creating a bus
         # for a sandbox whose terminate is in flight (leaks a reconnect
         # loop otherwise). Cleared on re-provision.
@@ -658,26 +667,32 @@ class SandboxManager(ABC):
         )
         return False
 
-    def _get_or_create_event_bus(self, sandbox_id: UUID) -> PodEventBus:
-        """Lazily build the per-sandbox :class:`PodEventBus`. Refuses to
-        create one for a terminated sandbox (see ``_terminated_sandboxes``).
+    def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
+        """Lazily build the per-(sandbox, directory) :class:`PodEventBus`.
+        Refuses to create one for a terminated sandbox.
+
+        Opencode-serve's ``Instance.provide`` middleware scopes /event per
+        ``?directory=`` query param, so each unique session directory on
+        a sandbox needs its own SSE stream.
 
         Replaces a cached bus that has self-closed (exhausted its reconnect
         budget) with a fresh one — otherwise callers would keep getting
         ``BUS_CLOSED_SENTINEL`` until the api server restarted.
         """
         self._init_serve_state()
+        key = (sandbox_id, directory)
         with self._event_buses_lock:
-            bus = self._event_buses.get(sandbox_id)
+            bus = self._event_buses.get(key)
             if bus is not None and not bus.closed:
                 return bus
             if bus is not None and bus.closed:
                 logger.warning(
                     "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
-                    "sandbox %s (prior bus exhausted its reconnect budget)",
+                    "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
                     sandbox_id,
+                    directory,
                 )
-                self._event_buses.pop(sandbox_id, None)
+                self._event_buses.pop(key, None)
             if sandbox_id in self._terminated_sandboxes:
                 raise RuntimeError(
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
@@ -698,17 +713,22 @@ class SandboxManager(ABC):
             bus = PodEventBus(
                 base_url=self._serve_base_url(sandbox_id),
                 auth=auth,
+                directory=directory,
                 event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
             )
-            self._event_buses[sandbox_id] = bus
+            self._event_buses[key] = bus
             logger.info(
-                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s", sandbox_id
+                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s dir=%s",
+                sandbox_id,
+                directory,
             )
             return bus
 
-    def _build_serve_client(self, sandbox_id: UUID) -> OpencodeServeClient:
+    def _build_serve_client(
+        self, sandbox_id: UUID, directory: str
+    ) -> OpencodeServeClient:
         password = self._read_opencode_password(sandbox_id)
-        bus = self._get_or_create_event_bus(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
         return OpencodeServeClient(
             base_url=self._serve_base_url(sandbox_id),
             password=password,
@@ -739,7 +759,7 @@ class SandboxManager(ABC):
         """
         packet_logger = get_packet_logger()
         session_path = self._session_directory(session_id)
-        client = self._build_serve_client(sandbox_id)
+        client = self._build_serve_client(sandbox_id, session_path)
         try:
             logger.info(
                 "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -24,9 +24,7 @@ from abc import abstractmethod
 from collections.abc import Callable
 from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 from typing import Any
-from typing import TYPE_CHECKING
 from uuid import UUID
 
 import httpx
@@ -48,13 +46,19 @@ from onyx.server.features.build.sandbox.models import PushResult
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
+from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
+from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
+from onyx.server.features.build.sandbox.opencode.serve_client import (
+    translate_opencode_event,
+)
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 
-if TYPE_CHECKING:
-    from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
-    from onyx.server.features.build.sandbox.opencode.serve_client import (
-        OpencodeServeClient,
-    )
+# Re-export SSEKeepalive so existing ``from ...sandbox.base import
+# SSEKeepalive`` callers keep working after the move into sse.py.
+__all__ = ["SSEKeepalive"]
 
 logger = setup_logger()
 
@@ -85,20 +89,6 @@ _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 # "stream did not become ready".
 OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
 OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
-
-
-@dataclass
-class SSEKeepalive:
-    """Marker event yielded by sandbox-manager ACP clients when no real ACP
-    events have arrived for ``SSE_KEEPALIVE_INTERVAL`` seconds.
-
-    Defined here (rather than in any one backend's exec client) so every
-    backend yields the same class and ``isinstance`` checks in the
-    session-manager SSE pipeline work uniformly. Otherwise a Docker-emitted
-    keepalive would be a different class than a K8s-emitted keepalive and
-    one would fall through the manager's isinstance chain as "unrecognized"
-    and be silently dropped.
-    """
 
 
 class SandboxManager(ABC):
@@ -516,14 +506,6 @@ class SandboxManager(ABC):
         ``GeneratorExit``. Empty under ACP."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return
-        from onyx.server.features.build.sandbox.opencode.event_bus import (
-            BUS_CLOSED_SENTINEL,
-        )
-        from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
-        from onyx.server.features.build.sandbox.opencode.serve_client import (
-            translate_opencode_event,
-        )
-
         bus = self._get_or_create_event_bus(sandbox_id)
         state = _TurnState(session_id=opencode_session_id)
         sub = bus.subscribe(opencode_session_id)
@@ -563,7 +545,7 @@ class SandboxManager(ABC):
         if getattr(self, "_serve_state_initialized", False):
             return
         # One PodEventBus per sandbox, created lazily on first send_message.
-        self._event_buses: dict[UUID, "PodEventBus"] = {}
+        self._event_buses: dict[UUID, PodEventBus] = {}
         # Tombstone set: blocks late ``subscribe`` from re-creating a bus
         # for a sandbox whose terminate is in flight (leaks a reconnect
         # loop otherwise). Cleared on re-provision.
@@ -643,7 +625,7 @@ class SandboxManager(ABC):
         )
         return False
 
-    def _get_or_create_event_bus(self, sandbox_id: UUID) -> "PodEventBus":
+    def _get_or_create_event_bus(self, sandbox_id: UUID) -> PodEventBus:
         """Lazily build the per-sandbox :class:`PodEventBus`. Refuses to
         create one for a terminated sandbox (see ``_terminated_sandboxes``).
 
@@ -667,10 +649,6 @@ class SandboxManager(ABC):
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
                     "create a new event bus against its (deleted) backend"
                 )
-            from onyx.server.features.build.sandbox.opencode.event_bus import (
-                PodEventBus,
-            )
-
             password = self._read_opencode_password(sandbox_id)
             if password is None:
                 logger.warning(
@@ -694,9 +672,7 @@ class SandboxManager(ABC):
             )
             return bus
 
-    def _build_serve_client(self, sandbox_id: UUID) -> "OpencodeServeClient":
-        from onyx.server.features.build.sandbox.opencode import OpencodeServeClient
-
+    def _build_serve_client(self, sandbox_id: UUID) -> OpencodeServeClient:
         password = self._read_opencode_password(sandbox_id)
         bus = self._get_or_create_event_bus(sandbox_id)
         return OpencodeServeClient(

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -87,7 +87,7 @@ from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.configs import ATTACHMENTS_DIRECTORY
 from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
 from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
-from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
 from onyx.server.features.build.configs import SANDBOX_DOCKER_CPU_LIMIT
@@ -361,7 +361,7 @@ def build_container_create_kwargs(
     - **Env is a fixed allowlist**: ONYX_PAT, ONYX_SERVER_URL, plus the
       four serve-transport vars (``AGENT_TRANSPORT``,
       ``OPENCODE_SERVE_PORT``, the password env named by
-      ``OPENCODE_SERVER_PASSWORD_ENV``, and ``OPENCODE_CONFIG_CONTENT``).
+      ``OPENCODE_SERVER_PASSWORD``, and ``OPENCODE_CONFIG_CONTENT``).
       No caller can inject anything else. No S3/MinIO/Postgres/Redis
       credentials. No compose service hostnames.
     - **No host mounts**: only the per-sandbox named volume mounted at
@@ -379,7 +379,7 @@ def build_container_create_kwargs(
     would require the sandbox to be on the compose default network.
 
     ``opencode_password`` is generated per-provision by the manager and
-    injected as the env var named by ``OPENCODE_SERVER_PASSWORD_ENV``.
+    injected as the env var named by ``OPENCODE_SERVER_PASSWORD``.
     The api_server reads it back via ``docker inspect`` rather than
     persisting it on disk. ``opencode_config_json`` is the full
     ``opencode.json`` content (single-provider for Docker today), surfaced
@@ -400,7 +400,7 @@ def build_container_create_kwargs(
         "ONYX_SERVER_URL": api_server_url,
         "AGENT_TRANSPORT": AGENT_TRANSPORT.value,
         "OPENCODE_SERVE_PORT": str(OPENCODE_SERVE_PORT),
-        OPENCODE_SERVER_PASSWORD_ENV: opencode_password,
+        OPENCODE_SERVER_PASSWORD: opencode_password,
         "OPENCODE_CONFIG_CONTENT": opencode_config_json,
     }
 
@@ -1125,7 +1125,7 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
         except (APIError, NotFound):
             return None
         password: str | None = None
-        prefix = f"{OPENCODE_SERVER_PASSWORD_ENV}="
+        prefix = f"{OPENCODE_SERVER_PASSWORD}="
         for entry in env_list:
             if entry.startswith(prefix):
                 password = entry[len(prefix) :]

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -671,12 +671,14 @@ class DockerSandboxManager(SandboxManager):
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
-        # Tombstone + pop the bus under one lock so a concurrent subscribe
-        # can't race in and create a fresh bus against the dying container.
+        # Tombstone + pop every per-directory bus under one lock so a
+        # concurrent subscribe can't race in and create a fresh bus
+        # against the dying container.
         with self._event_buses_lock:
             self._terminated_sandboxes.add(sandbox_id)
-            bus = self._event_buses.pop(sandbox_id, None)
-        if bus is not None:
+            doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
+            doomed_buses = [self._event_buses.pop(k) for k in doomed_keys]
+        for bus in doomed_buses:
             try:
                 bus.close()
             except Exception:  # noqa: BLE001 — never let cleanup break terminate

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -36,19 +36,12 @@ Sandbox containers run with:
 
 Threat model — Docker vs Kubernetes parity gap
 ----------------------------------------------
-The LLM provider ``api_key`` is passed into the sandbox container via
-``OPENCODE_CONFIG_CONTENT`` (a Docker env var). Docker stores env vars in
-plaintext on the host's container metadata; anyone with access to the
-Docker daemon (e.g. operators running ``docker inspect``) can read it.
-This differs from the K8s backend, which loads the same config from a
-namespaced ``Secret`` (RBAC-scoped, mounted into env at boot).
-
-Self-hosted docker-compose deployers should treat host access to the
-Docker daemon as access to the LLM provider key. The single-process
-nature of docker-compose makes this practically equivalent to
-``cat .env`` — but the failure mode is more subtle (the key shows up
-in any ``docker inspect`` paste), so it's worth calling out. See the
-docker-opencode-serve.md doc for the operator-facing note.
+The LLM provider ``api_key`` is passed into the container via
+``OPENCODE_CONFIG_CONTENT`` (a plaintext Docker env var visible to
+``docker inspect``). K8s loads the same config from an RBAC-scoped
+``Secret``. Treat host access to the Docker daemon as access to the
+key; see ``docs/craft/docker-opencode-serve.md`` for the operator-facing
+note.
 
 Outbound communication is intentionally limited to:
 
@@ -564,11 +557,9 @@ class DockerSandboxManager(SandboxManager):
             )
 
         if all_llm_configs is not None and len(all_llm_configs) > 1:
-            # Docker is single-provider today — opencode-serve loads only
-            # one provider's config at container startup. Per-prompt
-            # ``agent_provider`` overrides will fail at runtime with a
-            # generic "provider not registered" from opencode. Warn at
-            # provision so operators see this before the first request.
+            # Docker is single-provider today: per-prompt agent_provider
+            # overrides will fail at opencode-serve with "provider not
+            # registered". Warn now so operators see it before the first turn.
             logger.warning(
                 "DockerSandboxManager.provision received %d LLM configs but only "
                 "the primary provider %r is bootstrapped; per-prompt provider "
@@ -584,16 +575,16 @@ class DockerSandboxManager(SandboxManager):
             tenant_id,
         )
 
-        # Re-provision: clear tombstone + cached connection info so
-        # subscribes can build a fresh bus against the new container.
+        # Re-provision: clear tombstone + cached info so subscribes can
+        # build a fresh bus against the new container.
         with self._event_buses_lock:
             self._terminated_sandboxes.discard(sandbox_id)
         self._invalidate_serve_connection_info(sandbox_id)
 
         container = self._reuse_existing_container(sandbox_id)
         if container is None:
-            # opencode-serve reads provider config from env at startup, so it
-            # must be in the create_kwargs before the container ever runs.
+            # opencode-serve reads provider config from env at startup;
+            # must be in create_kwargs before the container ever runs.
             opencode_password = secrets.token_urlsafe(32)
             opencode_config_json = json.dumps(
                 build_opencode_config(
@@ -689,8 +680,6 @@ class DockerSandboxManager(SandboxManager):
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
-        # Tombstone, pop every per-directory bus, and drop cached connection
-        # info — all in the mixin so the contract is shared with K8s.
         self._close_all_sandbox_buses(sandbox_id)
 
         container = self._get_container(sandbox_id)
@@ -856,8 +845,6 @@ echo "Session workspace setup complete"
         session_id: UUID,
         nextjs_port: int | None = None,  # noqa: ARG002
     ) -> None:
-        # Release the per-session event bus first so its SSE reader thread
-        # + httpx connection don't leak when the session goes away.
         self._close_session_buses(sandbox_id, session_id)
 
         container = self._get_container(sandbox_id)
@@ -1128,14 +1115,8 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
     def _load_serve_connection_info(
         self, sandbox_id: UUID
     ) -> ServeConnectionInfo | None:
-        """Build the serve connection info from the Docker container.
-
-        Single read of ``docker inspect``: the base URL is derived from
-        the deterministic container name; the password lives in the
-        container's env (set at create time by
-        ``build_container_create_kwargs``). Cached by the mixin so the
-        hot path doesn't hit dockerd on every prompt.
-        """
+        """One ``docker inspect`` to extract URL (container name) +
+        password (env, set at create time). Cached by the mixin."""
         container = self._get_container(sandbox_id)
         if container is None:
             return None

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -436,19 +436,13 @@ class DockerSandboxManager(SandboxManager):
         self._cpu_limit = SANDBOX_DOCKER_CPU_LIMIT
         self._snapshot_manager = SnapshotManager(get_default_file_store())
 
-        # Per-sandbox event buses, prompt locks, and termination tombstones —
-        # shared with the K8s manager via base.py.
         self._init_serve_state()
 
         build_dir = Path(__file__).parent.parent.parent
         self._agent_instructions_template_path = build_dir / "AGENTS.template.md"
 
-        # Auto-detect compose project so Docker Desktop groups sandbox
-        # containers under the same stack header as api_server. When
-        # api_server runs inside compose, its own container has the
-        # ``com.docker.compose.project`` label; we copy that value onto
-        # every sandbox we create. When api_server runs outside compose
-        # (e.g. unit tests) this resolves to None and no label is added.
+        # Match api_server's compose project so Docker Desktop groups sandboxes
+        # under the same stack header; None outside compose.
         self._compose_project = _detect_compose_project(self._docker)
 
         logger.info(
@@ -460,10 +454,6 @@ class DockerSandboxManager(SandboxManager):
             self._compose_project,
         )
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-
     def _ensure_sandbox_network(self) -> None:
         try:
             self._docker.networks.get(self._network_name)
@@ -471,10 +461,8 @@ class DockerSandboxManager(SandboxManager):
         except NotFound:
             pass
         logger.info("Creating sandbox network: %s", self._network_name)
-        # ``onyx_craft_sandbox`` is intentionally a plain bridge with
-        # internal=False so the agent can reach the public internet.
-        # Host-level firewall rules (DOCKER-USER chain) block IMDS at the
-        # network layer; app-level blocking is best-effort only.
+        # Plain bridge (internal=False) — agent needs public internet; host
+        # DOCKER-USER chain handles IMDS blocking.
         self._docker.networks.create(
             self._network_name,
             driver="bridge",
@@ -531,10 +519,6 @@ class DockerSandboxManager(SandboxManager):
             time.sleep(CONTAINER_READY_POLL_INTERVAL_SECONDS)
         return False
 
-    # ------------------------------------------------------------------
-    # Lifecycle
-    # ------------------------------------------------------------------
-
     def provision(
         self,
         sandbox_id: UUID,
@@ -559,18 +543,14 @@ class DockerSandboxManager(SandboxManager):
             tenant_id,
         )
 
-        # Re-provision clears the tombstone so future subscribes can build a
-        # fresh bus against the new container.
+        # Re-provision: clear tombstone so subscribes can build a fresh bus.
         with self._event_buses_lock:
             self._terminated_sandboxes.discard(sandbox_id)
 
-        # 1. Idempotency: reuse an existing container if at all possible.
         container = self._reuse_existing_container(sandbox_id)
         if container is None:
-            # 2. Build per-sandbox HTTP Basic password + opencode-serve config
-            #    before creating the container. opencode-serve loads its
-            #    provider list at startup, so this content has to be present
-            #    in env from the very first ``opencode serve`` invocation.
+            # opencode-serve reads provider config from env at startup, so it
+            # must be in the create_kwargs before the container ever runs.
             opencode_password = secrets.token_urlsafe(32)
             opencode_config_json = json.dumps(
                 build_opencode_config(
@@ -598,8 +578,6 @@ class DockerSandboxManager(SandboxManager):
                 f"Timeout waiting for sandbox container {container.name} to be running"
             )
 
-        # opencode-serve binds :4096 a few hundred ms to a few seconds after
-        # the container is reported running. No-op under AGENT_TRANSPORT=acp.
         if not self._wait_for_opencode_serve_ready(sandbox_id):
             raise RuntimeError(
                 f"opencode-serve never became ready in sandbox container {container.name}"
@@ -659,21 +637,16 @@ class DockerSandboxManager(SandboxManager):
             compose_project=self._compose_project,
         )
         try:
-            # ty can't statically verify TypedDict-unpack against ``run``'s
-            # 50+ named-parameter overloads; types are pinned by
-            # ``ContainerCreateKwargs`` at construction time.
+            # Types pinned by ContainerCreateKwargs; ty can't match run's overloads.
             return self._docker.containers.run(**create_kwargs)  # ty: ignore[no-matching-overload]
         except APIError as e:
-            # 409 means a concurrent request created the same container.
             if "Conflict" in str(e) or getattr(e, "status_code", None) == 409:
                 logger.info("Sandbox container %s already exists, reusing", sandbox_id)
                 return self._require_container(sandbox_id)
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
-        # Tombstone + pop every per-directory bus under one lock so a
-        # concurrent subscribe can't race in and create a fresh bus
-        # against the dying container.
+        # Tombstone + pop under one lock so subscribe can't race a fresh bus in.
         with self._event_buses_lock:
             self._terminated_sandboxes.add(sandbox_id)
             doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
@@ -694,8 +667,7 @@ class DockerSandboxManager(SandboxManager):
                     "Error removing sandbox container %s: %s", container.name, e
                 )
 
-        # Remove the per-sandbox named volume separately so terminate is safe
-        # to call when the container was already gone.
+        # Volume removal is separate so terminate works after manual container rm.
         volume_name = _sandbox_volume_name(sandbox_id)
         try:
             volume = self._docker.volumes.get(volume_name)
@@ -719,10 +691,6 @@ class DockerSandboxManager(SandboxManager):
         state = (container.attrs or {}).get("State") or {}
         return state.get("Status") == "running"
 
-    # ------------------------------------------------------------------
-    # Session workspace setup
-    # ------------------------------------------------------------------
-
     def _render_session_files(
         self,
         *,
@@ -732,16 +700,9 @@ class DockerSandboxManager(SandboxManager):
         user_name: str | None = None,
         user_role: str | None = None,
     ) -> _RenderedSessionFiles:
-        """Render shell-escaped session config files.
-
-        ``opencode_json`` is ``None`` under ``AGENT_TRANSPORT=serve`` —
-        opencode-serve loaded its provider config from
-        ``OPENCODE_CONFIG_CONTENT`` at startup and does not re-read
-        per-session ``opencode.json`` files; writing one would just
-        pollute snapshots. Under ``AGENT_TRANSPORT=acp`` we still emit
-        the per-session file because each exec'd ``opencode acp``
-        invocation loads it.
-        """
+        """Render shell-escaped session config files. ``opencode_json`` is None
+        under serve transport (config came from OPENCODE_CONFIG_CONTENT at
+        container startup); only acp transport needs the per-session file."""
         agent_instructions = generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
             skills_section=skills_section,
@@ -808,12 +769,10 @@ class DockerSandboxManager(SandboxManager):
             if nextjs_port is not None
             else ""
         )
-        # AGENT_TRANSPORT=serve uses pod-level OPENCODE_CONFIG_CONTENT; skip
-        # per-session opencode.json so snapshots stay clean.
         opencode_json_write = (
             f"printf '%s' '{rendered.opencode_json}' > {session_path}/opencode.json"
             if rendered.opencode_json is not None
-            else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
+            else "# serve transport: opencode.json is container-level (OPENCODE_CONFIG_CONTENT)"
         )
         setup_script = f"""
 set -e
@@ -890,10 +849,6 @@ echo "Session cleanup complete"
                 e,
             )
 
-    # ------------------------------------------------------------------
-    # Workspace queries
-    # ------------------------------------------------------------------
-
     def session_workspace_exists(
         self,
         sandbox_id: UUID,
@@ -949,10 +904,6 @@ echo "Session cleanup complete"
             except ValueError:
                 continue
         return out
-
-    # ------------------------------------------------------------------
-    # Snapshots
-    # ------------------------------------------------------------------
 
     def create_snapshot(
         self,
@@ -1138,10 +1089,6 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
         except ExecError as e:
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
 
-    # ------------------------------------------------------------------
-    # opencode serve transport hooks (called by SandboxManager base class)
-    # ------------------------------------------------------------------
-
     def _serve_base_url(self, sandbox_id: UUID) -> str:
         """Container-name URL on the sandbox bridge network.
 
@@ -1169,10 +1116,6 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
             if entry.startswith(prefix):
                 return entry[len(prefix) :]
         return None
-
-    # ------------------------------------------------------------------
-    # Agent messaging
-    # ------------------------------------------------------------------
 
     def send_message(
         self,
@@ -1268,10 +1211,6 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
                 client.stop()
             except Exception as e:
                 logger.warning("Failed to stop DockerACPExecClient: %s", e)
-
-    # ------------------------------------------------------------------
-    # File operations
-    # ------------------------------------------------------------------
 
     def list_directory(
         self, sandbox_id: UUID, session_id: UUID, path: str
@@ -1612,10 +1551,6 @@ echo WRITE_OK"""
             stream_stdin_to_container(container, ["/bin/sh", "-c", script], tar_bytes)
         except ExecError as e:
             raise RuntimeError(f"write_files_to_sandbox failed: {e}") from e
-
-    # ------------------------------------------------------------------
-    # Webapp / preview
-    # ------------------------------------------------------------------
 
     def get_webapp_url(self, sandbox_id: UUID, port: int) -> str:
         """Return an http URL the api_server can reach the sandbox on.

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -70,7 +70,6 @@ import threading
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import NamedTuple
 from typing import TypedDict
 from uuid import UUID
 
@@ -286,18 +285,6 @@ def build_sandbox_labels(
     if compose_project:
         labels["com.docker.compose.project"] = compose_project
     return labels
-
-
-class _RenderedSessionFiles(NamedTuple):
-    """Output of ``_render_session_files``.
-
-    Both fields are already shell-escaped for ``printf '%s' '...'``.
-    ``opencode_json`` is ``None`` when the per-session file is not
-    needed (serve transport loads its provider config from env).
-    """
-
-    agents_md: str
-    opencode_json: str | None
 
 
 def _opencode_json_write_snippet(opencode_json: str | None, session_path: str) -> str:
@@ -724,10 +711,11 @@ class DockerSandboxManager(SandboxManager):
         skills_section: str,
         user_name: str | None = None,
         user_role: str | None = None,
-    ) -> _RenderedSessionFiles:
-        """Render shell-escaped session config files. ``opencode_json`` is None
-        under serve transport (config came from OPENCODE_CONFIG_CONTENT at
-        container startup); only acp transport needs the per-session file."""
+    ) -> tuple[str, str | None]:
+        """Return ``(agents_md, opencode_json)`` shell-escaped for
+        ``printf '%s' '...'``. ``opencode_json`` is ``None`` under serve
+        (config came from ``OPENCODE_CONFIG_CONTENT`` at container startup);
+        only ACP needs the per-session file."""
         agent_instructions = generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
             skills_section=skills_section,
@@ -749,14 +737,9 @@ class DockerSandboxManager(SandboxManager):
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
                 )
             )
-        # Escape single quotes for ``printf '%s' '...'``.
-        return _RenderedSessionFiles(
-            agents_md=agent_instructions.replace("'", "'\\''"),
-            opencode_json=(
-                opencode_json.replace("'", "'\\''")
-                if opencode_json is not None
-                else None
-            ),
+        return (
+            agent_instructions.replace("'", "'\\''"),
+            opencode_json.replace("'", "'\\''") if opencode_json is not None else None,
         )
 
     def setup_session_workspace(
@@ -781,7 +764,7 @@ class DockerSandboxManager(SandboxManager):
 
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
-        rendered = self._render_session_files(
+        agents_md, opencode_json = self._render_session_files(
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
@@ -794,9 +777,7 @@ class DockerSandboxManager(SandboxManager):
             if nextjs_port is not None
             else ""
         )
-        opencode_json_write = _opencode_json_write_snippet(
-            rendered.opencode_json, session_path
-        )
+        opencode_json_write = _opencode_json_write_snippet(opencode_json, session_path)
         setup_script = f"""
 set -e
 echo "Creating session directory: {session_path}"
@@ -823,7 +804,7 @@ else
     mkdir -p {session_path}/outputs/web
 fi
 ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
-printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
+printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 {opencode_json_write}
 {nextjs_start}
 echo "Session workspace setup complete"
@@ -1092,19 +1073,17 @@ fi
         ``.opencode-data/`` — the symlink and config files are regenerated
         here so restored sessions still see the pushed skill files.
         """
-        rendered = self._render_session_files(
+        agents_md, opencode_json = self._render_session_files(
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
         )
-        opencode_json_write = _opencode_json_write_snippet(
-            rendered.opencode_json, session_path
-        )
+        opencode_json_write = _opencode_json_write_snippet(opencode_json, session_path)
         script = f"""
 set -e
 mkdir -p {session_path}/.opencode
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
-printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
+printf '%s' '{agents_md}' > {session_path}/AGENTS.md
 {opencode_json_write}
 """
         try:

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -61,6 +61,7 @@ import threading
 import time
 from collections.abc import Callable
 from collections.abc import Generator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict
 from uuid import UUID
@@ -276,6 +277,19 @@ def build_sandbox_labels(
     if compose_project:
         labels["com.docker.compose.project"] = compose_project
     return labels
+
+
+@dataclass(frozen=True)
+class _RenderedSessionFiles:
+    """Output of ``_render_session_files``.
+
+    Both fields are already shell-escaped for ``printf '%s' '...'``.
+    ``opencode_json`` is ``None`` when the per-session file is not
+    needed (serve transport loads its provider config from env).
+    """
+
+    agents_md: str
+    opencode_json: str | None
 
 
 class ContainerCreateKwargs(TypedDict):
@@ -715,18 +729,16 @@ class DockerSandboxManager(SandboxManager):
         skills_section: str,
         user_name: str | None = None,
         user_role: str | None = None,
-    ) -> tuple[str, str | None]:
-        """Render shell-escaped ``(AGENTS.md, opencode.json | None)``.
+    ) -> _RenderedSessionFiles:
+        """Render shell-escaped session config files.
 
-        Under ``AGENT_TRANSPORT=serve`` the second element is ``None`` —
+        ``opencode_json`` is ``None`` under ``AGENT_TRANSPORT=serve`` —
         opencode-serve loaded its provider config from
         ``OPENCODE_CONFIG_CONTENT`` at startup and does not re-read
-        per-session ``opencode.json`` files. Writing one would just
-        pollute snapshots.
-
-        Under ``AGENT_TRANSPORT=acp`` we still emit the per-session
-        ``opencode.json`` because each exec'd ``opencode acp`` invocation
-        loads it.
+        per-session ``opencode.json`` files; writing one would just
+        pollute snapshots. Under ``AGENT_TRANSPORT=acp`` we still emit
+        the per-session file because each exec'd ``opencode acp``
+        invocation loads it.
         """
         agent_instructions = generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
@@ -750,9 +762,13 @@ class DockerSandboxManager(SandboxManager):
                 )
             )
         # Escape single quotes for ``printf '%s' '...'``.
-        return (
-            agent_instructions.replace("'", "'\\''"),
-            opencode_json.replace("'", "'\\''") if opencode_json is not None else None,
+        return _RenderedSessionFiles(
+            agents_md=agent_instructions.replace("'", "'\\''"),
+            opencode_json=(
+                opencode_json.replace("'", "'\\''")
+                if opencode_json is not None
+                else None
+            ),
         )
 
     def setup_session_workspace(
@@ -777,7 +793,7 @@ class DockerSandboxManager(SandboxManager):
 
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
-        agents_md, opencode_json = self._render_session_files(
+        rendered = self._render_session_files(
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
@@ -793,8 +809,8 @@ class DockerSandboxManager(SandboxManager):
         # AGENT_TRANSPORT=serve uses pod-level OPENCODE_CONFIG_CONTENT; skip
         # per-session opencode.json so snapshots stay clean.
         opencode_json_write = (
-            f"printf '%s' '{opencode_json}' > {session_path}/opencode.json"
-            if opencode_json is not None
+            f"printf '%s' '{rendered.opencode_json}' > {session_path}/opencode.json"
+            if rendered.opencode_json is not None
             else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
         )
         setup_script = f"""
@@ -823,7 +839,7 @@ else
     mkdir -p {session_path}/outputs/web
 fi
 ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
-printf '%s' '{agents_md}' > {session_path}/AGENTS.md
+printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
 {opencode_json_write}
 {nextjs_start}
 echo "Session workspace setup complete"
@@ -1098,21 +1114,21 @@ fi
         ``.opencode-data/`` — the symlink and config files are regenerated
         here so restored sessions still see the pushed skill files.
         """
-        agents_md, opencode_json = self._render_session_files(
+        rendered = self._render_session_files(
             llm_config=llm_config,
             nextjs_port=nextjs_port,
             skills_section=skills_section,
         )
         opencode_json_write = (
-            f"printf '%s' '{opencode_json}' > {session_path}/opencode.json"
-            if opencode_json is not None
+            f"printf '%s' '{rendered.opencode_json}' > {session_path}/opencode.json"
+            if rendered.opencode_json is not None
             else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
         )
         script = f"""
 set -e
 mkdir -p {session_path}/.opencode
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
-printf '%s' '{agents_md}' > {session_path}/AGENTS.md
+printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
 {opencode_json_write}
 """
         try:

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -54,6 +54,7 @@ import io
 import json
 import mimetypes
 import re
+import secrets
 import shlex
 import tarfile
 import threading
@@ -72,8 +73,12 @@ from docker.models.containers import Container
 from onyx.db.enums import SandboxStatus
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import AGENT_TRANSPORT
+from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.configs import ATTACHMENTS_DIRECTORY
 from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
+from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
 from onyx.server.features.build.configs import SANDBOX_DOCKER_CPU_LIMIT
@@ -310,6 +315,8 @@ def build_container_create_kwargs(
     volume_name: str,
     memory_limit: str,
     cpu_limit: float,
+    opencode_password: str,
+    opencode_config_json: str,
     compose_project: str | None = None,
 ) -> ContainerCreateKwargs:
     """Build the kwargs dict for ``DockerClient.containers.create``.
@@ -317,8 +324,11 @@ def build_container_create_kwargs(
     Sandbox isolation invariants enforced here (locked down by
     ``test_docker_manager_config.py``):
 
-    - **Env is a fixed allowlist**: ONYX_PAT + ONYX_SERVER_URL only. No
-      caller can inject arbitrary env. No S3/MinIO/Postgres/Redis
+    - **Env is a fixed allowlist**: ONYX_PAT, ONYX_SERVER_URL, plus the
+      four serve-transport vars (``AGENT_TRANSPORT``,
+      ``OPENCODE_SERVE_PORT``, the password env named by
+      ``OPENCODE_SERVER_PASSWORD_ENV``, and ``OPENCODE_CONFIG_CONTENT``).
+      No caller can inject anything else. No S3/MinIO/Postgres/Redis
       credentials. No compose service hostnames.
     - **No host mounts**: only the per-sandbox named volume mounted at
       ``/workspace/sessions``. No Docker socket. No FileStore root.
@@ -333,6 +343,13 @@ def build_container_create_kwargs(
     inside the sandbox will hit over HTTPS) — not an internal compose DNS
     name. We emit a warning if it looks like the latter, since reaching it
     would require the sandbox to be on the compose default network.
+
+    ``opencode_password`` is generated per-provision by the manager and
+    injected as the env var named by ``OPENCODE_SERVER_PASSWORD_ENV``.
+    The api_server reads it back via ``docker inspect`` rather than
+    persisting it on disk. ``opencode_config_json`` is the full
+    ``opencode.json`` content (single-provider for Docker today), surfaced
+    as ``OPENCODE_CONFIG_CONTENT`` for opencode-serve to load at startup.
     """
     if _looks_like_internal_compose_host(api_server_url):
         logger.warning(
@@ -347,6 +364,10 @@ def build_container_create_kwargs(
     env = {
         "ONYX_PAT": onyx_pat,
         "ONYX_SERVER_URL": api_server_url,
+        "AGENT_TRANSPORT": AGENT_TRANSPORT.value,
+        "OPENCODE_SERVE_PORT": str(OPENCODE_SERVE_PORT),
+        OPENCODE_SERVER_PASSWORD_ENV: opencode_password,
+        "OPENCODE_CONFIG_CONTENT": opencode_config_json,
     }
 
     security_opts = ["no-new-privileges:true"]
@@ -400,6 +421,10 @@ class DockerSandboxManager(SandboxManager):
         self._memory_limit = SANDBOX_DOCKER_MEMORY_LIMIT
         self._cpu_limit = SANDBOX_DOCKER_CPU_LIMIT
         self._snapshot_manager = SnapshotManager(get_default_file_store())
+
+        # Per-sandbox event buses, prompt locks, and termination tombstones —
+        # shared with the K8s manager via base.py.
+        self._init_serve_state()
 
         build_dir = Path(__file__).parent.parent.parent
         self._agent_instructions_template_path = build_dir / "AGENTS.template.md"
@@ -501,10 +526,10 @@ class DockerSandboxManager(SandboxManager):
         sandbox_id: UUID,
         user_id: UUID,
         tenant_id: str,
-        llm_config: LLMProviderConfig,  # noqa: ARG002
+        llm_config: LLMProviderConfig,
         onyx_pat: str | None = None,
         *,
-        all_llm_configs: list[LLMProviderConfig] | None = None,  # noqa: ARG002 — serve-only
+        all_llm_configs: list[LLMProviderConfig] | None = None,  # noqa: ARG002 — see opencode-serve-migration §Multi-provider; Docker is single-provider today
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning")
@@ -520,10 +545,28 @@ class DockerSandboxManager(SandboxManager):
             tenant_id,
         )
 
+        # Re-provision clears the tombstone so future subscribes can build a
+        # fresh bus against the new container.
+        with self._event_buses_lock:
+            self._terminated_sandboxes.discard(sandbox_id)
+
         # 1. Idempotency: reuse an existing container if at all possible.
         container = self._reuse_existing_container(sandbox_id)
         if container is None:
-            # 2. Otherwise create a fresh one.
+            # 2. Build per-sandbox HTTP Basic password + opencode-serve config
+            #    before creating the container. opencode-serve loads its
+            #    provider list at startup, so this content has to be present
+            #    in env from the very first ``opencode serve`` invocation.
+            opencode_password = secrets.token_urlsafe(32)
+            opencode_config_json = json.dumps(
+                build_opencode_config(
+                    provider=llm_config.provider,
+                    model_name=llm_config.model_name,
+                    api_key=llm_config.api_key or None,
+                    api_base=llm_config.api_base,
+                    disabled_tools=OPENCODE_DISABLED_TOOLS,
+                )
+            )
             self._ensure_sandbox_network()
             volume_name = self._ensure_sandbox_volume(sandbox_id, tenant_id)
             container = self._create_sandbox_container(
@@ -532,11 +575,20 @@ class DockerSandboxManager(SandboxManager):
                 tenant_id=tenant_id,
                 onyx_pat=onyx_pat,
                 volume_name=volume_name,
+                opencode_password=opencode_password,
+                opencode_config_json=opencode_config_json,
             )
 
         if not self._wait_for_container_running(container):
             raise RuntimeError(
                 f"Timeout waiting for sandbox container {container.name} to be running"
+            )
+
+        # opencode-serve binds :4096 a few hundred ms to a few seconds after
+        # the container is reported running. No-op under AGENT_TRANSPORT=acp.
+        if not self._wait_for_opencode_serve_ready(sandbox_id):
+            raise RuntimeError(
+                f"opencode-serve never became ready in sandbox container {container.name}"
             )
 
         logger.info(
@@ -573,6 +625,8 @@ class DockerSandboxManager(SandboxManager):
         tenant_id: str,
         onyx_pat: str,
         volume_name: str,
+        opencode_password: str,
+        opencode_config_json: str,
     ) -> Container:
         """Run docker create + start with our security/network/labels invariants."""
         create_kwargs = build_container_create_kwargs(
@@ -586,6 +640,8 @@ class DockerSandboxManager(SandboxManager):
             volume_name=volume_name,
             memory_limit=self._memory_limit,
             cpu_limit=self._cpu_limit,
+            opencode_password=opencode_password,
+            opencode_config_json=opencode_config_json,
             compose_project=self._compose_project,
         )
         try:
@@ -601,6 +657,17 @@ class DockerSandboxManager(SandboxManager):
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
+        # Tombstone + pop the bus under one lock so a concurrent subscribe
+        # can't race in and create a fresh bus against the dying container.
+        with self._event_buses_lock:
+            self._terminated_sandboxes.add(sandbox_id)
+            bus = self._event_buses.pop(sandbox_id, None)
+        if bus is not None:
+            try:
+                bus.close()
+            except Exception:  # noqa: BLE001 — never let cleanup break terminate
+                logger.exception("PodEventBus close failed for sandbox %s", sandbox_id)
+
         container = self._get_container(sandbox_id)
         if container is not None:
             try:
@@ -648,11 +715,18 @@ class DockerSandboxManager(SandboxManager):
         skills_section: str,
         user_name: str | None = None,
         user_role: str | None = None,
-    ) -> tuple[str, str]:
-        """Render shell-escaped (AGENTS.md, opencode.json) for a session.
+    ) -> tuple[str, str | None]:
+        """Render shell-escaped ``(AGENTS.md, opencode.json | None)``.
 
-        Shared between fresh setup and post-restore regeneration since
-        neither AGENTS.md nor opencode.json is included in snapshots.
+        Under ``AGENT_TRANSPORT=serve`` the second element is ``None`` —
+        opencode-serve loaded its provider config from
+        ``OPENCODE_CONFIG_CONTENT`` at startup and does not re-read
+        per-session ``opencode.json`` files. Writing one would just
+        pollute snapshots.
+
+        Under ``AGENT_TRANSPORT=acp`` we still emit the per-session
+        ``opencode.json`` because each exec'd ``opencode acp`` invocation
+        loads it.
         """
         agent_instructions = generate_agent_instructions(
             template_path=self._agent_instructions_template_path,
@@ -664,19 +738,21 @@ class DockerSandboxManager(SandboxManager):
             user_name=user_name,
             user_role=user_role,
         )
-        opencode_json = json.dumps(
-            build_opencode_config(
-                provider=llm_config.provider,
-                model_name=llm_config.model_name,
-                api_key=llm_config.api_key or None,
-                api_base=llm_config.api_base,
-                disabled_tools=OPENCODE_DISABLED_TOOLS,
+        opencode_json: str | None = None
+        if AGENT_TRANSPORT == AgentTransport.ACP:
+            opencode_json = json.dumps(
+                build_opencode_config(
+                    provider=llm_config.provider,
+                    model_name=llm_config.model_name,
+                    api_key=llm_config.api_key or None,
+                    api_base=llm_config.api_base,
+                    disabled_tools=OPENCODE_DISABLED_TOOLS,
+                )
             )
-        )
         # Escape single quotes for ``printf '%s' '...'``.
         return (
             agent_instructions.replace("'", "'\\''"),
-            opencode_json.replace("'", "'\\''"),
+            opencode_json.replace("'", "'\\''") if opencode_json is not None else None,
         )
 
     def setup_session_workspace(
@@ -714,6 +790,13 @@ class DockerSandboxManager(SandboxManager):
             if nextjs_port is not None
             else ""
         )
+        # AGENT_TRANSPORT=serve uses pod-level OPENCODE_CONFIG_CONTENT; skip
+        # per-session opencode.json so snapshots stay clean.
+        opencode_json_write = (
+            f"printf '%s' '{opencode_json}' > {session_path}/opencode.json"
+            if opencode_json is not None
+            else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
+        )
         setup_script = f"""
 set -e
 echo "Creating session directory: {session_path}"
@@ -741,7 +824,7 @@ else
 fi
 ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
-printf '%s' '{opencode_json}' > {session_path}/opencode.json
+{opencode_json_write}
 {nextjs_start}
 echo "Session workspace setup complete"
 """
@@ -1020,12 +1103,17 @@ fi
             nextjs_port=nextjs_port,
             skills_section=skills_section,
         )
+        opencode_json_write = (
+            f"printf '%s' '{opencode_json}' > {session_path}/opencode.json"
+            if opencode_json is not None
+            else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
+        )
         script = f"""
 set -e
 mkdir -p {session_path}/.opencode
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
-printf '%s' '{opencode_json}' > {session_path}/opencode.json
+{opencode_json_write}
 """
         try:
             run_in_container(container, ["/bin/sh", "-c", script])
@@ -1033,7 +1121,39 @@ printf '%s' '{opencode_json}' > {session_path}/opencode.json
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
 
     # ------------------------------------------------------------------
-    # ACP messaging
+    # opencode serve transport hooks (called by SandboxManager base class)
+    # ------------------------------------------------------------------
+
+    def _serve_base_url(self, sandbox_id: UUID) -> str:
+        """Container-name URL on the sandbox bridge network.
+
+        api_server must be on ``SANDBOX_DOCKER_NETWORK`` (the
+        ``onyx_craft_sandbox`` bridge) for this to resolve — same
+        requirement as the push-daemon path.
+        """
+        return f"http://{_sandbox_container_name(sandbox_id)}:{OPENCODE_SERVE_PORT}"
+
+    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:
+        """Pull the per-container HTTP Basic password out of the
+        container's env (via ``docker inspect``). Returns ``None`` for
+        legacy containers provisioned before this code landed; the bus
+        falls back to no-auth in that case (logged loudly).
+        """
+        container = self._get_container(sandbox_id)
+        if container is None:
+            return None
+        try:
+            env_list = ((container.attrs or {}).get("Config") or {}).get("Env") or []
+        except (APIError, NotFound):
+            return None
+        prefix = f"{OPENCODE_SERVER_PASSWORD_ENV}="
+        for entry in env_list:
+            if entry.startswith(prefix):
+                return entry[len(prefix) :]
+        return None
+
+    # ------------------------------------------------------------------
+    # Agent messaging
     # ------------------------------------------------------------------
 
     def send_message(
@@ -1042,13 +1162,42 @@ printf '%s' '{opencode_json}' > {session_path}/opencode.json
         session_id: UUID,
         message: str,
         *,
-        opencode_session_id: str | None = None,  # noqa: ARG002 — serve-only
-        agent_provider: str | None = None,  # noqa: ARG002 — serve-only
-        agent_model: str | None = None,  # noqa: ARG002 — serve-only
-        on_opencode_session_resolved: (  # noqa: ARG002 — serve-only
-            Callable[[str], None] | None
-        ) = None,
+        opencode_session_id: str | None = None,
+        agent_provider: str | None = None,
+        agent_model: str | None = None,
+        on_opencode_session_resolved: Callable[[str], None] | None = None,
     ) -> Generator[ACPEvent, None, None]:
+        """Stream ACP events for one user message. Branches on
+        ``AGENT_TRANSPORT``:
+
+        - ``serve`` (default post-migration): drive long-lived
+          ``opencode serve`` HTTP inside the container via the base-class
+          ``_send_message_via_serve``.
+        - ``acp`` (rollback): exec ``opencode acp`` once per message via
+          :class:`DockerACPExecClient`. Deletion happens in the
+          drop-acp-layer follow-up.
+        """
+        if AGENT_TRANSPORT == AgentTransport.SERVE:
+            yield from self._send_message_via_serve(
+                sandbox_id,
+                session_id,
+                message,
+                opencode_session_id,
+                agent_provider,
+                agent_model,
+                on_opencode_session_resolved=on_opencode_session_resolved,
+            )
+            return
+        yield from self._send_message_via_acp(sandbox_id, session_id, message)
+
+    def _send_message_via_acp(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        message: str,
+    ) -> Generator[ACPEvent, None, None]:
+        """Original ACP path. Kept callable behind ``AGENT_TRANSPORT=acp``
+        as the rollback target for the serve migration."""
         container = self._require_container(sandbox_id)
         session_path = f"{SESSIONS_ROOT}/{session_id}"
         packet_logger = get_packet_logger()

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -34,6 +34,22 @@ Sandbox containers run with:
   network. As a result api_server / postgres / redis / minio /
   model_server are NOT reachable by service name from inside the sandbox.
 
+Threat model — Docker vs Kubernetes parity gap
+----------------------------------------------
+The LLM provider ``api_key`` is passed into the sandbox container via
+``OPENCODE_CONFIG_CONTENT`` (a Docker env var). Docker stores env vars in
+plaintext on the host's container metadata; anyone with access to the
+Docker daemon (e.g. operators running ``docker inspect``) can read it.
+This differs from the K8s backend, which loads the same config from a
+namespaced ``Secret`` (RBAC-scoped, mounted into env at boot).
+
+Self-hosted docker-compose deployers should treat host access to the
+Docker daemon as access to the LLM provider key. The single-process
+nature of docker-compose makes this practically equivalent to
+``cat .env`` — but the failure mode is more subtle (the key shows up
+in any ``docker inspect`` paste), so it's worth calling out. See the
+docker-opencode-serve.md doc for the operator-facing note.
+
 Outbound communication is intentionally limited to:
 
 1. Public internet over HTTPS (the bridge has default internet egress;
@@ -59,10 +75,9 @@ import shlex
 import tarfile
 import threading
 import time
-from collections.abc import Callable
 from collections.abc import Generator
-from dataclasses import dataclass
 from pathlib import Path
+from typing import NamedTuple
 from typing import TypedDict
 from uuid import UUID
 
@@ -114,6 +129,7 @@ from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
 )
@@ -279,8 +295,7 @@ def build_sandbox_labels(
     return labels
 
 
-@dataclass(frozen=True)
-class _RenderedSessionFiles:
+class _RenderedSessionFiles(NamedTuple):
     """Output of ``_render_session_files``.
 
     Both fields are already shell-escaped for ``printf '%s' '...'``.
@@ -290,6 +305,18 @@ class _RenderedSessionFiles:
 
     agents_md: str
     opencode_json: str | None
+
+
+def _opencode_json_write_snippet(opencode_json: str | None, session_path: str) -> str:
+    """Shell line for the per-session opencode.json under ACP, or a
+    no-op comment under serve (where the file is redundant — opencode-serve
+    already loaded its provider config from OPENCODE_CONFIG_CONTENT)."""
+    if opencode_json is None:
+        return (
+            "# AGENT_TRANSPORT=serve: opencode.json is container-level "
+            "via OPENCODE_CONFIG_CONTENT"
+        )
+    return f"printf '%s' '{opencode_json}' > {session_path}/opencode.json"
 
 
 class ContainerCreateKwargs(TypedDict):
@@ -527,13 +554,27 @@ class DockerSandboxManager(SandboxManager):
         llm_config: LLMProviderConfig,
         onyx_pat: str | None = None,
         *,
-        all_llm_configs: list[LLMProviderConfig] | None = None,  # noqa: ARG002 — see opencode-serve-migration §Multi-provider; Docker is single-provider today
+        all_llm_configs: list[LLMProviderConfig] | None = None,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning")
         if not SANDBOX_API_SERVER_URL:
             raise ValueError(
                 "SANDBOX_API_SERVER_URL must be set for Docker sandbox provisioning"
+            )
+
+        if all_llm_configs is not None and len(all_llm_configs) > 1:
+            # Docker is single-provider today — opencode-serve loads only
+            # one provider's config at container startup. Per-prompt
+            # ``agent_provider`` overrides will fail at runtime with a
+            # generic "provider not registered" from opencode. Warn at
+            # provision so operators see this before the first request.
+            logger.warning(
+                "DockerSandboxManager.provision received %d LLM configs but only "
+                "the primary provider %r is bootstrapped; per-prompt provider "
+                "overrides will fail until Docker grows multi-provider support.",
+                len(all_llm_configs),
+                llm_config.provider,
             )
 
         logger.info(
@@ -543,9 +584,11 @@ class DockerSandboxManager(SandboxManager):
             tenant_id,
         )
 
-        # Re-provision: clear tombstone so subscribes can build a fresh bus.
+        # Re-provision: clear tombstone + cached connection info so
+        # subscribes can build a fresh bus against the new container.
         with self._event_buses_lock:
             self._terminated_sandboxes.discard(sandbox_id)
+        self._invalidate_serve_connection_info(sandbox_id)
 
         container = self._reuse_existing_container(sandbox_id)
         if container is None:
@@ -646,16 +689,9 @@ class DockerSandboxManager(SandboxManager):
             raise RuntimeError(f"Failed to create sandbox container: {e}") from e
 
     def terminate(self, sandbox_id: UUID) -> None:
-        # Tombstone + pop under one lock so subscribe can't race a fresh bus in.
-        with self._event_buses_lock:
-            self._terminated_sandboxes.add(sandbox_id)
-            doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
-            doomed_buses = [self._event_buses.pop(k) for k in doomed_keys]
-        for bus in doomed_buses:
-            try:
-                bus.close()
-            except Exception:  # noqa: BLE001 — never let cleanup break terminate
-                logger.exception("PodEventBus close failed for sandbox %s", sandbox_id)
+        # Tombstone, pop every per-directory bus, and drop cached connection
+        # info — all in the mixin so the contract is shared with K8s.
+        self._close_all_sandbox_buses(sandbox_id)
 
         container = self._get_container(sandbox_id)
         if container is not None:
@@ -769,10 +805,8 @@ class DockerSandboxManager(SandboxManager):
             if nextjs_port is not None
             else ""
         )
-        opencode_json_write = (
-            f"printf '%s' '{rendered.opencode_json}' > {session_path}/opencode.json"
-            if rendered.opencode_json is not None
-            else "# serve transport: opencode.json is container-level (OPENCODE_CONFIG_CONTENT)"
+        opencode_json_write = _opencode_json_write_snippet(
+            rendered.opencode_json, session_path
         )
         setup_script = f"""
 set -e
@@ -822,6 +856,10 @@ echo "Session workspace setup complete"
         session_id: UUID,
         nextjs_port: int | None = None,  # noqa: ARG002
     ) -> None:
+        # Release the per-session event bus first so its SSE reader thread
+        # + httpx connection don't leak when the session goes away.
+        self._close_session_buses(sandbox_id, session_id)
+
         container = self._get_container(sandbox_id)
         if container is None:
             logger.debug(
@@ -1072,10 +1110,8 @@ fi
             nextjs_port=nextjs_port,
             skills_section=skills_section,
         )
-        opencode_json_write = (
-            f"printf '%s' '{rendered.opencode_json}' > {session_path}/opencode.json"
-            if rendered.opencode_json is not None
-            else "# AGENT_TRANSPORT=serve: opencode.json is container-level via OPENCODE_CONFIG_CONTENT"
+        opencode_json_write = _opencode_json_write_snippet(
+            rendered.opencode_json, session_path
         )
         script = f"""
 set -e
@@ -1089,20 +1125,16 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
         except ExecError as e:
             raise RuntimeError(f"Failed to regenerate session config: {e}") from e
 
-    def _serve_base_url(self, sandbox_id: UUID) -> str:
-        """Container-name URL on the sandbox bridge network.
+    def _load_serve_connection_info(
+        self, sandbox_id: UUID
+    ) -> ServeConnectionInfo | None:
+        """Build the serve connection info from the Docker container.
 
-        api_server must be on ``SANDBOX_DOCKER_NETWORK`` (the
-        ``onyx_craft_sandbox`` bridge) for this to resolve — same
-        requirement as the push-daemon path.
-        """
-        return f"http://{_sandbox_container_name(sandbox_id)}:{OPENCODE_SERVE_PORT}"
-
-    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:
-        """Pull the per-container HTTP Basic password out of the
-        container's env (via ``docker inspect``). Returns ``None`` for
-        legacy containers provisioned before this code landed; the bus
-        falls back to no-auth in that case (logged loudly).
+        Single read of ``docker inspect``: the base URL is derived from
+        the deterministic container name; the password lives in the
+        container's env (set at create time by
+        ``build_container_create_kwargs``). Cached by the mixin so the
+        hot path doesn't hit dockerd on every prompt.
         """
         container = self._get_container(sandbox_id)
         if container is None:
@@ -1111,45 +1143,18 @@ printf '%s' '{rendered.agents_md}' > {session_path}/AGENTS.md
             env_list = ((container.attrs or {}).get("Config") or {}).get("Env") or []
         except (APIError, NotFound):
             return None
+        password: str | None = None
         prefix = f"{OPENCODE_SERVER_PASSWORD_ENV}="
         for entry in env_list:
             if entry.startswith(prefix):
-                return entry[len(prefix) :]
-        return None
-
-    def send_message(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        message: str,
-        *,
-        opencode_session_id: str | None = None,
-        agent_provider: str | None = None,
-        agent_model: str | None = None,
-        on_opencode_session_resolved: Callable[[str], None] | None = None,
-    ) -> Generator[ACPEvent, None, None]:
-        """Stream ACP events for one user message. Branches on
-        ``AGENT_TRANSPORT``:
-
-        - ``serve`` (default post-migration): drive long-lived
-          ``opencode serve`` HTTP inside the container via the base-class
-          ``_send_message_via_serve``.
-        - ``acp`` (rollback): exec ``opencode acp`` once per message via
-          :class:`DockerACPExecClient`. Deletion happens in the
-          drop-acp-layer follow-up.
-        """
-        if AGENT_TRANSPORT == AgentTransport.SERVE:
-            yield from self._send_message_via_serve(
-                sandbox_id,
-                session_id,
-                message,
-                opencode_session_id,
-                agent_provider,
-                agent_model,
-                on_opencode_session_resolved=on_opencode_session_resolved,
-            )
-            return
-        yield from self._send_message_via_acp(sandbox_id, session_id, message)
+                password = entry[len(prefix) :]
+                break
+        return ServeConnectionInfo(
+            base_url=(
+                f"http://{_sandbox_container_name(sandbox_id)}:{OPENCODE_SERVE_PORT}"
+            ),
+            password=password,
+        )
 
     def _send_message_via_acp(
         self,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -47,7 +47,6 @@ import socket
 import tarfile
 import threading
 import time
-from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterator
 from pathlib import Path
@@ -115,6 +114,7 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
 )
@@ -1291,10 +1291,12 @@ class KubernetesSandboxManager(SandboxManager):
             )
 
         try:
-            # Re-provision: clear the tombstone so future subscribes can
-            # build a fresh bus against the new pod.
+            # Re-provision: clear the tombstone + cached connection info so
+            # future subscribes build a fresh bus against the new pod with
+            # the new Secret's password.
             with self._event_buses_lock:
                 self._terminated_sandboxes.discard(sandbox_id)
+            self._invalidate_serve_connection_info(sandbox_id)
 
             # Secret must exist before the Pod (env references it via
             # secretKeyRef). Pre-load every configured provider so
@@ -1530,19 +1532,9 @@ class KubernetesSandboxManager(SandboxManager):
 
     def terminate(self, sandbox_id: UUID) -> None:
         """Tear down the per-pod event bus, then delete Service + Pod."""
-        # Tombstone + pop all buses for this sandbox (one per directory)
-        # under one lock so a concurrent subscribe can't race in and create
-        # a fresh bus against the dying pod.
-        with self._event_buses_lock:
-            self._terminated_sandboxes.add(sandbox_id)
-            doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
-            doomed_buses = [self._event_buses.pop(k) for k in doomed_keys]
-        for bus in doomed_buses:
-            try:
-                bus.close()
-            except Exception:  # noqa: BLE001 — never let cleanup break terminate
-                logger.exception("PodEventBus close failed for sandbox %s", sandbox_id)
-
+        # Tombstone, pop every per-directory bus, and drop cached connection
+        # info — same contract as Docker, lives on the shared mixin.
+        self._close_all_sandbox_buses(sandbox_id)
         self._cleanup_kubernetes_resources(str(sandbox_id))
         logger.info("Terminated Kubernetes sandbox %s", sandbox_id)
 
@@ -1745,6 +1737,10 @@ echo "Session workspace setup complete"
             nextjs_port: Optional port where Next.js server is running (unused in K8s,
                         we use PID file instead)
         """
+        # Drop the per-session event bus first so its reader thread + httpx
+        # connection don't leak past the session's lifetime.
+        self._close_session_buses(sandbox_id, session_id)
+
         pod_name = self._get_pod_name(str(sandbox_id))
         session_path = f"/workspace/sessions/{session_id}"
 
@@ -2169,41 +2165,9 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         )
         return acp_client
 
-    def send_message(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        message: str,
-        *,
-        opencode_session_id: str | None = None,
-        agent_provider: str | None = None,
-        agent_model: str | None = None,
-        on_opencode_session_resolved: Callable[[str], None] | None = None,
-    ) -> Generator[ACPEvent, None, None]:
-        """Stream ACP events for one user message. Transport selected by
-        ``AGENT_TRANSPORT`` (configs.py).
-
-        - ``serve``: long-lived ``opencode serve`` inside the pod, driven
-          via :class:`OpencodeServeClient`. Requires ``opencode_session_id``
-          (or a successful preflight via :meth:`ensure_opencode_session`).
-          ``agent_provider``/``agent_model`` become the per-prompt model
-          override (``body["model"]`` on ``POST .../prompt_async``).
-        - ``acp`` (default): ephemeral ``opencode acp`` exec'd per message.
-          Documented in :meth:`_send_message_via_acp` — preserved here
-          unchanged for the rollback window of the migration plan.
-        """
-        if AGENT_TRANSPORT == AgentTransport.SERVE:
-            yield from self._send_message_via_serve(
-                sandbox_id,
-                session_id,
-                message,
-                opencode_session_id,
-                agent_provider,
-                agent_model,
-                on_opencode_session_resolved=on_opencode_session_resolved,
-            )
-            return
-        yield from self._send_message_via_acp(sandbox_id, session_id, message)
+    # ``send_message`` lives on the base class; it dispatches to
+    # ``_send_message_via_serve`` (in :class:`_ServeMixin`) or
+    # ``_send_message_via_acp`` (below) based on ``AGENT_TRANSPORT``.
 
     def _send_message_via_acp(
         self,
@@ -2322,13 +2286,22 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                     e,
                 )
 
-    def _serve_base_url(self, sandbox_id: UUID) -> str:
-        """In-cluster URL for opencode-serve. Routes via Service (not pod IP)
-        because telepresence drops arbitrary pod-IP traffic."""
+    def _load_serve_connection_info(
+        self, sandbox_id: UUID
+    ) -> ServeConnectionInfo | None:
+        """Build the serve connection info from the per-pod Secret.
+
+        URL is the in-cluster Service DNS, not the pod IP — telepresence
+        drops arbitrary pod-IP traffic, so the Service form is the one
+        that survives dev/local environments.
+        """
         service_name = self._get_service_name(str(sandbox_id))
-        return (
-            f"http://{service_name}.{self._namespace}.svc.cluster.local"
-            f":{OPENCODE_SERVE_PORT}"
+        return ServeConnectionInfo(
+            base_url=(
+                f"http://{service_name}.{self._namespace}.svc.cluster.local"
+                f":{OPENCODE_SERVE_PORT}"
+            ),
+            password=self._read_opencode_password(sandbox_id),
         )
 
     def list_directory(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1291,9 +1291,8 @@ class KubernetesSandboxManager(SandboxManager):
             )
 
         try:
-            # Re-provision: clear the tombstone + cached connection info so
-            # future subscribes build a fresh bus against the new pod with
-            # the new Secret's password.
+            # Re-provision: clear tombstone + cached info so subscribes
+            # build a fresh bus with the new Secret's password.
             with self._event_buses_lock:
                 self._terminated_sandboxes.discard(sandbox_id)
             self._invalidate_serve_connection_info(sandbox_id)
@@ -1531,9 +1530,7 @@ class KubernetesSandboxManager(SandboxManager):
                 self._wait_for_resource_deletion("pod", pod_name)
 
     def terminate(self, sandbox_id: UUID) -> None:
-        """Tear down the per-pod event bus, then delete Service + Pod."""
-        # Tombstone, pop every per-directory bus, and drop cached connection
-        # info — same contract as Docker, lives on the shared mixin.
+        """Tear down event buses, then delete Service + Pod."""
         self._close_all_sandbox_buses(sandbox_id)
         self._cleanup_kubernetes_resources(str(sandbox_id))
         logger.info("Terminated Kubernetes sandbox %s", sandbox_id)
@@ -1737,8 +1734,6 @@ echo "Session workspace setup complete"
             nextjs_port: Optional port where Next.js server is running (unused in K8s,
                         we use PID file instead)
         """
-        # Drop the per-session event bus first so its reader thread + httpx
-        # connection don't leak past the session's lifetime.
         self._close_session_buses(sandbox_id, session_id)
 
         pod_name = self._get_pod_name(str(sandbox_id))
@@ -2289,12 +2284,8 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
     def _load_serve_connection_info(
         self, sandbox_id: UUID
     ) -> ServeConnectionInfo | None:
-        """Build the serve connection info from the per-pod Secret.
-
-        URL is the in-cluster Service DNS, not the pod IP — telepresence
-        drops arbitrary pod-IP traffic, so the Service form is the one
-        that survives dev/local environments.
-        """
+        """Build serve connection info from the per-pod Secret. URL uses
+        the Service DNS (not pod IP) so telepresence dev paths work."""
         service_name = self._get_service_name(str(sandbox_id))
         return ServeConnectionInfo(
             base_url=(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -69,7 +69,7 @@ from onyx.server.features.build.configs import AGENT_TRANSPORT
 from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
 from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
-from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
@@ -621,7 +621,7 @@ class KubernetesSandboxManager(SandboxManager):
                 client.V1EnvVar(name="ONYX_PAT", value=onyx_pat),
                 client.V1EnvVar(name="ONYX_SERVER_URL", value=SANDBOX_API_SERVER_URL),
                 client.V1EnvVar(
-                    name=OPENCODE_SERVER_PASSWORD_ENV,
+                    name=OPENCODE_SERVER_PASSWORD,
                     value_from=client.V1EnvVarSource(
                         secret_key_ref=client.V1SecretKeySelector(
                             name=self._get_opencode_secret_name(sandbox_id),

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -426,8 +426,6 @@ class KubernetesSandboxManager(SandboxManager):
         self._s3_bucket = SANDBOX_S3_BUCKET
         self._service_account = SANDBOX_SERVICE_ACCOUNT_NAME
 
-        # Per-sandbox event buses, prompt locks, and termination tombstones —
-        # shared with the Docker manager via base.py.
         self._init_serve_state()
 
         # Load AGENTS.md template path
@@ -2324,17 +2322,9 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                     e,
                 )
 
-    # =====================================================================
-    # opencode serve transport (AGENT_TRANSPORT=serve)
-    # =====================================================================
-
     def _serve_base_url(self, sandbox_id: UUID) -> str:
-        """In-cluster URL for this sandbox's opencode-serve.
-
-        Routes via Service (not pod IP) because telepresence's
-        host→cluster VPN drops arbitrary pod-IP traffic on non-Service
-        ports.
-        """
+        """In-cluster URL for opencode-serve. Routes via Service (not pod IP)
+        because telepresence drops arbitrary pod-IP traffic."""
         service_name = self._get_service_name(str(sandbox_id))
         return (
             f"http://{service_name}.{self._namespace}.svc.cluster.local"

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -35,13 +35,11 @@ Use get_sandbox_manager() from base.py to get the appropriate implementation.
 
 import base64
 import binascii
-import contextlib
 import hashlib
 import io
 import json
 import mimetypes
 import os
-import queue
 import re
 import secrets
 import shlex
@@ -71,10 +69,8 @@ from onyx.server.features.build.api.packet_logger import get_packet_logger
 from onyx.server.features.build.configs import AGENT_TRANSPORT
 from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
-from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
 from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
-from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_CONTAINER_IMAGE
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
@@ -93,7 +89,6 @@ from onyx.server.features.build.sandbox.acp.base import ACPEvent
 from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
 from onyx.server.features.build.sandbox.base import BUN_IMAGE_CACHE_DIR
 from onyx.server.features.build.sandbox.base import SandboxManager
-from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.sandbox.kubernetes.docker.sandbox_daemon.models import (
     SnapshotCreateRequest,
 )
@@ -120,8 +115,6 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
-from onyx.server.features.build.sandbox.opencode import OpencodeServeClient
-from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
 )
@@ -148,12 +141,6 @@ _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 AGENT_PORT = 8081
 PUSH_DAEMON_PORT = 8731
 POD_READY_TIMEOUT_SECONDS = 60
-# After k8s reports the pod Ready, opencode-serve still has to finish its
-# own boot (config parse, provider registry init, HTTP server bind on :4096).
-# Empirically 1–3s warm, up to ~15s cold. Budget 30s so a slow boot fails
-# loudly here instead of as a downstream "stream did not become ready".
-OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
-OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
 # Progressive poll cadence: short intervals up front (pods usually become
 # Ready in 12–18s, so we want to catch the transition quickly), then back
 # off so a stuck pod doesn't hammer the API server. Each tuple is
@@ -439,25 +426,9 @@ class KubernetesSandboxManager(SandboxManager):
         self._s3_bucket = SANDBOX_S3_BUCKET
         self._service_account = SANDBOX_SERVICE_ACCOUNT_NAME
 
-        # One PodEventBus per (pod, directory). Opencode-serve's
-        # Instance.provide middleware scopes /event per ?directory= query,
-        # so each session directory needs its own SSE stream.
-        self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
-        # Tombstone set: blocks late ``subscribe`` from re-creating a bus
-        # for a sandbox whose terminate is in flight (leaks a reconnect
-        # loop otherwise). Cleared on re-provision.
-        self._terminated_sandboxes: set[UUID] = set()
-        self._event_buses_lock = threading.Lock()
-
-        # Per-(sandbox_id, build_session_id) locks that serialize concurrent
-        # send_message calls on a single build session. See
-        # SandboxManager.prompt_slot for why this is keyed on
-        # build_session_id rather than opencode_session_id — short version:
-        # the opencode id can rotate mid-turn via the
-        # on_opencode_session_resolved callback, and keying on it would
-        # break serialization precisely in the recovery path.
-        self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
-        self._prompt_locks_meta: threading.Lock = threading.Lock()
+        # Per-sandbox event buses, prompt locks, and termination tombstones —
+        # shared with the Docker manager via base.py.
+        self._init_serve_state()
 
         # Load AGENTS.md template path
         build_dir = Path(__file__).parent.parent.parent  # /onyx/server/features/build/
@@ -2369,381 +2340,6 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             f"http://{service_name}.{self._namespace}.svc.cluster.local"
             f":{OPENCODE_SERVE_PORT}"
         )
-
-    def _wait_for_opencode_serve_ready(
-        self,
-        sandbox_id: UUID,
-        timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
-    ) -> bool:
-        """Block until opencode-serve answers ``GET /doc`` with 200.
-
-        k8s pod readiness only proves the container's health probes pass.
-        opencode-serve binds ``:4096`` a few hundred ms to a few seconds
-        later, after it finishes config parse and provider registry init.
-        Returning ``RUNNING`` before that means the first prompt's bus
-        subscribe races a cold opencode — connection refused or stale-auth
-        401 burns the bus's reconnect budget and surfaces to the user as
-        ``stream did not become ready``.
-
-        No-op under AGENT_TRANSPORT=acp.
-        """
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return True
-
-        password = self._read_opencode_password(sandbox_id)
-        auth = httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
-        base_url = self._serve_base_url(sandbox_id)
-        deadline = time.time() + timeout
-        last_err: str | None = None
-        while time.time() < deadline:
-            try:
-                with httpx.Client(base_url=base_url, auth=auth, timeout=2.0) as client:
-                    r = client.get("/doc")
-                    if r.status_code == 200:
-                        logger.info(
-                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
-                            sandbox_id,
-                        )
-                        return True
-                    last_err = f"HTTP {r.status_code}"
-            except httpx.HTTPError as e:
-                last_err = f"{type(e).__name__}: {e}"
-            time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
-        logger.error(
-            "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
-            "after %.0fs (last error: %s)",
-            sandbox_id,
-            timeout,
-            last_err,
-        )
-        return False
-
-    def _get_or_create_event_bus(
-        self, sandbox_id: UUID, directory: str
-    ) -> "PodEventBus":
-        """Lazily build the per-(pod, directory) :class:`PodEventBus`.
-        Refuses to create one for a terminated sandbox.
-
-        Opencode-serve's ``Instance.provide`` middleware scopes /event
-        per ``?directory=`` query param, so we need one SSE stream per
-        unique session directory on the pod.
-
-        Replaces a cached bus that has self-closed (exhausted its reconnect
-        budget) with a fresh one — otherwise callers would keep getting
-        ``BUS_CLOSED_SENTINEL`` until the api server restarted.
-        """
-        key = (sandbox_id, directory)
-        with self._event_buses_lock:
-            bus = self._event_buses.get(key)
-            if bus is not None and not bus.closed:
-                return bus
-            if bus is not None and bus.closed:
-                logger.warning(
-                    "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
-                    "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
-                    sandbox_id,
-                    directory,
-                )
-                self._event_buses.pop(key, None)
-            if sandbox_id in self._terminated_sandboxes:
-                raise RuntimeError(
-                    f"Sandbox {sandbox_id} has been terminated; refusing to "
-                    "create a new event bus against its (deleted) pod"
-                )
-            password = self._read_opencode_password(sandbox_id)
-            if password is None:
-                logger.warning(
-                    "[SANDBOX-SERVE] No opencode password Secret for sandbox %s; "
-                    "bus will run without auth (likely a legacy pod, re-provision to fix)",
-                    sandbox_id,
-                )
-            auth = (
-                httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password)
-                if password
-                else None
-            )
-            bus = PodEventBus(
-                base_url=self._serve_base_url(sandbox_id),
-                auth=auth,
-                directory=directory,
-                event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
-            )
-            self._event_buses[key] = bus
-            logger.info(
-                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s dir=%s",
-                sandbox_id,
-                directory,
-            )
-            return bus
-
-    def _build_serve_client(
-        self, sandbox_id: UUID, directory: str
-    ) -> OpencodeServeClient:
-        password = self._read_opencode_password(sandbox_id)
-        bus = self._get_or_create_event_bus(sandbox_id, directory)
-        return OpencodeServeClient(
-            base_url=self._serve_base_url(sandbox_id),
-            password=password,
-            event_bus=bus,
-        )
-
-    @contextlib.contextmanager
-    def prompt_slot(
-        self,
-        sandbox_id: UUID,
-        build_session_id: UUID,
-    ) -> Generator[bool, None, None]:
-        """Try-acquire the serializing lock for one build session. See
-        :meth:`SandboxManager.prompt_slot` for why this is keyed on
-        build_session_id rather than opencode_session_id.
-
-        Returns ``False`` immediately (no waiting) if a turn is already in
-        flight — the caller MUST surface a clean Error to the user without
-        persisting any new user_message row.
-        """
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            yield True
-            return
-
-        key = (sandbox_id, build_session_id)
-        with self._prompt_locks_meta:
-            lock = self._prompt_locks.get(key)
-            if lock is None:
-                lock = threading.Lock()
-                self._prompt_locks[key] = lock
-
-        acquired = lock.acquire(blocking=False)
-        try:
-            if not acquired:
-                logger.warning(
-                    "[SANDBOX-SERVE] prompt_slot: refused — concurrent send_message "
-                    "on sandbox=%s build_session=%s",
-                    sandbox_id,
-                    build_session_id,
-                )
-            yield acquired
-        finally:
-            if acquired:
-                lock.release()
-
-    def ensure_opencode_session(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-    ) -> str | None:
-        """Resolve (or create) the persistent opencode-serve session id
-        for this build session. See :class:`SandboxManager`."""
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return None
-        session_path = f"/workspace/sessions/{session_id}"
-        logger.info(
-            "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
-            "sandbox=%s cwd=%s (passing id=None, so client will POST /session)",
-            session_id,
-            sandbox_id,
-            session_path,
-        )
-        with self._build_serve_client(sandbox_id, session_path) as client:
-            return client.ensure_session(
-                None,
-                directory=session_path,
-                title=f"build-session-{str(session_id)[:8]}",
-            )
-
-    def list_subagents(
-        self,
-        sandbox_id: UUID,
-        parent_opencode_session_id: str,
-    ) -> list[str]:
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return []
-        # Don't create a bus just to list — that spins up a reader thread
-        # for a caller that didn't ask for events. Walk all per-directory
-        # buses for this sandbox; the parent session lives in exactly one.
-        with self._event_buses_lock:
-            buses = [
-                b for (sid, _), b in self._event_buses.items() if sid == sandbox_id
-            ]
-        for bus in buses:
-            children = bus.list_children(parent_opencode_session_id)
-            if children:
-                return children
-        return []
-
-    def subscribe_to_opencode_session(
-        self,
-        sandbox_id: UUID,
-        opencode_session_id: str,
-        *,
-        directory: str,
-        keepalive_seconds: float = 15.0,
-    ) -> Generator[ACPEvent, None, None]:
-        """Stream translated ACP events for an opencode session (parent
-        or child). Never terminates on its own; caller closes via
-        ``GeneratorExit``."""
-        if AGENT_TRANSPORT != AgentTransport.SERVE:
-            return
-        from onyx.server.features.build.sandbox.opencode.event_bus import (
-            BUS_CLOSED_SENTINEL,
-        )
-        from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
-        from onyx.server.features.build.sandbox.opencode.serve_client import (
-            translate_opencode_event,
-        )
-
-        bus = self._get_or_create_event_bus(sandbox_id, directory)
-        state = _TurnState(session_id=opencode_session_id)
-        sub = bus.subscribe(opencode_session_id)
-        try:
-            last_event = time.monotonic()
-            while True:
-                try:
-                    raw = sub.queue.get(timeout=1.0)
-                except queue.Empty:
-                    if time.monotonic() - last_event >= keepalive_seconds:
-                        yield SSEKeepalive()
-                        last_event = time.monotonic()
-                    continue
-                if raw is BUS_CLOSED_SENTINEL:
-                    return
-                last_event = time.monotonic()
-                if raw.get("type") == "server.connected":
-                    continue
-                for acp_event in translate_opencode_event(raw, state):
-                    yield acp_event
-        finally:
-            bus.unsubscribe(sub)
-
-    def _send_message_via_serve(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        message: str,
-        opencode_session_id: str | None,
-        agent_provider: str | None,
-        agent_model: str | None,
-        *,
-        on_opencode_session_resolved: Callable[[str], None] | None = None,
-    ) -> Generator[ACPEvent, None, None]:
-        """Stream ACP events by driving the in-pod ``opencode serve`` via
-        :class:`OpencodeServeClient`. See
-        ``docs/craft/opencode-serve-migration.md``.
-
-        ``opencode_session_id`` is the caller-persisted id from
-        ``BuildSession.opencode_session_id``. If ``None``, fall back to
-        creating one inline — but the session manager *should* preflight
-        via :meth:`ensure_opencode_session` and persist before calling
-        here, to avoid creating a fresh opencode session per turn under
-        a race.
-        """
-        packet_logger = get_packet_logger()
-        session_path = f"/workspace/sessions/{session_id}"
-        client = self._build_serve_client(sandbox_id, session_path)
-        try:
-            logger.info(
-                "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "
-                "caller-supplied opencode_session_id=%s",
-                session_id,
-                opencode_session_id,
-            )
-            resolved_session_id = client.ensure_session(
-                opencode_session_id,
-                directory=session_path,
-                title=f"build-session-{str(session_id)[:8]}",
-            )
-            if resolved_session_id != opencode_session_id:
-                # Caller's persisted id was stale (404) or missing. Notify
-                # the caller so they can persist the new id; without this,
-                # _ensure_opencode_session_id would reload the same stale
-                # id from the DB on every turn, 404 again, and orphan a
-                # fresh opencode session per turn (one assistant message
-                # per orphan → conversation loses all prior context).
-                if opencode_session_id is not None:
-                    logger.warning(
-                        "[SANDBOX-SERVE] persisted opencode_session_id %s was "
-                        "invalid; replaced with %s for session=%s",
-                        opencode_session_id,
-                        resolved_session_id,
-                        session_id,
-                    )
-                if on_opencode_session_resolved is not None:
-                    on_opencode_session_resolved(resolved_session_id)
-
-            logger.info(
-                "[SANDBOX-SERVE] Sending message: session=%s opencode_session=%s api_pod=%s",
-                session_id,
-                resolved_session_id,
-                _API_SERVER_HOSTNAME,
-            )
-            packet_logger.log_session_start(session_id, sandbox_id, message)
-
-            events_count = 0
-            got_prompt_response = False
-            try:
-                for event in client.send_message(
-                    resolved_session_id,
-                    message,
-                    directory=session_path,
-                    model_provider=agent_provider,
-                    model_id=agent_model,
-                ):
-                    events_count += 1
-                    if isinstance(event, PromptResponse):
-                        got_prompt_response = True
-                    yield event
-
-                logger.info(
-                    "[SANDBOX-SERVE] send_message completed: session=%s events=%s got_prompt_response=%s",
-                    session_id,
-                    events_count,
-                    got_prompt_response,
-                )
-                packet_logger.log_session_end(
-                    session_id, success=True, events_count=events_count
-                )
-            except GeneratorExit:
-                logger.warning(
-                    "[SANDBOX-SERVE] GeneratorExit: session=%s events=%s, sending abort",
-                    session_id,
-                    events_count,
-                )
-                try:
-                    client.abort(resolved_session_id, directory=session_path)
-                except Exception as abort_err:
-                    logger.warning(
-                        "[SANDBOX-SERVE] abort failed on GeneratorExit: %s",
-                        abort_err,
-                    )
-                packet_logger.log_session_end(
-                    session_id,
-                    success=False,
-                    error="GeneratorExit",
-                    events_count=events_count,
-                )
-                raise
-            except Exception as e:
-                logger.error(
-                    "[SANDBOX-SERVE] Exception: session=%s events=%s error=%s",
-                    session_id,
-                    events_count,
-                    e,
-                )
-                try:
-                    client.abort(resolved_session_id, directory=session_path)
-                except Exception as abort_err:
-                    logger.warning(
-                        "[SANDBOX-SERVE] abort failed on Exception: %s",
-                        abort_err,
-                    )
-                packet_logger.log_session_end(
-                    session_id,
-                    success=False,
-                    error=f"Exception: {e}",
-                    events_count=events_count,
-                )
-                raise
-        finally:
-            client.close()
 
     def list_directory(
         self, sandbox_id: UUID, session_id: UUID, path: str

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -42,10 +42,10 @@ from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_REQUEST_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
-from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.sandbox.opencode.event_bus import _Subscription
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -1,0 +1,666 @@
+"""Shared opencode-serve transport plumbing.
+
+Lives outside ``base.py`` so the abstract supertype doesn't have to pull in
+concrete ``opencode.*`` modules — that would invert the dependency arrow
+(abstract → concrete). Both ``SandboxManager`` and any future serve-using
+class compose this mixin in.
+
+What lives here:
+
+- :class:`ServeConnectionInfo` — per-sandbox URL + password, cached at first
+  use so hot paths (every prompt, every event-bus rebuild) don't re-hit
+  ``docker inspect`` / ``kube get secret`` on every call.
+- :class:`_ServeMixin` — the prompt slot, event-bus cache, readiness probe,
+  serve send-message loop, and subscribe/list helpers. Subclasses provide
+  the backend-specific ``_load_serve_connection_info``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import queue
+import threading
+import time
+from abc import abstractmethod
+from collections.abc import Callable
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+import httpx
+from acp.schema import PromptResponse
+
+from onyx.server.features.build.api.packet_logger import get_packet_logger
+from onyx.server.features.build.configs import AGENT_TRANSPORT
+from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
+from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
+from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
+from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+from onyx.server.features.build.sandbox.opencode.serve_client import _TurnState
+from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
+from onyx.server.features.build.sandbox.opencode.serve_client import (
+    translate_opencode_event,
+)
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# ACPEvent is a union type defined in both backend modules. Using Any here
+# avoids a circular import; the real typing happens at the implementation.
+ACPEvent = Any
+
+# Hostname of the api_server process — surfaces in serve-transport logs so
+# operators can tell which replica is driving a given prompt.
+_API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
+
+# After the sandbox backend (pod/container) reports Ready, opencode-serve
+# still has to finish its own boot (config parse, provider registry init,
+# HTTP server bind on :4096). Empirically 1–3s warm, up to ~15s cold.
+OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
+OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
+
+
+@dataclass(frozen=True)
+class ServeConnectionInfo:
+    """Per-sandbox opencode-serve connection details.
+
+    Constant for the life of the container/pod (password is bound into env
+    at startup; URL is derived from a stable container name / Service DNS).
+    Cached by :class:`_ServeMixin` so we don't re-hit the backend control
+    plane (docker inspect / k8s Secret read) on every prompt.
+    """
+
+    base_url: str
+    # ``None`` for legacy sandboxes provisioned before HTTP Basic landed.
+    # Bus then runs without auth — the warning is emitted at load time.
+    password: str | None
+
+    def auth(self) -> httpx.BasicAuth | None:
+        if not self.password:
+            return None
+        return httpx.BasicAuth(OPENCODE_SERVER_USERNAME, self.password)
+
+
+class _ServeMixin:
+    """Shared opencode-serve plumbing for ``SandboxManager`` subclasses.
+
+    Owns:
+
+    - per-(sandbox, directory) :class:`PodEventBus` cache + tombstone
+    - per-(sandbox, build_session) prompt-slot lock
+    - per-sandbox :class:`ServeConnectionInfo` cache
+    - the wait-for-ready probe, send-message loop, subscribe loop
+
+    Subclasses implement :meth:`_load_serve_connection_info` (one call,
+    cached forever) and supply their backend-specific abort/cleanup.
+    """
+
+    # State is initialized exactly once via ``_init_serve_state`` — called
+    # from each subclass's ``_initialize`` under the singleton lock. The
+    # body is also thread-safe so a contributor who forgets to call it
+    # eagerly can't race two callers into creating two different lock
+    # objects.
+    _serve_state_init_lock = threading.Lock()
+
+    def _init_serve_state(self) -> None:
+        """Idempotent, thread-safe init for serve-transport state.
+
+        Safe to call multiple times; second and subsequent calls are
+        no-ops. The class-level lock guarantees two threads racing the
+        first call cannot both initialize and end up with different
+        ``_event_buses_lock`` objects.
+        """
+        if getattr(self, "_serve_state_initialized", False):
+            return
+        with _ServeMixin._serve_state_init_lock:
+            if getattr(self, "_serve_state_initialized", False):
+                return
+            # Per-(sandbox, directory): opencode-serve scopes /event by ?directory=.
+            self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
+            # Tombstone: blocks late subscribe from racing a terminate.
+            self._terminated_sandboxes: set[UUID] = set()
+            self._event_buses_lock = threading.Lock()
+            # Key on build_session_id, not opencode_session_id — see prompt_slot.
+            self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
+            self._prompt_locks_meta = threading.Lock()
+            # Per-sandbox connection info cache; loaded on first use,
+            # invalidated by terminate(). Keeps the hot path off docker
+            # inspect / kube secret reads.
+            self._serve_conn_info: dict[UUID, ServeConnectionInfo] = {}
+            self._serve_conn_info_lock = threading.Lock()
+            self._serve_state_initialized = True
+
+    # ------------------------------------------------------------------
+    # Backend hooks
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def _load_serve_connection_info(
+        self, sandbox_id: UUID
+    ) -> ServeConnectionInfo | None:
+        """Build the connection info for ``sandbox_id`` from the backend.
+
+        Called at most once per sandbox per process; the result is cached
+        until :meth:`_invalidate_serve_connection_info` (typically by
+        ``terminate``). Return ``None`` if the sandbox doesn't exist.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # ServeConnectionInfo cache
+    # ------------------------------------------------------------------
+
+    def _serve_connection_info(self, sandbox_id: UUID) -> ServeConnectionInfo:
+        """Return cached info, loading on first use. Raises if the
+        backend reports the sandbox is gone."""
+        info = self._serve_conn_info.get(sandbox_id)
+        if info is not None:
+            return info
+        with self._serve_conn_info_lock:
+            info = self._serve_conn_info.get(sandbox_id)
+            if info is not None:
+                return info
+            loaded = self._load_serve_connection_info(sandbox_id)
+            if loaded is None:
+                raise RuntimeError(
+                    f"No serve connection info for sandbox {sandbox_id}; "
+                    "container/pod is missing or hasn't been provisioned"
+                )
+            if loaded.password is None:
+                logger.warning(
+                    "[SANDBOX-SERVE] No opencode password for sandbox %s; "
+                    "bus will run without auth (legacy sandbox — re-provision to fix)",
+                    sandbox_id,
+                )
+            self._serve_conn_info[sandbox_id] = loaded
+            return loaded
+
+    def _invalidate_serve_connection_info(self, sandbox_id: UUID) -> None:
+        """Drop cached info — call on terminate or when the backend
+        reprovisions the sandbox under the same id."""
+        with self._serve_conn_info_lock:
+            self._serve_conn_info.pop(sandbox_id, None)
+
+    # ------------------------------------------------------------------
+    # Prompt slot
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def prompt_slot(
+        self,
+        sandbox_id: UUID,
+        build_session_id: UUID,
+    ) -> Generator[bool, None, None]:
+        """Non-blocking try-acquire of a per-(sandbox, build_session) lock
+        that serializes concurrent ``send_message`` calls on a build session.
+
+        Yields ``True`` if the slot was acquired and the caller may proceed
+        with the turn (lock is released on context exit), or ``False`` if a
+        turn is already in flight on this build session and the caller
+        should abort without side effects (no user_message persistence, no
+        prompt POST).
+
+        Why this exists: opencode-serve's ``prompt_async`` is fire-and-
+        forget and not concurrent-safe — empirically, a second POST while
+        a turn is in flight is silently dropped (no 409, no queue), and
+        the second subscriber catches the *first* turn's terminator. Without
+        serialization at this layer the user sees an empty response and a
+        phantom user_message is persisted with no assistant reply.
+
+        Keying on ``build_session_id`` (rather than ``opencode_session_id``)
+        is deliberate:
+          1. It's stable across opencode session id rotations triggered by
+             the ``on_opencode_session_resolved`` callback — concurrent
+             requests landing in the middle of a 404-then-mint sequence
+             still contend on the same lock.
+          2. It blocks first-turn races: two simultaneous prompts on a
+             fresh build session (where ``opencode_session_id`` is NULL
+             for both) both contend before each calls POST /session, so
+             only one opencode session is ever created.
+          3. It bounds the lock dict size to one entry per build session
+             instead of one per (build_session × pod_restart_count).
+
+        Under ``AGENT_TRANSPORT=acp`` (rollback path) this is a no-op
+        (yields ``True``) — the per-message exec'd ``opencode acp``
+        subprocess model has no shared state to serialize.
+        """
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            yield True
+            return
+
+        key = (sandbox_id, build_session_id)
+        with self._prompt_locks_meta:
+            lock = self._prompt_locks.get(key)
+            if lock is None:
+                lock = threading.Lock()
+                self._prompt_locks[key] = lock
+
+        acquired = lock.acquire(blocking=False)
+        try:
+            if not acquired:
+                logger.warning(
+                    "[SANDBOX-SERVE] prompt_slot: refused — concurrent send_message "
+                    "on sandbox=%s build_session=%s",
+                    sandbox_id,
+                    build_session_id,
+                )
+            yield acquired
+        finally:
+            if acquired:
+                lock.release()
+
+    # ------------------------------------------------------------------
+    # Session helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _session_directory(session_id: UUID) -> str:
+        return f"/workspace/sessions/{session_id}"
+
+    def ensure_opencode_session(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+    ) -> str | None:
+        """Return a stable opencode-serve session id for this build session.
+
+        Used only when ``AGENT_TRANSPORT=serve``. The caller (session
+        manager) persists the returned id on the ``BuildSession`` row so
+        subsequent ``send_message`` calls can hit the same opencode
+        session by id, eliminating the on-disk session/list heuristic
+        the ACP path uses.
+
+        Returns ``None`` under ACP — that transport has no notion of a
+        persistent session id and doesn't need this preflight.
+
+        Idempotent: calling twice for the same (sandbox, session) on serve
+        returns the same id (delegated to ``OpencodeServeClient.ensure_session``).
+        """
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return None
+        session_path = self._session_directory(session_id)
+        logger.info(
+            "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
+            "sandbox=%s directory=%s (passing id=None, so client will POST /session)",
+            session_id,
+            sandbox_id,
+            session_path,
+        )
+        with self._build_serve_client(sandbox_id, session_path) as client:
+            return client.ensure_session(
+                None,
+                directory=session_path,
+                title=f"build-session-{str(session_id)[:8]}",
+            )
+
+    def list_subagents(
+        self,
+        sandbox_id: UUID,
+        parent_opencode_session_id: str,
+    ) -> list[str]:
+        """Child opencode session ids spawned under the parent. Empty
+        under ACP (no shared event bus to track subagents)."""
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return []
+        # Walk existing buses only — don't spin up a reader thread just to list.
+        with self._event_buses_lock:
+            buses = [
+                bus for (sid, _), bus in self._event_buses.items() if sid == sandbox_id
+            ]
+        for bus in buses:
+            children = bus.list_children(parent_opencode_session_id)
+            if children:
+                return children
+        return []
+
+    # ------------------------------------------------------------------
+    # Readiness probe
+    # ------------------------------------------------------------------
+
+    def _wait_for_opencode_serve_ready(
+        self,
+        sandbox_id: UUID,
+        timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
+    ) -> bool:
+        """Block until opencode-serve answers a health probe with 200.
+
+        Backend readiness only proves the supervisor is up; opencode binds
+        :4096 a few seconds later. Skipping this races the first prompt's
+        bus subscribe → "stream did not become ready".
+        """
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return True
+
+        info = self._serve_connection_info(sandbox_id)
+        # One client across all polls — cheap (no real connection until first
+        # request) and saves the connection-setup churn during the worst
+        # phase of the probe (server actively refusing connections).
+        with OpencodeServeClient(
+            base_url=info.base_url, password=info.password, event_bus=None
+        ) as client:
+            deadline = time.time() + timeout
+            last_err = "no probe completed"
+            while time.time() < deadline:
+                try:
+                    if client.health_check():
+                        logger.info(
+                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
+                            sandbox_id,
+                        )
+                        return True
+                    last_err = "health_check returned False"
+                except Exception as e:
+                    last_err = f"{type(e).__name__}: {e}"
+                time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
+        logger.error(
+            "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
+            "after %.0fs (last error: %s)",
+            sandbox_id,
+            timeout,
+            last_err,
+        )
+        return False
+
+    # ------------------------------------------------------------------
+    # Event bus / serve client
+    # ------------------------------------------------------------------
+
+    def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
+        """Lazy per-(sandbox, directory) bus. Refuses to create for a terminated
+        sandbox. Replaces self-closed buses so callers don't wedge on
+        BUS_CLOSED_SENTINEL until restart."""
+        key = (sandbox_id, directory)
+        with self._event_buses_lock:
+            bus = self._event_buses.get(key)
+            if bus is not None and not bus.closed:
+                return bus
+            if bus is not None and bus.closed:
+                logger.warning(
+                    "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
+                    "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
+                    sandbox_id,
+                    directory,
+                )
+                self._event_buses.pop(key, None)
+            if sandbox_id in self._terminated_sandboxes:
+                raise RuntimeError(
+                    f"Sandbox {sandbox_id} has been terminated; refusing to "
+                    "create a new event bus against its (deleted) backend"
+                )
+            info = self._serve_connection_info(sandbox_id)
+            bus = PodEventBus(
+                base_url=info.base_url,
+                auth=info.auth(),
+                directory=directory,
+                event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
+            )
+            self._event_buses[key] = bus
+            logger.info(
+                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s dir=%s",
+                sandbox_id,
+                directory,
+            )
+            return bus
+
+    def _build_serve_client(
+        self, sandbox_id: UUID, directory: str
+    ) -> OpencodeServeClient:
+        info = self._serve_connection_info(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
+        return OpencodeServeClient(
+            base_url=info.base_url,
+            password=info.password,
+            event_bus=bus,
+        )
+
+    # ------------------------------------------------------------------
+    # Bus cleanup (called from terminate / cleanup_session_workspace)
+    # ------------------------------------------------------------------
+
+    def _close_session_buses(self, sandbox_id: UUID, session_id: UUID) -> None:
+        """Pop and close the per-(sandbox, session) event bus.
+
+        Call from each backend's ``cleanup_session_workspace`` — otherwise
+        the bus (and its reader thread + httpx connection) survives
+        session deletion and leaks until the api_server restarts.
+        """
+        directory = self._session_directory(session_id)
+        with self._event_buses_lock:
+            bus = self._event_buses.pop((sandbox_id, directory), None)
+        if bus is None:
+            return
+        try:
+            bus.close()
+        except Exception:
+            logger.exception(
+                "[SANDBOX-SERVE] PodEventBus close failed for sandbox=%s session=%s",
+                sandbox_id,
+                session_id,
+            )
+
+    def _close_all_sandbox_buses(self, sandbox_id: UUID) -> None:
+        """Pop every bus for ``sandbox_id``, set the tombstone, and close
+        them. Call from each backend's ``terminate`` before destroying the
+        container/pod so late subscribes can't race a fresh bus in."""
+        with self._event_buses_lock:
+            self._terminated_sandboxes.add(sandbox_id)
+            doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
+            doomed_buses = [self._event_buses.pop(k) for k in doomed_keys]
+        for bus in doomed_buses:
+            try:
+                bus.close()
+            except Exception:
+                logger.exception(
+                    "[SANDBOX-SERVE] PodEventBus close failed during terminate for %s",
+                    sandbox_id,
+                )
+        self._invalidate_serve_connection_info(sandbox_id)
+
+    # ------------------------------------------------------------------
+    # Send message via serve
+    # ------------------------------------------------------------------
+
+    def _send_message_via_serve(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        message: str,
+        opencode_session_id: str | None,
+        agent_provider: str | None,
+        agent_model: str | None,
+        *,
+        on_opencode_session_resolved: Callable[[str], None] | None = None,
+    ) -> Generator[ACPEvent, None, None]:
+        """Stream ACP events via the in-sandbox ``opencode serve``. Callers
+        should preflight ``opencode_session_id`` with
+        :meth:`ensure_opencode_session` to avoid one orphan session per turn.
+        """
+        packet_logger = get_packet_logger()
+        session_path = self._session_directory(session_id)
+        client = self._build_serve_client(sandbox_id, session_path)
+        try:
+            logger.info(
+                "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "
+                "caller-supplied opencode_session_id=%s",
+                session_id,
+                opencode_session_id,
+            )
+            resolved_session_id = client.ensure_session(
+                opencode_session_id,
+                directory=session_path,
+                title=f"build-session-{str(session_id)[:8]}",
+            )
+            if resolved_session_id != opencode_session_id:
+                # Notify caller so they persist the new id — without this we
+                # orphan one opencode session per turn (lose conversation context).
+                if opencode_session_id is not None:
+                    logger.warning(
+                        "[SANDBOX-SERVE] persisted opencode_session_id %s was "
+                        "invalid; replaced with %s for session=%s",
+                        opencode_session_id,
+                        resolved_session_id,
+                        session_id,
+                    )
+                if on_opencode_session_resolved is not None:
+                    on_opencode_session_resolved(resolved_session_id)
+
+            logger.info(
+                "[SANDBOX-SERVE] Sending message: session=%s opencode_session=%s api_pod=%s",
+                session_id,
+                resolved_session_id,
+                _API_SERVER_HOSTNAME,
+            )
+            packet_logger.log_session_start(session_id, sandbox_id, message)
+
+            events_count = 0
+            got_prompt_response = False
+            try:
+                for event in client.send_message(
+                    resolved_session_id,
+                    message,
+                    directory=session_path,
+                    model_provider=agent_provider,
+                    model_id=agent_model,
+                ):
+                    events_count += 1
+                    if isinstance(event, PromptResponse):
+                        got_prompt_response = True
+                    yield event
+
+                logger.info(
+                    "[SANDBOX-SERVE] send_message completed: session=%s events=%s got_prompt_response=%s",
+                    session_id,
+                    events_count,
+                    got_prompt_response,
+                )
+                packet_logger.log_session_end(
+                    session_id, success=True, events_count=events_count
+                )
+            except GeneratorExit:
+                self._abort_and_log_turn_failure(
+                    client=client,
+                    session_id=session_id,
+                    resolved_session_id=resolved_session_id,
+                    session_path=session_path,
+                    events_count=events_count,
+                    packet_logger=packet_logger,
+                    error="GeneratorExit",
+                    log_level=logging.WARNING,
+                )
+                raise
+            except Exception as e:
+                self._abort_and_log_turn_failure(
+                    client=client,
+                    session_id=session_id,
+                    resolved_session_id=resolved_session_id,
+                    session_path=session_path,
+                    events_count=events_count,
+                    packet_logger=packet_logger,
+                    error=f"Exception: {e}",
+                    log_level=logging.ERROR,
+                )
+                raise
+        finally:
+            client.close()
+
+    def _abort_and_log_turn_failure(
+        self,
+        *,
+        client: OpencodeServeClient,
+        session_id: UUID,
+        resolved_session_id: str,
+        session_path: str,
+        events_count: int,
+        packet_logger: Any,
+        error: str,
+        log_level: int,
+    ) -> None:
+        """Best-effort abort + structured log on a failed turn. Used by
+        both GeneratorExit and Exception legs of the send-message loop.
+        Swallowing the abort failure is intentional — we're already in an
+        error path."""
+        logger.log(
+            log_level,
+            "[SANDBOX-SERVE] turn failed: session=%s events=%s error=%s — sending abort",
+            session_id,
+            events_count,
+            error,
+        )
+        try:
+            client.abort(resolved_session_id, directory=session_path)
+        except Exception as abort_err:
+            logger.warning(
+                "[SANDBOX-SERVE] abort failed during turn cleanup: %s", abort_err
+            )
+        packet_logger.log_session_end(
+            session_id,
+            success=False,
+            error=error,
+            events_count=events_count,
+        )
+
+    # ------------------------------------------------------------------
+    # Subscribe stream (used by session manager for reattach/resume)
+    # ------------------------------------------------------------------
+
+    def subscribe_to_opencode_session(
+        self,
+        sandbox_id: UUID,
+        opencode_session_id: str,
+        *,
+        directory: str,
+        keepalive_seconds: float = 15.0,
+    ) -> Generator[ACPEvent, None, None]:
+        """Stream translated ACP events for an opencode session. Caller closes
+        via ``GeneratorExit``. ``directory`` is required: opencode-serve scopes
+        its session store per-directory, so the hydrate REST call needs it.
+        """
+        if AGENT_TRANSPORT != AgentTransport.SERVE:
+            return
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
+        state = _TurnState(session_id=opencode_session_id)
+        client = self._build_serve_client(sandbox_id, directory)
+
+        def fetch_message(mid: str) -> dict[str, Any] | None:
+            return client.get_message(opencode_session_id, mid, directory=directory)
+
+        sub = bus.subscribe(opencode_session_id)
+        try:
+            last_event = time.monotonic()
+            while True:
+                try:
+                    raw = sub.queue.get(timeout=1.0)
+                except queue.Empty:
+                    if time.monotonic() - last_event >= keepalive_seconds:
+                        yield SSEKeepalive()
+                        last_event = time.monotonic()
+                    continue
+                if raw is BUS_CLOSED_SENTINEL:
+                    return
+                last_event = time.monotonic()
+                if raw.get("type") == "server.connected":
+                    continue
+                for acp_event in translate_opencode_event(
+                    raw, state, fetch_message=fetch_message
+                ):
+                    yield acp_event
+        finally:
+            # Close client first so a flaky bus.unsubscribe doesn't leak the
+            # connection pool. Both calls are best-effort here.
+            try:
+                client.close()
+            except Exception:
+                logger.exception(
+                    "[SANDBOX-SERVE] client close failed in subscribe teardown"
+                )
+            try:
+                bus.unsubscribe(sub)
+            except Exception:
+                logger.exception(
+                    "[SANDBOX-SERVE] bus unsubscribe failed in subscribe teardown"
+                )

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -333,9 +333,11 @@ class _ServeMixin:
             )
 
     def _close_all_sandbox_buses(self, sandbox_id: UUID) -> None:
-        """Tombstone + pop + close every bus for ``sandbox_id``. Call from
-        ``terminate`` before destroying the container/pod so late subscribes
-        can't race a fresh bus in."""
+        """Tombstone + pop + close every bus for ``sandbox_id``, and drop
+        the per-build-session prompt-slot locks. Call from ``terminate``
+        before destroying the container/pod so late subscribes can't race
+        a fresh bus in, and so we don't leak one ``threading.Lock`` per
+        ``(sandbox_id, build_session_id)`` for the api_server's lifetime."""
         with self._event_buses_lock:
             self._terminated_sandboxes.add(sandbox_id)
             doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
@@ -348,6 +350,10 @@ class _ServeMixin:
                     "[SANDBOX-SERVE] PodEventBus close failed during terminate for %s",
                     sandbox_id,
                 )
+        with self._prompt_locks_meta:
+            stale = [k for k in self._prompt_locks if k[0] == sandbox_id]
+            for k in stale:
+                self._prompt_locks.pop(k, None)
         self._invalidate_serve_connection_info(sandbox_id)
 
     def _send_message_via_serve(

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -1,18 +1,8 @@
 """Shared opencode-serve transport plumbing.
 
-Lives outside ``base.py`` so the abstract supertype doesn't have to pull in
-concrete ``opencode.*`` modules — that would invert the dependency arrow
-(abstract → concrete). Both ``SandboxManager`` and any future serve-using
-class compose this mixin in.
-
-What lives here:
-
-- :class:`ServeConnectionInfo` — per-sandbox URL + password, cached at first
-  use so hot paths (every prompt, every event-bus rebuild) don't re-hit
-  ``docker inspect`` / ``kube get secret`` on every call.
-- :class:`_ServeMixin` — the prompt slot, event-bus cache, readiness probe,
-  serve send-message loop, and subscribe/list helpers. Subclasses provide
-  the backend-specific ``_load_serve_connection_info``.
+Lives outside ``base.py`` so the abstract supertype doesn't import concrete
+``opencode.*`` modules (would invert the dependency arrow). ``SandboxManager``
+composes ``_ServeMixin`` in.
 """
 
 from __future__ import annotations
@@ -50,34 +40,23 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# ACPEvent is a union type defined in both backend modules. Using Any here
-# avoids a circular import; the real typing happens at the implementation.
 ACPEvent = Any
 
-# Hostname of the api_server process — surfaces in serve-transport logs so
-# operators can tell which replica is driving a given prompt.
+# Tags serve-transport logs with the api_server replica handling the prompt.
 _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 
-# After the sandbox backend (pod/container) reports Ready, opencode-serve
-# still has to finish its own boot (config parse, provider registry init,
-# HTTP server bind on :4096). Empirically 1–3s warm, up to ~15s cold.
+# opencode-serve boot lags backend Ready by ~1–3s warm, up to ~15s cold.
 OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
 OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
 
 
 @dataclass(frozen=True)
 class ServeConnectionInfo:
-    """Per-sandbox opencode-serve connection details.
-
-    Constant for the life of the container/pod (password is bound into env
-    at startup; URL is derived from a stable container name / Service DNS).
-    Cached by :class:`_ServeMixin` so we don't re-hit the backend control
-    plane (docker inspect / k8s Secret read) on every prompt.
-    """
+    """Per-sandbox opencode-serve URL + Basic-auth password. Constant for
+    the life of the container/pod; cached by ``_ServeMixin``."""
 
     base_url: str
-    # ``None`` for legacy sandboxes provisioned before HTTP Basic landed.
-    # Bus then runs without auth — the warning is emitted at load time.
+    # ``None`` for legacy sandboxes — bus then runs without auth.
     password: str | None
 
     def auth(self) -> httpx.BasicAuth | None:
@@ -89,38 +68,23 @@ class ServeConnectionInfo:
 class _ServeMixin:
     """Shared opencode-serve plumbing for ``SandboxManager`` subclasses.
 
-    Owns:
-
-    - per-(sandbox, directory) :class:`PodEventBus` cache + tombstone
-    - per-(sandbox, build_session) prompt-slot lock
-    - per-sandbox :class:`ServeConnectionInfo` cache
-    - the wait-for-ready probe, send-message loop, subscribe loop
-
-    Subclasses implement :meth:`_load_serve_connection_info` (one call,
-    cached forever) and supply their backend-specific abort/cleanup.
+    Subclasses implement :meth:`_load_serve_connection_info`; the mixin
+    handles caching, the prompt slot, the event-bus map + tombstone, the
+    readiness probe, the send-message loop, and the subscribe stream.
     """
 
-    # State is initialized exactly once via ``_init_serve_state`` — called
-    # from each subclass's ``_initialize`` under the singleton lock. The
-    # body is also thread-safe so a contributor who forgets to call it
-    # eagerly can't race two callers into creating two different lock
-    # objects.
+    # Class-level so racing first-callers across instances can't both
+    # initialize and end up with different ``_event_buses_lock`` objects.
     _serve_state_init_lock = threading.Lock()
 
     def _init_serve_state(self) -> None:
-        """Idempotent, thread-safe init for serve-transport state.
-
-        Safe to call multiple times; second and subsequent calls are
-        no-ops. The class-level lock guarantees two threads racing the
-        first call cannot both initialize and end up with different
-        ``_event_buses_lock`` objects.
-        """
+        """Idempotent, thread-safe init for serve-transport state."""
         if getattr(self, "_serve_state_initialized", False):
             return
         with _ServeMixin._serve_state_init_lock:
             if getattr(self, "_serve_state_initialized", False):
                 return
-            # Per-(sandbox, directory): opencode-serve scopes /event by ?directory=.
+            # opencode-serve scopes /event by ``?directory=``, so one bus per session dir.
             self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
             # Tombstone: blocks late subscribe from racing a terminate.
             self._terminated_sandboxes: set[UUID] = set()
@@ -128,36 +92,21 @@ class _ServeMixin:
             # Key on build_session_id, not opencode_session_id — see prompt_slot.
             self._prompt_locks: dict[tuple[UUID, UUID], threading.Lock] = {}
             self._prompt_locks_meta = threading.Lock()
-            # Per-sandbox connection info cache; loaded on first use,
-            # invalidated by terminate(). Keeps the hot path off docker
-            # inspect / kube secret reads.
             self._serve_conn_info: dict[UUID, ServeConnectionInfo] = {}
             self._serve_conn_info_lock = threading.Lock()
             self._serve_state_initialized = True
-
-    # ------------------------------------------------------------------
-    # Backend hooks
-    # ------------------------------------------------------------------
 
     @abstractmethod
     def _load_serve_connection_info(
         self, sandbox_id: UUID
     ) -> ServeConnectionInfo | None:
-        """Build the connection info for ``sandbox_id`` from the backend.
-
-        Called at most once per sandbox per process; the result is cached
-        until :meth:`_invalidate_serve_connection_info` (typically by
-        ``terminate``). Return ``None`` if the sandbox doesn't exist.
-        """
+        """Build connection info from the backend. Called once per sandbox;
+        cached until ``_invalidate_serve_connection_info``. Return ``None``
+        if the sandbox doesn't exist."""
         ...
 
-    # ------------------------------------------------------------------
-    # ServeConnectionInfo cache
-    # ------------------------------------------------------------------
-
     def _serve_connection_info(self, sandbox_id: UUID) -> ServeConnectionInfo:
-        """Return cached info, loading on first use. Raises if the
-        backend reports the sandbox is gone."""
+        """Cached getter; loads on first use, raises if backend reports gone."""
         info = self._serve_conn_info.get(sandbox_id)
         if info is not None:
             return info
@@ -181,14 +130,9 @@ class _ServeMixin:
             return loaded
 
     def _invalidate_serve_connection_info(self, sandbox_id: UUID) -> None:
-        """Drop cached info — call on terminate or when the backend
-        reprovisions the sandbox under the same id."""
+        """Drop cached info; call on terminate / re-provision."""
         with self._serve_conn_info_lock:
             self._serve_conn_info.pop(sandbox_id, None)
-
-    # ------------------------------------------------------------------
-    # Prompt slot
-    # ------------------------------------------------------------------
 
     @contextlib.contextmanager
     def prompt_slot(
@@ -196,38 +140,18 @@ class _ServeMixin:
         sandbox_id: UUID,
         build_session_id: UUID,
     ) -> Generator[bool, None, None]:
-        """Non-blocking try-acquire of a per-(sandbox, build_session) lock
-        that serializes concurrent ``send_message`` calls on a build session.
+        """Non-blocking try-acquire of a per-build-session lock; yields True
+        if acquired, False if a turn is already in flight (caller must
+        abort without side effects).
 
-        Yields ``True`` if the slot was acquired and the caller may proceed
-        with the turn (lock is released on context exit), or ``False`` if a
-        turn is already in flight on this build session and the caller
-        should abort without side effects (no user_message persistence, no
-        prompt POST).
-
-        Why this exists: opencode-serve's ``prompt_async`` is fire-and-
-        forget and not concurrent-safe — empirically, a second POST while
-        a turn is in flight is silently dropped (no 409, no queue), and
-        the second subscriber catches the *first* turn's terminator. Without
-        serialization at this layer the user sees an empty response and a
-        phantom user_message is persisted with no assistant reply.
-
-        Keying on ``build_session_id`` (rather than ``opencode_session_id``)
-        is deliberate:
-          1. It's stable across opencode session id rotations triggered by
-             the ``on_opencode_session_resolved`` callback — concurrent
-             requests landing in the middle of a 404-then-mint sequence
-             still contend on the same lock.
-          2. It blocks first-turn races: two simultaneous prompts on a
-             fresh build session (where ``opencode_session_id`` is NULL
-             for both) both contend before each calls POST /session, so
-             only one opencode session is ever created.
-          3. It bounds the lock dict size to one entry per build session
-             instead of one per (build_session × pod_restart_count).
-
-        Under ``AGENT_TRANSPORT=acp`` (rollback path) this is a no-op
-        (yields ``True``) — the per-message exec'd ``opencode acp``
-        subprocess model has no shared state to serialize.
+        opencode-serve's ``prompt_async`` is fire-and-forget and not
+        concurrent-safe: a second POST while a turn is in flight is
+        silently dropped, the second subscriber catches the *first* turn's
+        terminator, and a phantom user_message gets persisted with no
+        assistant reply. Key on ``build_session_id`` (not
+        ``opencode_session_id``) so the lock survives id rotation from
+        ``on_opencode_session_resolved`` and bounds the dict to one entry
+        per build session. No-op under ACP.
         """
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             yield True
@@ -254,10 +178,6 @@ class _ServeMixin:
             if acquired:
                 lock.release()
 
-    # ------------------------------------------------------------------
-    # Session helpers
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _session_directory(session_id: UUID) -> str:
         return f"/workspace/sessions/{session_id}"
@@ -267,20 +187,9 @@ class _ServeMixin:
         sandbox_id: UUID,
         session_id: UUID,
     ) -> str | None:
-        """Return a stable opencode-serve session id for this build session.
-
-        Used only when ``AGENT_TRANSPORT=serve``. The caller (session
-        manager) persists the returned id on the ``BuildSession`` row so
-        subsequent ``send_message`` calls can hit the same opencode
-        session by id, eliminating the on-disk session/list heuristic
-        the ACP path uses.
-
-        Returns ``None`` under ACP — that transport has no notion of a
-        persistent session id and doesn't need this preflight.
-
-        Idempotent: calling twice for the same (sandbox, session) on serve
-        returns the same id (delegated to ``OpencodeServeClient.ensure_session``).
-        """
+        """Idempotent preflight to mint (or look up) the opencode-serve
+        session id for this build session. Caller persists it so later
+        turns hit the same session by id. Returns ``None`` under ACP."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return None
         session_path = self._session_directory(session_id)
@@ -303,8 +212,7 @@ class _ServeMixin:
         sandbox_id: UUID,
         parent_opencode_session_id: str,
     ) -> list[str]:
-        """Child opencode session ids spawned under the parent. Empty
-        under ACP (no shared event bus to track subagents)."""
+        """Child opencode session ids spawned under the parent. Empty under ACP."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return []
         # Walk existing buses only — don't spin up a reader thread just to list.
@@ -318,28 +226,20 @@ class _ServeMixin:
                 return children
         return []
 
-    # ------------------------------------------------------------------
-    # Readiness probe
-    # ------------------------------------------------------------------
-
     def _wait_for_opencode_serve_ready(
         self,
         sandbox_id: UUID,
         timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
     ) -> bool:
-        """Block until opencode-serve answers a health probe with 200.
-
-        Backend readiness only proves the supervisor is up; opencode binds
-        :4096 a few seconds later. Skipping this races the first prompt's
-        bus subscribe → "stream did not become ready".
-        """
+        """Block until opencode-serve answers ``GET /doc`` with 200. Backend
+        Ready only proves the supervisor is up; opencode binds :4096 a few
+        seconds later."""
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return True
 
         info = self._serve_connection_info(sandbox_id)
-        # One client across all polls — cheap (no real connection until first
-        # request) and saves the connection-setup churn during the worst
-        # phase of the probe (server actively refusing connections).
+        # One client across all polls — saves connect-setup churn while the
+        # server is actively refusing connections.
         with OpencodeServeClient(
             base_url=info.base_url, password=info.password, event_bus=None
         ) as client:
@@ -366,14 +266,10 @@ class _ServeMixin:
         )
         return False
 
-    # ------------------------------------------------------------------
-    # Event bus / serve client
-    # ------------------------------------------------------------------
-
     def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
-        """Lazy per-(sandbox, directory) bus. Refuses to create for a terminated
-        sandbox. Replaces self-closed buses so callers don't wedge on
-        BUS_CLOSED_SENTINEL until restart."""
+        """Lazy per-(sandbox, directory) bus. Refuses to create for a
+        terminated sandbox; replaces self-closed buses so callers don't
+        wedge on BUS_CLOSED_SENTINEL until restart."""
         key = (sandbox_id, directory)
         with self._event_buses_lock:
             bus = self._event_buses.get(key)
@@ -418,17 +314,10 @@ class _ServeMixin:
             event_bus=bus,
         )
 
-    # ------------------------------------------------------------------
-    # Bus cleanup (called from terminate / cleanup_session_workspace)
-    # ------------------------------------------------------------------
-
     def _close_session_buses(self, sandbox_id: UUID, session_id: UUID) -> None:
-        """Pop and close the per-(sandbox, session) event bus.
-
-        Call from each backend's ``cleanup_session_workspace`` — otherwise
-        the bus (and its reader thread + httpx connection) survives
-        session deletion and leaks until the api_server restarts.
-        """
+        """Release the per-(sandbox, session) bus. Call from
+        ``cleanup_session_workspace`` — without this the reader thread +
+        httpx connection survive session deletion."""
         directory = self._session_directory(session_id)
         with self._event_buses_lock:
             bus = self._event_buses.pop((sandbox_id, directory), None)
@@ -444,9 +333,9 @@ class _ServeMixin:
             )
 
     def _close_all_sandbox_buses(self, sandbox_id: UUID) -> None:
-        """Pop every bus for ``sandbox_id``, set the tombstone, and close
-        them. Call from each backend's ``terminate`` before destroying the
-        container/pod so late subscribes can't race a fresh bus in."""
+        """Tombstone + pop + close every bus for ``sandbox_id``. Call from
+        ``terminate`` before destroying the container/pod so late subscribes
+        can't race a fresh bus in."""
         with self._event_buses_lock:
             self._terminated_sandboxes.add(sandbox_id)
             doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
@@ -461,10 +350,6 @@ class _ServeMixin:
                 )
         self._invalidate_serve_connection_info(sandbox_id)
 
-    # ------------------------------------------------------------------
-    # Send message via serve
-    # ------------------------------------------------------------------
-
     def _send_message_via_serve(
         self,
         sandbox_id: UUID,
@@ -476,10 +361,9 @@ class _ServeMixin:
         *,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
     ) -> Generator[ACPEvent, None, None]:
-        """Stream ACP events via the in-sandbox ``opencode serve``. Callers
-        should preflight ``opencode_session_id`` with
-        :meth:`ensure_opencode_session` to avoid one orphan session per turn.
-        """
+        """Stream ACP events via the in-sandbox ``opencode serve``. Preflight
+        ``opencode_session_id`` via :meth:`ensure_opencode_session` to avoid
+        one orphan session per turn."""
         packet_logger = get_packet_logger()
         session_path = self._session_directory(session_id)
         client = self._build_serve_client(sandbox_id, session_path)
@@ -496,8 +380,8 @@ class _ServeMixin:
                 title=f"build-session-{str(session_id)[:8]}",
             )
             if resolved_session_id != opencode_session_id:
-                # Notify caller so they persist the new id — without this we
-                # orphan one opencode session per turn (lose conversation context).
+                # Caller must persist the new id or we orphan one opencode
+                # session per turn and lose conversation context.
                 if opencode_session_id is not None:
                     logger.warning(
                         "[SANDBOX-SERVE] persisted opencode_session_id %s was "
@@ -580,10 +464,8 @@ class _ServeMixin:
         error: str,
         log_level: int,
     ) -> None:
-        """Best-effort abort + structured log on a failed turn. Used by
-        both GeneratorExit and Exception legs of the send-message loop.
-        Swallowing the abort failure is intentional — we're already in an
-        error path."""
+        """Best-effort abort + structured log on a failed turn. Abort
+        failures are swallowed — we're already in an error path."""
         logger.log(
             log_level,
             "[SANDBOX-SERVE] turn failed: session=%s events=%s error=%s — sending abort",
@@ -603,10 +485,6 @@ class _ServeMixin:
             error=error,
             events_count=events_count,
         )
-
-    # ------------------------------------------------------------------
-    # Subscribe stream (used by session manager for reattach/resume)
-    # ------------------------------------------------------------------
 
     def subscribe_to_opencode_session(
         self,
@@ -650,8 +528,7 @@ class _ServeMixin:
                 ):
                     yield acp_event
         finally:
-            # Close client first so a flaky bus.unsubscribe doesn't leak the
-            # connection pool. Both calls are best-effort here.
+            # Close client first so a flaky unsubscribe doesn't leak the pool.
             try:
                 client.close()
             except Exception:

--- a/backend/onyx/server/features/build/sandbox/sse.py
+++ b/backend/onyx/server/features/build/sandbox/sse.py
@@ -1,0 +1,21 @@
+"""Marker types yielded by sandbox-manager ACP clients.
+
+Lives in its own module so that ``base.py`` can import the opencode
+package (which transitively imports this marker via ``serve_client.py``)
+without forming a circular import.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class SSEKeepalive:
+    """Marker event yielded by sandbox-manager ACP clients when no real ACP
+    events have arrived for ``SSE_KEEPALIVE_INTERVAL`` seconds.
+
+    Defined once in a leaf module so every backend yields the same class
+    and ``isinstance`` checks in the session-manager SSE pipeline work
+    uniformly. Otherwise a Docker-emitted keepalive would be a different
+    class than a K8s-emitted keepalive and one would fall through the
+    manager's isinstance chain as "unrecognized" and be silently dropped.
+    """

--- a/backend/onyx/server/features/build/sandbox/sse.py
+++ b/backend/onyx/server/features/build/sandbox/sse.py
@@ -1,21 +1,11 @@
-"""Marker types yielded by sandbox-manager ACP clients.
-
-Lives in its own module so that ``base.py`` can import the opencode
-package (which transitively imports this marker via ``serve_client.py``)
-without forming a circular import.
-"""
+"""SSE marker types. Lives in a leaf module so base.py and the opencode
+package don't form a circular import."""
 
 from dataclasses import dataclass
 
 
 @dataclass
 class SSEKeepalive:
-    """Marker event yielded by sandbox-manager ACP clients when no real ACP
-    events have arrived for ``SSE_KEEPALIVE_INTERVAL`` seconds.
-
-    Defined once in a leaf module so every backend yields the same class
-    and ``isinstance`` checks in the session-manager SSE pipeline work
-    uniformly. Otherwise a Docker-emitted keepalive would be a different
-    class than a K8s-emitted keepalive and one would fall through the
-    manager's isinstance chain as "unrecognized" and be silently dropped.
-    """
+    """Marker yielded when no real ACP events arrive within the keepalive
+    window. Defined once so isinstance checks in the session-manager pipeline
+    work uniformly across backends."""

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -90,10 +90,10 @@ from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.prompts import BUILD_NAMING_SYSTEM_PROMPT
 from onyx.server.features.build.session.prompts import BUILD_NAMING_USER_PROMPT

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -63,6 +63,7 @@ from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 
 _UNSET = object()
 
@@ -120,6 +121,11 @@ class StubSandboxManager(SandboxManager):
     """
 
     def __init__(self) -> None:
+        # Initialize serve-transport state from _ServeMixin so any test
+        # that ends up reaching prompt_slot/list_subagents on the stub
+        # gets the dicts/locks it expects.
+        self._init_serve_state()
+
         # Return-value hooks.
         self.provision_returns: SandboxInfo | None = None
         self.health_check_returns: bool | None = None
@@ -456,11 +462,27 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("get_upload_stats")
         return self.get_upload_stats_returns
 
-    def _serve_base_url(self, sandbox_id: UUID) -> str:
-        return f"http://stub-{str(sandbox_id)[:8]}:4096"
+    def _load_serve_connection_info(
+        self, sandbox_id: UUID
+    ) -> ServeConnectionInfo | None:
+        # Stub doesn't drive a real opencode-serve — return a deterministic
+        # URL + no password so any code path that touches the cache gets a
+        # reasonable value.
+        return ServeConnectionInfo(
+            base_url=f"http://stub-{str(sandbox_id)[:8]}:4096",
+            password=None,
+        )
 
-    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:  # noqa: ARG002
-        return None
+    def _send_message_via_acp(
+        self,
+        sandbox_id: UUID,  # noqa: ARG002
+        session_id: UUID,  # noqa: ARG002
+        message: str,  # noqa: ARG002
+    ) -> Generator[ACPEvent, None, None]:
+        # The stub overrides ``send_message`` directly, so this leg is
+        # unreachable. Defined to satisfy the ABC.
+        raise _not_configured("_send_message_via_acp")
+        yield  # pragma: no cover — make this a generator function
 
     def write_files_to_sandbox(
         self,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -457,10 +457,6 @@ class StubSandboxManager(SandboxManager):
         return self.get_upload_stats_returns
 
     def _serve_base_url(self, sandbox_id: UUID) -> str:
-        """Serve-transport base URL. Tests that don't exercise the serve
-        path can ignore this; the only callers are the base-class
-        ``_send_message_via_serve``/``_get_or_create_event_bus`` plumbing,
-        which these stubs don't touch."""
         return f"http://stub-{str(sandbox_id)[:8]}:4096"
 
     def _read_opencode_password(self, sandbox_id: UUID) -> str | None:  # noqa: ARG002

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -456,6 +456,16 @@ class StubSandboxManager(SandboxManager):
             raise _not_configured("get_upload_stats")
         return self.get_upload_stats_returns
 
+    def _serve_base_url(self, sandbox_id: UUID) -> str:
+        """Serve-transport base URL. Tests that don't exercise the serve
+        path can ignore this; the only callers are the base-class
+        ``_send_message_via_serve``/``_get_or_create_event_bus`` plumbing,
+        which these stubs don't touch."""
+        return f"http://stub-{str(sandbox_id)[:8]}:4096"
+
+    def _read_opencode_password(self, sandbox_id: UUID) -> str | None:  # noqa: ARG002
+        return None
+
     def write_files_to_sandbox(
         self,
         *,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -121,9 +121,7 @@ class StubSandboxManager(SandboxManager):
     """
 
     def __init__(self) -> None:
-        # Initialize serve-transport state from _ServeMixin so any test
-        # that ends up reaching prompt_slot/list_subagents on the stub
-        # gets the dicts/locks it expects.
+        # Tests hitting prompt_slot / list_subagents need the mixin state.
         self._init_serve_state()
 
         # Return-value hooks.

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -122,7 +122,13 @@ def _pool_container() -> Generator[_PoolContainer, None, None]:
     manager = DockerSandboxManager()
     sandbox_id = uuid4()
     user_id = uuid4()
-    llm_config = default_llm_config(api_key=os.environ["OPENAI_API_KEY"])
+    # Override the helper's default model — gpt-5-mini is the project's
+    # cheap-and-fast tier for live-LLM tests. ``default_llm_config``'s
+    # built-in default is not appropriate here.
+    llm_config = default_llm_config(
+        api_key=os.environ["OPENAI_API_KEY"],
+        model_name="gpt-5-mini",
+    )
 
     info = manager.provision(
         sandbox_id=sandbox_id,

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -54,6 +54,7 @@ import onyx.server.features.build.configs as cfg
 import onyx.server.features.build.sandbox.base as sandbox_base
 import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as docker_mgr
 from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_DOCKER_SOCKET
 from onyx.server.features.build.configs import SandboxBackend
@@ -83,8 +84,18 @@ _SKIP_NO_SOCKET = pytest.mark.skipif(
     not os.path.exists(SANDBOX_DOCKER_SOCKET),
     reason=f"Docker socket missing at {SANDBOX_DOCKER_SOCKET}",
 )
+_SKIP_NO_API_SERVER_URL = pytest.mark.skipif(
+    not SANDBOX_API_SERVER_URL,
+    reason="docker-serve streaming tests require SANDBOX_API_SERVER_URL "
+    "(provision threads it into the container's ONYX_SERVER_URL)",
+)
 
-pytestmark = [_SKIP_WRONG_BACKEND, _SKIP_NO_SOCKET, _SKIP_MISSING_KEY]
+pytestmark = [
+    _SKIP_WRONG_BACKEND,
+    _SKIP_NO_SOCKET,
+    _SKIP_NO_API_SERVER_URL,
+    _SKIP_MISSING_KEY,
+]
 
 
 # ----------------------------------------------------------------------

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -116,10 +116,20 @@ def _force_serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @dataclass(frozen=True)
 class _PoolContainer:
+    """Module-scoped state: provisioned container + the LLM config."""
+
+    sandbox_id: UUID
+    manager: DockerSandboxManager
+    llm_config: LLMProviderConfig
+
+
+@dataclass(frozen=True)
+class _Handle:
+    """Per-test state: pool container + a fresh session_id."""
+
     sandbox_id: UUID
     manager: DockerSandboxManager
     session_id: UUID
-    llm_config: LLMProviderConfig
 
 
 @pytest.fixture(scope="module")
@@ -152,25 +162,47 @@ def _pool_container() -> Generator[_PoolContainer, None, None]:
         f"unexpected directory_path shape: {info.directory_path!r}"
     )
 
-    session_id = uuid4()
-    manager.setup_session_workspace(
-        sandbox_id=sandbox_id,
-        session_id=session_id,
-        llm_config=llm_config,
-        nextjs_port=None,
-        skills_section="No skills available.",
-    )
-
     try:
         yield _PoolContainer(
             sandbox_id=sandbox_id,
             manager=manager,
-            session_id=session_id,
             llm_config=llm_config,
         )
     finally:
         try:
             manager.terminate(sandbox_id)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def handle(_pool_container: _PoolContainer) -> Generator[_Handle, None, None]:
+    """Fresh session per test on the shared pool container.
+
+    Reusing one session across tests would let prior turns' message
+    history bleed into later tests (e.g. ``test_yields_at_most_one_terminator``
+    pumping prompts into a session already populated by the simple-message
+    test). Each test mints its own session id; teardown removes it.
+    """
+    session_id = uuid4()
+    _pool_container.manager.setup_session_workspace(
+        sandbox_id=_pool_container.sandbox_id,
+        session_id=session_id,
+        llm_config=_pool_container.llm_config,
+        nextjs_port=None,
+        skills_section="No skills available.",
+    )
+    try:
+        yield _Handle(
+            sandbox_id=_pool_container.sandbox_id,
+            manager=_pool_container.manager,
+            session_id=session_id,
+        )
+    finally:
+        try:
+            _pool_container.manager.cleanup_session_workspace(
+                _pool_container.sandbox_id, session_id
+            )
         except Exception:
             pass
 
@@ -197,22 +229,22 @@ class _Collected:
 
 
 def _drive_turn(
-    pool: _PoolContainer,
+    h: _Handle,
     prompt: str,
     *,
     opencode_session_id: str | None = None,
 ) -> tuple[_Collected, str | None]:
     """One turn end-to-end via ``DockerSandboxManager.send_message``."""
     if opencode_session_id is None:
-        opencode_session_id = pool.manager.ensure_opencode_session(
-            pool.sandbox_id, pool.session_id
+        opencode_session_id = h.manager.ensure_opencode_session(
+            h.sandbox_id, h.session_id
         )
     assert opencode_session_id, "ensure_opencode_session must return an id under serve"
 
     out = _Collected()
-    for ev in pool.manager.send_message(
-        pool.sandbox_id,
-        pool.session_id,
+    for ev in h.manager.send_message(
+        h.sandbox_id,
+        h.session_id,
         prompt,
         opencode_session_id=opencode_session_id,
     ):
@@ -279,15 +311,13 @@ def test_read_opencode_password_roundtrips_via_docker_inspect(
     assert len(pw) >= 32
 
 
-def test_simple_message_streams_text_and_terminates(
-    _pool_container: _PoolContainer,
-) -> None:
+def test_simple_message_streams_text_and_terminates(handle: _Handle) -> None:
     """End-to-end smoke: drive one real turn against opencode-serve
     inside the Docker sandbox container, assert we get text deltas and a
     terminator. If this passes, the entire stack works: password injected
     correctly, bridge-network reachability, serve binds :4096, prompt
     POST + event SSE roundtrip, translator emits ACP events."""
-    out, _ = _drive_turn(_pool_container, "Say hi briefly.")
+    out, _ = _drive_turn(handle, "Say hi briefly.")
 
     assert out.term is not None, "send_message never terminated"
     assert out.term.stop_reason == "end_turn"
@@ -299,13 +329,11 @@ def test_simple_message_streams_text_and_terminates(
     )
 
 
-def test_bash_tool_call_lifecycle(
-    _pool_container: _PoolContainer,
-) -> None:
+def test_bash_tool_call_lifecycle(handle: _Handle) -> None:
     """Tool call lifecycle parity with K8s: exactly one ToolCallStart per
     call_id; ToolCallProgress sequence ends in status=completed."""
     out, _ = _drive_turn(
-        _pool_container,
+        handle,
         "Run the bash command `echo DOCKER_SERVE_OK` and then say DONE.",
     )
 
@@ -324,9 +352,7 @@ def test_bash_tool_call_lifecycle(
         )
 
 
-def test_multi_turn_session_terminates_each_turn(
-    _pool_container: _PoolContainer,
-) -> None:
+def test_multi_turn_session_terminates_each_turn(handle: _Handle) -> None:
     """Three back-to-back prompts on the same opencode session. Each
     must terminate cleanly. Catches event-bus cross-talk and stuck
     prompt-slot locks — both of which would block subsequent turns."""
@@ -339,31 +365,28 @@ def test_multi_turn_session_terminates_each_turn(
         ]
     ):
         out, opencode_session_id = _drive_turn(
-            _pool_container, prompt, opencode_session_id=opencode_session_id
+            handle, prompt, opencode_session_id=opencode_session_id
         )
         assert out.term is not None, f"turn {i + 1} did not terminate"
         assert out.errors == [], f"turn {i + 1} had errors: {out.errors}"
         assert len(out.text) > 0, f"turn {i + 1} produced no text"
 
 
-def test_yields_at_most_one_terminator(
-    _pool_container: _PoolContainer,
-) -> None:
+def test_yields_at_most_one_terminator(handle: _Handle) -> None:
     """opencode emits several end-of-turn signals (``message.updated``
     completed, ``session.idle``, ``session.status``→idle). Whichever
     fires first must terminate the turn; the rest must be suppressed.
     Catches a regression in the terminator-dedup logic on the shared
     base-class ``_send_message_via_serve`` path."""
-    pool = _pool_container
-    opencode_session_id: str | None = pool.manager.ensure_opencode_session(
-        pool.sandbox_id, pool.session_id
+    opencode_session_id: str | None = handle.manager.ensure_opencode_session(
+        handle.sandbox_id, handle.session_id
     )
     extra_terms = 0
     for i in range(3):
         term_count = 0
-        for ev in pool.manager.send_message(
-            pool.sandbox_id,
-            pool.session_id,
+        for ev in handle.manager.send_message(
+            handle.sandbox_id,
+            handle.session_id,
             f"Say '{i}'.",
             opencode_session_id=opencode_session_id,
         ):
@@ -376,18 +399,15 @@ def test_yields_at_most_one_terminator(
     )
 
 
-def test_prompt_slot_blocks_concurrent_turn(
-    _pool_container: _PoolContainer,
-) -> None:
+def test_prompt_slot_blocks_concurrent_turn(handle: _Handle) -> None:
     """``prompt_slot`` is the load-bearing lock that prevents the
     phantom-user_message bug. The Docker manager inherits the impl from
     base — this test confirms the lock state actually got initialized via
     ``_init_serve_state`` during ``_initialize``. A regression where
     Docker forgot to call it would surface as the lock dict missing."""
-    pool = _pool_container
-    with pool.manager.prompt_slot(pool.sandbox_id, pool.session_id) as outer:
+    with handle.manager.prompt_slot(handle.sandbox_id, handle.session_id) as outer:
         assert outer is True
-        with pool.manager.prompt_slot(pool.sandbox_id, pool.session_id) as inner:
+        with handle.manager.prompt_slot(handle.sandbox_id, handle.session_id) as inner:
             assert inner is False, (
                 "second concurrent prompt_slot acquire must return False"
             )
@@ -398,9 +418,8 @@ def test_terminate_then_subscribe_refuses(
 ) -> None:
     """After ``terminate``, late ``_get_or_create_event_bus`` calls MUST
     raise rather than spin a reader thread against the deleted container.
-    The K8s manager tombstones the sandbox_id; Docker inherits the same
-    machinery via base. This is in its own test (separate sandbox_id, not
-    the pool) so the teardown doesn't break other tests."""
+    Provision a fresh sandbox (so we don't blow away the pool container)
+    and wrap in try/finally so an assertion failure can't leak it."""
     pool = _pool_container
     sandbox_id = uuid4()
     pool.manager.provision(
@@ -410,7 +429,13 @@ def test_terminate_then_subscribe_refuses(
         llm_config=pool.llm_config,
         onyx_pat="ci-test-pat",
     )
-    pool.manager.terminate(sandbox_id)
-
-    with pytest.raises(RuntimeError, match="terminated"):
-        pool.manager._get_or_create_event_bus(sandbox_id)
+    try:
+        pool.manager.terminate(sandbox_id)
+        with pytest.raises(RuntimeError, match="terminated"):
+            pool.manager._get_or_create_event_bus(sandbox_id)
+    finally:
+        # Defensive cleanup in case ``terminate`` raised before completing.
+        try:
+            pool.manager.terminate(sandbox_id)
+        except Exception:
+            pass

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -1,0 +1,399 @@
+"""Streaming-output regression tests for ``DockerSandboxManager`` under
+``AGENT_TRANSPORT=serve``.
+
+Mirrors :mod:`test_opencode_serve_streaming` (which runs against a real
+``KubernetesSandboxManager`` pod) but provisions a real Docker sandbox
+container via :class:`DockerSandboxManager`. The tests assert on the
+``ACPEvent`` stream that ``send_message`` yields — the same events the
+session manager persists and the frontend renders — so any divergence
+between the Docker and K8s serve paths surfaces here.
+
+Why these aren't unit tests
+---------------------------
+The Docker serve port is mostly orchestration: provision generates a
+password, injects env, calls ``docker run``, the container's entrypoint
+exec's ``opencode serve``, the api_server side polls ``GET /doc`` until
+ready, then drives prompts over HTTP. Almost every load-bearing
+interaction is across a process boundary into ``opencode serve`` —
+something a mock can't validate. The matching K8s tests run on every
+PR via ``pr-craft-k8s-tests.yml``; this file does the same for the
+Docker lane.
+
+Skip conditions
+---------------
+Tests in this module pytest.skip unless ALL of the following hold:
+- ``SANDBOX_BACKEND=docker`` (deployer must opt-in; default is k8s).
+- ``OPENAI_API_KEY`` is set (we make real LLM calls).
+- The Docker daemon is reachable on the configured socket.
+
+The test runner must also be reachable to the sandbox container by name
+on the ``onyx_craft_sandbox`` bridge network — e.g. running via
+``docker compose exec api_server pytest ...``. From the host without
+bridge attachment, ``_wait_for_opencode_serve_ready`` will time out.
+That's a configuration error, not a test bug, so we don't silently skip;
+the readiness timeout surfaces a real diagnostic.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from dataclasses import dataclass
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from acp.schema import AgentMessageChunk
+from acp.schema import AgentThoughtChunk
+from acp.schema import Error
+from acp.schema import PromptResponse
+from acp.schema import ToolCallProgress
+from acp.schema import ToolCallStart
+
+import onyx.server.features.build.configs as cfg
+import onyx.server.features.build.sandbox.base as sandbox_base
+import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as docker_mgr
+from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SANDBOX_DOCKER_SOCKET
+from onyx.server.features.build.configs import SandboxBackend
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    _sandbox_container_name,
+)
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    DockerSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from tests.external_dependency_unit.craft._test_helpers import default_llm_config
+
+# ----------------------------------------------------------------------
+# Module-wide skip gate
+# ----------------------------------------------------------------------
+
+_SKIP_MISSING_KEY = pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="docker-serve streaming tests need a real OPENAI_API_KEY",
+)
+_SKIP_WRONG_BACKEND = pytest.mark.skipif(
+    SANDBOX_BACKEND != SandboxBackend.DOCKER,
+    reason="docker-serve streaming tests require SANDBOX_BACKEND=docker",
+)
+_SKIP_NO_SOCKET = pytest.mark.skipif(
+    not os.path.exists(SANDBOX_DOCKER_SOCKET),
+    reason=f"Docker socket missing at {SANDBOX_DOCKER_SOCKET}",
+)
+
+pytestmark = [_SKIP_WRONG_BACKEND, _SKIP_NO_SOCKET, _SKIP_MISSING_KEY]
+
+
+# ----------------------------------------------------------------------
+# Manager-side fixture: AGENT_TRANSPORT=serve at the import sites that
+# read it. configs.AGENT_TRANSPORT is captured at module import time, so
+# monkeypatching the env doesn't propagate — we patch the symbol where
+# the read happens (base.py is where send_message branches now, plus
+# the Docker manager for its own send_message branch).
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _force_serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cfg, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(docker_mgr, "AGENT_TRANSPORT", AgentTransport.SERVE)
+
+
+@dataclass(frozen=True)
+class _PoolContainer:
+    sandbox_id: UUID
+    manager: DockerSandboxManager
+    session_id: UUID
+    llm_config: LLMProviderConfig
+
+
+@pytest.fixture(scope="module")
+def _pool_container() -> Generator[_PoolContainer, None, None]:
+    """One Docker sandbox container per test module.
+
+    Provisioning a container is fast (~3s) but opencode-serve takes
+    another 1–5s to bind :4096. Amortizing across the module avoids
+    paying that cost per test.
+    """
+    manager = DockerSandboxManager()
+    sandbox_id = uuid4()
+    user_id = uuid4()
+    llm_config = default_llm_config(api_key=os.environ["OPENAI_API_KEY"])
+
+    info = manager.provision(
+        sandbox_id=sandbox_id,
+        user_id=user_id,
+        tenant_id="docker-streaming-test",
+        llm_config=llm_config,
+        onyx_pat="ci-test-pat",
+    )
+    assert info.directory_path.startswith("docker://"), (
+        f"unexpected directory_path shape: {info.directory_path!r}"
+    )
+
+    session_id = uuid4()
+    manager.setup_session_workspace(
+        sandbox_id=sandbox_id,
+        session_id=session_id,
+        llm_config=llm_config,
+        nextjs_port=None,
+        skills_section="No skills available.",
+    )
+
+    try:
+        yield _PoolContainer(
+            sandbox_id=sandbox_id,
+            manager=manager,
+            session_id=session_id,
+            llm_config=llm_config,
+        )
+    finally:
+        try:
+            manager.terminate(sandbox_id)
+        except Exception:
+            pass
+
+
+# ----------------------------------------------------------------------
+# Event-collection helpers (mirrors test_opencode_serve_streaming)
+# ----------------------------------------------------------------------
+
+
+class _Collected:
+    __slots__ = ("chunks", "thoughts", "tool_starts", "tool_progress", "term", "errors")
+
+    def __init__(self) -> None:
+        self.chunks: list[AgentMessageChunk] = []
+        self.thoughts: list[AgentThoughtChunk] = []
+        self.tool_starts: list[ToolCallStart] = []
+        self.tool_progress: list[ToolCallProgress] = []
+        self.term: PromptResponse | None = None
+        self.errors: list[Error] = []
+
+    @property
+    def text(self) -> str:
+        return "".join(c.content.text for c in self.chunks)  # type: ignore[union-attr]
+
+
+def _drive_turn(
+    pool: _PoolContainer,
+    prompt: str,
+    *,
+    opencode_session_id: str | None = None,
+) -> tuple[_Collected, str | None]:
+    """One turn end-to-end via ``DockerSandboxManager.send_message``."""
+    if opencode_session_id is None:
+        opencode_session_id = pool.manager.ensure_opencode_session(
+            pool.sandbox_id, pool.session_id
+        )
+    assert opencode_session_id, "ensure_opencode_session must return an id under serve"
+
+    out = _Collected()
+    for ev in pool.manager.send_message(
+        pool.sandbox_id,
+        pool.session_id,
+        prompt,
+        opencode_session_id=opencode_session_id,
+    ):
+        if isinstance(ev, AgentMessageChunk):
+            out.chunks.append(ev)
+        elif isinstance(ev, AgentThoughtChunk):
+            out.thoughts.append(ev)
+        elif isinstance(ev, ToolCallStart):
+            out.tool_starts.append(ev)
+        elif isinstance(ev, ToolCallProgress):
+            out.tool_progress.append(ev)
+        elif isinstance(ev, PromptResponse):
+            out.term = ev
+        elif isinstance(ev, Error):
+            out.errors.append(ev)
+        elif isinstance(ev, SSEKeepalive):
+            pass
+    return out, opencode_session_id
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+
+def test_provision_injects_serve_env_into_real_container(
+    _pool_container: _PoolContainer,
+) -> None:
+    """The container actually got AGENT_TRANSPORT=serve + the password +
+    OPENCODE_CONFIG_CONTENT in its env. Mock tests assert on
+    ``build_container_create_kwargs`` output; this asserts on what Docker
+    actually accepted. If the env-allowlist invariant regresses (e.g. a
+    contributor adds a new env via a different code path), this fails."""
+    pool = _pool_container
+    name = _sandbox_container_name(pool.sandbox_id)
+    container = pool.manager._docker.containers.get(name)
+    env_list: list[str] = container.attrs["Config"]["Env"]
+    env_keys = {entry.split("=", 1)[0] for entry in env_list}
+    # All four serve-related vars are present.
+    assert "AGENT_TRANSPORT" in env_keys
+    assert "OPENCODE_SERVER_PASSWORD" in env_keys
+    assert "OPENCODE_SERVE_PORT" in env_keys
+    assert "OPENCODE_CONFIG_CONTENT" in env_keys
+    # Sanity-check the transport value.
+    for entry in env_list:
+        if entry.startswith("AGENT_TRANSPORT="):
+            assert entry == "AGENT_TRANSPORT=serve"
+            break
+
+
+def test_read_opencode_password_roundtrips_via_docker_inspect(
+    _pool_container: _PoolContainer,
+) -> None:
+    """The api_server-side password lookup MUST return exactly what
+    opencode-serve in the container loaded — otherwise every request 401s.
+    This is the load-bearing invariant the Docker port adds, and a unit
+    test with a mocked container can't catch a divergence between
+    `build_container_create_kwargs` and `_read_opencode_password`."""
+    pool = _pool_container
+    pw = pool.manager._read_opencode_password(pool.sandbox_id)
+    assert pw is not None
+    # token_urlsafe(32) produces 43-char output; allow slack for future
+    # changes but the absolute floor is 32 chars for any reasonable secret.
+    assert len(pw) >= 32
+
+
+def test_simple_message_streams_text_and_terminates(
+    _pool_container: _PoolContainer,
+) -> None:
+    """End-to-end smoke: drive one real turn against opencode-serve
+    inside the Docker sandbox container, assert we get text deltas and a
+    terminator. If this passes, the entire stack works: password injected
+    correctly, bridge-network reachability, serve binds :4096, prompt
+    POST + event SSE roundtrip, translator emits ACP events."""
+    out, _ = _drive_turn(_pool_container, "Say hi briefly.")
+
+    assert out.term is not None, "send_message never terminated"
+    assert out.term.stop_reason == "end_turn"
+    assert out.errors == [], f"unexpected errors: {out.errors}"
+    assert len(out.text) > 0, "expected at least one AgentMessageChunk"
+    # Regression: user prompt must NOT leak into assistant text.
+    assert "Say hi briefly" not in out.text, (
+        f"user prompt leaked into assistant text: {out.text!r}"
+    )
+
+
+def test_bash_tool_call_lifecycle(
+    _pool_container: _PoolContainer,
+) -> None:
+    """Tool call lifecycle parity with K8s: exactly one ToolCallStart per
+    call_id; ToolCallProgress sequence ends in status=completed."""
+    out, _ = _drive_turn(
+        _pool_container,
+        "Run the bash command `echo DOCKER_SERVE_OK` and then say DONE.",
+    )
+
+    assert out.term is not None
+    assert out.errors == []
+    assert len(out.tool_starts) >= 1, "expected at least one ToolCallStart"
+    bash_starts = [s for s in out.tool_starts if s.kind == "execute"]
+    assert len(bash_starts) >= 1, (
+        f"no bash tool call seen; got kinds: {[s.kind for s in out.tool_starts]}"
+    )
+    for cid in {s.tool_call_id for s in out.tool_starts}:
+        progress = [p for p in out.tool_progress if p.tool_call_id == cid]
+        assert any(p.status == "completed" for p in progress), (
+            f"tool call {cid} never reached status=completed; "
+            f"statuses: {[p.status for p in progress]}"
+        )
+
+
+def test_multi_turn_session_terminates_each_turn(
+    _pool_container: _PoolContainer,
+) -> None:
+    """Three back-to-back prompts on the same opencode session. Each
+    must terminate cleanly. Catches event-bus cross-talk and stuck
+    prompt-slot locks — both of which would block subsequent turns."""
+    opencode_session_id: str | None = None
+    for i, prompt in enumerate(
+        [
+            "Say 'one' and nothing else.",
+            "Say 'two' and nothing else.",
+            "Say 'three' and nothing else.",
+        ]
+    ):
+        out, opencode_session_id = _drive_turn(
+            _pool_container, prompt, opencode_session_id=opencode_session_id
+        )
+        assert out.term is not None, f"turn {i + 1} did not terminate"
+        assert out.errors == [], f"turn {i + 1} had errors: {out.errors}"
+        assert len(out.text) > 0, f"turn {i + 1} produced no text"
+
+
+def test_yields_at_most_one_terminator(
+    _pool_container: _PoolContainer,
+) -> None:
+    """opencode emits several end-of-turn signals (``message.updated``
+    completed, ``session.idle``, ``session.status``→idle). Whichever
+    fires first must terminate the turn; the rest must be suppressed.
+    Catches a regression in the terminator-dedup logic on the shared
+    base-class ``_send_message_via_serve`` path."""
+    pool = _pool_container
+    opencode_session_id: str | None = pool.manager.ensure_opencode_session(
+        pool.sandbox_id, pool.session_id
+    )
+    extra_terms = 0
+    for i in range(3):
+        term_count = 0
+        for ev in pool.manager.send_message(
+            pool.sandbox_id,
+            pool.session_id,
+            f"Say '{i}'.",
+            opencode_session_id=opencode_session_id,
+        ):
+            if isinstance(ev, PromptResponse):
+                term_count += 1
+        if term_count != 1:
+            extra_terms += 1
+    assert extra_terms == 0, (
+        f"{extra_terms} turn(s) yielded ≠1 PromptResponse — terminator de-dup is broken"
+    )
+
+
+def test_prompt_slot_blocks_concurrent_turn(
+    _pool_container: _PoolContainer,
+) -> None:
+    """``prompt_slot`` is the load-bearing lock that prevents the
+    phantom-user_message bug. The Docker manager inherits the impl from
+    base — this test confirms the lock state actually got initialized via
+    ``_init_serve_state`` during ``_initialize``. A regression where
+    Docker forgot to call it would surface as the lock dict missing."""
+    pool = _pool_container
+    with pool.manager.prompt_slot(pool.sandbox_id, pool.session_id) as outer:
+        assert outer is True
+        with pool.manager.prompt_slot(pool.sandbox_id, pool.session_id) as inner:
+            assert inner is False, (
+                "second concurrent prompt_slot acquire must return False"
+            )
+
+
+def test_terminate_then_subscribe_refuses(
+    _pool_container: _PoolContainer,
+) -> None:
+    """After ``terminate``, late ``_get_or_create_event_bus`` calls MUST
+    raise rather than spin a reader thread against the deleted container.
+    The K8s manager tombstones the sandbox_id; Docker inherits the same
+    machinery via base. This is in its own test (separate sandbox_id, not
+    the pool) so the teardown doesn't break other tests."""
+    pool = _pool_container
+    sandbox_id = uuid4()
+    pool.manager.provision(
+        sandbox_id=sandbox_id,
+        user_id=uuid4(),
+        tenant_id="docker-streaming-test",
+        llm_config=pool.llm_config,
+        onyx_pat="ci-test-pat",
+    )
+    pool.manager.terminate(sandbox_id)
+
+    with pytest.raises(RuntimeError, match="terminated"):
+        pool.manager._get_or_create_event_bus(sandbox_id)

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -429,10 +429,13 @@ def test_terminate_then_subscribe_refuses(
         llm_config=pool.llm_config,
         onyx_pat="ci-test-pat",
     )
+    # Any directory works for the post-terminate check — the tombstone
+    # check fires before the per-(sandbox, directory) bus lookup.
+    directory = f"/workspace/sessions/{uuid4()}"
     try:
         pool.manager.terminate(sandbox_id)
         with pytest.raises(RuntimeError, match="terminated"):
-            pool.manager._get_or_create_event_bus(sandbox_id)
+            pool.manager._get_or_create_event_bus(sandbox_id, directory)
     finally:
         # Defensive cleanup in case ``terminate`` raised before completing.
         try:

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -302,9 +302,11 @@ def test_read_opencode_password_roundtrips_via_docker_inspect(
     opencode-serve in the container loaded — otherwise every request 401s.
     This is the load-bearing invariant the Docker port adds, and a unit
     test with a mocked container can't catch a divergence between
-    `build_container_create_kwargs` and `_read_opencode_password`."""
+    `build_container_create_kwargs` and `_load_serve_connection_info`."""
     pool = _pool_container
-    pw = pool.manager._read_opencode_password(pool.sandbox_id)
+    info = pool.manager._load_serve_connection_info(pool.sandbox_id)
+    assert info is not None
+    pw = info.password
     assert pw is not None
     # token_urlsafe(32) produces 43-char output; allow slack for future
     # changes but the absolute floor is 32 chars for any reasonable secret.

--- a/backend/tests/external_dependency_unit/craft/test_opencode_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_opencode_serve_streaming.py
@@ -47,8 +47,8 @@ from acp.schema import ToolCallProgress
 from acp.schema import ToolCallStart
 
 from onyx.server.features.build.configs import AgentTransport
-from onyx.server.features.build.sandbox.base import SSEKeepalive
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from tests.external_dependency_unit.craft._test_helpers import default_llm_config
 
 

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -36,7 +36,7 @@ from onyx.db.models import User
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import upsert_agent_plan
-from onyx.server.features.build.sandbox.base import SSEKeepalive
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.session.manager import BuildStreamingState
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.craft.stubs import StubSandboxManager

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -87,6 +87,10 @@ def test_labels_omit_user_id_when_none() -> None:
     assert labels[LABEL_SANDBOX_ID] == str(SANDBOX_ID)
 
 
+_OPENCODE_PASSWORD = "secret-password-fixture"
+_OPENCODE_CONFIG_JSON = '{"providers": {"openai": {"models": {"gpt-4": {}}}}}'
+
+
 @pytest.fixture
 def kwargs() -> ContainerCreateKwargs:
     return build_container_create_kwargs(
@@ -100,6 +104,8 @@ def kwargs() -> ContainerCreateKwargs:
         volume_name="onyx-craft-sandbox-12345678",
         memory_limit="2g",
         cpu_limit=1.0,
+        opencode_password=_OPENCODE_PASSWORD,
+        opencode_config_json=_OPENCODE_CONFIG_JSON,
     )
 
 
@@ -128,6 +134,11 @@ def test_container_kwargs_env_allowlist_excludes_storage_credentials(
     # Required env
     assert env["ONYX_PAT"] == "pat-redacted"
     assert env["ONYX_SERVER_URL"] == "http://api_server:8080"
+    # opencode-serve transport wiring
+    assert env["AGENT_TRANSPORT"] in {"acp", "serve"}
+    assert env["OPENCODE_SERVE_PORT"] == "4096"
+    assert env["OPENCODE_SERVER_PASSWORD"] == _OPENCODE_PASSWORD
+    assert env["OPENCODE_CONFIG_CONTENT"] == _OPENCODE_CONFIG_JSON
     # Forbidden env - any storage credential leaking into the sandbox would
     # let the agent read every snapshot/file in the deployment.
     forbidden = {
@@ -225,7 +236,14 @@ def test_container_kwargs_env_is_a_minimal_allowlist(
     """
     env = kwargs["environment"]
     assert isinstance(env, dict)
-    assert set(env.keys()) == {"ONYX_PAT", "ONYX_SERVER_URL"}
+    assert set(env.keys()) == {
+        "ONYX_PAT",
+        "ONYX_SERVER_URL",
+        "AGENT_TRANSPORT",
+        "OPENCODE_SERVE_PORT",
+        "OPENCODE_SERVER_PASSWORD",
+        "OPENCODE_CONFIG_CONTENT",
+    }
 
 
 def test_container_kwargs_mounts_only_workspace_sessions(
@@ -261,6 +279,8 @@ def test_container_kwargs_warns_on_internal_compose_host(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            opencode_password=_OPENCODE_PASSWORD,
+            opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
     assert any(
         "looks like an internal compose hostname" in r.getMessage()
@@ -286,6 +306,8 @@ def test_container_kwargs_no_warning_for_public_url(
             volume_name="vol",
             memory_limit="2g",
             cpu_limit=1.0,
+            opencode_password=_OPENCODE_PASSWORD,
+            opencode_config_json=_OPENCODE_CONFIG_JSON,
         )
     assert not any(
         "looks like an internal compose hostname" in r.getMessage()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -148,13 +148,13 @@ def test_render_session_files_returns_none_for_opencode_json_under_serve(
     ``OPENCODE_CONFIG_CONTENT`` at startup) and would pollute snapshots."""
     monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.SERVE)
     mgr = _bare_manager()
-    agents_md, opencode_json = mgr._render_session_files(
+    rendered = mgr._render_session_files(
         llm_config=llm_config,
         nextjs_port=None,
         skills_section="",
     )
-    assert agents_md  # not empty
-    assert opencode_json is None
+    assert rendered.agents_md  # not empty
+    assert rendered.opencode_json is None
 
 
 def test_render_session_files_writes_opencode_json_under_acp(
@@ -165,15 +165,15 @@ def test_render_session_files_writes_opencode_json_under_acp(
     still emitted because each exec'd ``opencode acp`` invocation reads it."""
     monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.ACP)
     mgr = _bare_manager()
-    _, opencode_json = mgr._render_session_files(
+    rendered = mgr._render_session_files(
         llm_config=llm_config,
         nextjs_port=None,
         skills_section="",
     )
-    assert opencode_json is not None
+    assert rendered.opencode_json is not None
     # Shell-escaped single quotes are present in the rendered form; the raw
     # JSON should still round-trip after the substitution is reversed.
-    raw = opencode_json.replace("'\\''", "'")
+    raw = rendered.opencode_json.replace("'\\''", "'")
     parsed: Any = json.loads(raw)
     assert "openai" in parsed.get("provider", {})
 
@@ -286,31 +286,12 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
     assert "provider" in config
 
-    # Second provision call must mint a NEW password — never re-use.
-    DockerSandboxManager._instance = None
-    mgr2 = _bare_manager()
-    mgr2._docker = MagicMock()  # type: ignore[attr-defined]
-    mgr2._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
-    mgr2._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
-    mgr2._memory_limit = "2g"  # type: ignore[attr-defined]
-    mgr2._cpu_limit = 1.0  # type: ignore[attr-defined]
-    mgr2._compose_project = None  # type: ignore[attr-defined]
-    mgr2._docker.containers.get.side_effect = dsm.NotFound("none")
-    mgr2._docker.networks.get.return_value = MagicMock()
-    mgr2._docker.volumes.get.return_value = MagicMock()
-    run_calls2: list[dict[str, Any]] = []
-    mgr2._docker.containers.run.side_effect = lambda **kw: (
-        run_calls2.append(kw) or fake_container
-    )
-    mgr2.provision(
-        sandbox_id=_SBX,
-        user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
-        tenant_id="tenant-abc",
-        llm_config=llm_config,
-        onyx_pat="pat-redacted",
-    )
-    pw2 = run_calls2[0]["environment"][OPENCODE_SERVER_PASSWORD_ENV]
-    assert pw2 != pw, "password must be unique per provision call"
+    # Fresh-per-call is provided by ``secrets.token_urlsafe(32)`` —
+    # asserting a second provision yields a different value is just
+    # restating stdlib's contract. Single-call shape check (above) plus
+    # the fact that the password is sourced from ``secrets.token_urlsafe``
+    # is the load-bearing invariant; testing it twice burns 30 lines of
+    # mock setup for no signal beyond reading the implementation.
 
 
 def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -1,0 +1,337 @@
+"""Unit tests for ``DockerSandboxManager`` serve-transport wiring.
+
+These tests exercise the pure logic added by the
+docker-sandbox-serve port — no Docker engine required. We use
+``object.__new__(DockerSandboxManager)`` to bypass ``_initialize``
+(which would try to open the Docker socket) and verify:
+
+- ``_serve_base_url`` produces the expected container-name URL.
+- ``_read_opencode_password`` round-trips the cleartext password from a
+  mocked container's ``inspect.Config.Env``, returns ``None`` for legacy
+  containers, and returns ``None`` when the container is gone.
+- ``_render_session_files`` returns ``None`` for ``opencode.json`` under
+  ``AGENT_TRANSPORT=serve`` (so snapshots stay clean) and a JSON blob
+  under ``AGENT_TRANSPORT=acp``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID
+
+import pytest
+
+import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as dsm
+from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    DockerSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+
+_SBX = UUID("12345678-1234-1234-1234-1234567890ab")
+
+
+def _bare_manager() -> DockerSandboxManager:
+    """Build a DockerSandboxManager without touching the Docker socket.
+
+    Skips ``_initialize`` (which constructs ``DockerClient`` and opens
+    the socket). For tests that don't need ``_docker``, this avoids the
+    flaky "Docker not running" failure mode on contributors' boxes.
+    """
+    # Reset the singleton so each test gets a fresh stub manager.
+    DockerSandboxManager._instance = None
+    mgr: DockerSandboxManager = object.__new__(DockerSandboxManager)
+    # Path-dependent attributes used by methods under test.
+    mgr._agent_instructions_template_path = (  # type: ignore[attr-defined]
+        dsm.Path(dsm.__file__).parent.parent.parent / "AGENTS.template.md"
+    )
+    # State the base class would set up via _init_serve_state — we use the
+    # same method here so tests stay in sync with real state shape.
+    mgr._init_serve_state()
+    return mgr
+
+
+def test_serve_base_url_uses_container_name_and_port() -> None:
+    """Sandboxes are addressed by container name on the bridge network.
+    K8s does the same thing with a Service DNS name."""
+    mgr = _bare_manager()
+    url = mgr._serve_base_url(_SBX)
+    assert url == f"http://sandbox-12345678:{OPENCODE_SERVE_PORT}"
+
+
+def test_read_opencode_password_parses_from_container_env() -> None:
+    """The cleartext password lives in the container's env (Docker
+    Engine API). Decoded on every read; never persisted on disk."""
+    mgr = _bare_manager()
+    fake_container = MagicMock()
+    fake_container.attrs = {
+        "Config": {
+            "Env": [
+                "ONYX_PAT=pat-redacted",
+                "ONYX_SERVER_URL=http://api_server:8080",
+                f"{OPENCODE_SERVER_PASSWORD_ENV}=correct-horse-battery-staple",
+                "AGENT_TRANSPORT=serve",
+            ]
+        }
+    }
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker.containers.get.return_value = fake_container
+
+    pw = mgr._read_opencode_password(_SBX)
+    assert pw == "correct-horse-battery-staple"
+
+
+def test_read_opencode_password_returns_none_for_legacy_container() -> None:
+    """A container provisioned before this code landed has no
+    ``OPENCODE_SERVER_PASSWORD`` in env. The bus then falls back to
+    no-auth and logs a warning."""
+    mgr = _bare_manager()
+    fake_container = MagicMock()
+    fake_container.attrs = {
+        "Config": {"Env": ["ONYX_PAT=pat", "ONYX_SERVER_URL=https://onyx.example.com"]}
+    }
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker.containers.get.return_value = fake_container
+
+    assert mgr._read_opencode_password(_SBX) is None
+
+
+def test_read_opencode_password_returns_none_when_container_missing() -> None:
+    """terminate() races provision() — looking up a deleted container
+    should fail gracefully, not raise."""
+    mgr = _bare_manager()
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker.containers.get.side_effect = dsm.NotFound("gone")
+
+    assert mgr._read_opencode_password(_SBX) is None
+
+
+def test_read_opencode_password_handles_password_with_equals_sign() -> None:
+    """``token_urlsafe(32)`` can produce ``=`` chars at the tail. The
+    parser must split on the FIRST equals only."""
+    mgr = _bare_manager()
+    weird_password = "tail==padding=="
+    fake_container = MagicMock()
+    fake_container.attrs = {
+        "Config": {
+            "Env": [
+                f"{OPENCODE_SERVER_PASSWORD_ENV}={weird_password}",
+            ]
+        }
+    }
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker.containers.get.return_value = fake_container
+
+    assert mgr._read_opencode_password(_SBX) == weird_password
+
+
+@pytest.fixture
+def llm_config() -> LLMProviderConfig:
+    return LLMProviderConfig(
+        provider="openai",
+        model_name="gpt-4o",
+        api_key="sk-test",
+        api_base=None,
+    )
+
+
+def test_render_session_files_returns_none_for_opencode_json_under_serve(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_config: LLMProviderConfig,
+) -> None:
+    """Under ``AGENT_TRANSPORT=serve`` the per-session ``opencode.json``
+    is redundant (opencode-serve loaded providers from
+    ``OPENCODE_CONFIG_CONTENT`` at startup) and would pollute snapshots."""
+    monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    mgr = _bare_manager()
+    agents_md, opencode_json = mgr._render_session_files(
+        llm_config=llm_config,
+        nextjs_port=None,
+        skills_section="",
+    )
+    assert agents_md  # not empty
+    assert opencode_json is None
+
+
+def test_render_session_files_writes_opencode_json_under_acp(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_config: LLMProviderConfig,
+) -> None:
+    """Under ``AGENT_TRANSPORT=acp`` (rollback) the per-session file is
+    still emitted because each exec'd ``opencode acp`` invocation reads it."""
+    monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.ACP)
+    mgr = _bare_manager()
+    _, opencode_json = mgr._render_session_files(
+        llm_config=llm_config,
+        nextjs_port=None,
+        skills_section="",
+    )
+    assert opencode_json is not None
+    # Shell-escaped single quotes are present in the rendered form; the raw
+    # JSON should still round-trip after the substitution is reversed.
+    raw = opencode_json.replace("'\\''", "'")
+    parsed: Any = json.loads(raw)
+    assert "openai" in parsed.get("provider", {})
+
+
+def test_init_serve_state_is_idempotent() -> None:
+    """``_init_serve_state`` is called from ``_initialize``; provision
+    paths must not blow up if called twice."""
+    mgr = _bare_manager()
+    first_lock = mgr._event_buses_lock
+    mgr._init_serve_state()  # second call
+    assert mgr._event_buses_lock is first_lock
+    assert mgr._event_buses == {}
+    assert mgr._terminated_sandboxes == set()
+
+
+def test_prompt_slot_serializes_on_docker_under_serve(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The K8s prompt_slot test asserts the lock contract for K8s; the
+    Docker manager inherits the same base impl, so the same invariant
+    must hold for Docker too. This catches a regression where Docker
+    forgot to call ``_init_serve_state`` and the lock dict would be
+    missing."""
+    import onyx.server.features.build.sandbox.base as sandbox_base
+
+    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    mgr = _bare_manager()
+
+    other_session = UUID("00000000-0000-0000-0000-000000000001")
+    with mgr.prompt_slot(_SBX, other_session) as outer:
+        assert outer is True
+        with mgr.prompt_slot(_SBX, other_session) as inner:
+            assert inner is False
+
+
+def test_provision_generates_fresh_password_and_injects_into_container_env(
+    monkeypatch: pytest.MonkeyPatch,
+    llm_config: LLMProviderConfig,
+) -> None:
+    """End-to-end verification that ``provision()`` mints a per-call
+    HTTP Basic password and threads it through ``build_container_create_kwargs``
+    into the Docker container's env. This is the load-bearing path the
+    Docker port adds: opencode-serve in the sandbox container reads the
+    password from env at startup; the api_server reads it back via
+    ``_read_opencode_password``. If they diverge, every request 401s."""
+    monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
+    # Skip the actual readiness HTTP probe — that needs a real container.
+    monkeypatch.setattr(
+        DockerSandboxManager,
+        "_wait_for_opencode_serve_ready",
+        lambda self, sandbox_id: True,  # noqa: ARG005 — patched callable
+    )
+
+    mgr = _bare_manager()
+    # Mock the Docker client surface used by provision().
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
+    mgr._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
+    mgr._memory_limit = "2g"  # type: ignore[attr-defined]
+    mgr._cpu_limit = 1.0  # type: ignore[attr-defined]
+    mgr._compose_project = None  # type: ignore[attr-defined]
+    # No existing container.
+    mgr._docker.containers.get.side_effect = dsm.NotFound("none")
+    # _ensure_sandbox_network — pretend it exists already.
+    mgr._docker.networks.get.return_value = MagicMock()
+    # _ensure_sandbox_volume — pretend it exists already.
+    mgr._docker.volumes.get.return_value = MagicMock()
+
+    # Capture the kwargs passed to containers.run.
+    fake_container = MagicMock()
+    fake_container.name = "sandbox-12345678"
+    fake_container.attrs = {"State": {"Status": "running"}}
+
+    run_calls: list[dict[str, Any]] = []
+
+    def _capture_run(**kwargs: Any) -> Any:
+        run_calls.append(kwargs)
+        return fake_container
+
+    mgr._docker.containers.run.side_effect = _capture_run
+
+    info = mgr.provision(
+        sandbox_id=_SBX,
+        user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        tenant_id="tenant-abc",
+        llm_config=llm_config,
+        onyx_pat="pat-redacted",
+    )
+
+    assert info.status.value == "running"
+    assert len(run_calls) == 1
+    env = run_calls[0]["environment"]
+    # All six required env vars are present.
+    assert set(env.keys()) == {
+        "ONYX_PAT",
+        "ONYX_SERVER_URL",
+        "AGENT_TRANSPORT",
+        "OPENCODE_SERVE_PORT",
+        OPENCODE_SERVER_PASSWORD_ENV,
+        "OPENCODE_CONFIG_CONTENT",
+    }
+    # AGENT_TRANSPORT mirrors the patched serve value.
+    assert env["AGENT_TRANSPORT"] == "serve"
+    # The password is a fresh token_urlsafe(32) — long-ish, no spaces.
+    pw = env[OPENCODE_SERVER_PASSWORD_ENV]
+    assert len(pw) >= 32
+    assert " " not in pw
+    # OPENCODE_CONFIG_CONTENT is valid JSON the agent can parse.
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    assert "provider" in config
+
+    # Second provision call must mint a NEW password — never re-use.
+    DockerSandboxManager._instance = None
+    mgr2 = _bare_manager()
+    mgr2._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr2._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
+    mgr2._network_name = "onyx_craft_sandbox"  # type: ignore[attr-defined]
+    mgr2._memory_limit = "2g"  # type: ignore[attr-defined]
+    mgr2._cpu_limit = 1.0  # type: ignore[attr-defined]
+    mgr2._compose_project = None  # type: ignore[attr-defined]
+    mgr2._docker.containers.get.side_effect = dsm.NotFound("none")
+    mgr2._docker.networks.get.return_value = MagicMock()
+    mgr2._docker.volumes.get.return_value = MagicMock()
+    run_calls2: list[dict[str, Any]] = []
+    mgr2._docker.containers.run.side_effect = lambda **kw: (
+        run_calls2.append(kw) or fake_container
+    )
+    mgr2.provision(
+        sandbox_id=_SBX,
+        user_id=UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        tenant_id="tenant-abc",
+        llm_config=llm_config,
+        onyx_pat="pat-redacted",
+    )
+    pw2 = run_calls2[0]["environment"][OPENCODE_SERVER_PASSWORD_ENV]
+    assert pw2 != pw, "password must be unique per provision call"
+
+
+def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
+    """The Docker manager must mirror K8s's cleanup contract: on
+    terminate the per-sandbox event bus is closed and the sandbox id
+    is added to ``_terminated_sandboxes`` so a late ``subscribe`` won't
+    spin up a fresh reader thread against a deleted container."""
+    mgr = _bare_manager()
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    # No real container — terminate should still cleanly run.
+    mgr._docker.containers.get.return_value = None
+    mgr._docker.volumes.get.side_effect = dsm.NotFound("none")
+
+    # Pre-seed an event bus so the terminate path takes the bus.close()
+    # branch (would silently no-op otherwise).
+    fake_bus = MagicMock()
+    fake_bus.closed = False
+    mgr._event_buses[_SBX] = fake_bus
+
+    mgr.terminate(_SBX)
+
+    assert _SBX in mgr._terminated_sandboxes
+    assert _SBX not in mgr._event_buses
+    fake_bus.close.assert_called_once()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -26,7 +26,7 @@ import pytest
 import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as dsm
 from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.configs import OPENCODE_SERVE_PORT
-from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD_ENV
+from onyx.server.features.build.configs import OPENCODE_SERVER_PASSWORD
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     DockerSandboxManager,
 )
@@ -73,7 +73,7 @@ def test_load_serve_connection_info_parses_password_from_container_env() -> None
             "Env": [
                 "ONYX_PAT=pat-redacted",
                 "ONYX_SERVER_URL=http://api_server:8080",
-                f"{OPENCODE_SERVER_PASSWORD_ENV}=correct-horse-battery-staple",
+                f"{OPENCODE_SERVER_PASSWORD}=correct-horse-battery-staple",
                 "AGENT_TRANSPORT=serve",
             ]
         }
@@ -122,7 +122,7 @@ def test_load_serve_connection_info_handles_password_with_equals_sign() -> None:
     fake_container.attrs = {
         "Config": {
             "Env": [
-                f"{OPENCODE_SERVER_PASSWORD_ENV}={weird_password}",
+                f"{OPENCODE_SERVER_PASSWORD}={weird_password}",
             ]
         }
     }
@@ -272,13 +272,13 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
         "ONYX_SERVER_URL",
         "AGENT_TRANSPORT",
         "OPENCODE_SERVE_PORT",
-        OPENCODE_SERVER_PASSWORD_ENV,
+        OPENCODE_SERVER_PASSWORD,
         "OPENCODE_CONFIG_CONTENT",
     }
     # AGENT_TRANSPORT mirrors the patched serve value.
     assert env["AGENT_TRANSPORT"] == "serve"
     # The password is a fresh token_urlsafe(32) — long-ish, no spaces.
-    pw = env[OPENCODE_SERVER_PASSWORD_ENV]
+    pw = env[OPENCODE_SERVER_PASSWORD]
     assert len(pw) >= 32
     assert " " not in pw
     # OPENCODE_CONFIG_CONTENT is valid JSON the agent can parse.

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -36,21 +36,14 @@ _SBX = UUID("12345678-1234-1234-1234-1234567890ab")
 
 
 def _bare_manager() -> DockerSandboxManager:
-    """Build a DockerSandboxManager without touching the Docker socket.
-
-    Skips ``_initialize`` (which constructs ``DockerClient`` and opens
-    the socket). For tests that don't need ``_docker``, this avoids the
-    flaky "Docker not running" failure mode on contributors' boxes.
-    """
-    # Reset the singleton so each test gets a fresh stub manager.
+    """DockerSandboxManager without touching the Docker socket: skips
+    ``_initialize`` so contributors without docker running can still run
+    these tests."""
     DockerSandboxManager._instance = None
     mgr: DockerSandboxManager = object.__new__(DockerSandboxManager)
-    # Path-dependent attributes used by methods under test.
     mgr._agent_instructions_template_path = (  # type: ignore[attr-defined]
         dsm.Path(dsm.__file__).parent.parent.parent / "AGENTS.template.md"
     )
-    # State the base class would set up via _init_serve_state — we use the
-    # same method here so tests stay in sync with real state shape.
     mgr._init_serve_state()
     return mgr
 
@@ -204,11 +197,8 @@ def test_init_serve_state_is_idempotent() -> None:
 def test_prompt_slot_serializes_on_docker_under_serve(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The K8s prompt_slot test asserts the lock contract for K8s; the
-    Docker manager inherits the same mixin impl, so the same invariant
-    must hold for Docker too. This catches a regression where Docker
-    forgot to call ``_init_serve_state`` and the lock dict would be
-    missing."""
+    """Pins the prompt-slot lock contract on Docker — same as the K8s
+    test, catches a regression if Docker skips ``_init_serve_state``."""
     from onyx.server.features.build.sandbox import serve_transport
 
     monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.SERVE)
@@ -225,12 +215,9 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     monkeypatch: pytest.MonkeyPatch,
     llm_config: LLMProviderConfig,
 ) -> None:
-    """End-to-end verification that ``provision()`` mints a per-call
-    HTTP Basic password and threads it through ``build_container_create_kwargs``
-    into the Docker container's env. This is the load-bearing path the
-    Docker port adds: opencode-serve in the sandbox container reads the
-    password from env at startup; the api_server reads it back via
-    ``_read_opencode_password``. If they diverge, every request 401s."""
+    """``provision()`` must mint a per-call HTTP Basic password and
+    thread it through ``build_container_create_kwargs`` into the
+    container env — otherwise every later request 401s."""
     monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.SERVE)
     monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
     # Skip the actual readiness HTTP probe — that needs a real container.
@@ -298,28 +285,19 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
     assert "provider" in config
 
-    # Fresh-per-call is provided by ``secrets.token_urlsafe(32)`` —
-    # asserting a second provision yields a different value is just
-    # restating stdlib's contract. Single-call shape check (above) plus
-    # the fact that the password is sourced from ``secrets.token_urlsafe``
-    # is the load-bearing invariant; testing it twice burns 30 lines of
-    # mock setup for no signal beyond reading the implementation.
+    # Fresh-per-call is stdlib's contract for ``secrets.token_urlsafe``;
+    # asserting it across two provisions is just re-stating that.
 
 
 def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
-    """The Docker manager must mirror K8s's cleanup contract: on
-    terminate the per-sandbox event bus is closed and the sandbox id
-    is added to ``_terminated_sandboxes`` so a late ``subscribe`` won't
-    spin up a fresh reader thread against a deleted container."""
+    """terminate must close every per-directory bus and add the sandbox
+    to ``_terminated_sandboxes`` so a late subscribe can't race in."""
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
-    # No real container — terminate should still cleanly run.
     mgr._docker.containers.get.return_value = None
     mgr._docker.volumes.get.side_effect = dsm.NotFound("none")
 
-    # Pre-seed per-directory event buses so the terminate path takes the
-    # bus.close() branch. Two buses on the same sandbox to exercise the
-    # "close every per-directory bus" behavior.
+    # Two buses on the same sandbox exercise the per-directory close path.
     fake_bus_a = MagicMock()
     fake_bus_a.closed = False
     fake_bus_b = MagicMock()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -153,13 +153,13 @@ def test_render_session_files_returns_none_for_opencode_json_under_serve(
     ``OPENCODE_CONFIG_CONTENT`` at startup) and would pollute snapshots."""
     monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.SERVE)
     mgr = _bare_manager()
-    rendered = mgr._render_session_files(
+    agents_md, opencode_json = mgr._render_session_files(
         llm_config=llm_config,
         nextjs_port=None,
         skills_section="",
     )
-    assert rendered.agents_md  # not empty
-    assert rendered.opencode_json is None
+    assert agents_md  # not empty
+    assert opencode_json is None
 
 
 def test_render_session_files_writes_opencode_json_under_acp(
@@ -170,15 +170,15 @@ def test_render_session_files_writes_opencode_json_under_acp(
     still emitted because each exec'd ``opencode acp`` invocation reads it."""
     monkeypatch.setattr(dsm, "AGENT_TRANSPORT", AgentTransport.ACP)
     mgr = _bare_manager()
-    rendered = mgr._render_session_files(
+    _agents_md, opencode_json = mgr._render_session_files(
         llm_config=llm_config,
         nextjs_port=None,
         skills_section="",
     )
-    assert rendered.opencode_json is not None
+    assert opencode_json is not None
     # Shell-escaped single quotes are present in the rendered form; the raw
     # JSON should still round-trip after the substitution is reversed.
-    raw = rendered.opencode_json.replace("'\\''", "'")
+    raw = opencode_json.replace("'\\''", "'")
     parsed: Any = json.loads(raw)
     assert "openai" in parsed.get("provider", {})
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -305,14 +305,19 @@ def test_terminate_closes_event_bus_and_tombstones_sandbox() -> None:
     mgr._docker.containers.get.return_value = None
     mgr._docker.volumes.get.side_effect = dsm.NotFound("none")
 
-    # Pre-seed an event bus so the terminate path takes the bus.close()
-    # branch (would silently no-op otherwise).
-    fake_bus = MagicMock()
-    fake_bus.closed = False
-    mgr._event_buses[_SBX] = fake_bus
+    # Pre-seed per-directory event buses so the terminate path takes the
+    # bus.close() branch. Two buses on the same sandbox to exercise the
+    # "close every per-directory bus" behavior.
+    fake_bus_a = MagicMock()
+    fake_bus_a.closed = False
+    fake_bus_b = MagicMock()
+    fake_bus_b.closed = False
+    mgr._event_buses[(_SBX, "/workspace/sessions/dir-a")] = fake_bus_a
+    mgr._event_buses[(_SBX, "/workspace/sessions/dir-b")] = fake_bus_b
 
     mgr.terminate(_SBX)
 
     assert _SBX in mgr._terminated_sandboxes
-    assert _SBX not in mgr._event_buses
-    fake_bus.close.assert_called_once()
+    assert all(k[0] != _SBX for k in mgr._event_buses)
+    fake_bus_a.close.assert_called_once()
+    fake_bus_b.close.assert_called_once()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -5,10 +5,10 @@ docker-sandbox-serve port — no Docker engine required. We use
 ``object.__new__(DockerSandboxManager)`` to bypass ``_initialize``
 (which would try to open the Docker socket) and verify:
 
-- ``_serve_base_url`` produces the expected container-name URL.
-- ``_read_opencode_password`` round-trips the cleartext password from a
-  mocked container's ``inspect.Config.Env``, returns ``None`` for legacy
-  containers, and returns ``None`` when the container is gone.
+- ``_load_serve_connection_info`` produces the expected container-name
+  URL + cleartext password from a mocked container's ``inspect.Config.Env``,
+  yields a ``None`` password for legacy containers, and returns ``None``
+  when the container is gone.
 - ``_render_session_files`` returns ``None`` for ``opencode.json`` under
   ``AGENT_TRANSPORT=serve`` (so snapshots stay clean) and a JSON blob
   under ``AGENT_TRANSPORT=acp``.
@@ -55,17 +55,24 @@ def _bare_manager() -> DockerSandboxManager:
     return mgr
 
 
-def test_serve_base_url_uses_container_name_and_port() -> None:
+def test_load_serve_connection_info_uses_container_name_and_port() -> None:
     """Sandboxes are addressed by container name on the bridge network.
     K8s does the same thing with a Service DNS name."""
     mgr = _bare_manager()
-    url = mgr._serve_base_url(_SBX)
-    assert url == f"http://sandbox-12345678:{OPENCODE_SERVE_PORT}"
+    fake_container = MagicMock()
+    fake_container.attrs = {"Config": {"Env": []}}
+    mgr._docker = MagicMock()  # type: ignore[attr-defined]
+    mgr._docker.containers.get.return_value = fake_container
+
+    info = mgr._load_serve_connection_info(_SBX)
+    assert info is not None
+    assert info.base_url == f"http://sandbox-12345678:{OPENCODE_SERVE_PORT}"
 
 
-def test_read_opencode_password_parses_from_container_env() -> None:
+def test_load_serve_connection_info_parses_password_from_container_env() -> None:
     """The cleartext password lives in the container's env (Docker
-    Engine API). Decoded on every read; never persisted on disk."""
+    Engine API). Decoded on every load; cached by the mixin so the hot
+    path doesn't re-hit ``docker inspect``."""
     mgr = _bare_manager()
     fake_container = MagicMock()
     fake_container.attrs = {
@@ -81,11 +88,12 @@ def test_read_opencode_password_parses_from_container_env() -> None:
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.return_value = fake_container
 
-    pw = mgr._read_opencode_password(_SBX)
-    assert pw == "correct-horse-battery-staple"
+    info = mgr._load_serve_connection_info(_SBX)
+    assert info is not None
+    assert info.password == "correct-horse-battery-staple"
 
 
-def test_read_opencode_password_returns_none_for_legacy_container() -> None:
+def test_load_serve_connection_info_yields_none_password_for_legacy() -> None:
     """A container provisioned before this code landed has no
     ``OPENCODE_SERVER_PASSWORD`` in env. The bus then falls back to
     no-auth and logs a warning."""
@@ -97,20 +105,22 @@ def test_read_opencode_password_returns_none_for_legacy_container() -> None:
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.return_value = fake_container
 
-    assert mgr._read_opencode_password(_SBX) is None
+    info = mgr._load_serve_connection_info(_SBX)
+    assert info is not None
+    assert info.password is None
 
 
-def test_read_opencode_password_returns_none_when_container_missing() -> None:
+def test_load_serve_connection_info_returns_none_when_container_missing() -> None:
     """terminate() races provision() — looking up a deleted container
     should fail gracefully, not raise."""
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.side_effect = dsm.NotFound("gone")
 
-    assert mgr._read_opencode_password(_SBX) is None
+    assert mgr._load_serve_connection_info(_SBX) is None
 
 
-def test_read_opencode_password_handles_password_with_equals_sign() -> None:
+def test_load_serve_connection_info_handles_password_with_equals_sign() -> None:
     """``token_urlsafe(32)`` can produce ``=`` chars at the tail. The
     parser must split on the FIRST equals only."""
     mgr = _bare_manager()
@@ -126,7 +136,9 @@ def test_read_opencode_password_handles_password_with_equals_sign() -> None:
     mgr._docker = MagicMock()  # type: ignore[attr-defined]
     mgr._docker.containers.get.return_value = fake_container
 
-    assert mgr._read_opencode_password(_SBX) == weird_password
+    info = mgr._load_serve_connection_info(_SBX)
+    assert info is not None
+    assert info.password == weird_password
 
 
 @pytest.fixture
@@ -193,13 +205,13 @@ def test_prompt_slot_serializes_on_docker_under_serve(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The K8s prompt_slot test asserts the lock contract for K8s; the
-    Docker manager inherits the same base impl, so the same invariant
+    Docker manager inherits the same mixin impl, so the same invariant
     must hold for Docker too. This catches a regression where Docker
     forgot to call ``_init_serve_state`` and the lock dict would be
     missing."""
-    import onyx.server.features.build.sandbox.base as sandbox_base
+    from onyx.server.features.build.sandbox import serve_transport
 
-    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.SERVE)
     mgr = _bare_manager()
 
     other_session = UUID("00000000-0000-0000-0000-000000000001")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
@@ -40,7 +40,7 @@ from uuid import uuid4
 
 import pytest
 
-import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+import onyx.server.features.build.sandbox.base as sandbox_base
 from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
@@ -53,8 +53,12 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 
 @pytest.fixture(autouse=True)
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``list_subagents`` and bus creation only kick in under SERVE."""
-    monkeypatch.setattr(ksm, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    """``list_subagents`` and bus creation only kick in under SERVE.
+
+    The methods live on ``SandboxManager`` (base) post-refactor, so we
+    patch the transport flag where the read happens.
+    """
+    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
 
 
 @pytest.fixture

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
@@ -32,7 +32,6 @@ future refactor that flattens the key back to ``sandbox_id`` (or scopes
 
 from __future__ import annotations
 
-import threading
 from collections.abc import Generator
 from queue import Empty
 from typing import Any
@@ -55,26 +54,33 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     """``list_subagents`` and bus creation only kick in under SERVE.
 
-    The methods live on ``SandboxManager`` (base) post-refactor, so we
-    patch the transport flag where the read happens.
+    The methods live on ``_ServeMixin`` (composed into ``SandboxManager``)
+    post-refactor; the transport flag is read at the mixin module.
     """
+    from onyx.server.features.build.sandbox import serve_transport
+
     monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.SERVE)
 
 
 @pytest.fixture
 def mgr() -> Generator[KubernetesSandboxManager, None, None]:
-    """Manager with just the event-bus state initialized — skips
-    ``_initialize`` so no kube config is required. Stubs the two helpers
-    ``_get_or_create_event_bus`` calls so we don't need real auth or pod
-    URLs."""
-    m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    m._event_buses = {}  # type: ignore[attr-defined]
-    m._event_buses_lock = threading.Lock()  # type: ignore[attr-defined]
-    m._terminated_sandboxes = set()  # type: ignore[attr-defined]
+    """Manager with just the serve-transport state initialized — skips
+    ``_initialize`` so no kube config is required. Stubs
+    ``_load_serve_connection_info`` so the mixin's caching layer doesn't
+    need a real Secret read."""
+    from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 
-    # Stub auth + URL lookups so we don't touch K8s.
-    m._read_opencode_password = lambda _sandbox_id: None  # type: ignore[assignment]
-    m._serve_base_url = lambda sandbox_id: f"http://{sandbox_id}.invalid:4096"  # type: ignore[assignment]
+    m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    m._init_serve_state()  # initializes _event_buses, _terminated_sandboxes, etc.
+
+    # Stub the cached connection-info loader so we don't touch K8s.
+    m._load_serve_connection_info = (  # type: ignore[assignment]
+        lambda sandbox_id: ServeConnectionInfo(
+            base_url=f"http://{sandbox_id}.invalid:4096",
+            password=None,
+        )
+    )
 
     try:
         yield m

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
@@ -52,11 +52,7 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 
 @pytest.fixture(autouse=True)
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``list_subagents`` and bus creation only kick in under SERVE.
-
-    The methods live on ``_ServeMixin`` (composed into ``SandboxManager``)
-    post-refactor; the transport flag is read at the mixin module.
-    """
+    """Force SERVE mode; lookup happens in the mixin module."""
     from onyx.server.features.build.sandbox import serve_transport
 
     monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
@@ -65,16 +61,13 @@ def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture
 def mgr() -> Generator[KubernetesSandboxManager, None, None]:
-    """Manager with just the serve-transport state initialized — skips
-    ``_initialize`` so no kube config is required. Stubs
-    ``_load_serve_connection_info`` so the mixin's caching layer doesn't
-    need a real Secret read."""
+    """Manager with just serve-transport state initialized; stubs the
+    connection-info loader so the test doesn't touch K8s."""
     from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 
     m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    m._init_serve_state()  # initializes _event_buses, _terminated_sandboxes, etc.
+    m._init_serve_state()
 
-    # Stub the cached connection-info loader so we don't touch K8s.
     m._load_serve_connection_info = (  # type: ignore[assignment]
         lambda sandbox_id: ServeConnectionInfo(
             base_url=f"http://{sandbox_id}.invalid:4096",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
@@ -26,7 +26,7 @@ from uuid import uuid4
 
 import pytest
 
-import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+import onyx.server.features.build.sandbox.base as sandbox_base
 from onyx.server.features.build.configs import AgentTransport
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
@@ -35,8 +35,12 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 
 @pytest.fixture(autouse=True)
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The lock is a no-op outside SERVE mode — force it on for these tests."""
-    monkeypatch.setattr(ksm, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    """The lock is a no-op outside SERVE mode — force it on for these tests.
+
+    ``prompt_slot`` lives on the SandboxManager base class, so we patch the
+    transport flag where the lock body reads it.
+    """
+    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
 
 
 @pytest.fixture
@@ -129,7 +133,7 @@ def test_prompt_slot_yields_true_when_not_in_serve_mode(
     """Outside SERVE mode (i.e., ACP transport), the slot is a no-op —
     it should always yield True without touching the lock dict, because
     each ACP call exec's its own opencode process and can't race."""
-    monkeypatch.setattr(ksm, "AGENT_TRANSPORT", AgentTransport.ACP)
+    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.ACP)
     # Two concurrent acquires on the same session both succeed — no lock.
     with mgr.prompt_slot(_SBX, _SES) as first:
         assert first is True

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
@@ -20,14 +20,13 @@ Bypasses ``_initialize`` (no K8s config needed) — pure lock logic.
 
 from __future__ import annotations
 
-import threading
 from uuid import UUID
 from uuid import uuid4
 
 import pytest
 
-import onyx.server.features.build.sandbox.base as sandbox_base
 from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.sandbox import serve_transport
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
@@ -37,19 +36,19 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     """The lock is a no-op outside SERVE mode — force it on for these tests.
 
-    ``prompt_slot`` lives on the SandboxManager base class, so we patch the
-    transport flag where the lock body reads it.
+    ``prompt_slot`` lives on the ``_ServeMixin`` (composed into
+    ``SandboxManager``) post-refactor; the transport flag is read at the
+    mixin module.
     """
-    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.SERVE)
+    monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.SERVE)
 
 
 @pytest.fixture
 def mgr() -> KubernetesSandboxManager:
-    """KubernetesSandboxManager with just the prompt-lock state populated —
+    """KubernetesSandboxManager with just the serve-transport state populated —
     skips _initialize so no kube config is required."""
     m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
-    m._prompt_locks = {}  # type: ignore[attr-defined]
-    m._prompt_locks_meta = threading.Lock()  # type: ignore[attr-defined]
+    m._init_serve_state()
     return m
 
 
@@ -133,7 +132,7 @@ def test_prompt_slot_yields_true_when_not_in_serve_mode(
     """Outside SERVE mode (i.e., ACP transport), the slot is a no-op —
     it should always yield True without touching the lock dict, because
     each ACP call exec's its own opencode process and can't race."""
-    monkeypatch.setattr(sandbox_base, "AGENT_TRANSPORT", AgentTransport.ACP)
+    monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.ACP)
     # Two concurrent acquires on the same session both succeed — no lock.
     with mgr.prompt_slot(_SBX, _SES) as first:
         assert first is True

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_prompt_slot.py
@@ -34,19 +34,14 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 
 @pytest.fixture(autouse=True)
 def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The lock is a no-op outside SERVE mode — force it on for these tests.
-
-    ``prompt_slot`` lives on the ``_ServeMixin`` (composed into
-    ``SandboxManager``) post-refactor; the transport flag is read at the
-    mixin module.
-    """
+    """Force SERVE — the lock is a no-op under ACP."""
     monkeypatch.setattr(serve_transport, "AGENT_TRANSPORT", AgentTransport.SERVE)
 
 
 @pytest.fixture
 def mgr() -> KubernetesSandboxManager:
-    """KubernetesSandboxManager with just the serve-transport state populated —
-    skips _initialize so no kube config is required."""
+    """Manager with just serve-transport state populated; skips
+    ``_initialize`` so no kube config is required."""
     m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     m._init_serve_state()
     return m

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -27,6 +27,8 @@ services:
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}
+      - AGENT_TRANSPORT=${AGENT_TRANSPORT:-serve}
+      - ENABLE_OPENCODE_DEBUGGING=${ENABLE_OPENCODE_DEBUGGING:-false}
     volumes:
       # api_server drives sandbox container lifecycle (provision / exec /
       # terminate) directly via the Docker Engine API.
@@ -47,6 +49,8 @@ services:
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}
+      - AGENT_TRANSPORT=${AGENT_TRANSPORT:-serve}
+      - ENABLE_OPENCODE_DEBUGGING=${ENABLE_OPENCODE_DEBUGGING:-false}
     volumes:
       - ${SANDBOX_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     networks:

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -1,27 +1,14 @@
-# Onyx Craft Docker-sandbox overlay.
-#
-# Layer this on top of ``docker-compose.yml`` to enable Craft's Docker
-# sandbox backend. ``install.sh --include-craft`` adds this overlay to
-# the compose CLI args automatically; non-Craft deployments never include
-# it and never inherit the host Docker socket mount.
-#
-# Usage::
-#
-#   docker compose \
-#     -f docker-compose.yml \
-#     -f docker-compose.craft.yml \
-#     up -d --wait
+# Onyx Craft Docker-sandbox overlay. Layer on top of docker-compose.yml.
+# install.sh --include-craft wires this in automatically.
 #
 # Trust boundary: api_server and background bind-mount /var/run/docker.sock
-# (root-equivalent on the host). Only run this overlay on hosts you fully
-# control.
+# (root-equivalent on host). Only run on hosts you fully control.
 services:
   api_server:
     environment:
-      # Backend selection (must be ``docker`` for the Docker sandbox path).
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
-      # Public Onyx URL the sandbox reaches over HTTPS via onyx-cli.
-      # Internal compose hostnames don't resolve from the sandbox bridge.
+      # Public Onyx URL — internal compose hostnames don't resolve from
+      # the sandbox bridge.
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
       - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.44}
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
@@ -30,12 +17,9 @@ services:
       - AGENT_TRANSPORT=${AGENT_TRANSPORT:-serve}
       - ENABLE_OPENCODE_DEBUGGING=${ENABLE_OPENCODE_DEBUGGING:-false}
     volumes:
-      # api_server drives sandbox container lifecycle (provision / exec /
-      # terminate) directly via the Docker Engine API.
       - ${SANDBOX_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
     networks:
-      # Join the sandbox bridge so api_server can proxy the Next.js preview
-      # iframe. Sandboxes themselves never join compose's default network.
+      # Bridge join lets api_server proxy the Next.js preview iframe.
       - default
       - onyx_craft_sandbox
 
@@ -58,9 +42,7 @@ services:
       - onyx_craft_sandbox
 
 networks:
-  # Pre-created by install.sh --include-craft (or manually via
-  # ``docker network create onyx_craft_sandbox``) so this overlay can
-  # attach to it without the main compose file having to declare it.
+  # Pre-created by install.sh --include-craft.
   onyx_craft_sandbox:
     name: onyx_craft_sandbox
     external: true

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -960,8 +960,8 @@ if [ -f "$ENV_FILE" ]; then
             # --include-craft requires the craft-tagged backend image (Node.js
             # + opencode CLI are only built into that image), so the tag is
             # forced rather than prompted for.
-            VERSION="craft-latest"
-            print_info "Update selected. Using craft-latest (required by --include-craft)."
+            VERSION="craft-edge"
+            print_info "Update selected. Using craft-edge (required by --include-craft)."
         else
             print_info "Update selected. Which tag would you like to deploy?"
             echo ""
@@ -1008,8 +1008,8 @@ else
     # Ask for version (skipped when --include-craft forces the craft-tagged
     # backend image, which is the only image that ships Node.js + opencode CLI).
     if [ "$INCLUDE_CRAFT" = true ]; then
-        VERSION="craft-latest"
-        print_info "Using craft-latest (required by --include-craft)."
+        VERSION="craft-edge"
+        print_info "Using craft-edge (required by --include-craft)."
     else
         print_info "Which tag would you like to deploy?"
         echo ""
@@ -1102,18 +1102,6 @@ else
         fi
         print_success "Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=docker)"
 
-        # Pre-create the dedicated sandbox bridge. docker-compose references
-        # it as external=true so it must exist before `compose up`.
-        SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
-        if ! ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
-            if ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
-                print_success "Created sandbox bridge network: $SANDBOX_NET"
-            else
-                print_warning "Could not create sandbox network $SANDBOX_NET — create it manually:"
-                echo "    docker network create $SANDBOX_NET"
-            fi
-        fi
-
         # Trust boundary warning. api_server + background mount the host
         # Docker socket so they can drive sandbox containers. Anything that
         # can talk to that socket is effectively root on the host.
@@ -1137,6 +1125,21 @@ else
     echo "  • Domain settings (for production)"
     echo "  • Onyx Craft (set ENABLE_CRAFT=true)"
     echo ""
+fi
+
+# Pre-create the dedicated sandbox bridge whenever --include-craft is set.
+# docker-compose references it as external=true so it must exist before
+# `compose up`, on BOTH first-install and update/restart paths.
+if [ "$INCLUDE_CRAFT" = true ]; then
+    SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
+    if ! ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
+        if ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} docker network create "$SANDBOX_NET" >/dev/null 2>&1; then
+            print_success "Created sandbox bridge network: $SANDBOX_NET"
+        else
+            print_warning "Could not create sandbox network $SANDBOX_NET — create it manually:"
+            echo "    docker network create $SANDBOX_NET"
+        fi
+    fi
 fi
 
 # Function to check if a port is available

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1130,9 +1130,7 @@ else
     echo ""
 fi
 
-# Pre-create the dedicated sandbox bridge whenever --include-craft is set.
-# docker-compose references it as external=true so it must exist before
-# `compose up`, on BOTH first-install and update/restart paths.
+# Pre-create the sandbox bridge — compose overlay references it as external.
 if [ "$INCLUDE_CRAFT" = true ]; then
     SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
     if ! ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -219,11 +219,14 @@ detect_compose_cmd || true
 # in the "docker" group. Group membership doesn't apply to the current shell,
 # so when we add the user to the group mid-script we instead prefix subsequent
 # docker commands with sudo to finish this run. Future runs (after the user
-# logs out and back in) won't need it. DOCKER_SUDO is an array so that it
-# expands to no argument at all (rather than an empty string) when unset.
-DOCKER_SUDO=()
+# logs out and back in) won't need it.
+#
+# Trailing ``env`` anchors the splat with a literal command so bash 3.2's
+# single-pass parser doesn't misclassify the inline ``VAR=val`` prefixes, and
+# so sudo's ``env_reset`` can't strip them (they're positional args to ``env``).
+DOCKER_SUDO=(env)
 refresh_docker_sudo() {
-    DOCKER_SUDO=()
+    DOCKER_SUDO=(env)
     if ! command -v docker &> /dev/null; then
         return
     fi
@@ -234,7 +237,7 @@ refresh_docker_sudo() {
         return
     fi
     if [[ "$OSTYPE" == "linux-gnu"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
-        DOCKER_SUDO=(sudo)
+        DOCKER_SUDO=(sudo env)
     fi
 }
 refresh_docker_sudo
@@ -573,7 +576,7 @@ fi
 # group membership in that case. The downstream daemon check will exit with
 # a clearer message if the daemon really is down.
 refresh_docker_sudo
-if (( ${#DOCKER_SUDO[@]} > 0 )); then
+if [[ "${DOCKER_SUDO[0]}" == "sudo" ]]; then
     if ! id -nG "$USER" | grep -qw docker; then
         if ! getent group docker &> /dev/null; then
             sudo groupadd docker
@@ -1310,7 +1313,7 @@ if [ $UP_EXIT -ne 0 ]; then
     (cd "${INSTALL_ROOT}/deployment" && ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
     echo ""
     print_info "Check the logs of any unhealthy service:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO[*]:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $([[ "${DOCKER_SUDO[0]}" == "sudo" ]] && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
     echo ""
     print_info "If the issue persists, please contact: founders@onyx.app"
     exit 1
@@ -1328,7 +1331,7 @@ else
     echo -e "${YELLOW}${BOLD}   ⚠️  Onyx containers started  ⚠️${NC}"
     echo -e "${YELLOW}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     print_info "Services may still be initializing. Check status with:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && ${DOCKER_SUDO[*]:+sudo }$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $([[ "${DOCKER_SUDO[0]}" == "sudo" ]] && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
 fi
 echo ""
 print_info "Access Onyx at:"

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -242,6 +242,15 @@ refresh_docker_sudo() {
 }
 refresh_docker_sudo
 
+# is_using_sudo: returns 0 iff DOCKER_SUDO currently runs commands under sudo.
+# Wraps the convention so callers don't open-code ``[[ "${DOCKER_SUDO[0]}" ==
+# "sudo" ]]`` everywhere — that pattern is forced by the ``env``-anchor
+# workaround (see comment above DOCKER_SUDO=). A future contributor reading
+# ``is_using_sudo`` doesn't need to know about bash 3.2 parsing quirks.
+is_using_sudo() {
+    [[ "${DOCKER_SUDO[0]}" == "sudo" ]]
+}
+
 # Ensures a required file is present. With --local, verifies the file exists on
 # disk. Otherwise, downloads it from the given URL. Returns 0 on success, 1 on
 # failure (caller should handle the exit).
@@ -576,7 +585,7 @@ fi
 # group membership in that case. The downstream daemon check will exit with
 # a clearer message if the daemon really is down.
 refresh_docker_sudo
-if [[ "${DOCKER_SUDO[0]}" == "sudo" ]]; then
+if is_using_sudo; then
     if ! id -nG "$USER" | grep -qw docker; then
         if ! getent group docker &> /dev/null; then
             sudo groupadd docker
@@ -1311,7 +1320,7 @@ if [ $UP_EXIT -ne 0 ]; then
     (cd "${INSTALL_ROOT}/deployment" && ${DOCKER_SUDO[@]+"${DOCKER_SUDO[@]}"} HOST_PORT="$HOST_PORT" IMAGE_TAG="$CURRENT_IMAGE_TAG" $COMPOSE_CMD "${COMPOSE_FILE_ARGS[@]}" ps)
     echo ""
     print_info "Check the logs of any unhealthy service:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $([[ "${DOCKER_SUDO[0]}" == "sudo" ]] && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $(is_using_sudo && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} logs <service>)"
     echo ""
     print_info "If the issue persists, please contact: founders@onyx.app"
     exit 1
@@ -1329,7 +1338,7 @@ else
     echo -e "${YELLOW}${BOLD}   ⚠️  Onyx containers started  ⚠️${NC}"
     echo -e "${YELLOW}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     print_info "Services may still be initializing. Check status with:"
-    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $([[ "${DOCKER_SUDO[0]}" == "sudo" ]] && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
+    echo "  (cd \"${INSTALL_ROOT}/deployment\" && $(is_using_sudo && echo "sudo ")$COMPOSE_CMD ${COMPOSE_FILE_ARGS[*]} ps)"
 fi
 echo ""
 print_info "Access Onyx at:"

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -242,11 +242,9 @@ refresh_docker_sudo() {
 }
 refresh_docker_sudo
 
-# is_using_sudo: returns 0 iff DOCKER_SUDO currently runs commands under sudo.
-# Wraps the convention so callers don't open-code ``[[ "${DOCKER_SUDO[0]}" ==
-# "sudo" ]]`` everywhere — that pattern is forced by the ``env``-anchor
-# workaround (see comment above DOCKER_SUDO=). A future contributor reading
-# ``is_using_sudo`` doesn't need to know about bash 3.2 parsing quirks.
+# 0 iff DOCKER_SUDO runs commands under sudo. Wrapped so callers don't
+# open-code the [0]-element check (the ``env``-anchor workaround above
+# precludes the cleaner `${#DOCKER_SUDO[@]} > 0` form).
 is_using_sudo() {
     [[ "${DOCKER_SUDO[0]}" == "sudo" ]]
 }

--- a/docs/craft/docker-opencode-serve.md
+++ b/docs/craft/docker-opencode-serve.md
@@ -1,0 +1,149 @@
+# Docker sandbox → opencode-serve
+
+Port `DockerSandboxManager` from the per-message `opencode acp` exec to the long-lived `opencode serve` HTTP transport that the Kubernetes backend already uses. Prerequisite for [`brutalize-acp.md`](./brutalize-acp.md), which deletes the ACP transport entirely.
+
+## Issues to Address
+
+`DockerSandboxManager.send_message` (`backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py:1039-1103`) spawns a `DockerACPExecClient` per user message — same per-process startup cost, same session-lifetime-tied-to-one-turn, same opencode-1.15.7-drops-the-terminator bug enumerated in [`opencode-serve-migration.md`](./opencode-serve-migration.md) §Issues. The Kubernetes backend already migrated; self-hosted docker-compose deployments are stuck on the buggy path.
+
+The blockers, all docker-specific:
+
+1. **No serve client wiring on the Docker manager.** `send_message` takes `opencode_session_id` / `agent_provider` / `agent_model` kwargs but marks them `noqa: ARG002 — serve-only` and ignores them. There is no `_send_message_via_serve`, no `ensure_opencode_session` override, no `prompt_slot` impl, no event bus.
+2. **No password provisioning.** The K8s manager creates a per-pod `V1Secret` holding `OPENCODE_SERVER_PASSWORD` + `OPENCODE_CONFIG_CONTENT` (`kubernetes_sandbox_manager.py:372-429`). Docker has no equivalent — `build_container_create_kwargs` (`docker_sandbox_manager.py:347-350`) is an env allowlist of `{ONYX_PAT, ONYX_SERVER_URL}` enforced by `test_docker_manager_config.py`.
+3. **No `OPENCODE_CONFIG_CONTENT` at provision time.** The K8s path uses pod-wide `build_multi_provider_opencode_config` so per-prompt model overrides can switch providers without restarting opencode (`opencode_config.py:1-7` — opencode-serve does not hot-reload config). The Docker path writes per-session `opencode.json` files via `build_opencode_config` in `setup_session_workspace` (`docker_sandbox_manager.py:668`) and `_regenerate_session_config` (`:1005-1033`, write at `:1018-1028`), which serve cannot pick up since it loaded its provider list at startup.
+4. **The image's entrypoint already runs `opencode serve`**, but only when `AGENT_TRANSPORT=serve` (`backend/onyx/server/features/build/sandbox/kubernetes/docker/entrypoint.sh:36` sets `TRANSPORT="${AGENT_TRANSPORT:-acp}"`, gate at `:46` (`[ "$TRANSPORT" != "serve" ]` → idle), serve branch at `:56-80`). The Docker manager today never sets `AGENT_TRANSPORT`, so the entrypoint falls through to the `tail -f /dev/null` idle branch and `opencode acp` is exec'd per message.
+5. **Network reachability.** K8s reaches opencode-serve via the per-pod `ClusterIP` Service at `service_name.namespace.svc.cluster.local:4096` (`kubernetes_sandbox_manager.py:2183-2194`). Docker would need to reach the sandbox container over the `onyx_craft_sandbox` bridge, by container name on port 4096. No host port mapping (would break isolation); api_server must be on the same bridge or have a route into it.
+
+## Important Notes
+
+### Why this is a separable PR from `brutalize-acp.md`
+
+Two distinct kinds of risk:
+
+- This PR adds a new code path to a previously single-path manager and verifies it works against a real `opencode serve` running in a Docker container. The blast radius is self-hosted users.
+- `brutalize-acp.md` deletes code that has already soaked. The blast radius is "did we miss a branch."
+
+Bundling them turns the deletion PR into a feature PR with a deletion riding along. Reviewer can't tell whether a failing test is "Docker serve has a bug" or "we missed an ACP branch." Keep them separate even if they land back-to-back.
+
+### Reuse vs. duplicate the K8s serve plumbing
+
+The K8s manager owns six pieces of serve plumbing that map cleanly to Docker:
+
+| K8s | Docker equivalent | Reuse strategy |
+|---|---|---|
+| `_get_service_name` → DNS name | container name on bridge | Different impl, same interface — keep on each manager |
+| `_get_opencode_secret_name` + `_provision_opencode_secret` (V1Secret) | per-container env var injected at create | Different impl, same interface — but factor the password generation (`secrets.token_urlsafe(32)`) and the cleartext value into a small helper if it's used in both |
+| `_read_opencode_password` | dict lookup from container env (read back via Docker inspect) | Different impl |
+| `_serve_base_url` | `f"http://{container_name}:{OPENCODE_SERVE_PORT}"` | Trivial |
+| `_wait_for_opencode_serve_ready` | identical logic against the new base_url | **Move to base.py** as a default impl taking `base_url` + `password`; both managers call it |
+| `_get_or_create_event_bus` + `_build_serve_client` + `_event_buses` cache | identical logic | **Move to base.py** as a mixin or default impl; the only manager-specific bit is `_serve_base_url` |
+
+The push daemon (`PUSH_DAEMON_PORT=8731`) is already reached via container name on the Docker bridge from the api_server (see `DockerSandboxManager._docker` and `docker_sandbox_manager.py:32-46` docstring). Serve reachability is the same pattern; no new networking design is needed.
+
+### Provisioning order and the env-allowlist invariant
+
+`test_docker_manager_config.py` locks down `build_container_create_kwargs` to a fixed env allowlist. Adding `OPENCODE_SERVER_PASSWORD`, `OPENCODE_CONFIG_CONTENT`, `OPENCODE_SERVE_PORT`, and `AGENT_TRANSPORT=serve` (transitional — see §Provisioning) means updating both the function and its test in the same change. Keep the invariant ("no S3/MinIO/Postgres/Redis creds, no compose service hostnames") and add only the four serve-related vars.
+
+Password generation happens during `provision()`, *before* `build_container_create_kwargs` is called, and the cleartext is passed through as a parameter. Do not store it on disk on the api_server — the only persistent store is the Docker container's env, which `_read_opencode_password` recovers via `client.containers.get(name).attrs["Config"]["Env"]`.
+
+### One-config-per-container (not one per session)
+
+Because opencode-serve loads providers at startup, the Docker manager must:
+
+- Drop the per-session `opencode.json` writing in `setup_session_workspace` and `_regenerate_session_config` (mirrors K8s, which already deletes this branch when `AGENT_TRANSPORT=serve` — `kubernetes_sandbox_manager.py:1459-1471`).
+- Build a single `build_multi_provider_opencode_config` at provision time and inject it as `OPENCODE_CONFIG_CONTENT`.
+- Accept that per-prompt provider switching now goes through the prompt-body model override that `OpencodeServeClient.send_message` already passes (see `_send_message_via_serve` in K8s).
+
+The per-session `opencode.json` files become dead but harmless. Leave them out rather than writing them — serve never reads them and they pollute snapshots.
+
+### LLM provider list at provision time
+
+K8s pulls `LLMProviderConfig` for every configured provider from the DB at provision (`kubernetes_sandbox_manager.py:1166-1174`). Docker's `provision()` (`docker_sandbox_manager.py:499-530`) takes a single `LLMProviderConfig`. To call `build_multi_provider_opencode_config`, the signature has to accept a list. Either:
+
+- Change `provision()` to take `llm_configs: list[LLMProviderConfig]` and have the session manager pass all configured providers (consistent with K8s), or
+- Keep the single-provider signature and call `build_opencode_config` to build a single-provider `OPENCODE_CONFIG_CONTENT` — same behavior as today's per-session file, but injected at startup instead.
+
+Pick the second for this PR — it minimizes the surface area of the change. The first is a follow-up if/when Docker users actually need cross-provider per-prompt switching.
+
+### Snapshots already capture `.opencode-data`
+
+`SnapshotManager` (`backend/onyx/server/features/build/sandbox/manager/snapshot_manager.py`) tars from the sandbox container. The shared `/workspace` volume that holds `XDG_DATA_HOME=/workspace/.opencode-data` (set indirectly by `entrypoint.sh:35-38` — `WORKSPACE_DATA_HOME` then `export XDG_DATA_HOME="${XDG_DATA_HOME:-$WORKSPACE_DATA_HOME}"`) is already snapshotted by both backends. No snapshot-format change.
+
+The K8s plan flagged "snapshot mid-turn could capture a half-written SQLite WAL" — same mitigation here. The Docker sidecar daemon doesn't exist, so the abort-before-tar logic lives in `DockerSandboxManager.create_snapshot` directly: call `OpencodeServeClient.abort` for any active session on the sandbox before invoking `tar`. Out of scope for this PR if `create_snapshot` is already not called mid-turn; verify and document.
+
+### Networking from api_server to sandbox container
+
+The api_server container needs to be on the `onyx_craft_sandbox` bridge network to resolve `sandbox-{id}` by name on port 4096. This is already true for the push-daemon path (`PUSH_DAEMON_PORT=8731` on the same bridge); no compose change. Verify by reading the compose file and the existing push-daemon code path before claiming "no change" in the PR description.
+
+## Implementation Strategy
+
+### Factor shared serve plumbing to `base.py`
+
+Today `SandboxManager` (`backend/onyx/server/features/build/sandbox/base.py`) already defines `prompt_slot`, `ensure_opencode_session`, `list_subagents`, and `subscribe_to_opencode_session` as abstract / no-op defaults. K8s overrides all four with the serve-only real implementations, each gated on `AGENT_TRANSPORT == AgentTransport.SERVE`. The other serve helpers (`_wait_for_opencode_serve_ready`, `_get_or_create_event_bus`, `_build_serve_client`, `_send_message_via_serve`, `_event_buses`/`_event_buses_lock`/`_terminated_sandboxes` state) live only on the K8s subclass.
+
+Move these to base:
+
+- `_wait_for_opencode_serve_ready` — promote to a concrete base method that calls two new abstracts: `_serve_base_url(sandbox_id) -> str` and `_read_opencode_password(sandbox_id) -> str | None`.
+- `_get_or_create_event_bus` + the `_event_buses` cache + `_event_buses_lock` + `_terminated_sandboxes` set.
+- `_build_serve_client`.
+- `_send_message_via_serve` — the whole body; it's already manager-agnostic once `_serve_base_url` and `_read_opencode_password` are abstract.
+- Replace the four base-class stubs (`prompt_slot`, `ensure_opencode_session`, `list_subagents`, `subscribe_to_opencode_session`) with the real K8s implementations, and delete the K8s overrides.
+
+Subclasses implement only `_serve_base_url` and `_read_opencode_password`.
+
+Doing this *before* writing the Docker serve path means the new path is ~50 lines, not ~500.
+
+### Parameter naming mismatch at the serve-client boundary
+
+`OpencodeServeClient.send_message` takes `model_provider` / `model_id`, but `KubernetesSandboxManager.send_message` (and the manager interface generally) takes `agent_provider` / `agent_model`. The K8s `_send_message_via_serve` does the rename at the call site. When the body moves to base.py, the rename moves with it — Docker's `send_message` keeps the manager-side names. Don't introduce a third naming convention.
+
+### Wire `DockerSandboxManager` to the new base
+
+1. **Password lifecycle.** In `provision()`, generate `secrets.token_urlsafe(32)`, build the `OPENCODE_CONFIG_CONTENT` JSON (single-provider via `build_opencode_config`), pass both into `build_container_create_kwargs`.
+
+2. **Env allowlist.** Extend `build_container_create_kwargs` to take `opencode_password: str` and `opencode_config_json: str`, add them to the env dict alongside `OPENCODE_SERVE_PORT=4096` and `AGENT_TRANSPORT=serve`. Update `test_docker_manager_config.py` to assert the new allowlist (still no S3/MinIO/Postgres/Redis creds, still no compose hostnames).
+
+3. **`_serve_base_url`.** Return `f"http://{_sandbox_container_name(sandbox_id)}:{OPENCODE_SERVE_PORT}"`.
+
+4. **`_read_opencode_password`.** Read the container's env via `self._docker.containers.get(name).attrs["Config"]["Env"]`, parse the `OPENCODE_SERVER_PASSWORD=...` line.
+
+5. **`send_message`.** Replace the entire body (minus packet logging) with a call to the new base-class `_send_message_via_serve` (which lives on base after the refactor) — or, if that turns out to be too invasive to factor, copy the K8s `_send_message_via_serve` body verbatim and minimize from there.
+
+6. **`ensure_opencode_session` override.** Same as K8s — build a serve client, call `client.ensure_session(None, cwd=session_path, title=...)`. Or just inherit the base-class impl after the refactor.
+
+7. **Session setup.** In `setup_session_workspace` (`docker_sandbox_manager.py:682-744`), drop the `printf '%s' '{opencode_json}' > {session_path}/opencode.json` line (around `:668`). Same for `_regenerate_session_config` (`:1005-1033`, write at `:1018-1028`), which is called from `restore_snapshot` (`:920`). AGENTS.md stays.
+
+8. **Cleanup on terminate.** When `terminate()` removes the container, the event bus + the cached opencode password go with it. The base-class `_terminated_sandboxes` machinery handles this generically; verify it fires for Docker by hooking it into `terminate()`.
+
+### Image considerations
+
+No image change required — the existing image already runs `opencode serve` when `AGENT_TRANSPORT=serve`. Once this PR lands and Docker injects `AGENT_TRANSPORT=serve` at container create, the entrypoint takes the serve branch.
+
+The `AGENT_TRANSPORT=serve` env var is transitional. It goes away in [`brutalize-acp.md`](./brutalize-acp.md), at which point the entrypoint becomes unconditional.
+
+### Documentation
+
+Update `docs/craft/opencode-serve-migration.md` §"Migration phases" to note Docker is now serve-by-default. Add a one-paragraph entry to `docs/craft/issues/opencode-serve-deploy-gotchas.md` for the docker-compose specifics: api_server needs to be on `onyx_craft_sandbox` bridge, the password lives in container env, snapshot/restore needs the abort-before-tar guard.
+
+## Tests
+
+**External-dependency-unit** (`backend/tests/external_dependency_unit/craft/`):
+- New file `test_docker_sandbox_serve_streaming.py` — mirror `test_opencode_serve_streaming.py` but against a Docker-provisioned sandbox container. Asserts ordered event sequence from `send_message`. Use a no-tools prompt for determinism.
+- Update `test_kubernetes_sandbox_file_ops.py` if any imports churn from the base.py refactor.
+
+**Unit** (`backend/tests/unit/onyx/server/features/build/sandbox/`):
+- `test_docker_manager_config.py` — extend the env-allowlist assertion to include the four new serve env vars. Assert the OLD allowlist no longer matches (catches regressions in either direction).
+- New `test_docker_provision_opencode_secret.py` — assert password generation is per-provision and that `OPENCODE_CONFIG_CONTENT` is a valid `build_opencode_config` JSON.
+
+**Integration** (`backend/tests/integration/tests/craft/`):
+- `test_messages_api.py` already covers the serve path generically; verify it runs against the Docker backend (`SANDBOX_BACKEND=docker`) in CI. If not, parametrize.
+
+**Existing tests that must not regress:**
+- `test_docker_acp_exec_client.py` — this test exercises the path being deleted by `brutalize-acp.md`, not this PR. It must still pass here (the ACP code is still in the tree).
+
+## Out of scope
+
+- Multi-provider `OPENCODE_CONFIG_CONTENT` for Docker. Single-provider is sufficient and matches today's behavior; follow-up when needed.
+- Deleting the Docker ACP exec client (`DockerACPExecClient`). That happens in [`brutalize-acp.md`](./brutalize-acp.md).
+- Changing the network policy / compose file to expose port 4096 to the host. Sandbox-to-host port mapping is an explicit isolation violation; the bridge-network path is the only path.
+- Cross-provider per-prompt switching on Docker. Comes for free once the multi-provider config is wired (separate PR).

--- a/docs/craft/docker/docker-compose-overview.md
+++ b/docs/craft/docker/docker-compose-overview.md
@@ -1,0 +1,635 @@
+# Running Onyx Craft on Docker Compose
+
+This guide walks through standing up Onyx Craft on the docker-compose
+backend with the `opencode serve` HTTP transport (`AGENT_TRANSPORT=serve`).
+It covers the happy path and every gotcha encountered during initial bring-up
+on macOS, so an agent can follow it without re-discovering each issue.
+
+If you only need the K8s path (cloud / kind), use the Kubernetes manager and
+ignore this whole doc — the Docker backend exists for self-hosted
+docker-compose deployers.
+
+---
+
+## TL;DR — Quick Start
+
+```bash
+# 1. Stage compose files (they're not in any release tag yet).
+WT=/path/to/onyx/checkout            # this repo, checked out on a branch with the Docker backend
+mkdir -p ~/onyx_data/deployment ~/onyx_data/data/nginx
+cp "$WT"/deployment/docker_compose/docker-compose.yml          ~/onyx_data/deployment/
+cp "$WT"/deployment/docker_compose/docker-compose.craft.yml    ~/onyx_data/deployment/
+cp "$WT"/deployment/docker_compose/env.template                ~/onyx_data/deployment/
+cp "$WT"/deployment/data/nginx/app.conf.template               ~/onyx_data/data/nginx/
+cp "$WT"/deployment/data/nginx/run-nginx.sh                    ~/onyx_data/data/nginx/
+
+# 2. Run installer in --local mode with craft.
+bash "$WT"/deployment/docker_compose/install.sh --local --include-craft
+
+# 3. Fix the .env (existing-env install path skips these; see "Required env vars" below).
+cat >> ~/onyx_data/deployment/.env <<'ENV'
+ENABLE_CRAFT=true
+SANDBOX_BACKEND=docker
+SANDBOX_API_SERVER_URL=http://host.docker.internal:3001
+HOST_PORT=3001
+ENV
+
+# 4. If running an unreleased PR (e.g. opencode-serve), build the backend
+#    and sandbox images locally and point .env at them. See "Running an
+#    unreleased PR" below.
+
+# 5. Bring it up.
+(cd ~/onyx_data/deployment && docker compose -f docker-compose.yml -f docker-compose.craft.yml up -d)
+
+# 6. Configure an LLM provider via Admin UI at http://localhost:3001
+#    (Craft will fail with "No default LLM model found" until you do this.)
+```
+
+---
+
+## Prerequisites
+
+- macOS with **Docker Desktop** (or OrbStack) — these provide `host.docker.internal`
+  resolution from inside the `onyx_craft_sandbox` bridge network, which the
+  sandbox container needs to reach api_server.
+- On Linux, replace `http://host.docker.internal:3001` with your machine's
+  reachable address (or use `--add-host` workarounds). Native Linux Docker
+  does *not* resolve `host.docker.internal` by default.
+- ~80 GB free Docker disk. Onyx's full stack pulls ~30 GB; local image
+  builds add another 10–15 GB; build cache balloons to 40+ GB if you let
+  it. See [OpenSearch read-only block](#opensearch-flipped-into-read-only-mode-disk-full) below.
+- An LLM API key (Anthropic / OpenAI / etc).
+
+---
+
+## Required env vars
+
+These must end up in `~/onyx_data/deployment/.env` after install:
+
+| Variable | Required? | Notes |
+|---|---|---|
+| `ENABLE_CRAFT=true` | yes | Install script sets this only on **fresh-install** path. If you ran `--include-craft` against an existing `.env`, append manually. |
+| `SANDBOX_BACKEND=docker` | yes | Same as above — install script gates on fresh-install. |
+| `SANDBOX_API_SERVER_URL=http://host.docker.internal:3001` | yes | Provision raises `ValueError("SANDBOX_API_SERVER_URL must be set")` without it. Must be a URL the sandbox container can reach **from the `onyx_craft_sandbox` bridge** — compose-internal hostnames (`api_server`, `nginx`) won't resolve there. Match the port to `HOST_PORT`. |
+| `HOST_PORT=3001` | only if 3000 conflicts | Default is 3000; nginx binds this on the host. Free up 3000 or change here. |
+| `IMAGE_TAG=craft-edge` | yes | `craft-latest` lags `main` by weeks and predates the Docker sandbox backend (see [image staleness](#image-staleness--published-tags-lag-main) below). Use `craft-edge`. |
+| `ONYX_BACKEND_IMAGE` | only when running unreleased PRs | Lets you override just the backend image without forcing model-server / web-server to the same tag. |
+| `SANDBOX_CONTAINER_IMAGE` | only when running unreleased PRs | Same idea for the sandbox image itself. Default is a pinned tag like `onyxdotapp/sandbox:v0.1.44`. |
+| `AGENT_TRANSPORT=serve` | for serve transport | `docker-compose.craft.yml` defaults this to `serve` (post-#11402); override to `acp` for the rollback path. Reaches the sandbox container via env passthrough. |
+| `ENABLE_OPENCODE_DEBUGGING=true` | optional | Dev-only pod-log viewer button in Craft UI. Default `false`. |
+
+`OPENCODE_SERVER_PASSWORD` / `OPENCODE_CONFIG_CONTENT` / `OPENCODE_SERVE_PORT`
+are **not** set by you — `DockerSandboxManager.provision()` mints the
+password (`secrets.token_urlsafe(32)`) and the config content per sandbox
+and injects them into the container env at create time.
+
+---
+
+## Setup flow in detail
+
+### 1. Stage compose files
+
+The install script normally downloads `docker-compose.yml` /
+`docker-compose.craft.yml` / `env.template` from the latest GitHub
+release. `docker-compose.craft.yml` doesn't exist in any release tag yet
+— craft is `main`-only. Pre-stage from a checkout:
+
+```bash
+WT=/path/to/onyx
+mkdir -p ~/onyx_data/deployment ~/onyx_data/data/nginx
+cp "$WT"/deployment/docker_compose/docker-compose.yml          ~/onyx_data/deployment/
+cp "$WT"/deployment/docker_compose/docker-compose.craft.yml    ~/onyx_data/deployment/
+cp "$WT"/deployment/docker_compose/env.template                ~/onyx_data/deployment/
+cp "$WT"/deployment/data/nginx/app.conf.template               ~/onyx_data/data/nginx/
+cp "$WT"/deployment/data/nginx/run-nginx.sh                    ~/onyx_data/data/nginx/
+```
+
+### 2. Run the installer
+
+```bash
+bash "$WT"/deployment/docker_compose/install.sh --local --include-craft
+```
+
+`--local` skips downloads and uses the pre-staged files. `--include-craft`
+opts into the Docker sandbox backend.
+
+The installer is **interactive** — it reads prompts directly from `/dev/tty`,
+so piping `2\n\n` as stdin does not work. Either run it from a terminal or
+adapt the prompts (Standard mode = `2`, keep existing env = blank).
+
+`--no-prompt` defaults to **Lite mode**, which is mutually exclusive with
+`--include-craft`. Don't combine them.
+
+### 3. Fix the .env
+
+When the installer detects an existing `.env`, it takes the
+"update / restart" branch and skips the Craft-specific env writes. You
+need to append them yourself:
+
+```bash
+cat >> ~/onyx_data/deployment/.env <<'ENV'
+ENABLE_CRAFT=true
+SANDBOX_BACKEND=docker
+SANDBOX_API_SERVER_URL=http://host.docker.internal:3001
+HOST_PORT=3001
+IMAGE_TAG=craft-edge
+ENV
+```
+
+If you also build local images for an unreleased PR, append the override
+vars (see next section).
+
+### 4. Bring up the stack
+
+```bash
+cd ~/onyx_data/deployment
+docker compose -f docker-compose.yml -f docker-compose.craft.yml up -d
+```
+
+The compose file references the `onyx_craft_sandbox` network as
+`external: true`. The installer creates it *only on the fresh-install
+path*. If you're updating an existing install with `--include-craft`,
+create it manually:
+
+```bash
+docker network create onyx_craft_sandbox
+```
+
+### 5. Configure an LLM provider
+
+Open <http://localhost:3001>, log in, go to **Admin Panel → Language
+Models**, and add a provider (Anthropic / OpenAI / OpenRouter). Until you
+do this, every Craft prompt fails with:
+
+```
+ValueError: No default LLM model found
+```
+
+### 6. Try a prompt in Craft
+
+Click **Craft** in the sidebar, send a prompt. Watch the api_server logs:
+
+```bash
+docker logs -f onyx-api_server-1 2>&1 | grep -E "SANDBOX-SERVE|SESSION-LIFECYCLE"
+```
+
+You should see:
+
+- `[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=… directory=/workspace/sessions/…`
+- `[SANDBOX-SERVE] Created PodEventBus for sandbox … dir=/workspace/sessions/…`
+- `[SANDBOX-SERVE] opencode-serve ready for sandbox …`
+- `[SESSION-LIFECYCLE] _send_message_via_serve: build_session=… caller-supplied opencode_session_id=…`
+- `[SANDBOX-SERVE] send_message completed: session=… events=… got_prompt_response=True`
+
+---
+
+## Running an unreleased PR (local image builds)
+
+Published `craft-edge` is built from `main`. If you're testing a PR that
+isn't merged yet, the published images **will not contain your code**.
+Build the affected images locally.
+
+### Backend image
+
+```bash
+cd /path/to/onyx
+docker build --build-arg ENABLE_CRAFT=true \
+    -t onyxdotapp/onyx-backend:craft-pr<N> \
+    -f backend/Dockerfile \
+    backend/
+```
+
+~10–20 min. The `ENABLE_CRAFT=true` build arg adds Node.js + opencode CLI
+to the backend image.
+
+Then in `.env`:
+
+```
+ONYX_BACKEND_IMAGE=onyxdotapp/onyx-backend:craft-pr<N>
+```
+
+**Do not** change `IMAGE_TAG` to point at your PR build — `IMAGE_TAG`
+applies to *every* image referenced in the compose file (model-server,
+web-server, etc.), and Docker will try to pull
+`onyxdotapp/onyx-model-server:craft-pr<N>` and fail. `ONYX_BACKEND_IMAGE`
+is a backend-only override.
+
+### Sandbox image
+
+The sandbox container has its own image (`onyxdotapp/sandbox:vX.Y.Z`)
+pinned in compose. The published version lags `main` substantially —
+e.g. `v0.1.44` ships an old `entrypoint.sh` that does `sleep infinity` and
+has no `AGENT_TRANSPORT=serve` gate, so the serve transport will time
+out waiting for opencode-serve on :4096 even though your api_server side
+is correct.
+
+Build the sandbox image:
+
+```bash
+docker build --network=host \
+    -t onyxdotapp/sandbox:pr<N> \
+    -f backend/onyx/server/features/build/sandbox/kubernetes/docker/Dockerfile \
+    backend/onyx/server/features/build/sandbox/kubernetes/docker/
+```
+
+`--network=host` bypasses Docker Desktop's HTTP proxy if `deb.debian.org`
+returns `Connection refused` during apt-get. Without it, the build can fail
+with "Unable to locate package python3-venv" / "Connection refused" against
+the Debian apt mirror.
+
+Then in `.env`:
+
+```
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:pr<N>
+```
+
+After updating `.env`, force-recreate api_server + background so they
+pick up the new env:
+
+```bash
+cd ~/onyx_data/deployment
+docker compose -f docker-compose.yml -f docker-compose.craft.yml \
+    up -d --no-build --force-recreate api_server background
+```
+
+`--no-build` is important — without it, compose tries to *build* the
+image (using the `build:` directive that's also in the compose file), and
+fails because the relative `../../backend` build context doesn't resolve
+from `~/onyx_data/deployment`.
+
+---
+
+## Issues you will hit (in roughly the order I hit them)
+
+### macOS bash 3.2: install script aborts with `unbound variable`
+
+Symptom (running `curl -fsSL …/install_onyx.sh | bash`):
+
+```
+/bin/bash: DOCKER_SUDO[@]: unbound variable
+```
+
+Cause: macOS still ships bash 3.2.57. Under `set -u`, expanding
+`"${arr[@]}"` from an empty `arr=()` errors out — even though the array
+was explicitly declared.
+
+Fix: ship a `run_docker()` wrapper that branches on
+`${#DOCKER_SUDO[@]} > 0` so the array splat only executes when
+populated. See PR #11424.
+
+### macOS bash 3.2: `HOST_PORT=3000: command not found`
+
+Symptom: after dropping `set -u`, install still fails:
+
+```
+install.sh: line 371: HOST_PORT=3000: command not found
+```
+
+Cause: bash 3.2's parser is single-pass — when a possibly-empty
+expansion sits in command position (`"${DOCKER_SUDO[@]}" VAR=val cmd`),
+the parser classifies `VAR=val` as a positional argument at parse time,
+not as an env-var prefix. When the array later expands to zero words,
+`VAR=val` ends up being interpreted as the command name. bash 4+
+re-evaluates after expansion, so Linux/CI never sees this. **Dropping
+`set -u` does not fix this.**
+
+Fix: same `run_docker()` wrapper — the call site becomes
+`VAR=val run_docker $cmd …`, where the leading token is now a literal
+env-var prefix on a function call (parser is happy), and the array splat
+is inside the function body away from command position.
+
+### Sudo path: env_reset strips inline VAR=val (open P1)
+
+Greptile flagged this on PR #11424 and the user merged before
+addressing it. When `DOCKER_SUDO=(sudo)` (Linux freshly-added-to-docker-
+group path), `run_docker` ends up calling `sudo docker compose`. sudo's
+default `env_reset` strips the inline `HOST_PORT=…` / `IMAGE_TAG=…`
+prefix because those reach sudo via the parent process's *environment*,
+not as positional arguments.
+
+Pre-PR-11424 the call form was
+`"${DOCKER_SUDO[@]}" VAR=val cmd`, which passes `VAR=val` as a sudo
+positional argument — sudo honors that even with `env_reset` active.
+
+Fix (not yet shipped): re-inject the relevant vars via explicit `env`
+inside the sudo branch of `run_docker`:
+
+```bash
+run_docker() {
+    if [ ${#DOCKER_SUDO[@]} -gt 0 ]; then
+        local env_args=()
+        [ -n "${HOST_PORT-}" ] && env_args+=("HOST_PORT=$HOST_PORT")
+        [ -n "${IMAGE_TAG-}" ] && env_args+=("IMAGE_TAG=$IMAGE_TAG")
+        "${DOCKER_SUDO[@]}" env ${env_args[@]+"${env_args[@]}"} "$@"
+    else
+        "$@"
+    fi
+}
+```
+
+### Install script skips network creation on existing-.env path
+
+Symptom:
+
+```
+network onyx_craft_sandbox declared as external, but could not be found
+✗ Failed to start Onyx services
+```
+
+Cause: install.sh's `docker network create onyx_craft_sandbox` runs
+only inside the fresh-install branch (`if [ ! -f $ENV_FILE ]`). When
+the script detects an existing `.env` it takes the update path and skips
+network creation entirely.
+
+Fix (PR #11402): move the network-create block out of the fresh-install
+gate so it runs whenever `--include-craft` is set:
+
+```bash
+if [ "$INCLUDE_CRAFT" = true ]; then
+    SANDBOX_NET="${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}"
+    if ! run_docker docker network inspect "$SANDBOX_NET" >/dev/null 2>&1; then
+        run_docker docker network create "$SANDBOX_NET" >/dev/null
+    fi
+fi
+```
+
+Workaround until fixed: `docker network create onyx_craft_sandbox` manually.
+
+### `docker-compose.craft.yml` doesn't pass AGENT_TRANSPORT through (pre-#11402)
+
+Symptom: setting `AGENT_TRANSPORT=serve` in `.env` has no effect — the
+api_server container's env doesn't have it.
+
+Cause: docker-compose only passes vars listed in a service's
+`environment:` block. Variables in `.env` feed compose *interpolation*
+but don't auto-propagate to containers.
+
+Fix (PR #11402): add explicit passthrough to both `api_server` and
+`background` services in `docker-compose.craft.yml`:
+
+```yaml
+environment:
+  - AGENT_TRANSPORT=${AGENT_TRANSPORT:-serve}
+  - ENABLE_OPENCODE_DEBUGGING=${ENABLE_OPENCODE_DEBUGGING:-false}
+```
+
+### Image staleness: published tags lag main
+
+Symptom A: api_server crashes on boot with
+`ValueError: 'docker' is not a valid SandboxBackend`. Cause: the
+`craft-latest` tag is built off a release (e.g. `v4.0.0`) that predates
+the Docker sandbox backend (PR #11222, May 20). The `SandboxBackend`
+enum in that image only has `LOCAL` and `KUBERNETES`.
+
+Fix: switch to `craft-edge` (rolling tag built from `main`):
+
+```
+IMAGE_TAG=craft-edge
+```
+
+Symptom B: `craft-edge` works for the Docker backend but is missing PR
+#11402's serve transport additions. `ensure_opencode_session()`
+returns `None` because base.py's stub never gets overridden by
+`DockerSandboxManager` (which doesn't implement `_serve_base_url` /
+`_read_opencode_password` in the published image).
+
+Fix: build the backend image locally. See "Running an unreleased PR" above.
+
+Symptom C: `opencode-serve never became ready for sandbox … after 30s
+(last error: ConnectError: [Errno 111] Connection refused)`. Cause:
+the sandbox image (`onyxdotapp/sandbox:v0.1.44`) ships an old
+`entrypoint.sh` that just runs `sleep infinity` — no AGENT_TRANSPORT
+gate, no `opencode serve` invocation. Even though your api_server sets
+all the right env vars in the sandbox container, the entrypoint doesn't
+read them.
+
+Fix: build the sandbox image locally too. See "Running an unreleased PR".
+
+### `IMAGE_TAG` applies to every image
+
+Symptom: pulling fails with `No such image:
+onyxdotapp/onyx-model-server:craft-pr<N>` after setting
+`IMAGE_TAG=craft-pr<N>`.
+
+Cause: `IMAGE_TAG` is referenced by the compose file's `image:` lines
+for *all* services, not just the backend.
+
+Fix: use `ONYX_BACKEND_IMAGE` to override just the backend image.
+
+### `compose up --force-recreate` triggers a build
+
+Symptom: `unable to prepare context: path "/path/to/Desktop/backend"
+not found` when the image-tag points at a local-only tag.
+
+Cause: when `image:` lookup fails to pull from registry, compose falls
+back to the `build:` directive in the compose file. The build context
+(`../../backend`) is relative to the compose file's directory, which
+won't resolve from `~/onyx_data/deployment`.
+
+Fix: pass `--no-build` to `docker compose up`.
+
+### `compose down/up` leaves orphan containers
+
+Symptom: `Conflict. The container name "/onyx-cache-1" is already in
+use by container "…"` even though `down` reported it was removed.
+
+Cause: a previous `up --force-recreate` interleaved with a partial
+build, leaving named containers in an inconsistent state.
+
+Fix:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.craft.yml down
+docker compose -f docker-compose.yml -f docker-compose.craft.yml up -d --no-build
+```
+
+### OpenSearch flipped into read-only mode (disk full)
+
+Symptom: api_server crashes with:
+
+```
+TransportError(429, 'cluster_block_exception',
+    'index [danswer_chunk_…] blocked by:
+     [TOO_MANY_REQUESTS/12/disk usage exceeded flood-stage watermark,
+      index has read-only-allow-delete block];')
+```
+
+Cause: Docker Desktop's virtual disk hit the 95% flood-stage watermark.
+On macOS, the Docker VM has a fixed-size disk; image pulls + builds eat
+into it. OpenSearch sees the VM disk, not the host disk.
+
+Fix:
+
+```bash
+docker builder prune -af              # build cache is often 40+ GB
+docker image prune -af --filter "until=24h"
+```
+
+After freeing enough space, OpenSearch lifts the block automatically
+when disk drops below the low watermark. Restart api_server to retry.
+
+### Port 3000 already in use
+
+Symptom: nginx fails to bind: `bind: address already in use`.
+
+Cause: another process (often a Node dev server) holds port 3000.
+
+Fix:
+
+```bash
+lsof -nP -iTCP:3000 -sTCP:LISTEN     # find PID
+# either kill it, or:
+echo "HOST_PORT=3001" >> ~/onyx_data/deployment/.env
+# then bring up the stack; access at http://localhost:3001
+```
+
+### Sandbox image apt build fails
+
+Symptom:
+
+```
+W: Failed to fetch http://deb.debian.org/debian/dists/bookworm/InRelease
+   Could not connect to deb.debian.org:80 … (111: Connection refused)
+E: Unable to locate package python3-venv
+```
+
+Cause: Docker Desktop sometimes routes buildkit's outbound HTTP through
+a proxy (`http.docker.internal:3128`) that's unreachable or misbehaving.
+
+Fix: build with host networking:
+
+```bash
+docker build --network=host -t … -f Dockerfile .
+```
+
+### "Finding sandbox..." stuck in UI
+
+Symptom: Craft UI shows "Finding sandbox..." indefinitely; no provision
+activity in api_server logs.
+
+Cause: there's a stale `Sandbox` row in the DB pointing at a container
+that's been removed. The UI is waiting on a sandbox the api_server
+thinks exists but can't reach.
+
+Fix:
+
+```bash
+docker exec onyx-relational_db-1 psql -U postgres -c \
+    "DELETE FROM sandbox WHERE id = '<sandbox-uuid>';"
+```
+
+After delete, the next prompt in Craft triggers a fresh provision.
+
+### Stale sandbox container running with old env
+
+Symptom: a sandbox container exists from a previous install but lacks
+the env vars the new code injects (no `AGENT_TRANSPORT`, no
+`OPENCODE_SERVER_PASSWORD`, etc.).
+
+Cause: the container was provisioned by a previous api_server image
+that didn't know about those vars. Restarting api_server doesn't
+rebuild existing containers.
+
+Fix: kill the container + its volume:
+
+```bash
+docker rm -f sandbox-<id>
+docker volume rm onyx-craft-sandbox-<id>
+docker exec onyx-relational_db-1 psql -U postgres -c \
+    "DELETE FROM sandbox WHERE id = '<full-uuid>';"
+```
+
+Next Craft prompt re-provisions with the current code's env injection.
+
+---
+
+## How to verify it's actually working
+
+1. **API server has the serve methods** (post-#11402 code is loaded):
+   ```bash
+   docker exec onyx-api_server-1 grep -c "_serve_base_url\|_read_opencode_password" \
+       /app/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+   # Expected: 2
+   ```
+
+2. **`SandboxBackend.DOCKER` exists** (post-#11222 code is loaded):
+   ```bash
+   docker exec onyx-api_server-1 python -c \
+       "from onyx.server.features.build.configs import SandboxBackend; print(list(SandboxBackend))"
+   # Expected: [..., <SandboxBackend.DOCKER: 'docker'>]
+   ```
+
+3. **Sandbox image's entrypoint gates on AGENT_TRANSPORT** (post-#11402 image):
+   ```bash
+   docker run --rm --entrypoint cat <your-sandbox-image> /workspace/entrypoint.sh \
+       | grep -E "AGENT_TRANSPORT|opencode serve"
+   # Expected: lines referencing both
+   ```
+
+4. **After a prompt fires**, a sandbox container should exist:
+   ```bash
+   docker ps --filter "name=sandbox-" --format "{{.Names}} {{.Status}} {{.Ports}}"
+   # Expected: one sandbox-<id8> Up, with port 4096 visible (internal)
+   ```
+
+5. **Inside that container**, opencode serve should be running:
+   ```bash
+   docker exec sandbox-<id8> ps auxw | grep opencode
+   # Expected: an `opencode serve` process; NOT just `sleep infinity`
+   ```
+
+6. **opencode-serve is reachable** from api_server:
+   ```bash
+   docker exec onyx-api_server-1 curl -fsS \
+       -u "opencode:$(docker inspect sandbox-<id8> --format '{{range .Config.Env}}{{println .}}{{end}}' \
+                       | grep '^OPENCODE_SERVER_PASSWORD=' | cut -d= -f2-)" \
+       http://sandbox-<id8>:4096/doc \
+     | head -c 100
+   # Expected: an OpenAPI / Swagger blob (non-empty)
+   ```
+
+7. **Logs show the full serve-transport sequence** when a prompt is sent:
+   ```bash
+   docker logs -f onyx-api_server-1 2>&1 | grep -E "SANDBOX-SERVE|SESSION-LIFECYCLE"
+   ```
+   You should see `ensure_opencode_session`, `Created PodEventBus`,
+   `opencode-serve ready`, `_send_message_via_serve`, `send_message completed`
+   — in that order, all within a few seconds of the prompt.
+
+---
+
+## Cleanup / teardown
+
+```bash
+# Stop the stack (keeps data):
+cd ~/onyx_data/deployment
+docker compose -f docker-compose.yml -f docker-compose.craft.yml down
+
+# Or use the installer:
+bash /path/to/install.sh --shutdown   # stop containers, keep volumes
+bash /path/to/install.sh --delete-data # stop AND wipe all data
+
+# Kill orphan sandbox containers:
+docker ps --filter "name=sandbox-" -q | xargs -r docker rm -f
+
+# Reclaim Docker disk after testing:
+docker builder prune -af
+docker image prune -af --filter "until=24h"
+```
+
+---
+
+## Related references
+
+- PR #11222 — `feat(craft): docker-compose sandbox backend` — added the
+  Docker manager + craft compose file.
+- PR #11334 — `feat(craft): opencode-serve transport with PodEventBus` —
+  added the serve transport on K8s.
+- PR #11402 — `feat(craft): port DockerSandboxManager to opencode-serve
+  transport` — Docker side of the serve port (this work).
+- PR #11424 — `fix(install): route DOCKER_SUDO via wrapper so bash 3.2
+  parses empty arrays` — install.sh fix for macOS.
+- `docs/craft/opencode-serve-migration.md` — design doc for the serve
+  transport.
+- `docs/craft/docker-opencode-serve.md` — design doc for the Docker
+  serve port.


### PR DESCRIPTION
## Description

Port `DockerSandboxManager` from per-message `opencode acp exec` to the long-lived `opencode serve` HTTP transport that the Kubernetes backend already uses. Self-hosted docker-compose deployments were stuck on the buggy per-turn ACP path (opencode 1.15.7 non-deterministically drops the terminator); this gets them onto the same code path as production.

### Key changes

- **New `sandbox/serve_transport.py` module + `_ServeMixin`.** The K8s manager's serve plumbing — event-bus cache, prompt-slot lock, readiness probe, `_get_or_create_event_bus`, `_build_serve_client`, `_send_message_via_serve`, `subscribe_to_opencode_session`, `ensure_opencode_session`, `list_subagents` — is now shared via a mixin composed into `SandboxManager`. Backends own only `_load_serve_connection_info` (one read, cached forever) plus the abstract methods of the contract.
- **`ServeConnectionInfo` cache.** Per-sandbox URL + password loaded once at first use, invalidated on terminate / re-provision. Hot paths no longer re-hit `docker inspect` / `kube get secret` on every prompt.
- **`send_message` lifted into the base.** The `if AGENT_TRANSPORT == SERVE: ... else: ACP` dispatch was duplicated in both backends. Now concrete on `SandboxManager`; backends implement only `_send_message_via_acp`.
- **Per-session bus cleanup.** `_close_session_buses` (new) is called from each backend's `cleanup_session_workspace`; `_close_all_sandbox_buses` (extracted) is called from each backend's `terminate`. Without these the per-session `PodEventBus` + its reader thread + httpx connection leaked one entry per deleted session until api_server restart.
- **DockerSandboxManager:** `provision()` mints a per-call `secrets.token_urlsafe(32)` HTTP Basic password + single-provider `OPENCODE_CONFIG_CONTENT`; `build_container_create_kwargs` injects them alongside `AGENT_TRANSPORT=serve` and `OPENCODE_SERVE_PORT=4096`. The per-session `opencode.json` write is ACP-only (matches K8s, keeps snapshots clean under serve). Warns at provision if multi-provider configs are passed — Docker is single-provider today, per-prompt overrides would fail at opencode-serve. The plaintext `OPENCODE_CONFIG_CONTENT` regression vs the K8s Secret is documented in the module-level threat-model docstring.
- **Concurrency / lifecycle fixes.** `_init_serve_state` is now lock-protected (race-safe across threads); the `_event_buses_lock` can't end up with two distinct objects across racing first-callers. `_wait_for_opencode_serve_ready` hoists `OpencodeServeClient` out of the poll loop and uses `client.health_check()` so the readiness contract has one implementation, not two. `_send_message_via_serve` `GeneratorExit` and `Exception` branches collapsed into one `_abort_and_log_turn_failure` helper.
- **Layering / import-cycle fix.** `SSEKeepalive` lives in a leaf `sandbox/sse.py`; `serve_transport.py` (concrete-transport helpers) sits beside `base.py` (abstract) so the supertype no longer imports concrete `opencode.*` modules. The back-compat re-export from `base.py` is gone; three callers updated to import from `sandbox.sse`.
- **Other cleanup.** `_RenderedSessionFiles` is now a `NamedTuple` (was a two-field frozen dataclass). `_opencode_json_write_snippet` helper dedupes the two render blocks in Docker's setup/regen paths. `install.sh` got an `is_using_sudo()` helper called from the three open-coded `${DOCKER_SUDO[0]} == "sudo"` checks.

Out of scope (per plan): multi-provider config for Docker, deleting `DockerACPExecClient` (separate PR), exposing port 4096 to host, integration test parametrization for `SANDBOX_BACKEND=docker`.

Planning doc: [`docs/craft/docker-opencode-serve.md`](docs/craft/docker-opencode-serve.md).

## How Has This Been Tested?

- **Unit tests.** `tests/unit/onyx/server/features/build/` — 293 passed (the 6 pre-existing `test_send_message_with_bus.py` failures on `main` remain unrelated). Affected suites: `test_docker_serve_plumbing` (Docker manager wiring), `test_event_bus_per_directory` (per-(sandbox, directory) bus keying), `test_prompt_slot` (cross-session serialization). All three exercise the `_ServeMixin` / `_load_serve_connection_info` surface.
- **`tests/common/craft/stubs.py`** updated for the new abstracts so consuming tests still instantiate.
- **Linters.** `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` — all clean.
- **End-to-end install.** `bash deployment/docker_compose/install.sh --no-prompt --no-wait` — all 5 containers up (nginx, web_server, api_server, code-interpreter, relational_db); `is_using_sudo` correctly returned false (no `sudo` prefix in printed compose commands). `--shutdown` cleanly stopped all 5.
- **No live Docker integration test against `SANDBOX_BACKEND=docker` yet** — adding one is called out as a follow-up.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check