### PR TITLE
fix(craft): skip LLM setup when a build-mode provider is already configured

### DIFF
--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -77,7 +77,6 @@ function getStepsForMode(
 ): OnboardingStep[] {
   switch (mode.type) {
     case "initial-onboarding":
-      // Full flow: page1 → llm-setup (only if admin and no provider configured yet) → user-info
       const steps: OnboardingStep[] = ["page1"];
 
       if (isAdmin && !hasAnyProvider) {

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -72,15 +72,15 @@ interface BuildOnboardingModalProps {
 function getStepsForMode(
   mode: OnboardingModalMode,
   isAdmin: boolean,
-  allProvidersConfigured: boolean,
+  hasAnyProvider: boolean,
   hasUserInfo: boolean
 ): OnboardingStep[] {
   switch (mode.type) {
     case "initial-onboarding":
-      // Full flow: page1 → llm-setup (if admin + not all configured) → user-info
+      // Full flow: page1 → llm-setup (only if admin and no provider configured yet) → user-info
       const steps: OnboardingStep[] = ["page1"];
 
-      if (isAdmin && !allProvidersConfigured) {
+      if (isAdmin && !hasAnyProvider) {
         steps.push("llm-setup");
       }
 
@@ -107,7 +107,6 @@ export default function BuildOnboardingModal({
   initialValues,
   isAdmin,
   hasUserInfo,
-  allProvidersConfigured,
   hasAnyProvider,
   onComplete,
   onLlmComplete,
@@ -115,8 +114,8 @@ export default function BuildOnboardingModal({
 }: BuildOnboardingModalProps) {
   // Compute steps based on mode
   const steps = useMemo(
-    () => getStepsForMode(mode, isAdmin, allProvidersConfigured, hasUserInfo),
-    [mode, isAdmin, allProvidersConfigured, hasUserInfo]
+    () => getStepsForMode(mode, isAdmin, hasAnyProvider, hasUserInfo),
+    [mode, isAdmin, hasAnyProvider, hasUserInfo]
   );
 
   // Determine initial step based on mode

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -24,11 +24,7 @@ interface MinimalLlmProvider {
 
 export const BUILD_MODE_PROVIDER_PREFIX = "build-mode-";
 
-/**
- * Get the best default LLM selection based on available providers.
- * Only considers providers created by Build mode (name prefixed with `build-mode-`).
- * Priority: Anthropic > OpenAI > OpenRouter > first available build-mode provider.
- */
+// Priority: Anthropic > OpenAI > OpenRouter > first available. Only build-mode providers count.
 export function getDefaultLlmSelection(
   llmProviders: MinimalLlmProvider[] | undefined
 ): BuildLlmSelection | null {
@@ -53,7 +49,6 @@ export function getDefaultLlmSelection(
     }
   }
 
-  // Fallback: first available build-mode provider, use its first visible model
   const firstProvider = buildProviders[0];
   if (firstProvider) {
     const firstModel = firstProvider.model_configurations.find(

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -22,18 +22,28 @@ interface MinimalLlmProvider {
   model_configurations: { name: string; is_visible: boolean }[];
 }
 
+export const BUILD_MODE_PROVIDER_PREFIX = "build-mode-";
+
 /**
  * Get the best default LLM selection based on available providers.
- * Priority: Anthropic > OpenAI > OpenRouter > first available
+ * Only considers providers created by Build mode (name prefixed with `build-mode-`).
+ * Priority: Anthropic > OpenAI > OpenRouter > first available build-mode provider.
  */
 export function getDefaultLlmSelection(
   llmProviders: MinimalLlmProvider[] | undefined
 ): BuildLlmSelection | null {
   if (!llmProviders || llmProviders.length === 0) return null;
 
+  const buildProviders = llmProviders.filter((p) =>
+    p.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX)
+  );
+  if (buildProviders.length === 0) return null;
+
   // Try each priority provider in order
   for (const { provider, modelName } of LLM_SELECTION_PRIORITY) {
-    const matchingProvider = llmProviders.find((p) => p.provider === provider);
+    const matchingProvider = buildProviders.find(
+      (p) => p.provider === provider
+    );
     if (matchingProvider) {
       return {
         providerName: matchingProvider.name ?? "",
@@ -43,8 +53,8 @@ export function getDefaultLlmSelection(
     }
   }
 
-  // Fallback: first available provider, use its first visible model
-  const firstProvider = llmProviders[0];
+  // Fallback: first available build-mode provider, use its first visible model
+  const firstProvider = buildProviders[0];
   if (firstProvider) {
     const firstModel = firstProvider.model_configurations.find(
       (m) => m.is_visible

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -19,9 +19,6 @@ import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 
 import type { LLMProviderDescriptor } from "@/lib/languageModels/types";
 
-// Build-mode providers are identified by a `name` prefixed with `build-mode-`
-// (see BuildOnboardingModal.handleConnect). Other LLM providers configured for
-// the workspace should not satisfy the build onboarding requirements.
 function isBuildModeProvider(provider: LLMProviderDescriptor): boolean {
   return !!provider.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX);
 }

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -12,11 +12,19 @@ import {
 import {
   getBuildUserPersona,
   setBuildUserPersona,
+  BUILD_MODE_PROVIDER_PREFIX,
 } from "@/app/craft/onboarding/constants";
 import { updateUserPersonalization } from "@/lib/userSettings";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 
 import type { LLMProviderDescriptor } from "@/lib/languageModels/types";
+
+// Build-mode providers are identified by a `name` prefixed with `build-mode-`
+// (see BuildOnboardingModal.handleConnect). Other LLM providers configured for
+// the workspace should not satisfy the build onboarding requirements.
+function isBuildModeProvider(provider: LLMProviderDescriptor): boolean {
+  return !!provider.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX);
+}
 
 // Check if all 3 build mode providers are configured (anthropic, openai, openrouter)
 function checkAllProvidersConfigured(
@@ -25,7 +33,9 @@ function checkAllProvidersConfigured(
   if (!llmProviders || llmProviders.length === 0) {
     return false;
   }
-  const configuredProviders = new Set(llmProviders.map((p) => p.provider));
+  const configuredProviders = new Set(
+    llmProviders.filter(isBuildModeProvider).map((p) => p.provider)
+  );
   return (
     configuredProviders.has(LLMProviderName.ANTHROPIC) &&
     configuredProviders.has(LLMProviderName.OPENAI) &&
@@ -33,11 +43,11 @@ function checkAllProvidersConfigured(
   );
 }
 
-// Check if at least one provider is configured
+// Check if at least one build-mode provider is configured
 function checkHasAnyProvider(
   llmProviders: LLMProviderDescriptor[] | undefined
 ): boolean {
-  return !!(llmProviders && llmProviders.length > 0);
+  return !!llmProviders?.some(isBuildModeProvider);
 }
 
 export function useOnboardingModal(): OnboardingModalController {


### PR DESCRIPTION
## Description

Onyx Craft was forcing admins through the LLM setup step whenever the `build_user_persona` cookie was missing, even if a build-mode LLM provider was already configured backend-side. This caused users to reconnect their LLM after clearing cookies.

- Scope `hasAnyProvider` and `getDefaultLlmSelection` to providers whose `name` starts with `build-mode-`, so unrelated workspace LLM providers don't satisfy (or muddle) the build onboarding requirements.
- Drop the `llm-setup` step from initial onboarding whenever any build-mode provider exists (previously gated on all three of Anthropic/OpenAI/OpenRouter being configured).
- `autoSelectBestLlm` already runs on user-info submit, so the `build_llm_selection` cookie repopulates from the existing build-mode provider on completion.

## How Has This Been Tested?

- `bunx tsc --noEmit` (clean)
- Pre-commit hooks: oxfmt, oxlint, TypeScript type check
- Locally tested cookie is replaced and llm config step doesn't show

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the LLM setup step in Build onboarding when a build‑mode provider already exists, so admins aren't forced to reconnect after clearing cookies. Scopes onboarding logic to providers named with the `build-mode-` prefix and updates default selection accordingly.

- **Bug Fixes**
  - Only consider providers with names starting with `build-mode-` for onboarding checks and default selection.
  - Show `llm-setup` only if the user is an admin and no build‑mode provider exists (previously required all three to skip).
  - Default LLM selection now chooses the best available build‑mode provider, falling back to its first visible model.

- **Refactors**
  - Trimmed comments; no behavior changes.

<sup>Written for commit b514d0635602f5c19b42315d4a37b77f5e0aa421. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11478?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



