### PR TITLE
feat(dev): add script to run onyx with kind from cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ backend/onyx/evals/data/
 backend/onyx/evals/one_off/*.json
 *.log
 *.csv
+/log/
 
 # secret files
 .env

--- a/docs/dev/run-all-k8s-cli.md
+++ b/docs/dev/run-all-k8s-cli.md
@@ -1,0 +1,100 @@
+# Run all Onyx services from the CLI (k8s mode)
+
+`scripts/run-all-k8s.sh` is the command-line equivalent of the **Run All Onyx
+Services (k8s)** compound launch config in `.vscode/launch.json`. Use it when
+you want to bring up the full stack without VS Code — for example from a
+plain terminal, a tmux session, or another agent's shell.
+
+For the VS Code debugger path, use `local-kubernetes.md` instead.
+
+## What it runs
+
+The script does what the compound launch does: the
+`k8s: telepresence intercept api_server` preLaunchTask, then 10 services in
+parallel:
+
+- `web_server` — `bun run dev` in `web/`
+- `api_server` — `uvicorn onyx.main:app --reload --port 8080`
+- `celery_primary`, `celery_light`, `celery_heavy`,
+  `celery_docfetching`, `celery_docprocessing`,
+  `celery_user_file_processing`, `celery_scheduled_tasks`,
+  `celery_beat` — each via `backend/scripts/dev_celery_reload.py`
+
+Each service writes to `backend/log/<service>.log`. `Ctrl-C` kills them all.
+
+## Prerequisites
+
+Same as `local-kubernetes.md`:
+
+- `kind-onyx-dev` kubectl context exists and the cluster is up
+  (`deployment/helm/dev/k8s-up.sh`)
+- Telepresence installed and either passwordless sudo configured or already
+  connected via `telepresence connect -n onyx`
+- `.venv` exists at the repo root (`uv sync`)
+- `.vscode/.env.k8s` exists (copied from `.vscode/.env.k8s.template` with
+  `GEN_AI_API_KEY` filled in)
+
+The script auto-injects `OPENSEARCH_ADMIN_PASSWORD` into `.env.k8s` by
+reading the `onyx-opensearch` Secret, the same way the VS Code preLaunchTask
+does.
+
+## Usage
+
+```bash
+./scripts/run-all-k8s.sh
+```
+
+Watch logs in another terminal:
+
+```bash
+tail -f backend/log/*.log
+# or just one service
+tail -f backend/log/api_server.log
+```
+
+## Differences vs. the VS Code launch
+
+- **No debugpy attach.** Services run as plain processes — no breakpoints,
+  no debugger. If you need to debug one service, run it via VS Code and the
+  others via this script (or just don't start the duplicate process in the
+  script).
+- **No per-service terminal pane.** Output is redirected to log files. If
+  you want everything in one stream, run `tail -f backend/log/*.log`.
+
+## Worktree setup
+
+If you're running this from a git worktree that doesn't have its own
+`.venv` or `.env.k8s`, symlink them from the main repo:
+
+```bash
+ln -s ~/Documents/code/onyx/.venv         <worktree>/.venv
+ln -s ~/Documents/code/onyx/.vscode/.env.k8s <worktree>/.vscode/.env.k8s
+```
+
+The script resolves `ROOT` from its own location (`$(dirname $0)/..`), so
+copy or symlink the script into each worktree where you want to run it, or
+just invoke it by absolute path from anywhere.
+
+### Stale `.next/` after symlinking `node_modules`
+
+If you also symlink `web/node_modules` between repos/worktrees, Next.js's
+`.next/` dev cache can reference hashed module names from the *other* repo's
+last build. Symptom in `backend/log/web_server.log`:
+
+```
+Error: Cannot find module 'require-in-the-middle-<hash>'
+error: script "dev" exited with code 1
+```
+
+Fix once, before running the script:
+
+```bash
+rm -rf web/.next
+```
+
+## Why this exists
+
+VS Code does not expose compound launch configurations to the `code` CLI —
+there's no `code --launch "<name>"` flag, and `vscode://` URIs don't accept
+launch config names. The only way to bring up the full stack outside of the
+VS Code Debug menu is to replicate the configs in a script.

--- a/docs/dev/run-all-k8s-cli.md
+++ b/docs/dev/run-all-k8s-cli.md
@@ -20,7 +20,8 @@ parallel:
   `celery_user_file_processing`, `celery_scheduled_tasks`,
   `celery_beat` — each via `backend/scripts/dev_celery_reload.py`
 
-Each service writes to `backend/log/<service>.log`. `Ctrl-C` kills them all.
+Each service writes to `log/<service>.log` at the repo root (gitignored).
+`Ctrl-C` kills them all.
 
 ## Prerequisites
 
@@ -41,15 +42,24 @@ does.
 ## Usage
 
 ```bash
-./scripts/run-all-k8s.sh
+ods k8s up
 ```
+
+Equivalent to running `scripts/run-all-k8s.sh` directly — `ods k8s up` is a
+thin wrapper around it.
 
 Watch logs in another terminal:
 
 ```bash
-tail -f backend/log/*.log
-# or just one service
-tail -f backend/log/api_server.log
+ods k8s logs                 # tail all 10 service logs
+ods k8s logs api_server      # tail just one
+```
+
+Stop everything (useful when the "up" terminal was killed and orphaned
+the services):
+
+```bash
+ods k8s down
 ```
 
 ## Differences vs. the VS Code launch
@@ -58,8 +68,8 @@ tail -f backend/log/api_server.log
   no debugger. If you need to debug one service, run it via VS Code and the
   others via this script (or just don't start the duplicate process in the
   script).
-- **No per-service terminal pane.** Output is redirected to log files. If
-  you want everything in one stream, run `tail -f backend/log/*.log`.
+- **No per-service terminal pane.** Output is redirected to log files. Use
+  `ods k8s logs` to tail them.
 
 ## Worktree setup
 
@@ -79,7 +89,7 @@ just invoke it by absolute path from anywhere.
 
 If you also symlink `web/node_modules` between repos/worktrees, Next.js's
 `.next/` dev cache can reference hashed module names from the *other* repo's
-last build. Symptom in `backend/log/web_server.log`:
+last build. Symptom in `log/web_server.log`:
 
 ```
 Error: Cannot find module 'require-in-the-middle-<hash>'

--- a/scripts/run-all-k8s.sh
+++ b/scripts/run-all-k8s.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# CLI equivalent of the "Run All Onyx Services (k8s)" compound launch config.
+# Runs the telepresence intercept preLaunchTask, then fans out all 10 services.
+# Ctrl-C kills them all. Logs go to backend/log/<service>.log.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$ROOT/backend/log"
+ENV_FILE="$ROOT/.vscode/.env.k8s"
+PY="$ROOT/.venv/bin/python"
+mkdir -p "$LOG_DIR"
+
+KUBE='kubectl --context kind-onyx-dev'
+kubectl config get-contexts -o name | grep -qx kind-onyx-dev \
+  || { echo 'error: kubectl context kind-onyx-dev not found' >&2; exit 1; }
+[ -f "$ENV_FILE" ] || { echo "error: $ENV_FILE not found" >&2; exit 1; }
+
+OS_PW=$($KUBE -n onyx get secret onyx-opensearch \
+  -o jsonpath='{.data.opensearch_admin_password}' 2>/dev/null | base64 -d || true)
+[ -n "$OS_PW" ] || { echo 'error: could not read opensearch admin password' >&2; exit 1; }
+
+TMP=$(mktemp)
+awk -v pw="$OS_PW" 'BEGIN{f=0} /^OPENSEARCH_ADMIN_PASSWORD=/{print "OPENSEARCH_ADMIN_PASSWORD=" pw; f=1; next} {print} END{if(!f) print "OPENSEARCH_ADMIN_PASSWORD=" pw}' "$ENV_FILE" > "$TMP" && mv "$TMP" "$ENV_FILE"
+
+telepresence connect --context kind-onyx-dev -n onyx
+telepresence leave onyx-api-server 2>/dev/null || true
+telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false
+
+export PYTHONUNBUFFERED=1 PYTHONPATH=. SANDBOX_BACKEND=kubernetes
+
+PIDS=()
+trap 'echo; echo "shutting down..."; kill "${PIDS[@]}" 2>/dev/null || true; wait; exit 0' INT TERM
+
+# Loads .env.k8s via python-dotenv (handles values like `<REPLACE THIS>` that bash source would choke on).
+DOTENV_RUN=("$PY" -m dotenv -f "$ENV_FILE" run --no-override --)
+
+run() {
+  local name=$1; shift
+  echo "→ $name (log: $LOG_DIR/${name}.log)"
+  ( "$@" ) >"$LOG_DIR/${name}.log" 2>&1 &
+  PIDS+=($!)
+}
+
+# Web server uses .vscode/.env.web (loaded by bun); doesn't need .env.k8s.
+cd "$ROOT/web"
+run web_server bun run dev
+
+cd "$ROOT/backend"
+run api_server "${DOTENV_RUN[@]}" "$PY" -m uvicorn onyx.main:app --reload --port 8080
+
+run celery_primary               "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.primary               worker --pool=threads --concurrency=4  --prefetch-multiplier=1 --loglevel=INFO --hostname=primary@%n               -Q celery
+run celery_light                 "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.light                 worker --pool=threads --concurrency=64 --prefetch-multiplier=8 --loglevel=INFO --hostname=light@%n                 -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+run celery_heavy                 "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.heavy                 worker --pool=threads --concurrency=4  --prefetch-multiplier=1 --loglevel=INFO --hostname=heavy@%n                 -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox
+run celery_docfetching           "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.docfetching           worker --pool=threads                       --prefetch-multiplier=1 --loglevel=INFO --hostname=docfetching@%n           -Q connector_doc_fetching
+ENABLE_MULTIPASS_INDEXING=false \
+run celery_docprocessing         "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.docprocessing         worker --pool=threads                       --prefetch-multiplier=1 --loglevel=INFO --hostname=docprocessing@%n         -Q docprocessing
+run celery_user_file_processing  "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.user_file_processing  worker --pool=threads --concurrency=2  --prefetch-multiplier=1 --loglevel=INFO --hostname=user_file_processing@%n  -Q user_file_processing,user_file_project_sync,user_file_delete
+run celery_scheduled_tasks       "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.scheduled_tasks       worker --pool=threads --concurrency=4  --prefetch-multiplier=1 --loglevel=INFO --hostname=scheduled_tasks@%n       -Q scheduled_tasks
+run celery_beat                  "${DOTENV_RUN[@]}" "$PY" scripts/dev_celery_reload.py -A onyx.background.celery.versioned_apps.beat                  beat   --loglevel=INFO
+
+echo
+echo "all services started. tail logs with:"
+echo "  tail -f $LOG_DIR/*.log"
+echo "ctrl-c to stop everything."
+wait

--- a/scripts/run-all-k8s.sh
+++ b/scripts/run-all-k8s.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-LOG_DIR="$ROOT/backend/log"
+LOG_DIR="$ROOT/log"
 ENV_FILE="$ROOT/.vscode/.env.k8s"
 PY="$ROOT/.venv/bin/python"
 mkdir -p "$LOG_DIR"

--- a/scripts/run-all-k8s.sh
+++ b/scripts/run-all-k8s.sh
@@ -23,6 +23,15 @@ OS_PW=$($KUBE -n onyx get secret onyx-opensearch \
 TMP=$(mktemp)
 awk -v pw="$OS_PW" 'BEGIN{f=0} /^OPENSEARCH_ADMIN_PASSWORD=/{print "OPENSEARCH_ADMIN_PASSWORD=" pw; f=1; next} {print} END{if(!f) print "OPENSEARCH_ADMIN_PASSWORD=" pw}' "$ENV_FILE" > "$TMP" && mv "$TMP" "$ENV_FILE"
 
+# If telepresence is already connected to a different context, bail — otherwise
+# `intercept` would silently attach to the wrong cluster's onyx-api-server.
+TP_CTX=$(telepresence status 2>/dev/null | awk '/Kubernetes context/{sub(/^[^:]*: */, ""); print; exit}' || true)
+if [ -n "$TP_CTX" ] && [ "$TP_CTX" != "kind-onyx-dev" ]; then
+  echo "error: telepresence is connected to context '$TP_CTX', expected 'kind-onyx-dev'." >&2
+  echo "       run 'telepresence quit -s' first, then re-run this script." >&2
+  exit 1
+fi
+
 telepresence connect --context kind-onyx-dev -n onyx
 telepresence leave onyx-api-server 2>/dev/null || true
 telepresence intercept onyx-api-server --namespace onyx --port 8080:8080 --mount=false

