### PR TITLE
feat(ee): Prometheus metrics for license seats and expiry

### DIFF
--- a/backend/ee/onyx/server/metrics/license_metrics.py
+++ b/backend/ee/onyx/server/metrics/license_metrics.py
@@ -33,19 +33,13 @@ class LicenseMetricsCollector(_CachedCollector):
         if MULTI_TENANT:
             return []
 
-        try:
-            with get_session_with_tenant(
-                tenant_id=POSTGRES_DEFAULT_SCHEMA
-            ) as db_session:
-                metadata = get_license_metadata(
-                    db_session, tenant_id=POSTGRES_DEFAULT_SCHEMA
-                )
-                if metadata is None:
-                    return []
-                used_seats = get_used_seats(POSTGRES_DEFAULT_SCHEMA)
-        except Exception:
-            logger.debug("Failed to collect license metrics", exc_info=True)
-            return []
+        with get_session_with_tenant(tenant_id=POSTGRES_DEFAULT_SCHEMA) as db_session:
+            metadata = get_license_metadata(
+                db_session, tenant_id=POSTGRES_DEFAULT_SCHEMA
+            )
+            if metadata is None:
+                return []
+            used_seats = get_used_seats(POSTGRES_DEFAULT_SCHEMA)
 
         total_seats = metadata.seats
         available_seats = max(0, total_seats - used_seats)

--- a/backend/ee/onyx/server/metrics/license_metrics.py
+++ b/backend/ee/onyx/server/metrics/license_metrics.py
@@ -73,7 +73,7 @@ class LicenseMetricsCollector(_CachedCollector):
             "Whether the license is active (1=active, 0=gated/expired)",
         )
         active.add_metric(
-            [], 1.0 if metadata.status == ApplicationStatus.ACTIVE else 0.0
+            [], 0.0 if metadata.status == ApplicationStatus.GATED_ACCESS else 1.0
         )
 
         return [seats_total, seats_used, seats_available, expires, active]

--- a/backend/ee/onyx/server/metrics/license_metrics.py
+++ b/backend/ee/onyx/server/metrics/license_metrics.py
@@ -1,0 +1,100 @@
+"""Prometheus collector for self-hosted license seat usage and expiry.
+
+Self-hosted only. Cloud tracks seats via Stripe subscriptions, not licenses, so
+this collector no-ops when ``MULTI_TENANT`` is set. Registered on the API
+server's default registry from ``main.py`` lifespan and exposed via ``/metrics``,
+letting operators alert on seat exhaustion and upcoming expiry in their own
+Prometheus/Alertmanager.
+
+Read at scrape time (the Collector pattern) so seat counts and expiry are fresh.
+Emits nothing when no license is installed — an absent series rather than zeros,
+so unlicensed instances don't trip "0 seats remaining" alerts.
+"""
+
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import REGISTRY
+
+from ee.onyx.db.license import get_license_metadata
+from ee.onyx.db.license import get_used_seats
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.server.metrics.indexing_pipeline import _CachedCollector
+from onyx.server.settings.models import ApplicationStatus
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+logger = setup_logger()
+
+
+class LicenseMetricsCollector(_CachedCollector):
+    """Emits license seat and expiry gauges, read from the license at scrape time."""
+
+    def _collect_fresh(self) -> list[GaugeMetricFamily]:
+        if MULTI_TENANT:
+            return []
+
+        try:
+            with get_session_with_tenant(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA
+            ) as db_session:
+                metadata = get_license_metadata(
+                    db_session, tenant_id=POSTGRES_DEFAULT_SCHEMA
+                )
+                if metadata is None:
+                    return []
+                used_seats = get_used_seats(POSTGRES_DEFAULT_SCHEMA)
+        except Exception:
+            logger.debug("Failed to collect license metrics", exc_info=True)
+            return []
+
+        total_seats = metadata.seats
+        available_seats = max(0, total_seats - used_seats)
+
+        seats_total = GaugeMetricFamily(
+            "onyx_license_seats_total",
+            "Total seats granted by the installed license",
+        )
+        seats_total.add_metric([], total_seats)
+
+        seats_used = GaugeMetricFamily(
+            "onyx_license_seats_used",
+            "Seats currently consumed by active users",
+        )
+        seats_used.add_metric([], used_seats)
+
+        seats_available = GaugeMetricFamily(
+            "onyx_license_seats_available",
+            "Seats remaining before the license limit is reached",
+        )
+        seats_available.add_metric([], available_seats)
+
+        expires = GaugeMetricFamily(
+            "onyx_license_expires_timestamp_seconds",
+            "Unix timestamp when the installed license expires",
+        )
+        expires.add_metric([], metadata.expires_at.timestamp())
+
+        active = GaugeMetricFamily(
+            "onyx_license_active",
+            "Whether the license is active (1=active, 0=gated/expired)",
+        )
+        active.add_metric(
+            [], 1.0 if metadata.status == ApplicationStatus.ACTIVE else 0.0
+        )
+
+        return [seats_total, seats_used, seats_available, expires, active]
+
+
+_license_collector = LicenseMetricsCollector()
+
+
+def register_license_metrics() -> None:
+    """Register the license metrics collector on the default Prometheus registry.
+
+    Called from the API server lifespan via ``fetch_ee_implementation_or_noop``,
+    so community builds skip it entirely.
+    """
+    try:
+        REGISTRY.register(_license_collector)
+    except ValueError:
+        logger.debug("License metrics collector already registered")

