### PR TITLE
fix: clarify S3 filestore region config

### DIFF
--- a/backend/onyx/file_store/README.md
+++ b/backend/onyx/file_store/README.md
@@ -1,6 +1,6 @@
 # Onyx File Store
 
-The Onyx file store provides a unified interface for storing files and large binary objects. It supports three storage backends: S3-compatible storage (AWS S3, MinIO, Digital Ocean Spaces, etc.), Google Cloud Storage (GCS), and PostgreSQL Large Objects.
+The Onyx file store provides a unified interface for storing files and large binary objects. It supports three storage backends: S3-compatible storage (AWS S3, MinIO, Cloudflare R2, Digital Ocean Spaces, etc.), Google Cloud Storage (GCS), and PostgreSQL Large Objects.
 
 ## Architecture
 
@@ -26,7 +26,7 @@ The backend is selected via the `FILE_STORE_BACKEND` environment variable:
 
 | Value | Backend | Description |
 |---|---|---|
-| `s3` (default) | S3-compatible | AWS S3, MinIO, Digital Ocean Spaces, etc. |
+| `s3` (default) | S3-compatible | AWS S3, MinIO, Cloudflare R2, Digital Ocean Spaces, etc. |
 | `gcs` | Google Cloud Storage | Native GCS with ADC/Workload Identity support |
 | `postgres` | PostgreSQL Large Objects | No external storage service required |
 
@@ -72,6 +72,17 @@ S3_AWS_SECRET_ACCESS_KEY=your-spaces-secret
 AWS_REGION_NAME=nyc3
 ```
 
+### Cloudflare R2
+
+```bash
+FILE_STORE_BACKEND=s3
+S3_FILE_STORE_BUCKET_NAME=your-bucket-name
+S3_ENDPOINT_URL=https://<account-id>.r2.cloudflarestorage.com
+S3_AWS_ACCESS_KEY_ID=your-r2-access-key
+S3_AWS_SECRET_ACCESS_KEY=your-r2-secret-key
+AWS_REGION_NAME=auto
+```
+
 ### Google Cloud Storage (GCS)
 
 ```bash
@@ -111,7 +122,7 @@ The file store works with any S3-compatible service. Simply configure:
 - `S3_FILE_STORE_BUCKET_NAME`: Your bucket/container name
 - `S3_ENDPOINT_URL`: The service endpoint URL
 - `S3_AWS_ACCESS_KEY_ID` and `S3_AWS_SECRET_ACCESS_KEY`: Your credentials
-- `AWS_REGION_NAME`: The region (any valid region name)
+- `AWS_REGION_NAME`: The provider-required signing region. Region or endpoint mismatches can surface as opaque `HeadBucket` failures such as HTTP 400 or 403. For Cloudflare R2, use `auto`.
 
 ### PostgreSQL Large Objects
 

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -267,6 +267,12 @@ class S3BackedFileStore(FileStore):
         """Initialize the S3 file store by ensuring the bucket exists"""
         s3_client = self._get_s3_client()
         bucket_name = self._get_bucket_name()
+        config_hint = (
+            "Verify S3_ENDPOINT_URL and AWS_REGION_NAME for the bucket. "
+            "For S3-compatible providers such as Cloudflare R2, a region "
+            "mismatch can surface as a generic HeadBucket failure; "
+            "Cloudflare R2 commonly uses AWS_REGION_NAME=auto."
+        )
 
         # Check if bucket exists
         try:
@@ -299,19 +305,16 @@ class S3BackedFileStore(FileStore):
             elif error_code == "403":
                 # Bucket exists but we don't have permission to access it
                 logger.warning(
-                    f"S3 bucket '{bucket_name}' exists but access is forbidden"
+                    "S3 bucket '%s' exists but access is forbidden. %s",
+                    bucket_name,
+                    config_hint,
                 )
                 raise RuntimeError(
-                    f"Access denied to S3 bucket '{bucket_name}'. Check credentials and permissions."
+                    f"Access denied to S3 bucket '{bucket_name}'. "
+                    f"Check credentials and permissions. {config_hint}"
                 )
             else:
                 # Some other error occurred
-                config_hint = (
-                    "Verify S3_ENDPOINT_URL and AWS_REGION_NAME for the bucket. "
-                    "For S3-compatible providers such as Cloudflare R2, a region "
-                    "mismatch can surface as a generic HeadBucket failure; "
-                    "Cloudflare R2 commonly uses AWS_REGION_NAME=auto."
-                )
                 logger.error(
                     "Failed to check S3 bucket '%s': %s. %s",
                     bucket_name,

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -306,8 +306,21 @@ class S3BackedFileStore(FileStore):
                 )
             else:
                 # Some other error occurred
