### PR TITLE
fix(clickup): use relative API endpoints

### DIFF
--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -65,7 +65,7 @@ class ClickupConnector(LoadConnector, PollConnector):
         return response.json()
 
     def _get_task_comments(self, task_id: str) -> list[TextSection]:
-        url_endpoint = f"/task/{task_id}/comment"
+        url_endpoint = f"task/{task_id}/comment"
         response = self._make_request(url_endpoint)
         comments = [
             TextSection(
@@ -104,7 +104,7 @@ class ClickupConnector(LoadConnector, PollConnector):
         elif self.connector_type == "space":
             params["space_ids[]"] = self.connector_ids  # ty: ignore[invalid-assignment]
 
-        url_endpoint = f"/team/{self.team_id}/task"
+        url_endpoint = f"team/{self.team_id}/task"
 
         while True:
             response = self._make_request(url_endpoint, params)

--- a/backend/tests/unit/onyx/connectors/clickup/test_clickup_connector.py
+++ b/backend/tests/unit/onyx/connectors/clickup/test_clickup_connector.py
@@ -1,0 +1,48 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.clickup.connector import CLICKUP_API_BASE_URL
+from onyx.connectors.clickup.connector import ClickupConnector
+
+
+def _mock_response(json_response: dict[str, Any]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_response
+    return response
+
+
+def test_get_all_tasks_filtered_uses_relative_endpoint() -> None:
+    connector = ClickupConnector(api_token="test-token", team_id="123")
+    response = _mock_response({"tasks": []})
+
+    with patch("onyx.connectors.clickup.connector.requests.get") as mock_get:
+        mock_get.return_value = response
+
+        list(connector._get_all_tasks_filtered())
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.args[0] == f"{CLICKUP_API_BASE_URL}/team/123/task"
+
+
+def test_get_task_comments_uses_relative_endpoint() -> None:
+    connector = ClickupConnector(api_token="test-token")
+    response = _mock_response(
+        {
+            "comments": [
+                {
+                    "id": "comment-1",
+                    "comment_text": "Looks good",
+                }
+            ]
+        }
+    )
+
+    with patch("onyx.connectors.clickup.connector.requests.get") as mock_get:
+        mock_get.return_value = response
+
+        sections = connector._get_task_comments("task-1")
+
+    mock_get.assert_called_once()
+    assert mock_get.call_args.args[0] == f"{CLICKUP_API_BASE_URL}/task/task-1/comment"
+    assert sections[0].text == "Looks good"


### PR DESCRIPTION
## Description

Fixes a ClickUp connector URL construction bug where task and comment endpoints were passed with a leading slash even though the request helper already inserts the separator after the API base URL.

That could produce URLs like:

`https://api.clickup.com/api/v2//team/<team_id>/task`

ClickUp can return a 404 for that shape even when the token and team ID are valid. This PR changes those call sites to use relative endpoints, so the connector now builds URLs like:

`https://api.clickup.com/api/v2/team/<team_id>/task`

I also added focused unit coverage for both affected request paths.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/connectors/clickup/test_clickup_connector.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ClickUp connector URL construction by using relative endpoints for tasks and comments, preventing double slashes in API URLs that returned 404s. Added unit tests to cover both request paths and guard against regressions.

<sup>Written for commit 9844b43a2e1da3c3dbe39efa80a287d791b13267. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11417?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

