### PR TITLE
chore(pre-commit): tsgo type check for widget + examples/widget

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,3 +185,17 @@ repos:
         language: system
         pass_filenames: false
         files: ^web/.*\.(ts|tsx)$
+
+      - id: widget-typescript-check
+        name: widget TypeScript type check
+        entry: bash -c 'cd widget && bunx tsgo --noEmit'
+        language: system
+        pass_filenames: false
+        files: ^(bun\.lock|widget/(.*\.(ts|tsx)|package\.json|tsconfig\.json))$
+
+      - id: examples-widget-typescript-check
+        name: examples/widget TypeScript type check
+        entry: bash -c 'cd examples/widget && bunx tsgo --noEmit'
+        language: system
+        pass_filenames: false
+        files: ^(bun\.lock|examples/widget/(.*\.(ts|tsx)|package\.json|tsconfig\.json))$

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "onyx",
+      "devDependencies": {
+        "@typescript/native-preview": "^7.0.0-dev.20260424.2",
+      },
     },
     "desktop": {
       "name": "onyx-desktop",
@@ -430,6 +433,22 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.60.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.60.0", "@typescript-eslint/types": "8.60.0", "@typescript-eslint/typescript-estree": "8.60.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.60.0", "", { "dependencies": { "@typescript-eslint/types": "8.60.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260527.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260527.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260527.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260527.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260527.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260527.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260527.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260527.2" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-piqkDwikVeizCFqA1lcwI5F4wOAtBdxuliWe77ApBNRyBPPvfCJB+u/HYi9/8t5nd0sWvFs6/qt/AzJ1CCoykQ=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260527.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3LqSu4DlxkEfeC/Z/29QMCJn5jjkDtXI7LYuxfmjdmAatS6umDKqm8J17fnP/7fyrZUMBTIYRwSDpChGV3G1ew=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260527.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-H4+sxE9qaBbLF83wMdWE0FsgfK0Pom+/O+/oxqyGzhVkDJlNt3vfpgQZMit48/Gm44AacGfBggJ9Dhbi3aeSFw=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260527.2", "", { "os": "linux", "cpu": "arm" }, "sha512-6I9Cv9ozwfS9zB9vRQDPIYseLX3artEO9jl3yVgLj4ishwlSF4cWAbIsjl5IztPaEgHv8coej/6tX1D0uaBzXg=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260527.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-BGUDMjC2Z3TTdZRkGGwhBLelkP5UYgO2rbep8aF4dS3fu7T5lFPPrnfS6EgqJgie+cF5Fsev7xEq8wWyBDM+lg=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260527.2", "", { "os": "linux", "cpu": "x64" }, "sha512-vpazOu+ozlxBo8U57YJMzsOPuxAV8H7fu36KJ8ea8At/D8pdGmOAy5TuB+9OBQV9JDe0OXJMy2kmbhOpmkTAmA=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260527.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-DBFnFE3V6AITkPO1K1VxXf3yEZKjU2FwtXlNwRqhzDu0rrL2SsJHOSrBDX+OacTxQFzZMxFcpiuhV8jHZALPEg=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260527.2", "", { "os": "win32", "cpu": "x64" }, "sha512-1tBlErMvQgcMqqYwsx4tytupcjCJcOUXD3vBn1Wb/kAvus1FzWQAFE0fcKBvLfcqLQfTiiEwKKEtbLjGmakqqg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 

--- a/package.json
+++ b/package.json
@@ -3,5 +3,8 @@
   "version": "0.0.0-private",
   "private": true,
   "packageManager": "bun@1.3.13",
-  "workspaces": ["widget", "examples/widget", "desktop"]
+  "workspaces": ["widget", "examples/widget", "desktop"],
+  "devDependencies": {
+    "@typescript/native-preview": "^7.0.0-dev.20260424.2"
+  }
 }

--- a/widget/tsconfig.json
+++ b/widget/tsconfig.json
@@ -26,10 +26,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- Add `widget-typescript-check` and `examples-widget-typescript-check` pre-commit hooks that run `bunx tsgo --noEmit` against each aux package, mirroring the existing `web/` `typescript-check` hook.
- Hoist `@typescript/native-preview` into the root `package.json` so the bun workspace resolves it from any subdir.
- Include `package.json`, `tsconfig.json`, and root `bun.lock` in each hook's `files` regex so dep upgrades (e.g. dependabot TypeScript bumps like #11458) actually trigger the check, not just source edits.
- Fix `widget/tsconfig.json`: drop deprecated `baseUrl` and prefix the `@/*` paths entry with `./`. tsgo rejects both, the Vite build did not surface either.

## Motivation
PR #11458 bumps TypeScript 5.9.3 -> 6.0.3 in `widget/` and `examples/widget/`. Neither package was covered by any automated type check (pre-commit's existing `typescript-check` is scoped to `^web/.*\.(ts|tsx)$`, and no CI workflow runs `tsc` against them). A regression introduced by a dep bump would only surface at `bun run build` time. These hooks close that gap.

## Test plan
- [x] `uvx pre-commit run widget-typescript-check --all-files` -> Passed
- [x] `uvx pre-commit run examples-widget-typescript-check --all-files` -> Passed
- [ ] Confirm CI runs the hooks via the existing pre-commit job
- [ ] Re-run dependabot PR #11458 on top of this branch to confirm the hook would catch a TS major-version regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pre-commit TypeScript checks for `widget/` and `examples/widget/` using `tsgo` to catch type regressions before build. Hoists `@typescript/native-preview` to the root, triggers checks on source/config/`bun.lock` changes, and fixes `widget/tsconfig.json` (remove `baseUrl`; prefix `@/*` with `./`).

<sup>Written for commit 69457d49f11d9bf3fc2cb5c22d40984ff23d5de5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11485?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

