### PR TITLE
fix(ci): pass S3/MinIO env vars to nightly provider chat test runner

### DIFF
--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -133,6 +133,9 @@ runs:
             -e INDEXING_MODEL_SERVER_HOST=inference_model_server \
             -e TEST_WEB_HOSTNAME=test-runner \
             -e AWS_REGION_NAME=us-west-2 \
+            -e S3_ENDPOINT_URL=http://minio:9000 \
+            -e S3_AWS_ACCESS_KEY_ID=minioadmin \
+            -e S3_AWS_SECRET_ACCESS_KEY=minioadmin \
             -e NIGHTLY_LLM_PROVIDER="${NIGHTLY_LLM_PROVIDER}" \
             -e NIGHTLY_LLM_MODELS="${MODELS}" \
             -e NIGHTLY_LLM_API_KEY="${NIGHTLY_LLM_API_KEY}" \


### PR DESCRIPTION
## Summary
- The nightly provider chat test runner (`docker run` in `run-nightly-provider-chat-test/action.yml`) was missing S3/MinIO env vars
- Pytest's in-process FastAPI `TestClient` lifespan calls `get_default_file_store().initialize()`, which does `head_bucket` against S3
- Without `S3_ENDPOINT_URL` + creds, boto3 fell back to the GitHub Actions runner's IAM credentials and hit real S3, returning `403 Forbidden` (`RuntimeError: Access denied to S3 bucket 'onyx-file-store-bucket'`)
- This mirrors the working pattern already used by `pr-integration-tests.yml:404-406`

Observed in nightly run [26509209189](https://github.com/onyx-dot-app/onyx/actions/runs/26509209189/job/78069612555).

## Test plan
- [x] Re-run nightly provider chat tests and confirm the TestClient lifespan no longer fails with `head_bucket` 403

  - Passing here: https://github.com/onyx-dot-app/onyx/actions/runs/26524530011

- [ ] Confirm at least one provider job (e.g. openai) reaches the actual test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass S3/MinIO env vars to the nightly provider chat test runner so the FastAPI TestClient initializes against MinIO instead of real AWS, preventing head_bucket 403s. Adds S3_ENDPOINT_URL, S3_AWS_ACCESS_KEY_ID, and S3_AWS_SECRET_ACCESS_KEY to the container env list.

<sup>Written for commit 83cb92cc2b4af1af0e0869c1861921197cb756a9. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11423?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

