### PR TITLE
fix(embeddings): allow selecting a LiteLLM model after configuration

### DIFF
--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -311,10 +311,18 @@ interface ProviderGroupProps {
   /**
    * Camel-cased spec of the active embedding model when it belongs to THIS
    * provider — passed straight through to `ProviderCredentialsModal` so
-   * `LiteLLMProviderModal` can preload its model-spec fields on edit.
+   * `LiteLLMProviderModal` can preload its model-spec fields on edit, and
+   * surfaced as a selectable card for providers whose registry list is empty
+   * (LiteLLM, Azure).
    */
   existingModel?: EmbeddingModel;
-  onSelectModel: (modelName: string) => void;
+  /**
+   * `customModel` is set when the staged model isn't in the static registry —
+   * e.g. a LiteLLM model defined via the providerCreationModal. The page
+   * threads it into Formik's `custom_model` so the submit path can use the
+   * full spec directly.
+   */
+  onSelectModel: (modelName: string, customModel?: EmbeddingModel) => void;
   onDeselectModel: () => void;
 }
 
@@ -328,7 +336,6 @@ function ProviderGroup({
   onSelectModel,
   onDeselectModel,
 }: ProviderGroupProps) {
-  const models = provider.embeddingModels;
   const isConfigured = isCloud ? !!existingCredentials : true;
   const disconnectModal = useCreateModal();
   const connectModal = useCreateModal();
@@ -336,7 +343,31 @@ function ProviderGroup({
   const providerCreationModal = useCreateModal();
   const [pendingConnectModel, setPendingConnectModel] =
     useState<EmbeddingModel | null>(null);
-  const providerGroupContainsCurrentModelName = models.some(
+  /**
+   * Models defined in-page via the "Add Configuration" / edit-credentials
+   * modal for providers whose registry list is empty (LiteLLM today). The
+   * backend doesn't persist per-provider model specs, so these live in
+   * component state until the user applies them via the form.
+   */
+  const [sessionDefinedModels, setSessionDefinedModels] = useState<
+    EmbeddingModel[]
+  >([]);
+
+  /**
+   * Models surfaced for THIS provider: static registry entries, the active
+   * backend model when it belongs here, and anything defined in-session via
+   * the credentials modal. De-duplicated by `modelName`; later entries win,
+   * so a freshly-defined model overrides its prior registry/existing copy.
+   */
+  const displayedModels = useMemo(() => {
+    const byName = new Map<string, EmbeddingModel>();
+    for (const m of provider.embeddingModels) byName.set(m.modelName, m);
+    if (existingModel) byName.set(existingModel.modelName, existingModel);
+    for (const m of sessionDefinedModels) byName.set(m.modelName, m);
+    return Array.from(byName.values());
+  }, [provider.embeddingModels, existingModel, sessionDefinedModels]);
+
+  const providerGroupContainsCurrentModelName = displayedModels.some(
     (m) => m.modelName === currentModelName
   );
 
@@ -347,6 +378,7 @@ function ProviderGroup({
       toast.success(`Disconnected ${provider.displayName}`);
       await mutate(SWR_KEYS.embeddingProviders);
       onDeselectModel();
+      setSessionDefinedModels([]);
       disconnectModal.toggle(false);
     } catch {
       toast.error(`Failed to disconnect ${provider.displayName}`);
@@ -451,8 +483,25 @@ function ProviderGroup({
       <providerCreationModal.Provider>
         <ProviderCredentialsModal
           provider={provider}
-          onSubmit={async () => {
+          existingCredentials={existingCredentials}
+          existingModel={existingModel}
+          onSubmit={async (req) => {
             await mutate(SWR_KEYS.embeddingProviders);
+            if (req?.modelName) {
+              const newModel: EmbeddingModel = {
+                modelName: req.modelName,
+                modelDim: req.modelDim ?? null,
+                normalize: req.normalize,
+                queryPrefix: req.queryPrefix ?? "",
+                passagePrefix: req.passagePrefix ?? "",
+                description: "",
+              };
+              setSessionDefinedModels((prev) => [
+                ...prev.filter((m) => m.modelName !== newModel.modelName),
+                newModel,
+              ]);
+              onSelectModel(newModel.modelName, newModel);
+            }
             providerCreationModal.toggle(false);
           }}
         />
@@ -509,7 +558,7 @@ function ProviderGroup({
           </GeneralLayouts.Section>
         </div>
 
-        {models.length === 0 ? (
+        {displayedModels.length === 0 ? (
           <SelectCard
             state="filled"
             rounding="md"
@@ -535,7 +584,7 @@ function ProviderGroup({
             />
           </SelectCard>
         ) : (
-          models.map((model) => {
+          displayedModels.map((model) => {
             const state = getModelState(model);
             const isPrioritized =
               state === "selected" ||
@@ -666,13 +715,23 @@ function EmbeddingModelCard({
 interface IndexSettingsFormValues {
   model_name: string;
   /**
-   * Populated when the staged model came from the "Add Custom Model" modal
-   * — i.e. it's not in `CLOUD_BASED_PROVIDERS` / `SELF_HOSTED_PROVIDERS`.
-   * The submit path uses this directly instead of looking the name up in
-   * the static registry. Cleared whenever the user selects a registered
-   * model.
+   * Populated when the staged model isn't in `CLOUD_BASED_PROVIDERS` /
+   * `SELF_HOSTED_PROVIDERS` — e.g. from the "Add Custom Model" modal or a
+   * LiteLLM model defined via the provider credentials modal. The submit
+   * path uses this directly instead of looking the name up in the static
+   * registry. Cleared whenever the user selects a registered model.
    */
   custom_model: EmbeddingModel | null;
+  /**
+   * Provider type for a staged non-registry `custom_model` that DOES belong
+   * to a cloud provider (e.g. LiteLLM, whose registry list is empty so its
+   * models live outside the registry). Submit path passes this to
+   * `resolveProviderName` so the backend receives `provider_type=litellm`
+   * instead of falling through to `CUSTOM` (which would route to the local
+   * model server). Null for registry models and for true `CUSTOM`-provider
+   * self-hosted models.
+   */
+  staged_provider_type: EmbeddingProviderName | null;
   enable_contextual_rag: boolean;
   contextual_rag_model_configuration_id: number | null;
 }
@@ -840,6 +899,7 @@ export default function IndexSettingsPage() {
     () => ({
       model_name: currentEmbeddingModel?.model_name ?? "",
       custom_model: null,
+      staged_provider_type: null,
       enable_contextual_rag: searchSettings?.enable_contextual_rag ?? false,
       contextual_rag_model_configuration_id:
         searchSettings?.contextual_rag_model_configuration_id ?? null,
@@ -937,7 +997,10 @@ export default function IndexSettingsPage() {
                 toast.error("Could not find the selected model");
                 return;
               }
-              const providerName = resolveProviderName(values.model_name, null);
+              const providerName = resolveProviderName(
+                values.model_name,
+                values.staged_provider_type
+              );
 
               const response = await setNewSearchSettings({
                 model: stagedModel,
@@ -986,6 +1049,7 @@ export default function IndexSettingsPage() {
                             customModel.modelName
                           );
                           void setFieldValue("custom_model", customModel);
+                          void setFieldValue("staged_provider_type", null);
                         }
                         customModelModal.toggle(false);
                       }}
@@ -1170,14 +1234,23 @@ export default function IndexSettingsPage() {
                                                     undefined)
                                                   : undefined
                                               }
-                                              onSelectModel={(name) => {
+                                              onSelectModel={(
+                                                name,
+                                                customModel
+                                              ) => {
                                                 void setFieldValue(
                                                   "model_name",
                                                   name
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
-                                                  null
+                                                  customModel ?? null
+                                                );
+                                                void setFieldValue(
+                                                  "staged_provider_type",
+                                                  customModel
+                                                    ? provider.providerName
+                                                    : null
                                                 );
                                               }}
                                               onDeselectModel={() => {
@@ -1187,6 +1260,10 @@ export default function IndexSettingsPage() {
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
+                                                  null
+                                                );
+                                                void setFieldValue(
+                                                  "staged_provider_type",
                                                   null
                                                 );
                                               }}
@@ -1232,6 +1309,10 @@ export default function IndexSettingsPage() {
                                                   "custom_model",
                                                   null
                                                 );
+                                                void setFieldValue(
+                                                  "staged_provider_type",
+                                                  null
+                                                );
                                               }}
                                               onDeselectModel={() => {
                                                 void setFieldValue(
@@ -1240,6 +1321,10 @@ export default function IndexSettingsPage() {
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
+                                                  null
+                                                );
+                                                void setFieldValue(
+                                                  "staged_provider_type",
                                                   null
                                                 );
                                               }}

--- a/web/tests/e2e/admin/index-settings/index_settings.spec.ts
+++ b/web/tests/e2e/admin/index-settings/index_settings.spec.ts
@@ -239,6 +239,118 @@ test.describe("Index Settings Page @exclusive", () => {
       ).toBeVisible({ timeout: 10000 });
     }
   });
+
+  // Regression test for issue #11298 — after defining a LiteLLM embedding
+  // model via "Add Configuration", the model must render as a selectable card
+  // and the submit path must send `provider_type=litellm` (not the CUSTOM
+  // fallback of `null`, which routes to the local model server).
+  test("adding a LiteLLM configuration stages a selectable model and submits provider_type=litellm", async ({
+    page,
+  }) => {
+    const litellmModelName = "my-litellm-model";
+
+    // Toggle the GET response so the provider list shows LiteLLM as configured
+    // after the PUT lands. This drives `isConfigured` in the ProviderGroup.
+    let providerSaved = false;
+
+    await page.route(TEST_EMBEDDING_API, async (route) => {
+      await route.fulfill({ status: 200, body: JSON.stringify({}) });
+    });
+    await page.route(EMBEDDING_PROVIDER_API, async (route) => {
+      const method = route.request().method();
+      if (method === "PUT") {
+        providerSaved = true;
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({ provider_type: "litellm" }),
+        });
+      } else if (method === "GET") {
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify(
+            providerSaved
+              ? [
+                  {
+                    provider_type: "litellm",
+                    api_key: "***",
+                    api_url: "https://litellm.example.com",
+                    api_version: null,
+                    deployment_name: null,
+                  },
+                ]
+              : []
+          ),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    // Capture the request body sent to /set-new-search-settings so we can
+    // assert provider_type is "litellm".
+    const setNewSettingsBody = new Promise<Record<string, unknown>>(
+      (resolve) => {
+        void page.route(SET_NEW_SETTINGS_API, async (route) => {
+          resolve(
+            JSON.parse(route.request().postData() ?? "{}") as Record<
+              string,
+              unknown
+            >
+          );
+          await route.fulfill({ status: 200, body: JSON.stringify({}) });
+        });
+      }
+    );
+
+    await navigateToIndexSettings(page);
+    await expandModelPicker(page);
+    await switchToCloudTab(page);
+
+    // LiteLLM's registry list is empty, so it shows "Add Configuration" rather
+    // than per-model "Connect" buttons.
+    const addConfigButton = page
+      .getByRole("button", { name: /add configuration/i })
+      .first();
+    await expect(addConfigButton).toBeVisible({ timeout: 10000 });
+    await addConfigButton.click();
+
+    const modal = page.getByRole("dialog", {
+      name: /set up litellm|manage litellm/i,
+    });
+    await expect(modal).toBeVisible({ timeout: 10000 });
+
+    await modal.getByLabel(/api base url/i).fill("https://litellm.example.com");
+    await modal.getByLabel(/api key/i).fill("sk-litellm-placeholder");
+    await modal.getByLabel(/model name/i).fill(litellmModelName);
+    await modal.getByLabel(/model dimension/i).fill("1536");
+
+    const submitButton = modal.getByRole("button", {
+      name: /^(connect|update)$/i,
+    });
+    await expect(submitButton).toBeEnabled({ timeout: 5000 });
+    await submitButton.click();
+    await expect(modal).not.toBeVisible({ timeout: 10000 });
+
+    // The freshly-defined model should render as a card and be staged as
+    // "Selected" — proving the user can actually pick it (the original bug
+    // was that only "Disconnect LiteLLM" was reachable).
+    await expect(page.getByText(litellmModelName, { exact: false })).toBeVisible(
+      { timeout: 10000 }
+    );
+    await expect(
+      page.getByRole("button", { name: /^selected$/i }).first()
+    ).toBeVisible({ timeout: 5000 });
+
+    // Apply the change and verify provider_type propagates as "litellm".
+    const applyButton = page.getByRole("button", { name: "Apply & Re-index" });
+    await expect(applyButton).toBeEnabled({ timeout: 5000 });
+    await applyButton.click();
+
+    const body = await setNewSettingsBody;
+    expect(body.provider_type).toBe("litellm");
+    expect(body.model_name).toBe(litellmModelName);
+    expect(body.model_dim).toBe(1536);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- After saving LiteLLM credentials, the page only rendered the "Disconnect LiteLLM" button — no selectable model card appeared, so the user could never apply the model they just configured.
- Even if a card had been shown, the submit path's `resolveProviderName` fell through to `CUSTOM` for any non-registry model, so the backend would have received `provider_type=null` and routed indexing to the local model server instead of LiteLLM.
- `ProviderGroup` now merges static-registry models with the active backend model and any session-defined models into a single `displayedModels` list. A freshly-configured LiteLLM model appears as a "Selected" card immediately.
- New form field `staged_provider_type` carries the cloud provider hint for non-registry models, so `resolveProviderName` returns `LITELLM` at submit time.

Closes #11298

## Test plan
- [ ] `npx playwright test web/tests/e2e/admin/index-settings/index_settings.spec.ts` — covers the LiteLLM flow end-to-end via the new "adding a LiteLLM configuration stages a selectable model and submits provider_type=litellm" test, asserting the staged card appears and the `/set-new-search-settings` body contains `provider_type=litellm`.
- [ ] Manual: go to **Admin → Index Settings**, expand **View All Models**, switch to the **Cloud-based** tab, click **Add Configuration** under LiteLLM, fill in API URL / key / model name / dimension, submit. The model card should appear as **Selected**. Click **Apply & Re-index** and confirm re-indexing kicks off with the LiteLLM provider.
- [ ] Regression: verify OpenAI / Cohere / Nomic / custom-self-hosted flows still stage models correctly and submit with the right `provider_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LiteLLM embedding model selection after configuration and sends `provider_type=litellm` on submit. Users can now pick the model they just added, and re-indexing uses LiteLLM instead of the local model server.

- **Bug Fixes**
  - Merged registry models, the active backend model, and session-defined models into a single `displayedModels` list so a newly added LiteLLM model appears as a selectable "Selected" card.
  - Added `staged_provider_type` to form state and pass it to `resolveProviderName` so non-registry models submit with `provider_type=litellm`; cleared when selecting registry models or on deselect.
  - Reset in-session models on disconnect and added an end-to-end test that stages a LiteLLM model and verifies the submit body includes `provider_type=litellm`.

<sup>Written for commit dafc9bc93a300d37857755618d2ef5e00262a3de. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11405?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

