### PR TITLE
feat(craft): remove file extension and MIME limits on uploads

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -874,8 +874,8 @@ def upload_file_endpoint(
     # Read file content (use sync file interface)
     content = file.file.read()
 
-    # Validate file (extension, mime type, size)
-    is_valid, error = validate_file(file.filename, file.content_type, len(content))
+    # Validate file size (extension/type are intentionally unrestricted)
+    is_valid, error = validate_file(len(content))
     if not is_valid:
         raise HTTPException(status_code=400, detail=error)
 

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -10,8 +10,6 @@ from onyx.db.models import User
 from onyx.db.notification import create_notification
 from onyx.feature_flags.factory import get_default_feature_flag_provider
 from onyx.feature_flags.interface import NoOpFeatureFlagProvider
-from onyx.file_processing.file_types import OnyxFileExtensions
-from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.server.features.build.configs import ENABLE_CRAFT
 from onyx.server.features.build.configs import MAX_UPLOAD_FILE_SIZE_BYTES
 from onyx.utils.logger import setup_logger
@@ -21,146 +19,14 @@ logger = setup_logger()
 # =============================================================================
 # File Upload Validation
 # =============================================================================
-
-# Additional extensions for code files (safe to read, not execute)
-CODE_FILE_EXTENSIONS: set[str] = {
-    ".py",
-    ".js",
-    ".ts",
-    ".tsx",
-    ".jsx",
-    ".css",
-    ".scss",
-    ".less",
-    ".java",
-    ".go",
-    ".rs",
-    ".cpp",
-    ".c",
-    ".h",
-    ".hpp",
-    ".cs",
-    ".rb",
-    ".php",
-    ".swift",
-    ".kt",
-    ".scala",
-    ".sh",
-    ".bash",
-    ".zsh",
-    ".env",
-    ".ini",
-    ".toml",
-    ".cfg",
-    ".properties",
-}
-
-# Additional MIME types for code files
-CODE_MIME_TYPES: set[str] = {
-    "text/x-python",
-    "text/x-java",
-    "text/x-c",
-    "text/x-c++",
-    "text/x-go",
-    "text/x-rust",
-    "text/x-shellscript",
-    "text/css",
-    "text/javascript",
-    "application/javascript",
-    "application/typescript",
-    "application/octet-stream",  # Generic (for code files with unknown type)
-}
-
-# Combine base Onyx extensions with code file extensions
-ALLOWED_EXTENSIONS: set[str] = (
-    OnyxFileExtensions.ALL_ALLOWED_EXTENSIONS | CODE_FILE_EXTENSIONS
-)
-
-# Combine base Onyx MIME types with code MIME types
-ALLOWED_MIME_TYPES: set[str] = OnyxMimeTypes.ALLOWED_MIME_TYPES | CODE_MIME_TYPES
-
-# Blocked extensions (executable/dangerous files)
-BLOCKED_EXTENSIONS: set[str] = {
-    # Windows executables
-    ".exe",
-    ".dll",
-    ".msi",
-    ".scr",
-    ".com",
-    ".bat",
-    ".cmd",
-    ".ps1",
-    # macOS
-    ".app",
-    ".dmg",
-    ".pkg",
-    # Linux
-    ".deb",
-    ".rpm",
-    ".so",
-    # Cross-platform
-    ".jar",
-    ".war",
-    ".ear",
-    # Other potentially dangerous
-    ".vbs",
-    ".vbe",
-    ".wsf",
-    ".wsh",
-    ".hta",
-    ".cpl",
-    ".reg",
-    ".lnk",
-    ".pif",
-}
+#
+# Craft does NOT restrict uploads by file extension or MIME type. Uploaded
+# files only ever execute inside the isolated per-user sandbox (locked-down
+# pod: non-root, dropped caps, egress-gated), which is the real security
+# boundary, and downloads are served as attachments. Only size is enforced.
 
 # Regex for sanitizing filenames (allow alphanumeric, dash, underscore, period)
 SAFE_FILENAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]")
