### PR TITLE
ci: tag stable releases with major/minor/patch aliases

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -31,6 +31,7 @@ jobs:
       is-cloud-tag: ${{ steps.check.outputs.is-cloud-tag }}
       is-beta: ${{ steps.check.outputs.is-beta }}
       is-beta-standalone: ${{ steps.check.outputs.is-beta-standalone }}
+      is-stable: ${{ steps.check.outputs.is-stable }}
       is-latest: ${{ steps.check.outputs.is-latest }}
       is-experimental-cc4a: ${{ steps.check.outputs.is-experimental-cc4a }}
       is-test-run: ${{ steps.check.outputs.is-test-run }}
@@ -157,6 +158,7 @@ jobs:
             echo "is-cloud-tag=$IS_CLOUD"
             echo "is-beta=$IS_BETA"
             echo "is-beta-standalone=$IS_BETA_STANDALONE"
+            echo "is-stable=$IS_STABLE"
             echo "is-latest=$IS_LATEST"
             echo "is-experimental-cc4a=$IS_EXPERIMENTAL_CC4A"
             echo "is-test-run=$IS_TEST_RUN"
@@ -623,6 +625,9 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta' || '' }}
+            type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
       - name: Create and push manifest
         env:
@@ -1052,6 +1057,9 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
+            type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
       - name: Create and push manifest
         env:
@@ -1475,6 +1483,9 @@ jobs:
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-experimental-cc4a == 'true' && 'craft-edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge' || '' }}
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta' || '' }}
+            type=semver,pattern={{version}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
       - name: Create and push manifest
         env:


### PR DESCRIPTION
## Summary
- Pushing a stable `vX.Y.Z` tag now also publishes `:X`, `:X.Y`, and `:X.Y.Z` aliases on `onyx-web-server`, `onyx-backend`, and `onyx-model-server`, so users can pin to a major or minor line.
- Adds the already-computed `is-stable` flag as a `determine-builds` output and uses `type=semver` patterns in the three `merge-*` jobs, gated on `is-stable` so betas / cloud / edge / nightly tags are unaffected.

## Caveats
- `:X` and `:X.Y` follow whichever stable tag was pushed most recently, so an out-of-order release (e.g. patching `v2.x` after `v3` is out) would move `:2` and `:2.x` to the older line. If we want strict "highest stable only" semantics, swap the `is-stable` gate for `is-latest`.

## Test plan
- [ ] Push a workflow_dispatch run on this branch and confirm no semver aliases are published (test runs are gated by `is-test-run`, and the branch ref is not a semver).
- [ ] On the next stable tag push, verify Docker Hub shows the new `:X`, `:X.Y`, `:X.Y.Z` tags on `onyx-web-server`, `onyx-backend`, and `onyx-model-server` in addition to the existing `:vX.Y.Z` / `:latest`.
- [ ] Verify a beta tag (e.g. `vX.Y.Z-beta.N`) does NOT publish the major/minor/patch aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes semver Docker tag aliases for stable releases. Pushing `vX.Y.Z` now also tags `:X`, `:X.Y`, and `:X.Y.Z` for `onyx-web-server`, `onyx-backend`, and `onyx-model-server`.

- **New Features**
  - Added `is-stable` to `determine-builds` and used `type=semver` in merge jobs to generate aliases.
  - Only runs for stable tags; beta/cloud/edge/nightly are unchanged.
  - Aliases follow the most recently pushed stable tag; out-of-order patches can move `:X` and `:X.Y`.

<sup>Written for commit e59ce81074b2d5d581752855cf66b8a77c5863ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11488?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

