### PR TITLE
fix(hierarchy): iterative upsert_parents to avoid RecursionError on deep chains

### DIFF
--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -197,8 +197,7 @@ def upsert_parents(
             break
         if parent_raw_id in visiting:
             # Cycle in the parent chain (e.g. A -> B -> A or A -> A). Stop
-            # walking; remaining ancestors in the cycle will fall back to the
-            # SOURCE node via resolve_parent_hierarchy_node_id.
+            # walking.
             logger.warning(
                 "Cycle detected in hierarchy parent chain for source=%s "
                 "at raw_node_id=%s (raw_parent_id=%s); falling back to SOURCE "

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -174,31 +174,55 @@ def upsert_parents(
     is_connector_public: bool = False,
 ) -> None:
     """
-    Upsert the parents of a hierarchy node.
+    Upsert the in-batch ancestors of ``node`` in oldest-to-newest order.
+
+    Walks ``raw_parent_id`` links iteratively (not recursively) so deeply nested
+    hierarchies — Notion page chains can exceed Python's recursion limit — and
+    cyclic parent references do not raise ``RecursionError``.
     """
-    if (
-        node.node_type == HierarchyNodeType.SOURCE
-        or (node.raw_parent_id not in node_by_id)
-        or (node.raw_parent_id in done_ids)
-    ):
-        return
-    parent_node = node_by_id[node.raw_parent_id]
-    upsert_parents(
-        db_session,
-        parent_node,
-        source,
-        node_by_id,
-        done_ids,
-        is_connector_public=is_connector_public,
-    )
-    upsert_hierarchy_node(
-        db_session,
-        parent_node,
-        source,
-        commit=False,
-        is_connector_public=is_connector_public,
-    )
-    done_ids.add(parent_node.raw_node_id)
+    # Walk ancestors, newest-first, collecting any that still need upserting.
+    # ``visiting`` seeded with ``node`` so a self-parent (A -> A) is treated as
+    # a cycle, not appended to ``pending``.
+    pending: list[PydanticHierarchyNode] = []
+    visiting: set[str] = {node.raw_node_id}
+    current = node
+    while True:
+        parent_raw_id = current.raw_parent_id
+        if (
+            current.node_type == HierarchyNodeType.SOURCE
+            or parent_raw_id is None
+            or parent_raw_id not in node_by_id
+            or parent_raw_id in done_ids
+        ):
+            break
+        if parent_raw_id in visiting:
+            # Cycle in the parent chain (e.g. A -> B -> A or A -> A). Stop
+            # walking; remaining ancestors in the cycle will fall back to the
+            # SOURCE node via resolve_parent_hierarchy_node_id.
+            logger.warning(
+                "Cycle detected in hierarchy parent chain for source=%s "
+                "at raw_node_id=%s (raw_parent_id=%s); falling back to SOURCE "
+                "for the cyclic ancestors.",
+                source,
+                current.raw_node_id,
+                parent_raw_id,
+            )
+            break
+        parent_node = node_by_id[parent_raw_id]
+        pending.append(parent_node)
+        visiting.add(parent_raw_id)
+        current = parent_node
+
+    # Drain oldest-first so each parent is persisted before its children.
+    for parent_node in reversed(pending):
+        upsert_hierarchy_node(
+            db_session,
+            parent_node,
+            source,
+            commit=False,
+            is_connector_public=is_connector_public,
+        )
+        done_ids.add(parent_node.raw_node_id)
 
 
 def upsert_hierarchy_node(

--- a/backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py
@@ -1,10 +1,9 @@
 """Regression tests for `upsert_parents` recursion safety.
 
-Sky Mavis (a customer with a deeply nested Notion workspace) hit a
-``RecursionError`` from ``upsert_parents`` because the function recursed once
-per ancestor and produced a stack ~1000 deep on real chains. These tests lock
-in the iterative implementation: a deep chain must complete, and a cyclic
-parent reference must not loop or crash.
+Deeply nested Notion workspaces produced parent chains longer than Python's
+default recursion limit, causing ``upsert_parents`` to raise ``RecursionError``.
+These tests lock in the iterative implementation: a deep chain must complete,
+and a cyclic parent reference must not loop or crash.
 """
 
 from collections.abc import Generator

--- a/backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py
@@ -1,0 +1,151 @@
+"""Regression tests for `upsert_parents` recursion safety.
+
+Sky Mavis (a customer with a deeply nested Notion workspace) hit a
+``RecursionError`` from ``upsert_parents`` because the function recursed once
+per ancestor and produced a stack ~1000 deep on real chains. These tests lock
+in the iterative implementation: a deep chain must complete, and a cyclic
+parent reference must not loop or crash.
+"""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import HierarchyNode as PydanticHierarchyNode
+from onyx.db.enums import HierarchyNodeType
+from onyx.db.hierarchy import ensure_source_node_exists
+from onyx.db.hierarchy import get_hierarchy_node_by_raw_id
+from onyx.db.hierarchy import upsert_hierarchy_nodes_batch
+from onyx.db.models import HierarchyNode
+
+# Notion can produce parent chains exceeding Python's default recursion limit
+# (sys.setrecursionlimit() defaults to 1000). 1500 is comfortably past that
+# while keeping the test fast.
+DEEP_CHAIN_DEPTH = 1500
+
+
+@pytest.fixture()
+def notion_source_node(
+    db_session: Session,
+) -> Generator[HierarchyNode, None, None]:
+    """Ensure the NOTION SOURCE node exists for the duration of the test."""
+    source_node = ensure_source_node_exists(
+        db_session, DocumentSource.NOTION, commit=False
+    )
+    db_session.flush()
+    yield source_node
+    db_session.rollback()
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_upsert_parents_handles_deep_chain(
+    db_session: Session,
+) -> None:
+    """A 1500-deep parent chain must upsert without RecursionError."""
+    tag = uuid4().hex[:8]
+    # Build chain: root -> n1 -> n2 -> ... -> n{DEPTH-1}
+    nodes: list[PydanticHierarchyNode] = []
+    for i in range(DEEP_CHAIN_DEPTH):
+        nodes.append(
+            PydanticHierarchyNode(
+                raw_node_id=f"deep_{tag}_{i}",
+                raw_parent_id=f"deep_{tag}_{i - 1}" if i > 0 else None,
+                display_name=f"Deep {i}",
+                node_type=HierarchyNodeType.PAGE,
+            )
+        )
+
+    # Pass the deepest child first so upsert_parents has to walk the entire
+    # chain in one call (this is the worst-case shape that originally blew the
+    # stack).
+    upsert_hierarchy_nodes_batch(
+        db_session,
+        list(reversed(nodes)),
+        DocumentSource.NOTION,
+        commit=False,
+    )
+
+    # Spot-check head, middle, tail.
+    head = get_hierarchy_node_by_raw_id(
+        db_session, f"deep_{tag}_0", DocumentSource.NOTION
+    )
+    middle = get_hierarchy_node_by_raw_id(
+        db_session, f"deep_{tag}_{DEEP_CHAIN_DEPTH // 2}", DocumentSource.NOTION
+    )
+    tail = get_hierarchy_node_by_raw_id(
+        db_session, f"deep_{tag}_{DEEP_CHAIN_DEPTH - 1}", DocumentSource.NOTION
+    )
+    assert head is not None
+    assert middle is not None
+    assert tail is not None
+    # Tail's parent should be the second-to-last node.
+    parent_of_tail = get_hierarchy_node_by_raw_id(
+        db_session, f"deep_{tag}_{DEEP_CHAIN_DEPTH - 2}", DocumentSource.NOTION
+    )
+    assert parent_of_tail is not None
+    assert tail.parent_id == parent_of_tail.id
+
+    db_session.rollback()
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_upsert_parents_handles_parent_cycle(
+    db_session: Session,
+) -> None:
+    """A two-node parent cycle must not raise or loop forever."""
+    tag = uuid4().hex[:8]
+    a_id = f"cycle_a_{tag}"
+    b_id = f"cycle_b_{tag}"
+    nodes = [
+        PydanticHierarchyNode(
+            raw_node_id=a_id,
+            raw_parent_id=b_id,
+            display_name=f"Cycle A {tag}",
+            node_type=HierarchyNodeType.PAGE,
+        ),
+        PydanticHierarchyNode(
+            raw_node_id=b_id,
+            raw_parent_id=a_id,
+            display_name=f"Cycle B {tag}",
+            node_type=HierarchyNodeType.PAGE,
+        ),
+    ]
+
+    # Must complete without RecursionError. The cycle is broken at one of the
+    # two nodes — the broken edge resolves to the SOURCE node — but both nodes
+    # should still be persisted.
+    upsert_hierarchy_nodes_batch(db_session, nodes, DocumentSource.NOTION, commit=False)
+
+    a_row = get_hierarchy_node_by_raw_id(db_session, a_id, DocumentSource.NOTION)
+    b_row = get_hierarchy_node_by_raw_id(db_session, b_id, DocumentSource.NOTION)
+    assert a_row is not None
+    assert b_row is not None
+
+    db_session.rollback()
+
+
+@pytest.mark.usefixtures("notion_source_node")
+def test_upsert_parents_handles_self_parent(
+    db_session: Session,
+) -> None:
+    """A node whose raw_parent_id equals its own raw_node_id must not loop."""
+    tag = uuid4().hex[:8]
+    self_id = f"self_{tag}"
+    nodes = [
+        PydanticHierarchyNode(
+            raw_node_id=self_id,
+            raw_parent_id=self_id,
+            display_name=f"Self {tag}",
+            node_type=HierarchyNodeType.PAGE,
+        ),
+    ]
+
+    upsert_hierarchy_nodes_batch(db_session, nodes, DocumentSource.NOTION, commit=False)
+
+    row = get_hierarchy_node_by_raw_id(db_session, self_id, DocumentSource.NOTION)
+    assert row is not None
+
+    db_session.rollback()


### PR DESCRIPTION
## Description

`upsert_parents` in `backend/onyx/db/hierarchy.py` recursed once per ancestor and only added to `done_ids` *after* the recursive call returned. Two failure modes were observed in production:

1. **Deep parent chain.** Notion lets users nest pages arbitrarily; chains >~1000 ancestors blow the Python recursion limit and raise `RecursionError`, killing the whole docfetching batch for the connector.
2. **Cycle / self-parent.** If the source ever returns a circular parent reference, `done_ids` is never populated for the cycle so recursion is unbounded.

A customer on v3.3.x hit (1) on a deeply nested Notion workspace. The code is byte-identical on v3.3.x, v4.0.1, and `main` — only one unrelated commit (`cbed2c21f5`, tier-management) touched `hierarchy.py` in that span — so upgrading without this fix would not have resolved it.

Rewrites `upsert_parents` as an iterative walk seeded with a `visiting` set. Depth is bounded by ancestor count rather than the call stack, and cycles break cleanly with a warning and the existing SOURCE-node fallback that `resolve_parent_hierarchy_node_id` already implements.

Linear: ENG-4121

## How Has This Been Tested?

New external-dependency-unit tests in `backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py`:

- 1500-deep parent chain (fails today with `RecursionError`, passes after the fix; verified by reproducing the recursion error against the old recursive logic in-memory)
- Two-node parent cycle (A → B → A)
- Self-parent (A → A)

Run with:

```
python -m dotenv -f .vscode/.env run -- pytest backend/tests/external_dependency_unit/hierarchy/test_upsert_parents_deep_chain.py
```

All three pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote parent upsert to be iterative to avoid RecursionError on deep hierarchies and to safely handle cycles/self-parent cases. This stabilizes doc fetching for Notion and other deeply nested sources. Addresses Linear ENG-4121.

- **Bug Fixes**
  - Replaced recursion in upsert_parents with an iterative walk using a visiting set; processes ancestors oldest-to-newest and avoids stack overflows.
  - Detects cycles/self-parent and stops, falling back to the SOURCE node; added regression tests for a 1500-deep chain, a two-node cycle, and a self-parent.

<sup>Written for commit 917b61f941f6db5aa068608ec413d279e92cd7f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11469?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