--- a/tools/ods/cmd/k8s.go
+++ b/tools/ods/cmd/k8s.go
@@ -1,0 +1,257 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+)
+
+// NewK8sCommand creates the parent "k8s" command for running Onyx against a
+// local kind cluster.
+func NewK8sCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "k8s",
+		Short: "Run Onyx against a local kind cluster",
+		Long: `Run Onyx against a local kind cluster (kind-onyx-dev).
+
+This is the CLI equivalent of the "Run All Onyx Services (k8s)" compound
+launch config in .vscode/launch.json. See docs/dev/run-all-k8s-cli.md
+and docs/dev/local-kubernetes.md.
+
+Commands:
+  up     Start web + api_server + all celery workers against kind-onyx-dev
+  down   Stop running services and tear down the telepresence intercept
+  logs   Tail logs from one or all services`,
+	}
+
+	cmd.AddCommand(newK8sUpCommand())
+	cmd.AddCommand(newK8sDownCommand())
+	cmd.AddCommand(newK8sLogsCommand())
+
+	return cmd
+}
+
+// k8sServices lists log filenames written by "ods k8s up", used for arg
+// validation and shell completion of "ods k8s logs".
+var k8sServices = []string{
+	"api_server",
+	"web_server",
+	"celery_primary",
+	"celery_light",
+	"celery_heavy",
+	"celery_docfetching",
+	"celery_docprocessing",
+	"celery_user_file_processing",
+	"celery_scheduled_tasks",
+	"celery_beat",
+}
+
+func newK8sLogsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs [service]",
+		Short: "Tail logs from one or all services",
+		Long: `Tail logs written by "ods k8s up" under log/.
+
+With no argument, tails every <service>.log in log/ (prefixed
+with the filename on each switch). With a service name, tails just
+that file.
+
+Examples:
+  ods k8s logs              # tail all 10 service logs
+  ods k8s logs api_server
+  ods k8s logs celery_docprocessing`,
+		Args:      cobra.MaximumNArgs(1),
+		ValidArgs: k8sServices,
+		Run: func(cmd *cobra.Command, args []string) {
+			runK8sLogs(args)
+		},
+	}
+
+	return cmd
+}
+
+func runK8sLogs(args []string) {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	logDir := filepath.Join(root, "log")
+
+	var tailArgs []string
+	if len(args) == 0 {
+		matches, err := filepath.Glob(filepath.Join(logDir, "*.log"))
+		if err != nil || len(matches) == 0 {
+			log.Fatalf("No log files found in %s (have you run \"ods k8s up\"?)", logDir)
+		}
+		tailArgs = append([]string{"-f"}, matches...)
+	} else {
+		service := args[0]
+		if !contains(k8sServices, service) {
+			log.Fatalf("Unknown service %q. Valid services:\n  %s", service, strings.Join(k8sServices, "\n  "))
+		}
+		logFile := filepath.Join(logDir, service+".log")
+		if _, err := os.Stat(logFile); err != nil {
+			log.Fatalf("Log file not found: %s (have you run \"ods k8s up\"?)", logFile)
+		}
+		tailArgs = []string{"-f", logFile}
+	}
+
+	tailCmd := exec.Command("tail", tailArgs...)
+	tailCmd.Stdout = os.Stdout
+	tailCmd.Stderr = os.Stderr
+	tailCmd.Stdin = os.Stdin
+	if err := tailCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if code := exitErr.ExitCode(); code != -1 {
+				os.Exit(code)
+			}
+		}
+		log.Fatalf("Failed to run tail: %v", err)
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func newK8sUpCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "Start all Onyx services against kind-onyx-dev",
+		Long: `Start web, api_server, and all celery workers locally with telepresence
+intercept routing in-cluster traffic to your laptop.
+
+Prerequisites (see docs/dev/local-kubernetes.md):
+  - kind-onyx-dev kubectl context exists and the cluster is up
+  - .venv at the repo root (uv sync)
+  - .vscode/.env.k8s exists (copy from .env.k8s.template, fill GEN_AI_API_KEY)
+  - telepresence installed; either passwordless sudo or already connected
+
+Each service logs to log/<service>.log. Ctrl-C stops everything.
+
+Examples:
+  ods k8s up
+  ods k8s logs    # in another terminal`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runK8sUp()
+		},
+	}
+
+	return cmd
+}
+
+func newK8sDownCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "down",
+		Short: "Stop running services and tear down the telepresence intercept",
+		Long: `Stop services started by "ods k8s up", leave the telepresence intercept
+on onyx-api-server, and quit the telepresence daemon.
+
+Useful when the "up" terminal was killed and orphaned the services, or
+to clean up from a different shell. In the happy path, Ctrl-C in the
+"up" terminal already handles this.
+
+Examples:
+  ods k8s down`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runK8sDown()
+		},
+	}
+
+	return cmd
+}
+
+// processPatterns are pgrep -f patterns matching processes started by "ods k8s up".
+var processPatterns = []string{
+	"dev_celery_reload",
+	"uvicorn onyx.main",
+	"next dev",
+}
+
+func runK8sDown() {
+	for _, pattern := range processPatterns {
+		killByPattern(pattern)
+	}
+
+	log.Info("Leaving telepresence intercept on onyx-api-server...")
+	leaveCmd := exec.Command("telepresence", "leave", "onyx-api-server")
+	leaveCmd.Stdout = os.Stdout
+	leaveCmd.Stderr = os.Stderr
+	// Ignore errors — intercept may not exist, which is fine.
+	_ = leaveCmd.Run()
+
+	log.Info("Quitting telepresence daemon...")
+	quitCmd := exec.Command("telepresence", "quit", "-s")
+	quitCmd.Stdout = os.Stdout
+	quitCmd.Stderr = os.Stderr
+	_ = quitCmd.Run()
+}
+
+// killByPattern sends SIGTERM to all processes matching the pgrep -f pattern.
+// Logs how many processes were killed; missing matches are not an error.
+func killByPattern(pattern string) {
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		// pgrep exits 1 when no matches found — not an error.
+		log.Debugf("No processes matching %q", pattern)
+		return
+	}
+
+	var pids []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			pids = append(pids, line)
+		}
+	}
+	if len(pids) == 0 {
+		log.Debugf("No processes matching %q", pattern)
+		return
+	}
+
+	log.Infof("Killing %d process(es) matching %q (pids: %v)", len(pids), pattern, pids)
+	killCmd := exec.Command("kill", append([]string{"-TERM"}, pids...)...)
+	if err := killCmd.Run(); err != nil {
+		log.Warnf("kill failed for pattern %q: %v", pattern, err)
+	}
+}
+
+func runK8sUp() {
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+
+	script := filepath.Join(root, "scripts", "run-all-k8s.sh")
+	if _, err := os.Stat(script); err != nil {
+		log.Fatalf("Script not found at %s: %v", script, err)
+	}
+
+	svcCmd := exec.Command(script)
+	svcCmd.Dir = root
+	svcCmd.Stdout = os.Stdout
+	svcCmd.Stderr = os.Stderr
+	svcCmd.Stdin = os.Stdin
+
+	if err := svcCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if code := exitErr.ExitCode(); code != -1 {
+				os.Exit(code)
+			}
+		}
+		log.Fatalf("Failed to run %s: %v", script, err)
+	}
+}

