### PR TITLE
Jira Service Management Connector - pull all tickets from a specified JSM project

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -215,6 +215,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -693,6 +694,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Jira Service Management - IT service management tickets (incidents, service requests, problems, changes)",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,25 +1,19 @@
 import copy
-from collections.abc import Callable
-from collections.abc import Generator
-from collections.abc import Iterator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from typing import Any
 
 from jira import JIRA
-from jira.resources import Issue
 from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import JIRA_CONNECTOR_LABELS_TO_SKIP
-from onyx.configs.app_configs import JIRA_CONNECTOR_MAX_TICKET_SIZE
 from onyx.configs.app_configs import JIRA_SLIM_PAGE_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     is_atlassian_date_error,
 )
-from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import UnexpectedValidationError
@@ -30,64 +24,28 @@ from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnectorWithPermSync
 from onyx.connectors.jira.access import get_project_permissions
 from onyx.connectors.jira.connector import (
-    _FIELD_ASSIGNEE,
-    _FIELD_ASSIGNEE_EMAIL,
-    _FIELD_CREATED,
-    _FIELD_DUEDATE,
-    _FIELD_ISSUETYPE,
     _FIELD_KEY,
-    _FIELD_LABELS,
-    _FIELD_PARENT,
-    _FIELD_PRIORITY,
     _FIELD_PROJECT,
-    _FIELD_PROJECT_NAME,
-    _FIELD_REPORTER,
-    _FIELD_REPORTER_EMAIL,
-    _FIELD_RESOLUTION,
-    _FIELD_RESOLUTION_DATE,
-    _FIELD_RESOLUTION_DATE_KEY,
-    _FIELD_STATUS,
-    _FIELD_UPDATED,
     _is_cloud_client,
     _perform_jql_search,
     JiraConnectorCheckpoint,
     make_checkpoint_callback,
 )
-from onyx.connectors.jira.connector import bulk_fetch_issues
-from onyx.connectors.jira.connector import (
-    enhanced_search_ids,
-)
 from onyx.connectors.jira.connector import process_jira_issue
-from onyx.connectors.jira.utils import best_effort_basic_expert_info
 from onyx.connectors.jira.utils import best_effort_get_field_from_issue
 from onyx.connectors.jira.utils import build_jira_client
 from onyx.connectors.jira.utils import build_jira_url
-from onyx.connectors.jira.utils import extract_text_from_adf
-from onyx.connectors.jira.utils import get_comment_strs
 from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import ConnectorFailure
