### PR TITLE
feat(claude): enable security-guidance plugin for the repo

### DIFF
--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -6,13 +6,22 @@ high-signal findings.
 
 ## Multi-tenancy
 
-- Onyx is multi-tenant. Database access must go through the tenant-aware
-  SQLAlchemy session that the request/Celery middleware sets up; new code
-  paths that obtain a session by other means and read tenant data are
-  suspect.
-- Celery tasks must propagate `tenant_id` through the existing task-sending
-  helpers. Do not read tenant state from module-level globals or share data
-  across tenants in caches keyed without `tenant_id`.
+- Onyx is multi-tenant. Database access on per-tenant data must go
+  through the tenant-aware SQLAlchemy session that the request/Celery
+  middleware sets up; new code paths that obtain a session by other
+  means and read tenant data are suspect. Reads from the public schema
+  (shared across tenants) must use the public-schema session manager
+  instead.
+- Celery tasks that touch tenant data must be `TenantAwareTask`s with
+  `tenant_id` passed in — that is the mechanism that sets the
+  tenant-id contextvar. Do not read tenant state from module-level
+  globals or share data across tenants in caches keyed without
+  `tenant_id`.
+- Redis and the filestore auto-prefix keys/paths with `tenant_id`, but
+  only through the known wrappers: new Redis client functions must be
+  added to the auto-prefix list, and S3-backed filestore access must
+  go through the filestore wrapper (postgres-backed filestores rely on
+  schema isolation instead).
 
 ## Authentication and authorization
 
@@ -34,7 +43,8 @@ high-signal findings.
   credentials as plaintext columns or stash them in unrelated tables.
 - Do not log API keys, OAuth tokens or codes, connector credentials,
   session cookies, or full request/response bodies that may contain
-  them. Redact before logging.
+  them. Redact before logging, and mask the same values in any error
+  message returned to the user.
 - Do not embed API keys, OAuth client secrets, or service-account JSON
   in source, tests, fixtures, seed data, or example configs. Tests
   should fetch secrets through `backend/tests/utils/aws_secrets.py`
@@ -49,10 +59,11 @@ high-signal findings.
 
 ## Connectors and outbound requests
 
-- Connectors and federated search code that fetch URLs derived from
-  user input must guard against SSRF: reject requests to private /
-  link-local / loopback IP ranges and cloud metadata endpoints unless
-  there is an explicit, documented allow-list.
+- Any user-configurable external call (connectors, federated search,
+  webhook URLs, OAuth redirect URIs, tool-call HTTP targets, etc.)
+  must guard against SSRF: reject requests to private / link-local /
+  loopback IP ranges and cloud metadata endpoints unless there is an
+  explicit, documented allow-list.
 - HTML, Markdown, or rich content fetched from external sources and
   later rendered in the web UI must be sanitized server-side or
   rendered through a sanitizing component.

--- a/.claude/claude-security-guidance.md
+++ b/.claude/claude-security-guidance.md
@@ -1,0 +1,67 @@
+# Security guidance for Onyx
+
+Additional review rules for this repository. Built-in vulnerability checks
+still apply; the rules below are repo-specific and should be treated as
+high-signal findings.
+
+## Multi-tenancy
+
+- Onyx is multi-tenant. Database access must go through the tenant-aware
+  SQLAlchemy session that the request/Celery middleware sets up; new code
+  paths that obtain a session by other means and read tenant data are
+  suspect.
+- Celery tasks must propagate `tenant_id` through the existing task-sending
+  helpers. Do not read tenant state from module-level globals or share data
+  across tenants in caches keyed without `tenant_id`.
+
+## Authentication and authorization
+
+- New FastAPI endpoints that read or mutate user-, chat-, document-, or
+  connector-scoped data must declare an auth dependency
+  (`current_user`, `current_chat_accessible_user`, `current_admin_user`,
+  etc.). Endpoints with no auth dependency must be deliberately public
+  and stateless.
+- Admin-only operations must use the admin user dependency, not an
+  in-handler role check that could be forgotten on a sibling route.
+- When loading a resource by ID from the database, verify it belongs to
+  the requesting user or tenant before returning it or acting on it
+  (no IDOR).
+
+## Credentials and secrets
+
+- Connector credentials must go through the encrypted credential storage
+  in `backend/onyx/db/credentials.py`. Do not read or write connector
+  credentials as plaintext columns or stash them in unrelated tables.
+- Do not log API keys, OAuth tokens or codes, connector credentials,
+  session cookies, or full request/response bodies that may contain
+  them. Redact before logging.
+- Do not embed API keys, OAuth client secrets, or service-account JSON
+  in source, tests, fixtures, seed data, or example configs. Tests
+  should fetch secrets through `backend/tests/utils/aws_secrets.py`
+  rather than reading env vars directly.
+
+## Database and input handling
+
+- Use SQLAlchemy ORM or parameterized queries. Do not interpolate
+  user-controlled values into raw SQL with f-strings or `%`-formatting.
+- Validate request bodies with Pydantic models at the FastAPI boundary
+  before passing values into DB or LLM code.
+
+## Connectors and outbound requests
+
+- Connectors and federated search code that fetch URLs derived from
+  user input must guard against SSRF: reject requests to private /
+  link-local / loopback IP ranges and cloud metadata endpoints unless
+  there is an explicit, documented allow-list.
+- HTML, Markdown, or rich content fetched from external sources and
+  later rendered in the web UI must be sanitized server-side or
+  rendered through a sanitizing component.
+
+## Frontend (web/)
+
+- Do not introduce new `dangerouslySetInnerHTML` usages without a
+  sanitizer. If sanitizing, the sanitizer must run on every render
+  path, not just the happy path.
+- Do not echo unsanitized backend strings into URLs passed to
+  `window.location`, `router.push`, or anchor `href` attributes
+  without validating the scheme.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "security-guidance@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ backend/onyx/evals/one_off/*.json
 .env
 jira_test_env
 settings.json
