### PR TITLE
chore(deploy): de-duplicate docker-compose files via templated render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .venv
 .mypy_cache
 .idea
+__pycache__/
 
 # testing
 /web/test-results/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,3 +169,11 @@ repos:
         language: system
         pass_filenames: false
         files: ^web/.*\.(ts|tsx)$
+
+      - id: render-docker-compose
+        name: render docker-compose files
+        description: "Regenerate top-level docker-compose.*.yml files from deployment/docker_compose/src/"
+        entry: python deployment/docker_compose/render.py --check
+        language: system
+        pass_filenames: false
+        files: ^deployment/docker_compose/(src/.*\.ya?ml|render\.py)$

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -45,3 +45,20 @@ downloaded during the initial setup. Feel free to edit the .env file to customiz
 located near the top of the file.
 
 IMAGE_TAG is the version of Onyx to run. It is recommended to leave it as latest to get all updates with each redeployment.
+
+## Editing the compose files
+
+The top-level `docker-compose.yml`, `docker-compose.prod.yml`, `docker-compose.prod-cloud.yml`, `docker-compose.prod-no-letsencrypt.yml`, and `docker-compose.multitenant-dev.yml` files are **generated** — do not edit them by hand. The source of truth lives under `src/`:
+
+- `src/services/<name>.yml` — canonical per-service fragments shared across deployments
+- `src/deployments/<name>.yml` — per-deployment composition (which services to include, plus overrides)
+
+To regenerate the top-level files after editing anything under `src/`:
+
+```
+python deployment/docker_compose/render.py
+```
+
+A `render-docker-compose` pre-commit hook runs `render.py --check` and fails the commit if any rendered file is out of sync with `src/`. Re-run `render.py` and commit the regenerated files together with the `src/` change.
+
+The other compose files (`docker-compose.dev.yml`, `docker-compose.onyx-lite.yml`, `docker-compose.craft.yml`, `docker-compose.resources.yml`, and the `docker-compose.mcp-*.yml` test files) are thin overlays or standalone test stacks and are still edited directly.

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -1,336 +1,281 @@
-name: onyx
+# =============================================================================
+# GENERATED FILE — DO NOT EDIT BY HAND.
+# Source: deployment/docker_compose/src/deployments/prod-cloud.yml
+# Regenerate with: python deployment/docker_compose/render.py
+# =============================================================================
 
+name: onyx
 services:
   api_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile.cloud
-    command: >
-      /bin/sh -c "alembic -n schema_private upgrade head &&
-      echo \"Starting Onyx Api Server\" &&
-      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    command: |
+      /bin/sh -c "alembic -n schema_private upgrade head && echo \"Starting Onyx Api Server\" && uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - inference_model_server
-      - minio
+      relational_db:
+        condition: service_started
+      opensearch:
+        condition: service_started
+      cache:
+        condition: service_started
+      inference_model_server:
+        condition: service_started
+      minio:
+        condition: service_started
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-    env_file:
-      - path: .env
-        required: false
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   background:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
     command: /app/scripts/supervisord_entrypoint.sh
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - inference_model_server
-      - indexing_model_server
+      relational_db:
+        condition: service_started
+      opensearch:
+        condition: service_started
+      cache:
+        condition: service_started
+      inference_model_server:
+        condition: service_started
+      indexing_model_server:
+        condition: service_started
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
-      - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-    env_file:
-      - path: .env
-        required: false
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
+      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
+      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   web_server:
-    image: onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}
+    image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../web
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
-        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
-        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+      - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+      - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+      - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - api_server
+    - api_server
     restart: unless-stopped
     environment:
-      - INTERNAL_URL=http://api_server:8080
-    env_file:
-      - path: .env
-        required: false
+      INTERNAL_URL: http://api_server:8080
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
-  # Uncomment the block below to enable the MCP server for Onyx.
-  # mcp_server:
-  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-  #   build:
-  #     context: ../../backend
-  #     dockerfile: Dockerfile
-  #   command: >
-  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-  #       exit 0;
-  #     else
-  #       exec python -m onyx.mcp_server_main;
-  #     fi"
-  #   env_file:
-  #     - path: .env
-  #       required: false
-  #   depends_on:
-  #     - relational_db
-  #     - cache
-  #   restart: "no"
-  #   environment:
-  #     - POSTGRES_HOST=relational_db
-  #     - REDIS_HOST=cache
-  #     # MCP Server Configuration
-  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #   extra_hosts:
-  #     - "host.docker.internal:host-gateway"
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   volumes:
-  #     - mcp_server_logs:/var/log/onyx
-
+        max-size: 50m
+        max-file: '6'
+  inference_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    command: |
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+    - path: .env
+      required: false
+    restart: on-failure
+    volumes:
+    - model_cache_huggingface:/app/.cache/huggingface/
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: '6'
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+  indexing_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    command: |
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+    - path: .env
+      required: false
+    restart: on-failure
+    environment:
+      INDEXING_ONLY: 'True'
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
+    volumes:
+    - indexing_huggingface_model_cache:/app/.cache/huggingface/
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: '6'
   relational_db:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
     restart: unless-stopped
-    # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
-      - path: .env
-        required: false
-    volumes:
-      - db_volume:/var/lib/postgresql/data
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-
-  inference_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    restart: on-failure
+    - path: .env
+      required: false
     environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/app/.cache/huggingface/
+    - db_volume:/var/lib/postgresql/data
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
-  indexing_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    restart: on-failure
-    environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      - INDEXING_ONLY=True
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-      - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
-    volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/app/.cache/huggingface/
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   opensearch:
     image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
-    # OpenSearch is the search backend and is enabled by default. To run against
-    # an external OpenSearch instance, set OPENSEARCH_HOST in your env and
-    # remove this service from the compose file (or skip it via the service list
-    # when running `docker compose up`).
     environment:
-      # We need discovery.type=single-node so that OpenSearch doesn't try
-      # forming a cluster and waiting for other nodes to become live.
-      - discovery.type=single-node
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
-      # We do this to avoid unstable performance from page swaps.
-      - bootstrap.memory_lock=true # Disable JVM heap memory swapping.
-      # Java heap should be ~50% of memory limit. For now we assume a limit of
-      # 4g although in practice the container can request more than this.
-      # See https://opster.com/guides/opensearch/opensearch-basics/opensearch-heap-size-usage-and-jvm-garbage-collection/
-      # Xms is the starting size, Xmx is the maximum size. These should be the
-      # same.
-      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      discovery.type: single-node
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      bootstrap.memory_lock: 'true'
+      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
     volumes:
-      - opensearch-data:/usr/share/opensearch/data
-    # These come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+    - opensearch-data:/usr/share/opensearch/data
     ulimits:
-      # Similarly to bootstrap.memory_lock, we don't want to impose limits on
-      # how much memory a process can lock from being swapped.
       memlock:
-        soft: -1 # Set memlock to unlimited (no soft or hard limit).
+        soft: -1
         hard: -1
       nofile:
-        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536.
+        soft: 65536
         hard: 65536
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   nginx:
     image: nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
     depends_on:
-      - api_server
-      - web_server
-    ports:
-      - "80:80"
-      - "443:443"
+    - api_server
+    - web_server
     volumes:
-      - ../data/nginx:/nginx-templates:ro
-      - ../data/certbot/conf:/etc/letsencrypt
-      - ../data/certbot/www:/var/www/certbot
+    - ../data/nginx:/nginx-templates:ro
+    - ../data/certbot/conf:/etc/letsencrypt
+    - ../data/certbot/www:/var/www/certbot
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    command: >
-      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
-      && cp -a /nginx-templates/. /etc/nginx/conf.d/
-      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
-      && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template.prod"
+        max-size: 50m
+        max-file: '6'
+    ports:
+    - 80:80
+    - 443:443
+    command: |
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf && cp -a /nginx-templates/. /etc/nginx/conf.d/ && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh && chmod +x /tmp/run-nginx.sh && /tmp/run-nginx.sh app.conf.template.prod"
     env_file:
-      - .env.nginx
+    - .env.nginx
     environment:
-      # Nginx proxy timeout settings (in seconds)
-      - NGINX_PROXY_CONNECT_TIMEOUT=${NGINX_PROXY_CONNECT_TIMEOUT:-300}
-      - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
-      - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
-
-  # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
   certbot:
     image: certbot/certbot
     restart: unless-stopped
     volumes:
-      - ../data/certbot/conf:/etc/letsencrypt
-      - ../data/certbot/www:/var/www/certbot
+    - ../data/certbot/conf:/etc/letsencrypt
+    - ../data/certbot/www:/var/www/certbot
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-
+        max-size: 50m
+        max-file: '6'
+    entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    env_file:
+    - path: .env
+      required: false
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
-      - minio_data:/data
+    - minio_data:/data
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test:
+      - CMD
+      - mc
+      - ready
+      - local
       interval: 30s
       timeout: 20s
       retries: 3
-
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    # docker silently mounts /data even without an explicit volume mount, which enables
-    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
-    # Use tmpfs to prevent creation of anonymous volumes for /data
+    env_file:
+    - path: .env
+      required: false
     tmpfs:
-      - /data
-
+    - /data
 volumes:
   db_volume:
   minio_data:
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  # mcp_server_logs:
-  # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -1,368 +1,299 @@
-name: onyx
+# =============================================================================
+# GENERATED FILE — DO NOT EDIT BY HAND.
+# Source: deployment/docker_compose/src/deployments/prod-no-letsencrypt.yml
+# Regenerate with: python deployment/docker_compose/render.py
+# =============================================================================
 
+name: onyx
 services:
   api_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "alembic upgrade head &&
