### PR TITLE
chore(helm): Bump Onyx Helm chart to 0.5.10

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.9
+version: 0.5.10
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,13 +17,8 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: fixed
-      description: Truncate child resource names to the 63-char Kubernetes
-        DNS-1123 label limit. Releases with longer fullnames previously
-        produced invalid Service/Deployment names for the celery-worker
-        docprocessing-metrics, scheduled-tasks-metrics, docfetching-metrics,
-        monitoring-metrics, primary-metrics, user-file-processing, and
-        scheduled-tasks templates. Adds an `onyx.resourceName` helper used
-        by the affected templates.
+      description: Allow sandbox NetworkPolicy traffic to the configured
+        Next.js dev server port range.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0


### PR DESCRIPTION
## Description

Bumps the Onyx Helm chart from 0.5.9 to 0.5.10 and updates the Artifact Hub changelog entry for the sandbox NetworkPolicy fix merged in #11445.

Publishing the next chart release will include the configured Next.js dev server port range in the sandbox push NetworkPolicy.

## How Has This Been Tested?

- `helm dependency build deployment/helm/charts/onyx`
- `helm lint deployment/helm/charts/onyx --set auth.userauth.values.user_auth_secret=placeholder --set auth.opensearch.values.opensearch_admin_password=StrongPassword123!`
- `helm template test-output deployment/helm/charts/onyx --set auth.userauth.values.user_auth_secret=placeholder --set auth.opensearch.values.opensearch_admin_password=StrongPassword123! >/tmp/onyx-chart-0.5.10.yaml`
- `helm template test-output deployment/helm/charts/onyx -f deployment/helm/charts/onyx/values-ci.yaml --show-only templates/network-policy-sandbox-push.yaml >/tmp/onyx-sandbox-push-policy.yaml`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
