### PR TITLE
fix(craft): mark notification read on click for relative links

### DIFF
--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -168,6 +168,9 @@ export default function NotificationsPopover({
         return;
       }
 
+      if (!notification.dismissed) {
+        handleDismiss(notification.id);
+      }
       onNavigate();
       router.push(link as Route);
     },


### PR DESCRIPTION
## Description

Clicking a notification with a relative `additional_data.link` (e.g. the Craft "awaiting approval" notification, which deep-links to `/craft/v1?sessionId=...`) navigated to the target but left the notification unread. The external-link branch already dismissed on click; this aligns the relative-link branch with the same behavior, so any actioned in-app notification is marked read.

## How Has This Been Tested?

- `bunx tsgo --noEmit --project tsconfig.types.json` passes.
- Manual: opened the notifications popover, clicked a relative-link notification — it now navigates and the unread indicator clears.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a notification with a relative `additional_data.link` now marks it as read before navigating, matching the external-link behavior. Fixes unread indicators sticking for Craft “awaiting approval” notifications that deep-link to `/craft/v1?...`.

<sup>Written for commit b6f56c31fe51615c8a979b20ec77479ea705a883. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

