### PR TITLE
fix(chat): lazy-load chat file bytes to stop api-server OOM

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -402,22 +402,38 @@ def _get_or_extract_plaintext(
 def load_chat_file(
     file_descriptor: FileDescriptor, db_session: Session
 ) -> ChatLoadedFile:
-    file_io = get_default_file_store().read_file(file_descriptor["id"], mode="b")
-    content = file_io.read()
+    """Build a ChatLoadedFile whose raw ``content`` bytes are loaded lazily.
 
-    # Extract text content if it's a text file type (not an image)
-    content_text = None
+    Chat sessions accumulate hundreds of files over time, and a new message
+    sent in such a session previously triggered an unbounded parallel fan-out
+    of full-bytes-into-memory reads, the vast majority of which were
+    immediately discarded by chat-history truncation. We now defer the raw
+    bytes read until something downstream actually accesses ``.content`` —
+    typically only a handful of files survive truncation per turn.
+
+    ``content_text`` (used for LLM context injection) and ``token_count``
+    remain eager because they're cheap: the cached-plaintext store hit avoids
+    reading the original bytes entirely on the common path, and token_count
+    is a single DB lookup.
+    """
+    file_id = file_descriptor["id"]
     # `FileDescriptor` is often JSON-roundtripped (e.g. JSONB / API), so `type`
     # may arrive as a raw string value instead of a `ChatFileType`.
     file_type = ChatFileType(file_descriptor["type"])
+    filename = file_descriptor.get("name")
 
+    # Extract text content if it's a text file type (not an image). The
+    # cached-plaintext path avoids reading the original bytes on the steady
+    # state; only the cache miss branch opens the binary stream.
+    content_text: str | None = None
     if file_type.is_text_file():
-        file_id = file_descriptor["id"]
 
         def _extract() -> str:
+            # Only invoked on cache miss; bytes-read happens here, not upfront.
+            file_io = get_default_file_store().read_file(file_id, mode="b")
             return extract_file_text(
                 file=file_io,
-                file_name=file_descriptor.get("name") or "",
+                file_name=filename or "",
                 break_on_unprocessable=False,
             )
 
@@ -432,7 +448,7 @@ def load_chat_file(
         except Exception as e:
             logger.warning(
                 "Failed to retrieve content for file %s: %s",
-                file_descriptor["id"],
+                file_id,
                 str(e),
             )
 
@@ -448,25 +464,32 @@ def load_chat_file(
             if user_file and user_file.token_count:
                 token_count = user_file.token_count
         except (ValueError, TypeError) as e:
-            logger.warning(
-                "Failed to get token count for file %s: %s", file_descriptor["id"], e
-            )
+            logger.warning("Failed to get token count for file %s: %s", file_id, e)
 
-    return ChatLoadedFile(
-        file_id=file_descriptor["id"],
-        content=content,
+    def _load_content() -> bytes:
+        return get_default_file_store().read_file(file_id, mode="b").read()
+
+    return ChatLoadedFile.lazy_loaded(
+        file_id=file_id,
         file_type=file_type,
-        filename=file_descriptor.get("name"),
+        filename=filename,
         content_text=content_text,
         token_count=token_count,
+        loader=_load_content,
     )
+
+
+_MAX_PARALLEL_CHAT_FILE_LOADS = 16
 
 
 def load_all_chat_files(
     chat_messages: list[ChatMessage],
     db_session: Session,
 ) -> list[ChatLoadedFile]:
-    # TODO There is likely a more efficient/standard way to load the files here.
+    # Returns lazy ChatLoadedFile instances — raw bytes are not read here.
+    # Defense-in-depth: even though per-file work is now cheap (DB lookup +
+    # optional cached-plaintext fetch), cap fan-out so no future regression
+    # can re-introduce a 500-thread storm.
     file_descriptors_for_history: list[FileDescriptor] = []
     for chat_message in chat_messages:
         if chat_message.files:
@@ -478,7 +501,8 @@ def load_all_chat_files(
             [
                 (load_chat_file, (file, db_session))
                 for file in file_descriptors_for_history
-            ]
+            ],
+            max_workers=_MAX_PARALLEL_CHAT_FILE_LOADS,
         ),
     )
     return files

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -117,8 +117,11 @@ class ChatLoadedFile(InMemoryChatFile):
         only on first access. ``content_text`` and ``token_count`` are passed
         eagerly because they're cheap (DB lookup + cached plaintext store hit).
         """
+        import threading
+
         from onyx.file_store.models import _LAZY_DONE_ATTR
         from onyx.file_store.models import _LAZY_LOADER_ATTR
+        from onyx.file_store.models import _LAZY_LOCK_ATTR
 
         inst = cls(
             file_id=file_id,
@@ -130,6 +133,7 @@ class ChatLoadedFile(InMemoryChatFile):
         )
         object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
         object.__setattr__(inst, _LAZY_DONE_ATTR, False)
+        object.__setattr__(inst, _LAZY_LOCK_ATTR, threading.Lock())
         return inst
 
 

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -117,11 +117,7 @@ class ChatLoadedFile(InMemoryChatFile):
         only on first access. ``content_text`` and ``token_count`` are passed
         eagerly because they're cheap (DB lookup + cached plaintext store hit).
         """
-        import threading
-
-        from onyx.file_store.models import _LAZY_DONE_ATTR
-        from onyx.file_store.models import _LAZY_LOADER_ATTR
-        from onyx.file_store.models import _LAZY_LOCK_ATTR
+        from onyx.file_store.models import install_lazy_content_loader
 
         inst = cls(
             file_id=file_id,
@@ -131,9 +127,7 @@ class ChatLoadedFile(InMemoryChatFile):
             content_text=content_text,
             token_count=token_count,
         )
-        object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
-        object.__setattr__(inst, _LAZY_DONE_ATTR, False)
-        object.__setattr__(inst, _LAZY_LOCK_ATTR, threading.Lock())
+        install_lazy_content_loader(inst, loader)
         return inst
 
 

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -1,11 +1,13 @@
 from collections.abc import Iterator
 from typing import Any
+from typing import Callable
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
+from onyx.file_store.models import ChatFileType
 from onyx.file_store.models import InMemoryChatFile
 from onyx.server.query_and_chat.models import MessageResponseIDInfo
 from onyx.server.query_and_chat.models import MultiModelMessageResponseIDInfo
@@ -96,6 +98,39 @@ class ChatFullResponse(BaseModel):
 class ChatLoadedFile(InMemoryChatFile):
     content_text: str | None
     token_count: int
+
+    # Named distinctly from the base ``lazy_from_descriptor`` so the subclass
+    # can require ``content_text`` / ``token_count`` without violating LSP on
+    # the override (ty/mypy correctly flag the broader subclass signature).
+    @classmethod
+    def lazy_loaded(
+        cls,
+        *,
+        file_id: str,
+        file_type: ChatFileType,
+        filename: str | None,
+        content_text: str | None,
+        token_count: int,
+        loader: Callable[[], bytes],
+    ) -> "ChatLoadedFile":
+        """Construct a ``ChatLoadedFile`` whose ``content`` bytes are loaded
+        only on first access. ``content_text`` and ``token_count`` are passed
+        eagerly because they're cheap (DB lookup + cached plaintext store hit).
+        """
+        from onyx.file_store.models import _LAZY_DONE_ATTR
+        from onyx.file_store.models import _LAZY_LOADER_ATTR
+
+        inst = cls(
+            file_id=file_id,
+            content=b"",
+            file_type=file_type,
+            filename=filename,
+            content_text=content_text,
+            token_count=token_count,
+        )
+        object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
+        object.__setattr__(inst, _LAZY_DONE_ATTR, False)
+        return inst
 
 
 class ToolCallSimple(BaseModel):

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -258,8 +258,22 @@ def _load_context_user_files_for_tools(
             str(user_file.id),
         )
 
-        def _load(file_id: str = user_file.file_id) -> bytes:
-            return get_default_file_store().read_file(file_id, mode="b").read()
+        def _load(
+            file_id: str = user_file.file_id, user_file_id: UUID = user_file.id
+        ) -> bytes:
+            # Preserve the pre-lazy degraded-but-functional behavior: if the
+            # underlying file is gone or temporarily unreachable, log it and
+            # hand PythonTool an empty payload instead of letting the
+            # exception propagate out of ChatFile.__getattribute__.
+            try:
+                return get_default_file_store().read_file(file_id, mode="b").read()
+            except Exception as e:
+                logger.warning(
+                    "Failed to load context file %s for Python execution: %s",
+                    user_file_id,
+                    e,
+                )
+                return b""
 
         chat_files.append(ChatFile.lazy_from_filename(filename=filename, loader=_load))
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -192,21 +192,26 @@ def _convert_loaded_files_to_chat_files(
 ) -> list[ChatFile]:
     """Convert ChatLoadedFile objects to ChatFile for tool usage (e.g., PythonTool).
 
-    Args:
-        loaded_files: List of ChatLoadedFile objects from the chat history
-
-    Returns:
-        List of ChatFile objects that can be passed to tools
+    Returns lazy ChatFile objects: ``.content`` materializes via the underlying
+    ``loaded_file.content`` only when a tool actually accesses it. Previously
+    this function gated on ``len(loaded_file.content) > 0`` to filter out
+    zero-byte files, but evaluating ``len(content)`` would force every lazy
+    file to materialize and defeat the OOM fix. The guard is dropped; tools
+    receive zero-byte content for empty files, which PythonTool handles fine
+    (sha256 of empty bytes + upload of an empty body — the LLM will see the
+    empty result and react).
     """
-    chat_files = []
+    chat_files: list[ChatFile] = []
     for loaded_file in loaded_files:
-        if len(loaded_file.content) > 0:
-            chat_files.append(
-                ChatFile(
-                    filename=loaded_file.filename or f"file_{loaded_file.file_id}",
-                    content=loaded_file.content,
-                )
+        filename = loaded_file.filename or f"file_{loaded_file.file_id}"
+        # Pull content via a closure so the bytes only flow through one
+        # materialization (the ChatLoadedFile's loader), then ride along.
+        chat_files.append(
+            ChatFile.lazy_from_filename(
+                filename=filename,
+                loader=lambda lf=loaded_file: lf.content,
             )
+        )
     return chat_files
 
 
@@ -225,11 +230,17 @@ def _load_context_user_files_for_tools(
     user_files: list[UserFile],
     existing_filenames: set[str],
 ) -> list[ChatFile]:
-    """Load raw tabular project/persona files for code-interpreter staging."""
+    """Stage tabular project/persona files for code-interpreter as lazy
+    ChatFile instances.
+
+    Raw bytes are not read here; each ChatFile carries a loader closure that
+    pulls from the file store only when PythonTool actually accesses
+    ``.content`` during staging. This avoids loading every project/persona
+    file into RAM for chats that never invoke the Python tool.
+    """
     if not user_files:
         return []
 
-    file_store = None
     chat_files: list[ChatFile] = []
     seen_file_ids: set[str] = set()
 
@@ -241,24 +252,16 @@ def _load_context_user_files_for_tools(
         if not mime_type_to_chat_file_type(user_file.file_type).use_metadata_only():
             continue
 
-        try:
-            if file_store is None:
-                file_store = get_default_file_store()
-            content = file_store.read_file(user_file.file_id, mode="b").read()
-        except Exception as e:
-            logger.warning(
-                "Failed to load context file %s for Python execution: %s",
-                user_file.id,
-                e,
-            )
-            continue
-
         filename = _deduped_filename(
             user_file.name or f"file_{user_file.id}",
             existing_filenames,
             str(user_file.id),
         )
-        chat_files.append(ChatFile(filename=filename, content=content))
+
+        def _load(file_id: str = user_file.file_id) -> bytes:
+            return get_default_file_store().read_file(file_id, mode="b").read()
+
+        chat_files.append(ChatFile.lazy_from_filename(filename=filename, loader=_load))
 
     return chat_files
 

--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -1,9 +1,16 @@
 import base64
 from enum import Enum
+from typing import Callable
 from typing import NotRequired
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict  # noreorder
+
+# Sidecar attribute names used by the lazy-content materialization shim. They
+# live on the instance via object.__setattr__ rather than as Pydantic fields,
+# so they don't affect serialization, validation, or model_dump output.
+_LAZY_LOADER_ATTR = "_lazy_content_loader"
+_LAZY_DONE_ATTR = "_lazy_content_materialized"
 
 
 class ChatFileType(str, Enum):
@@ -44,6 +51,46 @@ class InMemoryChatFile(BaseModel):
     content: bytes
     file_type: ChatFileType
     filename: str | None = None
+
+    @classmethod
+    def lazy_from_descriptor(
+        cls,
+        *,
+        file_id: str,
+        file_type: "ChatFileType",
+        filename: str | None,
+        loader: Callable[[], bytes],
+    ) -> "InMemoryChatFile":
+        """Construct an instance whose ``content`` bytes are loaded only on
+        first access.
+
+        Eager construction (``InMemoryChatFile(file_id=..., content=...)``) is
+        unchanged. Lazy instances start with ``content=b""`` and a stashed
+        loader; the first read of ``.content`` invokes the loader and memoizes
+        the result.
+        """
+        inst = cls(
+            file_id=file_id,
+            content=b"",
+            file_type=file_type,
+            filename=filename,
+        )
+        object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
+        object.__setattr__(inst, _LAZY_DONE_ATTR, False)
+        return inst
+
+    def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
+        if name == "content":
+            d = object.__getattribute__(self, "__dict__")
+            if d.get(_LAZY_LOADER_ATTR) is not None and not d.get(
+                _LAZY_DONE_ATTR, False
+            ):
+                # Materialize, write back through Pydantic so further reads
+                # are zero-overhead, then mark done.
+                data = d[_LAZY_LOADER_ATTR]()
+                BaseModel.__setattr__(self, "content", data)
+                object.__setattr__(self, _LAZY_DONE_ATTR, True)
+        return object.__getattribute__(self, name)
 
     def to_base64(self) -> str:
         if self.file_type == ChatFileType.IMAGE:

--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -15,6 +15,54 @@ _LAZY_DONE_ATTR = "_lazy_content_materialized"
 _LAZY_LOCK_ATTR = "_lazy_content_lock"
 
 
+def install_lazy_content_loader(
+    instance: BaseModel, loader: Callable[[], bytes]
+) -> None:
+    """Stash a lazy ``content`` loader + per-instance lock on a Pydantic model.
+
+    Used by ``lazy_from_*`` classmethod factories on models whose
+    ``content: bytes`` field should be populated on first read instead of at
+    construction. Pair with ``maybe_materialize_lazy_content``, which the
+    model's ``__getattribute__`` calls when ``content`` is accessed.
+
+    Sidecar attrs are written via ``object.__setattr__`` so they live on the
+    instance ``__dict__`` without becoming Pydantic fields — serialization
+    (``model_dump``) and equality are unaffected.
+    """
+    object.__setattr__(instance, _LAZY_LOADER_ATTR, loader)
+    object.__setattr__(instance, _LAZY_DONE_ATTR, False)
+    object.__setattr__(instance, _LAZY_LOCK_ATTR, threading.Lock())
+
+
+def maybe_materialize_lazy_content(instance: BaseModel) -> None:
+    """If a lazy loader is stashed and bytes haven't been read yet, invoke
+    the loader under a per-instance lock and write the bytes back through
+    Pydantic so subsequent reads of ``.content`` are zero-overhead field
+    accesses.
+
+    Two threads racing on first access must not both call the loader (that
+    would double-GET from S3), hence the per-instance ``threading.Lock``
+    with a double-checked guard inside the critical section.
+    """
+    d = object.__getattribute__(instance, "__dict__")
+    if d.get(_LAZY_LOADER_ATTR) is None or d.get(_LAZY_DONE_ATTR, False):
+        return
+    lock = d.get(_LAZY_LOCK_ATTR)
+    if lock is not None:
+        with lock:
+            if not d.get(_LAZY_DONE_ATTR, False):
+                data = d[_LAZY_LOADER_ATTR]()
+                BaseModel.__setattr__(instance, "content", data)
+                object.__setattr__(instance, _LAZY_DONE_ATTR, True)
+    else:
+        # Defensive: install_lazy_content_loader always provides a lock,
+        # but if a future caller wires up a loader without one, still
+        # memoize correctly.
+        data = d[_LAZY_LOADER_ATTR]()
+        BaseModel.__setattr__(instance, "content", data)
+        object.__setattr__(instance, _LAZY_DONE_ATTR, True)
+
+
 class ChatFileType(str, Enum):
     # Image types only contain the binary data
     IMAGE = "image"
@@ -77,34 +125,12 @@ class InMemoryChatFile(BaseModel):
             file_type=file_type,
             filename=filename,
         )
-        object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
-        object.__setattr__(inst, _LAZY_DONE_ATTR, False)
-        object.__setattr__(inst, _LAZY_LOCK_ATTR, threading.Lock())
+        install_lazy_content_loader(inst, loader)
         return inst
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
         if name == "content":
-            d = object.__getattribute__(self, "__dict__")
-            if d.get(_LAZY_LOADER_ATTR) is not None and not d.get(
-                _LAZY_DONE_ATTR, False
-            ):
-                # Lock the check-and-set so two threads racing on the first
-                # access don't both call the loader and double-GET from S3.
-                # ChatFile lives on PythonToolOverrideKwargs which can be
-                # accessed by worker threads, so this matters in practice.
-                lock = d.get(_LAZY_LOCK_ATTR)
-                if lock is not None:
-                    with lock:
-                        if not d.get(_LAZY_DONE_ATTR, False):
-                            data = d[_LAZY_LOADER_ATTR]()
-                            BaseModel.__setattr__(self, "content", data)
-                            object.__setattr__(self, _LAZY_DONE_ATTR, True)
-                else:
-                    # No lock present (shouldn't happen via lazy_from_*),
-                    # fall back to the un-locked path.
-                    data = d[_LAZY_LOADER_ATTR]()
-                    BaseModel.__setattr__(self, "content", data)
-                    object.__setattr__(self, _LAZY_DONE_ATTR, True)
+            maybe_materialize_lazy_content(self)
         return object.__getattribute__(self, name)
 
     def to_base64(self) -> str:

--- a/backend/onyx/file_store/models.py
+++ b/backend/onyx/file_store/models.py
@@ -1,4 +1,5 @@
 import base64
+import threading
 from enum import Enum
 from typing import Callable
 from typing import NotRequired
@@ -11,6 +12,7 @@ from typing_extensions import TypedDict  # noreorder
 # so they don't affect serialization, validation, or model_dump output.
 _LAZY_LOADER_ATTR = "_lazy_content_loader"
 _LAZY_DONE_ATTR = "_lazy_content_materialized"
+_LAZY_LOCK_ATTR = "_lazy_content_lock"
 
 
 class ChatFileType(str, Enum):
@@ -77,6 +79,7 @@ class InMemoryChatFile(BaseModel):
         )
         object.__setattr__(inst, _LAZY_LOADER_ATTR, loader)
         object.__setattr__(inst, _LAZY_DONE_ATTR, False)
+        object.__setattr__(inst, _LAZY_LOCK_ATTR, threading.Lock())
         return inst
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
@@ -85,11 +88,23 @@ class InMemoryChatFile(BaseModel):
             if d.get(_LAZY_LOADER_ATTR) is not None and not d.get(
                 _LAZY_DONE_ATTR, False
             ):
-                # Materialize, write back through Pydantic so further reads
-                # are zero-overhead, then mark done.
-                data = d[_LAZY_LOADER_ATTR]()
-                BaseModel.__setattr__(self, "content", data)
-                object.__setattr__(self, _LAZY_DONE_ATTR, True)
+                # Lock the check-and-set so two threads racing on the first
+                # access don't both call the loader and double-GET from S3.
+                # ChatFile lives on PythonToolOverrideKwargs which can be
+                # accessed by worker threads, so this matters in practice.
+                lock = d.get(_LAZY_LOCK_ATTR)
+                if lock is not None:
+                    with lock:
+                        if not d.get(_LAZY_DONE_ATTR, False):
+                            data = d[_LAZY_LOADER_ATTR]()
+                            BaseModel.__setattr__(self, "content", data)
+                            object.__setattr__(self, _LAZY_DONE_ATTR, True)
+                else:
+                    # No lock present (shouldn't happen via lazy_from_*),
+                    # fall back to the un-locked path.
+                    data = d[_LAZY_LOADER_ATTR]()
+                    BaseModel.__setattr__(self, "content", data)
+                    object.__setattr__(self, _LAZY_DONE_ATTR, True)
         return object.__getattribute__(self, name)
 
     def to_base64(self) -> str:

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from enum import Enum
 from typing import Any
 from typing import Callable
@@ -28,6 +29,7 @@ from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
 # ``ChatFile``. Mirrors the same pattern used by ``InMemoryChatFile``.
 _CHATFILE_LAZY_LOADER_ATTR = "_lazy_content_loader"
 _CHATFILE_LAZY_DONE_ATTR = "_lazy_content_materialized"
+_CHATFILE_LAZY_LOCK_ATTR = "_lazy_content_lock"
 
 TOOL_CALL_MSG_FUNC_NAME = "function_name"
 TOOL_CALL_MSG_ARGUMENTS = "arguments"
@@ -219,6 +221,7 @@ class ChatFile(BaseModel):
         inst = cls(filename=filename, content=b"")
         object.__setattr__(inst, _CHATFILE_LAZY_LOADER_ATTR, loader)
         object.__setattr__(inst, _CHATFILE_LAZY_DONE_ATTR, False)
+        object.__setattr__(inst, _CHATFILE_LAZY_LOCK_ATTR, threading.Lock())
         return inst
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
@@ -227,9 +230,19 @@ class ChatFile(BaseModel):
             if d.get(_CHATFILE_LAZY_LOADER_ATTR) is not None and not d.get(
                 _CHATFILE_LAZY_DONE_ATTR, False
             ):
-                data = d[_CHATFILE_LAZY_LOADER_ATTR]()
-                BaseModel.__setattr__(self, "content", data)
-                object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
+                # Lock the check-and-set so concurrent .content reads from
+                # tool worker threads don't both invoke the loader.
+                lock = d.get(_CHATFILE_LAZY_LOCK_ATTR)
+                if lock is not None:
+                    with lock:
+                        if not d.get(_CHATFILE_LAZY_DONE_ATTR, False):
+                            data = d[_CHATFILE_LAZY_LOADER_ATTR]()
+                            BaseModel.__setattr__(self, "content", data)
+                            object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
+                else:
+                    data = d[_CHATFILE_LAZY_LOADER_ATTR]()
+                    BaseModel.__setattr__(self, "content", data)
+                    object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
         return object.__getattribute__(self, name)
 
 

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from enum import Enum
 from typing import Any
+from typing import Callable
 from typing import Literal
 from uuid import UUID
 
@@ -22,6 +23,11 @@ from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import GeneratedImage
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
 from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
+
+# Sidecar attribute names for the lazy-content materialization shim on
+# ``ChatFile``. Mirrors the same pattern used by ``InMemoryChatFile``.
+_CHATFILE_LAZY_LOADER_ATTR = "_lazy_content_loader"
+_CHATFILE_LAZY_DONE_ATTR = "_lazy_content_materialized"
 
 TOOL_CALL_MSG_FUNC_NAME = "function_name"
 TOOL_CALL_MSG_ARGUMENTS = "arguments"
@@ -196,6 +202,35 @@ class ChatFile(BaseModel):
     content: bytes
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def lazy_from_filename(
+        cls,
+        *,
+        filename: str,
+        loader: Callable[[], bytes],
+    ) -> "ChatFile":
+        """Construct a ChatFile whose ``content`` is loaded on first access.
+
+        Existing eager construction (``ChatFile(filename=..., content=...)``)
+        is unchanged. PythonTool's ``.content`` access transparently triggers
+        the loader and memoizes the result.
+        """
+        inst = cls(filename=filename, content=b"")
+        object.__setattr__(inst, _CHATFILE_LAZY_LOADER_ATTR, loader)
+        object.__setattr__(inst, _CHATFILE_LAZY_DONE_ATTR, False)
+        return inst
+
+    def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
+        if name == "content":
+            d = object.__getattribute__(self, "__dict__")
+            if d.get(_CHATFILE_LAZY_LOADER_ATTR) is not None and not d.get(
+                _CHATFILE_LAZY_DONE_ATTR, False
+            ):
+                data = d[_CHATFILE_LAZY_LOADER_ATTR]()
+                BaseModel.__setattr__(self, "content", data)
+                object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
+        return object.__getattribute__(self, name)
 
 
 class PythonToolRichResponse(BaseModel):

--- a/backend/onyx/tools/models.py
+++ b/backend/onyx/tools/models.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import threading
 from enum import Enum
 from typing import Any
 from typing import Callable
@@ -19,17 +18,13 @@ from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.models import SearchDocsResponse
 from onyx.db.memory import UserMemoryContext
+from onyx.file_store.models import install_lazy_content_loader
+from onyx.file_store.models import maybe_materialize_lazy_content
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolErrorInfo
 from onyx.server.query_and_chat.streaming_models import GeneratedImage
 from onyx.tools.tool_implementations.images.models import FinalImageGenerationResponse
 from onyx.tools.tool_implementations.memory.models import MemoryToolResponse
-
-# Sidecar attribute names for the lazy-content materialization shim on
-# ``ChatFile``. Mirrors the same pattern used by ``InMemoryChatFile``.
-_CHATFILE_LAZY_LOADER_ATTR = "_lazy_content_loader"
-_CHATFILE_LAZY_DONE_ATTR = "_lazy_content_materialized"
-_CHATFILE_LAZY_LOCK_ATTR = "_lazy_content_lock"
 
 TOOL_CALL_MSG_FUNC_NAME = "function_name"
 TOOL_CALL_MSG_ARGUMENTS = "arguments"
@@ -219,30 +214,12 @@ class ChatFile(BaseModel):
         the loader and memoizes the result.
         """
         inst = cls(filename=filename, content=b"")
-        object.__setattr__(inst, _CHATFILE_LAZY_LOADER_ATTR, loader)
-        object.__setattr__(inst, _CHATFILE_LAZY_DONE_ATTR, False)
-        object.__setattr__(inst, _CHATFILE_LAZY_LOCK_ATTR, threading.Lock())
+        install_lazy_content_loader(inst, loader)
         return inst
 
     def __getattribute__(self, name: str):  # type: ignore[no-untyped-def]
         if name == "content":
-            d = object.__getattribute__(self, "__dict__")
-            if d.get(_CHATFILE_LAZY_LOADER_ATTR) is not None and not d.get(
-                _CHATFILE_LAZY_DONE_ATTR, False
-            ):
-                # Lock the check-and-set so concurrent .content reads from
-                # tool worker threads don't both invoke the loader.
-                lock = d.get(_CHATFILE_LAZY_LOCK_ATTR)
-                if lock is not None:
-                    with lock:
-                        if not d.get(_CHATFILE_LAZY_DONE_ATTR, False):
-                            data = d[_CHATFILE_LAZY_LOADER_ATTR]()
-                            BaseModel.__setattr__(self, "content", data)
-                            object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
-                else:
-                    data = d[_CHATFILE_LAZY_LOADER_ATTR]()
-                    BaseModel.__setattr__(self, "content", data)
-                    object.__setattr__(self, _CHATFILE_LAZY_DONE_ATTR, True)
+            maybe_materialize_lazy_content(self)
         return object.__getattribute__(self, name)
 
 

--- a/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
+++ b/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
@@ -204,6 +204,51 @@ class TestLazyShimContract:
         _ = f.to_base64()
         assert calls["n"] == 1
 
+    def test_concurrent_first_access_calls_loader_exactly_once(self) -> None:
+        """Two threads racing on the first ``.content`` read must not both
+        invoke the loader (would be a double S3 GET). The lazy shim takes a
+        per-instance ``threading.Lock`` to make check-and-set atomic."""
+        import threading
+
+        from onyx.chat.models import ChatLoadedFile
+
+        call_count = {"n": 0}
+        gate = threading.Event()
+
+        def slow_loader() -> bytes:
+            # Gate guarantees both threads observe _lazy_content_materialized
+            # is False before the first writer completes — without the lock,
+            # both would enter the load path.
+            gate.wait()
+            call_count["n"] += 1
+            return b"once"
+
+        f = ChatLoadedFile.lazy_loaded(
+            file_id="x",
+            file_type=ChatFileType.PLAIN_TEXT,
+            filename="x.txt",
+            content_text=None,
+            token_count=0,
+            loader=slow_loader,
+        )
+
+        results: list[bytes] = []
+
+        def reader() -> None:
+            results.append(f.content)
+
+        t1 = threading.Thread(target=reader)
+        t2 = threading.Thread(target=reader)
+        t1.start()
+        t2.start()
+        # Let both threads enter __getattribute__ and contend on the lock.
+        gate.set()
+        t1.join()
+        t2.join()
+
+        assert results == [b"once", b"once"]
+        assert call_count["n"] == 1
+
     def test_chat_file_lazy_content(self) -> None:
         calls = {"n": 0}
         cf = ChatFile.lazy_from_filename(

--- a/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
+++ b/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
@@ -1,0 +1,383 @@
+"""External-dependency tests for the lazy chat-file loading path.
+
+These tests guard the OOM fix: ``load_all_chat_files`` and friends must NOT
+read raw file bytes from the file store at construction time. Bytes are read
+only when a downstream consumer (e.g. PythonTool) actually accesses
+``.content``.
+
+Uses real Postgres + real file store; the file_store's ``read_file`` method is
+patched at module level with a counting wrapper so we can assert exactly when
+S3 reads happen.
+"""
+
+from collections.abc import Generator
+from io import BytesIO
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat.chat_utils import load_all_chat_files
+from onyx.chat.chat_utils import load_chat_file
+from onyx.chat.models import ChatLoadedFile
+from onyx.configs.constants import FileOrigin
+from onyx.configs.constants import MessageType
+from onyx.db.chat import create_chat_session
+from onyx.db.chat import create_new_chat_message
+from onyx.db.chat import get_or_create_root_message
+from onyx.file_store import file_store as file_store_module
+from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.models import ChatFileType
+from onyx.file_store.models import FileDescriptor
+from onyx.tools.models import ChatFile
+from tests.external_dependency_unit.conftest import create_test_user
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_file(content: bytes, *, file_type: str = "text/plain") -> str:
+    return get_default_file_store().save_file(
+        content=BytesIO(content),
+        display_name=None,
+        file_origin=FileOrigin.CHAT_UPLOAD,
+        file_type=file_type,
+        file_metadata={"test": True},
+    )
+
+
+def _descriptor(
+    file_id: str, *, type_: ChatFileType = ChatFileType.PLAIN_TEXT
+) -> FileDescriptor:
+    return {"id": file_id, "type": type_, "name": f"f_{file_id[:8]}.txt"}
+
+
+class _ReadCounter:
+    """Counts only RAW chat-file byte reads.
+
+    Reads of plaintext-cache files (``__plaintext__`` prefix) are intentionally
+    excluded — we want to measure original-file fetches that would dominate
+    memory, not the small cached plaintext store that's already a fast path.
+    """
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.read_ids: list[str] = []
+
+    def hits_for(self, file_id: str) -> int:
+        return self.read_ids.count(file_id)
+
+
+@pytest.fixture
+def read_counter(
+    db_session: Session,  # noqa: ARG001 — keeps tenant + file_store fixtures live
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[_ReadCounter, None, None]:
+    """Patch ``S3BackedFileStore.read_file`` to count raw chat-file reads."""
+    counter = _ReadCounter()
+    real_read_file = file_store_module.S3BackedFileStore.read_file
+
+    def _counting_read_file(self, file_id, mode=None, use_tempfile=False):  # type: ignore[no-untyped-def]
+        # Plaintext-cache reads use the ``plaintext_{file_id}`` naming
+        # convention (see onyx.file_store.utils.plaintext_file_name_for_id).
+        # These are by-design cheap and are not the OOM-relevant load — skip
+        # counting them.
+        if isinstance(file_id, str) and file_id.startswith("plaintext_"):
+            return real_read_file(self, file_id, mode=mode, use_tempfile=use_tempfile)
+        counter.count += 1
+        counter.read_ids.append(file_id)
+        return real_read_file(self, file_id, mode=mode, use_tempfile=use_tempfile)
+
+    with patch.object(
+        file_store_module.S3BackedFileStore, "read_file", _counting_read_file
+    ):
+        yield counter
+
+
+@pytest.fixture
+def file_cleanup(
+    db_session: Session,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
+) -> Generator[list[str], None, None]:
+    created: list[str] = []
+    try:
+        yield created
+    finally:
+        store = get_default_file_store()
+        for fid in created:
+            try:
+                store.delete_file(fid, error_on_missing=False)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Lazy InMemoryChatFile / ChatLoadedFile / ChatFile shim behavior
+# ---------------------------------------------------------------------------
+
+
+class TestLazyShimContract:
+    """Direct unit-style tests of the lazy primitives. Don't need DB/file store
+    but live here so they sit next to the integration tests they guard."""
+
+    def test_no_load_on_construction(self) -> None:
+        calls = {"n": 0}
+
+        def loader() -> bytes:
+            calls["n"] += 1
+            return b"data"
+
+        ChatLoadedFile.lazy_loaded(
+            file_id="x",
+            file_type=ChatFileType.PLAIN_TEXT,
+            filename="x.txt",
+            content_text="cached text",
+            token_count=3,
+            loader=loader,
+        )
+        assert calls["n"] == 0
+
+    def test_first_access_materializes_once_only(self) -> None:
+        calls = {"n": 0}
+
+        def loader() -> bytes:
+            calls["n"] += 1
+            return b"data"
+
+        f = ChatLoadedFile.lazy_loaded(
+            file_id="x",
+            file_type=ChatFileType.PLAIN_TEXT,
+            filename="x.txt",
+            content_text=None,
+            token_count=0,
+            loader=loader,
+        )
+        assert f.content == b"data"
+        assert f.content == b"data"
+        assert calls["n"] == 1
+
+    def test_non_content_attrs_do_not_trigger(self) -> None:
+        calls = {"n": 0}
+        f = ChatLoadedFile.lazy_loaded(
+            file_id="x",
+            file_type=ChatFileType.IMAGE,
+            filename="x.png",
+            content_text=None,
+            token_count=0,
+            loader=lambda: (calls.__setitem__("n", calls["n"] + 1), b"img")[1],
+        )
+        _ = f.file_id
+        _ = f.filename
+        _ = f.file_type
+        _ = f.content_text
+        _ = f.token_count
+        assert calls["n"] == 0
+
+    def test_to_file_descriptor_does_not_materialize(self) -> None:
+        calls = {"n": 0}
+        f = ChatLoadedFile.lazy_loaded(
+            file_id="abc",
+            file_type=ChatFileType.PLAIN_TEXT,
+            filename="x.txt",
+            content_text=None,
+            token_count=0,
+            loader=lambda: (calls.__setitem__("n", calls["n"] + 1), b"data")[1],
+        )
+        fd = f.to_file_descriptor()
+        assert fd["id"] == "abc"
+        assert calls["n"] == 0
+
+    def test_to_base64_materializes_image(self) -> None:
+        calls = {"n": 0}
+        f = ChatLoadedFile.lazy_loaded(
+            file_id="img",
+            file_type=ChatFileType.IMAGE,
+            filename="x.png",
+            content_text=None,
+            token_count=0,
+            loader=lambda: (calls.__setitem__("n", calls["n"] + 1), b"PNG-bytes")[1],
+        )
+        _ = f.to_base64()
+        assert calls["n"] == 1
+
+    def test_chat_file_lazy_content(self) -> None:
+        calls = {"n": 0}
+        cf = ChatFile.lazy_from_filename(
+            filename="x.csv",
+            loader=lambda: (calls.__setitem__("n", calls["n"] + 1), b"csv-bytes")[1],
+        )
+        assert calls["n"] == 0
+        _ = cf.filename
+        assert calls["n"] == 0
+        assert cf.content == b"csv-bytes"
+        assert cf.content == b"csv-bytes"
+        assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via real file_store: load_chat_file / load_all_chat_files
+# ---------------------------------------------------------------------------
+
+
+class TestLoadChatFileLazy:
+    def test_load_chat_file_does_not_read_bytes(
+        self,
+        read_counter: _ReadCounter,
+        file_cleanup: list[str],
+        db_session: Session,
+    ) -> None:
+        """``load_chat_file`` must not pull raw bytes from the file store at
+        construction. Bytes flow only when ``.content`` is touched."""
+        file_id = _write_file(b"sentinel-bytes", file_type="image/png")
+        file_cleanup.append(file_id)
+
+        loaded = load_chat_file(
+            {"id": file_id, "type": ChatFileType.IMAGE, "name": "icon.png"},
+            db_session,
+        )
+
+        # Construction must not have read raw bytes.
+        assert read_counter.hits_for(file_id) == 0, (
+            f"Expected 0 raw reads at construction; got "
+            f"{read_counter.hits_for(file_id)}. read_ids={read_counter.read_ids}"
+        )
+
+        # First .content access loads.
+        assert loaded.content == b"sentinel-bytes"
+        assert read_counter.hits_for(file_id) == 1
+
+        # Second access is memoized — no further reads.
+        assert loaded.content == b"sentinel-bytes"
+        assert read_counter.hits_for(file_id) == 1
+
+
+class TestLoadAllChatFilesLazy:
+    def test_returns_lazy_files_for_history(
+        self,
+        read_counter: _ReadCounter,
+        file_cleanup: list[str],
+        db_session: Session,
+    ) -> None:
+        """A chat session with N attached files yields N lazy instances and
+        triggers zero raw byte reads. The whole point: a heavy history doesn't
+        cost a single S3 GET until someone touches ``.content``."""
+        user = create_test_user(db_session, f"lazy-load-{uuid4().hex[:8]}")
+        chat = create_chat_session(
+            db_session=db_session,
+            description="lazy",
+            user_id=user.id,
+            persona_id=None,
+        )
+        root = get_or_create_root_message(chat.id, db_session)
+
+        parent = root
+        file_ids: list[str] = []
+        for i in range(10):
+            fid = _write_file(f"file-{i}".encode(), file_type="image/png")
+            file_ids.append(fid)
+            file_cleanup.append(fid)
+            parent = create_new_chat_message(
+                chat_session_id=chat.id,
+                parent_message=parent,
+                message=f"msg-{i}",
+                token_count=0,
+                message_type=MessageType.USER,
+                files=[_descriptor(fid, type_=ChatFileType.IMAGE)],
+                db_session=db_session,
+            )
+
+        # Replay the chat history (skip root) and call the loader.
+        chat_history = [
+            m for m in db_session.query(type(parent)).filter_by(chat_session_id=chat.id)
+        ]
+        chat_history = [m for m in chat_history if m.id != root.id]
+        assert len(chat_history) == 10
+
+        baseline = read_counter.count
+        loaded = load_all_chat_files(chat_history, db_session)
+        assert len(loaded) == 10
+        # No raw byte reads should have occurred during the load itself.
+        assert read_counter.count == baseline, (
+            f"load_all_chat_files made {read_counter.count - baseline} raw reads — "
+            f"expected 0. ids: {read_counter.read_ids[baseline:]}"
+        )
+
+        # Touch one file → exactly one read.
+        _ = loaded[0].content
+        assert read_counter.count == baseline + 1
+
+    def test_max_workers_capped_at_16(self) -> None:
+        """Defense-in-depth: even with 200 files passed in, the thread pool
+        is capped at 16 workers."""
+        from typing import Any
+        from typing import cast
+
+        captured: dict[str, int] = {}
+
+        def _spy(funcs, **kwargs):  # type: ignore[no-untyped-def]
+            captured["max_workers"] = kwargs.get("max_workers", -1)
+            return [None] * len(funcs)
+
+        with patch(
+            "onyx.chat.chat_utils.run_functions_tuples_in_parallel", side_effect=_spy
+        ):
+            # Synthetic 200-file "message" — we patch the parallel runner so
+            # actual DB/file_store access never happens. Casting through Any
+            # bypasses the ORM type contract that is irrelevant for this
+            # particular invariant check.
+            class _FakeMsg:
+                files = [
+                    {
+                        "id": f"id-{i}",
+                        "type": ChatFileType.PLAIN_TEXT,
+                        "name": f"f-{i}.txt",
+                    }
+                    for i in range(200)
+                ]
+
+            from onyx.chat.chat_utils import load_all_chat_files as _llc
+
+            _llc(cast(Any, [_FakeMsg()]), cast(Any, None))
+            assert captured["max_workers"] == 16
+
+
+# ---------------------------------------------------------------------------
+# process_message-layer consumers
+# ---------------------------------------------------------------------------
+
+
+class TestConvertLoadedFilesToChatFilesLazy:
+    """``_convert_loaded_files_to_chat_files`` must produce lazy ChatFiles —
+    it must not call ``len(loaded_file.content) > 0`` style guards that
+    would defeat the lazy fix."""
+
+    def test_wrapping_does_not_materialize(
+        self,
+        read_counter: _ReadCounter,
+        file_cleanup: list[str],
+        db_session: Session,
+    ) -> None:
+        from onyx.chat.process_message import _convert_loaded_files_to_chat_files
+
+        file_id = _write_file(b"some-bytes", file_type="image/png")
+        file_cleanup.append(file_id)
+        loaded = [
+            load_chat_file(
+                {"id": file_id, "type": ChatFileType.IMAGE, "name": "x.png"},
+                db_session,
+            )
+        ]
+
+        baseline = read_counter.count
+        chat_files = _convert_loaded_files_to_chat_files(loaded)
+        assert len(chat_files) == 1
+        # Wrapping must not have materialized anything.
+        assert read_counter.count == baseline
+
+        # And the wrapped ChatFile, when materialized, pulls exactly once.
+        assert chat_files[0].content == b"some-bytes"
+        assert read_counter.count == baseline + 1

--- a/backend/tests/unit/onyx/tools/test_tool_runner_chat_files.py
+++ b/backend/tests/unit/onyx/tools/test_tool_runner_chat_files.py
@@ -101,8 +101,15 @@ class TestChatFileConversion:
         assert chat_files[1].filename == "data.csv"
         assert chat_files[1].content == b"csv,data\n1,2"
 
-    def test_convert_files_with_none_content_skipped(self) -> None:
-        """Test that files with None content are skipped."""
+    def test_convert_files_with_empty_content_passes_through(self) -> None:
+        """Empty-content files now pass through with content=b"".
+
+        The previous ``len(loaded_file.content) > 0`` guard was removed when
+        chat-file loading went lazy — evaluating len() would force every lazy
+        file to materialize and defeat the OOM fix. PythonTool handles an
+        empty body fine (sha256 of b"" + empty upload; the LLM sees the empty
+        result and reacts), so passing zero-byte files through is intentional.
+        """
         from onyx.chat.models import ChatLoadedFile
         from onyx.chat.process_message import _convert_loaded_files_to_chat_files
         from onyx.file_store.models import ChatFileType
@@ -128,9 +135,12 @@ class TestChatFileConversion:
 
         chat_files = _convert_loaded_files_to_chat_files(loaded_files)
 
-        # Only the file with valid content should be included
-        assert len(chat_files) == 1
+        # Both files reach PythonTool; the empty one carries content=b"".
+        assert len(chat_files) == 2
         assert chat_files[0].filename == "valid.pdf"
+        assert chat_files[0].content == b"valid content"
+        assert chat_files[1].filename == "invalid.pdf"
+        assert chat_files[1].content == b""
 
     def test_convert_files_with_missing_filename_uses_fallback(self) -> None:
         """Test that files without filename use file_id as fallback."""
@@ -188,10 +198,50 @@ class TestChatFileConversion:
                 existing_filenames=set(),
             )
 
-        assert chat_files == [
-            ChatFile(filename="review_results.xlsx", content=b"raw xlsx bytes")
-        ]
-        mock_file_store.read_file.assert_called_once_with("stored-xlsx-file", mode="b")
+            # ChatFile is lazy: filename is set, but bytes are not read until
+            # PythonTool touches .content.
+            assert len(chat_files) == 1
+            assert chat_files[0].filename == "review_results.xlsx"
+            mock_file_store.read_file.assert_not_called()
+
+            # First .content access triggers the loader.
+            assert chat_files[0].content == b"raw xlsx bytes"
+            mock_file_store.read_file.assert_called_once_with(
+                "stored-xlsx-file", mode="b"
+            )
+
+    def test_context_user_file_loader_failure_returns_empty_bytes(self) -> None:
+        """If a project/persona file is deleted or temporarily unreachable
+        when PythonTool touches ``.content``, the lazy loader must catch and
+        return ``b""`` rather than raising out of ``__getattribute__``. This
+        preserves the degraded-but-functional behavior of the original eager
+        try/except + continue."""
+        from uuid import uuid4
+
+        from onyx.chat.process_message import _load_context_user_files_for_tools
+
+        user_file = UserFile(
+            id=uuid4(),
+            user_id=uuid4(),
+            file_id="missing-file",
+            name="ghost.csv",
+            file_type="text/csv",
+            token_count=10,
+        )
+
+        with patch(
+            "onyx.chat.process_message.get_default_file_store"
+        ) as mock_file_store_factory:
+            mock_file_store = mock_file_store_factory.return_value
+            mock_file_store.read_file.side_effect = FileNotFoundError("gone")
+
+            chat_files = _load_context_user_files_for_tools(
+                [user_file], existing_filenames=set()
+            )
+
+            assert len(chat_files) == 1
+            # Accessing .content does NOT raise; the loader swallows + logs.
+            assert chat_files[0].content == b""
 
     def test_context_non_tabular_user_files_not_loaded_for_tools(self) -> None:
         from uuid import uuid4
@@ -244,9 +294,9 @@ class TestChatFileConversion:
                 existing_filenames={"data.csv"},
             )
 
-        assert chat_files == [
-            ChatFile(filename=f"data_{user_file_id}.csv", content=b"a,b\n1,2")
-        ]
+            assert len(chat_files) == 1
+            assert chat_files[0].filename == f"data_{user_file_id}.csv"
+            assert chat_files[0].content == b"a,b\n1,2"
 
 
 class TestChatFileModel:


### PR DESCRIPTION
## Description

Some api-server pods OOMKill every few hours (exit 137, sub-15s memory spikes from ~1.1 GiB to >5 GiB). Root cause traced to `backend/onyx/chat/process_message.py:862`:

```python
files = load_all_chat_files(chat_history, db_session)
chat_files_for_tools = _convert_loaded_files_to_chat_files(files)
```

`load_all_chat_files` does an **unbounded parallel S3 fetch + full-bytes-into-memory** for every file ever attached to **any** message in the chat session. In some deployments there are chat sessions with **500+ accumulated files**. With `run_functions_tuples_in_parallel` defaulting to one thread per file, a single new message spawns 500+ threads each pulling a file from S3 and holding the bytes in RAM. Round-robin LB spreads the killer evenly across replicas — all pods restart at similar rates.

**Critical waste**: only the ~5–20 files attached to messages that *survive* chat-history truncation inside `convert_chat_history` are actually used. The other ~95% of loaded bytes are immediately garbage-collected.

There is an existing TODO at the call site acknowledging this is wrong.

### How this regressed

The eager `load_all_chat_files` shape predates current main, but the **memory impact was significantly amplified by PR #8489 "fix: Code interpreter takes files"** (merged 2026-02-16). Before that PR, the loaded files only fed `convert_chat_history` — which uses `.content_text` (cheap, plaintext-cached) and rarely touches raw `.content`. PR #8489 added `_convert_loaded_files_to_chat_files`, which shallow-copies every loaded file's bytes into a new `list[ChatFile]` that is then passed into `PythonTool` for every chat turn, regardless of whether the LLM intends to invoke the code interpreter. The combination — eager parallel byte-load × every-turn × every-history-file × the python_tool staging path — is what produces the sub-15s spikes.

Two compounding factors that surfaced this in production now:
1. Chat sessions doing long-running file-analysis workloads have organically accumulated hundreds of files (largest observed: ~530 unique files in one chat).
2. Round-robin load balancing across api replicas means a single heavy user's message-send spreads the OOM evenly across the entire fleet — no single "hot pod" to blame; all pods restart at similar rates.

### What changed

- `InMemoryChatFile` and `ChatFile`: added `.lazy_from_*` classmethods plus a `__getattribute__` override scoped to `"content"` only. Eager constructor call sites (uploads, generated files) are 100% unchanged.
- `ChatLoadedFile`: added `.lazy_loaded(...)` (separate name from the base method to avoid an LSP-violating override since the subclass requires `content_text` + `token_count`).
- `load_chat_file` now constructs lazy `ChatLoadedFile`s. The cached-plaintext fast path already avoids touching original bytes on the steady state, so `convert_chat_history`'s per-message text injection runs without ever hitting S3.
- `load_all_chat_files` caps `max_workers=16` as defense-in-depth.
- `_load_context_user_files_for_tools` had the same eager `read_file().read()` pattern for project/persona tabular files — fixed alongside.
- `_convert_loaded_files_to_chat_files` (the function introduced by #8489) previously gated on `len(loaded_file.content) > 0`, which would force every lazy file to materialize. Guard removed; empty-content files now pass through (sha256 of \`b""\` and an empty upload are both fine for PythonTool).

### Why this is a "real fix" and not just a band-aid

PythonTool already dedupes via a per-content sha256 cache, so most of its `.content` accesses on a heavy chat are wasted reads. With lazy `ChatFile`, only the files the LLM *actually* asks PythonTool to stage materialize their bytes — typically 0 (LLM never calls python_tool) or 1–5 (single-file analysis). The other 525+ files in a heavy chat never touch S3 on a given turn.

### Out of scope

- nginx sticky sessions: sticky would *concentrate* deaths on hot pods, not stop them — fix is correctness, not LB.
- The full summarization TODO at `process_message.py:860` — larger architectural change.
- The pre-#8489 design decision to fan-load `content_text` for all history files. Lazy loading neutralizes its cost; replacing it with on-demand history summarization is a separate effort.

## How Has This Been Tested?

10 new external-dependency-unit tests in `backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py`:

**Shim contract (no infra needed):**
- \`test_no_load_on_construction\` — \`.lazy_loaded(...)\` doesn't invoke the loader
- \`test_first_access_materializes_once_only\` — first \`.content\` triggers; second is memoized
- \`test_non_content_attrs_do_not_trigger\` — \`file_id\`, \`filename\`, \`file_type\`, \`content_text\`, \`token_count\` access does not load
- \`test_to_file_descriptor_does_not_materialize\` — descriptor extraction is cheap
- \`test_to_base64_materializes_image\` — image serialization correctly forces load
- \`test_chat_file_lazy_content\` — same invariants for \`ChatFile\`

**End-to-end with real Postgres + MinIO:**
- \`test_load_chat_file_does_not_read_bytes\` — wraps \`S3BackedFileStore.read_file\` with a counter, asserts zero raw reads at construction
- \`test_returns_lazy_files_for_history\` — 10-message chat with attached files, asserts zero raw reads after \`load_all_chat_files\` returns
- \`test_max_workers_capped_at_16\` — patches \`run_functions_tuples_in_parallel\`, asserts \`max_workers=16\` even with 200 files passed in
- \`test_wrapping_does_not_materialize\` — \`_convert_loaded_files_to_chat_files\` produces lazy \`ChatFile\`s

All 10 new tests pass; full \`backend/tests/external_dependency_unit/chat\` suite (31 tests) passes with no regressions.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
