### PR TITLE
fix(sharepoint): handle HTTP 423 locked sites as per-site failures (#11266) to release v4.0

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -283,7 +283,14 @@ TRANSIENT_TRANSPORT_EXCEPTIONS: tuple[type[BaseException], ...] = (
 # HTTP statuses we treat as transient and worth retrying.
 RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({429, 503})
 
-PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({403, 404, 410})
+# `GET /sites/getAllSites` returns the tenant-wide directory of every site
+# collection, not just sites the app principal can read. Per-site content
+# access is gated separately, so some listed sites will always reject reads.
+# 403/404/410 cover "no permission / removed / gone"; 423 ("notAllowed")
+# covers admin-locked or M365-archived sites (e.g. `Set-SPOSiteArchiveState
+# -ArchiveState Archived`). All four are per-site conditions — skip the
+# site and continue the run rather than aborting the whole tenant index.
+PER_SITE_GRAPH_FAILURE_STATUSES: frozenset[int] = frozenset({403, 404, 410, 423})
 
 
 def _is_per_site_graph_failure(e: ClientRequestException | HTTPError) -> bool:


### PR DESCRIPTION
Cherry-pick of commit 38d54dcea8 to release/v4.0 branch.

Original PR: #11266

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle SharePoint HTTP 423 (locked/notAllowed) responses as per-site failures, same as 403/404/410. Skips locked or archived sites and continues indexing, preventing tenant-wide aborts.

<sup>Written for commit eae540342f3d45a36db3fab72b9027def6d75596. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11416?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

