### PR TITLE
fix(craft): bind Next.js dev server to 0.0.0.0 so kube Service can reach it

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -159,7 +159,7 @@ set -e
 cd {session_path}/outputs/web
 {install_check}
 echo "Starting Next.js dev server on port {nextjs_port}..."
-nohup bun run dev -- -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
+nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
 NEXTJS_PID=$!
 echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -382,7 +382,7 @@ set -e
 cd {session_path}/outputs/web
 {install_check}
 echo "Starting Next.js dev server on port {nextjs_port}..."
-nohup bun run dev -- -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
+nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
 NEXTJS_PID=$!
 echo "Next.js server started with PID $NEXTJS_PID"
 echo $NEXTJS_PID > {session_path}/nextjs.pid


### PR DESCRIPTION
## Description

Bind the Next.js dev server to `0.0.0.0` so the Kubernetes Service can reach it during development. Updates the Docker and Kubernetes sandbox start scripts to pass `-H 0.0.0.0` to `bun run dev`. Without this, Next.js binds to localhost only and the cluster Service has no route to the pod.

## How Has This Been Tested?

Manually verified a sandbox session can serve traffic through the Kubernetes Service in dev.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check