### PR TITLE
feat(ods): add --no-verify flag to run-ci

### DIFF
--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -201,10 +201,11 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 
 	// Push the CI branch (force push in case it already exists)
 	log.Infof("Pushing CI branch: %s", ciBranch)
-	pushArgs := []string{"push", "--quiet", "-f", "-u", "origin", ciBranch}
+	pushArgs := []string{"push"}
 	if opts.NoVerify {
-		pushArgs = []string{"push", "--no-verify", "--quiet", "-f", "-u", "origin", ciBranch}
+		pushArgs = append(pushArgs, "--no-verify")
 	}
+	pushArgs = append(pushArgs, "--quiet", "-f", "-u", "origin", ciBranch)
 	if err := git.RunCommand(pushArgs...); err != nil {
 		// Switch back to original branch before exiting
 		if switchErr := git.RunCommand("switch", "--quiet", originalBranch); switchErr != nil {

--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -15,9 +15,10 @@ import (
 
 // RunCIOptions holds options for the run-ci command
 type RunCIOptions struct {
-	DryRun bool
-	Yes    bool
-	Rerun  bool
+	DryRun   bool
+	Yes      bool
+	Rerun    bool
+	NoVerify bool
 }
 
 // NewRunCICommand creates a new run-ci command
@@ -51,6 +52,7 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform all local operations but skip pushing to remote and creating PRs")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompts and automatically proceed")
 	cmd.Flags().BoolVar(&opts.Rerun, "rerun", false, "Update an existing CI PR with the latest fork changes to re-trigger CI")
+	cmd.Flags().BoolVar(&opts.NoVerify, "no-verify", false, "Skip pre-push hooks when pushing the CI branch")
 
 	return cmd
 }
@@ -199,7 +201,11 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 
 	// Push the CI branch (force push in case it already exists)
 	log.Infof("Pushing CI branch: %s", ciBranch)
-	if err := git.RunCommand("push", "--quiet", "-f", "-u", "origin", ciBranch); err != nil {
+	pushArgs := []string{"push", "--quiet", "-f", "-u", "origin", ciBranch}
+	if opts.NoVerify {
+		pushArgs = []string{"push", "--no-verify", "--quiet", "-f", "-u", "origin", ciBranch}
+	}
+	if err := git.RunCommand(pushArgs...); err != nil {
 		// Switch back to original branch before exiting
 		if switchErr := git.RunCommand("switch", "--quiet", originalBranch); switchErr != nil {
 			log.Warnf("Failed to switch back to original branch: %v", switchErr)


### PR DESCRIPTION
## Summary
- Adds a `--no-verify` flag to `ods run-ci` that passes `--no-verify` to the `git push` of the CI branch, skipping pre-push hooks
- Mirrors the existing `--no-verify` option on `ods cherry-pick`

## Test plan
- [ ] `ods run-ci <pr> --no-verify` skips pre-push hooks when pushing the CI branch
- [ ] `ods run-ci <pr>` (without the flag) still runs pre-push hooks as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--no-verify` flag to `ods run-ci` to skip pre-push hooks when pushing the CI branch. Mirrors the existing option on `ods cherry-pick`; default behavior is unchanged.

- **Refactors**
  - Build `git push` args incrementally and append `--no-verify` conditionally to avoid duplicating common flags.

<sup>Written for commit 74e292f9327caa43917c17ed9c3e28724ee893cf. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11410?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

