### PR TITLE
fix(smtp): allow unauthenticated and non-TLS relays (#10682)

### DIFF
--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -25,6 +25,7 @@ from onyx.configs.app_configs import SENDGRID_API_KEY
 from onyx.configs.app_configs import SMTP_PASS
 from onyx.configs.app_configs import SMTP_PORT
 from onyx.configs.app_configs import SMTP_SERVER
+from onyx.configs.app_configs import SMTP_STARTTLS
 from onyx.configs.app_configs import SMTP_USER
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import AuthType
@@ -289,8 +290,10 @@ def send_email_with_smtplib(
         msg.attach(html_part)
 
     with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as s:
-        s.starttls()
-        s.login(SMTP_USER, SMTP_PASS)
+        if SMTP_STARTTLS:
+            s.starttls()
+        if SMTP_USER and SMTP_PASS:
+            s.login(SMTP_USER, SMTP_PASS)
         s.send_message(msg)
 
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -284,9 +284,15 @@ SMTP_PORT = int(os.environ.get("SMTP_PORT") or "587")
 SMTP_USER = os.environ.get("SMTP_USER") or ""
 SMTP_PASS = os.environ.get("SMTP_PASS") or ""
 # Whether to issue STARTTLS on the SMTP connection. Default true preserves
-# behavior for hosted providers (Gmail / SendGrid / SES on port 587). Set to
-# false for internal/whitelisted relays that don't advertise STARTTLS.
-SMTP_STARTTLS = os.environ.get("SMTP_STARTTLS", "true").lower() == "true"
+# behavior for hosted providers (Gmail / SendGrid / SES on port 587). Only an
+# explicit opt-out disables it, so an empty value (e.g. an uncommented
+# `SMTP_STARTTLS=` in a .env file) doesn't silently drop credentials onto a
+# plaintext connection.
+SMTP_STARTTLS = os.environ.get("SMTP_STARTTLS", "true").lower() not in (
+    "false",
+    "0",
+    "no",
+)
 EMAIL_FROM = os.environ.get("EMAIL_FROM") or SMTP_USER
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY") or ""

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -283,10 +283,16 @@ SMTP_SERVER = os.environ.get("SMTP_SERVER") or ""
 SMTP_PORT = int(os.environ.get("SMTP_PORT") or "587")
 SMTP_USER = os.environ.get("SMTP_USER") or ""
 SMTP_PASS = os.environ.get("SMTP_PASS") or ""
+# Whether to issue STARTTLS on the SMTP connection. Default true preserves
+# behavior for hosted providers (Gmail / SendGrid / SES on port 587). Set to
+# false for internal/whitelisted relays that don't advertise STARTTLS.
+SMTP_STARTTLS = os.environ.get("SMTP_STARTTLS", "true").lower() == "true"
 EMAIL_FROM = os.environ.get("EMAIL_FROM") or SMTP_USER
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY") or ""
-EMAIL_CONFIGURED = all([SMTP_SERVER, SMTP_USER, SMTP_PASS]) or SENDGRID_API_KEY
+# SMTP creds are optional — relays whitelisted by IP need only a server
+# address. SendGrid path is independent and gated by its own API key.
+EMAIL_CONFIGURED = bool(SMTP_SERVER) or bool(SENDGRID_API_KEY)
 
 # If set, Onyx will listen to the `expires_at` returned by the identity
 # provider (e.g. Okta, Google, etc.) and force the user to re-authenticate

--- a/backend/tests/unit/onyx/auth/test_smtp_unauthenticated.py
+++ b/backend/tests/unit/onyx/auth/test_smtp_unauthenticated.py
@@ -1,0 +1,80 @@
+"""Regression coverage for #10682: SMTP without auth / without STARTTLS.
+
+`send_email_with_smtplib` must not call `starttls()` when STARTTLS is disabled
+and must not call `login()` when credentials are not configured — internal
+IP-whitelisted relays don't support either.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.auth import email_utils
+
+
+def _smtp_with_mock_session() -> tuple[MagicMock, MagicMock]:
+    """Build a context-manager mock for smtplib.SMTP whose __enter__ returns a
+    fresh MagicMock session — that session is what receives starttls / login /
+    send_message calls inside the `with` block."""
+    session = MagicMock(name="smtp_session")
+    smtp_cls = MagicMock(name="smtp_cls")
+    smtp_cls.return_value.__enter__.return_value = session
+    return smtp_cls, session
+
+
+def _call_send(monkeypatch: pytest.MonkeyPatch, **overrides: object) -> MagicMock:
+    """Patch the module-level SMTP config knobs, mock smtplib.SMTP, invoke
+    send_email_with_smtplib, and return the session mock so the test can
+    assert which methods fired."""
+    defaults: dict[str, object] = {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": 587,
+        "SMTP_USER": "u",
+        "SMTP_PASS": "p",
+        "SMTP_STARTTLS": True,
+    }
+    defaults.update(overrides)
+    for name, value in defaults.items():
+        monkeypatch.setattr(email_utils, name, value, raising=True)
+
+    smtp_cls, session = _smtp_with_mock_session()
+    with patch.object(email_utils.smtplib, "SMTP", smtp_cls):
+        email_utils.send_email_with_smtplib(
+            user_email="to@example.com",
+            subject="s",
+            html_body="<p>x</p>",
+            text_body="x",
+            mail_from="from@example.com",
+        )
+    return session
+
+
+def test_default_config_calls_starttls_and_login(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = _call_send(monkeypatch)
+    session.starttls.assert_called_once()
+    session.login.assert_called_once_with("u", "p")
+    session.send_message.assert_called_once()
+
+
+def test_starttls_disabled_skips_starttls(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _call_send(monkeypatch, SMTP_STARTTLS=False)
+    session.starttls.assert_not_called()
+    session.login.assert_called_once_with("u", "p")
+    session.send_message.assert_called_once()
+
+
+def test_empty_credentials_skip_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _call_send(monkeypatch, SMTP_USER="", SMTP_PASS="")
+    session.starttls.assert_called_once()
+    session.login.assert_not_called()
+    session.send_message.assert_called_once()
+
+
+def test_unauthenticated_relay_skips_both(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _call_send(monkeypatch, SMTP_USER="", SMTP_PASS="", SMTP_STARTTLS=False)
+    session.starttls.assert_not_called()
+    session.login.assert_not_called()
+    session.send_message.assert_called_once()

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -223,6 +223,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # SMTP_PORT=
 # SMTP_USER=
 # SMTP_PASS=
+# Set SMTP_STARTTLS=false for internal/IP-whitelisted relays that don't
+# advertise STARTTLS. Leave unset (defaults to true) for Gmail / SES / SendGrid.
+# SMTP_STARTTLS=
 # ENABLE_EMAIL_INVITES=
 # EMAIL_FROM=
 # OAUTH_CLIENT_ID=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -225,7 +225,7 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # SMTP_PASS=
 # Set SMTP_STARTTLS=false for internal/IP-whitelisted relays that don't
 # advertise STARTTLS. Leave unset (defaults to true) for Gmail / SES / SendGrid.
-# SMTP_STARTTLS=
+# SMTP_STARTTLS=false
 # ENABLE_EMAIL_INVITES=
 # EMAIL_FROM=
 # OAUTH_CLIENT_ID=

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1388,6 +1388,8 @@ configMap:
   SMTP_USER: ""
   # 'your-gmail-password'
   # SMTP_PASS: ""
+  # Set to "false" for internal/IP-whitelisted relays that don't advertise STARTTLS
+  SMTP_STARTTLS: ""
   # 'your-email@company.com' SMTP_USER missing used instead
   EMAIL_FROM: ""
   # MinIO/S3 Configuration override


### PR DESCRIPTION
## Description

Fixes #10682.

Deployments using an internal / IP-whitelisted SMTP relay (e.g. Postfix without auth, Mailhog) couldn't send email at all:

1. **`EMAIL_CONFIGURED`** in `backend/onyx/configs/app_configs.py:289` required `SMTP_USER` and `SMTP_PASS`, so server-only configurations were reported as "Email is not configured."
2. **`send_email_with_smtplib`** in `backend/onyx/auth/email_utils.py:291-294` called `starttls()` and `login()` unconditionally — so even if users worked around the gate by setting dummy credentials, the SMTP exchange crashed inside `starttls()` (servers that don't advertise it) or `login()` (servers that don't accept auth).

### Fix

- `EMAIL_CONFIGURED` now requires only `SMTP_SERVER` (or `SENDGRID_API_KEY`).
- `starttls()` is gated on a new `SMTP_STARTTLS` env var (default `true`, so Gmail / SES / SendGrid on 587 keep working).
- `login()` runs only when both `SMTP_USER` and `SMTP_PASS` are set.

Includes env.template and Helm chart entries for the new `SMTP_STARTTLS` knob.

All five `EMAIL_CONFIGURED` consumers (`auth/users.py`, `server/manage/users.py`, `server/documents/connector.py`, `ee/onyx/utils/license_notifications.py`, plus this module) treat it purely as a gate to decide whether to call `send_email`; none assume `SMTP_USER`/`SMTP_PASS` are populated, so loosening the predicate is safe.

## How Has This Been Tested?

- New unit test `backend/tests/unit/onyx/auth/test_smtp_unauthenticated.py` mocks `smtplib.SMTP` and covers the four combinations of `SMTP_STARTTLS` × creds: default-config, STARTTLS-off, no-creds, and unauthenticated-relay (both off). All pass locally.
- Pre-commit (ruff, ty) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows sending email through unauthenticated or non-STARTTLS SMTP relays by making auth optional and STARTTLS configurable. Keeps secure defaults for hosted providers on port 587 and treats `SMTP_STARTTLS` as fail-safe (only explicit false/0/no disables).

- **Bug Fixes**
  - `EMAIL_CONFIGURED` now requires only `SMTP_SERVER` (or `SENDGRID_API_KEY`).
  - Gated `starttls()` behind `SMTP_STARTTLS`; parsed as not in (`false`, `0`, `no`) so empty values don’t disable STARTTLS.
  - Call `login()` only when both `SMTP_USER` and `SMTP_PASS` are set.
  - Updated Docker Compose and Helm values; template shows `SMTP_STARTTLS=false` explicitly.
  - Added unit tests for all `SMTP_STARTTLS` × credentials combinations.

- **Migration**
  - For internal/non-STARTTLS relays: set `SMTP_STARTTLS=false`.
  - No changes needed for Gmail/SES/SendGrid on 587.

<sup>Written for commit ac2b87e6e177cb9169c1bea58d6944aa849ab83c. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11406?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