--- a/tools/ods/cmd/k8s.go
+++ b/tools/ods/cmd/k8s.go
@@ -192,12 +192,6 @@ func runK8sDown() {
 	leaveCmd.Stderr = os.Stderr
 	// Ignore errors — intercept may not exist, which is fine.
 	_ = leaveCmd.Run()
-
-	log.Info("Quitting telepresence daemon...")
-	quitCmd := exec.Command("telepresence", "quit", "-s")
-	quitCmd.Stdout = os.Stdout
-	quitCmd.Stderr = os.Stderr
-	_ = quitCmd.Run()
 }
 
 // killByPattern sends SIGTERM to all processes matching the pgrep -f pattern.

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -60,6 +60,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(NewScreenshotDiffCommand())
 	cmd.AddCommand(NewDesktopCommand())
 	cmd.AddCommand(NewDevCommand())
+	cmd.AddCommand(NewK8sCommand())
 	cmd.AddCommand(NewWebCommand())
 	cmd.AddCommand(NewLatestStableTagCommand())
 	cmd.AddCommand(NewWhoisCommand())


### PR DESCRIPTION
## Description

Adds a CLI path for bringing up the full Onyx stack against `kind-onyx-dev` without VS Code's compound launch config.

- `scripts/run-all-k8s.sh` — sets up the telepresence intercept on `onyx-api-server`, injects `OPENSEARCH_ADMIN_PASSWORD` from the in-cluster Secret, then fans out all 10 services (`web_server`, `api_server`, 8 Celery workers). Logs go to `log/<service>.log` at the repo root. Ctrl-C cleans up.
- `ods k8s up` — thin Go wrapper around the script.
- `ods k8s down` — kills orphaned services (`pgrep -f` for `dev_celery_reload` / `uvicorn onyx.main` / `next dev`), runs `telepresence leave` + `telepresence quit -s`. Useful when the `up` terminal died and the trap didn't fire.
- `ods k8s logs [service]` — tails one or all service logs. Service names tab-complete via cobra `ValidArgs`.
- `/log/` added to `.gitignore`.
- Docs at `docs/dev/run-all-k8s-cli.md`.

## How Has This Been Tested?

- `ods k8s up` brought up all 10 services live: uvicorn on `127.0.0.1:8080`, web on `:3000`, celery_beat scheduling, etc.
- `ods k8s logs api_server` streamed live api_server output, exited cleanly on Ctrl-C.
- `ods k8s down` killed 8 celery + 1 uvicorn + 1 next process and quit the telepresence daemons (verified `Not running` after).
- `git check-ignore` confirmed both `log/` and `log/api_server.log` are ignored.

## Important — ods version not bumped in this PR

The new `ods k8s ...` subcommands ship in this PR's Go source, but `pyproject.toml` still pins `onyx-devtools==0.7.8`. **Teammates running `uv sync` will not get the new commands** until a follow-up PR:

1. Tag `ods/v0.7.9` to trigger `.github/workflows/release-devtools.yml` → publishes to PyPI.
2. Bump the pin in `pyproject.toml` to `0.7.9`.

Until then, the underlying `scripts/run-all-k8s.sh` is invocable directly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check