### PR TITLE
refactor(backend): simplify validate_user_prompt_authorization

### DIFF
--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -11,8 +11,6 @@ from sqlalchemy.orm import Session
 from onyx.db.models import InputPrompt
 from onyx.db.models import InputPrompt__User
 from onyx.db.models import User
-from onyx.server.features.input_prompt.models import InputPromptSnapshot
-from onyx.server.manage.models import UserInfo
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -97,10 +95,8 @@ def update_input_prompt(
 
 
 def validate_user_prompt_authorization(user: User, input_prompt: InputPrompt) -> bool:
-    prompt = InputPromptSnapshot.from_model(input_prompt=input_prompt)
-
     # Public prompts cannot be modified via the user API (only admins via admin endpoints)
-    if prompt.is_public or prompt.user_id is None:
+    if input_prompt.is_public or input_prompt.user_id is None:
         return False
 
     # Anonymous users cannot modify user-owned prompts
@@ -108,8 +104,7 @@ def validate_user_prompt_authorization(user: User, input_prompt: InputPrompt) ->
         return False
 
     # User must own the prompt
-    user_details = UserInfo.from_model(user)
-    return str(user_details.id) == str(prompt.user_id)
+    return str(user.id) == str(input_prompt.user_id)
 
 
 def remove_public_input_prompt(input_prompt_id: int, db_session: Session) -> None:


### PR DESCRIPTION
## Summary
- Drop the unnecessary `InputPromptSnapshot.from_model(...)` and `UserInfo.from_model(...)` round-trips in `validate_user_prompt_authorization` — `is_public`, `user_id`, and `user.id` are already available directly on the SQLAlchemy models.
- Remove the now-unused `InputPromptSnapshot` and `UserInfo` imports from `backend/onyx/db/input_prompt.py`.

## Test plan
- [ ] Existing prompt authorization tests pass (update / delete user-owned prompts, reject public-prompt / anonymous / cross-user modifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined `validate_user_prompt_authorization` by reading `is_public`, `user_id`, and `user.id` directly from the SQLAlchemy models. Removed the `InputPromptSnapshot`/`UserInfo` conversions and their unused imports for less overhead and clearer logic.

<sup>Written for commit 6e13bff62b9f80095fc7ba10e2346465e7c1499f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11454?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

