### PR TITLE
feat(craft): Gmail external app

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -377,6 +377,7 @@ class ExternalAppType(str, PyEnum):
     """
 
     GOOGLE_CALENDAR = "GOOGLE_CALENDAR"
+    GMAIL = "GMAIL"
     SLACK = "SLACK"
     LINEAR = "LINEAR"
     CUSTOM = "CUSTOM"

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -1,0 +1,17 @@
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers.google_base import GoogleOAuthProvider
+
+
+class GmailProvider(GoogleOAuthProvider):
+    spec = GoogleOAuthProvider.build_spec(
+        app_type=ExternalAppType.GMAIL,
+        app_name="Gmail",
+        # gmail.modify covers read, send, label, and trash — but not permanent
+        # delete, which keeps the integration safer by default.
+        scope="https://www.googleapis.com/auth/gmail.modify",
+        upstream_url_patterns=["https://gmail\\.googleapis\\.com/gmail/.*"],
+        description=(
+            "Read, search, and send email from your Gmail account inside Onyx Craft."
+        ),
+        google_api_name="Gmail API",
+    )

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -1,5 +1,68 @@
 from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.actions import ExternalAppAction
+from onyx.external_apps.providers.actions import RestRoute
 from onyx.external_apps.providers.google_base import GoogleOAuthProvider
+
+
+# Gmail API v1 (https://gmail.googleapis.com/gmail/v1/users/{userId}/...); the
+# action is HTTP method + path. The skill targets `users/me`, but `{userId}`
+# matches any single segment so the catalog stays user-agnostic.
+class GmailAction(ExternalAppAction):
+    """Strongly-typed catalog ids for the Gmail provider."""
+
+    MESSAGES_READ = "gmail.messages.read"
+    LABELS_READ = "gmail.labels.read"
+    PROFILE_READ = "gmail.profile.read"
+    MESSAGES_SEND = "gmail.messages.send"
+    MESSAGES_MODIFY = "gmail.messages.modify"
+    MESSAGES_TRASH = "gmail.messages.trash"
+
+
+_USER = "/gmail/v1/users/{userId}"
+_MESSAGES = f"{_USER}/messages"
+_MESSAGE_ITEM = f"{_USER}/messages/{{messageId}}"
+_ENDPOINTS: list[EndpointSpec] = [
+    EndpointSpec(
+        id=GmailAction.MESSAGES_READ,
+        normalised_name="Read messages",
+        description="List or search messages and read a single message.",
+        matches=(
+            RestRoute(method="GET", path=_MESSAGES),
+            RestRoute(method="GET", path=_MESSAGE_ITEM),
+        ),
+    ),
+    EndpointSpec(
+        id=GmailAction.LABELS_READ,
+        normalised_name="List labels",
+        description="List the labels in the mailbox.",
+        matches=(RestRoute(method="GET", path=f"{_USER}/labels"),),
+    ),
+    EndpointSpec(
+        id=GmailAction.PROFILE_READ,
+        normalised_name="Read profile",
+        description="Read the connected account's Gmail profile.",
+        matches=(RestRoute(method="GET", path=f"{_USER}/profile"),),
+    ),
+    EndpointSpec(
+        id=GmailAction.MESSAGES_SEND,
+        normalised_name="Send a message",
+        description="Send an email from the connected account.",
+        matches=(RestRoute(method="POST", path=f"{_MESSAGES}/send"),),
+    ),
+    EndpointSpec(
+        id=GmailAction.MESSAGES_MODIFY,
+        normalised_name="Modify message labels",
+        description="Add or remove labels on a message (mark read, archive, …).",
+        matches=(RestRoute(method="POST", path=f"{_MESSAGE_ITEM}/modify"),),
+    ),
+    EndpointSpec(
+        id=GmailAction.MESSAGES_TRASH,
+        normalised_name="Trash a message",
+        description="Move a message to the trash.",
+        matches=(RestRoute(method="POST", path=f"{_MESSAGE_ITEM}/trash"),),
+    ),
+]
 
 
 class GmailProvider(GoogleOAuthProvider):
@@ -14,4 +77,5 @@ class GmailProvider(GoogleOAuthProvider):
             "Read, search, and send email from your Gmail account inside Onyx Craft."
         ),
         google_api_name="Gmail API",
+        endpoint_catalog=_ENDPOINTS,
     )

--- a/backend/onyx/external_apps/providers/google_base.py
+++ b/backend/onyx/external_apps/providers/google_base.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
+from onyx.external_apps.providers.base import OrgCredentialField
+
+# Google's OAuth 2.0 endpoints are shared across all Google APIs.
+_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+# Every Google provider authenticates with the same Cloud Console OAuth client.
+_CLIENT_CREDENTIAL_FIELDS = [
+    OrgCredentialField(
+        key="client_id",
+        label="Client ID",
+        description=(
+            "Found in Google Cloud Console → APIs & Services → "
+            "Credentials → OAuth 2.0 Client IDs."
+        ),
+    ),
+    OrgCredentialField(
+        key="client_secret",
+        label="Client Secret",
+        description="Found alongside the Client ID. Treat this like a password.",
+        secret=True,
+    ),
+]
+
+
+def _setup_instructions(google_api_name: str) -> str:
+    """The Cloud Console setup steps, identical across Google providers except
+    for which API the admin must enable."""
+    return (
+        "In Google Cloud Console: create a project (or pick one), enable the "
+        f"{google_api_name} under APIs & Services → Library, configure the "
+        "OAuth consent screen (External for personal Google accounts, Internal "
+        "for Workspace), then under APIs & Services → Credentials create an "
+        "OAuth 2.0 Client ID of type Web application. Add this Onyx instance's "
+        "callback URL (/craft/v1/apps/oauth/callback) to Authorized redirect "
+        "URIs. Then paste the Client ID and Client Secret below."
+    )
+
+
+class GoogleOAuthProvider(OAuthExternalAppProvider, abstract=True):
+    """Shared base for Google built-in providers (Calendar, Gmail, ...).
+
+    Google APIs share OAuth endpoints, the offline/consent authorize params,
+    the Cloud Console client-credential fields, and an identical token-exchange
+    response shape. Concrete subclasses only vary scope, upstream URL patterns,
+    and user-facing copy — built via :meth:`build_spec`.
+    """
+
+    @classmethod
+    def build_spec(
+        cls,
+        *,
+        app_type: Any,
+        app_name: str,
+        scope: str,
+        upstream_url_patterns: list[str],
+        description: str,
+        google_api_name: str,
+    ) -> OAuthProviderSpec:
+        return OAuthProviderSpec(
+            app_type=app_type,
+            app_name=app_name,
+            oauth=OAuthFlowSpec(
+                authorize_url=_AUTHORIZE_URL,
+                token_url=_TOKEN_URL,
+                scope=scope,
+                scope_param="scope",
+                # access_type=offline issues a refresh_token; prompt=consent
+                # forces fresh consent so Google reissues it on re-auth.
+                extra_authorize_params={
+                    "response_type": "code",
+                    "access_type": "offline",
+                    "prompt": "consent",
+                },
+            ),
+            descriptor=AdminDescriptorSpec(
+                description=description,
+                upstream_url_patterns=upstream_url_patterns,
+                auth_template={"Authorization": "Bearer {access_token}"},
+                required_org_credential_fields=list(_CLIENT_CREDENTIAL_FIELDS),
+                setup_instructions=_setup_instructions(google_api_name),
+            ),
+        )
+
+    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        access_token = response_data.get("access_token")
+        if not access_token:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "Google OAuth response did not contain an access token.",
+            )
+        creds: dict[str, Any] = {
+            "access_token": access_token,
+            "scope": response_data.get("scope"),
+            "token_type": response_data.get("token_type"),
+        }
+        if response_data.get("refresh_token"):
+            creds["refresh_token"] = response_data["refresh_token"]
+        if response_data.get("expires_in"):
+            creds["expires_in"] = response_data["expires_in"]
+        if response_data.get("id_token"):
+            creds["id_token"] = response_data["id_token"]
+        return creds

--- a/backend/onyx/external_apps/providers/google_base.py
+++ b/backend/onyx/external_apps/providers/google_base.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.base import AdminDescriptorSpec
 from onyx.external_apps.providers.base import OAuthExternalAppProvider
 from onyx.external_apps.providers.base import OAuthFlowSpec
@@ -49,21 +51,23 @@ class GoogleOAuthProvider(OAuthExternalAppProvider, abstract=True):
     """Shared base for Google built-in providers (Calendar, Gmail, ...).
 
     Google APIs share OAuth endpoints, the offline/consent authorize params,
