### PR TITLE
chore(helm): Bump harts to 0.5.13 w/ code interpreter 0.4.2

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 5.4.0
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
-  version: 0.3.3
-digest: sha256:86cd0edb99537f835dc3ca7841268d407428eae0b8309bae1eb33056dc07ac23
-generated: "2026-05-19T11:44:45.454116-07:00"
+  version: 0.4.2
+digest: sha256:582be82967d30c1f095f51264d63eaae77b9dc6a6f380db881bda9476366a6b6
+generated: "2026-05-28T12:24:39.943866-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.12
+version: 0.5.13
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,10 +17,11 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Inject `extraEnvFromSecret` into the `sandbox-proxy`
-        Deployment so the proxy receives credentials (e.g.
-        `ENCRYPTION_KEY_SECRET`) from the same Secret as the api_server,
-        enabling it to decrypt DB columns for egress credential injection.
+      description: Bump the `code-interpreter` subchart from 0.3.3 to 0.4.2,
+        which makes the executor egress lockdown configurable
+        (`kubernetesExecutor.netAdminLockdown`) and adds an always-applied
+        deny-all egress NetworkPolicy for executor/session pods running
+        untrusted code.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0
@@ -50,6 +51,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.3.3
+    version: 0.4.2
     repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description
Bumps the helm version to 0.5.13 while bumping code-interpreter to 0.4.2 such that it gets the new chart.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Helm `onyx` chart to 0.5.13, pulling in `code-interpreter` 0.4.2 for stronger egress controls on untrusted execution.

- New Features
  - Add `kubernetesExecutor.netAdminLockdown` flag to control executor egress lockdown.
  - Always apply a deny-all egress NetworkPolicy to executor/session pods running untrusted code.

- Dependencies
  - Bump `onyx` chart version to 0.5.13.
  - Bump `code-interpreter` subchart from 0.3.3 to 0.4.2.

<sup>Written for commit f52ae43136bb51359c31635999b695caffc28bda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11496?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

