### PR TITLE
fix: confluence perm sync draft 404s

### DIFF
--- a/backend/ee/onyx/external_permissions/confluence/page_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/page_access.py
@@ -182,7 +182,7 @@ def get_page_restrictions_with_per_ancestor_fetch(
 
     def _resolve(ancestor: dict[str, Any]) -> dict[str, Any] | None:
         ancestor_id = ancestor.get("id")
-        if not ancestor_id:
+        if ancestor_id is None:
             return None
         cache_key = str(ancestor_id)
         if cache_key in ancestor_restrictions_cache:

--- a/backend/ee/onyx/external_permissions/confluence/page_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/page_access.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 
 from onyx.access.models import ExternalAccess
@@ -69,29 +70,31 @@ def _extract_read_access_restrictions(
     )
 
 
-def get_page_restrictions(
+# Resolve an ancestor's read-restrictions; None means "unreadable, skip
+# and keep walking up" (e.g. a draft owned by another user).
+_AncestorRestrictionsResolver = Callable[[dict[str, Any]], dict[str, Any] | None]
+
+
+def _maybe_prefix_groups(group_names: set[str], add_prefix: bool) -> set[str]:
+    if not add_prefix:
+        return group_names
+    return {
+        build_ext_group_name_for_onyx(g, DocumentSource.CONFLUENCE) for g in group_names
+    }
+
+
+def _resolve_external_access(
     confluence_client: OnyxConfluence,
     page_id: str,
     page_restrictions: dict[str, Any],
     ancestors: list[dict[str, Any]],
-    add_prefix: bool = False,
+    resolve_ancestor_restrictions: _AncestorRestrictionsResolver,
+    add_prefix: bool,
 ) -> ExternalAccess | None:
-    """
-    This function gets the restrictions for a page. In Confluence, a child can have
-    at MOST the same level accessibility as its immediate parent.
-
-    If no restrictions are found anywhere, then return None, indicating that the page
-    should inherit the space's restrictions.
-
-    add_prefix: When True, prefix group IDs with source type (for indexing path).
-               When False (default), leave unprefixed (for permission sync path).
-    """
-    found_user_emails: set[str] = set()
-    found_group_names: set[str] = set()
-
-    # NOTE: need the found_any_restriction, since we can find restrictions
-    # but not be able to extract any user emails or group names
-    # in this case, we should just give no access
+    """Shared inheritance walk. Page-level restriction wins outright;
+    otherwise walk ancestors closest-parent-first (they arrive root-first)
+    and apply the closest one with a restriction. Returns None when
+    nothing restricts the page so the caller falls back to space-level."""
     found_user_emails, found_group_names, found_any_page_level_restriction = (
         _extract_read_access_restrictions(
             confluence_client=confluence_client,
@@ -99,43 +102,29 @@ def get_page_restrictions(
         )
     )
 
-    def _maybe_prefix_groups(group_names: set[str]) -> set[str]:
-        if add_prefix:
-            return {
-                build_ext_group_name_for_onyx(g, DocumentSource.CONFLUENCE)
-                for g in group_names
-            }
-        return group_names
-
-    # if there are individual page-level restrictions, then this is the accurate
-    # restriction for the page. You cannot both have page-level restrictions AND
-    # inherit restrictions from the parent.
     if found_any_page_level_restriction:
         return ExternalAccess(
             external_user_emails=found_user_emails,
-            external_user_group_ids=_maybe_prefix_groups(found_group_names),
+            external_user_group_ids=_maybe_prefix_groups(found_group_names, add_prefix),
             is_public=False,
         )
 
-    # ancestors seem to be in order from root to immediate parent
-    # https://community.atlassian.com/forums/Confluence-questions/Order-of-ancestors-in-REST-API-response-Confluence-Server-amp/qaq-p/2385981
-    # we want the restrictions from the immediate parent to take precedence, so we should
-    # reverse the list
     for ancestor in reversed(ancestors):
+        ancestor_restrictions = resolve_ancestor_restrictions(ancestor)
+        if ancestor_restrictions is None:
+            # Unreadable (draft / 403 / 404); skip and keep walking.
+            continue
         (
             ancestor_user_emails,
             ancestor_group_names,
             found_any_restrictions_in_ancestor,
         ) = _extract_read_access_restrictions(
             confluence_client=confluence_client,
-            restrictions=ancestor.get("restrictions", {}),
+            restrictions=ancestor_restrictions,
         )
         if found_any_restrictions_in_ancestor:
-            # if inheriting restrictions from the parent, then the first one we run into
-            # should be applied (the reason why we'd traverse more than one ancestor is if
-            # the ancestor also is in "inherit" mode.)
             logger.debug(
-                "Found user restrictions %s and group restrictions %sfor document %s based on ancestor %s",
+                "Found user restrictions %s and group restrictions %s for document %s based on ancestor %s",
                 ancestor_user_emails,
                 ancestor_group_names,
                 page_id,
@@ -143,9 +132,70 @@ def get_page_restrictions(
             )
             return ExternalAccess(
                 external_user_emails=ancestor_user_emails,
-                external_user_group_ids=_maybe_prefix_groups(ancestor_group_names),
+                external_user_group_ids=_maybe_prefix_groups(
+                    ancestor_group_names, add_prefix
+                ),
                 is_public=False,
             )
 
-    # we didn't find any restrictions, so the page inherits the space's restrictions
     return None
+
+
+def get_page_restrictions(
+    confluence_client: OnyxConfluence,
+    page_id: str,
+    page_restrictions: dict[str, Any],
+    ancestors: list[dict[str, Any]],
+    add_prefix: bool = False,
+) -> ExternalAccess | None:
+    """Standard expand-driven inheritance: read restrictions come from
+    inline data on the page and each ancestor.
+
+    add_prefix: True for the indexing path (Document.external_access) so
+    group IDs carry the source-type prefix the search filter expects;
+    False for the perm-sync path, where `upsert_document_external_perms`
+    adds the prefix instead.
+    """
+    return _resolve_external_access(
+        confluence_client=confluence_client,
+        page_id=page_id,
+        page_restrictions=page_restrictions,
+        ancestors=ancestors,
+        resolve_ancestor_restrictions=lambda ancestor: ancestor.get("restrictions", {}),
+        add_prefix=add_prefix,
+    )
+
+
+def get_page_restrictions_with_per_ancestor_fetch(
+    confluence_client: OnyxConfluence,
+    page_id: str,
+    page_restrictions: dict[str, Any],
+    ancestors: list[dict[str, Any]],
+    ancestor_restrictions_cache: dict[str, dict[str, Any] | None],
+    add_prefix: bool = False,
+) -> ExternalAccess | None:
+    """CONFCLOUD-77618 variant: each ancestor's restrictions come from
+    `restriction/byOperation`, with 403/404 -> "unreadable, skip" (the
+    only correct semantic for drafts owned by another user).
+    `ancestor_restrictions_cache` is caller-scoped per perm-sync run so
+    sibling pages sharing ancestors only pay the GET once."""
+
+    def _resolve(ancestor: dict[str, Any]) -> dict[str, Any] | None:
+        ancestor_id = ancestor.get("id")
+        if not ancestor_id:
+            return None
+        cache_key = str(ancestor_id)
+        if cache_key in ancestor_restrictions_cache:
+            return ancestor_restrictions_cache[cache_key]
+        restrictions = confluence_client.fetch_content_read_restrictions(cache_key)
+        ancestor_restrictions_cache[cache_key] = restrictions
+        return restrictions
+
+    return _resolve_external_access(
+        confluence_client=confluence_client,
+        page_id=page_id,
+        page_restrictions=page_restrictions,
+        ancestors=ancestors,
+        resolve_ancestor_restrictions=_resolve,
+        add_prefix=add_prefix,
+    )

--- a/backend/onyx/connectors/confluence/access.py
+++ b/backend/onyx/connectors/confluence/access.py
@@ -44,6 +44,48 @@ def get_page_restrictions(
     )
 
 
+def get_page_restrictions_with_per_ancestor_fetch(
+    confluence_client: OnyxConfluence,
+    page_id: str,
+    page_restrictions: dict[str, Any],
+    ancestors: list[dict[str, Any]],
+    ancestor_restrictions_cache: dict[str, dict[str, Any] | None],
+    add_prefix: bool = False,
+) -> ExternalAccess | None:
+    """CONFCLOUD-77618 variant of `get_page_restrictions`. Ancestors
+    arrive without inline restrictions; each is fetched via
+    `restriction/byOperation` with 403/404 swallowed for drafts. EE-only."""
+    if not global_version.is_ee_version():
+        return None
+
+    ee_get_per_ancestor = cast(
+        Callable[
+            [
+                OnyxConfluence,
+                str,
+                dict[str, Any],
+                list[dict[str, Any]],
+                dict[str, dict[str, Any] | None],
+                bool,
+            ],
+            ExternalAccess | None,
+        ],
+        fetch_versioned_implementation(
+            "onyx.external_permissions.confluence.page_access",
+            "get_page_restrictions_with_per_ancestor_fetch",
+        ),
+    )
+
+    return ee_get_per_ancestor(
+        confluence_client,
+        page_id,
+        page_restrictions,
+        ancestors,
+        ancestor_restrictions_cache,
+        add_prefix,
+    )
+
+
 def get_all_space_permissions(
     confluence_client: OnyxConfluence,
     is_cloud: bool,

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -19,6 +19,10 @@ from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.confluence.access import get_all_space_permissions
 from onyx.connectors.confluence.access import get_page_restrictions
+from onyx.connectors.confluence.access import (
+    get_page_restrictions_with_per_ancestor_fetch,
+)
+from onyx.connectors.confluence.onyx_confluence import Confcloud77618Error
 from onyx.connectors.confluence.onyx_confluence import extract_text_from_confluence_html
 from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
 from onyx.connectors.confluence.utils import build_confluence_document_id
@@ -74,12 +78,22 @@ _ATTACHMENT_EXPANSION_FIELDS = [
     "space",
     "metadata.labels",
 ]
+# Fast path: page + ancestor restrictions inlined. Subject to
+# CONFCLOUD-77618 / 76424 on draft/trashed/outdated ancestors.
 _RESTRICTIONS_EXPANSION_FIELDS = [
     "space",
     "restrictions.read.restrictions.user",
     "restrictions.read.restrictions.group",
     "ancestors.restrictions.read.restrictions.user",
     "ancestors.restrictions.read.restrictions.group",
+]
+# CONFCLOUD-77618 fallback: bare ancestors only; EE resolver fetches
+# each ancestor's restrictions via `restriction/byOperation`.
+_PER_PAGE_RESTRICTIONS_EXPANSION_FIELDS = [
+    "space",
+    "restrictions.read.restrictions.user",
+    "restrictions.read.restrictions.group",
+    "ancestors",
 ]
 
 _SLIM_DOC_BATCH_SIZE = 5000
@@ -998,6 +1012,7 @@ class ConfluenceConnector(
             end=end,
             callback=callback,
             include_permissions=False,
+            expand_per_page=False,
         )
 
     def retrieve_all_slim_docs_perm_sync(
@@ -1006,15 +1021,35 @@ class ConfluenceConnector(
         end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
     ) -> GenerateSlimDocumentOutput:
-        """
-        Return 'slim' docs (IDs + minimal permission data).
-        Does not fetch actual text. Used primarily for incremental permission sync.
-        """
-        return self._retrieve_all_slim_docs(
+        """Yield slim docs for permission sync. Tries the fast path
+        with ancestor restrictions inlined; on CONFCLOUD-77618 restarts
+        the run with per-page restriction lookups. Re-yielding docs
+        from the partial first attempt is safe -- the consumer's
+        `upsert_document_external_perms` is idempotent on `doc_id`."""
+        try:
+            yield from self._retrieve_all_slim_docs(
+                start=start,
+                end=end,
+                callback=callback,
+                include_permissions=True,
+                expand_per_page=False,
+            )
+            return
+        except Confcloud77618Error as e:
+            logger.warning(
+                "CONFCLOUD-77618: ancestor-restrictions expand 404'd "
+                "(URL=%s); restarting Confluence permission sync with "
+                "per-page restriction lookups. Already-yielded docs "
+                "will be re-yielded; DB writes are idempotent.",
+                e.url,
+            )
+
+        yield from self._retrieve_all_slim_docs(
             start=start,
             end=end,
             callback=callback,
             include_permissions=True,
+            expand_per_page=True,
         )
 
     def _retrieve_all_slim_docs(
@@ -1023,9 +1058,18 @@ class ConfluenceConnector(
         end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
         include_permissions: bool = True,
+        expand_per_page: bool = False,
     ) -> GenerateSlimDocumentOutput:
         doc_metadata_list: list[SlimDocument | HierarchyNode] = []
-        restrictions_expand = ",".join(_RESTRICTIONS_EXPANSION_FIELDS)
+
+        # Pruning (no perm sync) doesn't read restrictions; skip the
+        # expand entirely so it can't trip CONFCLOUD-77618.
+        if not include_permissions:
+            restrictions_expand: str | None = None
+        elif expand_per_page:
+            restrictions_expand = ",".join(_PER_PAGE_RESTRICTIONS_EXPANSION_FIELDS)
+        else:
+            restrictions_expand = ",".join(_RESTRICTIONS_EXPANSION_FIELDS)
 
         space_level_access_info: dict[str, ExternalAccess] = {}
         if include_permissions:
@@ -1037,12 +1081,30 @@ class ConfluenceConnector(
         for node in self._yield_space_hierarchy_nodes():
             doc_metadata_list.append(node)
 
+        # Per-page mode only: collapse shared ancestors to one GET each.
+        ancestor_restrictions_cache: dict[str, dict[str, Any] | None] = {}
+
         def get_external_access(
-            doc_id: str, restrictions: dict[str, Any], ancestors: list[dict[str, Any]]
+            doc_id: str,
+            restrictions: dict[str, Any],
+            ancestors: list[dict[str, Any]],
+            space_key: str | None,
         ) -> ExternalAccess | None:
-            return get_page_restrictions(
-                self.confluence_client, doc_id, restrictions, ancestors
-            ) or space_level_access_info.get(page_space_key)
+            if expand_per_page:
+                resolved = get_page_restrictions_with_per_ancestor_fetch(
+                    self.confluence_client,
+                    doc_id,
+                    restrictions,
+                    ancestors,
+                    ancestor_restrictions_cache,
+                )
+            else:
+                resolved = get_page_restrictions(
+                    self.confluence_client, doc_id, restrictions, ancestors
+                )
+            return resolved or (
+                space_level_access_info.get(space_key) if space_key else None
+            )
 
         # Query pages (with optional time filtering for indexing_start)
         page_query = self._construct_page_cql_query(start, end)
@@ -1055,7 +1117,6 @@ class ConfluenceConnector(
             for node in self._yield_ancestor_hierarchy_nodes(page):
                 doc_metadata_list.append(node)
 
-            page_id = _get_page_id(page)
             page_restrictions = page.get("restrictions") or {}
             page_space_key = page.get("space", {}).get("key")
             page_ancestors = page.get("ancestors", [])
@@ -1067,7 +1128,12 @@ class ConfluenceConnector(
                 SlimDocument(
                     id=page_id,
                     external_access=(
-                        get_external_access(page_id, page_restrictions, page_ancestors)
+                        get_external_access(
+                            page_id,
+                            page_restrictions,
+                            page_ancestors,
+                            page_space_key,
+                        )
                         if include_permissions
                         else None
                     ),
@@ -1077,7 +1143,8 @@ class ConfluenceConnector(
                 )
             )
 
-            # Query attachments for each page
+            # Attachments resolve from inline `restrictions` only; no
+            # ancestor walk, so per-page mode is a no-op for them.
             page_hierarchy_node_yielded = False
             attachment_query = self._construct_attachment_query(
                 _get_page_id(page), start, end
@@ -1120,7 +1187,10 @@ class ConfluenceConnector(
                         id=attachment_id,
                         external_access=(
                             get_external_access(
-                                attachment_id, attachment_restrictions, []
+                                attachment_id,
+                                attachment_restrictions,
+                                [],
+                                attachment_space_key,
                             )
                             if include_permissions
                             else None

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -95,6 +95,10 @@ _PER_PAGE_RESTRICTIONS_EXPANSION_FIELDS = [
     "restrictions.read.restrictions.group",
     "ancestors",
 ]
+# Pruning needs `space` + `ancestors` to populate hierarchy nodes and
+# parent ids; skipping them would flatten the graph. No restrictions
+# expand here, so CONFCLOUD-77618 can't fire.
+_PRUNING_EXPANSION_FIELDS = ["space", "ancestors"]
 
 _SLIM_DOC_BATCH_SIZE = 5000
 
@@ -1062,10 +1066,10 @@ class ConfluenceConnector(
     ) -> GenerateSlimDocumentOutput:
         doc_metadata_list: list[SlimDocument | HierarchyNode] = []
 
-        # Pruning (no perm sync) doesn't read restrictions; skip the
-        # expand entirely so it can't trip CONFCLOUD-77618.
+        # Pruning skips the restrictions expand (the CONFCLOUD-77618
+        # trigger) but still needs space + ancestors for hierarchy.
         if not include_permissions:
-            restrictions_expand: str | None = None
+            restrictions_expand = ",".join(_PRUNING_EXPANSION_FIELDS)
         elif expand_per_page:
             restrictions_expand = ",".join(_PER_PAGE_RESTRICTIONS_EXPANSION_FIELDS)
         else:

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -60,6 +60,15 @@ F = TypeVar("F", bound=Callable[..., Any])
 _PROBLEMATIC_EXPANSIONS = "body.storage.value"
 _REPLACEMENT_EXPANSIONS = "body.view.value"
 
+# CONFCLOUD-77618 / CONFCLOUD-76424: ancestor-restrictions expand on
+# content/search 404s the whole batch when an ancestor is unreadable
+# (draft / outdated / trashed). We detect the body signature and raise.
+_ANCESTOR_RESTRICTIONS_EXPAND_PREFIX = "ancestors.restrictions.read.restrictions."
+_CONFCLOUD_77618_404_BODY_SIGNATURES = (
+    "No content with id",
+    "Cannot find content. Outdated version/old_draft/trashed",
+)
+
 _USER_NOT_FOUND = "Unknown Confluence User"
 _USER_ID_TO_DISPLAY_NAME_CACHE: dict[str, str | None] = {}
 _USER_EMAIL_CACHE: dict[str, str | None] = {}
@@ -107,12 +116,35 @@ class ConfluenceRateLimitError(Exception):
     pass
 
 
+class Confcloud77618Error(Exception):
+    """Signal to the perm-sync caller that the ancestor-restrictions
+    expand 404'd on a draft / outdated / trashed ancestor and the run
+    must restart with per-page restriction lookups."""
+
+    def __init__(self, url: str, body: str) -> None:
+        super().__init__(
+            f"CONFCLOUD-77618: ancestor-restrictions expand 404 from "
+            f"{url}: {body[:500]}"
+        )
+        self.url = url
+        self.body = body
+
+
 class ConfluenceRestSpacePermissionsNotAvailableError(Exception):
     """Raised by REST-API space-permissions calls when the endpoint is missing
     on the upstream Confluence DC instance (e.g. DC < 9.1.0 returning 404).
 
     Callers use this as a signal to fall back to the legacy JSON-RPC path.
     """
+
+
+def _is_confcloud_77618_response(response: requests.Response) -> bool:
+    """Body-signature match for the CONFCLOUD-77618 / CONFCLOUD-76424 404
+    so unrelated 404s still propagate."""
+    if response.status_code != 404:
+        return False
+    body = response.text
+    return any(sig in body for sig in _CONFCLOUD_77618_404_BODY_SIGNATURES)
 
 
 class OnyxConfluence:
@@ -676,6 +708,16 @@ class OnyxConfluence:
                     )
                     continue
 
+                # CONFCLOUD-77618 / 76424: typed signal so the perm-sync
+                # caller can restart in per-page restriction-fetch mode.
+                if (
+                    _ANCESTOR_RESTRICTIONS_EXPAND_PREFIX in url_suffix
+                    and _is_confcloud_77618_response(raw_response)
+                ):
+                    raise Confcloud77618Error(
+                        url=url_suffix, body=raw_response.text
+                    ) from e
+
                 if raw_response.status_code in _SERVER_ERROR_CODES:
                     # Try reducing the page size -- Confluence often times out
                     # on large result sets (especially Cloud 504s).
@@ -792,6 +834,24 @@ class OnyxConfluence:
         expand_string = f"&expand={expand}" if expand else ""
         return f"rest/api/content/search?cql={cql}{expand_string}"
 
+    def fetch_content_read_restrictions(
+        self,
+        content_id: str,
+    ) -> dict[str, Any] | None:
+        """Fetch a single page's restrictions via the dedicated
+        ``content/{id}/restriction/byOperation`` endpoint. Returns
+        ``None`` on 403/404 so unreadable ancestors (drafts owned by
+        another user) resolve as "no inheritable restriction here".
+        ``advanced_mode=True`` bypasses the rate-limit wrapper's 7x
+        403-retry loop which would otherwise burn ~70s per draft."""
+        path = f"rest/api/content/{quote(content_id, safe='')}/restriction/byOperation"
+        response: requests.Response = self.get(path, advanced_mode=True)
+        if response.status_code in (403, 404):
+            return None
+        response.raise_for_status()
+        body = response.json()
+        return cast(dict[str, Any], body or {})
+
     def paginated_cql_retrieval(
         self,
         cql: str,
@@ -830,10 +890,8 @@ class OnyxConfluence:
         expand: str | None = None,
         limit: int | None = None,
     ) -> Iterator[dict[str, Any]]:
-        """
-        This function will paginate through the top level query first, then
-        paginate through all of the expansions.
-        """
+        """Paginate the top-level query, then each `_links.next` discovered
+        in the expansions."""
 
         def _traverse_and_update(data: dict | list) -> None:
             if isinstance(data, dict):

--- a/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
@@ -348,11 +348,12 @@ def test_perm_sync_no_retry_when_first_attempt_succeeds(
     assert call_kwargs[0]["expand_per_page"] is False
 
 
-def test_pruning_does_not_request_restrictions_expand(
+def test_pruning_expand_skips_restrictions_but_keeps_hierarchy(
     confluence_connector: ConfluenceConnector,
 ) -> None:
-    """Pruning ignores restrictions, so it must not send the expand
-    that's the sole 77618 trigger."""
+    """Pruning must drop the `restrictions.read.restrictions.*` expand
+    (the 77618 trigger) but keep `space` and `ancestors` so the
+    hierarchy graph isn't flattened."""
     captured_expands: list[str | None] = []
 
     def fake_paginate(**kwargs: Any) -> Iterator[Any]:
@@ -377,8 +378,13 @@ def test_pruning_does_not_request_restrictions_expand(
 
     assert captured_expands, "expected at least one CQL paginated call"
     for expand in captured_expands:
-        assert expand is None, (
-            f"pruning must not request a restrictions expand, got: {expand!r}"
+        assert expand is not None
+        fields = set(expand.split(","))
+        assert "space" in fields
+        assert "ancestors" in fields
+        assert not any(f.startswith("restrictions.read.restrictions.") for f in fields)
+        assert not any(
+            f.startswith("ancestors.restrictions.read.restrictions.") for f in fields
         )
 
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
@@ -1,0 +1,545 @@
+"""Regression invariants for the CONFCLOUD-77618 / CONFCLOUD-76424
+fallback: the offending 404 surfaces as a typed exception, perm-sync
+restarts in per-page mode on it, the per-page lookup hits the dedicated
+`restriction/byOperation` endpoint, and the EE walker skips unreadable
+ancestors while caching shared ones."""
+
+from collections.abc import Iterator
+from typing import Any
+from unittest import mock
+
+import pytest
+import requests
+from requests import HTTPError
+
+from ee.onyx.external_permissions.confluence.page_access import (
+    get_page_restrictions_with_per_ancestor_fetch,
+)
+from onyx.connectors.confluence.access import (
+    get_page_restrictions_with_per_ancestor_fetch as get_page_restrictions_with_per_ancestor_fetch_shim,
+)
+from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.confluence.onyx_confluence import _is_confcloud_77618_response
+from onyx.connectors.confluence.onyx_confluence import Confcloud77618Error
+from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.interfaces import CredentialsProviderInterface
+
+_CONFCLOUD_77618_BODY = (
+    '{"statusCode":404,"data":{"authorized":false,"valid":false,'
+    '"errors":[{"message":{"translation":'
+    '"No content with id <ContentId{id=12345}> can be found"}}],'
+    '"successful":false}}'
+)
+_CONFCLOUD_76424_BODY = (
+    '{"message":"Cannot find content. Outdated version/old_draft/trashed?'
+    ' Please provide valid ContentId."}'
+)
+
+
+def _make_response(
+    status_code: int,
+    json_data: dict[str, Any] | None = None,
+    body_text: str | None = None,
+) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    if json_data is not None:
+        response.json = mock.Mock(  # ty: ignore[invalid-assignment]
+            return_value=json_data
+        )
+    if body_text is not None:
+        response._content = body_text.encode()
+    if status_code >= 400:
+        response.reason = "Mock Error"
+        response.raise_for_status = mock.Mock(  # ty: ignore[invalid-assignment]
+            side_effect=HTTPError(response=response)
+        )
+    return response
+
+
+@pytest.fixture
+def mock_credentials_provider() -> mock.Mock:
+    provider = mock.Mock(spec=CredentialsProviderInterface)
+    provider.is_dynamic.return_value = False
+    provider.get_credentials.return_value = {"confluence_access_token": "dummy_token"}
+    provider.get_tenant_id.return_value = "test_tenant"
+    provider.get_provider_key.return_value = "test_key"
+    provider.__enter__ = mock.Mock(return_value=None)
+    provider.__exit__ = mock.Mock(return_value=None)
+    return provider
+
+
+@pytest.fixture
+def cloud_client(mock_credentials_provider: mock.Mock) -> OnyxConfluence:
+    client = OnyxConfluence(
+        is_cloud=True,
+        url="https://fake-cloud.atlassian.net",
+        credentials_provider=mock_credentials_provider,
+        timeout=10,
+    )
+    mock_internal = mock.Mock()
+    mock_internal.url = client._url
+    client._confluence = mock_internal
+    client._kwargs = client.shared_base_kwargs
+    return client
+
+
+# ---------------------------------------------------------------------------
+# 404 body signature predicate
+# ---------------------------------------------------------------------------
+
+
+def test_is_confcloud_77618_response_matches_canonical_body() -> None:
+    response = _make_response(404, body_text=_CONFCLOUD_77618_BODY)
+    assert _is_confcloud_77618_response(response) is True
+
+
+def test_is_confcloud_77618_response_matches_outdated_sibling() -> None:
+    response = _make_response(404, body_text=_CONFCLOUD_76424_BODY)
+    assert _is_confcloud_77618_response(response) is True
+
+
+def test_is_confcloud_77618_response_rejects_unrelated_404() -> None:
+    response = _make_response(404, body_text='{"message": "Not found"}')
+    assert _is_confcloud_77618_response(response) is False
+
+
+def test_is_confcloud_77618_response_rejects_non_404() -> None:
+    response = _make_response(500, body_text="No content with id <ContentId{id=1}>")
+    assert _is_confcloud_77618_response(response) is False
+
+
+# ---------------------------------------------------------------------------
+# _paginate_url: raises Confcloud77618Error on the offending 404
+# ---------------------------------------------------------------------------
+
+
+def test_paginate_url_raises_confcloud_77618_on_signature_match(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """77618 404 + ancestor-restrictions expand -> typed exception."""
+
+    def get_side_effect(
+        path: str,  # noqa: ARG001
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        return _make_response(404, body_text=_CONFCLOUD_77618_BODY)
+
+    cloud_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    with pytest.raises(Confcloud77618Error):
+        list(
+            cloud_client.paginated_cql_retrieval(
+                cql="type=page",
+                expand=(
+                    "ancestors.restrictions.read.restrictions.user,"
+                    "ancestors.restrictions.read.restrictions.group"
+                ),
+                limit=50,
+            )
+        )
+
+
+def test_paginate_url_propagates_unrelated_404(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """Body-signature gate: unrelated 404s propagate as HTTPError so
+    real auth/scope errors don't disguise as 77618 fallbacks."""
+
+    def get_side_effect(
+        path: str,  # noqa: ARG001
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        return _make_response(404, body_text='{"message": "Some other 404"}')
+
+    cloud_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    with pytest.raises(HTTPError):
+        list(
+            cloud_client.paginated_cql_retrieval(
+                cql="type=page",
+                expand="ancestors.restrictions.read.restrictions.user",
+                limit=50,
+            )
+        )
+
+
+def test_paginate_url_does_not_raise_77618_without_ancestor_expand(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """URL gate: 77618 only fires when the request URL carried the
+    ancestor-restrictions expand."""
+
+    def get_side_effect(
+        path: str,  # noqa: ARG001
+        params: dict[str, Any] | None = None,  # noqa: ARG001
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        return _make_response(404, body_text=_CONFCLOUD_77618_BODY)
+
+    cloud_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        get_side_effect
+    )
+
+    with pytest.raises(HTTPError) as exc_info:
+        list(
+            cloud_client.paginated_cql_retrieval(
+                cql="type=page",
+                expand="space,restrictions.read.restrictions.user",
+                limit=50,
+            )
+        )
+    assert not isinstance(exc_info.value, Confcloud77618Error)
+
+
+# ---------------------------------------------------------------------------
+# OnyxConfluence.fetch_content_read_restrictions (byOperation endpoint)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_content_read_restrictions_hits_byoperation_endpoint(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """Dedicated `restriction/byOperation` URL, SDK-aligned."""
+    captured: dict[str, str] = {}
+
+    def get_side_effect(
+        path: str,
+        advanced_mode: bool = False,  # noqa: ARG001
+    ) -> requests.Response:
+        captured["path"] = path
+        return _make_response(
+            200,
+            {
+                "read": {
+                    "operation": "read",
+                    "restrictions": {
+                        "user": {"results": [{"email": "u@example.com"}]},
+                        "group": {"results": []},
+                    },
+                },
+                "update": {
+                    "operation": "update",
+                    "restrictions": {
+                        "user": {"results": []},
+                        "group": {"results": []},
+                    },
+                },
+            },
+        )
+
+    cloud_client._confluence.get = mock.Mock(  # ty: ignore[invalid-assignment]
+        side_effect=get_side_effect
+    )
+
+    result = cloud_client.fetch_content_read_restrictions("999")
+    assert result is not None
+    assert "/restriction/byOperation" in captured["path"]
+    assert result["read"]["restrictions"]["user"]["results"][0]["email"] == (
+        "u@example.com"
+    )
+
+
+def test_fetch_content_read_restrictions_returns_none_on_403(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """403 = draft permission reply; silent skip."""
+    cloud_client._confluence.get = mock.Mock(  # ty: ignore[invalid-assignment]
+        return_value=_make_response(
+            403, body_text="confluence.user.view.draft.permission"
+        )
+    )
+    assert cloud_client.fetch_content_read_restrictions("draft-id") is None
+
+
+def test_fetch_content_read_restrictions_returns_none_on_404(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """404 = ancestor deleted between search and follow-up."""
+    cloud_client._confluence.get = mock.Mock(  # ty: ignore[invalid-assignment]
+        return_value=_make_response(404, body_text="not found")
+    )
+    assert cloud_client.fetch_content_read_restrictions("missing-id") is None
+
+
+def test_fetch_content_read_restrictions_raises_on_500(
+    cloud_client: OnyxConfluence,
+) -> None:
+    """5xx must propagate; can't silently mask as "no restriction"."""
+    cloud_client._confluence.get = mock.Mock(  # ty: ignore[invalid-assignment]
+        return_value=_make_response(500, body_text="boom")
+    )
+    with pytest.raises(HTTPError):
+        cloud_client.fetch_content_read_restrictions("any-id")
+
+
+# ---------------------------------------------------------------------------
+# retrieve_all_slim_docs_perm_sync: try-then-retry on Confcloud77618Error
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def confluence_connector() -> ConfluenceConnector:
+    return ConfluenceConnector(
+        wiki_base="https://fake-cloud.atlassian.net/wiki",
+        is_cloud=True,
+    )
+
+
+def test_perm_sync_retries_in_per_page_mode_on_77618(
+    confluence_connector: ConfluenceConnector,
+) -> None:
+    """On 77618 mid-stream, restart with expand_per_page=True. Pre-raise
+    yields are re-yielded; idempotent DB writes make this safe."""
+    call_kwargs: list[dict[str, Any]] = []
+
+    def fake_inner(**kwargs: Any) -> Iterator[list[Any]]:
+        call_kwargs.append(kwargs)
+        if not kwargs["expand_per_page"]:
+            yield ["doc-from-attempt-1"]
+            raise Confcloud77618Error(url="fake", body=_CONFCLOUD_77618_BODY)
+        yield ["doc-from-attempt-2-a"]
+        yield ["doc-from-attempt-2-b"]
+
+    with mock.patch.object(
+        confluence_connector,
+        "_retrieve_all_slim_docs",
+        side_effect=fake_inner,
+    ):
+        out = list(confluence_connector.retrieve_all_slim_docs_perm_sync())
+
+    assert out == [
+        ["doc-from-attempt-1"],
+        ["doc-from-attempt-2-a"],
+        ["doc-from-attempt-2-b"],
+    ]
+    assert len(call_kwargs) == 2
+    assert call_kwargs[0]["expand_per_page"] is False
+    assert call_kwargs[1]["expand_per_page"] is True
+    assert call_kwargs[0]["include_permissions"] is True
+    assert call_kwargs[1]["include_permissions"] is True
+
+
+def test_perm_sync_no_retry_when_first_attempt_succeeds(
+    confluence_connector: ConfluenceConnector,
+) -> None:
+    """Unaffected runs never enter the per-page branch."""
+    call_kwargs: list[dict[str, Any]] = []
+
+    def fake_inner(**kwargs: Any) -> Iterator[list[Any]]:
+        call_kwargs.append(kwargs)
+        yield ["doc"]
+
+    with mock.patch.object(
+        confluence_connector,
+        "_retrieve_all_slim_docs",
+        side_effect=fake_inner,
+    ):
+        out = list(confluence_connector.retrieve_all_slim_docs_perm_sync())
+
+    assert out == [["doc"]]
+    assert len(call_kwargs) == 1
+    assert call_kwargs[0]["expand_per_page"] is False
+
+
+def test_pruning_does_not_request_restrictions_expand(
+    confluence_connector: ConfluenceConnector,
+) -> None:
+    """Pruning ignores restrictions, so it must not send the expand
+    that's the sole 77618 trigger."""
+    captured_expands: list[str | None] = []
+
+    def fake_paginate(**kwargs: Any) -> Iterator[Any]:
+        captured_expands.append(kwargs.get("expand"))
+        return iter([])
+
+    fake_client = mock.Mock(spec=OnyxConfluence)
+    fake_client.cql_paginate_all_expansions.side_effect = fake_paginate
+
+    with mock.patch.object(
+        ConfluenceConnector,
+        "confluence_client",
+        new_callable=mock.PropertyMock,
+        return_value=fake_client,
+    ):
+        with mock.patch.object(
+            confluence_connector,
+            "_yield_space_hierarchy_nodes",
+            return_value=iter([]),
+        ):
+            list(confluence_connector.retrieve_all_slim_docs())
+
+    assert captured_expands, "expected at least one CQL paginated call"
+    for expand in captured_expands:
+        assert expand is None, (
+            f"pruning must not request a restrictions expand, got: {expand!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# EE: get_page_restrictions_with_per_ancestor_fetch
+# ---------------------------------------------------------------------------
+
+
+def _restriction_dict(user_emails: list[str]) -> dict[str, Any]:
+    return {
+        "read": {
+            "restrictions": {
+                "user": {"results": [{"email": e} for e in user_emails]},
+                "group": {"results": []},
+            }
+        }
+    }
+
+
+def test_per_ancestor_fetch_short_circuits_on_page_level_restriction() -> None:
+    """Page-level restriction wins outright -- never fetch ancestors."""
+    client = mock.Mock(spec=OnyxConfluence)
+    cache: dict[str, dict[str, Any] | None] = {}
+
+    result = get_page_restrictions_with_per_ancestor_fetch(
+        confluence_client=client,
+        page_id="doc/1",
+        page_restrictions=_restriction_dict(["page-restricted@example.com"]),
+        ancestors=[{"id": "anc-1"}, {"id": "anc-2"}],
+        ancestor_restrictions_cache=cache,
+    )
+    assert result is not None
+    assert result.external_user_emails == {"page-restricted@example.com"}
+    client.fetch_content_read_restrictions.assert_not_called()
+    assert cache == {}
+
+
+def test_per_ancestor_fetch_walks_ancestors_immediate_parent_first() -> None:
+    """Ancestors arrive root-first; closest restricted ancestor wins."""
+    client = mock.Mock(spec=OnyxConfluence)
+    fetch_results = {
+        "root": _restriction_dict(["root@example.com"]),
+        "parent": _restriction_dict(["parent@example.com"]),
+    }
+    client.fetch_content_read_restrictions.side_effect = lambda cid: fetch_results.get(
+        cid, {}
+    )
+
+    cache: dict[str, dict[str, Any] | None] = {}
+    result = get_page_restrictions_with_per_ancestor_fetch(
+        confluence_client=client,
+        page_id="doc/leaf",
+        page_restrictions={},
+        ancestors=[{"id": "root"}, {"id": "parent"}],
+        ancestor_restrictions_cache=cache,
+    )
+    assert result is not None
+    assert result.external_user_emails == {"parent@example.com"}
+
+
+def test_per_ancestor_fetch_skips_drafts_and_continues_up() -> None:
+    """Unreadable ancestor doesn't terminate the walk; closest visible
+    restriction wins."""
+    client = mock.Mock(spec=OnyxConfluence)
+    fetch_results: dict[str, dict[str, Any] | None] = {
+        "grandparent": _restriction_dict(["gp@example.com"]),
+        "parent-draft": None,
+    }
+    client.fetch_content_read_restrictions.side_effect = lambda cid: fetch_results[cid]
+
+    cache: dict[str, dict[str, Any] | None] = {}
+    result = get_page_restrictions_with_per_ancestor_fetch(
+        confluence_client=client,
+        page_id="doc/leaf",
+        page_restrictions={},
+        ancestors=[{"id": "grandparent"}, {"id": "parent-draft"}],
+        ancestor_restrictions_cache=cache,
+    )
+    assert result is not None
+    assert result.external_user_emails == {"gp@example.com"}
+
+
+def test_per_ancestor_fetch_returns_none_when_no_restrictions_anywhere() -> None:
+    """All ancestors unrestricted -> caller falls back to space-level."""
+    client = mock.Mock(spec=OnyxConfluence)
+    client.fetch_content_read_restrictions.return_value = {}
+
+    result = get_page_restrictions_with_per_ancestor_fetch(
+        confluence_client=client,
+        page_id="doc/leaf",
+        page_restrictions={},
+        ancestors=[{"id": "anc-1"}, {"id": "anc-2"}],
+        ancestor_restrictions_cache={},
+    )
+    assert result is None
+
+
+def test_per_ancestor_fetch_caches_shared_ancestors_across_calls() -> None:
+    """Cache collapses shared ancestors so a tainted batch doesn't
+    multiply API calls per sibling."""
+    client = mock.Mock(spec=OnyxConfluence)
+    client.fetch_content_read_restrictions.return_value = {}
+    cache: dict[str, dict[str, Any] | None] = {}
+
+    shared_ancestors = [{"id": "shared-1"}, {"id": "shared-2"}]
+
+    for page_num in range(5):
+        get_page_restrictions_with_per_ancestor_fetch(
+            confluence_client=client,
+            page_id=f"doc/{page_num}",
+            page_restrictions={},
+            ancestors=shared_ancestors,
+            ancestor_restrictions_cache=cache,
+        )
+
+    assert client.fetch_content_read_restrictions.call_count == 2
+
+
+def test_per_ancestor_fetch_caches_none_for_drafts() -> None:
+    """None results are cached -- no re-fetch for sibling pages."""
+    client = mock.Mock(spec=OnyxConfluence)
+    client.fetch_content_read_restrictions.return_value = None
+    cache: dict[str, dict[str, Any] | None] = {}
+
+    shared_ancestors = [{"id": "draft-anc"}]
+
+    for page_num in range(3):
+        get_page_restrictions_with_per_ancestor_fetch(
+            confluence_client=client,
+            page_id=f"doc/{page_num}",
+            page_restrictions={},
+            ancestors=shared_ancestors,
+            ancestor_restrictions_cache=cache,
+        )
+
+    assert client.fetch_content_read_restrictions.call_count == 1
+    assert cache == {"draft-anc": None}
+
+
+# ---------------------------------------------------------------------------
+# Shim resolution: `fetch_versioned_implementation` reaches the EE function
+# ---------------------------------------------------------------------------
+
+
+def test_per_ancestor_shim_resolves_to_ee_implementation(
+    enable_ee: None,  # noqa: ARG001 -- fixture sets EE mode for this test
+) -> None:
+    """End-to-end through the connector-side shim: with EE on, the shim's
+    `fetch_versioned_implementation` lookup must reach the EE function and
+    actually run it. Catches drift between the shim's module/attr strings
+    and the EE module path."""
+    client = mock.Mock(spec=OnyxConfluence)
+
+    result = get_page_restrictions_with_per_ancestor_fetch_shim(
+        confluence_client=client,
+        page_id="doc/1",
+        page_restrictions=_restriction_dict(["page-restricted@example.com"]),
+        ancestors=[],
+        ancestor_restrictions_cache={},
+    )
+
+    assert result is not None
+    assert result.external_user_emails == {"page-restricted@example.com"}
+    client.fetch_content_read_restrictions.assert_not_called()


### PR DESCRIPTION
## Description

When the confluence connector tries to expand ancestors for a page and the ancestors contain drafts, confluence throws a 404 because the service account can't get a user's draft info.  See https://jira.atlassian.com/browse/CONFCLOUD-77618

It's much less efficient to fetch ancestors page by page, but we fall back to that when this happens during perm sync. Also no longer fetching these permission expansions during pruning.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Confluence permission sync 404s caused by draft/outdated/trashed ancestor pages by detecting the bad expand and falling back to per-page restriction lookups. Also stops requesting ancestor restrictions during pruning to avoid unnecessary 404s.

- **Bug Fixes**
  - Detects CONFCLOUD-77618/76424 404s on `content/search` with `ancestors.restrictions.*`, raises a typed `Confcloud77618Error`, and restarts perm sync in per-page mode.
  - In per-page mode, fetches each ancestor’s read restrictions via `content/{id}/restriction/byOperation`; treats 403/404 as unreadable and continues upward; caches shared ancestors to avoid duplicate calls.
  - Uses a shared inheritance resolver and fixes group prefixing differences between indexing and perm-sync paths.
  - Pruning expands only `space` and `ancestors`; attachments use inline restrictions only. Adds unit tests for detection, restart behavior, EE shim wiring, caching, and expand behavior.

<sup>Written for commit 0cf4f06550847c22fb7bf385ccb2324d46da17f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11468?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

