### PR TITLE
feat(craft): action-approval chat UI + proxy/matcher fixes

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -19,6 +19,7 @@ on:
       - "web/src/refresh-components/**"
       - "web/.storybook/**"
       - "web/src/app/craft/components/tool-cards/**"
+      - "web/src/app/craft/components/approvals/**"
       - "web/package.json"
       - "web/bun.lock"
 permissions:

--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -110,6 +110,13 @@ SANDBOX_BACKEND=kubernetes
 
 ENABLE_CRAFT=true
 
+# Optional override: pin the api_server to a specific kubeconfig context so
+# it targets the right cluster regardless of the developer's current
+# `kubectl config current-context` (e.g. a stray EKS context picked up for
+# unrelated work). Leave unset to use whichever context is currently
+# selected. The dev value below assumes the local kind cluster.
+K8S_CONTEXT=kind-onyx-dev
+
 # Optional Sandbox debugging
 # ENABLE_OPENCODE_DEBUGGING=true
 

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -1,6 +1,10 @@
 """Composes recognition + policy resolution into a single verdict for an
 outbound request."""
 
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import EndpointPolicy
@@ -13,38 +17,66 @@ from onyx.external_apps.providers.registry import get_endpoint_catalog
 
 # DENY is the most restrictive verdict, ALWAYS the least; when several catalog
 # actions match one request (e.g. a batched GraphQL body) the strictest wins.
-_SEVERITY: dict[EndpointPolicy, int] = {
+# Higher integer means stricter, so `max(...)` is the right reducer.
+_POLICY_SEVERITY: dict[EndpointPolicy, int] = {
     EndpointPolicy.ALWAYS: 0,
     EndpointPolicy.ASK: 1,
     EndpointPolicy.DENY: 2,
 }
 
 
+@dataclass(frozen=True)
+class ActionMatch:
+    """The canonical "this request matched a catalog action" record.
+
+    Returned by ``match_action`` (with ``payload`` empty) and finalized by
+    ``ExternalAppActionMatcher`` (which decodes the request body and fills
+    ``payload`` via ``dataclasses.replace``). Consumed by ``GateAddon`` to
+    decide approval flow + credential injection.
+
+    ``action_type`` is the per-endpoint catalog id (e.g.
+    ``"slack.messages.write"``), not the owning app's all-caps type — the
+    frontend's label map keys off this. ``external_app_id`` is the gate's
+    seam to the connected app row for credential lookup.
+    """
+
+    action_type: str
+    policy: EndpointPolicy
+    external_app_id: int
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
 def match_action(
     db_session: Session,
     app: ExternalApp,
     request: ProxiedRequest,
-) -> EndpointPolicy | None:
-    """Resolve the policy verdict for ``request`` from ``app``'s stored policies.
+) -> ActionMatch | None:
+    """Resolve the matched catalog action and its policy verdict for ``request``.
 
     Stored rows are the source of truth: only catalog actions with a row for this
     app are gated (the catalog supplies recognition rules; an action with no row
-    is un-gated, not defaulted to ASK). Returns the most restrictive policy of the
-    matched actions, or ``None`` when nothing matches.
+    is un-gated, not defaulted to ASK). Returns the most restrictive matched
+    action, or ``None`` when nothing matches.
+
+    ``payload`` is left empty here — body decoding is the caller's
+    responsibility (it owns the raw content + content-type). The caller
+    finalizes via ``dataclasses.replace(match, payload=decoded)``.
     """
     context = MatchContext(request)
     stored = get_policies(db_session, app.id)
     catalog = get_endpoint_catalog(app.app_type)
-    matched_policies = [
-        stored[endpoint.id]
+    matched = [
+        ActionMatch(
+            action_type=endpoint.id,
+            policy=stored[endpoint.id],
+            external_app_id=app.id,
+        )
         for endpoint in catalog
         if endpoint.id in stored
         and any(rule_matches(rule, context) for rule in endpoint.matches)
     ]
-    if not matched_policies:
+    if not matched:
         return None
-    return _most_restrictive(matched_policies)
-
-
-def _most_restrictive(policies: list[EndpointPolicy]) -> EndpointPolicy:
-    return max(policies, key=_SEVERITY.__getitem__)
+    # Tie-break: most restrictive policy wins. `_POLICY_SEVERITY` is
+    # kept local to this module — callers don't need it.
+    return max(matched, key=lambda m: _POLICY_SEVERITY[m.policy])

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -5,34 +5,25 @@ The gate addon treats both a `None` return and any matcher exception as
 lockdown, not this heuristic.
 """
 
+import dataclasses
 import json
 import re
 from collections.abc import Iterable
-from dataclasses import dataclass
 from typing import Any
 from typing import Protocol
 from urllib.parse import parse_qs
 
 from mitmproxy import http
 
-from onyx.db.enums import EndpointPolicy
 from onyx.db.external_app import get_external_apps
 from onyx.db.models import ExternalApp
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-
-@dataclass(frozen=True)
-class ActionMatch:
-    action_type: str
-    payload: dict[str, Any]
-    policy: EndpointPolicy
-    # The connected app the request resolved to — for the gate's credential seam.
-    external_app_id: int
 
 
 class ActionMatcher(Protocol):
@@ -90,26 +81,22 @@ class ExternalAppActionMatcher:
                 path=(request.path or "").split("?", 1)[0],
                 body=request.raw_content,
             )
-            policy = match_action(db, app, proxied)
-            if policy is None:
+            matched = match_action(db, app, proxied)
+            if matched is None:
                 return None
+            # Hold a reference so the dataclasses.replace below can run
+            # outside the session; ActionMatch is frozen + the loaded
+            # fields (action_type, policy, external_app_id) are all
+            # session-detached primitives.
 
-            # `match_action` returns only the verdict, so the recorded action is
-            # the owning app (its app_type). Read the loaded columns inside the
-            # session so they're safe to use after it closes.
-            action_type = app.app_type.value
-            external_app_id = app.id
-
+        # Engine returns ActionMatch with empty payload — body decoding
+        # is the caller's job because it owns the raw content +
+        # content-type pair. Replace once we've decoded.
         payload = _decode_body(
             request.raw_content or b"",
             (request.headers.get("content-type") or "").lower(),
         )
-        return ActionMatch(
-            action_type=action_type,
-            external_app_id=external_app_id,
-            payload=payload or {},
-            policy=policy,
-        )
+        return dataclasses.replace(matched, payload=payload or {})
 
 
 def _decode_body(body: bytes, content_type: str) -> dict[str, Any] | None:

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -136,11 +136,19 @@ class GateAddon:
         `client_disconnected`. Best-effort.
         """
         conn_id = getattr(flow.client_conn, "id", None)
+        auth_header = flow.request.headers.get("Proxy-Authorization")
+        tag = _parse_proxy_auth_username(auth_header)
+
+        logger.debug(
+            "gate.http_connect conn_id=%s host=%s port=%s proxy_auth=%r parsed_tag=%s",
+            conn_id,
+            flow.request.host,
+            flow.request.port,
+            auth_header,
+            tag,
+        )
         if conn_id is None:
             return
-        tag = _parse_proxy_auth_username(
-            flow.request.headers.get("Proxy-Authorization")
-        )
         if tag:
             self._conn_session_tags[conn_id] = tag
 
@@ -764,13 +772,22 @@ class GateAddon:
         request directly, since there's no CONNECT to carry the header.
         """
         conn_id = getattr(flow.client_conn, "id", None)
