### PR TITLE
fix: jira dc v9 perm sync

### DIFF
--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -228,6 +228,25 @@ def _get_user_emails(jira_project: str, user_holders: list[Holder]) -> list[str]
     return emails
 
 
+def _describe_actor(actor: object) -> object:
+    """Render a project-role actor for triage logs. `jira.resources.PropertyHolder`
+    inherits object's default repr (only the memory address); dump its populated
+    attributes one level deep so unsupported/empty-name cases are debuggable."""
+    if isinstance(actor, dict):
+        return actor
+    if not hasattr(actor, "__dict__"):
+        return repr(actor)
+    return {
+        k: (
+            {ik: iv for ik, iv in vars(v).items() if not ik.startswith("_")}
+            if hasattr(v, "__dict__")
+            else v
+        )
+        for k, v in vars(actor).items()
+        if not k.startswith("_")
+    }
+
+
 def _classify_role_actor(actor: object) -> _RoleActorCategory:
     """Categorize a project-role actor across Cloud v3's nested
     `actorGroup`/`actorUser` shape and DC/Server's flat `type=atlassian-*-role-actor`
@@ -377,6 +396,14 @@ def _get_user_emails_and_groups_from_project_roles(
 
         for actor in role.actors:
             category = _classify_role_actor(actor)
+            logger.debug(
+                "Jira project %s project role %s actor classified; "
+                "category=%s actor=%s",
+                jira_project,
+                role_id,
+                category.value,
+                _describe_actor(actor),
+            )
 
             if category is _RoleActorCategory.GROUP:
                 actor_group_seen_count += 1

--- a/backend/ee/onyx/external_permissions/jira/page_access.py
+++ b/backend/ee/onyx/external_permissions/jira/page_access.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from enum import StrEnum
 
 from jira import JIRA
 from jira.resources import PermissionScheme
@@ -32,6 +33,17 @@ SUPPORTED_STATIC_HOLDER_TYPES = {
     HOLDER_TYPE_PROJECT_ROLE,
     HOLDER_TYPE_GROUP,
 }
+
+# Jira DC/Server returns project-role actors flat with this `type` discriminator;
+# Jira Cloud v3 instead wraps them in nested `actorGroup` / `actorUser` objects.
+ATLASSIAN_GROUP_ROLE_ACTOR_TYPE = "atlassian-group-role-actor"
+ATLASSIAN_USER_ROLE_ACTOR_TYPE = "atlassian-user-role-actor"
+
+
+class _RoleActorCategory(StrEnum):
+    GROUP = "group"
+    USER = "user"
+    UNSUPPORTED = "unsupported"
 
 
 def _get_role_id(holder: Holder) -> str | None:
@@ -216,6 +228,30 @@ def _get_user_emails(jira_project: str, user_holders: list[Holder]) -> list[str]
     return emails
 
 
+def _classify_role_actor(actor: object) -> _RoleActorCategory:
+    """Categorize a project-role actor across Cloud v3's nested
+    `actorGroup`/`actorUser` shape and DC/Server's flat `type=atlassian-*-role-actor`
+    shape."""
+    if (
+        _get_obj_value(actor, "actorGroup") is not None
+        or _get_raw_value(actor, "actorGroup") is not None
+    ):
+        return _RoleActorCategory.GROUP
+    if (
+        _get_obj_value(actor, "actorUser") is not None
+        or _get_raw_value(actor, "actorUser") is not None
+    ):
+        return _RoleActorCategory.USER
+
+    actor_type = _get_first_str_value(actor, ("type",))
+    if actor_type == ATLASSIAN_GROUP_ROLE_ACTOR_TYPE:
+        return _RoleActorCategory.GROUP
+    if actor_type == ATLASSIAN_USER_ROLE_ACTOR_TYPE:
+        return _RoleActorCategory.USER
+
+    return _RoleActorCategory.UNSUPPORTED
+
+
 def _get_actor_group_name(actor: object) -> str | None:
     for actor_group in [
         _get_obj_value(actor, "actorGroup"),
@@ -340,11 +376,9 @@ def _get_user_emails_and_groups_from_project_roles(
             continue
 
         for actor in role.actors:
-            actor_group = _get_obj_value(actor, "actorGroup") or _get_raw_value(
-                actor, "actorGroup"
-            )
-            # Handle group actors
-            if actor_group is not None:
+            category = _classify_role_actor(actor)
+
+            if category is _RoleActorCategory.GROUP:
                 actor_group_seen_count += 1
                 group_name = _get_actor_group_name(actor)
                 if group_name:
@@ -352,20 +386,23 @@ def _get_user_emails_and_groups_from_project_roles(
                 else:
                     actor_group_missing_name_count += 1
                     logger.warning(
-                        "Jira project %s project role %s has actorGroup with no "
-                        "name/displayName; actor_group=%s",
+                        "Jira project %s project role %s has group actor with no "
+                        "name/displayName; actor=%s",
                         jira_project,
                         role_id,
-                        actor_group,
+                        actor,
                     )
                 continue
 
-            actor_user = _get_obj_value(actor, "actorUser") or _get_raw_value(
-                actor, "actorUser"
-            )
-            # Handle user actors
-            if actor_user is not None:
+            if category is _RoleActorCategory.USER:
                 actor_user_seen_count += 1
+                # Prefer Cloud's nested `actorUser` (keeps accountId lookup);
+                # fall back to the actor itself for DC's flat shape.
+                actor_user = (
+                    _get_obj_value(actor, "actorUser")
+                    or _get_raw_value(actor, "actorUser")
+                    or actor
+                )
                 email = _get_actor_user_email(
                     jira_client=jira_client,
                     jira_project=jira_project,

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
@@ -183,3 +183,136 @@ def test_dynamic_only_holders_remain_empty_private_access(
     assert external_access.external_user_group_ids == set()
     assert external_access.is_public is False
     assert all(record.levelno < logging.ERROR for record in caplog.records)
+
+
+def test_project_role_dc_flat_group_actor_resolves_via_type_discriminator() -> None:
+    """A DC project-role actor with `type=atlassian-group-role-actor` and the
+    group identifier under `name` (no nested `actorGroup`) resolves to that
+    group."""
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10002"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(
+                id=12345,
+                displayName="jira-administrators",
+                type="atlassian-group-role-actor",
+                name="jira-administrators",
+            ),
+        ]
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == set()
+    assert external_access.external_user_group_ids == {"jira-administrators"}
+    assert external_access.is_public is False
+    jira_client.user.assert_not_called()
+
+
+def test_project_role_dc_flat_user_actor_resolves_via_type_discriminator() -> None:
+    """Jira DC user actors are also flat: `type=atlassian-user-role-actor`
+    with the DC username under `name`. Lookup must go through `jira.user(id=...)`."""
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10002"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(
+                id=67890,
+                displayName="DC Flat User",
+                type="atlassian-user-role-actor",
+                name="dc-flat-user",
+            ),
+        ]
+    )
+    jira_client.user.return_value = SimpleNamespace(
+        emailAddress="dc-flat-user@example.com",
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"dc-flat-user@example.com"}
+    assert external_access.external_user_group_ids == set()
+    jira_client.user.assert_called_once_with(id="dc-flat-user")
+
+
+def test_project_role_dc_flat_mixed_actors_resolve_groups_and_users() -> None:
+    """A single role on DC can mix group and user actors; both flat shapes
+    should be classified correctly in one pass."""
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10002"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(
+                id=1,
+                displayName="jira-developers",
+                type="atlassian-group-role-actor",
+                name="jira-developers",
+            ),
+            SimpleNamespace(
+                id=2,
+                displayName="release-team",
+                type="atlassian-group-role-actor",
+                name="release-team",
+            ),
+            SimpleNamespace(
+                id=3,
+                displayName="DC User One",
+                type="atlassian-user-role-actor",
+                name="dc-user-1",
+            ),
+        ]
+    )
+    jira_client.user.return_value = SimpleNamespace(
+        emailAddress="dc-user-1@example.com",
+    )
+
+    external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == {"dc-user-1@example.com"}
+    assert external_access.external_user_group_ids == {
+        "jira-developers",
+        "release-team",
+    }
+    jira_client.user.assert_called_once_with(id="dc-user-1")
+
+
+def test_project_role_unknown_actor_type_is_still_unsupported(
+    caplog: LogCaptureFixture,
+) -> None:
+    """A flat actor whose `type` doesn't match either known discriminator must
+    fall through to the unsupported branch — guards against silently mis-routing
+    future Atlassian actor types into groups/users."""
+    jira_client = _jira_client(JIRA_SERVER_API_VERSION)
+    jira_client.project_permissionscheme.return_value = _project_permissions(
+        _permission({"type": "projectRole", "parameter": "10002"})
+    )
+    jira_client.project_role.return_value = SimpleNamespace(
+        actors=[
+            SimpleNamespace(
+                id=1,
+                displayName="some-future-actor",
+                type="atlassian-future-role-actor",
+                name="future",
+            ),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        external_access = get_project_permissions(jira_client, PROJECT_KEY)
+
+    assert external_access is not None
+    assert external_access.external_user_emails == set()
+    assert external_access.external_user_group_ids == set()
+    assert any(
+        "unsupported actor shape" in record.getMessage() for record in caplog.records
+    )

--- a/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/jira/test_jira_page_access.py
@@ -239,6 +239,7 @@ def test_project_role_dc_flat_user_actor_resolves_via_type_discriminator() -> No
     assert external_access is not None
     assert external_access.external_user_emails == {"dc-flat-user@example.com"}
     assert external_access.external_user_group_ids == set()
+    assert external_access.is_public is False
     jira_client.user.assert_called_once_with(id="dc-flat-user")
 
 
@@ -283,6 +284,7 @@ def test_project_role_dc_flat_mixed_actors_resolve_groups_and_users() -> None:
         "jira-developers",
         "release-team",
     }
+    assert external_access.is_public is False
     jira_client.user.assert_called_once_with(id="dc-user-1")
 
 


### PR DESCRIPTION
## Description

handle flat permission structure for jira data center v9. Our previous implementation only worked for cloud and older DC versions.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes permission sync for Jira Data Center v9 by supporting its flat project-role actors. Adds explicit classification and better logging to match Cloud/older DC behavior.

- **Bug Fixes**
  - Detects group/user actors via `type` discriminators (`atlassian-group-role-actor`, `atlassian-user-role-actor`) alongside Cloud’s nested `actorGroup`/`actorUser`.
  - Resolves DC user emails via `user(id=<name>)` and collects group IDs from `name`; handles mixed role actors and prefers nested `actorUser` when present.
  - Adds structured debug logs with actor category and details; warns on unsupported shapes; tests for flat/mixed/unknown actors.

<sup>Written for commit 4b5e2b709ffa55072ef57b7aee2e3d7b70f8ba86. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11409?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

