### PR TITLE
chore(deps): downgrade transformers from 5.5.4 to 4.57.6 (#11479) to release v3.3

### DIFF
--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -342,7 +342,7 @@ h11==0.16.0
     #   uvicorn
 h2==4.3.0
     # via httpx
-hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 hpack==4.1.0
     # via h2
@@ -365,7 +365,6 @@ httpx==0.28.1
     #   fastmcp
     #   google-genai
     #   httpx-oauth
-    #   huggingface-hub
     #   langfuse
     #   langsmith
     #   litellm
@@ -378,7 +377,7 @@ httpx-sse==0.4.3
     #   cohere
     #   mcp
 hubspot-api-client==11.1.0
-huggingface-hub==1.12.0
+huggingface-hub==0.36.2
     # via tokenizers
 humanfriendly==10.0
     # via coloredlogs
@@ -833,6 +832,7 @@ requests==2.33.0
     #   google-cloud-storage
     #   google-genai
     #   hubspot-api-client
+    #   huggingface-hub
     #   jira
     #   kubernetes
     #   langfuse
@@ -980,9 +980,7 @@ tqdm==4.67.1
     #   unstructured
 trafilatura==1.12.2
 typer==0.20.0
-    # via
-    #   huggingface-hub
-    #   mcp
+    # via mcp
 types-awscrt==0.28.4
     # via botocore-stubs
 types-openpyxl==3.0.4.7

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -82,7 +82,6 @@ click==8.3.1
     # via
     #   black
     #   litellm
-    #   typer
     #   uvicorn
 cohere==5.6.1
     # via onyx
@@ -207,7 +206,7 @@ h11==0.16.0
     #   httpcore
     #   uvicorn
 hatchling==1.28.0
-hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
@@ -215,7 +214,6 @@ httpx==0.28.1
     # via
     #   cohere
     #   google-genai
-    #   huggingface-hub
     #   litellm
     #   mcp
     #   openai
@@ -223,7 +221,7 @@ httpx-sse==0.4.3
     # via
     #   cohere
     #   mcp
-huggingface-hub==1.12.0
+huggingface-hub==0.36.2
     # via tokenizers
 identify==2.6.15
     # via pre-commit
@@ -274,8 +272,6 @@ litellm==1.83.0
 mako==1.3.11
     # via alembic
 manygo==0.2.0
-markdown-it-py==4.0.0
-    # via rich
 markupsafe==3.0.3
     # via
     #   jinja2
@@ -287,8 +283,6 @@ matplotlib-inline==0.2.1
     #   ipython
 mcp==1.27.0
     # via claude-agent-sdk
-mdurl==0.1.2
-    # via markdown-it-py
 multidict==6.7.0
     # via
     #   aiobotocore
@@ -413,7 +407,6 @@ pygments==2.20.0
     #   ipython
     #   ipython-pygments-lexers
     #   pytest
-    #   rich
 pyjwt==2.12.0
     # via mcp
 pyparsing==3.2.5
@@ -473,6 +466,7 @@ requests==2.33.0
     #   google-cloud-bigquery
     #   google-cloud-storage
     #   google-genai
+    #   huggingface-hub
     #   kubernetes
     #   requests-oauthlib
     #   tiktoken
@@ -481,8 +475,6 @@ requests-oauthlib==1.3.1
     # via kubernetes
 retry==0.9.2
     # via onyx
-rich==14.2.0
-    # via typer
 rpds-py==0.29.0
     # via
     #   jsonschema
@@ -494,8 +486,6 @@ s3transfer==0.13.1
     # via boto3
 sentry-sdk==2.14.0
     # via onyx
-shellingham==1.5.4
-    # via typer
 six==1.17.0
     # via
     #   kubernetes
@@ -545,8 +535,6 @@ traitlets==5.14.3
 trove-classifiers==2025.12.1.14
     # via hatchling
 ty==0.0.31
-typer==0.20.0
-    # via huggingface-hub
 types-beautifulsoup4==4.12.0.3
 types-html5lib==1.1.11.13
     # via types-beautifulsoup4
@@ -585,7 +573,6 @@ typing-extensions==4.15.0
     #   referencing
     #   sqlalchemy
     #   starlette
-    #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -69,7 +69,6 @@ claude-agent-sdk==0.1.19
 click==8.3.1
     # via
     #   litellm
-    #   typer
     #   uvicorn
 cohere==5.6.1
     # via onyx
@@ -166,7 +165,7 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
@@ -174,7 +173,6 @@ httpx==0.28.1
     # via
     #   cohere
     #   google-genai
-    #   huggingface-hub
     #   litellm
     #   mcp
     #   openai
@@ -182,7 +180,7 @@ httpx-sse==0.4.3
     # via
     #   cohere
     #   mcp
-huggingface-hub==1.12.0
+huggingface-hub==0.36.2
     # via tokenizers
 idna==3.11
     # via
@@ -211,14 +209,10 @@ kubernetes==31.0.0
     # via onyx
 litellm==1.83.0
     # via onyx
-markdown-it-py==4.0.0
-    # via rich
 markupsafe==3.0.3
     # via jinja2
 mcp==1.27.0
     # via claude-agent-sdk
-mdurl==0.1.2
-    # via markdown-it-py
 monotonic==1.6
     # via posthog
 multidict==6.7.0
@@ -294,8 +288,6 @@ pydantic-core==2.33.2
     # via pydantic
 pydantic-settings==2.12.0
     # via mcp
-pygments==2.20.0
-    # via rich
 pyjwt==2.12.0
     # via mcp
 python-dateutil==2.8.2
@@ -330,6 +322,7 @@ requests==2.33.0
     #   google-cloud-bigquery
     #   google-cloud-storage
     #   google-genai
+    #   huggingface-hub
     #   kubernetes
     #   posthog
     #   requests-oauthlib
@@ -339,8 +332,6 @@ requests-oauthlib==1.3.1
     # via kubernetes
 retry==0.9.2
     # via onyx
-rich==14.2.0
-    # via typer
 rpds-py==0.29.0
     # via
     #   jsonschema
@@ -351,8 +342,6 @@ s3transfer==0.13.1
     # via boto3
 sentry-sdk==2.14.0
     # via onyx
-shellingham==1.5.4
-    # via typer
 six==1.17.0
     # via
     #   kubernetes
@@ -383,8 +372,6 @@ tqdm==4.67.1
     # via
     #   huggingface-hub
     #   openai
-typer==0.20.0
-    # via huggingface-hub
 types-requests==2.32.0.20250328
     # via cohere
 typing-extensions==4.15.0
@@ -403,7 +390,6 @@ typing-extensions==4.15.0
     #   pydantic-core
     #   referencing
     #   starlette
-    #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -78,7 +78,6 @@ click==8.3.1
     #   click-plugins
     #   click-repl
     #   litellm
-    #   typer
     #   uvicorn
 click-didyoumean==0.3.1
     # via celery
@@ -119,6 +118,7 @@ filelock==3.20.3
     # via
     #   huggingface-hub
     #   torch
+    #   transformers
 frozenlist==1.8.0
     # via
     #   aiohttp
@@ -188,7 +188,7 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
-hf-xet==1.4.3 ; platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
+hf-xet==1.4.3 ; platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
     # via huggingface-hub
 httpcore==1.0.9
     # via httpx
@@ -196,7 +196,6 @@ httpx==0.28.1
     # via
     #   cohere
     #   google-genai
-    #   huggingface-hub
     #   litellm
     #   mcp
     #   openai
@@ -204,7 +203,7 @@ httpx-sse==0.4.3
     # via
     #   cohere
     #   mcp
-huggingface-hub==1.12.0
+huggingface-hub==0.36.2
     # via
     #   accelerate
     #   sentence-transformers
@@ -243,14 +242,10 @@ kubernetes==31.0.0
     # via onyx
 litellm==1.83.0
     # via onyx
-markdown-it-py==4.0.0
-    # via rich
 markupsafe==3.0.3
     # via jinja2
 mcp==1.27.0
     # via claude-agent-sdk
-mdurl==0.1.2
-    # via markdown-it-py
 mpmath==1.3.0
     # via sympy
 multidict==6.7.0
@@ -379,8 +374,6 @@ pydantic-core==2.33.2
     # via pydantic
 pydantic-settings==2.12.0
     # via mcp
-pygments==2.20.0
-    # via rich
 pyjwt==2.12.0
     # via mcp
 python-dateutil==2.8.2
@@ -419,16 +412,16 @@ requests==2.33.0
     #   google-cloud-bigquery
     #   google-cloud-storage
     #   google-genai
+    #   huggingface-hub
     #   kubernetes
     #   requests-oauthlib
     #   tiktoken
+    #   transformers
     #   voyageai
 requests-oauthlib==1.3.1
     # via kubernetes
 retry==0.9.2
     # via onyx
-rich==14.2.0
-    # via typer
 rpds-py==0.29.0
     # via
     #   jsonschema
@@ -452,8 +445,6 @@ sentry-sdk==2.14.0
     # via onyx
 setuptools==80.9.0 ; python_full_version >= '3.12'
     # via torch
-shellingham==1.5.4
-    # via typer
 six==1.17.0
     # via
     #   kubernetes
@@ -495,14 +486,10 @@ tqdm==4.67.1
     #   openai
     #   sentence-transformers
     #   transformers
-transformers==5.5.4
+transformers==4.57.6
     # via sentence-transformers
 triton==3.5.1 ; platform_machine == 'x86_64' and sys_platform == 'linux'
     # via torch
-typer==0.20.0
-    # via
-    #   huggingface-hub
-    #   transformers
 types-requests==2.32.0.20250328
     # via cohere
 typing-extensions==4.15.0
@@ -523,7 +510,6 @@ typing-extensions==4.15.0
     #   sentence-transformers
     #   starlette
     #   torch
-    #   typer
     #   typing-inspection
 typing-inspection==0.4.2
     # via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,7 +188,13 @@ model_server = [
     "safetensors==0.5.3",
     "sentence-transformers==5.4.1",
     "torch==2.9.1",
-    "transformers==5.5.4",
+    # Do NOT upgrade to >=5 without addressing the `from_pretrained()` buffer
+    # corruption bug: persistent=False buffers (notably RoPE `inv_freq`) are
+    # loaded with garbage memory, producing all-NaN embeddings.
+    # See https://github.com/huggingface/transformers/issues/44534 and
+    # https://github.com/huggingface/transformers/issues/43950 (both closed
+    # wontfix upstream).
+    "transformers==4.57.6",
     "sentry-sdk[fastapi,celery,starlette]==2.14.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2607,22 +2607,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.12.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/52/1b54cb569509c725a32c1315261ac9fd0e6b91bbbf74d86fca10d3376164/huggingface_hub-1.12.0.tar.gz", hash = "sha256:7c3fe85e24b652334e5d456d7a812cd9a071e75630fac4365d9165ab5e4a34b6", size = 763091, upload-time = "2026-04-24T13:32:08.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/2b/ef03ddb96bd1123503c2bd6932001020292deea649e9bf4caa2cb65a85bf/huggingface_hub-1.12.0-py3-none-any.whl", hash = "sha256:d74939969585ee35748bd66de09baf84099d461bda7287cd9043bfb99b0e424d", size = 646806, upload-time = "2026-04-24T13:32:06.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -4679,7 +4678,7 @@ model-server = [
     { name = "sentence-transformers", specifier = "==5.4.1" },
     { name = "sentry-sdk", extras = ["fastapi", "celery", "starlette"], specifier = "==2.14.0" },
     { name = "torch", specifier = "==2.9.1" },
-    { name = "transformers", specifier = "==5.5.4" },
+    { name = "transformers", specifier = "==4.57.6" },
 ]
 
 [[package]]
