### PR TITLE
fix(ods): Auto-set DEVCONTAINER_REMOTE_USER=root on macOS (#11328) to release v4.0

### DIFF
--- a/tools/ods/cmd/dev_up.go
+++ b/tools/ods/cmd/dev_up.go
@@ -175,18 +175,29 @@ func ensureRemoteUser() {
 		return
 	}
 
-	if runtime.GOOS == "linux" {
+	setRemoteUserRoot := func(reason string) {
+		log.Debugf("%s — setting DEVCONTAINER_REMOTE_USER=root", reason)
+		if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {
+			log.Warnf("Failed to set DEVCONTAINER_REMOTE_USER: %v", err)
+		}
+	}
+
+	switch runtime.GOOS {
+	case "linux":
 		sock := os.Getenv("DOCKER_SOCK")
 		xdg := os.Getenv("XDG_RUNTIME_DIR")
 		// Heuristic: rootless Docker on Linux typically places its socket
 		// under $XDG_RUNTIME_DIR. If DOCKER_SOCK was set to a custom path
 		// outside XDG_RUNTIME_DIR, set DEVCONTAINER_REMOTE_USER=root manually.
 		if xdg != "" && strings.HasPrefix(sock, xdg) {
-			log.Debug("Rootless Docker detected — setting DEVCONTAINER_REMOTE_USER=root")
-			if err := os.Setenv("DEVCONTAINER_REMOTE_USER", "root"); err != nil {
-				log.Warnf("Failed to set DEVCONTAINER_REMOTE_USER: %v", err)
-			}
+			setRemoteUserRoot("Rootless Docker detected")
 		}
+	case "darwin":
+		// Docker Desktop on macOS bind-mounts host paths through the Linux VM
+		// as root-owned (no host-UID mapping like native Linux Docker), so
+		// init-dev-user.sh's WS_UID=0 branch always fires and rejects the
+		// non-root `dev` user.
+		setRemoteUserRoot("Docker Desktop on macOS")
 	}
 }
 


### PR DESCRIPTION
Cherry-pick of commit efb355b53410fe2a024b35ff3381841cb4f8d185 to release/v4.0 branch.

Original PR: #11328

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-set DEVCONTAINER_REMOTE_USER=root on macOS so dev containers start reliably under Docker Desktop. Keeps Linux behavior and adds clearer debug logs.

- **Bug Fixes**
  - macOS: Always set DEVCONTAINER_REMOTE_USER=root to avoid permission issues that block the non-root dev user.
  - Linux: Preserve rootless Docker heuristic; refactor to a small helper and log the reason when setting the value.

<sup>Written for commit 7635e05b9c3b420c21e7e0d9cea70dc095617571. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

