### PR TITLE
fix(crawler): install playwright system deps

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -93,10 +93,7 @@ RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
     apt-get update && \
     apt-get remove -y --allow-remove-essential \
         perl-base \
-        xserver-common \
-        xvfb \
         cmake \
-        libldap-2.5-0 \
         libxmlsec1-dev \
         pkg-config \
         gcc && \
@@ -106,6 +103,9 @@ RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
         # Install postgresql-client for easy manual tests
         postgresql-client && \
     apt-get autoremove -y && \
+    # Re-run after autoremove to restore any chromium runtime libs
+    # (libnss3, libnspr4, etc.) that got swept up by the cascade.
+    playwright install-deps chromium && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf ~/.cache/uv /tmp/*.txt && \
     rm -f /usr/local/lib/python3.11/site-packages/tornado/test/test.key


### PR DESCRIPTION
## Description

We were calling `playwright install-deps chromium`, but this `apt-get remove` was removing required system deps of playwright afterwards. Keep some of the less invasive deps and re-install playwright system deps to ensure correctness.

Closes https://github.com/onyx-dot-app/onyx/issues/11475

## How Has This Been Tested?

Confirmed minimal net size increase of the image.
```
onyxdotapp/onyx-backend:edge                                                                           b62ace55277a       4.48GB         1.08GB        
onyxdotapp/onyx-backend:latest                                                                         b2883dcd7d4a        4.5GB         1.08GB      
```
Confirmed chromium launches in the container without issue,
```
$ docker bake backend
$ docker run -it --rm onyxdotapp/onyx-backend:latest \
   /app/.cache/ms-playwright/chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell
[0528/175013.358723:ERROR:content/browser/zygote_host/zygote_host_impl_linux.cc:101] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Playwright Chromium in the backend Docker image by preserving required system libraries and re-running `playwright install-deps chromium` after cleanup. Prevents runtime errors like missing `libnss3`.

- **Bug Fixes**
  - Re-run `playwright install-deps chromium` after `apt-get autoremove` to restore Chromium runtime libs (e.g., `libnss3`, `libnspr4`).
  - Stop removing `xserver-common`, `xvfb`, and `libldap-2.5-0` to avoid cascading removal of Playwright deps.

<sup>Written for commit daaee3c185663288057970c2cd5bbbaddf270ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11480?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