-
-
-def validate_file_extension(filename: str) -> tuple[bool, str | None]:
-    """Validate file extension against allowlist.
-
-    Args:
-        filename: The filename to validate
-
-    Returns:
-        Tuple of (is_valid, error_message)
-    """
-    ext = Path(filename).suffix.lower()
-
-    if not ext:
-        return False, "File must have an extension"
-
-    if ext in BLOCKED_EXTENSIONS:
-        return False, f"File type '{ext}' is not allowed for security reasons"
-
-    if ext not in ALLOWED_EXTENSIONS:
-        return False, f"File type '{ext}' is not supported"
-
-    return True, None
-
-
-def validate_mime_type(content_type: str | None) -> bool:
-    """Validate MIME type against allowlist.
-
-    Args:
-        content_type: The Content-Type header value
-
-    Returns:
-        True if the MIME type is allowed, False otherwise
-    """
-    if not content_type:
-        # Allow missing content type - we'll validate by extension
-        return True
-
-    # Extract base MIME type (ignore charset etc.)
-    mime_type = content_type.split(";")[0].strip().lower()
-
-    if mime_type not in ALLOWED_MIME_TYPES:
-        return False
-
-    return True
 
 
 def validate_file_size(size: int) -> bool:
@@ -221,36 +87,18 @@ def sanitize_filename(filename: str) -> str:
     return filename
 
 
-def validate_file(
-    filename: str,
-    content_type: str | None,
-    size: int,
-) -> tuple[bool, str | None]:
+def validate_file(size: int) -> tuple[bool, str | None]:
     """Validate a file for upload.
 
-    Performs all validation checks:
-    - Extension validation
-    - MIME type validation
-    - Size validation
+    Only size is enforced; extension and MIME type are intentionally not
+    restricted (see the File Upload Validation note above).
 
     Args:
-        filename: The filename to validate
-        content_type: The Content-Type header value
         size: File size in bytes
 
     Returns:
         Tuple of (is_valid, error_message). error_message is None if valid.
     """