-    the Cloud Console client-credential fields, and an identical token-exchange
-    response shape. Concrete subclasses only vary scope, upstream URL patterns,
-    and user-facing copy — built via :meth:`build_spec`.
+    the Cloud Console client-credential fields, the bearer ``auth_template``,
+    and an identical token-exchange response shape. Concrete subclasses only
+    vary scope, upstream URL patterns, user-facing copy, and their action
+    catalog — assembled via :meth:`build_spec`.
     """
 
     @classmethod
     def build_spec(
         cls,
         *,
-        app_type: Any,
+        app_type: ExternalAppType,
         app_name: str,
         scope: str,
         upstream_url_patterns: list[str],
         description: str,
         google_api_name: str,
+        endpoint_catalog: list[EndpointSpec],
     ) -> OAuthProviderSpec:
         return OAuthProviderSpec(
             app_type=app_type,
@@ -88,6 +92,7 @@ class GoogleOAuthProvider(OAuthExternalAppProvider, abstract=True):
                 required_org_credential_fields=list(_CLIENT_CREDENTIAL_FIELDS),
                 setup_instructions=_setup_instructions(google_api_name),
             ),
+            endpoint_catalog=endpoint_catalog,
         )
 
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/external_apps/providers/google_calendar.py
+++ b/backend/onyx/external_apps/providers/google_calendar.py
@@ -1,16 +1,8 @@
-from typing import Any
-
 from onyx.db.enums import ExternalAppType
-from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.actions import ExternalAppAction
 from onyx.external_apps.providers.actions import RestRoute
-from onyx.external_apps.providers.base import AdminDescriptorSpec
-from onyx.external_apps.providers.base import OAuthExternalAppProvider
-from onyx.external_apps.providers.base import OAuthFlowSpec
-from onyx.external_apps.providers.base import OAuthProviderSpec
-from onyx.external_apps.providers.base import OrgCredentialField
+from onyx.external_apps.providers.google_base import GoogleOAuthProvider
 
 
 # Google Calendar REST v3 (https://www.googleapis.com/calendar/v3/...); the
@@ -77,77 +69,15 @@ _ENDPOINTS: list[EndpointSpec] = [
 ]
 
 
-class GoogleCalendarProvider(OAuthExternalAppProvider):
-    spec = OAuthProviderSpec(
+class GoogleCalendarProvider(GoogleOAuthProvider):
+    spec = GoogleOAuthProvider.build_spec(
         app_type=ExternalAppType.GOOGLE_CALENDAR,
         app_name="Google Calendar",
-        oauth=OAuthFlowSpec(
-            authorize_url="https://accounts.google.com/o/oauth2/v2/auth",
-            token_url="https://oauth2.googleapis.com/token",
-            scope="https://www.googleapis.com/auth/calendar",
-            scope_param="scope",
-            # access_type=offline issues a refresh_token; prompt=consent
-            # forces fresh consent so Google reissues it on re-auth.
-            extra_authorize_params={
-                "response_type": "code",
-                "access_type": "offline",
-                "prompt": "consent",
-            },
+        scope="https://www.googleapis.com/auth/calendar",
+        upstream_url_patterns=["https://www\\.googleapis\\.com/calendar/.*"],
+        description=(
+            "Read and create events on your Google Calendar from inside Onyx Craft."
         ),
-        descriptor=AdminDescriptorSpec(
-            description=(
-                "Read and create events on your Google Calendar from inside Onyx Craft."
-            ),
-            upstream_url_patterns=["https://www\\.googleapis\\.com/calendar/.*"],
-            auth_template={"Authorization": "Bearer {access_token}"},
-            required_org_credential_fields=[
-                OrgCredentialField(
-                    key="client_id",
-                    label="Client ID",
-                    description=(
-                        "Found in Google Cloud Console → APIs & Services → "
-                        "Credentials → OAuth 2.0 Client IDs."
-                    ),
-                ),
-                OrgCredentialField(
-                    key="client_secret",
-                    label="Client Secret",
-                    description=(
-                        "Found alongside the Client ID. Treat this like a password."
-                    ),
-                    secret=True,
-                ),
-            ],
-            setup_instructions=(
-                "In Google Cloud Console: create a project (or pick one), "
-                "enable the Google Calendar API under APIs & Services → "
-                "Library, configure the OAuth consent screen (External for "
-                "personal Google accounts, Internal for Workspace), then under "
-                "APIs & Services → Credentials create an OAuth 2.0 Client ID of "
-                "type Web application. Add this Onyx instance's callback URL "
-                "(/craft/v1/apps/oauth/callback) to Authorized redirect URIs. "
-                "Then paste the Client ID and Client Secret below."
-            ),
-        ),
+        google_api_name="Google Calendar API",
         endpoint_catalog=_ENDPOINTS,
     )
-
-    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
-        access_token = response_data.get("access_token")
-        if not access_token:
-            raise OnyxError(
-                OnyxErrorCode.BAD_GATEWAY,
-                "Google OAuth response did not contain an access token.",
-            )
-        creds: dict[str, Any] = {
-            "access_token": access_token,
-            "scope": response_data.get("scope"),
-            "token_type": response_data.get("token_type"),
-        }
-        if response_data.get("refresh_token"):
-            creds["refresh_token"] = response_data["refresh_token"]
-        if response_data.get("expires_in"):
-            creds["expires_in"] = response_data["expires_in"]
-        if response_data.get("id_token"):
-            creds["id_token"] = response_data["id_token"]
-        return creds

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -5,6 +5,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.base import ExternalAppProvider
+from onyx.external_apps.providers.gmail import GmailProvider
 from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
 from onyx.external_apps.providers.linear import LinearProvider
 from onyx.external_apps.providers.slack import SlackProvider
@@ -16,6 +17,7 @@ from onyx.server.features.build.api.models import OrgCredentialFieldDescriptor
 _PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
     SlackProvider,
     GoogleCalendarProvider,
+    GmailProvider,
     LinearProvider,
 ]
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: gmail
+description: Read, search, and send email from the connected user's Gmail via a light Gmail API wrapper.
+---
+
+# Gmail
+
+Call the Gmail API as the connected user via the bundled helper.
+
+## Usage
+
+    python .opencode/skills/gmail/gmail_api.py <command> [args]
+
+Read commands auto-paginate and prune empty fields. `send`, `modify`, and
+`trash` are the only writes; there is no permanent delete. `me` is always the
+connected user. Use `--raw` to skip empty-field pruning; `python gmail_api.py
+<command> -h` shows its flags.
+
+### List / search messages
+
+Lists message headers (From, Subject, Date, snippet). `--q` takes Gmail search
+syntax (e.g. `is:unread from:boss@x.com newer_than:7d`).
+
+```
+python gmail_api.py messages [--q QUERY] [--label LABEL_ID] [--limit N]
+```
+
+### One message
+
+Full message with decoded plain-text body.
+
+```
+python gmail_api.py message <message_id>
+```
+
+### Send a message (write)
+
+```
+python gmail_api.py send to@x.com "Subject" "Body text" \
+    [--cc a@x.com,b@x.com] [--bcc c@x.com]
+```
+
+### List labels
+
+```
+python gmail_api.py labels
+```
+
+### Modify labels on a message (write)
+
+Add or remove label IDs. Mark read by removing `UNREAD`; archive by removing
+`INBOX`.
+
+```
+python gmail_api.py modify <message_id> [--add LABEL,LABEL] [--remove LABEL,LABEL]
+```
+
+### Trash a message (write, reversible)
+
+```
+python gmail_api.py trash <message_id>
+```
+
+### Profile
+
+```
+python gmail_api.py profile
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "items": [...], "count": N,
+"truncated": bool}` (`truncated` means more results existed past `--limit`).
+Transport errors print to stderr and exit non-zero; Google's error JSON (with
+`code` and `message`) is included.
+
+## Notes
+
+- Message bodies are returned decoded from base64url; for multipart messages the
+  first `text/plain` part is used.
+- Common system label IDs: `INBOX`, `UNREAD`, `STARRED`, `SENT`, `TRASH`,
+  `SPAM`, `IMPORTANT`.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Gmail wrapper for the Onyx Craft sandbox.
+
+Common operations exposed as subcommands. Output is JSON on stdout. The
+Authorization header is injected by the Onyx egress gateway from the connected
+user's credentials, so no token handling happens here.
+"""
+
+import argparse
+import base64
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from email.message import EmailMessage
+from typing import Any
+
+_BASE = "https://gmail.googleapis.com/gmail/v1/users/me/"
+_PAGE_SIZE = 100
+_DEFAULT_LIMIT = 25
+_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE")
+# Headers worth surfacing from a metadata-format message fetch.
+_METADATA_HEADERS = ("From", "To", "Cc", "Subject", "Date")
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} so LLM-facing output stays
+    small. Booleans and 0 are kept — they carry signal."""
+    if isinstance(value, dict):
+        out = {k: _prune(v) for k, v in value.items()}
+        return {k: v for k, v in out.items() if v not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _seg(value: str) -> str:
+    """URL-encode a single path segment (ids may contain @ or /)."""
+    return urllib.parse.quote(value, safe="")
+
+
+def _req(
+    method: str,
+    path: str,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Call a Gmail endpoint; return parsed JSON ({} on empty/204).
+    Raises on transport failure (handled by the caller)."""
+    url = _BASE + path
+    if params:
+        clean = {k: v for k, v in params.items() if v is not None}
+        if clean:
+            url += "?" + urllib.parse.urlencode(clean, doseq=True)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json; charset=utf-8"} if data else {}
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        url, data=data, method=method, headers=headers
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw.strip() else {}
+
+
+def _list_ids(
+    path: str, params: dict[str, Any], key: str, limit: int
+) -> dict[str, Any]:
+    """Walk a list endpoint (`<key>` + `nextPageToken`) up to `limit`,
+    collecting the lightweight id records Gmail returns."""
+    items: list[Any] = []
+    token: str | None = None
+    while True:
+        q = dict(params, maxResults=min(_PAGE_SIZE, limit - len(items)))
+        if token:
+            q["pageToken"] = token
+        resp = _req("GET", path, params=q)
+        items.extend(resp.get(key) or [])
+        token = resp.get("nextPageToken")
+        if len(items) >= limit:
+            return {"items": items[:limit], "truncated": bool(token)}
+        if not token:
+            break
+    return {"items": items, "truncated": False}
+
+
+def _headers_to_dict(headers: list[dict[str, str]]) -> dict[str, str]:
+    wanted = {h.lower() for h in _METADATA_HEADERS}
+    return {
+        h["name"]: h["value"] for h in headers if h.get("name", "").lower() in wanted
+    }
+
+
+def _decode_b64url(data: str) -> str:
+    pad = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + pad).decode("utf-8", errors="replace")
+
+
+def _extract_plain_body(payload: dict[str, Any]) -> str:
+    """Pull the first text/plain part out of a message payload."""
+    if payload.get("mimeType") == "text/plain":
+        body_data = payload.get("body", {}).get("data")
+        if body_data:
+            return _decode_b64url(body_data)
+    for part in payload.get("parts") or []:
+        found = _extract_plain_body(part)
+        if found:
+            return found
+    return ""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="gmail_api.py", description="Gmail.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("messages", help="list / search message headers")
+    sp.add_argument("--q", help="Gmail search query")
+    sp.add_argument("--label", help="filter to a label id")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    sp = sub.add_parser("message", help="one message with decoded body")
+    sp.add_argument("message_id")
+
+    sp = sub.add_parser("send", help="send an email (write)")
+    sp.add_argument("to")
+    sp.add_argument("subject")
+    sp.add_argument("body")
+    sp.add_argument("--cc", help="comma-separated emails")
+    sp.add_argument("--bcc", help="comma-separated emails")
+
+    sub.add_parser("labels", help="list labels")
+
+    sp = sub.add_parser("modify", help="add/remove labels on a message (write)")
+    sp.add_argument("message_id")
+    sp.add_argument("--add", help="comma-separated label ids")
+    sp.add_argument("--remove", help="comma-separated label ids")
+
+    sp = sub.add_parser("trash", help="move a message to trash (write)")
+    sp.add_argument("message_id")
+
+    sub.add_parser("profile", help="the connected user's Gmail profile")
+
+    sp = sub.add_parser("call", help="raw Gmail request")
+    sp.add_argument("method", choices=_METHODS)
+    sp.add_argument("path", help="appended to users/me/")
+    sp.add_argument("json_body", nargs="?")
+    return p
+
+
+def _cmd_messages(a: argparse.Namespace) -> dict[str, Any]:
+    listed = _list_ids(
+        "messages",
+        {"q": a.q, "labelIds": a.label},
+        "messages",
+        a.limit,
+    )
+    summaries: list[dict[str, Any]] = []
+    for ref in listed["items"]:
+        msg = _req(
+            "GET",
+            f"messages/{_seg(ref['id'])}",
+            params={"format": "metadata", "metadataHeaders": list(_METADATA_HEADERS)},
+        )
+        summaries.append(
+            {
+                "id": msg.get("id"),
+                "threadId": msg.get("threadId"),
+                "labelIds": msg.get("labelIds"),
+                "snippet": msg.get("snippet"),
+                "headers": _headers_to_dict(msg.get("payload", {}).get("headers", [])),
+            }
+        )
+    return {
+        "ok": True,
+        "items": summaries,
+        "count": len(summaries),
+        "truncated": listed["truncated"],
+    }
+
+
+def _comma_list(value: str | None) -> list[str] | None:
+    if not value:
+        return None
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "messages":
+        return _cmd_messages(a)
+
+    if a.cmd == "message":
+        msg = _req(
+            "GET",
+            f"messages/{_seg(a.message_id)}",
+            params={"format": "full"},
+        )
+        payload = msg.get("payload", {})
+        return {
+            "ok": True,
+            "message": {
+                "id": msg.get("id"),
+                "threadId": msg.get("threadId"),
+                "labelIds": msg.get("labelIds"),
+                "snippet": msg.get("snippet"),
+                "headers": _headers_to_dict(payload.get("headers", [])),
+                "body": _extract_plain_body(payload),
+            },
+        }
+
+    if a.cmd == "send":
+        em = EmailMessage()
+        em["To"] = a.to
+        em["Subject"] = a.subject
+        if a.cc:
+            em["Cc"] = a.cc
+        if a.bcc:
+            em["Bcc"] = a.bcc
+        em.set_content(a.body)
+        raw = base64.urlsafe_b64encode(em.as_bytes()).decode("ascii")
+        sent = _req("POST", "messages/send", body={"raw": raw})
+        return {"ok": True, "sent": sent}
+
+    if a.cmd == "labels":
+        resp = _req("GET", "labels")
+        return {"ok": True, "labels": resp.get("labels") or []}
+
+    if a.cmd == "modify":
+        body: dict[str, Any] = {}
+        if add := _comma_list(a.add):
+            body["addLabelIds"] = add
+        if remove := _comma_list(a.remove):
+            body["removeLabelIds"] = remove
+        if not body:
+            return {"ok": False, "error": "nothing_to_modify"}
+        msg = _req("POST", f"messages/{_seg(a.message_id)}/modify", body=body)
+        return {"ok": True, "id": msg.get("id"), "labelIds": msg.get("labelIds")}
+
+    if a.cmd == "trash":
+        msg = _req("POST", f"messages/{_seg(a.message_id)}/trash")
+        return {"ok": True, "id": msg.get("id"), "labelIds": msg.get("labelIds")}
+
+    if a.cmd == "profile":
+        return {"ok": True, "profile": _req("GET", "profile")}
+
+    # `call` raw escape hatch
+    body = None
+    if a.json_body:
+        body = json.loads(a.json_body)
+        if not isinstance(body, dict):
+            return {"ok": False, "error": "json_body_not_object"}
+    resp = _req(a.method, a.path.lstrip("/"), body=body)
+    return {"ok": True, "data": resp}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    try:
+        result = _dispatch(a)
+    except json.JSONDecodeError as e:
+        print(f"invalid json_body: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code} calling Gmail: {detail}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling Gmail: {e.reason}", file=sys.stderr)
+        return 1
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
@@ -13,12 +13,16 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 from email.message import EmailMessage
 from typing import Any
 
 _BASE = "https://gmail.googleapis.com/gmail/v1/users/me/"
 _PAGE_SIZE = 100
 _DEFAULT_LIMIT = 25