-      echo \"Starting Onyx Api Server\" &&
-      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    command: |
+      /bin/sh -c "alembic upgrade head && echo \"Starting Onyx Api Server\" && uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - inference_model_server
-      - minio
+      relational_db:
+        condition: service_started
+      opensearch:
+        condition: service_started
+      cache:
+        condition: service_started
+      inference_model_server:
+        condition: service_started
+      minio:
+        condition: service_started
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - CODE_INTERPRETER_BASE_URL=${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
-      - USE_IAM_AUTH=${USE_IAM_AUTH}
-      - AWS_REGION_NAME=${AWS_REGION_NAME-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    env_file:
-      - path: .env
-        required: false
-    # Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
+        max-size: 50m
+        max-file: '6'
     volumes:
-      # optional, only for debugging purposes
-      - api_server_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
-
+    - api_server_logs:/var/log/onyx
+    - file-system:/app/file-system
   background:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
     command: /app/scripts/supervisord_entrypoint.sh
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - inference_model_server
-      - indexing_model_server
+    - relational_db
+    - opensearch
+    - cache
+    - inference_model_server
+    - indexing_model_server
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
-      - USE_IAM_AUTH=${USE_IAM_AUTH}
-      - AWS_REGION_NAME=${AWS_REGION_NAME-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    env_file:
-      - path: .env
-        required: false
-    # Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
+      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
+      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
-    volumes:
-      - background_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
+    volumes:
+    - background_logs:/var/log/onyx
+    - file-system:/app/file-system
   web_server:
-    image: onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}
+    image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../web
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
-        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+      - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+      - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - api_server
+    - api_server
     restart: unless-stopped
     environment:
-      - INTERNAL_URL=http://api_server:8080
-    env_file:
-      - path: .env
-        required: false
+      INTERNAL_URL: http://api_server:8080
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
-  # Uncomment the block below to enable the MCP server for Onyx.
-  # mcp_server:
-  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-  #   build:
-  #     context: ../../backend
-  #     dockerfile: Dockerfile
-  #   command: >
-  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-  #       exit 0;
-  #     else
-  #       exec python -m onyx.mcp_server_main;
-  #     fi"
-  #   env_file:
-  #     - path: .env
-  #       required: false
-  #   depends_on:
-  #     - relational_db
-  #     - cache
-  #   restart: "no"
-  #   environment:
-  #     - POSTGRES_HOST=relational_db
-  #     - REDIS_HOST=cache
-  #     # MCP Server Configuration
-  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #   extra_hosts:
-  #     - "host.docker.internal:host-gateway"
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   volumes:
-  #     - mcp_server_logs:/var/log/onyx
-
+        max-size: 50m
+        max-file: '6'
   inference_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
+    command: |
       /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
+    env_file:
+    - path: .env
+      required: false
     restart: on-failure
-    environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/app/.cache/huggingface/
-      # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log/onyx
+    - model_cache_huggingface:/app/.cache/huggingface/
+    - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
   indexing_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
+    command: |
       /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
       else
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
+    env_file:
+    - path: .env
+      required: false
     restart: on-failure
     environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      - INDEXING_ONLY=True
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-      - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
+      INDEXING_ONLY: 'True'
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/app/.cache/huggingface/
-      # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log/onyx
+    - indexing_huggingface_model_cache:/app/.cache/huggingface/
+    - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   relational_db:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
     restart: unless-stopped
-    # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
     volumes:
-      - db_volume:/var/lib/postgresql/data
+    - db_volume:/var/lib/postgresql/data
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   opensearch:
     image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
-    # OpenSearch is the search backend and is enabled by default. To run against
-    # an external OpenSearch instance, set OPENSEARCH_HOST in your env and
-    # remove this service from the compose file (or skip it via the service list
-    # when running `docker compose up`).
     environment:
-      # We need discovery.type=single-node so that OpenSearch doesn't try
-      # forming a cluster and waiting for other nodes to become live.
-      - discovery.type=single-node
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
-      # We do this to avoid unstable performance from page swaps.
-      - bootstrap.memory_lock=true # Disable JVM heap memory swapping.
-      # Java heap should be ~50% of memory limit. For now we assume a limit of
-      # 4g although in practice the container can request more than this.
-      # See https://opster.com/guides/opensearch/opensearch-basics/opensearch-heap-size-usage-and-jvm-garbage-collection/
-      # Xms is the starting size, Xmx is the maximum size. These should be the
-      # same.
-      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      discovery.type: single-node
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      bootstrap.memory_lock: 'true'
+      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
     volumes:
-      - opensearch-data:/usr/share/opensearch/data
-    # These come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+    - opensearch-data:/usr/share/opensearch/data
     ulimits:
-      # Similarly to bootstrap.memory_lock, we don't want to impose limits on
-      # how much memory a process can lock from being swapped.
       memlock:
-        soft: -1 # Set memlock to unlimited (no soft or hard limit).
+        soft: -1
         hard: -1
       nofile:
-        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536.
+        soft: 65536
         hard: 65536
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   nginx:
     image: nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
     depends_on:
-      - api_server
-      - web_server
-    ports:
-      - "80:80"
-      - "443:443"
+    - api_server
+    - web_server
     volumes:
-      - ../data/nginx:/nginx-templates:ro
-      - ../data/sslcerts:/etc/nginx/sslcerts
+    - ../data/nginx:/nginx-templates:ro
+    - ../data/sslcerts:/etc/nginx/sslcerts
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    command: >
-      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
-      && cp -a /nginx-templates/. /etc/nginx/conf.d/
-      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
-      && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template.no-letsencrypt"
+        max-size: 50m
+        max-file: '6'
+    ports:
+    - 80:80
+    - 443:443
+    command: |
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf && cp -a /nginx-templates/. /etc/nginx/conf.d/ && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh && chmod +x /tmp/run-nginx.sh && /tmp/run-nginx.sh app.conf.template.no-letsencrypt"
     env_file:
-      - .env.nginx
+    - .env.nginx
     environment:
-      # Nginx proxy timeout settings (in seconds)
-      - NGINX_PROXY_CONNECT_TIMEOUT=${NGINX_PROXY_CONNECT_TIMEOUT:-300}
-      - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
-      - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
-
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    env_file:
+    - path: .env
+      required: false
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
-      - minio_data:/data
+    - minio_data:/data
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test:
+      - CMD
+      - mc
+      - ready
+      - local
       interval: 30s
       timeout: 20s
       retries: 3
-
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    # docker silently mounts /data even without an explicit volume mount, which enables
-    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
-    # Use tmpfs to prevent creation of anonymous volumes for /data
+    env_file:
+    - path: .env
+      required: false
     tmpfs:
-      - /data
-
+    - /data
   code-interpreter:
     image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
-    command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
+    command:
+    - bash
+    - ./entrypoint.sh
+    - code-interpreter-api
     restart: unless-stopped
     env_file:
-      - path: .env
-        required: false
-
-    # Below is needed for the `docker-out-of-docker` execution mode
+    - path: .env
+      required: false
     user: root
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
-
+    - /var/run/docker.sock:/var/run/docker.sock
 volumes:
   db_volume:
   minio_data:
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  # for logs that we don't want to lose on container restarts
   api_server_logs:
   background_logs:
   inference_model_server_logs:
   indexing_model_server_logs:
-  # mcp_server_logs:
-  # Shared volume for persistent document storage (Craft file-system mode)
   file-system:
-  # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -1,416 +1,328 @@
-name: onyx
+# =============================================================================
+# GENERATED FILE — DO NOT EDIT BY HAND.
+# Source: deployment/docker_compose/src/deployments/prod.yml
+# Regenerate with: python deployment/docker_compose/render.py
+# =============================================================================
 
+name: onyx
 services:
   api_server:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "
-      alembic upgrade head &&
-      echo \"Starting Onyx Api Server\" &&
-      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    command: |
+      /bin/sh -c "alembic upgrade head && echo \"Starting Onyx Api Server\" && uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - minio
-      - inference_model_server
+      relational_db:
+        condition: service_started
+      opensearch:
+        condition: service_started
+      cache:
+        condition: service_started
+      inference_model_server:
+        condition: service_started
+      minio:
+        condition: service_started
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - CODE_INTERPRETER_BASE_URL=${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
-      - USE_IAM_AUTH=${USE_IAM_AUTH}
-      - AWS_REGION_NAME=${AWS_REGION_NAME-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    env_file:
-      - path: .env
-        required: false
-    # Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
+        max-size: 50m
+        max-file: '6'
     volumes:
-      - api_server_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
-
+    - api_server_logs:/var/log/onyx
+    - file-system:/app/file-system
   background:
-    image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
-    command: >
-      /bin/sh -c "
-      if [ -f /etc/ssl/certs/custom-ca.crt ]; then
+    command: |
+      /bin/sh -c " if [ -f /etc/ssl/certs/custom-ca.crt ]; then
         update-ca-certificates;
-      fi &&
-      /app/scripts/supervisord_entrypoint.sh"
+      fi && /app/scripts/supervisord_entrypoint.sh"
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - relational_db
-      - opensearch
-      - cache
-      - inference_model_server
-      - indexing_model_server
+    - relational_db
+    - opensearch
+    - cache
+    - inference_model_server
+    - indexing_model_server
     restart: unless-stopped
     environment:
-      - AUTH_TYPE=${AUTH_TYPE:-oidc}
-      - POSTGRES_HOST=relational_db
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=cache
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
-      - USE_IAM_AUTH=${USE_IAM_AUTH}
-      - AWS_REGION_NAME=${AWS_REGION_NAME-}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY-}
-      # MinIO configuration
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
-      - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    env_file:
-      - path: .env
-        required: false
-    # Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: relational_db
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: cache
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
+      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
+      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
-    volumes:
-      - background_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    # Uncomment the following lines if you need to include a custom CA certificate
-    # This section enables the use of a custom CA certificate
-    # If present, the custom CA certificate is mounted as a volume
-    # The container checks for its existence and updates the system's CA certificates
-    # This allows for secure communication with services using custom SSL certificates
-    # volumes:
-    #   # Maps to the CA_CERT_PATH environment variable in the Dockerfile
-    #   - ${CA_CERT_PATH:-./custom-ca.crt}:/etc/ssl/certs/custom-ca.crt:ro
-
+        max-size: 50m
+        max-file: '6'
+    volumes:
+    - background_logs:/var/log/onyx
+    - file-system:/app/file-system
   web_server:
-    image: onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}
+    image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../web
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
-        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
-        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+      - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+      - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+      - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+    env_file:
+    - path: .env
+      required: false
     depends_on:
-      - api_server
+    - api_server
     restart: unless-stopped
     environment:
-      - INTERNAL_URL=http://api_server:8080
-    env_file:
-      - path: .env
-        required: false
+      INTERNAL_URL: http://api_server:8080
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
-  # Uncomment the block below to enable the MCP server for Onyx.
-  # mcp_server:
-  #   image: onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}
-  #   build:
-  #     context: ../../backend
-  #     dockerfile: Dockerfile
-  #   command: >
-  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-  #       exit 0;
-  #     else
-  #       exec python -m onyx.mcp_server_main;
-  #     fi"
-  #   env_file:
-  #     - path: .env
-  #       required: false
-  #   depends_on:
-  #     - relational_db
-  #     - cache
-  #   restart: "no"
-  #   environment:
-  #     - POSTGRES_HOST=relational_db
-  #     - REDIS_HOST=cache
-  #     # MCP Server Configuration
-  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #   extra_hosts:
-  #     - "host.docker.internal:host-gateway"
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   volumes:
-  #     - mcp_server_logs:/var/log/onyx
-
+        max-size: 50m
+        max-file: '6'
+  inference_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    command: |
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+    - path: .env
+      required: false
+    restart: unless-stopped
+    volumes:
+    - model_cache_huggingface:/app/.cache/huggingface/
+    - inference_model_server_logs:/var/log/onyx
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: '6'
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+  indexing_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    command: |
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+    - path: .env
+      required: false
+    restart: unless-stopped
+    environment:
+      INDEXING_ONLY: 'True'
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
+    volumes:
+    - indexing_huggingface_model_cache:/app/.cache/huggingface/
+    - indexing_model_server_logs:/var/log/onyx
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: '6'
   relational_db:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
     restart: unless-stopped
-    # POSTGRES_USER and POSTGRES_PASSWORD should be set in .env file
     env_file:
-      - path: .env
-        required: false
-    volumes:
-      - db_volume:/var/lib/postgresql/data
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-
-  inference_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    restart: unless-stopped
+    - path: .env
+      required: false
     environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/app/.cache/huggingface/
-      # optional, only for debugging purposes
-      - inference_model_server_logs:/var/log/onyx
+    - db_volume:/var/lib/postgresql/data
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
-  indexing_model_server:
-    image: onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    restart: unless-stopped
-    environment:
-      - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
-      - INDEXING_ONLY=True
-      # Set to debug to get more fine-grained logs
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-      - VESPA_SEARCHER_THREADS=${VESPA_SEARCHER_THREADS:-1}
-    volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/app/.cache/huggingface/
-      # optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log/onyx
-    logging:
-      driver: json-file
-      options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   opensearch:
     image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
-    # OpenSearch is the search backend and is enabled by default. To run against
-    # an external OpenSearch instance, set OPENSEARCH_HOST in your env and
-    # remove this service from the compose file (or skip it via the service list
-    # when running `docker compose up`).
     environment:
-      # We need discovery.type=single-node so that OpenSearch doesn't try
-      # forming a cluster and waiting for other nodes to become live.
-      - discovery.type=single-node
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
-      # We do this to avoid unstable performance from page swaps.
-      - bootstrap.memory_lock=true # Disable JVM heap memory swapping.
-      # Java heap should be ~50% of memory limit. For now we assume a limit of
-      # 4g although in practice the container can request more than this.
-      # See https://opster.com/guides/opensearch/opensearch-basics/opensearch-heap-size-usage-and-jvm-garbage-collection/
-      # Xms is the starting size, Xmx is the maximum size. These should be the
-      # same.
-      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      discovery.type: single-node
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      bootstrap.memory_lock: 'true'
+      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
     volumes:
-      - opensearch-data:/usr/share/opensearch/data
-    # These come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+    - opensearch-data:/usr/share/opensearch/data
     ulimits:
-      # Similarly to bootstrap.memory_lock, we don't want to impose limits on
-      # how much memory a process can lock from being swapped.
       memlock:
-        soft: -1 # Set memlock to unlimited (no soft or hard limit).
+        soft: -1
         hard: -1
       nofile:
-        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536.
+        soft: 65536
         hard: 65536
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   nginx:
     image: nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
     depends_on:
-      - api_server
-      - web_server
-    ports:
-      - "80:80"
-      - "443:443"
+    - api_server
+    - web_server
     volumes:
-      - ../data/nginx:/nginx-templates:ro
-      - ../data/certbot/conf:/etc/letsencrypt
-      - ../data/certbot/www:/var/www/certbot
+    - ../data/nginx:/nginx-templates:ro
+    - ../data/certbot/conf:/etc/letsencrypt
+    - ../data/certbot/www:/var/www/certbot
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    command: >
-      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
-      && cp -a /nginx-templates/. /etc/nginx/conf.d/
-      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
-      && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template.prod"
+        max-size: 50m
+        max-file: '6'
+    ports:
+    - 80:80
+    - 443:443
+    command: |
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf && cp -a /nginx-templates/. /etc/nginx/conf.d/ && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh && chmod +x /tmp/run-nginx.sh && /tmp/run-nginx.sh app.conf.template.prod"
     env_file:
-      - .env.nginx
+    - .env.nginx
     environment:
-      # Nginx proxy timeout settings (in seconds)
-      - NGINX_PROXY_CONNECT_TIMEOUT=${NGINX_PROXY_CONNECT_TIMEOUT:-300}
-      - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
-      - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
     healthcheck:
       test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1/nginx-health",
-        ]
+      - CMD
+      - wget
+      - --quiet
+      - --tries=1
+      - --spider
+      - http://127.0.0.1/nginx-health
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 30s
-
-  # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
   certbot:
     image: certbot/certbot
     restart: unless-stopped
     volumes:
-      - ../data/certbot/conf:/etc/letsencrypt
-      - ../data/certbot/www:/var/www/certbot
+    - ../data/certbot/conf:/etc/letsencrypt
+    - ../data/certbot/www:/var/www/certbot
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-
+        max-size: 50m
+        max-file: '6'
+    entrypoint: /bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     restart: unless-stopped
+    env_file:
+    - path: .env
+      required: false
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
-      - minio_data:/data
+    - minio_data:/data
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test:
+      - CMD
+      - mc
+      - ready
+      - local
       interval: 30s
       timeout: 20s
       retries: 3
-
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    # docker silently mounts /data even without an explicit volume mount, which enables
-    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
-    # Use tmpfs to prevent creation of anonymous volumes for /data
+    env_file:
+    - path: .env
+      required: false
     tmpfs:
-      - /data
-
+    - /data
   code-interpreter:
     image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
-    command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
+    command:
+    - bash
+    - ./entrypoint.sh
+    - code-interpreter-api
     restart: unless-stopped
     env_file:
-      - path: .env
-        required: false
-
-    # Below is needed for the `docker-out-of-docker` execution mode
+    - path: .env
+      required: false
     user: root
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
-
+    - /var/run/docker.sock:/var/run/docker.sock
 volumes:
   db_volume:
   minio_data:
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  # for logs that we don't want to lose on container restarts
   api_server_logs:
   background_logs:
   inference_model_server_logs:
   indexing_model_server_logs:
-  # mcp_server_logs:
-  # Shared volume for persistent document storage (Craft file-system mode)
   file-system:
-  # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -1,41 +1,10 @@
 # =============================================================================
-# ONYX DOCKER COMPOSE
-# =============================================================================
-# This is the default configuration for Onyx. This file is fairly configurable,
-# also see env.template for possible settings.
-#
-# PRODUCTION DEPLOYMENT CHECKLIST:
-# To convert this setup to a production deployment following best practices,
-# follow the checklist below. Note that there are other ways to secure the Onyx
-# deployment so these are not strictly necessary for all teams.
-#
-# 1. SECURITY HARDENING:
-#    - Remove all port exposures except nginx (80/443)
-#    - Comment out ports for: api_server, relational_db, cache, minio
-#
-# 2. SSL/TLS SETUP:
-#    - Uncomment the certbot service (see below)
-#    - Add SSL certificate volumes to nginx service
-#    - Change nginx command from app.conf.template to app.conf.template.prod
-#
-# 3. ENVIRONMENT CONFIGURATION:
-#    - Replace env_file with explicit environment variables
-#
-# 4. AUTHENTICATION:
-#    - Select an authentication method like Basic, Google OAuth, OIDC, or SAML
-#
-# 5. CA CERTIFICATES:
-#    - Uncomment custom CA certificate volumes if needed
-#
-# 6. DOMAIN CONFIGURATION:
-#    - Set proper DOMAIN environment variable for nginx
-#    - Configure DNS and SSL certificates
-#
-# For a complete production setup, refer to docker-compose.prod.yml
+# GENERATED FILE — DO NOT EDIT BY HAND.
+# Source: deployment/docker_compose/src/deployments/default.yml
+# Regenerate with: python deployment/docker_compose/render.py
 # =============================================================================
 
 name: onyx
-
 services:
   api_server:
     image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
@@ -43,15 +12,12 @@ services:
       context: ../../backend
       dockerfile: Dockerfile
       args:
-        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-    command: >
-      /bin/sh -c "alembic upgrade head &&
-      echo \"Starting Onyx Api Server\" &&
-      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
-    # Check env.template and copy to .env for env vars
+      - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
+    command: |
+      /bin/sh -c "alembic upgrade head && echo \"Starting Onyx Api Server\" && uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     depends_on:
       relational_db:
         condition: service_started
@@ -65,232 +31,138 @@ services:
         condition: service_started
         required: false
     restart: unless-stopped
-    # DEV: To expose ports, either:
-    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
-    # 2. Uncomment the ports below
-    # ports:
-    #   - "8080:8080"
     environment:
-      # Auth Settings
-      - AUTH_TYPE=${AUTH_TYPE:-basic}
-      - FILE_STORE_BACKEND=${FILE_STORE_BACKEND:-s3}
-      - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=${REDIS_HOST:-cache}
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - CODE_INTERPRETER_BASE_URL=${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      # Onyx Craft configuration (disabled by default, set ENABLE_CRAFT=true in .env to enable)
-      # Use --include-craft with install script, or manually set in .env file
-      - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
-      - OUTPUTS_TEMPLATE_PATH=${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
-      - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
-      - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: ${REDIS_HOST:-cache}
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      AUTH_TYPE: ${AUTH_TYPE:-basic}
+      FILE_STORE_BACKEND: ${FILE_STORE_BACKEND:-s3}
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      ENABLE_CRAFT: ${ENABLE_CRAFT:-false}
+      SANDBOX_BACKEND: ${SANDBOX_BACKEND:-docker}
+      OUTPUTS_TEMPLATE_PATH: ${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
+      VENV_TEMPLATE_PATH: ${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
+      WEB_TEMPLATE_PATH: ${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
+        max-size: 50m
+        max-file: '6'
     healthcheck:
       test:
-        [
-          "CMD",
-          "python",
-          "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')",
-        ]
+      - CMD
+      - python
+      - -c
+      - import urllib.request; urllib.request.urlopen('http://localhost:8080/health')
       interval: 30s
       timeout: 20s
       retries: 3
-      # Generous start_period so that `docker compose up --wait` does not flag
-      # the container unhealthy while alembic migrations run on a fresh DB.
-      # Healthy is reported as soon as /health responds, so this does not slow
-      # down fast boots.
       start_period: 600s
-    # Optional, only for debugging purposes
     volumes:
-      - api_server_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
-
+    - api_server_logs:/var/log/onyx
+    - file-system:/app/file-system
   background:
     image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile
       args:
-        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-    command: >
-      /bin/sh -c "
-      if [ -f /app/scripts/setup_craft_templates.sh ]; then
+      - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
+    command: |
+      /bin/sh -c " if [ -f /app/scripts/setup_craft_templates.sh ]; then
         /app/scripts/setup_craft_templates.sh;
-      fi &&
-      if [ -f /etc/ssl/certs/custom-ca.crt ]; then
+      fi && if [ -f /etc/ssl/certs/custom-ca.crt ]; then
         update-ca-certificates;
-      fi &&
-      /app/scripts/supervisord_entrypoint.sh"
+      fi && /app/scripts/supervisord_entrypoint.sh"
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     depends_on:
-      relational_db:
-        condition: service_started
-      opensearch:
-        condition: service_started
-      cache:
-        condition: service_started
-      inference_model_server:
-        condition: service_started
-      indexing_model_server:
-        condition: service_started
+    - relational_db
+    - opensearch
+    - cache
+    - inference_model_server
+    - indexing_model_server
     restart: unless-stopped
     environment:
-      - FILE_STORE_BACKEND=${FILE_STORE_BACKEND:-s3}
-      - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
-      - OPENSEARCH_HOST=${OPENSEARCH_HOST:-opensearch}
-      - OPENSEARCH_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      - REDIS_HOST=${REDIS_HOST:-cache}
-      - MODEL_SERVER_HOST=${MODEL_SERVER_HOST:-inference_model_server}
-      - INDEXING_MODEL_SERVER_HOST=${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
-      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
-      - S3_AWS_ACCESS_KEY_ID=${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      - S3_AWS_SECRET_ACCESS_KEY=${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN:-}
-      - DISCORD_BOT_INVOKE_CHAR=${DISCORD_BOT_INVOKE_CHAR:-!}
-      # API Server connection for Discord bot message processing
-      - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-      - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-      # Onyx Craft configuration (set up automatically on container startup)
-      - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
-      - OUTPUTS_TEMPLATE_PATH=${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
-      - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
-      - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
-      - PERSISTENT_DOCUMENT_STORAGE_PATH=${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
-    # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you are using iam auth for postgres
-    # volumes:
-    #   - ./bundle.pem:/app/bundle.pem:ro
+      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: ${REDIS_HOST:-cache}
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
+      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
+      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
+      FILE_STORE_BACKEND: ${FILE_STORE_BACKEND:-s3}
+      ENABLE_CRAFT: ${ENABLE_CRAFT:-false}
+      SANDBOX_BACKEND: ${SANDBOX_BACKEND:-docker}
+      OUTPUTS_TEMPLATE_PATH: ${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
+      VENV_TEMPLATE_PATH: ${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
+      WEB_TEMPLATE_PATH: ${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
     extra_hosts:
-      - "host.docker.internal:host-gateway"
-    # Optional, only for debugging purposes
-    volumes:
-      - background_logs:/var/log/onyx
-      # Shared volume for persistent document storage (Craft file-system mode)
-      - file-system:/app/file-system
+    - host.docker.internal:host-gateway
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    # PRODUCTION: Uncomment the following lines if you need to include a custom CA certificate
-    # This section enables the use of a custom CA certificate
-    # If present, the custom CA certificate is mounted as a volume
-    # The container checks for its existence and updates the system's CA certificates
-    # This allows for secure communication with services using custom SSL certificates
-    # Optional volume mount for CA certificate
-    # volumes:
-    #   # Maps to the CA_CERT_PATH environment variable in the Dockerfile
-    #   - ${CA_CERT_PATH:-./custom-ca.crt}:/etc/ssl/certs/custom-ca.crt:ro
-
+        max-size: 50m
+        max-file: '6'
+    volumes:
+    - background_logs:/var/log/onyx
+    - file-system:/app/file-system
   web_server:
     image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../web
       dockerfile: Dockerfile
       args:
-        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
-        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
-        # Enterprise Edition only
-        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
-        # DO NOT TURN ON unless you have EXPLICIT PERMISSION from Onyx.
-        - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
-        - NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=4096"}
+      - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+      - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+      - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+      - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
+      - NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=4096"}
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     depends_on:
-      - api_server
+    - api_server
     restart: unless-stopped
     environment:
-      - INTERNAL_URL=${INTERNAL_URL:-http://api_server:8080}
+      INTERNAL_URL: ${INTERNAL_URL:-http://api_server:8080}
+    logging:
+      driver: json-file
+      options:
+        max-size: 50m
+        max-file: '6'
     healthcheck:
       test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "require('http').get('http://127.0.0.1:3000/', (r) => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))",
-        ]
+      - CMD
+      - node
+      - -e
+      - 'require(''http'').get(''http://127.0.0.1:3000/'', (r) => process.exit(r.statusCode < 500 ? 0 : 1)).on(''error'', () => process.exit(1))'
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 30s
-
-  # Uncomment the block below to enable the MCP server for Onyx.
-  # mcp_server:
-  #   image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
-  #   build:
-  #     context: ../../backend
-  #     dockerfile: Dockerfile
-  #   command: >
-  #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
-  #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';
-  #       exit 0;
-  #     else
-  #       exec python -m onyx.mcp_server_main;
-  #     fi"
-  #   env_file:
-  #     - path: .env
-  #       required: false
-  #   depends_on:
-  #     - relational_db
-  #     - cache
-  #   restart: "no"
-  #   environment:
-  #     - POSTGRES_HOST=${POSTGRES_HOST:-relational_db}
-  #     - REDIS_HOST=${REDIS_HOST:-cache}
-  #     # MCP Server Configuration
-  #     - MCP_SERVER_ENABLED=${MCP_SERVER_ENABLED:-false}
-  #     - MCP_SERVER_PORT=${MCP_SERVER_PORT:-8090}
-  #     - MCP_SERVER_CORS_ORIGINS=${MCP_SERVER_CORS_ORIGINS:-}
-  #     - API_SERVER_PROTOCOL=${API_SERVER_PROTOCOL:-http}
-  #     - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
-  #   extra_hosts:
-  #     - "host.docker.internal:host-gateway"
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   # Optional, only for debugging purposes
-  #   volumes:
-  #     - mcp_server_logs:/var/log/onyx
-
   inference_model_server:
     image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    # GPU Support: Uncomment the following lines to enable GPU support
-    # Requires nvidia-container-toolkit to be installed on the host
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-    command: >
+    command: |
       /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
@@ -298,49 +170,33 @@ services:
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     restart: unless-stopped
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - model_cache_huggingface:/app/.cache/huggingface/
-      # Optional, only for debugging purposes
-      - inference_model_server_logs:/var/log/onyx
+    - model_cache_huggingface:/app/.cache/huggingface/
+    - inference_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
+        max-size: 50m
+        max-file: '6'
     healthcheck:
       test:
-        [
-          "CMD",
-          "python",
-          "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')",
-        ]
+      - CMD
+      - python
+      - -c
+      - import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')
       interval: 20s
       timeout: 5s
       retries: 3
-      # Generous start_period to absorb HuggingFace model downloads on first
-      # boot. Healthy is reported as soon as /api/health responds.
       start_period: 600s
-
   indexing_model_server:
     image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    # GPU Support: Uncomment the following lines to enable GPU support
-    # Requires nvidia-container-toolkit to be installed on the host
-    # deploy:
-    #   resources:
-    #     reservations:
-    #       devices:
-    #         - driver: nvidia
-    #           count: all
-    #           capabilities: [gpu]
-    command: >
+    command: |
       /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
         echo 'Skipping service...';
         exit 0;
@@ -348,250 +204,165 @@ services:
         exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
       fi"
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     restart: unless-stopped
     environment:
-      - INDEXING_ONLY=True
+      INDEXING_ONLY: 'True'
     volumes:
-      # Not necessary, this is just to reduce download time during startup
-      - indexing_huggingface_model_cache:/app/.cache/huggingface/
-      # Optional, only for debugging purposes
-      - indexing_model_server_logs:/var/log/onyx
+    - indexing_huggingface_model_cache:/app/.cache/huggingface/
+    - indexing_model_server_logs:/var/log/onyx
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
+        max-size: 50m
+        max-file: '6'
     healthcheck:
       test:
-        [
-          "CMD",
-          "python",
-          "-c",
-          "import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')",
-        ]
+      - CMD
+      - python
+      - -c
+      - import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')
       interval: 20s
       timeout: 5s
       retries: 3
-      # Generous start_period to absorb HuggingFace model downloads on first
-      # boot. Healthy is reported as soon as /api/health responds.
       start_period: 600s
-
   relational_db:
     image: postgres:15.2-alpine
     shm_size: 1g
     command: -c 'max_connections=250'
-    env_file:
-      - path: .env
-        required: false
     restart: unless-stopped
-    # PRODUCTION: Override the defaults by passing in the environment variables
+    env_file:
+    - path: .env
+      required: false
     environment:
-      - POSTGRES_USER=${POSTGRES_USER:-postgres}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
-    # DEV: To expose ports, either:
-    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
-    # 2. Uncomment the ports below
-    # ports:
-    #   - "5432:5432"
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+    volumes:
+    - db_volume:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      test:
+      - CMD-SHELL
+      - pg_isready -U ${POSTGRES_USER:-postgres}
       interval: 10s
       timeout: 5s
       retries: 5
-    volumes:
-      - db_volume:/var/lib/postgresql/data
-
   opensearch:
     image: opensearchproject/opensearch:3.6.0
     restart: unless-stopped
-    # OpenSearch is the search backend and is enabled by default. To run against
-    # an external OpenSearch instance, set OPENSEARCH_HOST in your env and
-    # remove this service from the compose file (or skip it via the service list
-    # when running `docker compose up`).
     environment:
-      # We need discovery.type=single-node so that OpenSearch doesn't try
-      # forming a cluster and waiting for other nodes to become live.
-      - discovery.type=single-node
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
-      # We do this to avoid unstable performance from page swaps.
-      - bootstrap.memory_lock=true # Disable JVM heap memory swapping.
-      # Java heap should be ~50% of memory limit. For now we assume a limit of
-      # 4g although in practice the container can request more than this.
-      # See https://opster.com/guides/opensearch/opensearch-basics/opensearch-heap-size-usage-and-jvm-garbage-collection/
-      # Xms is the starting size, Xmx is the maximum size. These should be the
-      # same.
-      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      discovery.type: single-node
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      bootstrap.memory_lock: 'true'
+      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
     volumes:
-      - opensearch-data:/usr/share/opensearch/data
-    # These come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+    - opensearch-data:/usr/share/opensearch/data
     ulimits:
-      # Similarly to bootstrap.memory_lock, we don't want to impose limits on
-      # how much memory a process can lock from being swapped.
       memlock:
-        soft: -1 # Set memlock to unlimited (no soft or hard limit).
+        soft: -1
         hard: -1
       nofile:
-        soft: 65536 # Maximum number of open files for the opensearch user - set to at least 65536.
+        soft: 65536
         hard: 65536
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-
+        max-size: 50m
+        max-file: '6'
   nginx:
     image: nginx:1.25.5-alpine
     restart: unless-stopped
-    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
-    # if api_server / web_server are not up
     depends_on:
       api_server:
         condition: service_healthy
       web_server:
         condition: service_healthy
-    env_file:
-      - path: .env
-        required: false
-    environment:
-      - DOMAIN=localhost
-      # Nginx proxy timeout settings (in seconds)
-      - NGINX_PROXY_CONNECT_TIMEOUT=${NGINX_PROXY_CONNECT_TIMEOUT:-300}
-      - NGINX_PROXY_SEND_TIMEOUT=${NGINX_PROXY_SEND_TIMEOUT:-300}
-      - NGINX_PROXY_READ_TIMEOUT=${NGINX_PROXY_READ_TIMEOUT:-300}
-    ports:
-      - "${HOST_PORT_80:-80}:80"
-      - "${HOST_PORT:-3000}:80" # allow for localhost:3000 usage, since that is the norm
     volumes:
-      # Mount templates read-only; the startup command copies them into
-      # the writable /etc/nginx/conf.d/ inside the container.  This avoids
-      # "Permission denied" errors on Windows Docker bind mounts.
-      - ../data/nginx:/nginx-templates:ro
-    # PRODUCTION: Add SSL certificate volumes for HTTPS support:
-    #   - ../data/certbot/conf:/etc/letsencrypt
-    #   - ../data/certbot/www:/var/www/certbot
+    - ../data/nginx:/nginx-templates:ro
     logging:
       driver: json-file
       options:
-        max-size: "50m"
-        max-file: "6"
-    # The specified script waits for the api_server to start up.
-    # Without this we've seen issues where nginx shows no error logs but
-    # does not receive any traffic
-    # PRODUCTION: Change to app.conf.template.prod for production nginx config
-    command: >
-      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
-      && cp -a /nginx-templates/. /etc/nginx/conf.d/
-      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
-      && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template"
+        max-size: 50m
+        max-file: '6'
+    env_file:
+    - path: .env
+      required: false
+    environment:
+      DOMAIN: localhost
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
+    ports:
+    - ${HOST_PORT_80:-80}:80
+    - ${HOST_PORT:-3000}:80
+    command: |
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf && cp -a /nginx-templates/. /etc/nginx/conf.d/ && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh && chmod +x /tmp/run-nginx.sh && /tmp/run-nginx.sh app.conf.template"
     healthcheck:
       test:
-        [
-          "CMD",
-          "wget",
-          "--quiet",
-          "--tries=1",
-          "--spider",
-          "http://127.0.0.1/nginx-health",
-        ]
+      - CMD
+      - wget
+      - --quiet
+      - --tries=1
+      - --spider
+      - http://127.0.0.1/nginx-health
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 30s
-
   cache:
     image: redis:7.4-alpine
     restart: unless-stopped
-    # DEV: To expose ports, either:
-    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
-    # 2. Uncomment the ports below
-    # ports:
-    #   - "6379:6379"
-    # docker silently mounts /data even without an explicit volume mount, which enables
-    # persistence. explicitly setting save and appendonly forces ephemeral behavior.
     command: redis-server --save "" --appendonly no
     env_file:
-      - path: .env
-        required: false
-    # Use tmpfs to prevent creation of anonymous volumes for /data
+    - path: .env
+      required: false
     tmpfs:
-      - /data
-
+    - /data
   minio:
     image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
-    profiles: ["s3-filestore"]
     restart: unless-stopped
-    # DEV: To expose ports, either:
-    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
-    # 2. Uncomment the ports below
-    # ports:
-    #   - "9004:9000"
-    #   - "9005:9001"
     env_file:
-      - path: .env
-        required: false
+    - path: .env
+      required: false
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      # Note: we've seen the default bucket creation logic not work in some cases
       MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
     volumes:
-      - minio_data:/data
+    - minio_data:/data
     command: server /data --console-address ":9001"
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test:
+      - CMD
+      - mc
+      - ready
+      - local
       interval: 30s
       timeout: 20s
       retries: 3
-
+    profiles:
+    - s3-filestore
   code-interpreter:
     image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
-    command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
+    command:
+    - bash
+    - ./entrypoint.sh
+    - code-interpreter-api
     restart: unless-stopped
     env_file:
-      - path: .env
-        required: false
-
-    # Below is needed for the `docker-out-of-docker` execution mode
-    # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock
+    - path: .env
+      required: false
     user: root
     volumes:
-      - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
-
-    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
-    # privileged: true
-
-  # PRODUCTION: Uncomment the following certbot service for SSL certificate management
-  # certbot:
-  #   image: certbot/certbot
-  #   restart: unless-stopped
-  #   volumes:
-  #     - ../data/certbot/conf:/etc/letsencrypt
-  #     - ../data/certbot/www:/var/www/certbot
-  #   logging:
-  #     driver: json-file
-  #     options:
-  #       max-size: "50m"
-  #       max-file: "6"
-  #   entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
-
+    - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
 volumes:
-  # Necessary for persisting data for use
   db_volume:
   minio_data:
-  # Caches to prevent re-downloading models, not strictly necessary
   model_cache_huggingface:
   indexing_huggingface_model_cache:
-  # Logs preserved across container restarts
   api_server_logs:
   background_logs:
-  # mcp_server_logs:
   inference_model_server_logs:
   indexing_model_server_logs:
-  # Shared volume for persistent document storage (Craft file-system mode)
   file-system:
-  # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/render.py
+++ b/deployment/docker_compose/render.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Render flat docker-compose files from canonical service fragments.
+
+Source of truth lives under `src/`:
+  * `src/services/<name>.yml` — canonical per-service definitions
+  * `src/deployments/<name>.yml` — composition + per-deployment overrides
+
+Each deployment file has the following top-level keys:
+  * `name`          — compose project name
+  * `include`       — list of service fragment names to pull in from src/services/
+  * `services`      — per-service field overrides, deep-merged into the fragments
+  * `volumes`       — top-level named-volume declarations
+  * `networks`      — top-level network declarations (optional)
+
+Run `python render.py` to (re)write the top-level `docker-compose.*.yml` files.
+Run `python render.py --check` for the pre-commit hook (exits non-zero on drift).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+HERE = Path(__file__).resolve().parent
+SRC = HERE / "src"
+SERVICES_DIR = SRC / "services"
+DEPLOYMENTS_DIR = SRC / "deployments"
+
+# Maps src/deployments/<key>.yml → top-level output filename
+DEPLOYMENTS: dict[str, str] = {
+    "default": "docker-compose.yml",
+    "prod": "docker-compose.prod.yml",
+    "prod-cloud": "docker-compose.prod-cloud.yml",
+    "prod-no-letsencrypt": "docker-compose.prod-no-letsencrypt.yml",
+    "multitenant-dev": "docker-compose.multitenant-dev.yml",
+}
+
+BANNER = (
+    "# =============================================================================\n"
+    "# GENERATED FILE — DO NOT EDIT BY HAND.\n"
+    "# Source: deployment/docker_compose/src/deployments/{name}.yml\n"
+    "# Regenerate with: python deployment/docker_compose/render.py\n"
+    "# =============================================================================\n"
+)
+
+
+def _env_to_dict(env: Any) -> dict[str, Any]:
+    """Normalize compose `environment:` to a dict.
+
+    Accepts either dict form ({KEY: value}) or list form (["KEY=value", ...]).
+    """
+    if env is None:
+        return {}
+    if isinstance(env, dict):
+        return dict(env)
+    if isinstance(env, list):
+        out: dict[str, Any] = {}
+        for item in env:
+            if not isinstance(item, str):
+                raise ValueError(f"environment list entry must be string, got {item!r}")
+            key, sep, value = item.partition("=")
+            out[key] = value if sep else None
+        return out
+    raise ValueError(f"environment must be dict or list, got {type(env).__name__}")
+
+
+def _depends_on_to_dict(dep: Any) -> dict[str, Any]:
+    """Normalize compose `depends_on:` to dict form."""
+    if dep is None:
+        return {}
+    if isinstance(dep, dict):
+        return dict(dep)
+    if isinstance(dep, list):
+        return {svc: {"condition": "service_started"} for svc in dep}
+    raise ValueError(f"depends_on must be dict or list, got {type(dep).__name__}")
+
+
+def _merge_service(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Deep-merge a service override on top of a base service definition.
+
+    Rules:
+      * Dicts merge recursively, override wins on key collisions.
+      * Lists are replaced wholesale by the override.
+      * Scalars are replaced.
+      * `environment` is normalized to dict on both sides and key-merged.
+      * `depends_on` is normalized to dict on both sides and key-merged.
+    """
+    out = dict(base)
+    for key, ov in override.items():
+        if key == "environment":
+            merged_env = _env_to_dict(base.get("environment"))
+            merged_env.update(_env_to_dict(ov))
+            out["environment"] = merged_env
+            continue
+        if key == "depends_on":
+            merged_dep = _depends_on_to_dict(base.get("depends_on"))
+            merged_dep.update(_depends_on_to_dict(ov))
+            out["depends_on"] = merged_dep
+            continue
+        if key in base and isinstance(base[key], dict) and isinstance(ov, dict):
+            out[key] = _merge_dict(base[key], ov)
+        else:
+            out[key] = ov
+    return out
+
+
+def _merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for key, ov in override.items():
+        if key in base and isinstance(base[key], dict) and isinstance(ov, dict):
+            out[key] = _merge_dict(base[key], ov)
+        else:
+            out[key] = ov
+    return out
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} did not parse as a mapping")
+    return data
+
+
+def _load_fragment(name: str) -> dict[str, Any]:
+    """Load src/services/<name>.yml and return the single service definition."""
+    path = SERVICES_DIR / f"{name}.yml"
+    if not path.exists():
+        raise FileNotFoundError(f"Service fragment not found: {path}")
+    doc = _load_yaml(path)
+    services = doc.get("services") or {}
+    if name not in services:
+        raise ValueError(f"{path} must define services.{name}")
+    return services[name]
+
+
+class _ComposeDumper(yaml.SafeDumper):
+    """Dumper that emits readable, deterministic compose YAML.
+
+    * Keys are emitted in declaration order (`sort_keys=False`).
+    * Multi-line strings use literal block scalars so commands stay readable.
+    """
+
+
+def _str_representer(dumper: yaml.SafeDumper, value: str) -> yaml.ScalarNode:
+    if "\n" in value:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", value, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value)
+
+
+def _none_representer(dumper: yaml.SafeDumper, _value: None) -> yaml.ScalarNode:
+    # Compose convention: `db_volume:` (bare key) rather than `db_volume: null`.
+    return dumper.represent_scalar("tag:yaml.org,2002:null", "")
+
+
+_ComposeDumper.add_representer(str, _str_representer)
+_ComposeDumper.add_representer(type(None), _none_representer)
+
+
+def render(name: str) -> str:
+    """Render a deployment to a YAML string (without the banner)."""
+    deployment_path = DEPLOYMENTS_DIR / f"{name}.yml"
+    deployment = _load_yaml(deployment_path)
+
+    project_name = deployment.get("name")
+    if not project_name:
+        raise ValueError(f"{deployment_path} must define `name:`")
+
+    include = deployment.get("include") or []
+    if not isinstance(include, list):
+        raise ValueError(f"{deployment_path}: `include:` must be a list")
+
+    overrides = deployment.get("services") or {}
+    if not isinstance(overrides, dict):
+        raise ValueError(f"{deployment_path}: `services:` must be a mapping")
+
+    # Build merged services in include-order so the rendered file orders them
+    # consistently. Overrides for services not in `include:` are still emitted
+    # (rare, but useful for one-off services like Craft sandboxes).
+    merged_services: dict[str, Any] = {}
+    for service_name in include:
+        base = _load_fragment(service_name)
+        ov = overrides.get(service_name) or {}
+        merged_services[service_name] = _merge_service(base, ov)
+
+    for service_name, ov in overrides.items():
+        if service_name not in merged_services:
+            merged_services[service_name] = ov
+
+    out: dict[str, Any] = {"name": project_name, "services": merged_services}
+
+    for top_key in ("volumes", "networks", "configs", "secrets"):
+        if top_key in deployment:
+            out[top_key] = deployment[top_key]
+
+    return yaml.dump(
+        out,
+        Dumper=_ComposeDumper,
+        sort_keys=False,
+        default_flow_style=False,
+        width=1000,
+    )
+
+
+def render_all() -> dict[str, str]:
+    """Render every deployment. Returns {output_path: content} mapping."""
+    return {
+        DEPLOYMENTS[name]: BANNER.format(name=name) + "\n" + render(name)
+        for name in DEPLOYMENTS
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail (exit 1) if any rendered file would change instead of writing.",
+    )
+    args = parser.parse_args()
+
+    rendered = render_all()
+    drift: list[str] = []
+    for filename, content in rendered.items():
+        target = HERE / filename
+        existing = target.read_text(encoding="utf-8") if target.exists() else None
+        if existing == content:
+            continue
+        if args.check:
+            drift.append(filename)
+            continue
+        target.write_text(content, encoding="utf-8")
+        print(f"wrote {filename}")
+
+    if args.check and drift:
+        print(
+            "ERROR: rendered docker-compose files are out of date.\n"
+            "Run: python deployment/docker_compose/render.py\n"
+            "Drifted files:\n  - "
+            + "\n  - ".join(drift),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployment/docker_compose/src/deployments/default.yml
+++ b/deployment/docker_compose/src/deployments/default.yml
@@ -1,0 +1,245 @@
+# =============================================================================
+# ONYX DOCKER COMPOSE — default community deployment
+# =============================================================================
+# This is the default configuration for Onyx. This file is fairly configurable;
+# also see env.template for possible settings.
+#
+# PRODUCTION DEPLOYMENT CHECKLIST:
+# To convert this setup to a production deployment following best practices,
+# follow the checklist below. Note that there are other ways to secure the Onyx
+# deployment so these are not strictly necessary for all teams.
+#
+# 1. SECURITY HARDENING:
+#    - Remove all port exposures except nginx (80/443)
+#    - Comment out ports for: api_server, relational_db, cache, minio
+#
+# 2. SSL/TLS SETUP:
+#    - Uncomment the certbot service (see below)
+#    - Add SSL certificate volumes to nginx service
+#    - Change nginx command from app.conf.template to app.conf.template.prod
+#
+# 3. ENVIRONMENT CONFIGURATION:
+#    - Replace env_file with explicit environment variables
+#
+# 4. AUTHENTICATION:
+#    - Select an authentication method like Basic, Google OAuth, OIDC, or SAML
+#
+# 5. CA CERTIFICATES:
+#    - Uncomment custom CA certificate volumes if needed
+#
+# 6. DOMAIN CONFIGURATION:
+#    - Set proper DOMAIN environment variable for nginx
+#    - Configure DNS and SSL certificates
+#
+# For a complete production setup, refer to docker-compose.prod.yml
+# =============================================================================
+
+name: onyx
+
+include:
+  - api_server
+  - background
+  - web_server
+  - inference_model_server
+  - indexing_model_server
+  - relational_db
+  - opensearch
+  - nginx
+  - cache
+  - minio
+  - code-interpreter
+
+services:
+  api_server:
+    build:
+      args:
+        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
+    depends_on:
+      relational_db:
+        condition: service_started
+      opensearch:
+        condition: service_started
+      cache:
+        condition: service_started
+      inference_model_server:
+        condition: service_started
+      minio:
+        condition: service_started
+        required: false
+    # DEV: To expose ports, either:
+    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
+    # 2. Uncomment the ports below
+    # ports:
+    #   - "8080:8080"
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-basic}
+      FILE_STORE_BACKEND: ${FILE_STORE_BACKEND:-s3}
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      # Onyx Craft configuration (disabled by default, set ENABLE_CRAFT=true in
+      # .env to enable). Use --include-craft with install script, or manually
+      # set in .env file.
+      ENABLE_CRAFT: ${ENABLE_CRAFT:-false}
+      SANDBOX_BACKEND: ${SANDBOX_BACKEND:-docker}
+      OUTPUTS_TEMPLATE_PATH: ${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
+      VENV_TEMPLATE_PATH: ${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
+      WEB_TEMPLATE_PATH: ${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+      # Generous start_period so that `docker compose up --wait` does not flag
+      # the container unhealthy while alembic migrations run on a fresh DB.
+      # Healthy is reported as soon as /health responds, so this does not slow
+      # down fast boots.
+      start_period: 600s
+    volumes:
+      - api_server_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  background:
+    build:
+      args:
+        - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
+    command: >
+      /bin/sh -c "
+      if [ -f /app/scripts/setup_craft_templates.sh ]; then
+        /app/scripts/setup_craft_templates.sh;
+      fi &&
+      if [ -f /etc/ssl/certs/custom-ca.crt ]; then
+        update-ca-certificates;
+      fi &&
+      /app/scripts/supervisord_entrypoint.sh"
+    environment:
+      FILE_STORE_BACKEND: ${FILE_STORE_BACKEND:-s3}
+      # Onyx Craft configuration (set up automatically on container startup)
+      ENABLE_CRAFT: ${ENABLE_CRAFT:-false}
+      SANDBOX_BACKEND: ${SANDBOX_BACKEND:-docker}
+      OUTPUTS_TEMPLATE_PATH: ${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
+      VENV_TEMPLATE_PATH: ${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
+      WEB_TEMPLATE_PATH: ${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    volumes:
+      - background_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  web_server:
+    build:
+      args:
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+        # Enterprise Edition only
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+        # DO NOT TURN ON unless you have EXPLICIT PERMISSION from Onyx.
+        - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
+        - NODE_OPTIONS=${NODE_OPTIONS:-"--max-old-space-size=4096"}
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/', (r) => process.exit(r.statusCode < 500 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  inference_model_server:
+    volumes:
+      - model_cache_huggingface:/app/.cache/huggingface/
+      # Optional, only for debugging purposes
+      - inference_model_server_logs:/var/log/onyx
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')"]
+      interval: 20s
+      timeout: 5s
+      retries: 3
+      # Generous start_period to absorb HuggingFace model downloads on first
+      # boot. Healthy is reported as soon as /api/health responds.
+      start_period: 600s
+
+  indexing_model_server:
+    volumes:
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
+      # Optional, only for debugging purposes
+      - indexing_model_server_logs:/var/log/onyx
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9000/api/health')"]
+      interval: 20s
+      timeout: 5s
+      retries: 3
+      # Generous start_period to absorb HuggingFace model downloads on first
+      # boot. Healthy is reported as soon as /api/health responds.
+      start_period: 600s
+
+  relational_db:
+    # DEV: To expose ports, either:
+    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
+    # 2. Uncomment the ports below
+    # ports:
+    #   - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    profiles: ["s3-filestore"]
+    # DEV: To expose ports, either:
+    # 1. Use docker-compose.dev.yml: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --wait
+    # 2. Uncomment the ports below
+    # ports:
+    #   - "9004:9000"
+    #   - "9005:9001"
+
+  nginx:
+    depends_on:
+      api_server:
+        condition: service_healthy
+      web_server:
+        condition: service_healthy
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      DOMAIN: localhost
+      # Nginx proxy timeout settings (in seconds)
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
+    ports:
+      - "${HOST_PORT_80:-80}:80"
+      - "${HOST_PORT:-3000}:80" # allow for localhost:3000 usage, since that is the norm
+    # The specified script waits for the api_server to start up.
+    # Without this we've seen issues where nginx shows no error logs but
+    # does not receive any traffic.
+    # PRODUCTION: Change to app.conf.template.prod for production nginx config
+    command: >
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
+      && cp -a /nginx-templates/. /etc/nginx/conf.d/
+      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
+      && chmod +x /tmp/run-nginx.sh
+      && /tmp/run-nginx.sh app.conf.template"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/nginx-health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  # Necessary for persisting data for use
+  db_volume:
+  minio_data:
+  # Caches to prevent re-downloading models, not strictly necessary
+  model_cache_huggingface:
+  indexing_huggingface_model_cache:
+  # Logs preserved across container restarts
+  api_server_logs:
+  background_logs:
+  inference_model_server_logs:
+  indexing_model_server_logs:
+  # Shared volume for persistent document storage (Craft file-system mode)
+  file-system:
+  # Persistent data for OpenSearch.
+  opensearch-data:

--- a/deployment/docker_compose/src/deployments/multitenant-dev.yml
+++ b/deployment/docker_compose/src/deployments/multitenant-dev.yml
@@ -1,45 +1,37 @@
-# =============================================================================
-# GENERATED FILE — DO NOT EDIT BY HAND.
-# Source: deployment/docker_compose/src/deployments/multitenant-dev.yml
-# Regenerate with: python deployment/docker_compose/render.py
-# =============================================================================
-
 name: onyx
+
+include:
+  - api_server
+  - background
+  - web_server
+  - inference_model_server
+  - indexing_model_server
+  - relational_db
+  - opensearch
+  - nginx
+  - minio
+  - cache
+  - code-interpreter
+
 services:
   api_server:
-    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: |
-      /bin/sh -c " alembic -n schema_private upgrade head && echo \"Starting Onyx Api Server\" && uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
-    env_file:
-    - path: .env
-      required: false
-    depends_on:
-    - relational_db
-    - opensearch
-    - cache
-    - inference_model_server
-    - minio
-    restart: unless-stopped
+    command: >
+      /bin/sh -c "
+      alembic -n schema_private upgrade head &&
+      echo \"Starting Onyx Api Server\" &&
+      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    ports:
+      - "8080:8080"
     environment:
-      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
-      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
-      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      REDIS_HOST: ${REDIS_HOST:-cache}
-      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
-      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
-      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: 'true'
-      MULTI_TENANT: 'true'
+      ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: "true"
+      MULTI_TENANT: "true"
       LOG_LEVEL: DEBUG
       AUTH_TYPE: cloud
-      REQUIRE_EMAIL_VERIFICATION: 'false'
-      DISABLE_TELEMETRY: 'true'
+      REQUIRE_EMAIL_VERIFICATION: "false"
+      DISABLE_TELEMETRY: "true"
       IMAGE_TAG: test
-      DEV_MODE: 'true'
+      DEV_MODE: "true"
+      # Auth Settings
       SESSION_EXPIRE_TIME_SECONDS: ${SESSION_EXPIRE_TIME_SECONDS:-}
       ENCRYPTION_KEY_SECRET: ${ENCRYPTION_KEY_SECRET:-}
       VALID_EMAIL_DOMAINS: ${VALID_EMAIL_DOMAINS:-}
@@ -57,18 +49,23 @@ services:
       OPENID_CONFIG_URL: ${OPENID_CONFIG_URL:-}
       TRACK_EXTERNAL_IDP_EXPIRY: ${TRACK_EXTERNAL_IDP_EXPIRY:-}
       CORS_ALLOWED_ORIGIN: ${CORS_ALLOWED_ORIGIN:-}
+      # Gen AI Settings
       GEN_AI_MAX_TOKENS: ${GEN_AI_MAX_TOKENS:-}
       LLM_SOCKET_READ_TIMEOUT: ${LLM_SOCKET_READ_TIMEOUT:-}
       MAX_CHUNKS_FED_TO_CHAT: ${MAX_CHUNKS_FED_TO_CHAT:-}
       DISABLE_LITELLM_STREAMING: ${DISABLE_LITELLM_STREAMING:-}
       LITELLM_EXTRA_HEADERS: ${LITELLM_EXTRA_HEADERS:-}
       GEN_AI_API_KEY: ${GEN_AI_API_KEY:-}
+      # Query Options
       DOC_TIME_DECAY: ${DOC_TIME_DECAY:-}
       HYBRID_ALPHA: ${HYBRID_ALPHA:-}
       EDIT_KEYWORD_QUERY: ${EDIT_KEYWORD_QUERY:-}
+      # Other services
       POSTGRES_DEFAULT_SCHEMA: ${POSTGRES_DEFAULT_SCHEMA:-}
       WEB_DOMAIN: ${WEB_DOMAIN:-}
+      # MinIO configuration
       S3_FILE_STORE_BUCKET_NAME: ${S3_FILE_STORE_BUCKET_NAME:-}
+      # Don't change the NLP model configs unless you know what you're doing
       EMBEDDING_BATCH_SIZE: ${EMBEDDING_BATCH_SIZE:-}
       DOCUMENT_ENCODER_MODEL: ${DOCUMENT_ENCODER_MODEL:-}
       DOC_EMBEDDING_DIM: ${DOC_EMBEDDING_DIM:-}
@@ -84,82 +81,57 @@ services:
       LOG_POSTGRES_CONN_COUNTS: ${LOG_POSTGRES_CONN_COUNTS:-}
       CELERY_BROKER_POOL_LIMIT: ${CELERY_BROKER_POOL_LIMIT:-}
       LITELLM_CUSTOM_ERROR_MESSAGE_MAPPINGS: ${LITELLM_CUSTOM_ERROR_MESSAGE_MAPPINGS:-}
+      # Egnyte OAuth Configs
       EGNYTE_CLIENT_ID: ${EGNYTE_CLIENT_ID:-}
       EGNYTE_CLIENT_SECRET: ${EGNYTE_CLIENT_SECRET:-}
       EGNYTE_LOCALHOST_OVERRIDE: ${EGNYTE_LOCALHOST_OVERRIDE:-}
+      # Linear OAuth Configs
       LINEAR_CLIENT_ID: ${LINEAR_CLIENT_ID:-}
       LINEAR_CLIENT_SECRET: ${LINEAR_CLIENT_SECRET:-}
+      # Analytics Configs
       SENTRY_DSN: ${SENTRY_DSN:-}
+      # Chat Configs
       HARD_DELETE_CHATS: ${HARD_DELETE_CHATS:-}
+      # Show extra/uncommon connectors
       SHOW_EXTRA_CONNECTORS: ${SHOW_EXTRA_CONNECTORS:-true}
+      # Enables the use of bedrock models or IAM Auth
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_REGION_NAME: ${AWS_REGION_NAME:-}
       API_KEY_HASH_ROUNDS: ${API_KEY_HASH_ROUNDS:-}
+      # Seeding configuration
       USE_IAM_AUTH: ${USE_IAM_AUTH:-}
       OPENAI_DEFAULT_API_KEY: ${OPENAI_DEFAULT_API_KEY:-}
+      # Vespa Language Forcing
+      # See: https://docs.vespa.ai/en/linguistics.html
       VESPA_LANGUAGE_OVERRIDE: ${VESPA_LANGUAGE_OVERRIDE:-}
-    extra_hosts:
-    - host.docker.internal:host-gateway
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
-    ports:
-    - 8080:8080
     healthcheck:
       test:
-      - CMD
-      - python
-      - -c
-      - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')",
+        ]
       interval: 30s
       timeout: 20s
       retries: 3
+      # Generous start_period so that `docker compose up --wait` does not flag
+      # the container unhealthy while alembic migrations run on a fresh DB.
       start_period: 600s
+
   background:
-    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    command: |
-      /bin/sh -c " if [ -f /etc/ssl/certs/custom-ca.crt ]; then
-        update-ca-certificates;
-      fi && /app/scripts/supervisord_entrypoint.sh"
-    env_file:
-    - path: .env
-      required: false
-    depends_on:
-    - relational_db
-    - opensearch
-    - cache
-    - inference_model_server
-    - indexing_model_server
-    restart: unless-stopped
     environment:
-      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
-      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
-      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      REDIS_HOST: ${REDIS_HOST:-cache}
-      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
-      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
-      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
-      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
-      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
-      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
-      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
-      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
-      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
       ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: ${ENABLE_PAID_ENTERPRISE_EDITION_FEATURES:-false}
-      MULTI_TENANT: 'true'
+      MULTI_TENANT: "true"
       LOG_LEVEL: ${LOG_LEVEL:-info}
       AUTH_TYPE: cloud
-      REQUIRE_EMAIL_VERIFICATION: 'false'
+      REQUIRE_EMAIL_VERIFICATION: "false"
       DISABLE_TELEMETRY: ${DISABLE_TELEMETRY:-}
       IMAGE_TAG: test
       ENCRYPTION_KEY_SECRET: ${ENCRYPTION_KEY_SECRET:-}
       JWT_PUBLIC_KEY_URL: ${JWT_PUBLIC_KEY_URL:-}
+      # Gen AI Settings (Needed by OnyxBot)
       GEN_AI_MAX_TOKENS: ${GEN_AI_MAX_TOKENS:-}
       LLM_SOCKET_READ_TIMEOUT: ${LLM_SOCKET_READ_TIMEOUT:-}
       MAX_CHUNKS_FED_TO_CHAT: ${MAX_CHUNKS_FED_TO_CHAT:-}
@@ -167,9 +139,11 @@ services:
       DISABLE_LITELLM_STREAMING: ${DISABLE_LITELLM_STREAMING:-}
       LITELLM_EXTRA_HEADERS: ${LITELLM_EXTRA_HEADERS:-}
       GEN_AI_API_KEY: ${GEN_AI_API_KEY:-}
+      # Query Options
       DOC_TIME_DECAY: ${DOC_TIME_DECAY:-}
       HYBRID_ALPHA: ${HYBRID_ALPHA:-}
       EDIT_KEYWORD_QUERY: ${EDIT_KEYWORD_QUERY:-}
+      # Other Services
       POSTGRES_USER: ${POSTGRES_USER:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       DB_READONLY_USER: ${DB_READONLY_USER:-}
@@ -178,12 +152,14 @@ services:
       POSTGRES_DEFAULT_SCHEMA: ${POSTGRES_DEFAULT_SCHEMA:-}
       WEB_DOMAIN: ${WEB_DOMAIN:-}
       S3_FILE_STORE_BUCKET_NAME: ${S3_FILE_STORE_BUCKET_NAME:-}
+      # Don't change the NLP model configs unless you know what you're doing
       DOCUMENT_ENCODER_MODEL: ${DOCUMENT_ENCODER_MODEL:-}
       DOC_EMBEDDING_DIM: ${DOC_EMBEDDING_DIM:-}
       NORMALIZE_EMBEDDINGS: ${NORMALIZE_EMBEDDINGS:-}
       ASYM_QUERY_PREFIX: ${ASYM_QUERY_PREFIX:-}
       ASYM_PASSAGE_PREFIX: ${ASYM_PASSAGE_PREFIX:-}
       MODEL_SERVER_PORT: ${MODEL_SERVER_PORT:-}
+      # Indexing Configs
       VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-}
       ENABLED_CONNECTOR_TYPES: ${ENABLED_CONNECTOR_TYPES:-}
       DISABLE_INDEX_UPDATE_ON_SWAP: ${DISABLE_INDEX_UPDATE_ON_SWAP:-}
@@ -198,231 +174,108 @@ services:
       GITHUB_CONNECTOR_BASE_URL: ${GITHUB_CONNECTOR_BASE_URL:-}
       MAX_DOCUMENT_CHARS: ${MAX_DOCUMENT_CHARS:-}
       MAX_FILE_SIZE_BYTES: ${MAX_FILE_SIZE_BYTES:-}
+      # Egnyte OAuth Configs
       EGNYTE_CLIENT_ID: ${EGNYTE_CLIENT_ID:-}
       EGNYTE_CLIENT_SECRET: ${EGNYTE_CLIENT_SECRET:-}
       EGNYTE_LOCALHOST_OVERRIDE: ${EGNYTE_LOCALHOST_OVERRIDE:-}
+      # Linear OAuth Configs
       LINEAR_CLIENT_ID: ${LINEAR_CLIENT_ID:-}
       LINEAR_CLIENT_SECRET: ${LINEAR_CLIENT_SECRET:-}
+      # Celery Configs (defaults are set in the supervisord.conf file.
+      # prefer doing that to have one source of defaults)
       CELERY_WORKER_DOCFETCHING_CONCURRENCY: ${CELERY_WORKER_DOCFETCHING_CONCURRENCY:-}
       CELERY_WORKER_DOCPROCESSING_CONCURRENCY: ${CELERY_WORKER_DOCPROCESSING_CONCURRENCY:-}
       CELERY_WORKER_LIGHT_CONCURRENCY: ${CELERY_WORKER_LIGHT_CONCURRENCY:-}
       CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER: ${CELERY_WORKER_LIGHT_PREFETCH_MULTIPLIER:-}
+      # Onyx SlackBot Configs
       ONYX_BOT_DISABLE_DOCS_ONLY_ANSWER: ${ONYX_BOT_DISABLE_DOCS_ONLY_ANSWER:-}
       ONYX_BOT_FEEDBACK_VISIBILITY: ${ONYX_BOT_FEEDBACK_VISIBILITY:-}
       ONYX_BOT_DISPLAY_ERROR_MSGS: ${ONYX_BOT_DISPLAY_ERROR_MSGS:-}
       NOTIFY_SLACKBOT_NO_ANSWER: ${NOTIFY_SLACKBOT_NO_ANSWER:-}
       ONYX_BOT_MAX_QPM: ${ONYX_BOT_MAX_QPM:-}
       ONYX_BOT_MAX_WAIT_TIME: ${ONYX_BOT_MAX_WAIT_TIME:-}
+      # Log all of Onyx prompts and interactions with the LLM
       LOG_ONYX_MODEL_INTERACTIONS: ${LOG_ONYX_MODEL_INTERACTIONS:-}
       LOG_VESPA_TIMING_INFORMATION: ${LOG_VESPA_TIMING_INFORMATION:-}
+      # Analytics Configs
       SENTRY_DSN: ${SENTRY_DSN:-}
+      # Enterprise Edition stuff
       USE_IAM_AUTH: ${USE_IAM_AUTH:-}
       AWS_REGION_NAME: ${AWS_REGION_NAME:-}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      # Seeding configuration
       OPENAI_DEFAULT_API_KEY: ${OPENAI_DEFAULT_API_KEY:-}
-    extra_hosts:
-    - host.docker.internal:host-gateway
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
+
   web_server:
-    image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
     build:
-      context: ../../web
-      dockerfile: Dockerfile
       args:
-      - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
-      - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
-      - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
-      - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
-    env_file:
-    - path: .env
-      required: false
-    depends_on:
-    - api_server
-    restart: unless-stopped
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+        # Enterprise Edition only
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+        # DO NOT TURN ON unless you have EXPLICIT PERMISSION from Onyx.
+        - NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED=${NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED:-false}
     environment:
-      INTERNAL_URL: ${INTERNAL_URL:-http://api_server:8080}
       WEB_DOMAIN: ${WEB_DOMAIN:-}
       THEME_IS_DARK: ${THEME_IS_DARK:-}
+      # Enterprise Edition only
       ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: ${ENABLE_PAID_ENTERPRISE_EDITION_FEATURES:-false}
       NEXT_PUBLIC_CUSTOM_REFRESH_URL: ${NEXT_PUBLIC_CUSTOM_REFRESH_URL:-}
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
+
   inference_model_server:
-    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: |
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    env_file:
-    - path: .env
-      required: false
     restart: on-failure
-    volumes:
-    - model_cache_huggingface:/app/.cache/huggingface/
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
     environment:
       MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      # Analytics Configs
       SENTRY_DSN: ${SENTRY_DSN:-}
+
   indexing_model_server:
-    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile.model_server
-    command: |
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
-    env_file:
-    - path: .env
-      required: false
     restart: on-failure
     environment:
-      INDEXING_ONLY: 'True'
       INDEX_BATCH_SIZE: ${INDEX_BATCH_SIZE:-}
       MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
       LOG_LEVEL: ${LOG_LEVEL:-info}
       CLIENT_EMBEDDING_TIMEOUT: ${CLIENT_EMBEDDING_TIMEOUT:-}
+      # Analytics Configs
       SENTRY_DSN: ${SENTRY_DSN:-}
-    volumes:
-    - indexing_huggingface_model_cache:/app/.cache/huggingface/
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
+
   relational_db:
-    image: postgres:15.2-alpine
-    shm_size: 1g
-    command: -c 'max_connections=250'
-    restart: unless-stopped
-    env_file:
-    - path: .env
-      required: false
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
       DB_READONLY_USER: ${DB_READONLY_USER:-}
       DB_READONLY_PASSWORD: ${DB_READONLY_PASSWORD:-}
-    volumes:
-    - db_volume:/var/lib/postgresql/data
     ports:
-    - 5432:5432
-  opensearch:
-    image: opensearchproject/opensearch:3.6.0
-    restart: unless-stopped
-    environment:
-      discovery.type: single-node
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
-      bootstrap.memory_lock: 'true'
-      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
-    volumes:
-    - opensearch-data:/usr/share/opensearch/data
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536
-        hard: 65536
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
+      - "5432:5432"
+
   nginx:
-    image: nginx:1.25.5-alpine
-    restart: unless-stopped
-    depends_on:
-    - api_server
-    - web_server
-    volumes:
-    - ../data/nginx:/nginx-templates:ro
-    logging:
-      driver: json-file
-      options:
-        max-size: 50m
-        max-file: '6'
     environment:
       DOMAIN: localhost
     ports:
-    - ${HOST_PORT_80:-80}:80
-    - ${HOST_PORT:-3000}:80
-    command: |
-      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf && cp -a /nginx-templates/. /etc/nginx/conf.d/ && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh && chmod +x /tmp/run-nginx.sh && /tmp/run-nginx.sh app.conf.template"
+      - "${HOST_PORT_80:-80}:80"
+      - "${HOST_PORT:-3000}:80" # allow for localhost:3000 usage, since that is the norm
+    command: >
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
+      && cp -a /nginx-templates/. /etc/nginx/conf.d/
+      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
+      && chmod +x /tmp/run-nginx.sh
+      && /tmp/run-nginx.sh app.conf.template"
+
   minio:
-    image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
-    restart: unless-stopped
-    env_file:
-    - path: .env
-      required: false
-    environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
-    volumes:
-    - minio_data:/data
-    command: server /data --console-address ":9001"
-    healthcheck:
-      test:
-      - CMD
-      - mc
-      - ready
-      - local
-      interval: 30s
-      timeout: 20s
-      retries: 3
     ports:
-    - 9004:9000
-    - 9005:9001
+      - "9004:9000"
+      - "9005:9001"
+
   cache:
-    image: redis:7.4-alpine
-    restart: unless-stopped
-    command: redis-server --save "" --appendonly no
-    env_file:
-    - path: .env
-      required: false
-    tmpfs:
-    - /data
     ports:
-    - 6379:6379
-  code-interpreter:
-    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
-    command:
-    - bash
-    - ./entrypoint.sh
-    - code-interpreter-api
-    restart: unless-stopped
-    env_file:
-    - path: .env
-      required: false
-    user: root
-    volumes:
-    - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
+      - "6379:6379"
+
 volumes:
   db_volume:
   minio_data:
   model_cache_huggingface:
   indexing_huggingface_model_cache:
+  # Persistent data for OpenSearch.
   opensearch-data:

--- a/deployment/docker_compose/src/deployments/prod-cloud.yml
+++ b/deployment/docker_compose/src/deployments/prod-cloud.yml
@@ -1,0 +1,107 @@
+name: onyx
+
+include:
+  - api_server
+  - background
+  - web_server
+  - inference_model_server
+  - indexing_model_server
+  - relational_db
+  - opensearch
+  - nginx
+  - certbot
+  - minio
+  - cache
+
+services:
+  api_server:
+    build:
+      dockerfile: Dockerfile.cloud
+    command: >
+      /bin/sh -c "alembic -n schema_private upgrade head &&
+      echo \"Starting Onyx Api Server\" &&
+      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - inference_model_server
+      - minio
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+
+  background:
+    command: /app/scripts/supervisord_entrypoint.sh
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - inference_model_server
+      - indexing_model_server
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+
+  web_server:
+    build:
+      args:
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+    environment:
+      INTERNAL_URL: http://api_server:8080
+
+  inference_model_server:
+    restart: on-failure
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+
+  indexing_model_server:
+    restart: on-failure
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
+
+  relational_db:
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+
+  nginx:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../data/nginx:/nginx-templates:ro
+      - ../data/certbot/conf:/etc/letsencrypt
+      - ../data/certbot/www:/var/www/certbot
+    command: >
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
+      && cp -a /nginx-templates/. /etc/nginx/conf.d/
+      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
+      && chmod +x /tmp/run-nginx.sh
+      && /tmp/run-nginx.sh app.conf.template.prod"
+    env_file:
+      - .env.nginx
+    environment:
+      # Nginx proxy timeout settings (in seconds)
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
+
+volumes:
+  db_volume:
+  minio_data:
+  model_cache_huggingface:
+  indexing_huggingface_model_cache:
+  # Persistent data for OpenSearch.
+  opensearch-data:

--- a/deployment/docker_compose/src/deployments/prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/src/deployments/prod-no-letsencrypt.yml
@@ -1,0 +1,132 @@
+name: onyx
+
+include:
+  - api_server
+  - background
+  - web_server
+  - inference_model_server
+  - indexing_model_server
+  - relational_db
+  - opensearch
+  - nginx
+  - minio
+  - cache
+  - code-interpreter
+
+services:
+  api_server:
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - inference_model_server
+      - minio
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    volumes:
+      # optional, only for debugging purposes
+      - api_server_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  background:
+    command: /app/scripts/supervisord_entrypoint.sh
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    volumes:
+      - background_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  web_server:
+    build:
+      args:
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+    environment:
+      INTERNAL_URL: http://api_server:8080
+
+  inference_model_server:
+    restart: on-failure
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - model_cache_huggingface:/app/.cache/huggingface/
+      # optional, only for debugging purposes
+      - inference_model_server_logs:/var/log/onyx
+
+  indexing_model_server:
+    restart: on-failure
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
+    volumes:
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
+      # optional, only for debugging purposes
+      - indexing_model_server_logs:/var/log/onyx
+
+  relational_db:
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+
+  nginx:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../data/nginx:/nginx-templates:ro
+      - ../data/sslcerts:/etc/nginx/sslcerts
+    command: >
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
+      && cp -a /nginx-templates/. /etc/nginx/conf.d/
+      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
+      && chmod +x /tmp/run-nginx.sh
+      && /tmp/run-nginx.sh app.conf.template.no-letsencrypt"
+    env_file:
+      - .env.nginx
+    environment:
+      # Nginx proxy timeout settings (in seconds)
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
+
+  code-interpreter:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  db_volume:
+  minio_data:
+  model_cache_huggingface:
+  indexing_huggingface_model_cache:
+  # for logs that we don't want to lose on container restarts
+  api_server_logs:
+  background_logs:
+  inference_model_server_logs:
+  indexing_model_server_logs:
+  # Shared volume for persistent document storage (Craft file-system mode)
+  file-system:
+  # Persistent data for OpenSearch.
+  opensearch-data:

--- a/deployment/docker_compose/src/deployments/prod.yml
+++ b/deployment/docker_compose/src/deployments/prod.yml
@@ -1,0 +1,143 @@
+name: onyx
+
+include:
+  - api_server
+  - background
+  - web_server
+  - inference_model_server
+  - indexing_model_server
+  - relational_db
+  - opensearch
+  - nginx
+  - certbot
+  - minio
+  - cache
+  - code-interpreter
+
+services:
+  api_server:
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - minio
+      - inference_model_server
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+      CODE_INTERPRETER_BASE_URL: ${CODE_INTERPRETER_BASE_URL:-http://code-interpreter:8000}
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    volumes:
+      - api_server_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  background:
+    command: >
+      /bin/sh -c "
+      if [ -f /etc/ssl/certs/custom-ca.crt ]; then
+        update-ca-certificates;
+      fi &&
+      /app/scripts/supervisord_entrypoint.sh"
+    environment:
+      AUTH_TYPE: ${AUTH_TYPE:-oidc}
+      POSTGRES_HOST: relational_db
+      REDIS_HOST: cache
+      USE_IAM_AUTH: ${USE_IAM_AUTH}
+      AWS_REGION_NAME: ${AWS_REGION_NAME-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY-}
+      PERSISTENT_DOCUMENT_STORAGE_PATH: ${PERSISTENT_DOCUMENT_STORAGE_PATH:-/app/file-system}
+    volumes:
+      - background_logs:/var/log/onyx
+      # Shared volume for persistent document storage (Craft file-system mode)
+      - file-system:/app/file-system
+
+  web_server:
+    build:
+      args:
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+        - NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED=${NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED:-}
+    environment:
+      INTERNAL_URL: http://api_server:8080
+
+  inference_model_server:
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - model_cache_huggingface:/app/.cache/huggingface/
+      # optional, only for debugging purposes
+      - inference_model_server_logs:/var/log/onyx
+
+  indexing_model_server:
+    environment:
+      MIN_THREADS_ML_MODELS: ${MIN_THREADS_ML_MODELS:-}
+      # Set to debug to get more fine-grained logs
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      VESPA_SEARCHER_THREADS: ${VESPA_SEARCHER_THREADS:-1}
+    volumes:
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
+      # optional, only for debugging purposes
+      - indexing_model_server_logs:/var/log/onyx
+
+  relational_db:
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+
+  nginx:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../data/nginx:/nginx-templates:ro
+      - ../data/certbot/conf:/etc/letsencrypt
+      - ../data/certbot/www:/var/www/certbot
+    command: >
+      /bin/sh -c "rm -f /etc/nginx/conf.d/default.conf
+      && cp -a /nginx-templates/. /etc/nginx/conf.d/
+      && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
+      && chmod +x /tmp/run-nginx.sh
+      && /tmp/run-nginx.sh app.conf.template.prod"
+    env_file:
+      - .env.nginx
+    environment:
+      # Nginx proxy timeout settings (in seconds)
+      NGINX_PROXY_CONNECT_TIMEOUT: ${NGINX_PROXY_CONNECT_TIMEOUT:-300}
+      NGINX_PROXY_SEND_TIMEOUT: ${NGINX_PROXY_SEND_TIMEOUT:-300}
+      NGINX_PROXY_READ_TIMEOUT: ${NGINX_PROXY_READ_TIMEOUT:-300}
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1/nginx-health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  code-interpreter:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+volumes:
+  db_volume:
+  minio_data:
+  model_cache_huggingface:
+  indexing_huggingface_model_cache:
+  # for logs that we don't want to lose on container restarts
+  api_server_logs:
+  background_logs:
+  inference_model_server_logs:
+  indexing_model_server_logs:
+  # Shared volume for persistent document storage (Craft file-system mode)
+  file-system:
+  # Persistent data for OpenSearch.
+  opensearch-data:

--- a/deployment/docker_compose/src/services/api_server.yml
+++ b/deployment/docker_compose/src/services/api_server.yml
@@ -1,0 +1,40 @@
+services:
+  api_server:
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile
+    command: >
+      /bin/sh -c "alembic upgrade head &&
+      echo \"Starting Onyx Api Server\" &&
+      uvicorn onyx.main:app --host 0.0.0.0 --port 8080"
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - inference_model_server
+      - minio
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: ${REDIS_HOST:-cache}
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+    # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you
+    # are using iam auth for postgres
+    # volumes:
+    #   - ./bundle.pem:/app/bundle.pem:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"

--- a/deployment/docker_compose/src/services/background.yml
+++ b/deployment/docker_compose/src/services/background.yml
@@ -1,0 +1,57 @@
+services:
+  background:
+    image: ${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile
+    command: >
+      /bin/sh -c "
+      if [ -f /etc/ssl/certs/custom-ca.crt ]; then
+        update-ca-certificates;
+      fi &&
+      /app/scripts/supervisord_entrypoint.sh"
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      - relational_db
+      - opensearch
+      - cache
+      - inference_model_server
+      - indexing_model_server
+    restart: unless-stopped
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-relational_db}
+      OPENSEARCH_HOST: ${OPENSEARCH_HOST:-opensearch}
+      OPENSEARCH_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      REDIS_HOST: ${REDIS_HOST:-cache}
+      MODEL_SERVER_HOST: ${MODEL_SERVER_HOST:-inference_model_server}
+      INDEXING_MODEL_SERVER_HOST: ${INDEXING_MODEL_SERVER_HOST:-indexing_model_server}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_AWS_ACCESS_KEY_ID: ${S3_AWS_ACCESS_KEY_ID:-minioadmin}
+      S3_AWS_SECRET_ACCESS_KEY: ${S3_AWS_SECRET_ACCESS_KEY:-minioadmin}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_BOT_INVOKE_CHAR: ${DISCORD_BOT_INVOKE_CHAR:-!}
+      # API Server connection for Discord bot message processing
+      API_SERVER_PROTOCOL: ${API_SERVER_PROTOCOL:-http}
+      API_SERVER_HOST: ${API_SERVER_HOST:-api_server}
+    # PRODUCTION: Uncomment the line below to use if IAM_AUTH is true and you
+    # are using iam auth for postgres
+    # volumes:
+    #   - ./bundle.pem:/app/bundle.pem:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+    # PRODUCTION: Uncomment the following lines if you need to include a custom
+    # CA certificate. This section enables the use of a custom CA certificate.
+    # If present, the custom CA certificate is mounted as a volume; the
+    # container checks for its existence and updates the system's CA
+    # certificates. This allows for secure communication with services using
+    # custom SSL certificates.
+    # volumes:
+    #   # Maps to the CA_CERT_PATH environment variable in the Dockerfile
+    #   - ${CA_CERT_PATH:-./custom-ca.crt}:/etc/ssl/certs/custom-ca.crt:ro

--- a/deployment/docker_compose/src/services/cache.yml
+++ b/deployment/docker_compose/src/services/cache.yml
@@ -1,0 +1,14 @@
+services:
+  cache:
+    image: redis:7.4-alpine
+    restart: unless-stopped
+    # docker silently mounts /data even without an explicit volume mount, which
+    # enables persistence. explicitly setting save and appendonly forces
+    # ephemeral behavior.
+    command: redis-server --save "" --appendonly no
+    env_file:
+      - path: .env
+        required: false
+    # Use tmpfs to prevent creation of anonymous volumes for /data
+    tmpfs:
+      - /data

--- a/deployment/docker_compose/src/services/certbot.yml
+++ b/deployment/docker_compose/src/services/certbot.yml
@@ -1,0 +1,14 @@
+services:
+  # follows https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
+  certbot:
+    image: certbot/certbot
+    restart: unless-stopped
+    volumes:
+      - ../data/certbot/conf:/etc/letsencrypt
+      - ../data/certbot/www:/var/www/certbot
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/deployment/docker_compose/src/services/code-interpreter.yml
+++ b/deployment/docker_compose/src/services/code-interpreter.yml
@@ -1,0 +1,15 @@
+services:
+  code-interpreter:
+    image: onyxdotapp/code-interpreter:${CODE_INTERPRETER_IMAGE_TAG:-latest}
+    command: ["bash", "./entrypoint.sh", "code-interpreter-api"]
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    # Below is needed for the `docker-out-of-docker` execution mode
+    # For Linux rootless Docker, set DOCKER_SOCK_PATH=${XDG_RUNTIME_DIR}/docker.sock
+    user: root
+    volumes:
+      - ${DOCKER_SOCK_PATH:-/var/run/docker.sock}:/var/run/docker.sock
+    # uncomment below + comment out the above to use the `docker-in-docker` execution mode
+    # privileged: true

--- a/deployment/docker_compose/src/services/indexing_model_server.yml
+++ b/deployment/docker_compose/src/services/indexing_model_server.yml
@@ -1,0 +1,36 @@
+services:
+  indexing_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    # GPU Support: Uncomment the following lines to enable GPU support
+    # Requires nvidia-container-toolkit to be installed on the host
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+    command: >
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+      - path: .env
+        required: false
+    restart: unless-stopped
+    environment:
+      INDEXING_ONLY: "True"
+    volumes:
+      # Not necessary, this is just to reduce download time during startup
+      - indexing_huggingface_model_cache:/app/.cache/huggingface/
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"

--- a/deployment/docker_compose/src/services/inference_model_server.yml
+++ b/deployment/docker_compose/src/services/inference_model_server.yml
@@ -1,0 +1,34 @@
+services:
+  inference_model_server:
+    image: ${ONYX_MODEL_SERVER_IMAGE:-onyxdotapp/onyx-model-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile.model_server
+    # GPU Support: Uncomment the following lines to enable GPU support
+    # Requires nvidia-container-toolkit to be installed on the host
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+    command: >
+      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
+        echo 'Skipping service...';
+        exit 0;
+      else
+        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
+      fi"
+    env_file:
+      - path: .env
+        required: false
+    restart: unless-stopped
+    volumes:
+      # Not necessary, this is just to reduce download time during startup
+      - model_cache_huggingface:/app/.cache/huggingface/
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"

--- a/deployment/docker_compose/src/services/minio.yml
+++ b/deployment/docker_compose/src/services/minio.yml
@@ -1,0 +1,20 @@
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      # Note: we've seen the default bucket creation logic not work in some cases
+      MINIO_DEFAULT_BUCKETS: ${S3_FILE_STORE_BUCKET_NAME:-onyx-file-store-bucket}
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 20s
+      retries: 3

--- a/deployment/docker_compose/src/services/nginx.yml
+++ b/deployment/docker_compose/src/services/nginx.yml
@@ -1,0 +1,19 @@
+services:
+  nginx:
+    image: nginx:1.25.5-alpine
+    restart: unless-stopped
+    # nginx will immediately crash with `nginx: [emerg] host not found in upstream`
+    # if api_server / web_server are not up
+    depends_on:
+      - api_server
+      - web_server
+    volumes:
+      # Mount templates read-only; the startup command copies them into
+      # the writable /etc/nginx/conf.d/ inside the container.  This avoids
+      # "Permission denied" errors on Windows Docker bind mounts.
+      - ../data/nginx:/nginx-templates:ro
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"

--- a/deployment/docker_compose/src/services/opensearch.yml
+++ b/deployment/docker_compose/src/services/opensearch.yml
@@ -1,0 +1,37 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:3.6.0
+    restart: unless-stopped
+    # OpenSearch is the search backend and is enabled by default. To run against
+    # an external OpenSearch instance, set OPENSEARCH_HOST in your env and
+    # remove this service from the compose file (or skip it via the service list
+    # when running `docker compose up`).
+    environment:
+      # We need discovery.type=single-node so that OpenSearch doesn't try
+      # forming a cluster and waiting for other nodes to become live.
+      discovery.type: single-node
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: ${OPENSEARCH_ADMIN_PASSWORD:-StrongPassword123!}
+      # This and the JVM config below come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+      # We do this to avoid unstable performance from page swaps.
+      bootstrap.memory_lock: "true"
+      # Java heap should be ~50% of memory limit. For now we assume a limit of
+      # 4g although in practice the container can request more than this.
+      # See https://opster.com/guides/opensearch/opensearch-basics/opensearch-heap-size-usage-and-jvm-garbage-collection/
+      OPENSEARCH_JAVA_OPTS: -Xms2g -Xmx2g
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    # These come from the example in https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+    ulimits:
+      # Similarly to bootstrap.memory_lock, we don't want to impose limits on
+      # how much memory a process can lock from being swapped.
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"

--- a/deployment/docker_compose/src/services/relational_db.yml
+++ b/deployment/docker_compose/src/services/relational_db.yml
@@ -1,0 +1,14 @@
+services:
+  relational_db:
+    image: postgres:15.2-alpine
+    shm_size: 1g
+    command: -c 'max_connections=250'
+    restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+    volumes:
+      - db_volume:/var/lib/postgresql/data

--- a/deployment/docker_compose/src/services/web_server.yml
+++ b/deployment/docker_compose/src/services/web_server.yml
@@ -1,0 +1,23 @@
+services:
+  web_server:
+    image: ${ONYX_WEB_SERVER_IMAGE:-onyxdotapp/onyx-web-server:${IMAGE_TAG:-latest}}
+    build:
+      context: ../../web
+      dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_DISABLE_LOGOUT=${NEXT_PUBLIC_DISABLE_LOGOUT:-}
+        # Enterprise Edition only
+        - NEXT_PUBLIC_THEME=${NEXT_PUBLIC_THEME:-}
+    env_file:
+      - path: .env
+        required: false
+    depends_on:
+      - api_server
+    restart: unless-stopped
+    environment:
+      INTERNAL_URL: ${INTERNAL_URL:-http://api_server:8080}
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "6"


### PR DESCRIPTION
## Summary

- 5 standalone `docker-compose*.yml` files shared ~30% of their YAML for the same set of services (Postgres, Redis, OpenSearch, MinIO, model servers, nginx, api_server, background, web_server) with no shared-fragment mechanism. Adding a service meant editing 5 files; silent drift had accumulated (image-var presence, restart policies, env_file blocks, logging blocks).
- Introduce a canonical source under `deployment/docker_compose/src/`:
  - `src/services/<name>.yml` — per-service fragments (single source of truth, 12 services)
  - `src/deployments/<name>.yml` — per-deployment composition (5 deployments)
- The 5 top-level `docker-compose*.yml` files are now generated artifacts (with a `DO NOT EDIT BY HAND` banner) produced by `render.py`, which deep-merges per-deployment overrides on top of the canonical fragments.
- A `render-docker-compose` pre-commit hook runs `render.py --check` and fails commits when generated files are out of sync with `src/`.

Top-level filenames are preserved unchanged, so `install.sh`, `install.ps1`, `backend/scripts/restart_containers.sh`, and every `.github/workflows/pr-*.yml` that does `cd deployment/docker_compose && docker compose -f docker-compose.yml -f ...` continue to work without modification.

## Normalizations applied

All are either no-op-when-unset env defaults or harmonizations of pre-existing patterns. Diffs were verified by parsing old/new with PyYAML and comparing service-by-service — no behavioral diffs outside this list:

- Image envs unified: `${ONYX_BACKEND_IMAGE:-onyxdotapp/onyx-backend:${IMAGE_TAG:-latest}}` (and `_WEB_SERVER_IMAGE`, `_MODEL_SERVER_IMAGE`) applied everywhere instead of just 2 of 5 files
- `env_file: - path: .env, required: false` block harmonized across services that previously lacked it (cache, minio, model servers, relational_db in some files)
- `logging:` block (json-file, 50m × 6) harmonized on `web_server` to match the other services
- `relational_db` gains the `POSTGRES_USER`/`POSTGRES_PASSWORD` default env block in all deployments (previously only in some)
- A few previously-hardcoded values become `${VAR:-<previous_value>}`: `POSTGRES_HOST`, `REDIS_HOST`, `INTERNAL_URL`, `API_SERVER_HOST`/`API_SERVER_PROTOCOL` on background, `DOCKER_SOCK_PATH` — same default, just newly-overridable
- `nginx` env_file is deployment-specific (`.env.nginx` for prod/prod-cloud/prod-no-letsencrypt, `path: .env` for default, none for multitenant-dev) and is preserved per-deployment via the override

## Reviewer guidance

- The line-count delta is dominated by `docker compose`-style reformatting (PyYAML dump orders keys by declaration, list-form `environment:` rewrites to dict form). The rendered files are equivalent modulo the normalizations above.
- To audit a single deployment, compare normalized outputs:
  ```
  docker compose -f deployment/docker_compose/docker-compose.prod.yml config --no-interpolate
  ```
  vs the corresponding file on `main`. The only diffs should match the bullets above.
- Source of truth: edit anything under `deployment/docker_compose/src/`, then run `python deployment/docker_compose/render.py`. The pre-commit hook will block you if you forget.

## Test plan

- [ ] CI passes — these workflows already exercise the rendered files and will gate the PR:
  - `.github/workflows/pr-database-tests.yml`
  - `.github/workflows/pr-external-dependency-unit-tests.yml`
  - `.github/workflows/pr-craft-k8s-tests.yml`
  - `.github/workflows/pr-python-model-tests.yml`
  - `.github/workflows/pr-integration-tests.yml`
  - `.github/workflows/pr-playwright-tests.yml`
- [ ] `pre-commit run render-docker-compose --all-files` passes on a clean checkout
- [ ] Editing a file under `src/` without re-rendering causes the hook to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated five duplicate docker-compose files into a templated system with canonical service fragments and per-deployment configs, rendered into the existing top-level files. This removes drift, keeps current filenames and workflows working, and adds a pre-commit check to enforce sync.

- **Refactors**
  - Added `deployment/docker_compose/src/services/*.yml` (shared fragments) and `deployment/docker_compose/src/deployments/*.yml` (per-deployment includes/overrides).
  - Introduced `deployment/docker_compose/render.py` to deep-merge and regenerate `docker-compose*.yml` with a “DO NOT EDIT” banner.
  - Added a `render-docker-compose` `pre-commit` hook (`python deployment/docker_compose/render.py --check`).
  - Normalized configs: consistent `${ONYX_BACKEND_IMAGE}`, `${ONYX_WEB_SERVER_IMAGE}`, `${ONYX_MODEL_SERVER_IMAGE}`; added `env_file` where missing; unified logging blocks; defaulted `POSTGRES_USER`/`POSTGRES_PASSWORD` in all deployments; made several envs overridable via `${VAR:-default}`; preserved per-deployment `nginx` env_file.
  - Kept top-level filenames unchanged; existing install scripts and CI continue to work.

- **Migration**
  - Edit only under `deployment/docker_compose/src/`.
  - Regenerate with `python deployment/docker_compose/render.py`.
  - The `render-docker-compose` hook will block commits if rendered files are out of sync.

<sup>Written for commit 72b51afac38199ae5108da1d052ed39c742eb3a0. Summary will update on new commits. <a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

