### PR TITLE
fix(docker): typo in the nginx conf name in no-letsencrypt compose file (#11236) to release v4.0

### DIFF
--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -300,7 +300,7 @@ services:
       && cp -a /nginx-templates/. /etc/nginx/conf.d/
       && sed 's/\r$//' /etc/nginx/conf.d/run-nginx.sh > /tmp/run-nginx.sh
       && chmod +x /tmp/run-nginx.sh
-      && /tmp/run-nginx.sh app.conf.template.prod.no-letsencrypt"
+      && /tmp/run-nginx.sh app.conf.template.no-letsencrypt"
     env_file:
       - .env.nginx
     environment:


### PR DESCRIPTION
Cherry-pick of commit 44ce6146c6700f40fd50d9f7c1b53d99e9bbf1d9 to release/v4.0 branch.

Original PR: #11236

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the Nginx template name in `docker-compose.prod-no-letsencrypt.yml`. The `run-nginx.sh` script now references `app.conf.template.no-letsencrypt`, allowing the no-LetsEncrypt setup to start correctly.

<sup>Written for commit 1e86a0249695708b29a3a05e2acbeba5eba89f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11476?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