-        if conn_id is not None:
-            cached = self._conn_session_tags.get(conn_id)
-            if cached:
-                return cached
-        return _parse_proxy_auth_username(
-            flow.request.headers.get("Proxy-Authorization")
+        cached = self._conn_session_tags.get(conn_id) if conn_id else None
+        direct_auth_header = flow.request.headers.get("Proxy-Authorization")
+        direct = _parse_proxy_auth_username(direct_auth_header)
+        tag = cached or direct
+
+        logger.debug(
+            "gate.session_tag_extract conn_id=%s host=%s cached=%s "
+            "direct=%s direct_proxy_auth=%r resolved=%s",
+            conn_id,
+            flow.request.host,
+            cached,
+            direct,
+            direct_auth_header,
+            tag,
         )
+        return tag
 
 
 # -----------------------------------------------------------------------
@@ -781,8 +798,11 @@ class GateAddon:
 def _parse_proxy_auth_username(header_value: str | None) -> str | None:
     """Extract the basic-auth username from a `Proxy-Authorization` header.
 
-    The proxy-tag plugin encodes the BuildSession id as the username with an
-    empty password: `Basic base64("<session_id>:")`. Never raises.
+    The proxy-tag plugin encodes the BuildSession id as the username and
+    uses a placeholder password (the password is required for Python's
+    `urllib.request.ProxyHandler` to emit the header at all, but the
+    proxy treats it as discardable — see session-proxy-tag.ts). Never
+    raises.
     """
     if not header_value:
         return None

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/opencode-plugins/session-proxy-tag.ts
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/opencode-plugins/session-proxy-tag.ts
@@ -19,9 +19,8 @@ function taggedProxyUrl(
   if (!base) return undefined;
   try {
     const url = new URL(base);
-    // Empty password: the proxy's src-IP anchor already bounds tag
-    // tampering to within the same user.
-    return `${url.protocol}//${encodeURIComponent(sessionId)}@${url.host}`;
+    // The proxy treats the username as the session tag and discards the password
+    return `${url.protocol}//${encodeURIComponent(sessionId)}:x@${url.host}`;
   } catch {
     return undefined;
   }

--- a/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/k8s_client.py
@@ -1,3 +1,5 @@
+import os
+
 from kubernetes import config
 
 from onyx.utils.logger import setup_logger
@@ -13,8 +15,17 @@ def load_kube_config() -> None:
     except config.ConfigException:
         pass
 
+    # Optional override for dev: pin to a specific kubeconfig context
+    # so the api_server targets the right cluster regardless of the
+    # developer's `kubectl config current-context` (e.g. a stray EKS
+    # context selected for unrelated work).
+    context = os.environ.get("K8S_CONTEXT") or None
+
     try:
-        config.load_kube_config()
-        logger.info("loaded kubeconfig from default location")
+        config.load_kube_config(context=context)
+        logger.info(
+            "loaded kubeconfig from default location (context=%s)",
+            context or "<current-context>",
+        )
     except config.ConfigException as e:
         raise RuntimeError(f"Failed to load Kubernetes configuration: {e}") from e

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -21,6 +21,7 @@ from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppPolicy
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.sandbox_proxy.action_matcher import DBSessionFactory
@@ -66,7 +67,11 @@ def test_match_slack_rest_uses_stored_override(
     _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.ALWAYS)
 
     request = ProxiedRequest(method="POST", path="/api/chat.postMessage")
-    assert match_action(db_session, app, request) == EndpointPolicy.ALWAYS
+    assert match_action(db_session, app, request) == ActionMatch(
+        action_type="slack.messages.write",
+        policy=EndpointPolicy.ALWAYS,
+        external_app_id=app.id,
+    )
 
 
 def test_match_slack_rest_unset_returns_none(
@@ -91,7 +96,11 @@ def test_match_google_calendar_method_and_path(
         method="DELETE",
         path="/calendar/v3/calendars/primary/events/evt123",
     )
-    assert match_action(db_session, app, delete_req) == EndpointPolicy.DENY
+    assert match_action(db_session, app, delete_req) == ActionMatch(
+        action_type="gcal.events.delete",
+        policy=EndpointPolicy.DENY,
+        external_app_id=app.id,
+    )
 
     # Same path, read method → a different action with no stored row → None
     # (un-gated), not DENY.
@@ -113,7 +122,11 @@ def test_match_linear_graphql_body(
         {"query": "mutation { issueCreate(input: $i) { issue { id } } }"}
     ).encode()
     request = ProxiedRequest(method="POST", path="/graphql", body=body)
-    assert match_action(db_session, app, request) == EndpointPolicy.DENY
+    assert match_action(db_session, app, request) == ActionMatch(
+        action_type="linear.issues.create",
+        policy=EndpointPolicy.DENY,
+        external_app_id=app.id,
+    )
 
 
 def test_off_catalog_request_returns_none(
@@ -142,7 +155,12 @@ def test_graphql_batched_most_restrictive_wins(
         ]
     ).encode()
     request = ProxiedRequest(method="POST", path="/graphql", body=body)
-    assert match_action(db_session, app, request) == EndpointPolicy.DENY
+    # Strictest (DENY) wins; its action_type is the one carried forward.
+    assert match_action(db_session, app, request) == ActionMatch(
+        action_type="linear.issues.create",
+        policy=EndpointPolicy.DENY,
+        external_app_id=app.id,
+    )
 
 
 # ── ExternalAppActionMatcher: full proxy-request → verdict bridge ───
@@ -187,9 +205,9 @@ def test_external_app_matcher_resolves_app_and_verdict(
     match = matcher.match(_slack_request(), "public")
 
     assert match is not None
-    # `match_action` returns only the verdict, so the recorded action is the
-    # owning app's type, not the specific catalog endpoint.
-    assert match.action_type == ExternalAppType.SLACK.value
+    # The recorded action_type is the per-endpoint catalog id (what the
+    # FE label map keys off), not the owning app's all-caps type.
+    assert match.action_type == "slack.messages.write"
     assert match.policy == EndpointPolicy.DENY
     assert match.payload == {"channel": "C1", "text": "hi"}
     # The app id is threaded through for the gate's credential-injection seam.

--- a/web/.storybook/README.md
+++ b/web/.storybook/README.md
@@ -66,7 +66,7 @@ Use the theme toggle (paint roller icon) in the Storybook toolbar to switch betw
 
 The production Storybook is deployed as a static site on Vercel. The build runs `bun run storybook:build` which outputs to `storybook-static/`, and Vercel serves that directory.
 
-Deploys are triggered on merges to `main` when files in `web/lib/opal/`, `web/src/refresh-components/`, `web/.storybook/`, or any `Apps/`-layer source path (currently `web/src/app/craft/components/tool-cards/`) change.
+Deploys are triggered on merges to `main` when files in `web/lib/opal/`, `web/src/refresh-components/`, `web/.storybook/`, or any `Apps/`-layer source path change.
 
 ## Component Layers
 
@@ -78,13 +78,13 @@ The sidebar organizes components by their layer in the design system:
 | **Components** | `lib/opal/src/components/` | Button, OpenButton, Tag |
 | **Layouts** | `lib/opal/src/layouts/` | Content, ContentAction, IllustrationContent |
 | **refresh-components** | `src/refresh-components/` | Inputs, tables, modals, text, cards, tiles, etc. |
-| **Apps** | `src/app/<app>/...` | Per-app feature components (currently: Craft tool-cards) |
+| **Apps** | `src/app/<app>/...` | Per-app feature components |
 
 ### Apps layer
 
 The `Apps/` layer is a deliberately bounded extension of the catalog: feature components that have **multi-state visual contracts** (statuses, variants, kinds) and are **data-driven** (take props, don't fetch) earn a story. Components that orchestrate state — fetch data, manage SWR, own context — stay out of Storybook; they belong in the running app.
 
 Current coverage:
-- `Apps/Craft/Tool Cards/*` — the per-tool rendering surfaces consumed by `BuildMessageList`. See `src/app/craft/components/tool-cards/`.
+- `Apps/Craft/` - components built specifically for Craft's UI
 
 Title format: `Apps/<App>/<Category>/<Name>`, e.g. `Apps/Craft/Tool Cards/Bash Body`.

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@opal/utils";
 import Logo from "@/refresh-components/Logo";
 import TextChunk from "@/app/craft/components/TextChunk";
@@ -25,6 +25,13 @@ interface BuildMessageListProps {
   autoScrollEnabled?: boolean;
   /** Ref to the end marker div for scroll detection */
   messagesEndRef?: React.RefObject<HTMLDivElement>;
+  /**
+   * Trailing content attached to the last assistant block — either the
+   * in-progress streaming area (if visible) or the last saved assistant
+   * message. Used to render the approval cards inline so they read as
+   * part of the agent's last turn instead of a separate message.
+   */
+  trailingAssistantSlot?: React.ReactNode;
 }
 
 /**
@@ -42,6 +49,7 @@ export default function BuildMessageList({
   isStreaming = false,
   autoScrollEnabled = true,
   messagesEndRef: externalMessagesEndRef,
+  trailingAssistantSlot,
 }: BuildMessageListProps) {
   const internalMessagesEndRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = externalMessagesEndRef ?? internalMessagesEndRef;
@@ -181,7 +189,10 @@ export default function BuildMessageList({
     return { nodes, pinnedTodo };
   };
 
-  const renderAgentMessage = (message: BuildMessage) => {
+  const renderAgentMessage = (
+    message: BuildMessage,
+    trailing?: React.ReactNode
+  ) => {
     const savedStreamItems = message.message_metadata?.streamItems as
       | StreamItem[]
       | undefined;
@@ -214,10 +225,22 @@ export default function BuildMessageList({
           ) : (
             <TextChunk content={message.content} />
           )}
+          {trailing}
         </div>
       </div>
     );
   };
+
+  // Index of the last saved assistant message — used to anchor the
+  // trailingAssistantSlot (e.g. approval cards) when no streaming
+  // response is currently in-flight. When streaming, the slot rides
+  // along with the streaming area instead.
+  const lastAssistantIndex = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i]?.type === "assistant") return i;
+    }
+    return -1;
+  }, [messages]);
 
   const streamRender = hasStreamItems
     ? renderStreamItems(streamItems, {
@@ -229,13 +252,23 @@ export default function BuildMessageList({
   return (
     <div className="flex flex-col items-center px-4 pb-4">
       <div className="w-full max-w-2xl rounded-16 p-4">
-        {messages.map((message) =>
-          message.type === "user" ? (
-            <UserMessage key={message.id} content={message.content} />
-          ) : message.type === "assistant" ? (
-            renderAgentMessage(message)
-          ) : null
-        )}
+        {messages.map((message, idx) => {
+          if (message.type === "user") {
+            return <UserMessage key={message.id} content={message.content} />;
+          }
+          if (message.type === "assistant") {
+            // Anchor the trailing slot (e.g. approval cards) under the
+            // last saved assistant message — but only when there's no
+            // live streaming area, since that case has its own anchor
+            // below.
+            const trailing =
+              !showStreamingArea && idx === lastAssistantIndex
+                ? trailingAssistantSlot
+                : null;
+            return renderAgentMessage(message, trailing);
+          }
+          return null;
+        })}
 
         {showStreamingArea && (
           <div className="flex items-start gap-3 py-4">
@@ -258,6 +291,7 @@ export default function BuildMessageList({
               ) : (
                 streamRender?.nodes
               )}
+              {trailingAssistantSlot}
             </div>
           </div>
         )}

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -30,6 +30,7 @@ import InputBar, { InputBarHandle } from "@/app/craft/components/InputBar";
 import ScheduledRunBanner from "@/app/craft/components/ScheduledRunBanner";
 import BuildWelcome from "@/app/craft/components/BuildWelcome";
 import BuildMessageList from "@/app/craft/components/BuildMessageList";
+import LiveApprovalsRegion from "@/app/craft/components/approvals/LiveApprovalsRegion";
 import SandboxStatusIndicator from "@/app/craft/components/SandboxStatusIndicator";
 import UpgradePlanModal from "@/app/craft/components/UpgradePlanModal";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -403,6 +404,11 @@ export default function BuildChatPanel({
               streamItems={session?.streamItems ?? []}
               isStreaming={isRunning}
               autoScrollEnabled={isAtBottom}
+              trailingAssistantSlot={
+                <LiveApprovalsRegion
+                  sessionId={sessionId ?? existingSessionId ?? null}
+                />
+              }
             />
           )}
         </div>

--- a/web/src/app/craft/components/approvals/ApprovalCard.stories.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ApprovalCard from "@/app/craft/components/approvals/ApprovalCard";
+import type { ApprovalView } from "@/app/craft/types/approvals";
+
+const meta: Meta<typeof ApprovalCard> = {
+  title: "Apps/Craft/Approvals/Approval Card",
+  component: ApprovalCard,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ApprovalCard>;
+
+function approval(overrides: Partial<ApprovalView>): ApprovalView {
+  return {
+    approval_id: "appr-01HX3K9M4Q7W2",
+    session_id: "sess-01HX3K9M4Q7W2",
+    action_type: "slack.send_message",
+    payload: {},
+    created_at: "2026-05-28T15:42:11Z",
+    decision: null,
+    decided_at: null,
+    is_live: true,
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Collapsed — the real-world default. Single header row: shield icon,
+// label, chevron, and the Approve / Reject buttons inline. The user can
+// decide without expanding; the payload is one click away when they
+// want to verify.
+// ──────────────────────────────────────────────────────────────────────────
+
+export const Collapsed: Story = {
+  args: {
+    approval: approval({
+      action_type: "slack.send_message",
+      payload: {
+        channel: "#eng-craft",
+        text: "Heads up — the docfetching worker is restarting in 5min for the new tracing flag rollout.",
+      },
+    }),
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Expanded states. Each story passes defaultOpen so the body is
+// visible without a click. These pin the card-level chrome (header,
+// border, buttons + auto-rendered payload inset); the payload variants
+// themselves are covered in PayloadView's own stories.
+// ──────────────────────────────────────────────────────────────────────────
+
+// Short string values fit inline in the payload's value column.
+export const SlackShortMessage: Story = {
+  args: {
+    defaultOpen: true,
+    approval: approval({
+      action_type: "slack.send_message",
+      payload: {
+        channel: "#eng-craft",
+        text: "Heads up — the docfetching worker is restarting in 5min for the new tracing flag rollout.",
+      },
+    }),
+  },
+};
+
+// Long string values trigger the Show more / Show less toggle on
+// their row.
+export const SlackLongMessageTruncated: Story = {
+  args: {
+    defaultOpen: true,
+    approval: approval({
+      action_type: "slack.send_message",
+      payload: {
+        channel: "#customer-acme-corp",
+        text:
+          "Hi team — wanted to flag that the connector backfill we kicked off last night completed " +
+          "successfully across all 3 spaces. We re-indexed ~412k documents and ran a sample audit " +
+          "against the previous index to confirm chunk parity (99.7% overlap, the gap is from the " +
+          "new sentence-splitter heuristic that handles inline code blocks differently). The next " +
+          "step is to swap traffic over once the embedding model deploy lands tomorrow morning.",
+      },
+    }),
+  },
+};
+
+// Mixed-type payload: an array of objects value falls through to
+// pretty-printed JSON in its row's value column.
+export const SlackWithAttachments: Story = {
+  args: {
+    defaultOpen: true,
+    approval: approval({
+      action_type: "slack.send_message",
+      payload: {
+        channel: "#eng-craft",
+        attachments: [{ fallback: "Build failed", color: "danger" }],
+      },
+    }),
+  },
+};
+
+// New integration where the action_type isn't in actionLabels yet —
+// the header label falls back to the raw action_type string. The
+// payload still renders structurally; no per-integration FE work was
+// needed.
+export const UnknownActionTypeLabel: Story = {
+  args: {
+    defaultOpen: true,
+    approval: approval({
+      action_type: "linear.create_issue",
+      payload: {
+        team_id: "ENG",
+        title: "Investigate connector retry backoff",
+        description: "Customer reported gaps after rate-limit storms.",
+        priority: 2,
+        labels: ["bug", "reliability"],
+      },
+    }),
+  },
+};

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -5,7 +5,7 @@ import { useSWRConfig } from "swr";
 
 import { Button, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgChevronDown, SvgShield } from "@opal/icons";
+import { SvgChevronDown, SvgLoader } from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
@@ -25,22 +25,31 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 interface ApprovalCardProps {
   approval: ApprovalView;
+  defaultOpen?: boolean;
 }
 
 /**
  * ApprovalCard - one row per pending approval. Mirrors CraftToolCard's
- * shape: shield icon + label + chevron in a hover-tinted header row,
- * with the structured payload preview and Approve/Reject buttons in the
- * expandable body. Reads as a sibling to the tool cards above.
+ * shape: spinning loader + label + chevron in a hover-tinted header
+ * row, with the structured payload preview in the expandable body.
+ * Approve and Reject sit in the header so the user can decide without
+ * expanding — the label alone is enough context for most low-stakes
+ * actions, and the payload is one click away when verification is
+ * needed.
  *
- * Defaults to open — the user explicitly needs the payload visible to
- * make a decision, not behind a click.
+ * Visual treatment: status-info (blue) border on a transparent body.
+ * Pairs with the SvgLoader spinner (also status-info) to read as
+ * "agent is paused waiting on you" — distinct from the regular tool
+ * cards (no border) but not alarming.
  */
-export default function ApprovalCard({ approval }: ApprovalCardProps) {
+export default function ApprovalCard({
+  approval,
+  defaultOpen = false,
+}: ApprovalCardProps) {
   const { mutate } = useSWRConfig();
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
 
   // Guards setState after the post-decision SWR revalidation drops
   // this row from /live and the card unmounts mid-await.
@@ -71,6 +80,10 @@ export default function ApprovalCard({ approval }: ApprovalCardProps) {
         setErrorMessage(
           e instanceof Error ? e.message : "Failed to submit decision"
         );
+        // Expand so the error message + the payload the user tried to
+        // approve are both visible. Avoids the "click Approve in a
+        // collapsed card, nothing visible changes" dead end.
+        setIsOpen(true);
       }
     } finally {
       // Card usually unmounts on the next render once /live drops the
@@ -83,46 +96,76 @@ export default function ApprovalCard({ approval }: ApprovalCardProps) {
   }
 
   return (
-    <div className="rounded-08 border border-status-warning-03 bg-status-warning-00">
+    <div className="rounded-08 border border-status-info-03 overflow-hidden">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger asChild>
-          <button className="w-full text-left rounded-md px-3 py-2 transition-colors hover:bg-background-tint-02">
-            <div className="flex items-center gap-2 min-w-0 w-full">
-              <SvgShield className="size-4 shrink-0 stroke-status-warning-05" />
+        {/*
+         * Header row: shield+label is one trigger, chevron at the far
+         * right is a second trigger (so the chevron sits in the
+         * conventional position, after the action buttons). Action
+         * buttons sit between as siblings — they can't live inside a
+         * trigger (nested <button> is invalid HTML) and we don't want
+         * clicking Approve to also toggle the collapse.
+         *
+         * Hover tint lives on the row container via `has-[...]:` so
+         * it spans across the action buttons when the user hovers
+         * either trigger. Hovering an action button doesn't match the
+         * selector (no `data-approval-trigger` on those), so the row
+         * goes clear and the button's own hover state takes over.
+         */}
+        <div
+          className={cn(
+            "flex items-center gap-1 pr-2 transition-colors",
+            "has-[[data-approval-trigger]:hover]:bg-background-tint-02"
+          )}
+        >
+          <CollapsibleTrigger asChild>
+            <button
+              data-approval-trigger
+              className="flex items-center gap-2 min-w-0 flex-1 text-left px-3 py-1.5"
+            >
+              <SvgLoader className="size-4 shrink-0 stroke-status-info-05 animate-spin" />
               <Text font="main-ui-muted" color="text-04" nowrap>
                 {label}
               </Text>
+            </button>
+          </CollapsibleTrigger>
+          <Button
+            prominence="primary"
+            size="sm"
+            disabled={submitting}
+            onClick={() => decide("APPROVED")}
+          >
+            Approve
+          </Button>
+          <Button
+            prominence="secondary"
+            size="sm"
+            disabled={submitting}
+            onClick={() => decide("REJECTED")}
+          >
+            Reject
+          </Button>
+          <CollapsibleTrigger asChild>
+            <button
+              data-approval-trigger
+              aria-label={isOpen ? "Hide details" : "Show details"}
+              className="p-1.5"
+            >
               <SvgChevronDown
                 className={cn(
-                  "size-4 stroke-text-03 transition-transform duration-150 shrink-0 ml-auto",
+                  "size-4 stroke-text-03 transition-transform duration-150",
                   !isOpen && "-rotate-90"
                 )}
               />
-            </div>
-          </button>
-        </CollapsibleTrigger>
+            </button>
+          </CollapsibleTrigger>
+        </div>
         <CollapsibleContent>
-          <div className="px-3 pb-3 pt-0 flex flex-col gap-3">
+          <div className="p-2 flex flex-col gap-3">
             <PayloadView
               actionType={approval.action_type}
               payload={approval.payload}
             />
-            <div className="flex items-center gap-2">
-              <Button
-                prominence="primary"
-                disabled={submitting}
-                onClick={() => decide("APPROVED")}
-              >
-                Approve
-              </Button>
-              <Button
-                prominence="secondary"
-                disabled={submitting}
-                onClick={() => decide("REJECTED")}
-              >
-                Reject
-              </Button>
-            </div>
             {errorMessage && (
               <div className="text-status-error-05">
                 <Text font="secondary-body" color="inherit">

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useSWRConfig } from "swr";
+
+import { Button, Text } from "@opal/components";
+import { cn } from "@opal/utils";
+import { SvgChevronDown, SvgShield } from "@opal/icons";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/refresh-components/Collapsible";
+import {
+  ApprovalConflictError,
+  postApprovalDecision,
+} from "@/app/craft/services/apiServices";
+import {
+  ApprovalSubmitDecision,
+  ApprovalView,
+} from "@/app/craft/types/approvals";
+import { resolveActionLabel } from "@/app/craft/components/approvals/actionLabels";
+import PayloadView from "@/app/craft/components/approvals/PayloadView";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+interface ApprovalCardProps {
+  approval: ApprovalView;
+}
+
+/**
+ * ApprovalCard - one row per pending approval. Mirrors CraftToolCard's
+ * shape: shield icon + label + chevron in a hover-tinted header row,
+ * with the structured payload preview and Approve/Reject buttons in the
+ * expandable body. Reads as a sibling to the tool cards above.
+ *
+ * Defaults to open — the user explicitly needs the payload visible to
+ * make a decision, not behind a click.
+ */
+export default function ApprovalCard({ approval }: ApprovalCardProps) {
+  const { mutate } = useSWRConfig();
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isOpen, setIsOpen] = useState(true);
+
+  // Guards setState after the post-decision SWR revalidation drops
+  // this row from /live and the card unmounts mid-await.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const label = resolveActionLabel(approval.action_type);
+  const swrKey = SWR_KEYS.buildSessionLiveApprovals(approval.session_id);
+
+  async function decide(decision: ApprovalSubmitDecision) {
+    setSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await postApprovalDecision(approval.approval_id, decision);
+      void mutate(swrKey);
+    } catch (e) {
+      // 409 = already resolved (by someone else, or expired by the
+      // proxy). Same UX as a successful submit: refetch and unmount.
+      if (e instanceof ApprovalConflictError) {
+        void mutate(swrKey);
+        return;
+      }
+      if (mountedRef.current) {
+        setErrorMessage(
+          e instanceof Error ? e.message : "Failed to submit decision"
+        );
+      }
+    } finally {
+      // Card usually unmounts on the next render once /live drops the
+      // row, but if revalidation lags or the row stays visible we
+      // still need to unstick the buttons.
+      if (mountedRef.current) {
+        setSubmitting(false);
+      }
+    }
+  }
+
+  return (
+    <div className="rounded-08 border border-status-warning-03 bg-status-warning-00">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <button className="w-full text-left rounded-md px-3 py-2 transition-colors hover:bg-background-tint-02">
+            <div className="flex items-center gap-2 min-w-0 w-full">
+              <SvgShield className="size-4 shrink-0 stroke-status-warning-05" />
+              <Text font="main-ui-muted" color="text-04" nowrap>
+                {label}
+              </Text>
+              <SvgChevronDown
+                className={cn(
+                  "size-4 stroke-text-03 transition-transform duration-150 shrink-0 ml-auto",
+                  !isOpen && "-rotate-90"
+                )}
+              />
+            </div>
+          </button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="px-3 pb-3 pt-0 flex flex-col gap-3">
+            <PayloadView
+              actionType={approval.action_type}
+              payload={approval.payload}
+            />
+            <div className="flex items-center gap-2">
+              <Button
+                prominence="primary"
+                disabled={submitting}
+                onClick={() => decide("APPROVED")}
+              >
+                Approve
+              </Button>
+              <Button
+                prominence="secondary"
+                disabled={submitting}
+                onClick={() => decide("REJECTED")}
+              >
+                Reject
+              </Button>
+            </div>
+            {errorMessage && (
+              <div className="text-status-error-05">
+                <Text font="secondary-body" color="inherit">
+                  {errorMessage}
+                </Text>
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -96,7 +96,7 @@ export default function ApprovalCard({
   }
 
   return (
-    <div className="rounded-08 border border-status-info-03 overflow-hidden">
+    <div className="rounded-08 border border-status-info-03 overflow-hidden bg-background-neutral-00">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         {/*
          * Header row: shield+label is one trigger, chevron at the far

--- a/web/src/app/craft/components/approvals/LiveApprovalsRegion.tsx
+++ b/web/src/app/craft/components/approvals/LiveApprovalsRegion.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import ApprovalCard from "@/app/craft/components/approvals/ApprovalCard";
+import { useLiveApprovals } from "@/app/craft/hooks/useLiveApprovals";
+
+interface LiveApprovalsRegionProps {
+  sessionId: string | null;
+}
+
+// Renders one ApprovalCard per row returned by /live (already filtered
+// to undecided + within wait window). No outer logo/wrapper — caller is
+// responsible for placing this inside the previous assistant message
+// region so cards visually attach to the agent's last turn.
+//
+// SWR cache invalidation is owned by useBuildStreaming's
+// approval_requested handler and by ApprovalCard itself after a
+// decision — this component just reads.
+export default function LiveApprovalsRegion({
+  sessionId,
+}: LiveApprovalsRegionProps) {
+  const { data } = useLiveApprovals(sessionId);
+
+  if (!sessionId || !data || data.items.length === 0) {
+    return null;
+  }
+
+  const sorted = [...data.items].sort(
+    (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)
+  );
+
+  return (
+    <div data-testid="live-approvals-region" className="flex flex-col gap-3">
+      {sorted.map((approval) => (
+        <ApprovalCard key={approval.approval_id} approval={approval} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/craft/components/approvals/PayloadView.stories.tsx
+++ b/web/src/app/craft/components/approvals/PayloadView.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import PayloadView from "@/app/craft/components/approvals/PayloadView";
+
+const meta: Meta<typeof PayloadView> = {
+  title: "Apps/Craft/Approvals/Payload View",
+  component: PayloadView,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PayloadView>;
+
+// ──────────────────────────────────────────────────────────────────────────
+// The structured renderer walks the top-level keys of `payload` and
+// renders each as a labelled row, picking a format per value type.
+// These stories pin the visual contract for each type the renderer
+// understands so adding a new integration on the backend doesn't need
+// any matching FE work.
+// ──────────────────────────────────────────────────────────────────────────
+
+export const ShortStrings: Story = {
+  args: {
+    actionType: "slack.send_message",
+    payload: {
+      channel: "#eng-craft",
+      text: "Heads up — the docfetching worker is restarting in 5min.",
+    },
+  },
+};
+
+// Strings past STRING_TRUNCATE_AT (~300 chars) render with Show more /
+// Show less. The toggle only controls its own row; other rows are
+// unaffected.
+export const LongStringWithShowMore: Story = {
+  args: {
+    actionType: "slack.send_message",
+    payload: {
+      channel: "#customer-acme-corp",
+      text:
+        "Hi team — wanted to flag that the connector backfill we kicked off last night completed " +
+        "successfully across all 3 spaces. We re-indexed ~412k documents and ran a sample audit " +
+        "against the previous index to confirm chunk parity (99.7% overlap, the gap is from the " +
+        "new sentence-splitter heuristic that handles inline code blocks differently). The next " +
+        "step is to swap traffic over once the embedding model deploy lands tomorrow morning.",
+    },
+  },
+};
+
+// Numbers, booleans, and arrays of primitives all flatten to inline
+// values in the value column.
+export const MixedPrimitives: Story = {
+  args: {
+    actionType: "linear.create_issue",
+    payload: {
+      team_id: "ENG",
+      title: "Investigate connector retry backoff",
+      description:
+        "Customer reported gaps after rate-limit storms. Looks related to our retry-budget cap.",
+      priority: 2,
+      labels: ["bug", "reliability", "customer-reported"],
+      assignee_active: true,
+    },
+  },
+};
+
+// Nested objects render as pretty-printed JSON inside the value column.
+// The InsetBlock's max-height + scroll handles deep nesting.
+export const NestedObject: Story = {
+  args: {
+    actionType: "hubspot.update_contact",
+    payload: {
+      contact_id: "vid:1247-9023-1144",
+      properties: {
+        company: "Acme Corp",
+        lifecycle_stage: "customer",
+        plan: "enterprise",
+      },
+    },
+  },
+};
+
+// Array of objects falls through to pretty-printed JSON. Each object's
+// JSON spans 4 lines (open brace + 2 fields + close brace), so even a
+// 2-element array crosses the 8-line truncation threshold and gets a
+// Show more / Show less button.
+export const ArrayOfObjects: Story = {
+  args: {
+    actionType: "linear.bulk_label",
+    payload: {
+      issue_id: "ENG-1247",
+      labels: [
+        { name: "bug", color: "#e11d48" },
+        { name: "reliability", color: "#f59e0b" },
+      ],
+    },
+  },
+};
+
+// Comma-joined primitives past the string-truncation threshold render
+// with Show more, just like long string values do.
+export const LongArrayOfPrimitives: Story = {
+  args: {
+    actionType: "github.add_assignees",
+    payload: {
+      repository: "onyx-dot-app/onyx",
+      issue_number: 12047,
+      assignees: Array.from(
+        { length: 40 },
+        (_, i) => `eng-team-member-${(i + 1).toString().padStart(3, "0")}`
+      ),
+    },
+  },
+};
+
+// Deeply populated nested object — the value's pretty-printed JSON is
+// dozens of lines, so it renders truncated by default with a Show more
+// toggle to reveal the full structure.
+export const LargeNestedObject: Story = {
+  args: {
+    actionType: "hubspot.update_contact",
+    payload: {
+      contact_id: "vid:1247-9023-1144",
+      properties: Object.fromEntries(
+        Array.from({ length: 25 }, (_, i) => [
+          `custom_field_${i + 1}`,
+          `value-${i + 1}`,
+        ])
+      ),
+    },
+  },
+};
+
+// Keys under the column cap auto-size to fit the widest one across
+// rows — no ellipsis needed.
+export const WideKeysAllFit: Story = {
+  args: {
+    actionType: "github.create_pr",
+    payload: {
+      repository: "onyx-dot-app/onyx",
+      branch: "whuang/feature",
+      head_commit_sha: "8a383f69a1",
+      title: "Add structured payload renderer",
+    },
+  },
+};
+
+// A key longer than the 10rem column cap cuts off with a CSS ellipsis.
+// Hover the truncated key to see the full string via the native title
+// attribute (the same affordance used elsewhere in the app for
+// hover-for-full).
+export const TruncatedWideKey: Story = {
+  args: {
+    actionType: "legacy.update_external_user",
+    payload: {
+      external_user_reference_id_for_legacy_migration: "usr_abc123",
+      lifecycle_stage_at_time_of_record_creation: "qualified_lead",
+      plan: "enterprise",
+    },
+  },
+};
+
+// Null / undefined values are filtered out before rendering. An empty
+// payload (or one containing only nulls) falls to a "No payload"
+// notice rather than an empty inset.
+export const EmptyPayload: Story = {
+  args: {
+    actionType: "noop.action",
+    payload: {},
+  },
+};

--- a/web/src/app/craft/components/approvals/PayloadView.tsx
+++ b/web/src/app/craft/components/approvals/PayloadView.tsx
@@ -120,6 +120,11 @@ function StructuredValue({ value }: { value: unknown }) {
     );
   }
   if (Array.isArray(value)) {
+    // Empty arrays go through JSON so they render as `[]` (matching
+    // how empty objects render)
+    if (value.length === 0) {
+      return <NestedJsonValue value={value} />;
+    }
     // Arrays of primitives flatten to a comma-joined line; arrays of
     // objects fall through to JSON so per-object structure stays
     // legible.

--- a/web/src/app/craft/components/approvals/PayloadView.tsx
+++ b/web/src/app/craft/components/approvals/PayloadView.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, Text } from "@opal/components";
+import { cn } from "@opal/utils";
+
+interface PayloadViewProps {
+  actionType: string;
+  payload: Record<string, unknown>;
+}
+
+const SLACK_BODY_TRUNCATE_AT = 300;
+
+interface SlackSendMessagePayload {
+  channel: string;
+  text: string;
+}
+
+function isSlackSendMessagePayload(
+  payload: Record<string, unknown>
+): payload is Record<string, unknown> & SlackSendMessagePayload {
+  return (
+    typeof payload.channel === "string" &&
+    payload.channel.length > 0 &&
+    typeof payload.text === "string"
+  );
+}
+
+/**
+ * Code-block surface for the JSON fallback. Matches the styling of
+ * tool-card bodies (BashBody/SearchBody/etc.) so payload previews read
+ * as a sibling to the tool output above them.
+ */
+function JsonBlock({ value }: { value: unknown }) {
+  return (
+    <div
+      className={cn(
+        "rounded-08 border-[0.5px] overflow-hidden px-3 py-2 max-h-[18rem] overflow-y-auto",
+        "bg-background-neutral-01 border-border-01",
+        "whitespace-pre-wrap wrap-break-word"
+      )}
+    >
+      <Text as="p" font="secondary-mono" color="text-04">
+        {JSON.stringify(value, null, 2)}
+      </Text>
+    </div>
+  );
+}
+
+function MalformedNotice() {
+  return (
+    <Text font="secondary-body" color="text-03">
+      Payload did not match expected shape.
+    </Text>
+  );
+}
+
+function SlackSendMessageView({
+  payload,
+}: {
+  payload: SlackSendMessagePayload;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const body = payload.text;
+  const needsTruncation = body.length > SLACK_BODY_TRUNCATE_AT && !expanded;
+  const shown = needsTruncation
+    ? `${body.slice(0, SLACK_BODY_TRUNCATE_AT)}…`
+    : body;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Text font="secondary-body" color="text-03">
+        Channel
+      </Text>
+      <Text font="main-ui-body" color="text-05">
+        {payload.channel}
+      </Text>
+      <Text font="secondary-body" color="text-03">
+        Message
+      </Text>
+      <Text font="main-ui-body" color="text-05">
+        {shown}
+      </Text>
+      {body.length > SLACK_BODY_TRUNCATE_AT && (
+        <div className="self-start">
+          <Button
+            prominence="tertiary"
+            size="sm"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PayloadView({ actionType, payload }: PayloadViewProps) {
+  switch (actionType) {
+    case "slack.send_message": {
+      if (!isSlackSendMessagePayload(payload)) {
+        return (
+          <div className="flex flex-col gap-2">
+            <MalformedNotice />
+            <JsonBlock value={payload} />
+          </div>
+        );
+      }
+      return <SlackSendMessageView payload={payload} />;
+    }
+    default:
+      return <JsonBlock value={payload} />;
+  }
+}

--- a/web/src/app/craft/components/approvals/PayloadView.tsx
+++ b/web/src/app/craft/components/approvals/PayloadView.tsx
@@ -1,89 +1,62 @@
 "use client";
 
-import { useState } from "react";
+import { Fragment, useState } from "react";
 
 import { Button, Text } from "@opal/components";
 import { cn } from "@opal/utils";
 
 interface PayloadViewProps {
+  // Reserved: lets future specialized views (e.g. diffs, rich
+  // previews) branch on action_type. Today every action renders
+  // through the structured auto-renderer below — no per-action FE
+  // work is needed for new integrations.
   actionType: string;
   payload: Record<string, unknown>;
 }
 
-const SLACK_BODY_TRUNCATE_AT = 300;
+// Past this length a string value renders with Show more / Show less.
+// Sized to fit ~3 lines at the approval card's typical width.
+const STRING_TRUNCATE_AT = 300;
 
-interface SlackSendMessagePayload {
-  channel: string;
-  text: string;
-}
-
-function isSlackSendMessagePayload(
-  payload: Record<string, unknown>
-): payload is Record<string, unknown> & SlackSendMessagePayload {
-  return (
-    typeof payload.channel === "string" &&
-    payload.channel.length > 0 &&
-    typeof payload.text === "string"
-  );
-}
+// Past this many lines a pretty-printed JSON value renders with Show
+// more. Sized to keep small nested objects fully visible while
+// truncating anything that would dominate the inset.
+const JSON_TRUNCATE_AT_LINES = 8;
 
 /**
- * Code-block surface for the JSON fallback. Matches the styling of
- * tool-card bodies (BashBody/SearchBody/etc.) so payload previews read
- * as a sibling to the tool output above them.
+ * Inset card that frames every payload display. Sits inside the
+ * ApprovalCard's outer border on a slightly tinted background so the
+ * payload reads as a distinct content region, not a continuation of
+ * the card chrome.
  */
-function JsonBlock({ value }: { value: unknown }) {
+function InsetBlock({ children }: { children: React.ReactNode }) {
   return (
     <div
       className={cn(
         "rounded-08 border-[0.5px] overflow-hidden px-3 py-2 max-h-[18rem] overflow-y-auto",
-        "bg-background-neutral-01 border-border-01",
-        "whitespace-pre-wrap wrap-break-word"
+        "bg-background-neutral-01 border-border-01"
       )}
     >
-      <Text as="p" font="secondary-mono" color="text-04">
-        {JSON.stringify(value, null, 2)}
-      </Text>
+      {children}
     </div>
   );
 }
 
-function MalformedNotice() {
-  return (
-    <Text font="secondary-body" color="text-03">
-      Payload did not match expected shape.
-    </Text>
-  );
-}
-
-function SlackSendMessageView({
-  payload,
-}: {
-  payload: SlackSendMessagePayload;
-}) {
+function StringValue({ text }: { text: string }) {
   const [expanded, setExpanded] = useState(false);
-  const body = payload.text;
-  const needsTruncation = body.length > SLACK_BODY_TRUNCATE_AT && !expanded;
+  const needsTruncation = text.length > STRING_TRUNCATE_AT && !expanded;
   const shown = needsTruncation
-    ? `${body.slice(0, SLACK_BODY_TRUNCATE_AT)}…`
-    : body;
-
+    ? `${text.slice(0, STRING_TRUNCATE_AT)}…`
+    : text;
   return (
-    <div className="flex flex-col gap-1">
-      <Text font="secondary-body" color="text-03">
-        Channel
-      </Text>
-      <Text font="main-ui-body" color="text-05">
-        {payload.channel}
-      </Text>
-      <Text font="secondary-body" color="text-03">
-        Message
-      </Text>
-      <Text font="main-ui-body" color="text-05">
-        {shown}
-      </Text>
-      {body.length > SLACK_BODY_TRUNCATE_AT && (
-        <div className="self-start">
+    <div className="flex flex-col gap-1 items-start">
+      <div className="whitespace-pre-wrap wrap-break-word">
+        <Text font="main-ui-body" color="text-05">
+          {shown}
+        </Text>
+      </div>
+      {text.length > STRING_TRUNCATE_AT && (
+        <div className="self-end">
           <Button
             prominence="tertiary"
             size="sm"
@@ -97,20 +70,137 @@ function SlackSendMessageView({
   );
 }
 
-export default function PayloadView({ actionType, payload }: PayloadViewProps) {
-  switch (actionType) {
-    case "slack.send_message": {
-      if (!isSlackSendMessagePayload(payload)) {
-        return (
-          <div className="flex flex-col gap-2">
-            <MalformedNotice />
-            <JsonBlock value={payload} />
-          </div>
-        );
-      }
-      return <SlackSendMessageView payload={payload} />;
-    }
-    default:
-      return <JsonBlock value={payload} />;
+function NestedJsonValue({ value }: { value: unknown }) {
+  const [expanded, setExpanded] = useState(false);
+  const full = JSON.stringify(value, null, 2);
+  const lines = full.split("\n");
+  const isLong = lines.length > JSON_TRUNCATE_AT_LINES;
+  const needsTruncation = isLong && !expanded;
+  // Truncate at a line boundary so the preview doesn't end mid-token.
+  // The "…" line gives a visual cue that more is hidden.
+  const shown = needsTruncation
+    ? `${lines.slice(0, JSON_TRUNCATE_AT_LINES).join("\n")}\n…`
+    : full;
+  return (
+    <div className="flex flex-col gap-1 items-start">
+      <div className="whitespace-pre-wrap wrap-break-word">
+        <Text as="p" font="secondary-mono" color="text-04">
+          {shown}
+        </Text>
+      </div>
+      {isLong && (
+        <div className="self-end">
+          <Button
+            prominence="tertiary"
+            size="sm"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Routes a single payload value to the right renderer based on its
+ * runtime type. Kept exhaustive so adding a new branch (e.g. dates) is
+ * a single edit.
+ */
+function StructuredValue({ value }: { value: unknown }) {
+  if (typeof value === "string") {
+    return <StringValue text={value} />;
   }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return (
+      <Text font="main-ui-body" color="text-05">
+        {String(value)}
+      </Text>
+    );
+  }
+  if (Array.isArray(value)) {
+    // Arrays of primitives flatten to a comma-joined line; arrays of
+    // objects fall through to JSON so per-object structure stays
+    // legible.
+    const allPrimitive = value.every(
+      (v) =>
+        typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+    );
+    if (allPrimitive) {
+      // Route through StringValue so a very long comma-joined list
+      // gets the same Show more treatment as a long string.
+      return <StringValue text={value.map((v) => String(v)).join(", ")} />;
+    }
+    return <NestedJsonValue value={value} />;
+  }
+  if (typeof value === "object" && value !== null) {
+    return <NestedJsonValue value={value} />;
+  }
+  // null / undefined are filtered out at the entries level, so we
+  // shouldn't land here. Render nothing if we do.
+  return null;
+}
+
+/**
+ * Walks the top-level keys of a payload and renders each as a labelled
+ * row. Heuristics by value type — short strings inline, long strings
+ * with Show more, primitives as-is, nested objects and arrays of
+ * objects fall back to pretty-printed JSON.
+ *
+ * This is the default renderer for every approval action. Per-action
+ * specialization isn't required for new integrations; the only
+ * per-action work is the human-readable label in `actionLabels.ts`.
+ * Specialized views (diffs, rich previews) can still be added by
+ * branching on `actionType` in `PayloadView` below.
+ */
+function StructuredPayloadView({
+  payload,
+}: {
+  payload: Record<string, unknown>;
+}) {
+  const entries = Object.entries(payload).filter(
+    ([, v]) => v !== null && v !== undefined
+  );
+  if (entries.length === 0) {
+    return (
+      <InsetBlock>
+        <Text font="secondary-body" color="text-03">
+          No payload.
+        </Text>
+      </InsetBlock>
+    );
+  }
+  return (
+    <InsetBlock>
+      {/*
+       * CSS grid so the key column auto-sizes to the widest key across
+       * all rows. A flex layout would only align widths row-by-row,
+       * making each row's key column independent.
+       *
+       * The 10rem cap prevents one unusually long key (e.g.
+       * `external_user_reference_id`) from eating most of the row.
+       * Keys over the cap render with a CSS ellipsis; the native
+       * `title` attribute below surfaces the full key on hover.
+       */}
+      <div className="grid grid-cols-[minmax(5rem,10rem)_1fr] gap-x-3 gap-y-2">
+        {entries.map(([key, value]) => (
+          <Fragment key={key}>
+            <div className="pt-0.5 min-w-0 truncate" title={key}>
+              <Text font="secondary-body" color="text-03">
+                {key}
+              </Text>
+            </div>
+            <div className="min-w-0">
+              <StructuredValue value={value} />
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </InsetBlock>
+  );
+}
+
+export default function PayloadView({ payload }: PayloadViewProps) {
+  return <StructuredPayloadView payload={payload} />;
 }

--- a/web/src/app/craft/components/approvals/actionLabels.ts
+++ b/web/src/app/craft/components/approvals/actionLabels.ts
@@ -1,0 +1,7 @@
+export const actionLabels: Record<string, string> = {
+  "slack.send_message": "Craft is trying to send a message in Slack",
+};
+
+export function resolveActionLabel(actionType: string): string {
+  return actionLabels[actionType] ?? actionType;
+}

--- a/web/src/app/craft/components/approvals/actionLabels.ts
+++ b/web/src/app/craft/components/approvals/actionLabels.ts
@@ -1,5 +1,33 @@
+// Human-readable labels for the per-endpoint action_ids emitted by the
+// backend matcher. Keys mirror the `id` values defined on each catalog
+// endpoint under `backend/onyx/external_apps/providers/<app>.py`.
+//
+// Unrecognized keys fall through to the raw action_id string — preferable
+// to "SLACK" or similar all-caps app-type fallback, since the action_id
+// is at least specific (e.g. "slack.messages.write").
 export const actionLabels: Record<string, string> = {
-  "slack.send_message": "Craft is trying to send a message in Slack",
+  // Slack
+  "slack.messages.write": "Craft wants to send a message in Slack",
+  "slack.messages.read": "Craft wants to read messages in Slack",
+  "slack.channels.read": "Craft wants to list Slack channels",
+  "slack.users.read": "Craft wants to read Slack user info",
+  "slack.search.read": "Craft wants to search Slack",
+
+  // Linear
+  "linear.viewer.read": "Craft wants to read your Linear account",
+  "linear.teams.read": "Craft wants to list Linear teams",
+  "linear.issues.read": "Craft wants to read Linear issues",
+  "linear.projects.read": "Craft wants to read Linear projects",
+  "linear.issues.create": "Craft wants to create a Linear issue",
+  "linear.comments.create": "Craft wants to comment on a Linear issue",
+
+  // Google Calendar
+  "gcal.calendars.read": "Craft wants to list your calendars",
+  "gcal.events.read": "Craft wants to read calendar events",
+  "gcal.freebusy.read": "Craft wants to check your free/busy schedule",
+  "gcal.events.create": "Craft wants to create a calendar event",
+  "gcal.events.update": "Craft wants to update a calendar event",
+  "gcal.events.delete": "Craft wants to delete a calendar event",
 };
 
 export function resolveActionLabel(actionType: string): string {

--- a/web/src/app/craft/hooks/useLiveApprovals.ts
+++ b/web/src/app/craft/hooks/useLiveApprovals.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import useSWR from "swr";
+
+import { fetchLiveApprovals } from "@/app/craft/services/apiServices";
+import { ApprovalListResponse } from "@/app/craft/types/approvals";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+// Thin SWR wrapper. Every component that needs to invalidate this list
+// can do so with globalMutate on the same SWR key — no callback prop.
+export function useLiveApprovals(sessionId: string | null) {
+  return useSWR<ApprovalListResponse>(
+    sessionId ? SWR_KEYS.buildSessionLiveApprovals(sessionId) : null,
+    sessionId ? () => fetchLiveApprovals(sessionId) : null
+  );
+}

--- a/web/src/app/craft/hooks/useLiveApprovals.ts
+++ b/web/src/app/craft/hooks/useLiveApprovals.ts
@@ -6,11 +6,21 @@ import { fetchLiveApprovals } from "@/app/craft/services/apiServices";
 import { ApprovalListResponse } from "@/app/craft/types/approvals";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
+// How often to re-check /live for server-side state changes the client
+// has no streaming signal for: an approval expiring (180s server cap),
+// being decided by another device, or being decided by a collaborator.
+// New approvals already arrive via the `approval_requested` packet path,
+// so this poll is the "catch removals" loop, not the primary signal.
+const LIVE_APPROVALS_REFRESH_MS = 10_000;
+
 // Thin SWR wrapper. Every component that needs to invalidate this list
 // can do so with globalMutate on the same SWR key — no callback prop.
 export function useLiveApprovals(sessionId: string | null) {
   return useSWR<ApprovalListResponse>(
     sessionId ? SWR_KEYS.buildSessionLiveApprovals(sessionId) : null,
-    sessionId ? () => fetchLiveApprovals(sessionId) : null
+    sessionId ? () => fetchLiveApprovals(sessionId) : null,
+    {
+      refreshInterval: LIVE_APPROVALS_REFRESH_MS,
+    }
   );
 }

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -72,14 +72,15 @@ interface BuildOnboardingModalProps {
 function getStepsForMode(
   mode: OnboardingModalMode,
   isAdmin: boolean,
-  hasAnyProvider: boolean,
+  allProvidersConfigured: boolean,
   hasUserInfo: boolean
 ): OnboardingStep[] {
   switch (mode.type) {
     case "initial-onboarding":
+      // Full flow: page1 → llm-setup (if admin + not all configured) → user-info
       const steps: OnboardingStep[] = ["page1"];
 
-      if (isAdmin && !hasAnyProvider) {
+      if (isAdmin && !allProvidersConfigured) {
         steps.push("llm-setup");
       }
 
@@ -106,6 +107,7 @@ export default function BuildOnboardingModal({
   initialValues,
   isAdmin,
   hasUserInfo,
+  allProvidersConfigured,
   hasAnyProvider,
   onComplete,
   onLlmComplete,
@@ -113,8 +115,8 @@ export default function BuildOnboardingModal({
 }: BuildOnboardingModalProps) {
   // Compute steps based on mode
   const steps = useMemo(
-    () => getStepsForMode(mode, isAdmin, hasAnyProvider, hasUserInfo),
-    [mode, isAdmin, hasAnyProvider, hasUserInfo]
+    () => getStepsForMode(mode, isAdmin, allProvidersConfigured, hasUserInfo),
+    [mode, isAdmin, allProvidersConfigured, hasUserInfo]
   );
 
   // Determine initial step based on mode

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -22,24 +22,18 @@ interface MinimalLlmProvider {
   model_configurations: { name: string; is_visible: boolean }[];
 }
 
-export const BUILD_MODE_PROVIDER_PREFIX = "build-mode-";
-
-// Priority: Anthropic > OpenAI > OpenRouter > first available. Only build-mode providers count.
+/**
+ * Get the best default LLM selection based on available providers.
+ * Priority: Anthropic > OpenAI > OpenRouter > first available
+ */
 export function getDefaultLlmSelection(
   llmProviders: MinimalLlmProvider[] | undefined
 ): BuildLlmSelection | null {
   if (!llmProviders || llmProviders.length === 0) return null;
 
-  const buildProviders = llmProviders.filter((p) =>
-    p.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX)
-  );
-  if (buildProviders.length === 0) return null;
-
   // Try each priority provider in order
   for (const { provider, modelName } of LLM_SELECTION_PRIORITY) {
-    const matchingProvider = buildProviders.find(
-      (p) => p.provider === provider
-    );
+    const matchingProvider = llmProviders.find((p) => p.provider === provider);
     if (matchingProvider) {
       return {
         providerName: matchingProvider.name ?? "",
@@ -49,7 +43,8 @@ export function getDefaultLlmSelection(
     }
   }
 
-  const firstProvider = buildProviders[0];
+  // Fallback: first available provider, use its first visible model
+  const firstProvider = llmProviders[0];
   if (firstProvider) {
     const firstModel = firstProvider.model_configurations.find(
       (m) => m.is_visible

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -12,16 +12,11 @@ import {
 import {
   getBuildUserPersona,
   setBuildUserPersona,
-  BUILD_MODE_PROVIDER_PREFIX,
 } from "@/app/craft/onboarding/constants";
 import { updateUserPersonalization } from "@/lib/userSettings";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 
 import type { LLMProviderDescriptor } from "@/lib/languageModels/types";
-
-function isBuildModeProvider(provider: LLMProviderDescriptor): boolean {
-  return !!provider.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX);
-}
 
 // Check if all 3 build mode providers are configured (anthropic, openai, openrouter)
 function checkAllProvidersConfigured(
@@ -30,9 +25,7 @@ function checkAllProvidersConfigured(
   if (!llmProviders || llmProviders.length === 0) {
     return false;
   }
-  const configuredProviders = new Set(
-    llmProviders.filter(isBuildModeProvider).map((p) => p.provider)
-  );
+  const configuredProviders = new Set(llmProviders.map((p) => p.provider));
   return (
     configuredProviders.has(LLMProviderName.ANTHROPIC) &&
     configuredProviders.has(LLMProviderName.OPENAI) &&
@@ -40,11 +33,11 @@ function checkAllProvidersConfigured(
   );
 }
 
-// Check if at least one build-mode provider is configured
+// Check if at least one provider is configured
 function checkHasAnyProvider(
   llmProviders: LLMProviderDescriptor[] | undefined
 ): boolean {
-  return !!llmProviders?.some(isBuildModeProvider);
+  return !!(llmProviders && llmProviders.length > 0);
 }
 
 export function useOnboardingModal(): OnboardingModalController {

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -13,6 +13,11 @@ import {
   DirectoryListing,
   SharingScope,
 } from "@/app/craft/types/streamingTypes";
+import {
+  ApprovalListResponse,
+  ApprovalSubmitDecision,
+  ApprovalView,
+} from "@/app/craft/types/approvals";
 import { BUILD_API_BASE } from "@/app/craft/v1/constants";
 
 // =============================================================================
@@ -654,6 +659,62 @@ export async function fetchPptxPreview(
     );
   }
 
+  return res.json();
+}
+
+// =============================================================================
+// Approvals API
+// =============================================================================
+
+export async function fetchLiveApprovals(
+  sessionId: string
+): Promise<ApprovalListResponse> {
+  const res = await fetch(
+    `${BUILD_API_BASE}/approvals/sessions/${sessionId}/live`
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch live approvals: ${res.status}`);
+  }
+
+  return res.json();
+}
+
+// Lets the approval card distinguish "already resolved" from a generic
+// network error so both can flow through the same SWR revalidation
+// while keeping logs clean.
+export class ApprovalConflictError extends Error {
+  public readonly statusCode: number = 409;
+
+  constructor(detail: string) {
+    super(detail);
+    this.name = "ApprovalConflictError";
+  }
+}
+
+export async function postApprovalDecision(
+  approvalId: string,
+  decision: ApprovalSubmitDecision
+): Promise<ApprovalView> {
+  const res = await fetch(
+    `${BUILD_API_BASE}/approvals/${approvalId}/decision`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ decision }),
+    }
+  );
+
+  if (res.status === 409) {
+    const body = (await res.json().catch(() => ({}))) as { detail?: string };
+    throw new ApprovalConflictError(body.detail ?? "decision conflict");
+  }
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(
+      errorData.detail || `Failed to post approval decision: ${res.status}`
+    );
+  }
   return res.json();
 }
 

--- a/web/src/app/craft/types/approvals.ts
+++ b/web/src/app/craft/types/approvals.ts
@@ -1,0 +1,20 @@
+export type ApprovalDecision = "APPROVED" | "REJECTED" | "EXPIRED";
+
+// Decisions a client may submit. EXPIRED is server-only (the proxy
+// writes it on timeout), so the union excludes it.
+export type ApprovalSubmitDecision = "APPROVED" | "REJECTED";
+
+export interface ApprovalView {
+  approval_id: string;
+  session_id: string;
+  action_type: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+  decision: ApprovalDecision | null;
+  decided_at: string | null;
+  is_live: boolean;
+}
+
+export interface ApprovalListResponse {
+  items: ApprovalView[];
+}


### PR DESCRIPTION
## Description

Phase 3 of the action-approval flow: the chat UI. When the agent's outbound call hits an `ASK` policy, the proxy parks it and writes an `action_approval` row; this PR renders those rows as inline cards in the chat with Approve / Reject.

**FE**
- `ApprovalCard`, `PayloadView`, `LiveApprovalsRegion`, `useLiveApprovals` hook, action-label map
- Storybook coverage under `Apps/Craft/Approvals/*`

**BE (fixes uncovered while wiring up end-to-end)**
- session-proxy-tag plugin emits `:x` placeholder password — `urllib.request.ProxyHandler` silently drops `Proxy-Authorization` without it
- `match_action` returns per-endpoint action_id (e.g. `slack.messages.write`) instead of app type (`SLACK`); FE label map keys off it
- Consolidates `MatchedAction` into the existing `ActionMatch` dataclass
- `gate.http_connect` / `gate.session_tag_extract` DEBUG logs for proxy-auth tracing

**Housekeeping**
- Reverts #11478 (rohoswagger's "skip LLM setup when a build-mode provider is already configured") — conflicted with this branch's onboarding flow.

## How Has This Been Tested?

- End-to-end on local kind cluster: Slack OAuth → prompt → card renders → Approve injects creds → Reject blocks
- `test_action_matching.py` updated for the new `ActionMatch` shape
- Storybook visual review of every payload variant

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live approvals to the Craft chat UI with inline, collapsible cards anchored to the streaming area or the last assistant turn. Also threads per-endpoint action IDs through the proxy and fixes proxy auth tagging for reliable session tagging.

- New Features
  - Inline approval cards: Approve/Reject in header, error messaging, default-collapsed; anchored under the streaming block or last assistant message; oldest-first.
  - Structured `PayloadView`: per-key rows; supports primitives, arrays (empty arrays render as []), and nested objects; long strings/JSON get “Show more”; action labels via `actionLabels` with fallback to `action_type`.
  - Client APIs and hook: `fetchLiveApprovals`, `postApprovalDecision` (throws `ApprovalConflictError` on 409), `useLiveApprovals`; `LiveApprovalsRegion` renders current items; backend matcher now returns `ActionMatch` with per-endpoint `action_type` + `external_app_id`.
  - Proxy plumbing: proxy decodes bodies and threads `ActionMatch` payloads; improved session tag extraction/logs for `Proxy-Authorization`; `session-proxy-tag` now sends `username:password` with a placeholder password.
  - Storybook: stories for `ApprovalCard` and `PayloadView`; deploy workflow watches `web/src/app/craft/components/approvals/**`; README clarifies Apps layer scope.
  - Onboarding: show LLM setup for admins unless Anthropic, OpenAI, and OpenRouter are all configured; default model pick considers all providers.

- Migration
  - Local dev: set `DEV_MODE=true` to enable the seed endpoint.
  - If using the k8s sandbox, set `K8S_CONTEXT` (e.g., `kind-onyx-dev`).
  - For snapshot streaming, set `SANDBOX_S3_BUCKET` and an endpoint (`AWS_ENDPOINT_URL` or `S3_ENDPOINT_URL`) if using custom S3/MinIO.

<sup>Written for commit 316a0d4374d5508fa60aee888d71672a79783e96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11403?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