-!.claude/settings.json
 
 # others
 /deployment/data/nginx/app.conf
@@ -67,3 +66,4 @@ plans/
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+!.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ backend/onyx/evals/one_off/*.json
 .env
 jira_test_env
 settings.json
+!.claude/settings.json
 
 # others
 /deployment/data/nginx/app.conf


### PR DESCRIPTION
## Summary

- Enable the official Anthropic [security-guidance plugin](https://code.claude.com/docs/en/security-guidance) via checked-in `.claude/settings.json`, so it loads for every contributor's local Claude Code sessions and for Claude Code on the web (where user-scope installs do not reach).
- Add `.claude/claude-security-guidance.md` with Onyx-specific review rules (multi-tenancy, auth/IDOR, encrypted credential storage, SSRF in connectors, frontend XSS sinks, test secret handling via `backend/tests/utils/aws_secrets.py`). The plugin's end-of-turn and commit reviews load this alongside the built-in checklist.
- Loosen the unanchored `settings.json` rule in `.gitignore` with `!.claude/settings.json` so the plugin config can be tracked. No other `settings.json` exists in the repo today.

The plugin adds three review layers on top of normal sessions: a deterministic per-edit pattern match (no model cost), a background end-of-turn diff review, and a deeper agentic review on `git commit`/`git push`. None of them block writes — findings are surfaced back to Claude as instructions.

## Test plan

- [ ] In a fresh Claude Code session in this repo, confirm the plugin loads (`/plugin` lists `security-guidance@claude-plugins-official` as enabled).
- [ ] Make a deliberately risky edit (e.g. `eval(user_input)` in a scratch file) and confirm the per-edit pattern warning fires.
- [ ] End a turn after editing a file and confirm the background diff review runs (check `~/.claude/security/log.txt`).
- [ ] Confirm `.claude/settings.local.json` (personal kanban hooks) still works alongside the new `.claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the `security-guidance@claude-plugins-official` plugin across the repo to add per-edit, end-of-turn, and commit-time security reviews in Claude Code. Adds shared config and refines Onyx-specific rules so guidance runs consistently and catches common pitfalls.

- New Features
  - Add and track `.claude/settings.json` to enable `security-guidance@claude-plugins-official` for local and web sessions.
  - Add `.claude/claude-security-guidance.md` with checks for multi-tenancy, auth/IDOR, encrypted credential storage (incl. test secret handling), DB/input validation, SSRF across any user-configurable external call, and frontend XSS; incorporate review feedback: require the public-schema session manager, use `TenantAwareTask` for tenant context, note Redis/S3 tenant-prefixing caveats, and mask secrets in logs and user-facing errors.

- Refactors
  - Group `!.claude/settings.json` with other `.claude` rules in `.gitignore` for clarity.

<sup>Written for commit f547607c11767e2ecf0fcc2c31052b03d0d7bff8. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