@@ -7457,22 +7456,23 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "5.5.4"
+version = "4.57.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
+    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
-    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/1e244ab2ab50a863e6b52cc55761910567fa532b69a6740f6e99c5fdbd98/transformers-5.5.4.tar.gz", hash = "sha256:2e67cadba81fc7608cc07c4dd54f524820bc3d95b1cabd0ef3db7733c4f8b82e", size = 8227649, upload-time = "2026-04-13T16:55:55.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/fb/162a66789c65e5afa3b051309240c26bf37fbc8fea285b4546ae747995a2/transformers-5.5.4-py3-none-any.whl", hash = "sha256:0bd6281b82966fe5a7a16f553ea517a9db1dee6284d7cb224dfd88fc0dd1c167", size = 10236696, upload-time = "2026-04-13T16:55:51.497Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Cherry-pick of commit 755bf3a86fb1046735cd17fbb54c1ce34b751797 to release/v3.3 branch.

Original PR: #11479

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hotfix: downgrade `transformers` to 4.57.6 to fix a v5 `from_pretrained()` buffer bug that caused NaN embeddings in the model server. Also align `huggingface-hub` and prune unneeded deps.

- **Dependencies**
  - Downgraded `transformers` 5.5.4 → 4.57.6 across `pyproject.toml`, `uv.lock`, and `backend/requirements/*`.
  - Pinned `huggingface-hub` 1.12.0 → 0.36.2; switched dependency chain from `httpx` to `requests`; ensured `filelock` is present.
  - Removed unused CLI deps pulled by newer hubs: `typer`, `rich`, `markdown-it-py`, `mdurl`, `pygments`, `shellingham`.
  - Cleaned `hf-xet` platform marker; added a guard comment to block `transformers` ≥5 until the buffer issue is fixed.

<sup>Written for commit 5cd4383608a9766fcc981fbc595bfa314dbf363b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11487?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