--- a/backend/ee/onyx/server/metrics/license_metrics.py
+++ b/backend/ee/onyx/server/metrics/license_metrics.py
@@ -68,13 +68,19 @@ class LicenseMetricsCollector(_CachedCollector):
         )
         expires.add_metric([], metadata.expires_at.timestamp())
 
+        # Mirror the license-enforcement middleware's two block conditions:
+        # fully-expired (GATED_ACCESS) or seat limit exceeded (used > total).
+        # Status alone never carries SEAT_LIMIT_EXCEEDED, so the seat check is
+        # explicit here.
+        access_blocked = (
+            metadata.status == ApplicationStatus.GATED_ACCESS
+            or used_seats > total_seats
+        )
         active = GaugeMetricFamily(
             "onyx_license_active",
-            "Whether the license is active (1=active, 0=gated/expired)",
+            "License access status (1=ok, 0=blocked: expired/gated or seat limit exceeded)",
         )
-        active.add_metric(
-            [], 0.0 if metadata.status == ApplicationStatus.GATED_ACCESS else 1.0
-        )
+        active.add_metric([], 0.0 if access_blocked else 1.0)
 
         return [seats_total, seats_used, seats_available, expires, active]
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -347,7 +347,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
 
     # Self-hosted license seat + expiry gauges on /metrics (EE-only, no-op on CE)
     fetch_ee_implementation_or_noop(
-        "ee.onyx.server.metrics.license_metrics", "register_license_metrics"
+        "onyx.server.metrics.license_metrics", "register_license_metrics"
     )()
 
     verify_auth = fetch_versioned_implementation(

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -162,6 +162,7 @@ from onyx.utils.middleware import add_onyx_request_id_middleware
 from onyx.utils.telemetry import get_or_generate_uuid
 from onyx.utils.telemetry import optional_telemetry
 from onyx.utils.telemetry import RecordType
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from onyx.utils.variable_functionality import global_version
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
@@ -343,6 +344,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
             "readonly": SqlEngine.get_readonly_engine(),
         },
     )
+
+    # Self-hosted license seat + expiry gauges on /metrics (EE-only, no-op on CE)
+    fetch_ee_implementation_or_noop(
+        "ee.onyx.server.metrics.license_metrics", "register_license_metrics"
+    )()
 
     verify_auth = fetch_versioned_implementation(
         "onyx.auth.users", "verify_auth_setting"

--- a/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
+++ b/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
@@ -50,6 +50,25 @@ class TestLicenseMetricsCollector:
         )
         assert values["onyx_license_active"] == 1.0
 