+# Each listed message needs its own metadata GET (Gmail's list returns only
+# id/threadId), so fan them out concurrently rather than N sequential calls.
+_MAX_FETCH_WORKERS = 8
 _METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE")
 # Headers worth surfacing from a metadata-format message fetch.
 _METADATA_HEADERS = ("From", "To", "Cc", "Subject", "Date")
@@ -148,6 +152,22 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _message_summary(ref: dict[str, Any]) -> dict[str, Any]:
+    """Fetch one message's metadata and reduce it to the summary fields."""
+    msg = _req(
+        "GET",
+        f"messages/{_seg(ref['id'])}",
+        params={"format": "metadata", "metadataHeaders": list(_METADATA_HEADERS)},
+    )
+    return {
+        "id": msg.get("id"),
+        "threadId": msg.get("threadId"),
+        "labelIds": msg.get("labelIds"),
+        "snippet": msg.get("snippet"),
+        "headers": _headers_to_dict(msg.get("payload", {}).get("headers", [])),
+    }
+
+
 def _cmd_messages(a: argparse.Namespace) -> dict[str, Any]:
     listed = _list_ids(
         "messages",
@@ -155,22 +175,14 @@ def _cmd_messages(a: argparse.Namespace) -> dict[str, Any]:
         "messages",
         a.limit,
     )
