### PR TITLE
fix(craft): open Next.js dev port range in sandbox NetworkPolicy

### DIFF
--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -39,11 +39,9 @@ spec:
         # AGENT_TRANSPORT=serve. See docs/craft/opencode-serve-migration.md.
         - protocol: TCP
           port: {{ .Values.configMap.OPENCODE_SERVE_PORT | default 4096 }}
-        # Next.js dev servers — one per session, dynamically allocated from
-        # SANDBOX_NEXTJS_PORT_START..SANDBOX_NEXTJS_PORT_END (defaults
-        # 3010..3100). The webapp proxy in api-server connects to these
-        # through the per-sandbox Service; without this allow rule the
-        # default-deny on NetworkPolicy drops the connection silently.
+        # Next.js dev servers, one per session. PORT_END is exclusive
+        # (Python range() — see build_session.py); k8s endPort is inclusive,
+        # hence sub 1.
         - protocol: TCP
           port: {{ .Values.configMap.SANDBOX_NEXTJS_PORT_START | default 3010 }}
           endPort: {{ sub (int (.Values.configMap.SANDBOX_NEXTJS_PORT_END | default 3100)) 1 }}

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -39,4 +39,12 @@ spec:
         # AGENT_TRANSPORT=serve. See docs/craft/opencode-serve-migration.md.
         - protocol: TCP
           port: {{ .Values.configMap.OPENCODE_SERVE_PORT | default 4096 }}
+        # Next.js dev servers — one per session, dynamically allocated from
+        # SANDBOX_NEXTJS_PORT_START..SANDBOX_NEXTJS_PORT_END (defaults
+        # 3010..3100). The webapp proxy in api-server connects to these
+        # through the per-sandbox Service; without this allow rule the
+        # default-deny on NetworkPolicy drops the connection silently.
+        - protocol: TCP
+          port: {{ .Values.configMap.SANDBOX_NEXTJS_PORT_START | default 3010 }}
+          endPort: {{ sub (int (.Values.configMap.SANDBOX_NEXTJS_PORT_END | default 3100)) 1 }}
 {{- end }}


### PR DESCRIPTION
## Description

Opens the Next.js dev server port range in the sandbox NetworkPolicy so per-session dev servers are reachable from the api-server webapp proxy. Without this, the default-deny policy silently drops connections to dynamically-allocated dev server ports.

Port range is configurable via `SANDBOX_NEXTJS_PORT_START` / `SANDBOX_NEXTJS_PORT_END` (defaults 3010–3100).

## How Has This Been Tested?

Verified Helm template renders the expected `ports` entry with `port`/`endPort` covering the configured range, and confirmed via deployed sandbox that the api-server proxy can now reach session dev servers.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check