+    def test_active_one_during_grace_period(self) -> None:
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with (
+            patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", False),
+            patch("ee.onyx.server.metrics.license_metrics.get_session_with_tenant"),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_license_metadata",
+                return_value=_metadata(10, ApplicationStatus.GRACE_PERIOD),
+            ),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_used_seats",
+                return_value=9,
+            ),
+        ):
+            values = _values(collector.collect())
+
+        assert values["onyx_license_active"] == 1.0
+        assert values["onyx_license_seats_available"] == 1
+
     def test_active_zero_when_gated(self) -> None:
         collector = LicenseMetricsCollector(cache_ttl=0)
         with (

--- a/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
+++ b/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
@@ -1,0 +1,87 @@
+"""Tests for the self-hosted license Prometheus collector."""
+
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from prometheus_client.core import GaugeMetricFamily
+
+from ee.onyx.server.metrics.license_metrics import LicenseMetricsCollector
+from onyx.server.settings.models import ApplicationStatus
+
+_EXPIRES_AT = datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+
+def _values(families: list[GaugeMetricFamily]) -> dict[str, float]:
+    return {f.name: f.samples[0].value for f in families}
+
+
+def _metadata(seats: int, status: ApplicationStatus) -> MagicMock:
+    metadata = MagicMock()
+    metadata.seats = seats
+    metadata.status = status
+    metadata.expires_at = _EXPIRES_AT
+    return metadata
+
+
+class TestLicenseMetricsCollector:
+    def test_emits_seat_and_expiry_gauges(self) -> None:
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with (
+            patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", False),
+            patch("ee.onyx.server.metrics.license_metrics.get_session_with_tenant"),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_license_metadata",
+                return_value=_metadata(10, ApplicationStatus.ACTIVE),
+            ),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_used_seats",
+                return_value=7,
+            ),
+        ):
+            values = _values(collector.collect())
+
+        assert values["onyx_license_seats_total"] == 10
+        assert values["onyx_license_seats_used"] == 7
+        assert values["onyx_license_seats_available"] == 3
+        assert values["onyx_license_expires_timestamp_seconds"] == (
+            _EXPIRES_AT.timestamp()
+        )
+        assert values["onyx_license_active"] == 1.0
+
+    def test_active_zero_when_gated(self) -> None:
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with (
+            patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", False),
+            patch("ee.onyx.server.metrics.license_metrics.get_session_with_tenant"),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_license_metadata",
+                return_value=_metadata(5, ApplicationStatus.GATED_ACCESS),
+            ),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_used_seats",
+                return_value=5,
+            ),
+        ):
+            values = _values(collector.collect())
+
+        assert values["onyx_license_active"] == 0.0
+        assert values["onyx_license_seats_available"] == 0
+
+    def test_empty_when_multi_tenant(self) -> None:
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", True):
+            assert collector.collect() == []
+
+    def test_empty_when_no_license(self) -> None:
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with (
+            patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", False),
+            patch("ee.onyx.server.metrics.license_metrics.get_session_with_tenant"),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_license_metadata",
+                return_value=None,
+            ),
+        ):
+            assert collector.collect() == []

--- a/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
+++ b/backend/tests/unit/ee/onyx/server/metrics/test_license_metrics.py
@@ -88,6 +88,27 @@ class TestLicenseMetricsCollector:
         assert values["onyx_license_active"] == 0.0
         assert values["onyx_license_seats_available"] == 0
 
+    def test_active_zero_when_seat_limit_exceeded(self) -> None:
+        # ACTIVE license but used > seats — the enforcement middleware 402-blocks
+        # this, so active must read 0 even though status is not GATED_ACCESS.
+        collector = LicenseMetricsCollector(cache_ttl=0)
+        with (
+            patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", False),
+            patch("ee.onyx.server.metrics.license_metrics.get_session_with_tenant"),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_license_metadata",
+                return_value=_metadata(5, ApplicationStatus.ACTIVE),
+            ),
+            patch(
+                "ee.onyx.server.metrics.license_metrics.get_used_seats",
+                return_value=8,
+            ),
+        ):
+            values = _values(collector.collect())
+
+        assert values["onyx_license_active"] == 0.0
+        assert values["onyx_license_seats_available"] == 0
+
     def test_empty_when_multi_tenant(self) -> None:
         collector = LicenseMetricsCollector(cache_ttl=0)
         with patch("ee.onyx.server.metrics.license_metrics.MULTI_TENANT", True):


### PR DESCRIPTION
## Description

Exposes self-hosted license seat utilization and expiry as Prometheus gauges on the API server `/metrics`, so operators can configure their own seat-exhaustion and expiry alerts (the original ask: notify when down to X seats left).

**Metrics** (self-hosted only — no-op on cloud + CE):
- `onyx_license_seats_total`
- `onyx_license_seats_used`
- `onyx_license_seats_available`
- `onyx_license_expires_timestamp_seconds`
- `onyx_license_active` — 0 when access is blocked, mirroring the license-enforcement middleware: `GATED_ACCESS` (expired past grace) **or** `used_seats > seats` (seat limit exceeded → 402)

**Design:**
- `LicenseMetricsCollector` reuses the `_CachedCollector` scrape-time pattern + existing `get_license_metadata`/`get_used_seats` helpers.
- Guarded by `MULTI_TENANT` — cloud uses Stripe subscriptions, not licenses; never mixed.
- No license installed → empty series (not zeros), so unlicensed instances don't false-alert.
- `seats_available` clamps at 0 to match the existing `SeatUsageResponse` API; overage is derivable from used/total.
- Registered from `main.py` lifespan via `fetch_ee_implementation_or_noop` (CE no-ops).

**Example alerts:** `onyx_license_seats_available <= 2`, `(onyx_license_expires_timestamp_seconds - time()) < 14*86400`, `onyx_license_active == 0`.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check