-    summaries: list[dict[str, Any]] = []
-    for ref in listed["items"]:
-        msg = _req(
-            "GET",
-            f"messages/{_seg(ref['id'])}",
-            params={"format": "metadata", "metadataHeaders": list(_METADATA_HEADERS)},
-        )
-        summaries.append(
-            {
-                "id": msg.get("id"),
-                "threadId": msg.get("threadId"),
-                "labelIds": msg.get("labelIds"),
-                "snippet": msg.get("snippet"),
-                "headers": _headers_to_dict(msg.get("payload", {}).get("headers", [])),
-            }
-        )
+    refs = listed["items"]
+    # Fan the per-message metadata GETs out concurrently: a page of N is then
+    # ~one round-trip of latency instead of N sequential ones. `map` preserves
+    # input order and re-raises the first failure (same fail-fast as a loop).
+    with ThreadPoolExecutor(
+        max_workers=min(_MAX_FETCH_WORKERS, len(refs) or 1)
+    ) as pool:
+        summaries = list(pool.map(_message_summary, refs))
     return {
         "ok": True,
         "items": summaries,

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -171,6 +171,7 @@ _REGISTRY: Final = BuiltInSkillRegistry(
         ExternalAppBuiltInProvider(
             skill_id="google-calendar", app_type=ExternalAppType.GOOGLE_CALENDAR
         ),
+        ExternalAppBuiltInProvider(skill_id="gmail", app_type=ExternalAppType.GMAIL),
     )
 )
 

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -1,14 +1,20 @@
-import { SvgSlack, SvgLinear } from "@opal/logos";
+import { SvgSlack, SvgLinear, SvgGmail } from "@opal/logos";
 import { SvgCalendar, SvgPlug } from "@opal/icons";
 import { IconFunctionComponent } from "@opal/types";
 
 // Mirrors `onyx.db.enums.ExternalAppType` on the backend.
