### PR TITLE
fix(craft): drop build-mode provider prefix; hide onboarding modal

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -7,8 +7,6 @@ from uuid import UUID
 
 from sqlalchemy import desc
 from sqlalchemy import exists
-from sqlalchemy import select
-from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import MessageType
@@ -19,11 +17,9 @@ from onyx.db.enums import SharingScope
 from onyx.db.models import Artifact
 from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
-from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Sandbox
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
-from onyx.server.manage.llm.models import LLMProviderView
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -554,62 +550,3 @@ def clear_nextjs_ports_for_user(db_session: Session, user_id: UUID) -> int:
     db_session.flush()
     logger.info("Cleared %s nextjs_port allocations for user %s", result, user_id)
     return result
-
-
-def fetch_llm_provider_by_type_for_build_mode(
-    db_session: Session, provider_type: str
-) -> LLMProviderView | None:
-    """Fetch an LLM provider by its provider type (e.g., "anthropic", "openai").
-
-    Resolution priority:
-    1. First try to find a provider named "build-mode-{type}" (e.g., "build-mode-anthropic")
-    2. If not found, fall back to any provider that matches the type
-
-    Args:
-        db_session: Database session
-        provider_type: The provider type (e.g., "anthropic", "openai", "openrouter")
-
-    Returns:
-        LLMProviderView if found, None otherwise
-    """
-    from onyx.db.llm import fetch_existing_llm_provider
-
-    # First try to find a "build-mode-{type}" provider
-    build_mode_name = f"build-mode-{provider_type}"
-    provider_model = fetch_existing_llm_provider(
-        name=build_mode_name, db_session=db_session
-    )
-
-    # If not found, fall back to any provider that matches the type
-    if not provider_model:
-        provider_model = db_session.scalar(
-            select(LLMProviderModel)
-            .where(LLMProviderModel.provider == provider_type)
-            .options(
-                selectinload(LLMProviderModel.model_configurations),
-                selectinload(LLMProviderModel.groups),
-                selectinload(LLMProviderModel.personas),
-            )
-        )
-
-    if not provider_model:
-        return None
-    return LLMProviderView.from_model(provider_model)
-
-
-def fetch_all_build_mode_llm_providers(
-    db_session: Session,
-) -> list[LLMProviderView]:
-    """Every ``build-mode-*`` LLM provider configured for this tenant."""
-    provider_models = list(
-        db_session.scalars(
-            select(LLMProviderModel)
-            .where(LLMProviderModel.name.like("build-mode-%"))
-            .options(
-                selectinload(LLMProviderModel.model_configurations),
-                selectinload(LLMProviderModel.groups),
-                selectinload(LLMProviderModel.personas),
-            )
-        )
-    )
-    return [LLMProviderView.from_model(p) for p in provider_models]

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -32,6 +32,7 @@ from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SessionOrigin
 from onyx.db.llm import fetch_default_llm_model
+from onyx.db.llm import fetch_existing_llm_providers
 from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
@@ -60,12 +61,6 @@ from onyx.server.features.build.db.build_session import allocate_nextjs_port
 from onyx.server.features.build.db.build_session import create_build_session__no_commit
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import delete_build_session__no_commit
-from onyx.server.features.build.db.build_session import (
-    fetch_all_build_mode_llm_providers,
-)
-from onyx.server.features.build.db.build_session import (
-    fetch_llm_provider_by_type_for_build_mode,
-)
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import get_empty_session_for_user
 from onyx.server.features.build.db.build_session import get_session_messages
@@ -113,26 +108,32 @@ def get_all_build_mode_llm_configs(
     db_session: DBSession,
     default: LLMProviderConfig,
 ) -> list[LLMProviderConfig]:
-    """``default`` first, then every other ``build-mode-*`` provider with a
+    """``default`` first, then every other configured LLM provider with a
     visible model. Used at sandbox provision time so every configured
     provider is pre-registered in opencode.json and per-prompt model
     overrides can cross providers without a pod restart.
     """
     configs: list[LLMProviderConfig] = [default]
     seen_providers: set[str] = {default.provider}
-    for provider in fetch_all_build_mode_llm_providers(db_session):
-        if provider.provider in seen_providers:
+    for provider_model in fetch_existing_llm_providers(db_session, flow_type_filter=[]):
+        if provider_model.provider in seen_providers:
             continue
-        seen_providers.add(provider.provider)
-        visible_models = [m for m in provider.model_configurations if m.is_visible]
+        seen_providers.add(provider_model.provider)
+        visible_models = [
+            m for m in provider_model.model_configurations if m.is_visible
+        ]
         if not visible_models:
             continue
         configs.append(
             LLMProviderConfig(
-                provider=provider.provider,
+                provider=provider_model.provider,
                 model_name=visible_models[0].name,
-                api_key=provider.api_key,
-                api_base=provider.api_base,
+                api_key=(
+                    provider_model.api_key.get_value(apply_mask=False)
+                    if provider_model.api_key
+                    else None
+                ),
+                api_base=provider_model.api_base,
             )
         )
     return configs
@@ -372,19 +373,31 @@ class SessionManager:
             ValueError: If no LLM provider is configured
         """
         if requested_provider_type and requested_model_name:
-            # Look up provider by type (e.g., "anthropic", "openai", "openrouter")
-            provider = fetch_llm_provider_by_type_for_build_mode(
-                self._db_session, requested_provider_type
+            # Find any provider in the DB matching the requested type
+            # (e.g., "anthropic", "openai", "openrouter").
+            provider_model = next(
+                (
+                    p
+                    for p in fetch_existing_llm_providers(
+                        self._db_session, flow_type_filter=[]
+                    )
+                    if p.provider == requested_provider_type
+                ),
+                None,
             )
-            if provider:
+            if provider_model:
                 # Use the requested model directly - the provider's API will
                 # reject invalid models. This allows users to use models that
                 # aren't explicitly configured as "visible" in the admin UI.
                 return LLMProviderConfig(
-                    provider=provider.provider,
+                    provider=provider_model.provider,
                     model_name=requested_model_name,
-                    api_key=provider.api_key,
-                    api_base=provider.api_base,
+                    api_key=(
+                        provider_model.api_key.get_value(apply_mask=False)
+                        if provider_model.api_key
+                        else None
+                    ),
+                    api_base=provider_model.api_base,
                 )
             else:
                 logger.warning(

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -5,10 +5,14 @@ providers baked into ``OPENCODE_CONFIG_CONTENT``. Bugs here surface as
 "Model not found: <provider>/<model>" errors at agent invocation time
 because per-prompt overrides can only target providers that were
 pre-registered when the pod was created.
+
+Build mode is provider-agnostic: any LLM provider in the DB is eligible,
+no naming convention required.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import cast
 from unittest.mock import MagicMock
@@ -24,33 +28,52 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
 from onyx.server.features.build.session.manager import SessionManager
-from onyx.server.manage.llm.models import LLMProviderView
-from onyx.server.manage.llm.models import ModelConfigurationView
 
 
-def _model(name: str, is_visible: bool = True) -> ModelConfigurationView:
-    return ModelConfigurationView(
-        name=name,
-        is_visible=is_visible,
-        supports_image_input=False,
-    )
+@dataclass
+class _FakeModelConfig:
+    name: str
+    is_visible: bool = True
+
+
+class _FakeEncryptedApiKey:
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    def get_value(self, apply_mask: bool = True) -> str | None:  # noqa: ARG002
+        return self._value
+
+    def __bool__(self) -> bool:
+        return self._value is not None
+
+
+@dataclass
+class _FakeProvider:
+    """Stand-in for ``LLMProviderModel`` — only the attributes
+    ``get_all_build_mode_llm_configs`` reads."""
+
+    provider: str
+    model_configurations: list[_FakeModelConfig]
+    api_key: _FakeEncryptedApiKey
+    api_base: str | None = None
+
+
+def _model(name: str, is_visible: bool = True) -> _FakeModelConfig:
+    return _FakeModelConfig(name=name, is_visible=is_visible)
 
 
 def _provider(
     *,
-    name: str,
     provider: str,
-    models: list[ModelConfigurationView],
+    models: list[_FakeModelConfig],
     api_key: str | None = "k",
     api_base: str | None = None,
-) -> LLMProviderView:
-    return LLMProviderView(
-        id=1,
-        name=name,
+) -> _FakeProvider:
+    return _FakeProvider(
         provider=provider,
-        api_key=api_key,
-        api_base=api_base,
         model_configurations=models,
+        api_key=_FakeEncryptedApiKey(api_key),
+        api_base=api_base,
     )
 
 
@@ -62,10 +85,10 @@ _OPENAI_DEFAULT = LLMProviderConfig(
 )
 
 
-def _run(rows: list[LLMProviderView]) -> list[LLMProviderConfig]:
-    """Invoke under a patched ``fetch_all_build_mode_llm_providers``."""
+def _run(rows: list[_FakeProvider]) -> list[LLMProviderConfig]:
+    """Invoke under a patched ``fetch_existing_llm_providers``."""
     with patch(
-        "onyx.server.features.build.session.manager.fetch_all_build_mode_llm_providers",
+        "onyx.server.features.build.session.manager.fetch_existing_llm_providers",
         return_value=rows,
     ):
         # db_session is unused once the fetch is patched.
@@ -84,7 +107,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                     api_key="k-anthropic",
@@ -101,7 +123,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[_model("claude-hidden", is_visible=False)],
                 )
@@ -113,7 +134,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[],
                 )