-    # Validate extension
-    ext_valid, ext_error = validate_file_extension(filename)
-    if not ext_valid:
-        return False, ext_error
-
-    # Validate MIME type
-    if not validate_mime_type(content_type):
-        return False, f"MIME type '{content_type}' is not supported"
-
-    # Validate file size
     if not validate_file_size(size):
         return (
             False,

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -29,24 +29,6 @@ logger = setup_logger()
 SAFE_FILENAME_PATTERN = re.compile(r"[^a-zA-Z0-9._-]")
 
 
-def validate_file_size(size: int) -> bool:
-    """Validate file size against limit.
-
-    Args:
-        size: File size in bytes
-
-    Returns:
-        True if the file size is allowed, False otherwise
-    """
-    if size <= 0:
-        return False
-
-    if size > MAX_UPLOAD_FILE_SIZE_BYTES:
-        return False
-
-    return True
-
-
 def sanitize_filename(filename: str) -> str:
     """Sanitize filename to prevent path traversal and other issues.
 
@@ -99,7 +81,10 @@ def validate_file(size: int) -> tuple[bool, str | None]:
     Returns:
         Tuple of (is_valid, error_message). error_message is None if valid.
     """
-    if not validate_file_size(size):
+    if size <= 0:
+        return False, "File is empty"
+
+    if size > MAX_UPLOAD_FILE_SIZE_BYTES:
         return (
             False,
             f"File size exceeds maximum allowed size of {MAX_UPLOAD_FILE_SIZE_BYTES} bytes",

--- a/backend/tests/integration/tests/craft/test_upload_api.py
+++ b/backend/tests/integration/tests/craft/test_upload_api.py
@@ -2,7 +2,7 @@
 
 Exercises the upload endpoint via the live API server so we pin both the
 happy-path response shape and the boundary error mapping (auth, foreign
-session, size/count/cumulative caps, blocked extensions, Unicode filenames).
+session, size/count/cumulative caps, arbitrary extensions, Unicode filenames).
 """
 
 from __future__ import annotations
@@ -161,8 +161,13 @@ def test_upload_over_cumulative_cap_returns_429(admin_user: DATestUser) -> None:
     assert response.status_code == 429
 
 
-def test_upload_rejects_blocked_extension_via_http(admin_user: DATestUser) -> None:
-    """Uploading evil.exe is rejected with a 4xx (blocked extension)."""
+def test_upload_accepts_any_extension_via_http(admin_user: DATestUser) -> None:
+    """Uploads are not restricted by extension/MIME; a .exe uploads fine.
+
+    The sandbox is the security boundary, not an extension allow/blocklist, so
+    a previously-blocked type (here ``evil.exe``) must now succeed. This guards
+    against any reintroduction of extension filtering.
+    """
     session_id = _create_session_id(admin_user)
 
     headers = {
@@ -174,9 +179,7 @@ def test_upload_rejects_blocked_extension_via_http(admin_user: DATestUser) -> No
         headers=headers,
         cookies=admin_user.cookies,
     )
-    assert 400 <= response.status_code < 500
-    # Sanity check: this must NOT silently succeed.
-    assert response.status_code != 201
+    assert response.status_code == 201
 
 
 def test_upload_with_unicode_filename_persists_correctly(

--- a/backend/tests/unit/onyx/server/features/build/test_upload_validation.py
+++ b/backend/tests/unit/onyx/server/features/build/test_upload_validation.py
@@ -1,50 +1,20 @@
 """File upload validation tests (unit / pure-logic half).
 
 Tests pin the contract for the pure validation helpers in
-`onyx.server.features.build.utils`: extension allowlist, MIME allowlist,
-size cap, and filename sanitization. The HTTP boundary and manager-side
-collision/disk behavior live in ext-dep / integration tests.
+`onyx.server.features.build.utils`: size cap and filename sanitization.
+Craft intentionally does NOT restrict uploads by extension or MIME type
+(the sandbox is the security boundary), so those checks are absent. The
+HTTP boundary and manager-side collision/disk behavior live in
+ext-dep / integration tests.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from onyx.server.features.build.configs import MAX_UPLOAD_FILE_SIZE_BYTES
 from onyx.server.features.build.utils import sanitize_filename
 from onyx.server.features.build.utils import validate_file
-from onyx.server.features.build.utils import validate_file_extension
-from onyx.server.features.build.utils import validate_mime_type
-
-
-@pytest.mark.parametrize("filename", ["data.csv", "notes.txt", "report.pdf"])
-def test_allowed_extension_accepted(filename: str) -> None:
-    """Common allowed extensions (.csv, .txt, .pdf) pass extension validation."""
-    is_valid, error = validate_file_extension(filename)
-    assert is_valid is True
-    assert error is None
-
-
-@pytest.mark.parametrize("filename", ["malware.exe", "payload.dll"])
-def test_blocked_extension_rejected(filename: str) -> None:
-    """Executable extensions are rejected with an error message."""
-    is_valid, error = validate_file_extension(filename)
-    assert is_valid is False
-    assert error is not None
-    assert "not allowed" in error
-
-
-def test_mime_type_must_be_allowed() -> None:
-    """A MIME type outside the allowlist is rejected; allowed types pass."""
-    # Allowed type passes.
-    assert validate_mime_type("text/csv") is True
-    # Disallowed type is rejected.
-    assert validate_mime_type("application/x-msdownload") is False
-    # Empty / None Content-Type is permitted (extension-only validation).
-    assert validate_mime_type(None) is True
-    assert validate_mime_type("") is True
 
 
 def test_sanitize_filename_strips_path_components() -> None:
@@ -76,38 +46,23 @@ def test_sanitize_filename_caps_length_preserves_extension() -> None:
     assert Path(result).stem != ""
 
 
-@pytest.mark.parametrize(
-    "filename, content_type, size, expected_valid, error_fragment",
-    [
-        # Extension check trips first.
-        ("evil.exe", "application/octet-stream", 100, False, "not allowed"),
-        # MIME check trips when extension is fine but content type is wrong.
-        ("data.csv", "application/x-msdownload", 100, False, "MIME"),
-        # Size check trips when extension + MIME are fine but size is over cap.
-        (
-            "data.csv",
-            "text/csv",
-            MAX_UPLOAD_FILE_SIZE_BYTES + 1,
-            False,
-            "size",
-        ),
-        # Happy path: all three pass.
-        ("data.csv", "text/csv", 100, True, None),
-    ],
-)
-def test_validate_file_combines_extension_mime_size(
-    filename: str,
-    content_type: str,
-    size: int,
-    expected_valid: bool,
-    error_fragment: str | None,
-) -> None:
-    """`validate_file` applies all three checks; each can independently reject."""
-    is_valid, error = validate_file(filename, content_type, size)
-    assert is_valid is expected_valid
-    if expected_valid:
-        assert error is None
-    else:
-        assert error is not None
-        assert error_fragment is not None
-        assert error_fragment.lower() in error.lower()
+def test_validate_file_accepts_any_size_within_cap() -> None:
+    """Only size is enforced - a normal-sized file is accepted."""
+    is_valid, error = validate_file(100)
+    assert is_valid is True
+    assert error is None
+
+
+def test_validate_file_rejects_oversize() -> None:
+    """A file over the per-file cap is rejected."""
+    is_valid, error = validate_file(MAX_UPLOAD_FILE_SIZE_BYTES + 1)
+    assert is_valid is False
+    assert error is not None
+    assert "size" in error.lower()
+
+
+def test_validate_file_rejects_empty() -> None:
+    """A zero-byte file is rejected."""
+    is_valid, error = validate_file(0)
+    assert is_valid is False
+    assert error is not None

--- a/backend/tests/unit/onyx/server/features/build/test_upload_validation.py
+++ b/backend/tests/unit/onyx/server/features/build/test_upload_validation.py
@@ -62,7 +62,8 @@ def test_validate_file_rejects_oversize() -> None:
 
 
 def test_validate_file_rejects_empty() -> None:
-    """A zero-byte file is rejected."""
+    """A zero-byte file is rejected with an empty-file message, not a size-cap one."""
     is_valid, error = validate_file(0)
     assert is_valid is False
     assert error is not None
+    assert "empty" in error.lower()

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -403,7 +403,6 @@ const InputBar = memo(
               className="hidden"
               multiple
               onChange={handleFileSelect}
-              accept="*/*"
             />
 
             {/* Attached Files */}

--- a/web/src/app/craft/contexts/UploadFilesContext.tsx
+++ b/web/src/app/craft/contexts/UploadFilesContext.tsx
@@ -73,53 +73,11 @@ const MAX_TOTAL_SIZE_BYTES = 200 * 1024 * 1024;
 /** Maximum files per session - matches BUILD_MAX_UPLOAD_FILES_PER_SESSION */
 const MAX_FILES_PER_SESSION = 20;
 
-/** Blocked file extensions (executables/dangerous) - matches backend BLOCKED_EXTENSIONS */
-const BLOCKED_EXTENSIONS = new Set([
-  // Windows executables
-  ".exe",
-  ".dll",
-  ".msi",
-  ".scr",
-  ".com",
-  ".bat",
-  ".cmd",
-  ".ps1",
-  // macOS
-  ".app",
-  ".dmg",
-  ".pkg",
-  // Linux
-  ".deb",
-  ".rpm",
-  ".so",
-  // Cross-platform
-  ".jar",
-  ".war",
-  ".ear",
-  // Other potentially dangerous
-  ".vbs",
-  ".vbe",
-  ".wsf",
-  ".wsh",
-  ".hta",
-  ".cpl",
-  ".reg",
-  ".lnk",
-  ".pif",
-]);
-
 /** Format bytes to human-readable string */
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-/** Get file extension (lowercase, including dot) */
-function getFileExtension(filename: string): string {
-  const lastDot = filename.lastIndexOf(".");
-  if (lastDot === -1) return "";
-  return filename.slice(lastDot).toLowerCase();
 }
 
 /** Validation result for a single file */
@@ -130,30 +88,14 @@ interface FileValidationResult {
 
 /** Validate a single file before upload */
 function validateFile(file: File): FileValidationResult {
-  // Check file size
+  // Check file size. Extension/type are intentionally not restricted - uploaded
+  // files only run inside the isolated sandbox, which is the security boundary.
   if (file.size > MAX_FILE_SIZE_BYTES) {
     return {
       valid: false,
       error: `File too large (${formatBytes(
         file.size
       )}). Maximum is ${formatBytes(MAX_FILE_SIZE_BYTES)}.`,
-    };
-  }
-
-  // Check blocked extensions
-  const ext = getFileExtension(file.name);
-  if (ext && BLOCKED_EXTENSIONS.has(ext)) {
-    return {
-      valid: false,
-      error: `File type '${ext}' is not allowed for security reasons.`,
-    };
-  }
-
-  // Check for missing extension
-  if (!ext) {
-    return {
-      valid: false,
-      error: "File must have an extension.",
     };
   }
 
@@ -633,7 +575,7 @@ export function UploadFilesProvider({ children }: UploadFilesProviderProps) {
 
   /**
    * Upload files. Uses activeSessionId internally.
-   * Validates files before upload (size, extension, batch limits).
+   * Validates files before upload (size, batch limits).
    */
   const uploadFiles = useCallback(
     async (files: File[]): Promise<BuildFile[]> => {

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -259,7 +259,7 @@ export default function UserLibraryModal({
                     style={{ display: "none" }}
                     onChange={handleFileUpload}
                     disabled={isUploading}
-                    accept=".xlsx,.xls,.docx,.doc,.pptx,.ppt,.csv,.json,.txt,.pdf,.zip"
+                    accept="*/*"
                   />
                   <Button
                     disabled={isUploading}

--- a/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/v1/configure/components/UserLibraryModal.tsx
@@ -259,7 +259,6 @@ export default function UserLibraryModal({
                     style={{ display: "none" }}
                     onChange={handleFileUpload}
                     disabled={isUploading}
-                    accept="*/*"
                   />
                   <Button
                     disabled={isUploading}


### PR DESCRIPTION
## Description

Removes file-extension and MIME-type allow/block lists on Craft file uploads (chat input-bar attachments and the User Library). Uploads are now constrained only by size (and per-session count/total caps); filename sanitization is retained.

Rationale: the extension allow/blocklist was not a real security control — `.py`/`.sh`/etc. were already allowed, and uploaded files only ever run inside the isolated per-user sandbox (non-root, drop-ALL caps, egress-gated), which is the actual security boundary. Downloads are served as attachments, so the lists weren't mitigating XSS either. Removing them lets users upload scripts and any file type for the agent to use, without maintaining an ever-growing extension list.

Changes:
- `build/utils.py`: drop the extension/MIME constants and `validate_file_extension`/`validate_mime_type`; `validate_file()` is now size-only.
- `sessions_api.py`: upload endpoint calls the size-only validator.
- Frontend (`UploadFilesContext.tsx`, `UserLibraryModal.tsx`): remove the client-side blocklist; file pickers accept `*/*`.

## How Has This Been Tested?

- Unit tests rewritten to pin the new spec (any extension/MIME accepted within the size cap; empty/oversize rejected); sanitization tests retained. Pass locally.
- Integration test flipped from "rejects `.exe`" to "accepts a previously-blocked extension" (asserts 201) to guard against reintroducing a block.
- `ruff` + TypeScript type check pass via pre-commit.
- Multi-agent review (backend/frontend/security): confirmed no remaining restriction paths, traversal/zip-slip defenses intact, no server-side parser newly exposed on the changed path, and downloads remain `Content-Disposition: attachment`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed file-extension and MIME-type limits on Craft uploads so users can upload any file type. Validation is size-only; filenames are sanitized and execution stays inside the per-user sandbox.

- **New Features**
  - Backend: `validate_file(size)` enforces size only and returns distinct errors for empty vs oversize; upload endpoint updated.
  - Frontend: removed client-side blocklist; removed `accept` attributes so inputs allow any file.
  - Tests: updated unit/integration to assert size-only behavior; `.exe` uploads return 201; empty-file error is pinned.

<sup>Written for commit 92d387fa0dece1cee02f5aa4128ac965df454222. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11440?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

