### PR TITLE
fix(helm): truncate child resource names to 63-char limit

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,13 +16,14 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Sandbox egress proxy for Craft action approvals. Adds the
-        `sandbox-proxy` Deployment, Service, NetworkPolicy, PDB, and RBAC
-        (gated on `configMap.ENABLE_CRAFT=true`) plus `SANDBOX_PROXY_HOST`/
-        `SANDBOX_PROXY_PORT` configmap wiring. Sandbox egress routes through
-        the proxy, which gates external actions on user approval; the sandbox
-        NetworkPolicy also allows opencode-serve ingress on `:4096`.
+    - kind: fixed
+      description: Truncate child resource names to the 63-char Kubernetes
+        DNS-1123 label limit. Releases with longer names (e.g. 29+ chars)
+        previously produced invalid Service/Deployment names for the
+        celery-worker-docprocessing-metrics, celery-worker-scheduled-tasks-metrics,
+        celery-worker-docfetching-metrics, and celery-worker-user-file-processing
+        resources. Adds an `onyx.resourceName` helper used by the affected
+        templates.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -18,12 +18,12 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Truncate child resource names to the 63-char Kubernetes
-        DNS-1123 label limit. Releases with longer names (e.g. 29+ chars)
-        previously produced invalid Service/Deployment names for the
-        celery-worker-docprocessing-metrics, celery-worker-scheduled-tasks-metrics,
-        celery-worker-docfetching-metrics, and celery-worker-user-file-processing
-        resources. Adds an `onyx.resourceName` helper used by the affected
-        templates.
+        DNS-1123 label limit. Releases with longer fullnames previously
+        produced invalid Service/Deployment names for the celery-worker
+        docprocessing-metrics, scheduled-tasks-metrics, docfetching-metrics,
+        monitoring-metrics, primary-metrics, user-file-processing, and
+        scheduled-tasks templates. Adds an `onyx.resourceName` helper used
+        by the affected templates.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -31,6 +31,20 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Build a child resource name as `<fullname>-<suffix>`, truncated to 63 chars to
+satisfy the Kubernetes DNS-1123 label limit that applies to Services, Pods,
+Deployments, HPAs, etc. Use this in place of
+  {{ include "onyx.fullname" . }}-<suffix>
+whenever the suffix could push the rendered name over 63 chars for a long
+release name. Callers must pass `(list . "<suffix>")`.
+*/}}
+{{- define "onyx.resourceName" -}}
+{{- $ctx := index . 0 -}}
+{{- $suffix := index . 1 -}}
+{{- printf "%s-%s" (include "onyx.fullname" $ctx) $suffix | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "onyx.labels" -}}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docfetching-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docfetching-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_docfetching.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docprocessing-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-docprocessing-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-docprocessing-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_docprocessing.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-monitoring-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-monitoring-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-monitoring-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-monitoring-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_monitoring.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-primary-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-primary-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-primary-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-primary-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_primary.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+  name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+    name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   minReplicas: {{ .Values.celery_worker_scheduled_tasks.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_scheduled_tasks.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-metrics-service.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-metrics-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks-metrics
+  name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks-metrics") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- if .Values.celery_worker_scheduled_tasks.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+  name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+    name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   minReplicaCount: {{ .Values.celery_worker_scheduled_tasks.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_scheduled_tasks.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_scheduled_tasks.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-scheduled-tasks
+  name: {{ include "onyx.resourceName" (list . "celery-worker-scheduled-tasks") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_scheduled_tasks.deploymentLabels }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-hpa.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-user-file-processing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
+    name: {{ include "onyx.resourceName" (list . "celery-worker-user-file-processing") }}
   minReplicas: {{ .Values.celery_worker_user_file_processing.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.celery_worker_user_file_processing.autoscaling.maxReplicas }}
   metrics:

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing-scaledobject.yaml
@@ -2,14 +2,14 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-user-file-processing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
+    name: {{ include "onyx.resourceName" (list . "celery-worker-user-file-processing") }}
   minReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.minReplicas | default 1 }}
   maxReplicaCount: {{ .Values.celery_worker_user_file_processing.autoscaling.maxReplicas | default 10 }}
   pollingInterval: {{ .Values.celery_worker_user_file_processing.autoscaling.pollingInterval | default 30 }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-user-file-processing.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "onyx.fullname" . }}-celery-worker-user-file-processing
+  name: {{ include "onyx.resourceName" (list . "celery-worker-user-file-processing") }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.celery_worker_user_file_processing.deploymentLabels }}


### PR DESCRIPTION
## Description

Several Helm templates build resource names by appending a long suffix to `{{ include "onyx.fullname" . }}`. For releases with longer names, the rendered name can exceed Kubernetes' 63-char DNS-1123 label limit, and the apply fails with:

```
Service "<release>-celery-worker-docprocessing-metrics" is invalid:
metadata.name: Invalid value: "...": must be no more than 63 characters
```

For a release whose fullname is ~29 chars, the following resource names overflow today:

| Resource | Suffix len | Total |
|---|---|---|
| `celery-worker-docprocessing-metrics` Service | 36 | 65 |
| `celery-worker-scheduled-tasks-metrics` Service | 38 | 67 |
| `celery-worker-user-file-processing` Deployment / HPA / ScaledObject | 35 | 64 |
| `celery-worker-docfetching-metrics` Service | 34 | 63 (at limit) |

### Fix

Add an `onyx.resourceName` helper in `_helpers.tpl` that builds `<fullname>-<suffix>` and truncates to 63 chars (mirroring the existing `onyx.fullname` pattern):

```go
{{- define "onyx.resourceName" -}}
{{- $ctx := index . 0 -}}
{{- $suffix := index . 1 -}}
{{- printf "%s-%s" (include "onyx.fullname" $ctx) $suffix | trunc 63 | trimSuffix "-" -}}
{{- end }}
```

Migrate the affected templates to use it. The HPA and ScaledObject reference the Deployment via the same helper call with the same suffix, so their `scaleTargetRef.name` stays in sync after truncation.

Short release names render identically to before (truncation is a no-op), so existing deployments are unaffected.

Bumps chart version to 0.5.9.

## How Has This Been Tested?

`helm lint` on the chart, and `helm template` runs with both a long release name (~29 chars, the longest currently in use) and a short one (`onyx`):

**Long release name, with all affected workers enabled** — all previously-overflowing names now fit at exactly 63 chars:

```
[Service]                 len=63  <release>-celery-worker-docfetching-metrics
[Service]                 len=63  <release>-celery-worker-docprocessing-metri
[Service]                 len=63  <release>-celery-worker-scheduled-tasks-met
[Deployment]              len=63  <release>-celery-worker-user-file-processin
[HorizontalPodAutoscaler] len=63  <release>-celery-worker-user-file-processin
[ScaledObject]            len=63  <release>-celery-worker-user-file-processin  (keda engine)
```

The HPA's `scaleTargetRef.name` and the ScaledObject's `scaleTargetRef.name` both match the Deployment name (verified in rendered output).

**Short release name (`onyx`)** — output unchanged from main:

```
name: onyx-celery-worker-docprocessing-metrics
name: onyx-celery-worker-user-file-processing
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check