@@ -125,7 +145,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[
                         _model("claude-opus-4-6"),
@@ -141,7 +160,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[
                         _model("claude-hidden-1", is_visible=False),
@@ -153,12 +171,11 @@ class TestGetAllBuildModeLlmConfigs:
         assert configs[1].model_name == "claude-opus-4-7"
 
     def test_dedupes_when_default_provider_also_in_build_mode_rows(self) -> None:
-        """If the default's provider type is also tagged as build-mode, we
-        keep the default (with its real config) and skip the duplicate."""
+        """If a fetched provider has the same type as the default, we keep
+        the default (with its real config) and skip the duplicate."""
         configs = _run(
             [
                 _provider(
-                    name="build-mode-openai",
                     provider="openai",
                     models=[_model("gpt-4o-mini")],
                     api_key="k-build-openai",
@@ -166,19 +183,17 @@ class TestGetAllBuildModeLlmConfigs:
             ]
         )
         assert configs == [_OPENAI_DEFAULT]
-        # The default's api_key wins; we never overwrite with the build-mode row's.
+        # The default's api_key wins; we never overwrite with the fetched row's.
         assert configs[0].api_key == "k-openai"
 
     def test_multiple_distinct_build_mode_providers(self) -> None:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                 ),
                 _provider(
-                    name="build-mode-google",
                     provider="google",
                     models=[_model("gemini-2.5-pro")],
                 ),
@@ -195,7 +210,6 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                 )

--- a/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
+++ b/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { createContext, useContext } from "react";
-import { useRouter } from "next/navigation";
+// import { useRouter } from "next/navigation";
 import { useOnboardingModal } from "@/app/craft/onboarding/hooks/useOnboardingModal";
-import BuildOnboardingModal from "@/app/craft/onboarding/components/BuildOnboardingModal";
-import NoLlmProvidersModal from "@/app/craft/onboarding/components/NoLlmProvidersModal";
+// import BuildOnboardingModal from "@/app/craft/onboarding/components/BuildOnboardingModal";
+// import NoLlmProvidersModal from "@/app/craft/onboarding/components/NoLlmProvidersModal";
 import { OnboardingModalController } from "@/app/craft/onboarding/types";
 import { useUser } from "@/providers/UserProvider";
 
@@ -28,7 +28,7 @@ interface BuildOnboardingProviderProps {
 export function BuildOnboardingProvider({
   children,
 }: BuildOnboardingProviderProps) {
-  const router = useRouter();
+  // const router = useRouter();
   const { user } = useUser();
   const controller = useOnboardingModal();
 
@@ -41,20 +41,23 @@ export function BuildOnboardingProvider({
     );
   }
 
-  // Non-admin users with no LLM providers cannot use Craft
-  // Don't show modal while loading to prevent flash
-  const showNoProvidersModal =
-    !controller.isLoading && !controller.isAdmin && !controller.hasAnyProvider;
+  // ONBOARDING MODAL TEMPORARILY DISABLED.
+  // The unified onboarding modal (initial-onboarding, edit-user-info, add-llm)
+  // and the no-providers gate are disabled while we re-think the flow.
+  // Uncomment the block below to restore them.
+  //
+  // // Non-admin users with no LLM providers cannot use Craft
+  // // Don't show modal while loading to prevent flash
+  // const showNoProvidersModal =
+  //   !controller.isLoading && !controller.isAdmin && !controller.hasAnyProvider;
 
   return (
     <OnboardingContext.Provider value={controller}>
-      {/* Block non-admin users when no LLM providers are configured */}
-      <NoLlmProvidersModal
+      {/* Onboarding modal renders are disabled — see comment above. */}
+      {/* <NoLlmProvidersModal
         open={showNoProvidersModal}
         onClose={() => router.push("/app")}
       />
-
-      {/* Unified onboarding modal - only show if not blocked by no providers */}
       {!showNoProvidersModal && (
         <BuildOnboardingModal
           mode={controller.mode}
@@ -68,7 +71,7 @@ export function BuildOnboardingProvider({
           onLlmComplete={controller.completeLlmSetup}
           onClose={controller.close}
         />
-      )}
+      )} */}
 
       {/* Build content - always rendered, modals overlay it */}
       {children}

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -106,6 +106,7 @@ export default function BuildOnboardingModal({
   initialValues,
   isAdmin,
   hasUserInfo,
+  allProvidersConfigured: _allProvidersConfigured,
   hasAnyProvider,
   onComplete,
   onLlmComplete,
@@ -218,7 +219,7 @@ export default function BuildOnboardingModal({
     setConnectionStatus("testing");
     setErrorMessage("");
 
-    const providerName = `build-mode-${currentProviderConfig.providerName}`;
+    const providerName = currentProviderConfig.providerName;
     const payload = {
       name: providerName,
       provider: currentProviderConfig.providerName,

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -3,7 +3,7 @@
 // =============================================================================
 
 export interface BuildLlmSelection {
-  providerName: string; // e.g., "build-mode-anthropic" (LLMProviderDescriptor.name)
+  providerName: string; // LLMProviderDescriptor.name
   provider: string; // e.g., "anthropic"
   modelName: string; // e.g., "claude-opus-4-7"
 }
@@ -22,24 +22,15 @@ interface MinimalLlmProvider {
   model_configurations: { name: string; is_visible: boolean }[];
 }
 
-export const BUILD_MODE_PROVIDER_PREFIX = "build-mode-";
-
-// Priority: Anthropic > OpenAI > OpenRouter > first available. Only build-mode providers count.
+// Priority: Anthropic > OpenAI > OpenRouter > first available.
 export function getDefaultLlmSelection(
   llmProviders: MinimalLlmProvider[] | undefined
 ): BuildLlmSelection | null {
   if (!llmProviders || llmProviders.length === 0) return null;
 
-  const buildProviders = llmProviders.filter((p) =>
-    p.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX)
-  );
-  if (buildProviders.length === 0) return null;
-
   // Try each priority provider in order
   for (const { provider, modelName } of LLM_SELECTION_PRIORITY) {
-    const matchingProvider = buildProviders.find(
-      (p) => p.provider === provider
-    );
+    const matchingProvider = llmProviders.find((p) => p.provider === provider);
     if (matchingProvider) {
       return {
         providerName: matchingProvider.name ?? "",
@@ -49,7 +40,7 @@ export function getDefaultLlmSelection(
     }
   }
 
-  const firstProvider = buildProviders[0];
+  const firstProvider = llmProviders[0];
   if (firstProvider) {
     const firstModel = firstProvider.model_configurations.find(
       (m) => m.is_visible

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState, useMemo, useEffect } from "react";
+import { useCallback, useState, useMemo } from "react";
 import { useUser } from "@/providers/UserProvider";
 import { useLLMProviders } from "@/hooks/useLanguageModels";
 import { LLMProviderName } from "@/lib/languageModels/types";
@@ -12,27 +12,21 @@ import {
 import {
   getBuildUserPersona,
   setBuildUserPersona,
-  BUILD_MODE_PROVIDER_PREFIX,
 } from "@/app/craft/onboarding/constants";
 import { updateUserPersonalization } from "@/lib/userSettings";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 
 import type { LLMProviderDescriptor } from "@/lib/languageModels/types";
 
-function isBuildModeProvider(provider: LLMProviderDescriptor): boolean {
-  return !!provider.name?.startsWith(BUILD_MODE_PROVIDER_PREFIX);
-}
-
-// Check if all 3 build mode providers are configured (anthropic, openai, openrouter)
+// Check if all 3 recommended providers (anthropic, openai, openrouter) are
+// configured — any provider matching the type counts.
 function checkAllProvidersConfigured(
   llmProviders: LLMProviderDescriptor[] | undefined
 ): boolean {
   if (!llmProviders || llmProviders.length === 0) {
     return false;
   }
-  const configuredProviders = new Set(
-    llmProviders.filter(isBuildModeProvider).map((p) => p.provider)
-  );
+  const configuredProviders = new Set(llmProviders.map((p) => p.provider));
   return (
     configuredProviders.has(LLMProviderName.ANTHROPIC) &&
     configuredProviders.has(LLMProviderName.OPENAI) &&
@@ -40,11 +34,11 @@ function checkAllProvidersConfigured(
   );
 }
 
-// Check if at least one build-mode provider is configured
+// Check if at least one LLM provider is configured
 function checkHasAnyProvider(
   llmProviders: LLMProviderDescriptor[] | undefined
 ): boolean {
-  return !!llmProviders?.some(isBuildModeProvider);
+  return !!(llmProviders && llmProviders.length > 0);
 }
 
 export function useOnboardingModal(): OnboardingModalController {
@@ -62,7 +56,7 @@ export function useOnboardingModal(): OnboardingModalController {
 
   // Modal mode state
   const [mode, setMode] = useState<OnboardingModalMode>({ type: "closed" });
-  const [hasInitialized, setHasInitialized] = useState(false);
+  // const [hasInitialized, setHasInitialized] = useState(false);
 
   // Compute initial values for the form (read fresh on every render)
   const existingPersona = getBuildUserPersona();
@@ -85,39 +79,41 @@ export function useOnboardingModal(): OnboardingModalController {
     return !!getBuildUserPersona()?.workArea;
   }, [user]);
 
-  // Check if all providers are configured (skip LLM step entirely if so)
+  // Check if all 3 recommended providers are configured.
   const allProvidersConfigured = useMemo(
     () => checkAllProvidersConfigured(llmProviders),
     [llmProviders]
   );
 
-  // Check if at least one provider is configured (allow skipping LLM step)
+  // Check if at least one provider is configured.
   const hasAnyProvider = useMemo(
     () => checkHasAnyProvider(llmProviders),
     [llmProviders]
   );
 
-  // Auto-open initial onboarding modal on first load
-  // Shows if: user info (role) missing OR (admin AND no providers configured)
-  useEffect(() => {
-    if (hasInitialized || isLoadingLlm || !user) return;
-
-    const needsUserInfo = !hasUserInfo;
-    const needsLlmSetup = isAdmin && !hasAnyProvider;
-
-    if (needsUserInfo || needsLlmSetup) {
-      setMode({ type: "initial-onboarding" });
-    }
-
-    setHasInitialized(true);
-  }, [
-    hasInitialized,
-    isLoadingLlm,
-    user,
-    hasUserInfo,
-    isAdmin,
-    hasAnyProvider,
-  ]);
+  // ONBOARDING MODAL TEMPORARILY DISABLED — see BuildOnboardingProvider.
+  // The auto-open effect is commented out so the modal never opens itself.
+  // Uncomment to restore.
+  //
+  // useEffect(() => {
+  //   if (hasInitialized || isLoadingLlm || !user) return;
+  //
+  //   const needsUserInfo = !hasUserInfo;
+  //   const needsLlmSetup = isAdmin && !hasAnyProvider;
+  //
+  //   if (needsUserInfo || needsLlmSetup) {
+  //     setMode({ type: "initial-onboarding" });
+  //   }
+  //
+  //   setHasInitialized(true);
+  // }, [
+  //   hasInitialized,
+  //   isLoadingLlm,
+  //   user,
+  //   hasUserInfo,
+  //   isAdmin,
+  //   hasAnyProvider,
+  // ]);
 
   // Complete user info callback
   const completeUserInfo = useCallback(

--- a/web/src/app/craft/onboarding/types.ts
+++ b/web/src/app/craft/onboarding/types.ts
@@ -41,7 +41,7 @@ export interface OnboardingModalController {
   // State
   isAdmin: boolean;
   hasUserInfo: boolean; // User has completed user-info (workArea set)
-  allProvidersConfigured: boolean; // All 3 providers (anthropic, openai, openrouter) are configured
+  allProvidersConfigured: boolean; // All 3 recommended providers (anthropic, openai, openrouter) are configured
   hasAnyProvider: boolean; // At least 1 provider is configured (allows skipping)
   isLoading: boolean; // True while LLM providers are loading
 


### PR DESCRIPTION
## Description

Two-part fix in response to the bug where users with existing non-build-mode `openai` / `anthropic` / `openrouter` providers were stuck on the onboarding LLM-setup screen (introduced by #11478).

1. **Drop the `build-mode-` provider naming convention.** Craft used to look up LLM providers by a `build-mode-{type}` name and filter `LIKE 'build-mode-%'` at provision time. Any provider matching the requested type is now eligible — Craft is provider-agnostic.
   - Frontend: dropped `BUILD_MODE_PROVIDER_PREFIX`, the prefix filter in `getDefaultLlmSelection`, the prefix when creating providers in `handleConnect`, and the prefix filter in `checkAllProvidersConfigured` / `checkHasAnyProvider`.
   - Backend: deleted `fetch_llm_provider_by_type_for_build_mode` and `fetch_all_build_mode_llm_providers` from `db/build_session.py`. `session/manager.py` now uses the existing `fetch_existing_llm_providers` from `onyx.db.llm` and filters by provider type in Python.

2. **Temporarily hide the onboarding modal.** The initial-onboarding, edit-user-info, add-LLM, and no-providers modals are commented out in `BuildOnboardingProvider` and the auto-open `useEffect` is commented out in `useOnboardingModal`. The hook and component files are otherwise unchanged so uncommenting brings them back.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py` — 10/10 pass.
- `bunx tsc --noEmit` in `web/` — clean.
- `ruff check` and `ty check` on touched backend dirs — clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes users getting stuck on the LLM onboarding screen by removing the `build-mode-` provider naming requirement and making Craft provider-agnostic. Temporarily disables the onboarding modal to unblock usage.

- **Bug Fixes**
  - Dropped `build-mode-` prefix across frontend and backend; any provider matching the requested type is valid.
  - Backend now uses `fetch_existing_llm_providers` and filters by type in Python; removed build-mode-specific fetch helpers.
  - Provider config assembly picks the first visible model per provider and avoids duplicating the default provider; reads decrypted API keys when present.
  - Frontend no longer prefixes provider names when creating providers; `getDefaultLlmSelection` no longer filters by prefix.
  - Onboarding modal and the "no providers" gate are disabled (auto-open removed) to prevent blocking.

<sup>Written for commit 0fee709e3a4a0f1c4e2ad72c110f948994319159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11499?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