-export type ExternalAppType = "SLACK" | "GOOGLE_CALENDAR" | "LINEAR" | "CUSTOM";
+export type ExternalAppType =
+  | "SLACK"
+  | "GOOGLE_CALENDAR"
+  | "GMAIL"
+  | "LINEAR"
+  | "CUSTOM";
 
 const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
   {
     SLACK: SvgSlack,
     GOOGLE_CALENDAR: SvgCalendar,
+    GMAIL: SvgGmail,
     LINEAR: SvgLinear,
   };
 


### PR DESCRIPTION
## Description
Adds gmail as a built-in external app for craft

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Gmail as a built-in external app for Craft so users can read, search, and send email. Also adds a shared Google OAuth base and refactors Calendar to use it, and wires Gmail into the web app with its icon.

- New Features
  - Added Gmail provider with scope `https://www.googleapis.com/auth/gmail.modify`; registered in providers, enums, built-in skills, and web registry (`SvgGmail`).
  - Added sandbox Gmail skill with `gmail_api.py` to list/search, read, send, label, and trash messages (no permanent delete).
  - Admins: enable the Gmail API and reuse the same Google OAuth client (Client ID/Secret) in org settings.

- Refactors
  - Introduced `GoogleOAuthProvider` to centralize Google OAuth flow, credentials, setup instructions, and token extraction; `GoogleCalendarProvider` now extends it.

<sup>Written for commit 00ceef7eea81373a2fc7ec20c44ea605251ca91e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



