### PR TITLE
fix(opal/settings-layouts): replace non-existent SvgDatabase with SvgServer in stories

### DIFF
--- a/web/lib/opal/src/layouts/settings/SettingsLayouts.stories.tsx
+++ b/web/lib/opal/src/layouts/settings/SettingsLayouts.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as SettingsLayouts from "@opal/layouts/settings/components";
-import { SvgSettings, SvgDatabase, SvgUser } from "@opal/icons";
+import { SvgSettings, SvgServer, SvgUser } from "@opal/icons";
 import { Button } from "@opal/components";
 
 const meta: Meta = {
@@ -33,7 +33,7 @@ export const WithActions: Story = {
   render: () => (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
-        icon={SvgDatabase}
+        icon={SvgServer}
         title="Data Sources"
         description="Manage connected data sources"
         rightChildren={<Button prominence="primary">Add source</Button>}


### PR DESCRIPTION
## Description

`SettingsLayouts.stories.tsx` imported `SvgDatabase` from `@opal/icons`, which does not exist. Replaced with `SvgServer` — the closest semantic match for a "Data Sources" story.

## Additional Options

- [ ] This PR should be cherry-picked to the release branch
- [x] This PR should bypass the Linear check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced non-existent `SvgDatabase` in `SettingsLayouts.stories.tsx` with `SvgServer` from `@opal/icons` to fix Storybook rendering. Keeps the "Data Sources" story icon accurate and removes a broken import.

<sup>Written for commit e191445c48ae7def05a840d700156202374e8037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11456?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->