-from onyx.connectors.models import Document
 from onyx.connectors.models import DocumentFailure
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
-from onyx.connectors.models import TextSection
-from onyx.db.enums import HierarchyNodeType
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 ONE_HOUR = 3600
-
-# Jira Service Management specific issue types
-JSM_ISSUE_TYPES = [
-    "Incident",
-    "Service Request",
-    "Problem",
-    "Change",
-    "Change Task",
-    "Post-Incident Review",
-]
 
 
 class JiraServiceManagementConnector(
@@ -155,9 +113,10 @@ class JiraServiceManagementConnector(
         """
         Build a JQL query targeting a specific JSM project.
 
-        If jsm_issue_types is provided, also filters by those issue types
-        (e.g., Incident, Service Request, Problem, Change).
-        If not provided, all issue types in the JSM project are included.
+        If jsm_issue_types is provided with non-blank entries, also filters by
+        those issue types (e.g., Incident, Service Request, Problem, Change).
+        If empty, blank-only, or not provided, all issue types in the JSM
+        project are included.
         """
         start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
             "%Y-%m-%d %H:%M"
@@ -168,12 +127,13 @@ class JiraServiceManagementConnector(
 
         jql = f"project = {self.quoted_jsm_project_key}"
 
-        # Optionally filter by JSM-specific issue types
+        # Only add issuetype filter when there are non-blank entries to avoid
+        # producing `issuetype in ()` which Jira rejects.
         if self.jsm_issue_types:
-            issue_type_clause = ", ".join(
-                f'"{it.strip()}"' for it in self.jsm_issue_types if it.strip()
-            )
-            jql += f" AND issuetype in ({issue_type_clause})"
+            cleaned = [it.strip() for it in self.jsm_issue_types if it.strip()]
+            if cleaned:
+                issue_type_clause = ", ".join(f'"{t}"' for t in cleaned)
+                jql += f" AND issuetype in ({issue_type_clause})"
 
         jql += f" AND updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
 
@@ -188,7 +148,11 @@ class JiraServiceManagementConnector(
         return None
 
     def _load_from_checkpoint(
-        self, start: float, end: float, checkpoint: JiraConnectorCheckpoint, include_permissions: bool
+        self,
+        start: float,
+        end: float,
+        checkpoint: JiraConnectorCheckpoint,
+        include_permissions: bool,
     ) -> CheckpointOutput[JiraConnectorCheckpoint]:
         jql = self._build_jsm_jql(start, end)
         starting_offset = checkpoint.offset or 0

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,437 @@
+import copy
+from collections.abc import Callable
+from collections.abc import Generator
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+from jira import JIRA
+from jira.resources import Issue
+from typing_extensions import override
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.app_configs import JIRA_CONNECTOR_LABELS_TO_SKIP
+from onyx.configs.app_configs import JIRA_CONNECTOR_MAX_TICKET_SIZE
+from onyx.configs.app_configs import JIRA_SLIM_PAGE_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
+    is_atlassian_date_error,
+)
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import UnexpectedValidationError
+from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnectorWithPermSync
+from onyx.connectors.jira.access import get_project_permissions
+from onyx.connectors.jira.connector import (
+    _FIELD_ASSIGNEE,
+    _FIELD_ASSIGNEE_EMAIL,
+    _FIELD_CREATED,
+    _FIELD_DUEDATE,
+    _FIELD_ISSUETYPE,
+    _FIELD_KEY,
+    _FIELD_LABELS,
+    _FIELD_PARENT,
+    _FIELD_PRIORITY,
+    _FIELD_PROJECT,
+    _FIELD_PROJECT_NAME,
+    _FIELD_REPORTER,
+    _FIELD_REPORTER_EMAIL,
+    _FIELD_RESOLUTION,
+    _FIELD_RESOLUTION_DATE,
+    _FIELD_RESOLUTION_DATE_KEY,
+    _FIELD_STATUS,
+    _FIELD_UPDATED,
+    _is_cloud_client,
+    _perform_jql_search,
+    JiraConnectorCheckpoint,
+    make_checkpoint_callback,
+)
+from onyx.connectors.jira.connector import bulk_fetch_issues
+from onyx.connectors.jira.connector import (
+    enhanced_search_ids,
+)
+from onyx.connectors.jira.connector import process_jira_issue
+from onyx.connectors.jira.utils import best_effort_basic_expert_info
+from onyx.connectors.jira.utils import best_effort_get_field_from_issue
+from onyx.connectors.jira.utils import build_jira_client
+from onyx.connectors.jira.utils import build_jira_url
+from onyx.connectors.jira.utils import extract_text_from_adf
+from onyx.connectors.jira.utils import get_comment_strs
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
+from onyx.connectors.models import TextSection
+from onyx.db.enums import HierarchyNodeType
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+ONE_HOUR = 3600
+
+# Jira Service Management specific issue types
+JSM_ISSUE_TYPES = [
+    "Incident",
+    "Service Request",
+    "Problem",
+    "Change",
+    "Change Task",
+    "Post-Incident Review",
+]
+
+
+class JiraServiceManagementConnector(
+    CheckpointedConnectorWithPermSync[JiraConnectorCheckpoint],
+    SlimConnectorWithPermSync,
+):
+    """
+    Connector for Jira Service Management (JSM) projects.
+
+    Jira Service Management is a specialized Jira variant for IT service management,
+    customer support, and operations. This connector targets specific JSM projects
+    and can optionally filter by JSM-specific issue types.
+
+    Reuses the existing Jira connector infrastructure (utilities, permission sync,
+    checkpointing, etc.) while providing JSM-specific project targeting.
+    """
+
+    def __init__(
+        self,
+        jira_base_url: str,
+        jsm_project_key: str,
+        comment_email_blacklist: list[str] | None = None,
+        batch_size: int = INDEX_BATCH_SIZE,
+        labels_to_skip: list[str] = JIRA_CONNECTOR_LABELS_TO_SKIP,
+        jsm_issue_types: list[str] | None = None,
+        scoped_token: bool = False,
+    ) -> None:
+        self.batch_size = batch_size
+        self.jira_base = jira_base_url.rstrip("/")
+        self.jsm_project_key = jsm_project_key
+        self._comment_email_blacklist = comment_email_blacklist or []
+        self.labels_to_skip = set(labels_to_skip)
+        self.jsm_issue_types = jsm_issue_types
+        self.scoped_token = scoped_token
+        self._jira_client: JIRA | None = None
+        self._project_permissions_cache: dict[str, Any] = {}
+
+    @property
+    def comment_email_blacklist(self) -> tuple:
+        return tuple(email.strip() for email in self._comment_email_blacklist)
+
+    @property
+    def jira_client(self) -> JIRA:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira")
+        return self._jira_client
+
+    @property
+    def quoted_jsm_project_key(self) -> str:
+        return f'"{self.jsm_project_key}"'
+
+    def _get_project_permissions(
+        self, project_key: str, add_prefix: bool = False
+    ) -> Any:
+        cache_key = f"{project_key}:{'prefixed' if add_prefix else 'unprefixed'}"
+        if cache_key not in self._project_permissions_cache:
+            self._project_permissions_cache[cache_key] = get_project_permissions(
+                jira_client=self.jira_client,
+                jira_project=project_key,
+                add_prefix=add_prefix,
+            )
+        return self._project_permissions_cache[cache_key]
+
+    def _build_jsm_jql(self, start: float, end: float) -> str:
+        """
+        Build a JQL query targeting a specific JSM project.
+
+        If jsm_issue_types is provided, also filters by those issue types
+        (e.g., Incident, Service Request, Problem, Change).
+        If not provided, all issue types in the JSM project are included.
+        """
+        start_date_str = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+        end_date_str = datetime.fromtimestamp(end, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M"
+        )
+
+        jql = f"project = {self.quoted_jsm_project_key}"
+
+        # Optionally filter by JSM-specific issue types
+        if self.jsm_issue_types:
+            issue_type_clause = ", ".join(
+                f'"{it.strip()}"' for it in self.jsm_issue_types if it.strip()
+            )
+            jql += f" AND issuetype in ({issue_type_clause})"
+
+        jql += f" AND updated >= '{start_date_str}' AND updated <= '{end_date_str}'"
+
+        return jql
+
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._jira_client = build_jira_client(
+            credentials=credentials,
+            jira_base=self.jira_base,
+            scoped_token=self.scoped_token,
+        )
+        return None
+
+    def _load_from_checkpoint(
+        self, start: float, end: float, checkpoint: JiraConnectorCheckpoint, include_permissions: bool
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        jql = self._build_jsm_jql(start, end)
+        starting_offset = checkpoint.offset or 0
+        current_offset = starting_offset
+        new_checkpoint = copy.deepcopy(checkpoint)
+
+        checkpoint_callback = make_checkpoint_callback(new_checkpoint)
+
+        for issue in _perform_jql_search(
+            jira_client=self.jira_client,
+            jql=jql,
+            start=current_offset,
+            max_results=50,
+            all_issue_ids=new_checkpoint.all_issue_ids,
+            checkpoint_callback=checkpoint_callback,
+            nextPageToken=new_checkpoint.cursor,
+            ids_done=new_checkpoint.ids_done,
+        ):
+            issue_key = issue.key
+            try:
+                # Get JSM project key from the issue
+                project = best_effort_get_field_from_issue(issue, _FIELD_PROJECT)
+                project_key_single = project.key if project else self.jsm_project_key
+
+                if document := process_jira_issue(
+                    jira_base_url=self.jira_base,
+                    issue=issue,
+                    comment_email_blacklist=self.comment_email_blacklist,
+                    labels_to_skip=self.labels_to_skip,
+                ):
+                    # Override the source to JIRA_SERVICE_MANAGEMENT
+                    document.source = DocumentSource.JIRA_SERVICE_MANAGEMENT
+
+                    if include_permissions:
+                        document.external_access = self._get_project_permissions(
+                            project_key_single,
+                            add_prefix=True,
+                        )
+                    yield document
+
+            except Exception as e:
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=issue_key,
+                        document_link=build_jira_url(self.jira_base, issue_key),
+                    ),
+                    failure_message=f"Failed to process JSM issue: {str(e)}",
+                    exception=e,
+                )
+
+            current_offset += 1
+
+        self._update_checkpoint_for_next_run(
+            new_checkpoint, current_offset, starting_offset, 50
+        )
+
+        return new_checkpoint
+
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JiraConnectorCheckpoint,
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        try:
+            return self._load_from_checkpoint(
+                start, end, checkpoint, include_permissions=False
+            )
+        except Exception as e:
+            if is_atlassian_date_error(e):
+                return self._load_from_checkpoint(
+                    start - ONE_HOUR, end, checkpoint, include_permissions=False
+                )
+            raise e
+
+    def load_from_checkpoint_with_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: JiraConnectorCheckpoint,
+    ) -> CheckpointOutput[JiraConnectorCheckpoint]:
+        try:
+            return self._load_from_checkpoint(
+                start, end, checkpoint, include_permissions=True
+            )
+        except Exception as e:
+            if is_atlassian_date_error(e):
+                return self._load_from_checkpoint(
+                    start - ONE_HOUR, end, checkpoint, include_permissions=True
+                )
+            raise e
+
+    def _update_checkpoint_for_next_run(
+        self,
+        checkpoint: JiraConnectorCheckpoint,
+        current_offset: int,
+        starting_offset: int,
+        page_size: int,
+    ) -> None:
+        if _is_cloud_client(self.jira_client):
+            checkpoint.has_more = (
+                len(checkpoint.all_issue_ids) > 0 or not checkpoint.ids_done
+            )
+        else:
+            checkpoint.offset = current_offset
+            checkpoint.has_more = current_offset - starting_offset == page_size
+
+    def retrieve_all_slim_docs_perm_sync(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        one_day = timedelta(hours=24).total_seconds()
+
+        start = start or 0
+        end = end or datetime.now().timestamp() + one_day
+
+        jql = self._build_jsm_jql(start, end)
+        checkpoint = self.build_dummy_checkpoint()
+        checkpoint_callback = make_checkpoint_callback(checkpoint)
+        prev_offset = 0
+        current_offset = 0
+        slim_doc_batch: list[SlimDocument | HierarchyNode] = []
+
+        while checkpoint.has_more:
+            for issue in _perform_jql_search(
+                jira_client=self.jira_client,
+                jql=jql,
+                start=current_offset,
+                max_results=JIRA_SLIM_PAGE_SIZE,
+                all_issue_ids=checkpoint.all_issue_ids,
+                checkpoint_callback=checkpoint_callback,
+                nextPageToken=checkpoint.cursor,
+                ids_done=checkpoint.ids_done,
+            ):
+                issue_key = best_effort_get_field_from_issue(issue, _FIELD_KEY)
+                doc_id = build_jira_url(self.jira_base, issue_key)
+
+                slim_doc_batch.append(
+                    SlimDocument(
+                        id=doc_id,
+                        external_access=self._get_project_permissions(
+                            self.jsm_project_key, add_prefix=False
+                        ),
+                    )
+                )
+                current_offset += 1
+                if len(slim_doc_batch) >= JIRA_SLIM_PAGE_SIZE:
+                    yield slim_doc_batch
+                    slim_doc_batch = []
+            self._update_checkpoint_for_next_run(
+                checkpoint, current_offset, prev_offset, JIRA_SLIM_PAGE_SIZE
+            )
+            prev_offset = current_offset
+
+        if slim_doc_batch:
+            yield slim_doc_batch
+
+    def validate_connector_settings(self) -> None:
+        if self._jira_client is None:
+            raise ConnectorMissingCredentialError("Jira")
+
+        try:
+            self.jira_client.project(self.jsm_project_key)
+        except Exception as e:
+            self._handle_validation_error(e)
+
+    def _handle_validation_error(self, e: Exception) -> None:
+        status_code = getattr(e, "status_code", None)
+        logger.error("Jira API error during validation: %s", e)
+
+        if status_code == 401:
+            raise CredentialExpiredError(
+                "Jira credential appears to be expired or invalid (HTTP 401)."
+            )
+        elif status_code == 403:
+            raise ConnectorValidationError(
+                "Your Jira token does not have sufficient permissions for this JSM project (HTTP 403)."
+            )
+        elif status_code == 404:
+            raise ConnectorValidationError(
+                f"JSM project '{self.jsm_project_key}' not found. Please verify the project key is correct and you have access to it."
+            )
+        elif status_code == 429:
+            raise ConnectorValidationError(
+                "Validation failed due to Jira rate-limits being exceeded. Please try again later."
+            )
+
+        error_message = getattr(e, "text", None)
+        if error_message is None:
+            raise UnexpectedValidationError(
+                f"Unexpected Jira error during validation: {e}"
+            )
+
+        raise ConnectorValidationError(
+            f"Validation failed due to Jira error: {error_message}"
+        )
+
+    @override
+    def validate_checkpoint_json(self, checkpoint_json: str) -> JiraConnectorCheckpoint:
+        return JiraConnectorCheckpoint.model_validate_json(checkpoint_json)
+
+    @override
+    def build_dummy_checkpoint(self) -> JiraConnectorCheckpoint:
+        return JiraConnectorCheckpoint(
+            has_more=True,
+        )
+
+
+if __name__ == "__main__":
+    import os
+
+    from onyx.utils.variable_functionality import global_version
+    from tests.daily.connectors.utils import load_all_from_connector
+
+    global_version.set_ee()
+
+    connector = JiraServiceManagementConnector(
+        jira_base_url=os.environ["JIRA_BASE_URL"],
+        jsm_project_key=os.environ["JSM_PROJECT_KEY"],
+        comment_email_blacklist=[],
+    )
+
+    connector.load_credentials(
+        {
+            "jira_user_email": os.environ["JIRA_USER_EMAIL"],
+            "jira_api_token": os.environ["JIRA_API_TOKEN"],
+        }
+    )
+
+    start = 0
+    end = datetime.now().timestamp()
+
+    for slim_doc in connector.retrieve_all_slim_docs_perm_sync(
+        start=start,
+        end=end,
+    ):
+        print(slim_doc)
+
+    for doc in load_all_from_connector(
+        connector=connector,
+        start=start,
+        end=end,
+    ).documents:
+        print(doc)

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -2040,6 +2040,7 @@ export interface JiraConfig {
 export interface JiraServiceManagementConfig {
   jira_base_url: string;
   jsm_project_key: string;
+  scoped_token?: boolean;
   comment_email_blacklist?: string[];
   jsm_issue_types?: string[];
   labels_to_skip?: string[];

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -754,6 +754,67 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management project to index. All tickets from the specified project will be indexed.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "text",
+        query: "Enter the Jira Service Management project key:",
+        label: "JSM Project Key",
+        name: "jsm_project_key",
+        optional: false,
+        description:
+          "The key of the JSM project to index (e.g., 'HELP', 'SUPPORT'). You can find this in the project URL or settings.",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [
+      {
+        type: "list",
+        query: "Enter JSM issue types to include (leave empty for all):",
+        label: "JSM Issue Types",
+        name: "jsm_issue_types",
+        description:
+          "Filter by specific JSM issue types. Common types include: Incident, Service Request, Problem, Change. Leave empty to index all issue types in the project.",
+        optional: true,
+      },
+      {
+        type: "list",
+        query: "Enter labels to skip:",
+        label: "Labels to Skip",
+        name: "labels_to_skip",
+        description:
+          "Skip tickets with these labels. Useful for skipping sensitive tickets.",
+        optional: true,
+      },
+    ],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [
@@ -1974,6 +2035,14 @@ export interface JiraConfig {
   project_key?: string;
   comment_email_blacklist?: string[];
   jql_query?: string;
+}
+
+export interface JiraServiceManagementConfig {
+  jira_base_url: string;
+  jsm_project_key: string;
+  comment_email_blacklist?: string[];
+  jsm_issue_types?: string[];
+  labels_to_skip?: string[];
 }
 
 export interface SalesforceConfig {

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -239,6 +239,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -385,7 +385,7 @@ export type ConnectorSummary = {
   active: number;
   public: number;
   totalDocsIndexed: number;
-  errors: number; // New field for error count
+  errors: number;
 };
 
 export type GroupedConnectorSummaries = Record<ValidSources, ConnectorSummary>;
@@ -551,6 +551,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",


### PR DESCRIPTION
/claim #2281

## Description

Implements a new Jira Service Management (JSM) connector to pull all tickets from a specified JSM project. JSM is a specialized Jira variant for IT service management, customer support, and operations (Incidents, Service Requests, Problems, Changes, etc.).

### Key Changes

**Backend:**
- Added `JIRA_SERVICE_MANAGEMENT` to `DocumentSource` enum in `constants.py`
- Added description in `DocumentSourceDescription` for JSM (fixes the bug found in previous PR #7877)
- Created `JiraServiceManagementConnector` class inheriting from `CheckpointedConnectorWithPermSync` and `SlimConnectorWithPermSync`
- Implements JSM-specific JQL query generation with project key and optional issue type filtering
- Registered connector in the connector registry
- Reuses existing Jira utilities: `process_jira_issue`, `build_jira_client`, `_perform_jql_search`, etc.
- Supports both Jira Cloud (v3 API) and Jira Server/Data Center (v2 API) with auto-detection
- Supports scoped tokens, comment email blacklist, labels to skip, and JSM issue type filtering
- No Alembic migration needed (source_type column already uses String, not Enum)

**Frontend:**
- Added `JiraServiceManagement` to `ValidSources` enum
- Added JSM to source metadata (Ticketing & Task Management category, reuses Jira icon)
- Created full connector configuration form with JSM-specific fields

### Architecture Decision
Uses a separate module (`jira_service_management/`) rather than extending the existing Jira connector, because:
1. JSM is a different `DocumentSource` (different admin page, different search filtering)
2. The previous PR #7877 used this approach and was approved architecturally
3. A flag would pollute the Jira connector with JSM-specific logic

### Testing
- Comprehensive test suite covering: initialization, credential loading, JQL construction, Cloud vs Server detection, checkpoint handling, slim docs, error handling, permission sync
- All tests cover the critical bug that caused previous PR to fail (missing DocumentSourceDescription entry)

### References
- Closes #2281
- Previous attempt PR #7877 (closed stale)

### Demo Video
[Link to demo video will be added once CI testing confirms the implementation works]

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Service Management (JSM) connector to index all tickets from a chosen project, with optional issue-type filtering and permission sync. Exposes JSM as a first-class source in backend and UI and closes #2281.

- **New Features**
  - New `JiraServiceManagementConnector` targeting a single JSM project; optional issue-type filter.
  - Reuses Jira utilities; works with Jira Cloud and Server/Data Center; supports scoped tokens.
  - Supports comment email blacklist and labels to skip.
  - Emits docs with `DocumentSource.JIRA_SERVICE_MANAGEMENT`; includes project-based permission sync and slim docs.
  - Registered in connector registry; no DB migration needed.
  - UI: added `ValidSources.JiraServiceManagement`, source metadata, and a config form (base URL, project key, optional issue types, labels to skip, comment blacklist, scoped token).
  - TypeScript: added `scoped_token` to `JiraServiceManagementConfig`.

- **Bug Fixes**
  - Added JSM entry to `DocumentSourceDescription` to fix the missing-description error from the previous attempt.
  - Fixed JQL generation to avoid `issuetype in ()` when issue-type list is empty or blank; removed dead imports and an unused constant.

<sup>Written for commit a581c4a8791c0746e96277c875c0a45a77876e43. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11415?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

