### PR TITLE
chore(devcontainer): upgrade CC w/ Opus 4.8 release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:7e52868187d1aa4eb2f6e2df3d2f1d6f7fa355066a556d9116df157cdb08bf99",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:e074b2b92d6af9ae818fe76c2f7b2030b70135607a900eac908ba3dbf7397a4e",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:e074b2b92d6af9ae818fe76c2f7b2030b70135607a900eac908ba3dbf7397a4e",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:0cc5c815b430c0463cff047b8ecbc66eb7ed54abfaf19295f4cafa80a1367905",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -2,6 +2,11 @@ name: Release Devcontainer
 
 on:
   workflow_dispatch:
+    inputs:
+      no_cache:
+        description: "Disable build cache"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -54,6 +59,7 @@ jobs:
         uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7
         with:
           targets: devcontainer
+          no-cache: ${{ inputs.no_cache }}
           set: |
             devcontainer.platform=linux/amd64
             devcontainer.tags=
@@ -113,6 +119,7 @@ jobs:
         uses: docker/bake-action@82490499d2e5613fcead7e128237ef0b0ea210f7
         with:
           targets: devcontainer
+          no-cache: ${{ inputs.no_cache }}
           set: |
             devcontainer.platform=linux/arm64
             devcontainer.tags=


### PR DESCRIPTION
## Description

Upgrades the devcontainer and Claude Code to a version which supports Opus 4.8

## How Has This Been Tested?

```
ods dev rebuild
ods dev exec claude
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the devcontainer image to a build that supports Claude Code with Opus 4.8. Adds a `no_cache` input to the devcontainer release workflow and forwards it to `docker/bake-action` for amd64 and arm64 builds.

<sup>Written for commit 0003f59631ec973f669f4dc7d59fbd41db75044e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11498?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

