### PR TITLE
ci: run backend unit tests in parallel on 4cpu runner

### DIFF
--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -43,7 +43,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python == 'true'
     # See https://runs-on.com/runners/linux/
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}-backend-check"]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "run-id=${{ github.run_id }}-backend-check"]
     timeout-minutes: 45
 
 
@@ -74,4 +74,4 @@ jobs:
 
     - name: Run Tests
       shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
-      run: py.test -o junit_family=xunit2 -xv --ff backend/tests/unit
+      run: py.test -o junit_family=xunit2 -v --ff --maxfail=1 -n auto backend/tests/unit

--- a/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_license_enforcement.py
@@ -39,7 +39,10 @@ class TestPathAllowlist:
     as the source of truth to ensure tests stay in sync with production code.
     """
 
-    @pytest.mark.parametrize("path", list(LICENSE_ENFORCEMENT_ALLOWED_PREFIXES))
+    # Sorted so the parametrization order is deterministic across pytest-xdist
+    # workers; iterating the frozenset directly varies with per-process hash
+    # randomization, which makes xdist abort on a collection mismatch.
+    @pytest.mark.parametrize("path", sorted(LICENSE_ENFORCEMENT_ALLOWED_PREFIXES))
     def test_allowed_paths_are_allowed(self, path: str) -> None:
         """All paths in LICENSE_ENFORCEMENT_ALLOWED_PREFIXES should be allowed."""
         assert _is_path_allowed(path) is True


### PR DESCRIPTION
## What

The Python unit test workflow (`pr-python-tests.yml`) was running single-threaded — the `py.test` invocation had no `-n` flag, so `pytest-xdist` (already a declared dev dependency) went unused.

This PR:
- Adds `-n auto` so the unit suite runs across multiple workers via `pytest-xdist`.
- Bumps the runner from `2cpu-linux-arm64` to `4cpu-linux-arm64` so the parallelism has cores to actually use.
- Swaps `-x` for `--maxfail=1` — `-x` (stop on first failure) doesn't compose cleanly with xdist, whereas `--maxfail` is honored across workers.

## Why

Faster CI feedback on backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run backend unit tests in parallel with `pytest-xdist` on a `4cpu-linux-arm64` runner to speed up CI; sort a parametrized test for deterministic xdist collection.
Swap `-x` for `--maxfail=1` and enable `-n auto` for correct stop-on-failure across workers.

<sup>Written for commit 6c27dcfae7177e9e222d5e8211e1869ef9361520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11501?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

