### PR TITLE
feat(craft): remove dedicated build-mode provider requirement

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -47,7 +47,6 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
-from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.manager import UploadLimitExceededError
 from onyx.server.features.build.utils import sanitize_filename
@@ -401,7 +400,8 @@ def restore_session(
                 # Fall through to TERMINATED handling below
 
         session_manager = SessionManager(db_session)
-        llm_config = session_manager._get_llm_config(None, None, user)
+        # One access-scoped read → default config + all pre-registered configs.
+        llm_config, all_llm_configs = session_manager.build_llm_configs(user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
             # Mint/look up the PAT before flipping to PROVISIONING so that a
@@ -417,11 +417,6 @@ def restore_session(
             )
             db_session.commit()
 
-            # Pre-register every build-mode provider so per-prompt model
-            # overrides can cross providers without re-provisioning the pod.
-            all_llm_configs = get_all_build_mode_llm_configs(
-                db_session, default=llm_config, user=user
-            )
             sandbox_manager.provision(
                 sandbox_id=sandbox.id,
                 user_id=user.id,

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -141,6 +141,11 @@ def create_session(
         return DetailedSessionResponse.from_session_response(
             base_response, session_loaded_in_sandbox=True
         )
+    except OnyxError:
+        # e.g. no provider exposes a supported model; let the global handler
+        # return its own status code instead of collapsing to 429/500.
+        db_session.rollback()
+        raise
     except ValueError as e:
         logger.exception("Session creation failed")
         db_session.rollback()
@@ -396,7 +401,7 @@ def restore_session(
                 # Fall through to TERMINATED handling below
 
         session_manager = SessionManager(db_session)
-        llm_config = session_manager._get_llm_config(None, None)
+        llm_config = session_manager._get_llm_config(None, None, user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
             # Mint/look up the PAT before flipping to PROVISIONING so that a
@@ -415,7 +420,7 @@ def restore_session(
             # Pre-register every build-mode provider so per-prompt model
             # overrides can cross providers without re-provisioning the pod.
             all_llm_configs = get_all_build_mode_llm_configs(
-                db_session, default=llm_config
+                db_session, default=llm_config, user=user
             )
             sandbox_manager.provision(
                 sandbox_id=sandbox.id,

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -125,6 +125,13 @@ SANDBOX_SERVICE_ACCOUNT_NAME = os.environ.get(
 
 ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 
+# Provider types Onyx Craft can run on (v0), in priority order. A provider is
+# only usable if the requesting user can access it (can_user_access_llm_provider).
+# Keep in sync with BUILD_MODE_PROVIDERS keys in the frontend
+# (web/src/app/craft/onboarding/constants.ts); enforced by
+# test_build_mode_provider_types_sync.py.
+BUILD_MODE_ALLOWED_PROVIDER_TYPES = ["anthropic", "openai", "openrouter"]
+
 # Dev/debug-only: when true, exposes a frontend button + SSE endpoint that
 # tails the user's sandbox pod's opencode-serve container logs. Never
 # enable in prod — the logs include LLM I/O and tool invocations that may

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -132,6 +132,16 @@ ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 # test_build_mode_provider_types_sync.py.
 BUILD_MODE_ALLOWED_PROVIDER_TYPES = ["anthropic", "openai", "openrouter"]
 
+# Recommended (default) Craft model per provider type. Keeps the headless/wake
+# default model consistent with the frontend's interactive default. Keep in sync
+# with the recommended models in BUILD_MODE_PROVIDERS (frontend); enforced by
+# test_build_mode_provider_types_sync.py.
+BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE = {
+    "anthropic": "claude-opus-4-7",
+    "openai": "gpt-5.5",
+    "openrouter": "moonshotai/kimi-k2.6",
+}
+
 # Dev/debug-only: when true, exposes a frontend button + SSE endpoint that
 # tails the user's sandbox pod's opencode-serve container logs. Never
 # enable in prod — the logs include LLM I/O and tool invocations that may

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -578,6 +578,8 @@ def fetch_all_supported_build_llm_providers(
     )
     user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
+    # persona=None: Craft has no persona context, so a provider restricted to
+    # specific personas is intentionally excluded even when otherwise public.
     return [
         LLMProviderView.from_model(p)
         for p in provider_models

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -11,16 +11,21 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
 from onyx.configs.constants import MessageType
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
+from onyx.db.llm import can_user_access_llm_provider
+from onyx.db.llm import fetch_user_group_ids
 from onyx.db.models import Artifact
 from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Sandbox
+from onyx.db.models import User
+from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_END
 from onyx.server.features.build.configs import SANDBOX_NEXTJS_PORT_START
 from onyx.server.manage.llm.models import LLMProviderView
@@ -556,60 +561,27 @@ def clear_nextjs_ports_for_user(db_session: Session, user_id: UUID) -> int:
     return result
 
 
-def fetch_llm_provider_by_type_for_build_mode(
-    db_session: Session, provider_type: str
-) -> LLMProviderView | None:
-    """Fetch an LLM provider by its provider type (e.g., "anthropic", "openai").
-
-    Resolution priority:
-    1. First try to find a provider named "build-mode-{type}" (e.g., "build-mode-anthropic")
-    2. If not found, fall back to any provider that matches the type
-
-    Args:
-        db_session: Database session
-        provider_type: The provider type (e.g., "anthropic", "openai", "openrouter")
-
-    Returns:
-        LLMProviderView if found, None otherwise
-    """
-    from onyx.db.llm import fetch_existing_llm_provider
-
-    # First try to find a "build-mode-{type}" provider
-    build_mode_name = f"build-mode-{provider_type}"
-    provider_model = fetch_existing_llm_provider(
-        name=build_mode_name, db_session=db_session
-    )
-
-    # If not found, fall back to any provider that matches the type
-    if not provider_model:
-        provider_model = db_session.scalar(
-            select(LLMProviderModel)
-            .where(LLMProviderModel.provider == provider_type)
-            .options(
-                selectinload(LLMProviderModel.model_configurations),
-                selectinload(LLMProviderModel.groups),
-                selectinload(LLMProviderModel.personas),
-            )
-        )
-
-    if not provider_model:
-        return None
-    return LLMProviderView.from_model(provider_model)
-
-
-def fetch_all_build_mode_llm_providers(
-    db_session: Session,
+def fetch_all_supported_build_llm_providers(
+    db_session: Session, user: User
 ) -> list[LLMProviderView]:
-    """Every ``build-mode-*`` LLM provider configured for this tenant."""
-    provider_models = list(
-        db_session.scalars(
-            select(LLMProviderModel)
-            .where(LLMProviderModel.name.like("build-mode-%"))
-            .options(
-                selectinload(LLMProviderModel.model_configurations),
-                selectinload(LLMProviderModel.groups),
-                selectinload(LLMProviderModel.personas),
-            )
+    """Every provider of a Craft-supported type (anthropic, openai, openrouter)
+    that the ``user`` can access. Respects is_public / group restrictions so a
+    user never gets a sandbox keyed with a provider they can't use."""
+    provider_models = db_session.scalars(
+        select(LLMProviderModel)
+        .where(LLMProviderModel.provider.in_(BUILD_MODE_ALLOWED_PROVIDER_TYPES))
+        .options(
+            selectinload(LLMProviderModel.model_configurations),
+            selectinload(LLMProviderModel.groups),
+            selectinload(LLMProviderModel.personas),
         )
     )
-    return [LLMProviderView.from_model(p) for p in provider_models]
+    user_group_ids = fetch_user_group_ids(db_session, user)
+    is_admin = user.role == UserRole.ADMIN
+    return [
+        LLMProviderView.from_model(p)
+        for p in provider_models
+        if can_user_access_llm_provider(
+            p, user_group_ids, persona=None, is_admin=is_admin
+        )
+    ]

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -55,6 +55,7 @@ from onyx.server.features.build.api.packets import BuildPacket
 from onyx.server.features.build.api.packets import ErrorPacket
 from onyx.server.features.build.api.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from onyx.server.features.build.configs import BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE
 from onyx.server.features.build.configs import MAX_TOTAL_UPLOAD_SIZE_BYTES
 from onyx.server.features.build.configs import MAX_UPLOAD_FILES_PER_SESSION
 from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
@@ -109,29 +110,41 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 
+def _model_for_provider(provider: LLMProviderView) -> str | None:
+    """The Craft model to register for ``provider``: the type's recommended
+    model when defined, else the first visible model. None if the provider has
+    no usable (visible) model."""
+    visible_models = [m for m in provider.model_configurations if m.is_visible]
+    if not visible_models:
+        return None
+    return BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE.get(
+        provider.provider, visible_models[0].name
+    )
+
+
 def get_all_build_mode_llm_configs(
-    db_session: DBSession,
+    providers: list[LLMProviderView],
     default: LLMProviderConfig,
-    user: User,
 ) -> list[LLMProviderConfig]:
-    """``default`` first, then every other user-accessible supported-type
-    provider with a visible model. Used at sandbox provision time so every
-    configured provider is pre-registered in opencode.json and per-prompt model
-    overrides can cross providers without a pod restart.
+    """``default`` first, then one config per other supported provider type
+    from ``providers`` (an already-fetched, access-filtered list). Used at
+    sandbox provision time so every configured provider is pre-registered in
+    opencode.json and per-prompt model overrides can cross providers without a
+    pod restart.
     """
     configs: list[LLMProviderConfig] = [default]
     seen_providers: set[str] = {default.provider}
-    for provider in fetch_all_supported_build_llm_providers(db_session, user):
+    for provider in providers:
         if provider.provider in seen_providers:
             continue
-        seen_providers.add(provider.provider)
-        visible_models = [m for m in provider.model_configurations if m.is_visible]
-        if not visible_models:
+        model_name = _model_for_provider(provider)
+        if model_name is None:
             continue
+        seen_providers.add(provider.provider)
         configs.append(
             LLMProviderConfig(
                 provider=provider.provider,
-                model_name=visible_models[0].name,
+                model_name=model_name,
                 api_key=provider.api_key,
                 api_base=provider.api_base,
             )
@@ -351,31 +364,54 @@ class SessionManager:
     # LLM Configuration
     # =========================================================================
 
+    def build_llm_configs(
+        self,
+        user: User,
+        requested_provider_type: str | None = None,
+        requested_model_name: str | None = None,
+    ) -> tuple[LLMProviderConfig, list[LLMProviderConfig]]:
+        """Single access-scoped fetch → (default config, all pre-registered
+        configs). ``configs[0]`` is the default. Used at provision time so the
+        default and the cross-provider override list share one DB read.
+
+        Raises:
+            OnyxError: If no accessible supported provider is configured.
+        """
+        providers = fetch_all_supported_build_llm_providers(self._db_session, user)
+        default = self._select_default_llm_config(
+            providers, requested_provider_type, requested_model_name
+        )
+        return default, get_all_build_mode_llm_configs(providers, default)
+
     def _get_llm_config(
         self,
         requested_provider_type: str | None,
         requested_model_name: str | None,
         user: User,
     ) -> LLMProviderConfig:
-        """Get LLM config for sandbox provisioning.
+        """The default Craft LLM config only (see ``build_llm_configs``)."""
+        return self.build_llm_configs(
+            user, requested_provider_type, requested_model_name
+        )[0]
 
-        Resolution priority:
-        1. User's requested provider/model (from cookie), if the type is an
-           accessible supported provider
-        2. Highest-priority accessible supported provider, with its first
-           visible model
+    @staticmethod
+    def _select_default_llm_config(
+        providers: list[LLMProviderView],
+        requested_provider_type: str | None,
+        requested_model_name: str | None,
+    ) -> LLMProviderConfig:
+        """Resolution priority over an already-fetched accessible list:
+        1. The user's requested provider/model (cookie), if the type is present.
+           The model is used verbatim — the provider's API rejects invalid
+           models, so this also allows models not marked "visible".
+        2. Highest-priority supported provider with its recommended model.
 
         Raises:
-            OnyxError: If no accessible supported provider is configured
+            OnyxError: If no accessible supported provider is configured.
         """
-        providers = fetch_all_supported_build_llm_providers(self._db_session, user)
-
         if requested_provider_type and requested_model_name:
             for provider in providers:
                 if provider.provider == requested_provider_type:
-                    # Use the requested model directly - the provider's API
-                    # rejects invalid models, so this also allows models not
-                    # marked "visible" in the admin UI.
                     return LLMProviderConfig(
                         provider=provider.provider,
                         model_name=requested_model_name,
@@ -387,39 +423,25 @@ class SessionManager:
                 requested_provider_type,
             )
 
-        # Fallback (headless provision / sandbox wake): the interactive path
-        # supplies the model via the cookie; here pick the best available.
-        default_config = self._default_build_llm_config(providers)
-        if default_config is None:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                "No accessible LLM provider of a supported type "
-                f"({', '.join(BUILD_MODE_ALLOWED_PROVIDER_TYPES)}) is configured.",
-            )
-        return default_config
-
-    @staticmethod
-    def _default_build_llm_config(
-        providers: list[LLMProviderView],
-    ) -> LLMProviderConfig | None:
-        """Highest-priority supported provider (per BUILD_MODE_ALLOWED_PROVIDER_TYPES)
-        with a visible model, from an already-fetched accessible list."""
         for provider_type in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
             for provider in providers:
                 if provider.provider != provider_type:
                     continue
-                visible_models = [
-                    m for m in provider.model_configurations if m.is_visible
-                ]
-                if not visible_models:
+                model_name = _model_for_provider(provider)
+                if model_name is None:
                     continue
                 return LLMProviderConfig(
                     provider=provider.provider,
-                    model_name=visible_models[0].name,
+                    model_name=model_name,
                     api_key=provider.api_key,
                     api_base=provider.api_base,
                 )
-        return None
+
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "No accessible LLM provider of a supported type "
+            f"({', '.join(BUILD_MODE_ALLOWED_PROVIDER_TYPES)}) is configured.",
+        )
 
     # =========================================================================
     # Session CRUD Operations
@@ -463,20 +485,17 @@ class SessionManager:
         user: User,
         user_id: UUID,
         tenant_id: str,
-        llm_config: LLMProviderConfig,
+        all_llm_configs: list[LLMProviderConfig],
     ) -> None:
-        """Ensure PAT, then provision the pod with every configured
-        provider pre-loaded so per-prompt model overrides can cross
-        providers without a pod restart."""
+        """Ensure PAT, then provision the pod with every configured provider
+        pre-loaded so per-prompt model overrides can cross providers without a
+        pod restart. ``all_llm_configs[0]`` is the default model."""
         onyx_pat = ensure_sandbox_pat(self._db_session, sandbox, user)
-        all_llm_configs = get_all_build_mode_llm_configs(
-            self._db_session, default=llm_config, user=user
-        )
         sandbox_info = self._sandbox_manager.provision(
             sandbox_id=sandbox.id,
             user_id=user_id,
             tenant_id=tenant_id,
-            llm_config=llm_config,
+            llm_config=all_llm_configs[0],
             onyx_pat=onyx_pat,
             all_llm_configs=all_llm_configs,
         )
@@ -564,7 +583,7 @@ class SessionManager:
         if user is None:
             raise ValueError(f"User {user_id} not found")
 
-        llm_config = self._get_llm_config(None, None, user)
+        _, all_llm_configs = self.build_llm_configs(user)
 
         if sandbox is None:
             sandbox = create_sandbox__no_commit(
@@ -584,7 +603,7 @@ class SessionManager:
                 user_id,
             )
 
-        self._provision_sandbox(sandbox, user, user_id, tenant_id, llm_config)
+        self._provision_sandbox(sandbox, user, user_id, tenant_id, all_llm_configs)
         return sandbox
 
     def _wait_for_provisioning_to_complete(
@@ -678,8 +697,10 @@ class SessionManager:
         if not user:
             raise ValueError(f"User {user_id} not found")
 
-        # Get LLM config (uses user's selection or falls back to default)
-        llm_config = self._get_llm_config(llm_provider_type, llm_model_name, user)
+        # Resolve the default + all pre-registered provider configs in one read.
+        llm_config, all_llm_configs = self.build_llm_configs(
+            user, llm_provider_type, llm_model_name
+        )
 
         # Allocate port for this session (per-session port allocation).
         # Both LOCAL and KUBERNETES backends use the same port allocation
@@ -731,7 +752,9 @@ class SessionManager:
                     sandbox_id,
                     user_id,
                 )
-                self._provision_sandbox(sandbox, user, user_id, tenant_id, llm_config)
+                self._provision_sandbox(
+                    sandbox, user, user_id, tenant_id, all_llm_configs
+                )
             elif sandbox.status.is_active():
                 # Verify pod is healthy before reusing (use short timeout for quick check)
                 if not self._sandbox_manager.health_check(sandbox_id, timeout=5.0):
@@ -752,7 +775,7 @@ class SessionManager:
                         "Re-provisioning sandbox %s for user %s", sandbox_id, user_id
                     )
                     self._provision_sandbox(
-                        sandbox, user, user_id, tenant_id, llm_config
+                        sandbox, user, user_id, tenant_id, all_llm_configs
                     )
                 else:
                     logger.info(
@@ -781,7 +804,7 @@ class SessionManager:
                 "Created sandbox record %s for session %s", sandbox_id, session_id
             )
 
-            self._provision_sandbox(sandbox, user, user_id, tenant_id, llm_config)
+            self._provision_sandbox(sandbox, user, user_id, tenant_id, all_llm_configs)
 
         # Set up session workspace within the sandbox
         logger.info(

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -31,12 +31,13 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SessionOrigin
-from onyx.db.llm import fetch_default_llm_model
 from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
 from onyx.db.models import User
 from onyx.db.users import fetch_user_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.factory import get_default_llm
 from onyx.llm.models import LanguageModelInput
@@ -53,6 +54,7 @@ from onyx.server.features.build.api.packets import ApprovalRequestedPacket
 from onyx.server.features.build.api.packets import BuildPacket
 from onyx.server.features.build.api.packets import ErrorPacket
 from onyx.server.features.build.api.rate_limit import get_user_rate_limit_status
+from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
 from onyx.server.features.build.configs import MAX_TOTAL_UPLOAD_SIZE_BYTES
 from onyx.server.features.build.configs import MAX_UPLOAD_FILES_PER_SESSION
 from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
@@ -61,10 +63,7 @@ from onyx.server.features.build.db.build_session import create_build_session__no
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import delete_build_session__no_commit
 from onyx.server.features.build.db.build_session import (
-    fetch_all_build_mode_llm_providers,
-)
-from onyx.server.features.build.db.build_session import (
-    fetch_llm_provider_by_type_for_build_mode,
+    fetch_all_supported_build_llm_providers,
 )
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import get_empty_session_for_user
@@ -96,6 +95,7 @@ from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.prompts import BUILD_NAMING_SYSTEM_PROMPT
 from onyx.server.features.build.session.prompts import BUILD_NAMING_USER_PROMPT
+from onyx.server.manage.llm.models import LLMProviderView
 from onyx.skills.push import build_user_skills_payload
 from onyx.skills.push import hydrate_sandbox_skills
 from onyx.tracing.flows import LLMFlow
@@ -112,15 +112,16 @@ logger = setup_logger()
 def get_all_build_mode_llm_configs(
     db_session: DBSession,
     default: LLMProviderConfig,
+    user: User,
 ) -> list[LLMProviderConfig]:
-    """``default`` first, then every other ``build-mode-*`` provider with a
-    visible model. Used at sandbox provision time so every configured
-    provider is pre-registered in opencode.json and per-prompt model
+    """``default`` first, then every other user-accessible supported-type
+    provider with a visible model. Used at sandbox provision time so every
+    configured provider is pre-registered in opencode.json and per-prompt model
     overrides can cross providers without a pod restart.
     """
     configs: list[LLMProviderConfig] = [default]
     seen_providers: set[str] = {default.provider}
-    for provider in fetch_all_build_mode_llm_providers(db_session):
+    for provider in fetch_all_supported_build_llm_providers(db_session, user):
         if provider.provider in seen_providers:
             continue
         seen_providers.add(provider.provider)
@@ -354,59 +355,71 @@ class SessionManager:
         self,
         requested_provider_type: str | None,
         requested_model_name: str | None,
+        user: User,
     ) -> LLMProviderConfig:
         """Get LLM config for sandbox provisioning.
 
         Resolution priority:
-        1. User's requested provider/model (from cookie)
-        2. System default provider
-
-        Args:
-            requested_provider_type: Provider type from user's cookie (e.g., "anthropic", "openai")
-            requested_model_name: Model name from user's cookie (e.g., "claude-opus-4-5")
-
-        Returns:
-            LLMProviderConfig for sandbox provisioning
+        1. User's requested provider/model (from cookie), if the type is an
+           accessible supported provider
+        2. Highest-priority accessible supported provider, with its first
+           visible model
 
         Raises:
-            ValueError: If no LLM provider is configured
+            OnyxError: If no accessible supported provider is configured
         """
+        providers = fetch_all_supported_build_llm_providers(self._db_session, user)
+
         if requested_provider_type and requested_model_name:
-            # Look up provider by type (e.g., "anthropic", "openai", "openrouter")
-            provider = fetch_llm_provider_by_type_for_build_mode(
-                self._db_session, requested_provider_type
+            for provider in providers:
+                if provider.provider == requested_provider_type:
+                    # Use the requested model directly - the provider's API
+                    # rejects invalid models, so this also allows models not
+                    # marked "visible" in the admin UI.
+                    return LLMProviderConfig(
+                        provider=provider.provider,
+                        model_name=requested_model_name,
+                        api_key=provider.api_key,
+                        api_base=provider.api_base,
+                    )
+            logger.warning(
+                "Requested provider type %s not accessible, falling back",
+                requested_provider_type,
             )
-            if provider:
-                # Use the requested model directly - the provider's API will
-                # reject invalid models. This allows users to use models that
-                # aren't explicitly configured as "visible" in the admin UI.
+
+        # Fallback (headless provision / sandbox wake): the interactive path
+        # supplies the model via the cookie; here pick the best available.
+        default_config = self._default_build_llm_config(providers)
+        if default_config is None:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "No accessible LLM provider of a supported type "
+                f"({', '.join(BUILD_MODE_ALLOWED_PROVIDER_TYPES)}) is configured.",
+            )
+        return default_config
+
+    @staticmethod
+    def _default_build_llm_config(
+        providers: list[LLMProviderView],
+    ) -> LLMProviderConfig | None:
+        """Highest-priority supported provider (per BUILD_MODE_ALLOWED_PROVIDER_TYPES)
+        with a visible model, from an already-fetched accessible list."""
+        for provider_type in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
+            for provider in providers:
+                if provider.provider != provider_type:
+                    continue
+                visible_models = [
+                    m for m in provider.model_configurations if m.is_visible
+                ]
+                if not visible_models:
+                    continue
                 return LLMProviderConfig(
                     provider=provider.provider,
-                    model_name=requested_model_name,
+                    model_name=visible_models[0].name,
                     api_key=provider.api_key,
                     api_base=provider.api_base,
                 )
-            else:
-                logger.warning(
-                    "Requested provider type %s not found, falling back to default",
-                    requested_provider_type,
-                )
-
-        # Fallback to system default
-        default_model = fetch_default_llm_model(self._db_session)
-        if not default_model:
-            raise ValueError("No default LLM model found")
-
-        return LLMProviderConfig(
-            provider=default_model.llm_provider.provider,
-            model_name=default_model.name,
-            api_key=(
-                default_model.llm_provider.api_key.get_value(apply_mask=False)
-                if default_model.llm_provider.api_key
-                else None
-            ),
-            api_base=default_model.llm_provider.api_base,
-        )
+        return None
 
     # =========================================================================
     # Session CRUD Operations
@@ -457,7 +470,7 @@ class SessionManager:
         providers without a pod restart."""
         onyx_pat = ensure_sandbox_pat(self._db_session, sandbox, user)
         all_llm_configs = get_all_build_mode_llm_configs(
-            self._db_session, default=llm_config
+            self._db_session, default=llm_config, user=user
         )
         sandbox_info = self._sandbox_manager.provision(
             sandbox_id=sandbox.id,
@@ -551,7 +564,7 @@ class SessionManager:
         if user is None:
             raise ValueError(f"User {user_id} not found")
 
-        llm_config = self._get_llm_config(None, None)
+        llm_config = self._get_llm_config(None, None, user)
 
         if sandbox is None:
             sandbox = create_sandbox__no_commit(
@@ -660,8 +673,13 @@ class SessionManager:
                     f"Maximum concurrent sandboxes ({SANDBOX_MAX_CONCURRENT_PER_ORG}) reached"
                 )
 
+        # Fetch user early — needed for provider access checks, PAT, AGENTS.md.
+        user = fetch_user_by_id(self._db_session, user_id)
+        if not user:
+            raise ValueError(f"User {user_id} not found")
+
         # Get LLM config (uses user's selection or falls back to default)
-        llm_config = self._get_llm_config(llm_provider_type, llm_model_name)
+        llm_config = self._get_llm_config(llm_provider_type, llm_model_name, user)
 
         # Allocate port for this session (per-session port allocation).
         # Both LOCAL and KUBERNETES backends use the same port allocation
@@ -692,11 +710,6 @@ class SessionManager:
             user_id,
             nextjs_port,
         )
-
-        # Fetch user early — needed for PAT provisioning and AGENTS.md personalization
-        user = fetch_user_by_id(self._db_session, user_id)
-        if not user:
-            raise ValueError(f"User {user_id} not found")
 
         # Check if user already has a sandbox (one sandbox per user model)
         existing_sandbox = get_sandbox_by_user_id(self._db_session, user_id)

--- a/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
@@ -1,0 +1,77 @@
+"""Permission scoping for Craft provider selection (real DB).
+
+``fetch_all_supported_build_llm_providers`` must respect LLM-provider access
+control (is_public / group membership) so a user never gets a sandbox keyed
+with a provider's API key they aren't entitled to use.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import upsert_llm_provider
+from onyx.db.models import User
+from onyx.db.models import UserRole
+from onyx.server.features.build.db.build_session import (
+    fetch_all_supported_build_llm_providers,
+)
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from tests.external_dependency_unit.craft._test_helpers import add_user_to_group
+from tests.external_dependency_unit.craft._test_helpers import make_group
+from tests.external_dependency_unit.craft._test_helpers import make_user
+
+
+def _make_group_restricted_anthropic_provider(
+    db_session: Session, group_id: int
+) -> int:
+    provider = upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=f"craft-access-test-{uuid4().hex[:8]}",
+            provider="anthropic",
+            api_key="sk-ant-not-used",
+            api_key_changed=True,
+            is_public=False,
+            groups=[group_id],
+            model_configurations=[
+                ModelConfigurationUpsertRequest(name="claude-opus-4-7", is_visible=True)
+            ],
+        ),
+        db_session=db_session,
+    )
+    db_session.commit()
+    return provider.id
+
+
+def _has_provider(db_session: Session, user: User, provider_id: int) -> bool:
+    return any(
+        view.id == provider_id
+        for view in fetch_all_supported_build_llm_providers(db_session, user)
+    )
+
+
+def test_group_restricted_provider_scoped_by_membership(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    group = make_group(db_session)
+    member = make_user(db_session)
+    add_user_to_group(db_session, member, group)
+    non_member = make_user(db_session)
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    db_session.commit()
+
+    provider_id = _make_group_restricted_anthropic_provider(db_session, group.id)
+    try:
+        # Group member and admin (admins bypass group restrictions) can use it.
+        assert _has_provider(db_session, member, provider_id)
+        assert _has_provider(db_session, admin, provider_id)
+        # A non-member must NOT get it — otherwise their sandbox would be keyed
+        # with a provider they can't access.
+        assert not _has_provider(db_session, non_member, provider_id)
+    finally:
+        remove_llm_provider(db_session, provider_id)
+        db_session.commit()

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -68,7 +68,7 @@ class TestProvisionTransitions:
             user=test_user,
             user_id=test_user.id,
             tenant_id=TEST_TENANT_ID,
-            llm_config=default_llm_config(),
+            all_llm_configs=[default_llm_config()],
         )
         db_session.commit()
         db_session.refresh(sandbox)
@@ -100,7 +100,7 @@ class TestProvisionFailureRollback:
                 user=test_user,
                 user_id=test_user.id,
                 tenant_id=TEST_TENANT_ID,
-                llm_config=default_llm_config(),
+                all_llm_configs=[default_llm_config()],
             )
 
         # The endpoint's exception handler rolls back. Simulate that here.

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -65,17 +65,8 @@ _OPENAI_DEFAULT = LLMProviderConfig(
 
 
 def _run(rows: list[LLMProviderView]) -> list[LLMProviderConfig]:
-    """Invoke under a patched ``fetch_all_supported_build_llm_providers``."""
-    with patch(
-        "onyx.server.features.build.session.manager.fetch_all_supported_build_llm_providers",
-        return_value=rows,
-    ):
-        # db_session/user are unused once the fetch is patched.
-        return get_all_build_mode_llm_configs(
-            db_session=cast(Session, None),
-            default=_OPENAI_DEFAULT,
-            user=cast(User, MagicMock()),
-        )
+    """``get_all_build_mode_llm_configs`` is pure over an already-fetched list."""
+    return get_all_build_mode_llm_configs(rows, _OPENAI_DEFAULT)
 
 
 class TestGetAllBuildModeLlmConfigs:
@@ -124,7 +115,8 @@ class TestGetAllBuildModeLlmConfigs:
         )
         assert configs == [_OPENAI_DEFAULT]
 
-    def test_picks_first_visible_model_when_multiple_visible(self) -> None:
+    def test_prefers_recommended_model_over_first_visible(self) -> None:
+        # Anthropic's recommended model wins even though it isn't first in the list.
         configs = _run(
             [
                 _provider(
@@ -138,7 +130,20 @@ class TestGetAllBuildModeLlmConfigs:
                 )
             ]
         )
-        assert configs[1].model_name == "claude-opus-4-6"
+        assert configs[1].model_name == "claude-opus-4-7"
+
+    def test_uses_first_visible_for_type_without_recommended(self) -> None:
+        # A provider type with no recommended-model entry falls back to first visible.
+        configs = _run(
+            [
+                _provider(
+                    name="Google",
+                    provider="google",
+                    models=[_model("gemini-2.5-pro"), _model("gemini-2.5-flash")],
+                )
+            ]
+        )
+        assert configs[1].model_name == "gemini-2.5-pro"
 
     def test_skips_hidden_models_when_picking_first(self) -> None:
         configs = _run(
@@ -361,7 +366,7 @@ class TestSessionManagerProvisionForwardsAllLlmConfigs:
         manager._db_session = cast(Session, MagicMock())  # type: ignore[attr-defined]
         manager._sandbox_manager = sandbox_manager  # type: ignore[attr-defined]
 
-        expected_configs = [
+        all_configs = [
             _OPENAI_DEFAULT,
             LLMProviderConfig(
                 provider="anthropic",
@@ -377,10 +382,6 @@ class TestSessionManagerProvisionForwardsAllLlmConfigs:
                 return_value="pat-token",
             ),
             patch(
-                "onyx.server.features.build.session.manager.get_all_build_mode_llm_configs",
-                return_value=expected_configs,
-            ) as mock_get_all_configs,
-            patch(
                 "onyx.server.features.build.session.manager.update_sandbox_status__no_commit"
             ),
         ):
@@ -389,13 +390,13 @@ class TestSessionManagerProvisionForwardsAllLlmConfigs:
                 user=user,
                 user_id=user_id,
                 tenant_id=tenant_id,
-                llm_config=_OPENAI_DEFAULT,
+                all_llm_configs=all_configs,
             )
 
-        mock_get_all_configs.assert_called_once()
         sandbox_manager.provision.assert_called_once()
         kwargs = sandbox_manager.provision.call_args.kwargs
-        assert kwargs["all_llm_configs"] == expected_configs
+        assert kwargs["all_llm_configs"] == all_configs
+        # default model is the first entry
         assert kwargs["llm_config"] == _OPENAI_DEFAULT
         assert kwargs["sandbox_id"] == sandbox_id
         assert kwargs["onyx_pat"] == "pat-token"

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -9,6 +9,7 @@ pre-registered when the pod was created.
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from datetime import datetime
 from typing import cast
 from unittest.mock import MagicMock
@@ -20,6 +21,7 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
 from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
@@ -63,15 +65,16 @@ _OPENAI_DEFAULT = LLMProviderConfig(
 
 
 def _run(rows: list[LLMProviderView]) -> list[LLMProviderConfig]:
-    """Invoke under a patched ``fetch_all_build_mode_llm_providers``."""
+    """Invoke under a patched ``fetch_all_supported_build_llm_providers``."""
     with patch(
-        "onyx.server.features.build.session.manager.fetch_all_build_mode_llm_providers",
+        "onyx.server.features.build.session.manager.fetch_all_supported_build_llm_providers",
         return_value=rows,
     ):
-        # db_session is unused once the fetch is patched.
+        # db_session/user are unused once the fetch is patched.
         return get_all_build_mode_llm_configs(
             db_session=cast(Session, None),
             default=_OPENAI_DEFAULT,
+            user=cast(User, MagicMock()),
         )
 
 
@@ -84,7 +87,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                     api_key="k-anthropic",
@@ -101,7 +104,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-hidden", is_visible=False)],
                 )
@@ -113,7 +116,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[],
                 )
@@ -125,7 +128,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[
                         _model("claude-opus-4-6"),
@@ -141,7 +144,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[
                         _model("claude-hidden-1", is_visible=False),
@@ -158,7 +161,7 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-openai",
+                    name="OpenAI",
                     provider="openai",
                     models=[_model("gpt-4o-mini")],
                     api_key="k-build-openai",
@@ -173,12 +176,12 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                 ),
                 _provider(
-                    name="build-mode-google",
+                    name="Google",
                     provider="google",
                     models=[_model("gemini-2.5-pro")],
                 ),
@@ -195,13 +198,139 @@ class TestGetAllBuildModeLlmConfigs:
         configs = _run(
             [
                 _provider(
-                    name="build-mode-anthropic",
+                    name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
                 )
             ]
         )
         assert configs[0] == _OPENAI_DEFAULT
+
+
+class TestGetLlmConfigFallback:
+    """``SessionManager._get_llm_config(None, None, user)`` resolves to the
+    highest-priority accessible provider of a supported type (anthropic >
+    openai > openrouter), using that provider's first visible model."""
+
+    @staticmethod
+    def _manager() -> SessionManager:
+        manager = SessionManager.__new__(SessionManager)
+        manager._db_session = cast(Session, MagicMock())  # type: ignore[attr-defined]
+        return manager
+
+    @staticmethod
+    def _user() -> User:
+        return cast(User, MagicMock())
+
+    @staticmethod
+    def _patch_providers(
+        providers: list[LLMProviderView],
+    ) -> AbstractContextManager[MagicMock]:
+        return patch(
+            "onyx.server.features.build.session.manager."
+            "fetch_all_supported_build_llm_providers",
+            return_value=providers,
+        )
+
+    def test_uses_highest_priority_provider_first_visible_model(self) -> None:
+        provider = _provider(
+            name="Anthropic",
+            provider="anthropic",
+            models=[_model("claude-opus-4-7")],
+            api_key="k-anthropic",
+        )
+        with self._patch_providers([provider]):
+            config = self._manager()._get_llm_config(None, None, self._user())
+        assert (config.provider, config.model_name) == (
+            "anthropic",
+            "claude-opus-4-7",
+        )
+        assert config.api_key == "k-anthropic"
+
+    def test_type_priority_anthropic_over_openai(self) -> None:
+        with self._patch_providers(
+            [
+                _provider(name="o", provider="openai", models=[_model("gpt-5.5")]),
+                _provider(
+                    name="a",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-7")],
+                ),
+            ]
+        ):
+            config = self._manager()._get_llm_config(None, None, self._user())
+        assert config.provider == "anthropic"
+
+    def test_ignores_unsupported_provider_type(self) -> None:
+        # An azure provider is not a supported type -> treated as none.
+        with self._patch_providers(
+            [_provider(name="az", provider="azure", models=[_model("gpt-5.5")])]
+        ):
+            try:
+                self._manager()._get_llm_config(None, None, self._user())
+            except OnyxError as e:
+                assert e.status_code == 400
+            else:
+                raise AssertionError("expected OnyxError")
+
+    def test_skips_provider_without_visible_model(self) -> None:
+        with self._patch_providers(
+            [
+                _provider(
+                    name="a",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-7", is_visible=False)],
+                ),
+                _provider(name="o", provider="openai", models=[_model("gpt-5.5")]),
+            ]
+        ):
+            config = self._manager()._get_llm_config(None, None, self._user())
+        assert (config.provider, config.model_name) == ("openai", "gpt-5.5")
+
+    def test_raises_onyx_error_when_no_supported_provider(self) -> None:
+        with self._patch_providers([]):
+            try:
+                self._manager()._get_llm_config(None, None, self._user())
+            except OnyxError as e:
+                assert e.status_code == 400
+            else:
+                raise AssertionError("expected OnyxError")
+
+    def test_requested_provider_and_model_used_verbatim(self) -> None:
+        # The interactive path supplies the model via cookie; honor it as-is
+        # (even a model not marked visible) as long as the type is accessible.
+        provider = _provider(
+            name="Anthropic",
+            provider="anthropic",
+            models=[_model("claude-opus-4-7")],
+            api_key="k-anthropic",
+        )
+        with self._patch_providers([provider]):
+            config = self._manager()._get_llm_config(
+                "anthropic", "claude-sonnet-4-6", self._user()
+            )
+        assert (config.provider, config.model_name) == (
+            "anthropic",
+            "claude-sonnet-4-6",
+        )
+
+    def test_requested_unsupported_type_falls_back(self) -> None:
+        # A stale cookie pointing at a non-supported type is ignored; we fall
+        # back to the highest-priority accessible supported provider.
+        with self._patch_providers(
+            [
+                _provider(
+                    name="a", provider="anthropic", models=[_model("claude-opus-4-7")]
+                )
+            ]
+        ):
+            config = self._manager()._get_llm_config(
+                "azure", "some-azure-model", self._user()
+            )
+        assert (config.provider, config.model_name) == (
+            "anthropic",
+            "claude-opus-4-7",
+        )
 
 
 class TestSessionManagerProvisionForwardsAllLlmConfigs:

--- a/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
+++ b/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
@@ -1,0 +1,33 @@
+"""Guards that the backend Craft-allowed provider types stay in sync with the
+frontend source of truth (``BUILD_MODE_PROVIDERS`` keys in
+``web/src/app/craft/onboarding/constants.ts``). Drift (e.g. adding a type on one
+side only) fails CI instead of silently mismatching onboarding vs. provisioning."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+
+
+def _find_frontend_constants() -> Path:
+    rel = Path("web/src/app/craft/onboarding/constants.ts")
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / rel
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"Could not locate {rel} above {__file__}")
+
+
+def _frontend_provider_keys() -> list[str]:
+    text = _find_frontend_constants().read_text()
+    start = text.index("export const BUILD_MODE_PROVIDERS")
+    end = text.index("\n];", start)
+    # Within BUILD_MODE_PROVIDERS only provider objects carry a `key:` field
+    # (models use `name:`), so this captures provider types in order.
+    return re.findall(r'key:\s*"([^"]+)"', text[start:end])
+
+
+def test_backend_provider_types_match_frontend() -> None:
+    assert _frontend_provider_keys() == BUILD_MODE_ALLOWED_PROVIDER_TYPES

--- a/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
+++ b/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
@@ -9,25 +9,44 @@ import re
 from pathlib import Path
 
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from onyx.server.features.build.configs import BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE
 
 
-def _find_frontend_constants() -> Path:
+def _build_mode_providers_block() -> str:
     rel = Path("web/src/app/craft/onboarding/constants.ts")
     for parent in Path(__file__).resolve().parents:
         candidate = parent / rel
         if candidate.exists():
-            return candidate
+            text = candidate.read_text()
+            start = text.index("export const BUILD_MODE_PROVIDERS")
+            return text[start : text.index("\n];", start)]
     raise FileNotFoundError(f"Could not locate {rel} above {__file__}")
 
 
 def _frontend_provider_keys() -> list[str]:
-    text = _find_frontend_constants().read_text()
-    start = text.index("export const BUILD_MODE_PROVIDERS")
-    end = text.index("\n];", start)
     # Within BUILD_MODE_PROVIDERS only provider objects carry a `key:` field
     # (models use `name:`), so this captures provider types in order.
-    return re.findall(r'key:\s*"([^"]+)"', text[start:end])
+    return re.findall(r'key:\s*"([^"]+)"', _build_mode_providers_block())
+
+
+def _frontend_recommended_by_type() -> dict[str, str]:
+    block = _build_mode_providers_block()
+    result: dict[str, str] = {}
+    # Split into per-provider chunks on `key: "..."`, then within each find the
+    # model object flagged `recommended: true`.
+    for m in re.finditer(r'key:\s*"([^"]+)".*?models:\s*\[(.*?)\]', block, re.DOTALL):
+        key, models_blob = m.group(1), m.group(2)
+        rec = re.search(
+            r'name:\s*"([^"]+)"[^}]*?recommended:\s*true', models_blob, re.DOTALL
+        )
+        if rec:
+            result[key] = rec.group(1)
+    return result
 
 
 def test_backend_provider_types_match_frontend() -> None:
     assert _frontend_provider_keys() == BUILD_MODE_ALLOWED_PROVIDER_TYPES
+
+
+def test_backend_recommended_models_match_frontend() -> None:
+    assert _frontend_recommended_by_type() == BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -119,7 +119,7 @@ export function BuildLLMPopover({
               provider.provider_display_name || provider.provider,
             modelName: model.name,
             displayName: model.display_name || model.name,
-            isRecommended: isRecommendedModel(provider.provider, model.name),
+            isRecommended: isRecommendedModel(model.name),
             isConfigured: true,
           });
         });

--- a/web/src/app/craft/hooks/useBuildLlmSelection.ts
+++ b/web/src/app/craft/hooks/useBuildLlmSelection.ts
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback } from "react";
 import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
   BuildLlmSelection,
+  BUILD_MODE_PROVIDERS,
   getBuildLlmSelection,
   setBuildLlmSelection,
   clearBuildLlmSelection,
@@ -22,14 +23,19 @@ export function useBuildLlmSelection(
     () => getBuildLlmSelection()
   );
 
-  // Validate that a selection is still valid against current providers.
-  // Only checks that the provider exists
+  // A cookie selection is valid only if the provider exists AND its model is
+  // still real — either exposed by the provider or a curated model for the type.
+  // Guards stale cookies pointing at a removed/renamed model (e.g. an old default).
   const isSelectionValid = useCallback(
     (sel: BuildLlmSelection | null): boolean => {
       if (!sel || !llmProviders) return false;
-      return llmProviders.some(
-        (p) => p.provider === sel.provider || p.name === sel.providerName
-      );
+      const provider = llmProviders.find((p) => p.provider === sel.provider);
+      if (!provider) return false;
+      if (provider.model_configurations.some((m) => m.name === sel.modelName)) {
+        return true;
+      }
+      const curated = BUILD_MODE_PROVIDERS.find((p) => p.key === sel.provider);
+      return Boolean(curated?.models.some((m) => m.name === sel.modelName));
     },
     [llmProviders]
   );

--- a/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
+++ b/web/src/app/craft/onboarding/BuildOnboardingProvider.tsx
@@ -41,20 +41,18 @@ export function BuildOnboardingProvider({
     );
   }
 
-  // Non-admin users with no LLM providers cannot use Craft
-  // Don't show modal while loading to prevent flash
+  // Non-admins can't configure providers, so block them when none of the
+  // supported providers is accessible.
   const showNoProvidersModal =
     !controller.isLoading && !controller.isAdmin && !controller.hasAnyProvider;
 
   return (
     <OnboardingContext.Provider value={controller}>
-      {/* Block non-admin users when no LLM providers are configured */}
       <NoLlmProvidersModal
         open={showNoProvidersModal}
         onClose={() => router.push("/app")}
       />
 
-      {/* Unified onboarding modal - only show if not blocked by no providers */}
       {!showNoProvidersModal && (
         <BuildOnboardingModal
           mode={controller.mode}
@@ -62,7 +60,6 @@ export function BuildOnboardingProvider({
           initialValues={controller.initialValues}
           isAdmin={controller.isAdmin}
           hasUserInfo={controller.hasUserInfo}
-          allProvidersConfigured={controller.allProvidersConfigured}
           hasAnyProvider={controller.hasAnyProvider}
           onComplete={controller.completeUserInfo}
           onLlmComplete={controller.completeLlmSetup}
@@ -70,7 +67,6 @@ export function BuildOnboardingProvider({
         />
       )}
 
-      {/* Build content - always rendered, modals overlay it */}
       {children}
     </OnboardingContext.Provider>
   );

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -61,7 +61,6 @@ interface BuildOnboardingModalProps {
   initialValues: InitialValues;
   isAdmin: boolean;
   hasUserInfo: boolean;
-  allProvidersConfigured: boolean;
   hasAnyProvider: boolean;
   onComplete: (info: BuildUserInfo) => Promise<void>;
   onLlmComplete: () => Promise<void>;
@@ -72,15 +71,15 @@ interface BuildOnboardingModalProps {
 function getStepsForMode(
   mode: OnboardingModalMode,
   isAdmin: boolean,
-  allProvidersConfigured: boolean,
+  hasAnyProvider: boolean,
   hasUserInfo: boolean
 ): OnboardingStep[] {
   switch (mode.type) {
     case "initial-onboarding":
-      // Full flow: page1 → llm-setup (if admin + not all configured) → user-info
+      // Full flow: page1 → llm-setup (if admin + no provider yet) → user-info
       const steps: OnboardingStep[] = ["page1"];
 
-      if (isAdmin && !allProvidersConfigured) {
+      if (isAdmin && !hasAnyProvider) {
         steps.push("llm-setup");
       }
 
@@ -107,7 +106,6 @@ export default function BuildOnboardingModal({
   initialValues,
   isAdmin,
   hasUserInfo,
-  allProvidersConfigured,
   hasAnyProvider,
   onComplete,
   onLlmComplete,
@@ -115,8 +113,8 @@ export default function BuildOnboardingModal({
 }: BuildOnboardingModalProps) {
   // Compute steps based on mode
   const steps = useMemo(
-    () => getStepsForMode(mode, isAdmin, allProvidersConfigured, hasUserInfo),
-    [mode, isAdmin, allProvidersConfigured, hasUserInfo]
+    () => getStepsForMode(mode, isAdmin, hasAnyProvider, hasUserInfo),
+    [mode, isAdmin, hasAnyProvider, hasUserInfo]
   );
 
   // Determine initial step based on mode
@@ -220,7 +218,7 @@ export default function BuildOnboardingModal({
     setConnectionStatus("testing");
     setErrorMessage("");
 
-    const providerName = `build-mode-${currentProviderConfig.providerName}`;
+    const providerName = currentProviderConfig.label;
     const payload = {
       name: providerName,
       provider: currentProviderConfig.providerName,

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -258,8 +258,18 @@ export default function BuildOnboardingModal({
       );
 
       if (!response.ok) {
+        // Surface the backend detail (e.g. a name collision) so the user gets
+        // an actionable message instead of a generic failure.
+        const detail = await response
+          .json()
+          .then((b) => (typeof b?.detail === "string" ? b.detail : null))
+          .catch(() => null);
+        const isConflict = response.status === 409 || response.status === 400;
         setErrorMessage(
-          "There was an issue creating the provider. Please try again."
+          detail ??
+            (isConflict
+              ? `A provider named "${providerName}" already exists — remove or rename it in Admin → LLM Providers, then retry.`
+              : "There was an issue creating the provider. Please try again.")
         );
         setConnectionStatus("error");
         return;

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -5,76 +5,14 @@ import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import Text from "@/refresh-components/texts/Text";
 import { Tooltip } from "@opal/components";
+import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
-  LLMProviderName,
-  LLMProviderDescriptor,
-} from "@/lib/languageModels/types";
+  BUILD_MODE_PROVIDERS as PROVIDERS,
+  type ProviderKey,
+} from "@/app/craft/onboarding/constants";
 
-// Provider configurations
-export type ProviderKey = "anthropic" | "openai" | "openrouter";
-
-interface ModelOption {
-  name: string;
-  label: string;
-  recommended?: boolean;
-}
-
-export interface ProviderConfig {
-  key: ProviderKey;
-  label: string;
-  providerName: LLMProviderName;
-  recommended?: boolean;
-  models: ModelOption[];
-  apiKeyPlaceholder: string;
-  apiKeyUrl: string;
-  apiKeyLabel: string;
-}
-
-export const PROVIDERS: ProviderConfig[] = [
-  {
-    key: "anthropic",
-    label: "Anthropic",
-    providerName: LLMProviderName.ANTHROPIC,
-    recommended: true,
-    models: [
-      { name: "claude-opus-4-7", label: "Claude Opus 4.7", recommended: true },
-      { name: "claude-opus-4-6", label: "Claude Opus 4.6" },
-      { name: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-    ],
-    apiKeyPlaceholder: "sk-ant-...",
-    apiKeyUrl: "https://console.anthropic.com/dashboard",
-    apiKeyLabel: "Anthropic Console",
-  },
-  {
-    key: "openai",
-    label: "OpenAI",
-    providerName: LLMProviderName.OPENAI,
-    models: [
-      { name: "gpt-5.2", label: "GPT-5.2", recommended: true },
-      { name: "gpt-5.1", label: "GPT-5.1" },
-    ],
-    apiKeyPlaceholder: "sk-...",
-    apiKeyUrl: "https://platform.openai.com/api-keys",
-    apiKeyLabel: "OpenAI Dashboard",
-  },
-  {
-    key: "openrouter",
-    label: "OpenRouter",
-    providerName: LLMProviderName.OPENROUTER,
-    models: [
-      {
-        name: "moonshotai/kimi-k2-thinking",
-        label: "Kimi K2 Thinking",
-        recommended: true,
-      },
-      { name: "google/gemini-3-pro-preview", label: "Gemini 3 Pro" },
-      { name: "qwen/qwen3-235b-a22b-thinking-2507", label: "Qwen3 235B" },
-    ],
-    apiKeyPlaceholder: "sk-or-...",
-    apiKeyUrl: "https://openrouter.ai/keys",
-    apiKeyLabel: "OpenRouter Dashboard",
-  },
-];
+export { PROVIDERS };
+export type { ProviderKey };
 
 interface SelectableButtonProps {
   selected: boolean;

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -3,128 +3,15 @@
 // =============================================================================
 
 export interface BuildLlmSelection {
-  providerName: string; // e.g., "build-mode-anthropic" (LLMProviderDescriptor.name)
+  providerName: string; // LLMProviderDescriptor.name (any configured provider)
   provider: string; // e.g., "anthropic"
   modelName: string; // e.g., "claude-opus-4-7"
 }
 
-// Priority order for smart default LLM selection
-const LLM_SELECTION_PRIORITY = [
-  { provider: "anthropic", modelName: "claude-opus-4-7" },
-  { provider: "openai", modelName: "gpt-5.5" },
-  { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
-] as const;
+export type ProviderKey = "anthropic" | "openai" | "openrouter";
 
-// Minimal provider interface for selection logic
-interface MinimalLlmProvider {
-  name: string | null;
-  provider: string;
-  model_configurations: { name: string; is_visible: boolean }[];
-}
-
-/**
- * Get the best default LLM selection based on available providers.
- * Priority: Anthropic > OpenAI > OpenRouter > first available
- */
-export function getDefaultLlmSelection(
-  llmProviders: MinimalLlmProvider[] | undefined
-): BuildLlmSelection | null {
-  if (!llmProviders || llmProviders.length === 0) return null;
-
-  // Try each priority provider in order
-  for (const { provider, modelName } of LLM_SELECTION_PRIORITY) {
-    const matchingProvider = llmProviders.find((p) => p.provider === provider);
-    if (matchingProvider) {
-      return {
-        providerName: matchingProvider.name ?? "",
-        provider: matchingProvider.provider,
-        modelName,
-      };
-    }
-  }
-
-  // Fallback: first available provider, use its first visible model
-  const firstProvider = llmProviders[0];
-  if (firstProvider) {
-    const firstModel = firstProvider.model_configurations.find(
-      (m) => m.is_visible
-    );
-    return {
-      providerName: firstProvider.name ?? "",
-      provider: firstProvider.provider,
-      modelName: firstModel?.name ?? "",
-    };
-  }
-
-  return null;
-}
-
-// Recommended models config (for UI display)
-export const RECOMMENDED_BUILD_MODELS = {
-  preferred: {
-    provider: "anthropic",
-    modelName: "claude-opus-4-7",
-    displayName: "Claude Opus 4.7",
-  },
-  alternatives: [
-    { provider: "anthropic", modelName: "claude-opus-4-6" },
-    { provider: "anthropic", modelName: "claude-sonnet-4-6" },
-    { provider: "openai", modelName: "gpt-5.5" },
-    { provider: "openai", modelName: "gpt-5.4" },
-    { provider: "openai", modelName: "gpt-5.3" },
-    { provider: "openrouter", modelName: "minimax/minimax-m2.1" },
-  ],
-} as const;
-
-// Cookie utilities
-const BUILD_LLM_COOKIE_KEY = "build_llm_selection";
-
-export function getBuildLlmSelection(): BuildLlmSelection | null {
-  if (typeof document === "undefined") return null;
-  const cookie = document.cookie
-    .split("; ")
-    .find((row) => row.startsWith(`${BUILD_LLM_COOKIE_KEY}=`));
-  if (!cookie) return null;
-  try {
-    const value = cookie.split("=")[1];
-    if (!value) return null;
-    return JSON.parse(decodeURIComponent(value));
-  } catch {
-    return null;
-  }
-}
-
-export function setBuildLlmSelection(selection: BuildLlmSelection): void {
-  if (typeof document === "undefined") return;
-  const value = encodeURIComponent(JSON.stringify(selection));
-  // Cookie expires in 1 year
-  const expires = new Date(
-    Date.now() + 365 * 24 * 60 * 60 * 1000
-  ).toUTCString();
-  document.cookie = `${BUILD_LLM_COOKIE_KEY}=${value}; path=/; expires=${expires}; SameSite=Lax`;
-}
-
-export function clearBuildLlmSelection(): void {
-  if (typeof document === "undefined") return;
-  document.cookie = `${BUILD_LLM_COOKIE_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
-}
-
-export function isRecommendedModel(
-  provider: string,
-  modelName: string
-): boolean {
-  const { preferred, alternatives } = RECOMMENDED_BUILD_MODELS;
-  // Exact match for preferred model
-  if (preferred.provider === provider && modelName === preferred.modelName) {
-    return true;
-  }
-  // Exact match for alternatives
-  return alternatives.some(
-    (alt) => alt.provider === provider && modelName === alt.modelName
-  );
-}
-
-// Curated providers for Build mode (shared between BuildOnboardingModal and BuildLLMPopover)
+// Single source of truth for Craft providers/models; everything below derives
+// from it (allowed types, recommended flags, default selection).
 export interface BuildModeModel {
   name: string;
   label: string;
@@ -132,7 +19,7 @@ export interface BuildModeModel {
 }
 
 export interface BuildModeProvider {
-  key: string;
+  key: ProviderKey;
   label: string;
   providerName: string;
   recommended?: boolean;
@@ -177,8 +64,8 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     providerName: "openrouter",
     models: [
       {
-        name: "minimax/minimax-m2.1",
-        label: "MiniMax M2.1",
+        name: "moonshotai/kimi-k2.6",
+        label: "Kimi K2.6",
         recommended: true,
       },
     ],
@@ -187,6 +74,88 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     apiKeyLabel: "OpenRouter Dashboard",
   },
 ];
+
+// Allowed provider types are just the curated providers' keys. Keep
+// BUILD_MODE_PROVIDERS in sync with the backend BUILD_MODE_ALLOWED_PROVIDER_TYPES
+// (enforced by test_build_mode_provider_types_sync.py).
+const ALLOWED_PROVIDER_TYPES = new Set<string>(
+  BUILD_MODE_PROVIDERS.map((p) => p.key)
+);
+const RECOMMENDED_MODEL_NAMES = new Set(
+  BUILD_MODE_PROVIDERS.flatMap((p) =>
+    p.models.filter((m) => m.recommended).map((m) => m.name)
+  )
+);
+
+interface MinimalLlmProvider {
+  name: string | null;
+  provider: string;
+}
+
+export function isSupportedProviderType(provider: string): boolean {
+  return ALLOWED_PROVIDER_TYPES.has(provider);
+}
+
+export function isRecommendedModel(modelName: string): boolean {
+  return RECOMMENDED_MODEL_NAMES.has(modelName);
+}
+
+function defaultModelForType(key: ProviderKey): string {
+  const p = BUILD_MODE_PROVIDERS.find((x) => x.key === key)!;
+  return (p.models.find((m) => m.recommended) ?? p.models[0]!).name;
+}
+
+// Highest-priority configured provider of a supported type, with that type's
+// recommended model. Access control is enforced server-side at session create.
+export function getDefaultLlmSelection(
+  llmProviders: MinimalLlmProvider[] | undefined
+): BuildLlmSelection | null {
+  if (!llmProviders || llmProviders.length === 0) return null;
+
+  for (const p of BUILD_MODE_PROVIDERS) {
+    const match = llmProviders.find((lp) => lp.provider === p.key);
+    if (match) {
+      return {
+        providerName: match.name ?? "",
+        provider: match.provider,
+        modelName: defaultModelForType(p.key),
+      };
+    }
+  }
+
+  return null;
+}
+
+const BUILD_LLM_COOKIE_KEY = "build_llm_selection";
+
+export function getBuildLlmSelection(): BuildLlmSelection | null {
+  if (typeof document === "undefined") return null;
+  const cookie = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${BUILD_LLM_COOKIE_KEY}=`));
+  if (!cookie) return null;
+  try {
+    const value = cookie.split("=")[1];
+    if (!value) return null;
+    return JSON.parse(decodeURIComponent(value));
+  } catch {
+    return null;
+  }
+}
+
+export function setBuildLlmSelection(selection: BuildLlmSelection): void {
+  if (typeof document === "undefined") return;
+  const value = encodeURIComponent(JSON.stringify(selection));
+  const expires = new Date(
+    Date.now() + 365 * 24 * 60 * 60 * 1000
+  ).toUTCString();
+  document.cookie = `${BUILD_LLM_COOKIE_KEY}=${value}; path=/; expires=${expires}; SameSite=Lax`;
+}
+
+export function clearBuildLlmSelection(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${BUILD_LLM_COOKIE_KEY}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+}
 
 // =============================================================================
 // User Info Constants

--- a/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
+++ b/web/src/app/craft/onboarding/hooks/useOnboardingModal.ts
@@ -3,7 +3,6 @@
 import { useCallback, useState, useMemo, useEffect } from "react";
 import { useUser } from "@/providers/UserProvider";
 import { useLLMProviders } from "@/hooks/useLanguageModels";
-import { LLMProviderName } from "@/lib/languageModels/types";
 import {
   OnboardingModalMode,
   OnboardingModalController,
@@ -12,32 +11,17 @@ import {
 import {
   getBuildUserPersona,
   setBuildUserPersona,
+  isSupportedProviderType,
 } from "@/app/craft/onboarding/constants";
 import { updateUserPersonalization } from "@/lib/userSettings";
 import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 
 import type { LLMProviderDescriptor } from "@/lib/languageModels/types";
 
-// Check if all 3 build mode providers are configured (anthropic, openai, openrouter)
-function checkAllProvidersConfigured(
-  llmProviders: LLMProviderDescriptor[] | undefined
-): boolean {
-  if (!llmProviders || llmProviders.length === 0) {
-    return false;
-  }
-  const configuredProviders = new Set(llmProviders.map((p) => p.provider));
-  return (
-    configuredProviders.has(LLMProviderName.ANTHROPIC) &&
-    configuredProviders.has(LLMProviderName.OPENAI) &&
-    configuredProviders.has(LLMProviderName.OPENROUTER)
-  );
-}
-
-// Check if at least one provider is configured
 function checkHasAnyProvider(
   llmProviders: LLMProviderDescriptor[] | undefined
 ): boolean {
-  return !!(llmProviders && llmProviders.length > 0);
+  return !!llmProviders?.some((p) => isSupportedProviderType(p.provider));
 }
 
 export function useOnboardingModal(): OnboardingModalController {
@@ -78,13 +62,6 @@ export function useOnboardingModal(): OnboardingModalController {
     return !!getBuildUserPersona()?.workArea;
   }, [user]);
 
-  // Check if all providers are configured (skip LLM step entirely if so)
-  const allProvidersConfigured = useMemo(
-    () => checkAllProvidersConfigured(llmProviders),
-    [llmProviders]
-  );
-
-  // Check if at least one provider is configured (allow skipping LLM step)
   const hasAnyProvider = useMemo(
     () => checkHasAnyProvider(llmProviders),
     [llmProviders]
@@ -171,7 +148,6 @@ export function useOnboardingModal(): OnboardingModalController {
     refetchLlmProviders,
     isAdmin,
     hasUserInfo,
-    allProvidersConfigured,
     hasAnyProvider,
     isLoading: isLoadingLlm,
   };

--- a/web/src/app/craft/onboarding/types.ts
+++ b/web/src/app/craft/onboarding/types.ts
@@ -41,8 +41,7 @@ export interface OnboardingModalController {
   // State
   isAdmin: boolean;
   hasUserInfo: boolean; // User has completed user-info (workArea set)
-  allProvidersConfigured: boolean; // All 3 providers (anthropic, openai, openrouter) are configured
-  hasAnyProvider: boolean; // At least 1 provider is configured (allows skipping)
+  hasAnyProvider: boolean; // A configured provider exposes a supported model
   isLoading: boolean; // True while LLM providers are loading
 
   // Callbacks

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -91,6 +91,20 @@ export interface CreateSessionOptions {
   llmModelName?: string | null;
 }
 
+// Pull the backend's human-readable error detail out of a failed response,
+// falling back to the status code when the body isn't the expected shape.
+async function errorDetail(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json();
+    if (typeof body?.detail === "string" && body.detail.trim()) {
+      return body.detail;
+    }
+  } catch {
+    // body wasn't JSON — fall through
+  }
+  return `${fallback}: ${res.status}`;
+}
+
 export async function createSession(
   options?: CreateSessionOptions
 ): Promise<ApiDetailedSessionResponse> {
@@ -105,7 +119,7 @@ export async function createSession(
   });
 
   if (!res.ok) {
-    throw new Error(`Failed to create session: ${res.status}`);
+    throw new Error(await errorDetail(res, "Failed to create session"));
   }
 
   return res.json();


### PR DESCRIPTION
## Description

Onyx Craft previously required a **dedicated `build-mode-*` LLM provider**: non-admins with none were hard-blocked (`NoLlmProvidersModal` → bounced to `/app`), admins were forced through an API-key setup step, and provider detection keyed off the `build-mode-` name prefix.

Craft now runs on **any already-configured provider of a supported type** (`anthropic`, `openai`, `openrouter`), regardless of name.

**Backend**
- Match providers by *type* instead of the `build-mode-` name prefix. `fetch_all_build_mode_llm_providers` → `fetch_all_supported_build_llm_providers` (scoped by provider type).
- `_get_llm_config` `(None, None)` fallback now picks the highest-priority supported provider's first visible model; raises a Craft-specific error when none are configured. Added `BUILD_MODE_ALLOWED_PROVIDER_TYPES`.

**Frontend**
- Type-based provider detection in onboarding.
- Deleted the blocking `NoLlmProvidersModal` — non-admins are never blocked; admin LLM-setup is optional/skippable.
- Consolidated the duplicated provider/model lists into a single source of truth.
- `createSession` now surfaces the backend error `detail` instead of a bare status code.

**Defaults:** `claude-opus-4-7` (Anthropic), `gpt-5.5` (OpenAI), `moonshotai/kimi-k2.6` (OpenRouter).

The `onyx-craft-enabled` feature flag (access gate) is unchanged.

## How Has This Been Tested?

- Backend unit tests in `test_get_all_build_mode_llm_configs.py` (15 passing), including 5 new `_get_llm_config` fallback cases: plain provider resolution, anthropic > openai priority, skip-provider-without-visible-model, raise-when-none-configured, and requested-model-used-verbatim.
- `bun lint` (oxlint) clean; frontend typecheck clean for `src/app/craft/*`.
- All pre-commit hooks pass (ty, ruff, oxfmt, oxlint, tsc).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Craft no longer requires dedicated `build-mode-*` providers. It now runs on any configured `anthropic`, `openai`, or `openrouter` provider, picks a recommended default per type with strict per-user access checks, and returns clear errors when none are available.

- **New Features**
  - Backend: `BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE` sets per‑type defaults; default resolves to the cookie’s model when the type is accessible, else the highest‑priority type’s recommended model. `fetch_all_supported_build_llm_providers(db, user)` filters by public/group access with admin bypass; persona‑restricted providers are excluded. Session APIs pass `user`, raise `OnyxError` with detail, and reuse one access‑scoped read via `build_llm_configs`. Backend↔frontend sync tests enforce allowed types and recommended models; added a real‑DB test for group‑scoped access.
  - Frontend: single source of truth via `BUILD_MODE_PROVIDERS`; default selection and “recommended” derive from it (`isRecommendedModel(modelName)`). Cookie validation now checks provider and model (falls back if stale). Onboarding blocks non‑admins only when no supported provider is accessible; the admin LLM‑setup step shows only if none is configured. Provider creation and session create surface backend `detail` on failure.
  - Defaults: `claude-opus-4-7`, `gpt-5.5`, `moonshotai/kimi-k2.6`. `onyx-craft-enabled` unchanged.

- **Refactors**
  - Single access‑scoped fetch for LLM configs: `build_llm_configs(user, type, model)` returns the default and the full preregistration list; `_get_llm_config` delegates to it. Sandbox provision now receives `all_llm_configs` and uses the first as default; tests updated to match the new signature.
  - `get_all_build_mode_llm_configs(providers, default)` prefers each type’s recommended model, fixes dedupe with no‑visible‑model providers, and no longer queries the DB directly. Tests updated accordingly.

<sup>Written for commit 68478ac223f5335fda8788102e8d812f90f18b19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11502?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

