### PR TITLE
fix(api-key): clean up synthetic user associations on delete (#11118)

### DIFF
--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -22,6 +22,7 @@ from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import assign_user_to_default_groups__no_commit
+from onyx.db.users import delete_user_from_db
 from onyx.server.api_key.models import APIKeyArgs
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
@@ -234,5 +235,7 @@ def remove_api_key(db_session: Session, api_key_id: int) -> None:
         )
 
     db_session.delete(existing_api_key)
-    db_session.delete(user_associated_with_key)
-    db_session.commit()
+    # The synthetic API-key user has rows in user__user_group (and may have
+    # other FK-bearing associations); route through the canonical user-delete
+    # helper so all of them are cleaned up before the user row is removed.
+    delete_user_from_db(user_associated_with_key, db_session)

--- a/backend/tests/integration/tests/api_key/test_api_key.py
+++ b/backend/tests/integration/tests/api_key/test_api_key.py
@@ -218,3 +218,55 @@ def test_admin_key_passes_current_user(reset: None) -> None:  # noqa: ARG001
     assert resp.status_code == 200, (
         f"Admin key should access /query/valid-tags, got {resp.status_code}: {resp.text}"
     )
+
+
+def test_delete_admin_api_key_with_group_membership(reset: None) -> None:  # noqa: ARG001
+    """Deleting an ADMIN API key must clean up its default-group membership.
+
+    Regression test for #11118: the synthetic SERVICE_ACCOUNT user backing an
+    ADMIN/BASIC API key is auto-assigned to a default group at creation, so
+    deleting the key must remove that user__user_group row before the user is
+    deleted — otherwise the FK constraint fires.
+    """
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    admin_key: DATestAPIKey = APIKeyManager.create(
+        api_key_role=UserRole.ADMIN,
+        user_performing_action=admin_user,
+    )
+
+    admin_ids_before, _ = _get_default_group_user_ids(admin_user)
+    assert str(admin_key.user_id) in admin_ids_before
+
+    APIKeyManager.delete(api_key=admin_key, user_performing_action=admin_user)
+    APIKeyManager.verify(
+        api_key=admin_key,
+        user_performing_action=admin_user,
+        verify_deleted=True,
+    )
+
+    admin_ids_after, _ = _get_default_group_user_ids(admin_user)
+    assert str(admin_key.user_id) not in admin_ids_after
+
+
+def test_delete_basic_api_key_with_group_membership(reset: None) -> None:  # noqa: ARG001
+    """Same regression as the ADMIN case, but for BASIC role / Basic group."""
+    admin_user: DATestUser = UserManager.create(name="admin_user")
+
+    basic_key: DATestAPIKey = APIKeyManager.create(
+        api_key_role=UserRole.BASIC,
+        user_performing_action=admin_user,
+    )
+
+    _, basic_ids_before = _get_default_group_user_ids(admin_user)
+    assert str(basic_key.user_id) in basic_ids_before
+
+    APIKeyManager.delete(api_key=basic_key, user_performing_action=admin_user)
+    APIKeyManager.verify(
+        api_key=basic_key,
+        user_performing_action=admin_user,
+        verify_deleted=True,
+    )
+
+    _, basic_ids_after = _get_default_group_user_ids(admin_user)
+    assert str(basic_key.user_id) not in basic_ids_after


### PR DESCRIPTION
## Description

Fixes #11118.

Deleting an \`ADMIN\` or \`BASIC\` API key was failing with a foreign-key violation:

```
update or delete on table \"user\" violates foreign key constraint
\"user__user_group_user_id_fkey\" on table \"user__user_group\"
```

\`insert_api_key\` auto-assigns the synthetic \`SERVICE_ACCOUNT\` user backing the key to a default group (\`api_key.py:114-119\`), but \`remove_api_key\` deleted the user without first removing that \`user__user_group\` row. The \`User__UserGroup.user_id\` column declares \`ondelete=\"CASCADE\"\` on the model, but the original migration (\`a570b80a5f20_usergroup_tables.py\`) created the FK without it — and SQLAlchemy's declarative \`ondelete\` only takes effect at CREATE TABLE time — so the cascade never actually existed in Postgres.

Routing the delete through \`delete_user_from_db\` (the canonical helper already used by the normal user-deletion path) cleans up \`user__user_group\`, \`document_set__user\`, \`persona__user\`, \`SamlAccount\`, EE external groups, and nulls out \`DocumentSet\`/\`Persona\` ownership before deleting the user. Matches the existing codebase pattern; no schema migration needed.

## How Has This Been Tested?

- Added two integration tests in \`backend/tests/integration/tests/api_key/test_api_key.py\` covering delete of an ADMIN key (Admin default group) and a BASIC key (Basic default group). Each test asserts the group membership exists before delete and is gone after.
- Pre-commit (ruff, ty) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FK errors when deleting ADMIN/BASIC API keys by removing the key’s synthetic `SERVICE_ACCOUNT` user via the canonical `delete_user_from_db` path. This cleans up default-group membership and related associations before deletion, with integration tests added to prevent regressions.

<sup>Written for commit 4f2cd9c2614445b1454497b09459e48280aad436. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11404?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

