### PR TITLE
test(craft): share sandbox_proxy test factories in conftest

### DIFF
--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -1,17 +1,31 @@
-"""Shared `StaticLookup` stub for sandbox_proxy tests.
+"""Shared stubs and factories for sandbox_proxy unit tests.
 
-Two shapes: `StaticLookup({ip: identity, ...})` keys by source IP;
-`StaticLookup.single(identity_or_none)` returns the same identity for any IP.
+- `StaticLookup` — `SandboxIPLookup` stub keyed by source IP.
+- `make_resolved_sandbox` / `make_flow` — value + mitmproxy-flow factories.
+- `StubResolver` — identity resolver stub (sandbox + session) for the gate.
 """
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+from uuid import UUID
+from uuid import uuid4
+
+from mitmproxy import http
+
+from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SandboxIdentity
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 
+_SANDBOX_ID = UUID("11111111-1111-1111-1111-111111111111")
+
 
 class StaticLookup(SandboxIPLookup):
-    """`SandboxIPLookup` Protocol stub with a fixed in-memory map."""
+    """`SandboxIPLookup` Protocol stub with a fixed in-memory map.
+
+    Two shapes: `StaticLookup({ip: identity, ...})` keys by source IP;
+    `StaticLookup.single(identity_or_none)` returns the same identity for any IP.
+    """
 
     def __init__(
         self,
@@ -48,3 +62,93 @@ class StaticLookup(SandboxIPLookup):
 
     def stop(self) -> None:
         return None
+
+
+def make_resolved_sandbox(
+    *,
+    user_id: UUID | None = None,
+    tenant_id: str = "public",
+    sandbox_id: UUID = _SANDBOX_ID,
+    sandbox_name: str = "sandbox-aaaa1111",
+    sandbox_ip: str = "10.0.0.1",
+) -> ResolvedSandbox:
+    return ResolvedSandbox(
+        sandbox_id=sandbox_id,
+        user_id=user_id if user_id is not None else uuid4(),
+        tenant_id=tenant_id,
+        sandbox_name=sandbox_name,
+        sandbox_ip=sandbox_ip,
+    )
+
+
+def make_flow(
+    *,
+    host: str = "slack.com",
+    peername: tuple[str, int] | None = ("10.0.0.1", 12345),
+    raw_content: bytes | None = b"{}",
+    port: int = 443,
+    method: str = "POST",
+    path_components: tuple[str, ...] = (),
+    conn_id: str = "conn-default",
+    proxy_auth: str | None = None,
+    headers: dict[str, str] | None = None,
+) -> http.HTTPFlow:
+    flow = MagicMock(spec=http.HTTPFlow)
+    flow.client_conn = MagicMock()
+    flow.client_conn.peername = peername
+    flow.client_conn.id = conn_id
+    flow.request = MagicMock()
+    flow.request.host = host
+    flow.request.port = port
+    flow.request.method = method
+    flow.request.path_components = path_components
+    flow.request.raw_content = raw_content
+    flow.request.stream = False
+    # Real dict (not MagicMock) so `.get(...)` and the metadata flag lookups
+    # behave; seed arbitrary headers and/or the session tag.
+    request_headers = dict(headers) if headers is not None else {}
+    if proxy_auth is not None:
+        request_headers["Proxy-Authorization"] = proxy_auth
+    flow.request.headers = request_headers
+    flow.response = None
+    flow.metadata = {}
+    return flow
+
+
+class StubResolver:
+    """`SessionResolver` stub with canned returns (resolves sandbox + session)."""
+
+    def __init__(
+        self,
+        *,
+        sandbox: ResolvedSandbox | None = None,
+        sandbox_exc: Exception | None = None,
+        session_by_id: UUID | None = None,
+        session_by_id_exc: Exception | None = None,
+    ) -> None:
+        self._sandbox = sandbox
+        self._sandbox_exc = sandbox_exc
+        self._session_by_id = session_by_id
+        self._session_by_id_exc = session_by_id_exc
+        self.resolve_sandbox_calls = 0
+        self.resolve_session_by_id_calls: list[tuple[UUID, UUID, str]] = []
+
+    def resolve_sandbox(
+        self,
+        src_ip: str,  # noqa: ARG002
+    ) -> ResolvedSandbox | None:
+        self.resolve_sandbox_calls += 1
+        if self._sandbox_exc is not None:
+            raise self._sandbox_exc
+        return self._sandbox
+
+    def resolve_session_by_id(
+        self,
+        session_id: UUID,
+        user_id: UUID,
+        tenant_id: str,
+    ) -> UUID | None:
+        self.resolve_session_by_id_calls.append((session_id, user_id, tenant_id))
+        if self._session_by_id_exc is not None:
+            raise self._session_by_id_exc
+        return self._session_by_id

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -30,55 +30,15 @@ from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
 from onyx.sandbox_proxy.addons.gate import PARSER_MAX_BODY_BYTES
-from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 
 # ---------------------------------------------------------------------------
 # Stubs
 # ---------------------------------------------------------------------------
-
-
-_SENTINEL = object()
-
-
-class _StubResolver:
-    """`_Resolver` Protocol stub with canned returns."""
-
-    def __init__(
-        self,
-        *,
-        sandbox: Any = _SENTINEL,
-        sandbox_exc: Exception | None = None,
-        session_by_id: Any = _SENTINEL,
-        session_by_id_exc: Exception | None = None,
-    ) -> None:
-        self._sandbox = sandbox
-        self._sandbox_exc = sandbox_exc
-        self._session_by_id = session_by_id
-        self._session_by_id_exc = session_by_id_exc
-        self.resolve_sandbox_calls = 0
-        self.resolve_session_by_id_calls: list[tuple[UUID, UUID, str]] = []
-
-    def resolve_sandbox(
-        self,
-        src_ip: str,  # noqa: ARG002
-    ) -> ResolvedSandbox | None:
-        self.resolve_sandbox_calls += 1
-        if self._sandbox_exc is not None:
-            raise self._sandbox_exc
-        return None if self._sandbox is _SENTINEL else self._sandbox  # type: ignore[no-any-return]
-
-    def resolve_session_by_id(
-        self,
-        session_id: UUID,
-        user_id: UUID,
-        tenant_id: str,
-    ) -> UUID | None:
-        self.resolve_session_by_id_calls.append((session_id, user_id, tenant_id))
-        if self._session_by_id_exc is not None:
-            raise self._session_by_id_exc
-        return None if self._session_by_id is _SENTINEL else self._session_by_id  # type: ignore[no-any-return]
 
 
 class _StubMatcher:
@@ -117,20 +77,6 @@ def _noop_cache_factory(tenant_id: str) -> Any:  # noqa: ARG001
     raise AssertionError("cache factory unexpectedly used")
 
 
-def _sandbox(
-    *,
-    user_id: UUID | None = None,
-    tenant_id: str = "public",
-) -> ResolvedSandbox:
-    return ResolvedSandbox(
-        sandbox_id=UUID("11111111-1111-1111-1111-111111111111"),
-        user_id=user_id if user_id is not None else uuid4(),
-        tenant_id=tenant_id,
-        sandbox_name="sandbox-aaaa1111",
-        sandbox_ip="10.0.0.1",
-    )
-
-
 def _ctx(
     *,
     tenant_id: str = "public",
@@ -145,38 +91,6 @@ def _ctx(
         sandbox_name="sandbox-aaaa1111",
         sandbox_ip="10.0.0.1",
     )
-
-
-def _flow(
-    *,
-    peername: tuple[str, int] | None = ("10.0.0.1", 12345),
-    raw_content: bytes | None = b"{}",
-    host: str = "slack.com",
-    port: int = 443,
-    method: str = "POST",
-    path_components: tuple[str, ...] = (),
-    conn_id: str = "conn-default",
-    proxy_auth: str | None = None,
-) -> http.HTTPFlow:
-    flow = MagicMock(spec=http.HTTPFlow)
-    flow.client_conn = MagicMock()
-    flow.client_conn.peername = peername
-    flow.client_conn.id = conn_id
-    flow.request = MagicMock()
-    flow.request.host = host
-    flow.request.port = port
-    flow.request.method = method
-    flow.request.path_components = path_components
-    flow.request.raw_content = raw_content
-    flow.request.stream = False
-    # Real dict (not MagicMock) so `.get(...)` returns None, not a truthy mock.
-    flow.request.headers = (
-        {"Proxy-Authorization": proxy_auth} if proxy_auth is not None else {}
-    )
-    flow.response = None
-    # Real dict (not MagicMock) so the snapshot-stream flag lookup isn't truthy.
-    flow.metadata = {}
-    return flow
 
 
 def _build(


### PR DESCRIPTION
## Description

Pure test-infra refactor: extracts the duplicated `sandbox_proxy` unit-test helpers into `conftest.py` as shared factories/stubs, so `test_gate.py` (and future proxy tests) reuse them instead of re-declaring local copies.

- `make_flow` — mitmproxy `HTTPFlow` mock factory (supersets the old local one: adds a `headers` seed alongside `proxy_auth`).
- `make_resolved_sandbox` — `ResolvedSandbox` value factory.
- `StubResolver` — identity resolver stub (sandbox + session), now strictly typed: dropped the `Any`/sentinel since `None` already meant "not found".

`test_gate.py` drops its local `_flow`/`_sandbox`/`_StubResolver` and imports the shared versions (aliased to keep call sites unchanged). No behavior change.

## How Has This Been Tested?

- `ruff check` / `ruff format` / `ty check` clean on the changed files.
- `pytest tests/unit/sandbox_proxy/test_gate.py tests/unit/sandbox_proxy/test_identity.py` → 50 passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share `sandbox_proxy` unit-test factories and stubs via `tests/unit/sandbox_proxy/conftest.py` to remove duplication and improve typing across tests. No runtime behavior changes.

- **Refactors**
  - Added shared helpers: `make_flow` (mock `mitmproxy` `HTTPFlow` with optional `headers`/`Proxy-Authorization`), `make_resolved_sandbox`, and `StubResolver` (uses `None` for “not found”).
  - Updated `test_gate.py` to import these helpers (aliased to keep call sites), removing local `_flow`/`_sandbox`/`_StubResolver`.

<sup>Written for commit 80f2b061e15a1aa522a43c4352a23fa8dac262f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11467?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