-                logger.error("Failed to check S3 bucket '%s': %s", bucket_name, e)
-                raise RuntimeError(f"Failed to check S3 bucket '{bucket_name}': {e}")
+                config_hint = (
+                    "Verify S3_ENDPOINT_URL and AWS_REGION_NAME for the bucket. "
+                    "For S3-compatible providers such as Cloudflare R2, a region "
+                    "mismatch can surface as a generic HeadBucket failure; "
+                    "Cloudflare R2 commonly uses AWS_REGION_NAME=auto."
+                )
+                logger.error(
+                    "Failed to check S3 bucket '%s': %s. %s",
+                    bucket_name,
+                    e,
+                    config_hint,
+                )
+                raise RuntimeError(
+                    f"Failed to check S3 bucket '{bucket_name}': {e}. {config_hint}"
+                )
 
     def has_file(
         self,

--- a/backend/tests/unit/file_store/test_file_store.py
+++ b/backend/tests/unit/file_store/test_file_store.py
@@ -166,6 +166,31 @@ class TestExternalStorageFileStore:
         assert "Cloudflare R2" in message
         mock_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
 
+    def test_s3_initialize_forbidden_mentions_region_configuration(self) -> None:
+        """Test forbidden HeadBucket errors include region and endpoint hints"""
+        mock_client = Mock()
+        mock_client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}},
+            "HeadBucket",
+        )
+
+        file_store = S3BackedFileStore(
+            bucket_name="test-bucket",
+            aws_region_name="us-east-2",
+            s3_endpoint_url="https://example.r2.cloudflarestorage.com",
+        )
+        file_store._s3_client = mock_client
+
+        with pytest.raises(RuntimeError) as exc_info:
+            file_store.initialize()
+
+        message = str(exc_info.value)
+        assert "Access denied" in message
+        assert "S3_ENDPOINT_URL" in message
+        assert "AWS_REGION_NAME" in message
+        assert "Cloudflare R2" in message
+        mock_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
+
     def test_s3_key_generation_default_prefix(self) -> None:
         """Test S3 key generation with default prefix"""
         with (

--- a/backend/tests/unit/file_store/test_file_store.py
+++ b/backend/tests/unit/file_store/test_file_store.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 from sqlalchemy import create_engine
 from sqlalchemy import DateTime
 from sqlalchemy import Enum
@@ -140,6 +141,30 @@ class TestExternalStorageFileStore:
             file_store = S3BackedFileStore(bucket_name="my-test-bucket")
             bucket_name: str = file_store._get_bucket_name()
             assert bucket_name == "my-test-bucket"
+
+    def test_s3_initialize_bad_request_mentions_region_configuration(self) -> None:
+        """Test HeadBucket errors include region and endpoint configuration hints"""
+        mock_client = Mock()
+        mock_client.head_bucket.side_effect = ClientError(
+            {"Error": {"Code": "400", "Message": "Bad Request"}},
+            "HeadBucket",
+        )
+
+        file_store = S3BackedFileStore(
+            bucket_name="test-bucket",
+            aws_region_name="us-east-2",
+            s3_endpoint_url="https://example.r2.cloudflarestorage.com",
+        )
+        file_store._s3_client = mock_client
+
+        with pytest.raises(RuntimeError) as exc_info:
+            file_store.initialize()
+
+        message = str(exc_info.value)
+        assert "S3_ENDPOINT_URL" in message
+        assert "AWS_REGION_NAME" in message
+        assert "Cloudflare R2" in message
+        mock_client.head_bucket.assert_called_once_with(Bucket="test-bucket")
 
     def test_s3_key_generation_default_prefix(self) -> None:
         """Test S3 key generation with default prefix"""

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -64,6 +64,17 @@ POSTGRES_PASSWORD=password
 DB_READONLY_USER=db_readonly_user
 DB_READONLY_PASSWORD=password
 
+# File Store Backend: "s3" (default) or "postgres"
+# For AWS S3 or S3-compatible providers, set S3_ENDPOINT_URL, bucket,
+# credentials, and AWS_REGION_NAME to the bucket signing region.
+# Cloudflare R2 commonly uses AWS_REGION_NAME=auto.
+#FILE_STORE_BACKEND=s3
+#S3_ENDPOINT_URL=http://minio:9000
+#S3_AWS_ACCESS_KEY_ID=minioadmin
+#S3_AWS_SECRET_ACCESS_KEY=minioadmin
+#S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket
+#AWS_REGION_NAME=
+
 # If setting the vespa language is required, set this ('en', 'de', etc.).
 # See: https://docs.vespa.ai/en/linguistics.html 
 #VESPA_LANGUAGE_OVERRIDE=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -121,6 +121,9 @@ S3_ENDPOINT_URL=http://minio:9000
 S3_AWS_ACCESS_KEY_ID=minioadmin
 S3_AWS_SECRET_ACCESS_KEY=minioadmin
 S3_FILE_STORE_BUCKET_NAME=onyx-file-store-bucket
+## Set AWS_REGION_NAME to the bucket signing region for AWS S3 and
+## S3-compatible providers. For Cloudflare R2, use "auto".
+# AWS_REGION_NAME=
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=minioadmin
 
@@ -169,7 +172,6 @@ MINIO_ROOT_PASSWORD=minioadmin
 ## AWS Configuration
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
-# AWS_REGION_NAME=
 # Set to true when using IAM authentication for Postgres connections.
 USE_IAM_AUTH=false
 

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -73,6 +73,33 @@ auth:
       REDIS_PASSWORD: redis_password
 ```
 
+## Using an external S3-compatible file store
+
+To use AWS S3 or another S3-compatible service instead of the bundled MinIO
+service, disable MinIO and set the S3 endpoint, bucket, and signing region in
+`configMap`. Cloudflare R2 commonly requires `AWS_REGION_NAME: "auto"`; other
+providers require their bucket region.
+
+```yaml
+minio:
+  enabled: false
+
+configMap:
+  FILE_STORE_BACKEND: "s3"
+  S3_ENDPOINT_URL: "https://<account-id>.r2.cloudflarestorage.com"
+  S3_FILE_STORE_BUCKET_NAME: "<bucket-name>"
+  AWS_REGION_NAME: "auto"
+
+auth:
+  objectStorage:
+    values:
+      s3_aws_access_key_id: "<access-key-id>"
+      s3_aws_secret_access_key: "<secret-access-key>"
+```
+
+If `HeadBucket` returns a generic HTTP 400 or 403 on startup, verify that both
+`S3_ENDPOINT_URL` and `AWS_REGION_NAME` match the bucket provider and region.
+
 ## Sourcing secrets from an external secret manager (ESO)
 
 The chart can render an `ExternalSecret` CR that has [External Secrets

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1392,6 +1392,9 @@ configMap:
   EMAIL_FROM: ""
   # MinIO/S3 Configuration override
   S3_ENDPOINT_URL: ""  # only used if minio is not enabled
+  # Set this for AWS S3 and S3-compatible providers that require a signing region.
+  # For example, Cloudflare R2 uses "auto".
+  AWS_REGION_NAME: ""
   S3_FILE_STORE_BUCKET_NAME: ""
   # Gen AI Settings
   GEN_AI_MAX_TOKENS: ""


### PR DESCRIPTION
## Summary
- add AWS_REGION_NAME to Helm filestore config and document external S3-compatible storage
- surface S3_ENDPOINT_URL/AWS_REGION_NAME hints when HeadBucket fails with opaque errors
- document Cloudflare R2 region setup in file store and docker compose templates

Closes #10971

## Testing
- python -m py_compile backend\\onyx\\file_store\\file_store.py backend\\tests\\unit\\file_store\\test_file_store.py
- git diff --check

Not run: pytest/ruff in this local environment because fastapi_users and ruff are not installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies S3/S3-compatible region configuration across docs, Helm, and Docker templates, and improves S3 init errors with clear hints. Adds Cloudflare R2 guidance and tests to prevent opaque `HeadBucket` 400/403 failures.

- **New Features**
  - Added `AWS_REGION_NAME` to Helm `values.yaml` and docker-compose templates; documented signing region requirements (R2 uses "auto").
  - Documented external S3-compatible setup with Cloudflare R2 examples; updated file store README and Helm docs with 400/403 troubleshooting.

- **Bug Fixes**
  - `HeadBucket` 400 and 403 errors now include `S3_ENDPOINT_URL`/`AWS_REGION_NAME` hints in logs and exceptions.
  - Added unit tests to ensure error messages surface region/endpoint guidance for 400 and 403 cases.

<sup>Written for commit 6887178a289e7fa4f712ed066d8829a7cd07c91e. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11435?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

