### PR TITLE
fix(craft): scope opencode-serve /event SSE per directory

### DIFF
--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -433,6 +433,7 @@ class SandboxManager(ABC):
         sandbox_id: UUID,  # noqa: ARG002
         opencode_session_id: str,  # noqa: ARG002
         *,
+        directory: str,  # noqa: ARG002
         keepalive_seconds: float = 15.0,  # noqa: ARG002
     ) -> Generator["ACPEvent", None, None]:
         """Stream events for an arbitrary opencode session without

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -326,8 +326,10 @@ class KubernetesSandboxManager(SandboxManager):
         self._s3_bucket = SANDBOX_S3_BUCKET
         self._service_account = SANDBOX_SERVICE_ACCOUNT_NAME
 
-        # One PodEventBus per pod, created lazily on first send_message.
-        self._event_buses: dict[UUID, PodEventBus] = {}
+        # One PodEventBus per (pod, directory). Opencode-serve's
+        # Instance.provide middleware scopes /event per ?directory= query,
+        # so each session directory needs its own SSE stream.
+        self._event_buses: dict[tuple[UUID, str], PodEventBus] = {}
         # Tombstone set: blocks late ``subscribe`` from re-creating a bus
         # for a sandbox whose terminate is in flight (leaks a reconnect
         # loop otherwise). Cleared on re-provision.
@@ -1386,12 +1388,14 @@ class KubernetesSandboxManager(SandboxManager):
 
     def terminate(self, sandbox_id: UUID) -> None:
         """Tear down the per-pod event bus, then delete Service + Pod."""
-        # Tombstone + pop under one lock so a concurrent subscribe can't
-        # race in and create a fresh bus against the dying pod.
+        # Tombstone + pop all buses for this sandbox (one per directory)
+        # under one lock so a concurrent subscribe can't race in and create
+        # a fresh bus against the dying pod.
         with self._event_buses_lock:
             self._terminated_sandboxes.add(sandbox_id)
-            bus = self._event_buses.pop(sandbox_id, None)
-        if bus is not None:
+            doomed_keys = [k for k in self._event_buses if k[0] == sandbox_id]
+            doomed_buses = [self._event_buses.pop(k) for k in doomed_keys]
+        for bus in doomed_buses:
             try:
                 bus.close()
             except Exception:  # noqa: BLE001 — never let cleanup break terminate
@@ -2241,25 +2245,33 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         )
         return False
 
-    def _get_or_create_event_bus(self, sandbox_id: UUID) -> "PodEventBus":
-        """Lazily build the per-pod :class:`PodEventBus`. Refuses to
-        create one for a terminated sandbox (see ``_terminated_sandboxes``).
+    def _get_or_create_event_bus(
+        self, sandbox_id: UUID, directory: str
+    ) -> "PodEventBus":
+        """Lazily build the per-(pod, directory) :class:`PodEventBus`.
+        Refuses to create one for a terminated sandbox.
+
+        Opencode-serve's ``Instance.provide`` middleware scopes /event
+        per ``?directory=`` query param, so we need one SSE stream per
+        unique session directory on the pod.
 
         Replaces a cached bus that has self-closed (exhausted its reconnect
         budget) with a fresh one — otherwise callers would keep getting
         ``BUS_CLOSED_SENTINEL`` until the api server restarted.
         """
+        key = (sandbox_id, directory)
         with self._event_buses_lock:
-            bus = self._event_buses.get(sandbox_id)
+            bus = self._event_buses.get(key)
             if bus is not None and not bus.closed:
                 return bus
             if bus is not None and bus.closed:
                 logger.warning(
                     "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
-                    "sandbox %s (prior bus exhausted its reconnect budget)",
+                    "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
                     sandbox_id,
+                    directory,
                 )
