### PR TITLE
feat(craft): wire egress proxy for secret decryption + secrets-injection plans

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.10
+version: 0.5.11
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,9 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Allow sandbox NetworkPolicy traffic to the configured
-        Next.js dev server port range.
+    - kind: changed
+      description: Inject `extraEnvFromSecret` into the `sandbox-proxy`
+        Deployment so the proxy receives credentials (e.g.
+        `ENCRYPTION_KEY_SECRET`) from the same Secret as the api_server,
+        enabling it to decrypt DB columns for egress credential injection.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -82,6 +82,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.config.envConfigMapName }}
+            {{- with .Values.extraEnvFromSecret }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           resources:
             {{- toYaml .Values.sandboxProxy.resources | nindent 12 }}
           readinessProbe:

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -1,0 +1,137 @@
+# Plan 1 — Egress Credential-Injection Seam
+
+This is the foundation of the Craft secret-injection workstream: keep long-lived secrets (LLM
+provider keys, the Onyx PAT) **out of the sandbox pod** and hold them only in the egress proxy.
+The sandbox is a low-trust environment that runs agent-authored code, so it shouldn't hold
+credentials at rest; the proxy (`backend/onyx/sandbox_proxy/`) is a separate, locked-down
+Deployment that already forces all egress through itself, MITMs TLS with a CA the sandbox trusts,
+and resolves sandbox identity by source IP — the natural place to broker secrets.
+
+It defines **one** egress credential-injection seam, **shared with the external-apps work**
+(Danelegend, PRs #11033–#11413). External-app credentials, LLM keys, and the Onyx PAT all inject
+through it. The workstream is three plans: this seam, then the [Onyx PAT resolver](./02-onyx-pat.md)
+and [LLM provider-key resolver](./03-llm-key.md), which plug into it and are independent of each
+other.
+
+## Landing plan (PRs)
+
+Roughly one PR per plan, flag-gated and independently revertible:
+
+1. **Prerequisite** — wire `ENCRYPTION_KEY_SECRET` into the proxy Deployment.
+2. **This seam** — interface + dispatcher + rendering helper + config + observability; lands inert
+  (no resolvers registered).
+3. **[Onyx PAT resolver](./02-onyx-pat.md)** and 4. **[LLM key resolver](./03-llm-key.md)** — each one
+  atomic, flag-gated PR (placeholder + resolver + routing together). Independent; land in parallel.
+
+Sequence: 1 + 2 first, then 3 and 4 in parallel. Each migration must ship atomically behind its
+flag — the pod-side placeholder only takes effect once its resolver is live. The external-apps
+convergence (retire `action_matcher.py`, register Dane's resolver) is a separate PR in that track.
+
+## Issues to Address
+
+Two secrets are currently provisioned into the pod: the LLM key in `OPENCODE_CONFIG_CONTENT`, and
+the Onyx PAT in the `ONYX_PAT` env var (both in `kubernetes_sandbox_manager.py`). This seam relocates
+them to the proxy so they no longer reside in the sandbox. Separately, the external-apps work already resolves per-user app
+credentials server-side — `get_external_app_credentials(db, user_id, url)` (added in the open PR
+#11086) matches the outbound URL against an app's `upstream_url_patterns` and renders its
+`auth_template`; the skill wrappers send no auth — and expects the proxy to inject them. **But the
+proxy injection step doesn't exist yet, for anyone.** Both efforts need the same primitive; building
+them as separate request-hook paths would collide over the same headers. This plan builds the one
+seam; the LLM/PAT resolvers (plans 2 & 3) and Dane's external-app resolver plug into it. It can land
+with zero resolvers (pure substrate).
+
+## Important Notes
+
+**Trust boundary, already in place.** All egress is iptables-forced through the proxy
+(`firewall-init.sh`); its NetworkPolicy only admits the sandbox namespace; it MITMs TLS; and
+`IdentityResolver.resolve_sandbox(src_ip)` (`identity.py`) yields `ResolvedSandbox` (`sandbox_id`,
+`user_id`, `tenant_id`, …). `GateAddon` already has a `db_session_factory` (`server.py`).
+
+**One dispatcher, many resolvers.** Define `CredentialResolver.resolve(request, identity) -> Injection | None`: return rendered auth headers to set; `None` if the host doesn't match (pass
+through); or signal **block** (fail-closed) if the host matches but the secret can't be resolved.
+Three resolvers plug in:
+
+- **ExternalAppResolver** — Dane's, per-**user** (creds are per-user), from `external_app` rows.
+- **LLMProviderKeyResolver** — per-**tenant** (sandboxes share the tenant's keys), from `llm_provider`.
+- **OnyxPatResolver** — per-**sandbox** (each sandbox has its own PAT).
+
+The dispatcher resolves identity once, passes the full `ResolvedSandbox`, and tries resolvers
+first-match-by-host. Hosts are disjoint (external-app hosts vs LLM provider hosts vs the Onyx API
+host), so this is conflict-free; if an overlap ever surfaces, fix the order explicitly.
+
+**Reuse the external-apps matching + rendering contract.** An `external_app` models
+`upstream_url_patterns` (regex) + `auth_template` (a `{header: "Bearer {token}"}` dict rendered via
+`format_map`, fail-closed on any missing placeholder). LLM/PAT resolvers supply their templates and
+values from code rather than DB rows, but the render-and-overwrite step is identical. Don't build a
+parallel matcher — the current `sandbox_proxy/action_matcher.py` is a stopgap to be retired (step 6).
+
+**Placeholder/overwrite contract (single source — referenced by plans 2 & 3).** Clients need a
+*non-empty* credential to build a request (onyx-cli treats empty as "unconfigured"; opencode's AI
+SDK throws if the key is unset). So the pod ships a fixed, non-secret **placeholder constant** in
+place of each real credential, and the proxy **overwrites** the auth header(s) named in the resolved
+template — set/replace, never append; all other headers (e.g. Anthropic's `anthropic-version`) left
+intact. Overwrite is unconditional for matched hosts; the proxy doesn't need to recognize the
+placeholder value. A resolver may match one host or several.
+
+**Decryption: `ENCRYPTION_KEY_SECRET` on the proxy (prerequisite, step 1).** The proxy decrypts DB
+columns with the same machinery as the api_server (`EncryptedString`, `LLMProviderView.from_model`);
+no-op in MIT, real in EE/cloud. Trade-off: it can now decrypt any encrypted column it can reach, so
+its access surface matters more. **Coordination flag:** external-app creds are stored plaintext
+today (unlike `llm_provider.api_key` and the PAT) — encrypt them with Dane if we're hardening this.
+
+**Inject at `requestheaders` (single source for streaming-safety).** Injection only rewrites a
+request header, so the dispatcher runs in `requestheaders` — headers and source IP are available
+before the body. It never reads the request body or the response, so large prompts and SSE
+responses pass through untouched. A matched+injected flow is flagged in `flow.metadata` (mirroring
+the snapshot stream flag) so the `request` hook skips the stopgap gating path.
+
+**Compose with policy/approval gating.** Hook order: resolve identity → policy decision → inject
+(only if allowed) → forward. Dane's #11366 adds `ALWAYS`/`ASK`/`DENY` policy + an action catalog
+the proxy will consume, routing `ASK` through the existing approval flow. Injection and policy are
+separate concerns at the same hook.
+
+**Coordination / ownership.** The seam lives in `sandbox_proxy/` (ours): we own the dispatcher, the
+`CredentialResolver` interface, the fail-closed/ordering contract, and the LLM/PAT resolvers; Dane
+owns the ExternalAppResolver. Agree the interface before either side builds the injection step.
+
+## Implementation Strategy
+
+1. **Wire `ENCRYPTION_KEY_SECRET` into the proxy Deployment (prerequisite — land first).** From the
+  same K8s Secret the api_server uses.
+2. **Define `CredentialResolver` + the dispatcher** in a new module `sandbox_proxy/injection/`. The
+  dispatcher holds an ordered resolver list, is constructed in `server.py`, and is passed to
+   `GateAddon` like `snapshot_policy`. It runs in `requestheaders`: first host match wins → render +
+   overwrite headers → flag the flow to skip gating. Matched-but-unresolvable → block via the
+   existing 403 helper; unmatched → pass through. Reuse the resolved `ResolvedSandbox`; keep
+   injection independent of gating.
+3. **Shared rendering helper** — `auth_template` `format_map`, fail-closed — used by all resolvers.
+4. **Config.** A seam enable flag plus per-resolver flags (e.g. `*_INJECTION_ENABLED`), read at
+  startup like `SnapshotEgressPolicy.from_env()`, so plans 2 & 3 and Dane's apps roll out
+   independently.
+5. **Observability.** A structured log per injection (host, sandbox_id, tenant_id, resolver, result)
+  — never the secret value.
+6. **Converge with external apps.** Support Dane adapting `get_external_app_credentials` into a
+  `CredentialResolver`; retire `sandbox_proxy/action_matcher.py` for his #11366 catalog.
+
+## Tests
+
+External-dependency unit tests (proxy + DB real, sandbox mocked — matches the existing
+`sandbox_proxy/` suite):
+
+- Matched request → target header **overwritten** (not duplicated), other headers intact; unmatched
+host passes through.
+- Fail-closed: matched host with an unresolvable secret → 403, not forwarded.
+- Multiple resolvers registered → first host match wins; an injected flow skips the gating path.
+- Identity: the resolver receives the correct `ResolvedSandbox` for the source IP.
+- Feature-flag off → no-op.
+
+Don't test mitmproxy's header API or Pydantic ([[feedback_dont_test_framework_validation]]).
+Per-resolver behavior is exercised by plans 2/3 and Dane's tests.
+
+## Out of scope
+
+- Removing `ONYX_PAT` / the LLM key from the pod — plans 2 and 3.
+- The ExternalAppResolver and external-app credential encryption — Dane's, coordinated.
+- Policy enforcement (#11366) — composes at the same hook but is separate.
+- PAT scopes (`plans/whuang/pat_system/SCOPES.md`, unimplemented).
+

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -1,0 +1,74 @@
+# Plan 2 — Onyx PAT Resolver
+
+Reference: [Plan 1](./01-framework.md) for project context and the shared seam this plugs into.
+
+## Issues to Address
+
+The sandbox authenticates back to the Onyx API server with a CRAFT-type Personal Access Token,
+currently provisioned into the pod as the `ONYX_PAT` env var (`kubernetes_sandbox_manager.py`;
+docker manager too). It's a 30-day token scoped to the owning user (`ensure_sandbox_pat`,
+`sandbox.py`). This plan moves it out of the pod so it lives only in the proxy: an `OnyxPatResolver`
+behind the [Plan 1](./01-framework.md) seam injects auth on requests to the Onyx API host.
+
+## Important Notes
+
+**Blocker — the Onyx API host is on `NO_PROXY`, so the proxy never sees that traffic.**
+`_compute_no_proxy_list()` (`kubernetes_sandbox_manager.py`) adds the `SANDBOX_API_SERVER_URL`
+hostname. Routing it through the proxy (step 2) is the central change of this plan; the external-app
+and LLM hosts already traverse the proxy.
+
+**onyx-cli works with a non-empty placeholder (confirmed against v1.0.3 Go source).** `IsConfigured()`
+only checks the token is non-empty (no format validation), and the client sets it on **both**
+`Authorization` and `X-Onyx-Authorization` — so per Plan 1's placeholder/overwrite contract, keep
+`ONYX_PAT` a non-empty placeholder and have the resolver overwrite both headers. onyx-cli honors
+`HTTPS_PROXY`/`NO_PROXY` (it clones `http.DefaultTransport`) and trusts the proxy MITM CA via
+`SSL_CERT_FILE` (which Go honors; it ignores `REQUESTS_CA_BUNDLE`) plus the system-store install in
+`firewall-init.sh` — so it routes through the proxy once off `NO_PROXY`. That path isn't exercised
+today, so cover it with an integration test. `ONYX_SERVER_URL` stays set (onyx-cli appends `/api`).
+
+**How the resolver obtains the PAT: read + decrypt the stored per-sandbox PAT (chosen).** The proxy
+has `ENCRYPTION_KEY_SECRET` (Plan 1), so `OnyxPatResolver` reuses the PAT provisioning already mints
+and stores encrypted on the `Sandbox` row (`ensure_sandbox_pat`): resolve `sandbox_id` from source
+IP, read the row, decrypt. Provisioning is unchanged except the pod gets the placeholder; lifecycle
+is unchanged (30-day, rotated on re-provision).
+
+> **Pre-implementation check.** Confirm the `Sandbox` PAT column stores the *raw token encrypted*
+> (recoverable), not just the SHA-256 lookup hash. If only the hash, persist the raw token encrypted
+> at provisioning — acceptable under [[project_craft_beta_no_backcompat]]. This gates the chosen path.
+
+*Alternative (not chosen):* the resolver mints + caches its own session PAT (`create_pat`), revoked
+on teardown — tighter lifecycle, more machinery. Revisit only if we want per-session revocation.
+
+**What the resolver injects.** `Authorization: Bearer <pat>` + `X-Onyx-Authorization: Bearer <pat>`,
+and `X-Onyx-Tenant-ID = resolved.tenant_id` (the server resolves the PAT via the standard auth path
+and the tenant via `add_onyx_tenant_id_middleware`).
+
+Scopes are out of scope — see Plan 1 (a CRAFT PAT grants full user access today).
+
+## Implementation Strategy
+
+1. **Stop pre-populating the real PAT.** In `kubernetes_sandbox_manager.py` and the docker manager,
+   set `ONYX_PAT` to the Plan 1 placeholder. `ensure_sandbox_pat` keeps minting and storing the
+   encrypted PAT on the `Sandbox` row — the resolver reads from there.
+
+2. **Route API traffic through the proxy.** Remove the `SANDBOX_API_SERVER_URL` hostname from
+   `_compute_no_proxy_list()` (keep `127.0.0.1`/`localhost`); verify the proxy can reach the API host.
+
+3. **Implement `OnyxPatResolver`** for the Onyx API host: read + decrypt the `Sandbox` PAT, overwrite
+   both `Authorization` and `X-Onyx-Authorization`, set `X-Onyx-Tenant-ID`; fail closed if identity
+   or token can't be resolved.
+
+4. **Config**: an enable flag for the PAT resolver, separate from the LLM-key resolver.
+
+## Tests
+
+Integration test (CI only — [[feedback_no_integration_tests_locally]]) in
+`backend/tests/integration/tests/craft/`:
+
+- A request with the placeholder, routed through the proxy from a known sandbox IP, reaches the API
+  and authenticates as the owning user (proxy overwrote the headers + set the tenant header).
+- A request from an unidentifiable source IP to the API host is blocked (fail-closed).
+
+External-dependency unit test in `sandbox_proxy/`: given a `Sandbox` row with a stored PAT, a request
+from that sandbox's IP gets both auth headers overwritten and the tenant header set; and
+`_compute_no_proxy_list` no longer contains the API host.

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -1,0 +1,75 @@
+# Plan 3 — LLM Provider-Key Resolver
+
+Reference: [Plan 1](./01-framework.md) for project context and the shared seam this plugs into.
+Independent of plan 2.
+
+## Issues to Address
+
+The LLM provider key is currently written into the opencode config: `_build_provider_block` sets
+`provider.<id>.options.apiKey = <real key>` (`opencode_config.py`), and the JSON is mounted as
+`OPENCODE_CONFIG_CONTENT` (`kubernetes_sandbox_manager.py`). This plan moves the key out of the pod
+so it lives only in the proxy: an `LLMProviderKeyResolver` behind the [Plan 1](./01-framework.md)
+seam injects the per-tenant provider key on outbound LLM requests. It's the cleanest of the three:
+LLM traffic already traverses and MITMs through the proxy.
+
+## Important Notes
+
+**Placeholder.** Per Plan 1's placeholder/overwrite contract, set each provider's `options.apiKey`
+to the placeholder — required because opencode's AI SDK throws `LoadAPIKeyError` before sending if
+the key is unset (opencode #21737). Never set `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` in the pod.
+
+**Per-provider auth_templates** (matched by host; overwrite only the named header — Plan 1):
+
+| Provider | Host | auth_template |
+|---|---|---|
+| OpenAI | `api.openai.com` | `{"Authorization": "Bearer {key}"}` |
+| Anthropic | `api.anthropic.com` | `{"x-api-key": "{key}"}` — leave `anthropic-version` intact |
+| Google Gemini | `generativelanguage.googleapis.com` | `{"x-goog-api-key": "{key}"}`; strip any `?key=` param |
+| OpenRouter | `openrouter.ai` | `{"Authorization": "Bearer {key}"}` |
+
+**Key source.** Build-mode `llm_provider` rows: `fetch_all_build_mode_llm_providers` /
+`fetch_llm_provider_by_type_for_build_mode` (`build_session.py`) return `LLMProviderView` with the
+key decrypted via `LLMProviderView.from_model()` (works because the proxy has `ENCRYPTION_KEY_SECRET`
+— Plan 1). The resolver: `tenant_id` from `ResolvedSandbox` → `get_session_with_tenant` → fetch by
+provider/host.
+
+**Custom `api_base`.** A tenant may set a custom endpoint via `LLMProvider.api_base`
+(`opencode_config.py`), so the host differs from canonical. The resolver loads the tenant's
+build-mode providers (including `api_base`) and matches both canonical and custom hosts — miss this
+and the request 401s.
+
+**Keep opencode pointed at the real provider hosts** — don't repoint `baseURL` at the proxy; traffic
+already routes and MITMs through the proxy, so host-matching stays simple.
+
+**Multi-provider sessions** (`enabled_providers`) work for free: matching keys on each request's
+host. **Streaming** is stream-safe via Plan 1 (injection runs at `requestheaders`, never reads body
+or response).
+
+## Implementation Strategy
+
+1. **Emit placeholders instead of real keys.** In `_build_provider_block` /
+   `build_multi_provider_opencode_config` (`opencode_config.py`), write the Plan 1 placeholder for
+   each `options.apiKey`, behind the LLM-key resolver flag. Keep `model`, `enabled_providers`, base
+   URLs, and `api_base`; ensure the pod never sets the provider env keys. *While here:* the custom
+   endpoint is written as `block["api"]`, but the current opencode schema uses
+   `provider.<id>.options.baseURL` — fix it ([[project_craft_beta_no_backcompat]]).
+
+2. **Implement `LLMProviderKeyResolver`** for the LLM provider hosts (canonical + tenant `api_base`):
+   resolve `tenant_id`, fetch + decrypt the matching build-mode provider's key, render the host's
+   auth_template (leaving `anthropic-version` intact); fail closed if no provider/key for that
+   host+tenant.
+
+3. **Config**: an enable flag, independent of the PAT resolver.
+
+## Tests
+
+External-dependency unit tests (real DB + provider config, sandbox mocked) extending `sandbox_proxy/`:
+
+- OpenAI-bound request with the placeholder → `Authorization` overwritten with the decrypted tenant key.
+- Anthropic-bound request → `x-api-key` set, `anthropic-version` left intact.
+- Custom `api_base` provider → resolver host-matches the custom host and injects.
+- Fail-closed: a provider-host request from a tenant with no configured provider is blocked.
+- `opencode_config` output carries only the placeholder, never a real key, with the flag on. Pin
+  against the spec, not the constant ([[feedback_tests_pin_spec_not_impl]]).
+
+One test per header convention is enough; assert the header the resolver *produces*.


### PR DESCRIPTION
## Description

Prerequisite for the Craft secret-injection workstream (brokering LLM keys + the Onyx PAT from the egress proxy instead of the sandbox pod). The proxy must decrypt DB columns, which needs `ENCRYPTION_KEY_SECRET`. In cloud/EE that key lives only in `onyx-app-secrets`, injected via `extraEnvFromSecret` — and the `sandbox-proxy` Deployment was the one backend workload missing that block.

- `sandbox-proxy/deployment.yaml` — add the `extraEnvFromSecret` `secretRef` block, mirroring `api-deployment.yaml`. The `configMap.ENCRYPTION_KEY_SECRET` path was already covered via the existing `configMapRef`.
- `Chart.yaml` — patch bump `0.5.10 → 0.5.11` + changelog entry (chart is published per-version).
- `docs/craft/features/secrets-injection/` — design docs for the seam and the PAT/LLM-key resolvers (follow-up PRs).

No app code changes: no-op in MIT, key present in EE/cloud.

## How Has This Been Tested?

- `helm template` with `extraEnvFromSecret` set → proxy renders `secretRef: onyx-app-secrets`; without it → no dangling ref (key resolves via `configMapRef`).
- `helm lint` → 0 failures.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