-                self._event_buses.pop(sandbox_id, None)
+                self._event_buses.pop(key, None)
             if sandbox_id in self._terminated_sandboxes:
                 raise RuntimeError(
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
@@ -2280,17 +2292,22 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             bus = PodEventBus(
                 base_url=self._serve_base_url(sandbox_id),
                 auth=auth,
+                directory=directory,
                 event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
             )
-            self._event_buses[sandbox_id] = bus
+            self._event_buses[key] = bus
             logger.info(
-                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s", sandbox_id
+                "[SANDBOX-SERVE] Created PodEventBus for sandbox %s dir=%s",
+                sandbox_id,
+                directory,
             )
             return bus
 
-    def _build_serve_client(self, sandbox_id: UUID) -> OpencodeServeClient:
+    def _build_serve_client(
+        self, sandbox_id: UUID, directory: str
+    ) -> OpencodeServeClient:
         password = self._read_opencode_password(sandbox_id)
-        bus = self._get_or_create_event_bus(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
         return OpencodeServeClient(
             base_url=self._serve_base_url(sandbox_id),
             password=password,
@@ -2353,7 +2370,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             sandbox_id,
             session_path,
         )
-        with self._build_serve_client(sandbox_id) as client:
+        with self._build_serve_client(sandbox_id, session_path) as client:
             return client.ensure_session(
                 None,
                 directory=session_path,
@@ -2368,18 +2385,24 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         if AGENT_TRANSPORT != AgentTransport.SERVE:
             return []
         # Don't create a bus just to list — that spins up a reader thread
-        # for a caller that didn't ask for events.
+        # for a caller that didn't ask for events. Walk all per-directory
+        # buses for this sandbox; the parent session lives in exactly one.
         with self._event_buses_lock:
-            bus = self._event_buses.get(sandbox_id)
-        if bus is None:
-            return []
-        return bus.list_children(parent_opencode_session_id)
+            buses = [
+                b for (sid, _), b in self._event_buses.items() if sid == sandbox_id
+            ]
+        for bus in buses:
+            children = bus.list_children(parent_opencode_session_id)
+            if children:
+                return children
+        return []
 
     def subscribe_to_opencode_session(
         self,
         sandbox_id: UUID,
         opencode_session_id: str,
         *,
+        directory: str,
         keepalive_seconds: float = 15.0,
     ) -> Generator[ACPEvent, None, None]:
         """Stream translated ACP events for an opencode session (parent
@@ -2395,7 +2418,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             translate_opencode_event,
         )
 
-        bus = self._get_or_create_event_bus(sandbox_id)
+        bus = self._get_or_create_event_bus(sandbox_id, directory)
         state = _TurnState(session_id=opencode_session_id)
         sub = bus.subscribe(opencode_session_id)
         try:
@@ -2442,7 +2465,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         """
         packet_logger = get_packet_logger()
         session_path = f"/workspace/sessions/{session_id}"
-        client = self._build_serve_client(sandbox_id)
+        client = self._build_serve_client(sandbox_id, session_path)
         try:
             logger.info(
                 "[SESSION-LIFECYCLE] _send_message_via_serve: build_session=%s "

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -53,11 +53,17 @@ class PodEventBus:
         base_url: str,
         auth: httpx.Auth | None,
         *,
+        directory: str | None = None,
         connect_timeout: float = 10.0,
         event_read_timeout: float | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._auth = auth
+        # Opencode-serve's Instance.provide middleware scopes /event per
+        # ?directory= query param. Without it, the SSE stream only sees the
+        # default Instance (server.connected, server.heartbeat) — session
+        # events are routed to the per-directory Instance.
+        self._directory = directory
         self._connect_timeout = connect_timeout
         # Per-read inactivity timeout for the SSE /event stream. ``None`` means
         # block indefinitely between server frames (legacy behavior); a float
@@ -217,10 +223,12 @@ class PodEventBus:
             write=10.0,
             pool=10.0,
         )
+        params = {"directory": self._directory} if self._directory else None
         with httpx.stream(
             "GET",
             f"{self._base_url}/event",
             auth=self._auth,
+            params=params,
             timeout=timeout,
         ) as response:
             response.raise_for_status()

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -88,9 +88,10 @@ class PodEventBus:
     def closed(self) -> bool:
         """True once the bus has either been explicitly closed or self-closed
         after exhausting its reconnect budget. Callers that cache buses
-        (e.g. ``KubernetesSandboxManager._event_buses``) should check this
-        before reusing a bus — a closed bus will only deliver
-        ``BUS_CLOSED_SENTINEL`` to subscribers."""
+        (e.g. ``KubernetesSandboxManager._event_buses``, keyed by
+        ``(sandbox_id, directory)``) should check this before reusing a bus —
+        a closed bus will only deliver ``BUS_CLOSED_SENTINEL`` to
+        subscribers."""
         return self._closed
 
     def subscribe(self, session_id: str) -> _Subscription:
@@ -234,8 +235,9 @@ class PodEventBus:
             response.raise_for_status()
             self.stream_ready.set()
             logger.info(
-                "PodEventBus connected to %s/event (status=%s)",
+                "PodEventBus connected to %s/event?directory=%s (status=%s)",
                 self._base_url,
+                self._directory,
                 response.status_code,
             )
             buf = ""

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -17,8 +17,10 @@ from collections.abc import Generator
 from queue import Empty
 from typing import Any
 
+import httpx
 import pytest
 
+from onyx.server.features.build.sandbox.opencode import event_bus as event_bus_mod
 from onyx.server.features.build.sandbox.opencode.event_bus import _extract_session_id
 from onyx.server.features.build.sandbox.opencode.event_bus import _parse_sse_block
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
@@ -385,6 +387,64 @@ def test_close_signals_subscribers_even_with_full_queue(bus: PodEventBus) -> Non
 def test_close_is_idempotent(bus: PodEventBus) -> None:
     bus.close()
     bus.close()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# /event request scoping — directory query parameter
+# ---------------------------------------------------------------------------
+#
+# opencode-serve's ``Instance.provide`` middleware reads ``?directory=`` off
+# the /event request and routes the subscription to that directory's
+# Instance. Without the query param, the SSE stream only sees the default
+# Instance (server.connected + server.heartbeat) and session events for
+# /workspace/sessions/<id> never arrive — sessions on the same pod silently
+# fail or cross-talk depending on which one connected first. These tests
+# pin the wire-level contract.
+
+
+class _CapturingStream:
+    """Stand-in for ``httpx.stream``'s return value. Records the kwargs the
+    bus passed (URL, params, auth, timeout) and raises a ``ConnectError`` on
+    ``__enter__`` so ``_read_one_stream`` exits without trying to consume a
+    response body."""
+
+    captured: dict[str, Any] = {}
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).captured = {"args": args, "kwargs": kwargs}
+
+    def __enter__(self) -> Any:
+        raise httpx.ConnectError("test stop")
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def test_read_one_stream_passes_directory_as_query_param(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the bus is constructed with ``directory=...``, the GET /event
+    call MUST include ``?directory=...`` so opencode-serve scopes the
+    subscription to that Instance. Without this param, no session events
+    are delivered — which is exactly the bug this PR fixes."""
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _CapturingStream)
+    bus = PodEventBus(
+        base_url="http://test.invalid:4096",
+        auth=None,
+        directory="/workspace/sessions/abc-123",
+    )
+    try:
+        with pytest.raises(httpx.ConnectError):
+            bus._read_one_stream()
+    finally:
+        bus.close()
+
+    kwargs = _CapturingStream.captured["kwargs"]
+    args = _CapturingStream.captured["args"]
+    assert kwargs["params"] == {"directory": "/workspace/sessions/abc-123"}
+    # The directory must travel as a query param, not be baked into the path —
+    # the URL stays the bare /event endpoint.
+    assert args == ("GET", "http://test.invalid:4096/event")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus_per_directory.py
@@ -1,0 +1,367 @@
+"""Tests for per-(sandbox_id, directory) :class:`PodEventBus` keying in
+:class:`KubernetesSandboxManager`.
+
+Production bug (May 2026): when two build sessions ran on the same
+opencode-serve pod, both sessions shared one bus subscribed to
+``GET /event`` with no ``?directory=`` query param. opencode-serve's
+``Instance.provide`` middleware scopes /event per directory, so the
+shared bus only saw the default Instance's global events
+(``server.connected``, ``server.heartbeat``) — *no* session events for
+either session. Both sessions hung waiting for terminators that would
+never arrive.
+
+The fix:
+
+1. ``PodEventBus`` accepts ``directory=...`` and passes it as
+   ``?directory=`` to /event (wire-level scoping; tested in
+   ``test_event_bus.py``).
+2. ``KubernetesSandboxManager._event_buses`` is keyed by
+   ``(sandbox_id, directory)`` — one bus per session directory on the
+   pod. Parallel sessions get *distinct* buses, each subscribed to its
+   own ``?directory=``, so events stay scoped end to end.
+3. ``terminate(sandbox_id)`` closes **all** per-directory buses for the
+   sandbox in one shot — otherwise tearing down a pod would leak any
+   bus that wasn't keyed by the sandbox's most-recent directory.
+4. ``list_subagents`` walks every per-directory bus for the sandbox
+   (the parent session lives in exactly one of them).
+
+These tests pin those invariants directly against the manager so a
+future refactor that flattens the key back to ``sandbox_id`` (or scopes
+``terminate`` to one directory) fails loudly.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Generator
+from queue import Empty
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.configs import AgentTransport
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _serve_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``list_subagents`` and bus creation only kick in under SERVE."""
+    monkeypatch.setattr(ksm, "AGENT_TRANSPORT", AgentTransport.SERVE)
+
+
+@pytest.fixture
+def mgr() -> Generator[KubernetesSandboxManager, None, None]:
+    """Manager with just the event-bus state initialized — skips
+    ``_initialize`` so no kube config is required. Stubs the two helpers
+    ``_get_or_create_event_bus`` calls so we don't need real auth or pod
+    URLs."""
+    m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    m._event_buses = {}  # type: ignore[attr-defined]
+    m._event_buses_lock = threading.Lock()  # type: ignore[attr-defined]
+    m._terminated_sandboxes = set()  # type: ignore[attr-defined]
+
+    # Stub auth + URL lookups so we don't touch K8s.
+    m._read_opencode_password = lambda _sandbox_id: None  # type: ignore[assignment]
+    m._serve_base_url = lambda sandbox_id: f"http://{sandbox_id}.invalid:4096"  # type: ignore[assignment]
+
+    try:
+        yield m
+    finally:
+        # Close any buses the test created so reader threads don't linger.
+        with m._event_buses_lock:
+            buses = list(m._event_buses.values())
+            m._event_buses.clear()
+        for bus in buses:
+            bus.close()
+
+
+# Two distinct session directories on the same pod — the production
+# scenario the bug reproduced under.
+_DIR_A = "/workspace/sessions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_DIR_B = "/workspace/sessions/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_SES_A = "ses_A"
+_SES_B = "ses_B"
+
+
+def _make_part_delta(session_id: str, text: str) -> dict[str, Any]:
+    """Minimal ``message.part.delta`` shape the bus dispatcher routes by
+    ``properties.sessionID``."""
+    return {
+        "type": "message.part.delta",
+        "properties": {
+            "sessionID": session_id,
+            "messageID": "msg1",
+            "partID": "p1",
+            "field": "text",
+            "delta": text,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-(sandbox_id, directory) keying
+# ---------------------------------------------------------------------------
+
+
+def test_two_directories_on_same_pod_get_distinct_buses(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """The core fix: two sessions on the same pod (same sandbox_id, but
+    different session directories) MUST get separate ``PodEventBus``
+    instances — one per ``?directory=``. If they shared a bus, the bus
+    would be subscribed to a single Instance's event stream and the
+    other session's events would never arrive."""
+    sandbox_id = uuid4()
+    bus_a = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_b = mgr._get_or_create_event_bus(sandbox_id, _DIR_B)
+    assert bus_a is not bus_b
+    # Each bus carries its own ``?directory=`` for the GET /event call.
+    assert bus_a._directory == _DIR_A
+    assert bus_b._directory == _DIR_B
+
+
+def test_same_directory_returns_cached_bus(mgr: KubernetesSandboxManager) -> None:
+    """Memoization: repeat calls for the same ``(sandbox_id, directory)``
+    return the same bus instance — otherwise every send_message would
+    spin up a fresh reader thread + httpx client."""
+    sandbox_id = uuid4()
+    bus_1 = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_2 = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    assert bus_1 is bus_2
+
+
+def test_different_sandboxes_same_directory_get_distinct_buses(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """Same directory string on two different pods is still two buses —
+    the sandbox_id half of the key keeps cross-pod isolation."""
+    sandbox_1, sandbox_2 = uuid4(), uuid4()
+    bus_1 = mgr._get_or_create_event_bus(sandbox_1, _DIR_A)
+    bus_2 = mgr._get_or_create_event_bus(sandbox_2, _DIR_A)
+    assert bus_1 is not bus_2
+
+
+# ---------------------------------------------------------------------------
+# Parallel-session scoping — events stay per-session AND per-directory
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_sessions_packets_stay_scoped_to_their_directory(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """End-to-end scoping invariant for two parallel sessions on one pod:
+
+    Wire layer: each bus passes its own ``?directory=`` so opencode-serve
+    only emits that directory's events into that bus (already covered by
+    the wire-level test in ``test_event_bus.py``). Application layer: a
+    subscriber on bus A must not see packets that arrived on bus B —
+    even when the events would have matched their session ID had they
+    arrived on the wrong bus.
+
+    Simulates production by:
+    1. Creating two buses (one per session directory).
+    2. Subscribing to each bus with its own session ID.
+    3. Dispatching session A's packets ONLY into bus A
+       (opencode-serve would never route them to bus B because the bus
+       is subscribed to a different ``?directory=``).
+    4. Verifying each subscriber's queue contains only its own packets.
+
+    If the manager regresses to one-bus-per-pod, both subscriptions
+    would end up on the same bus and this test would still pass — but
+    the wire-level test would catch that. If the bus regresses to
+    fanning out across all subscribers regardless of session ID, this
+    test catches it.
+    """
+    sandbox_id = uuid4()
+    bus_a = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_b = mgr._get_or_create_event_bus(sandbox_id, _DIR_B)
+
+    sub_a = bus_a.subscribe(_SES_A)
+    sub_b = bus_b.subscribe(_SES_B)
+
+    # Three packets for session A, dispatched into bus A only.
+    for chunk in ("hello", " ", "world"):
+        bus_a._dispatch(_make_part_delta(_SES_A, chunk))
+
+    # Two packets for session B, dispatched into bus B only.
+    for chunk in ("foo", "bar"):
+        bus_b._dispatch(_make_part_delta(_SES_B, chunk))
+
+    # Drain — subscriber A gets only A's packets, in order.
+    a_deltas: list[str] = []
+    while True:
+        try:
+            evt = sub_a.queue.get_nowait()
+        except Empty:
+            break
+        assert evt is not None
+        a_deltas.append(evt["properties"]["delta"])
+
+    b_deltas: list[str] = []
+    while True:
+        try:
+            evt = sub_b.queue.get_nowait()
+        except Empty:
+            break
+        assert evt is not None
+        b_deltas.append(evt["properties"]["delta"])
+
+    assert a_deltas == ["hello", " ", "world"]
+    assert b_deltas == ["foo", "bar"]
+
+
+def test_parallel_session_subscriber_does_not_see_other_session_on_its_own_bus(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """Defense-in-depth: even if opencode-serve mis-routed a foreign
+    session's event onto bus A (e.g. opencode emitted a cross-Instance
+    leak, or our scoping assumption was wrong), the bus's own
+    session-ID filter must still drop it. This pins the second layer of
+    isolation independent of the wire-level scoping."""
+    sandbox_id = uuid4()
+    bus_a = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    sub_a = bus_a.subscribe(_SES_A)
+
+    # Foreign packet for session B arrives on bus A — must be dropped.
+    bus_a._dispatch(_make_part_delta(_SES_B, "ghost"))
+    with pytest.raises(Empty):
+        sub_a.queue.get_nowait()
+
+    # And the real packet for session A still arrives.
+    bus_a._dispatch(_make_part_delta(_SES_A, "real"))
+    real_evt = sub_a.queue.get_nowait()
+    assert real_evt is not None
+    assert real_evt["properties"]["delta"] == "real"
+
+
+# ---------------------------------------------------------------------------
+# terminate() must close ALL per-directory buses for the sandbox
+# ---------------------------------------------------------------------------
+
+
+def test_terminate_closes_every_per_directory_bus_for_sandbox(
+    mgr: KubernetesSandboxManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bug's mirror image: with the new keying, ``terminate`` must
+    iterate every key whose first element is ``sandbox_id`` and close
+    each bus. If somebody regresses ``terminate`` to ``_event_buses.pop(
+    sandbox_id, None)`` (the old single-key form), the other directory's
+    bus would leak — its reader thread + httpx client would survive the
+    pod deletion and eventually exhaust the reconnect budget against a
+    dead pod."""
+    sandbox_id = uuid4()
+    # Two buses on the same pod, plus one on an unrelated pod that must
+    # NOT be touched.
+    bus_a = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_b = mgr._get_or_create_event_bus(sandbox_id, _DIR_B)
+    other_sandbox = uuid4()
+    bus_other = mgr._get_or_create_event_bus(other_sandbox, _DIR_A)
+
+    # Stub out the K8s teardown — we only care about the bus-close path.
+    monkeypatch.setattr(mgr, "_cleanup_kubernetes_resources", lambda _sandbox_str: None)
+
+    mgr.terminate(sandbox_id)
+
+    # Both of the terminated sandbox's buses are closed and removed.
+    assert bus_a.closed
+    assert bus_b.closed
+    with mgr._event_buses_lock:
+        keys = list(mgr._event_buses.keys())
+    assert (sandbox_id, _DIR_A) not in keys
+    assert (sandbox_id, _DIR_B) not in keys
+
+    # The unrelated sandbox's bus survives.
+    assert not bus_other.closed
+    assert (other_sandbox, _DIR_A) in keys
+
+    # And the tombstone is set so a late ``_get_or_create_event_bus``
+    # against the terminated sandbox can't race in and rebuild a bus.
+    with pytest.raises(RuntimeError, match="terminated"):
+        mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+
+
+# ---------------------------------------------------------------------------
+# list_subagents must walk every per-directory bus for the sandbox
+# ---------------------------------------------------------------------------
+
+
+def test_list_subagents_finds_parent_in_any_per_directory_bus(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """Subagent parent-child mappings live on whichever bus the
+    ``session.created`` event happened to land on (i.e. the bus for the
+    parent's directory). With per-directory keying, ``list_subagents``
+    must walk every bus belonging to the sandbox; a regression that
+    only checks one bus would intermittently return ``[]`` for parents
+    whose directory wasn't the first key inserted."""
+    sandbox_id = uuid4()
+    # Two buses, but the parent session.created event arrives only on
+    # bus B — list_subagents must still find it.
+    mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_b = mgr._get_or_create_event_bus(sandbox_id, _DIR_B)
+
+    bus_b._dispatch(
+        {
+            "type": "session.created",
+            "properties": {
+                "sessionID": "ses_child",
+                "info": {"id": "ses_child", "parentID": "ses_parent"},
+            },
+        }
+    )
+
+    assert mgr.list_subagents(sandbox_id, "ses_parent") == ["ses_child"]
+
+
+def test_list_subagents_returns_empty_when_no_bus_holds_the_parent(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """Sanity: with buses present but no session.created seen, the
+    method must return ``[]`` — not raise, not return some other
+    session's children."""
+    sandbox_id = uuid4()
+    mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    mgr._get_or_create_event_bus(sandbox_id, _DIR_B)
+    assert mgr.list_subagents(sandbox_id, "ses_unknown_parent") == []
+
+
+def test_list_subagents_does_not_create_a_bus_just_to_check(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """``list_subagents`` is called on hot paths (UI polling); it must
+    not spin up a bus + reader thread for a sandbox that has none.
+    Empty pod → empty list, zero side effects."""
+    sandbox_id = uuid4()
+    assert mgr.list_subagents(sandbox_id, "ses_anything") == []
+    with mgr._event_buses_lock:
+        assert mgr._event_buses == {}
+
+
+# ---------------------------------------------------------------------------
+# Self-closed bus replacement still works under per-directory keying
+# ---------------------------------------------------------------------------
+
+
+def test_self_closed_bus_is_replaced_for_same_directory(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    """The existing self-close replacement path (see
+    ``test_bus_closed_property.py``) must still work after the keying
+    change — otherwise a pod that survives a transient outage would
+    stay wedged on its dead bus forever."""
+    sandbox_id = uuid4()
+    bus_1 = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    bus_1.close()  # simulate self-close from exhausted reconnect budget
+    assert bus_1.closed
+
+    bus_2 = mgr._get_or_create_event_bus(sandbox_id, _DIR_A)
+    assert bus_2 is not bus_1
+    assert not bus_2.closed


### PR DESCRIPTION
## Description

Scopes the `opencode-serve` `/event` SSE stream by session directory so multiple sessions sharing a pod don't cross-talk or miss events.

- Keys `PodEventBus` by `(sandbox_id, directory)` and passes `?directory=` to `/event`.
- `terminate` closes all per-directory buses for a pod; `list_subagents` searches existing buses for the parent.
- Client paths now include the session directory when ensuring sessions and sending messages.
- `subscribe_to_opencode_session(..., directory=...)` now requires the session directory (e.g. `/workspace/sessions/{session_id}`).

## How Has This Been Tested?

Manually verified that concurrent sessions on the same pod each receive only their own events and that termination closes all per-directory buses.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check