### PR TITLE
fix(craft): bump opencode-serve readiness timeout to 60s for CI cold path

### DIFF
--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -43,9 +43,10 @@ SandboxEvent = Any
 # Tags serve-transport logs with the api_server replica handling the prompt.
 _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 
-# opencode-serve boot lags backend Ready by ~1–3s warm, up to ~15s cold.
-OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
+# 60s covers cold-start in CI under shared-CPU pressure; 30s was too tight.
+OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 60
 OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.5
+_OPENCODE_SERVE_READY_PROGRESS_LOG_INTERVAL_SECONDS = 10.0
 
 
 @dataclass(frozen=True)
@@ -230,19 +231,38 @@ class _ServeMixin:
         with OpencodeServeClient(
             base_url=info.base_url, password=info.password, event_bus=None
         ) as client:
-            deadline = time.time() + timeout
+            start = time.time()
+            deadline = start + timeout
             last_err = "no probe completed"
+            next_progress_log = (
+                start + _OPENCODE_SERVE_READY_PROGRESS_LOG_INTERVAL_SECONDS
+            )
             while time.time() < deadline:
                 try:
                     if client.health_check():
                         logger.info(
-                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
+                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s "
+                            "after %.1fs",
                             sandbox_id,
+                            time.time() - start,
                         )
                         return True
                     last_err = "health_check returned False"
                 except Exception as e:
                     last_err = f"{type(e).__name__}: {e}"
+                now = time.time()
+                if now >= next_progress_log:
+                    logger.info(
+                        "[SANDBOX-SERVE] still waiting on opencode-serve for "
+                        "sandbox %s (%.0fs/%.0fs, last error: %s)",
+                        sandbox_id,
+                        now - start,
+                        timeout,
+                        last_err,
+                    )
+                    next_progress_log = (
+                        now + _OPENCODE_SERVE_READY_PROGRESS_LOG_INTERVAL_SECONDS
+                    )
                 time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
         logger.error(
             "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "


### PR DESCRIPTION
## Description

Bumps `OPENCODE_SERVE_READY_TIMEOUT_SECONDS` from 30s to 60s and adds periodic progress logging during the wait.

### Why

The Craft K8s test suite intermittently fails with `opencode-serve never became ready in sandbox pod` even though the pod itself reaches K8s-Ready. The 30s constant was calibrated for local dev (M-series Mac, warm pod) where opencode binds `:4096` in <1s. CI runs on a shared 4-vCPU GitHub runner with workflow-configured `SANDBOX_POD_CPU_REQUEST: 100m` to fit 4 concurrent test pods — under that throttling, bun cold start + first-ever sqlite migration can spill past 30s for a fresh pod. Bumping to 60s covers the CI cold path while still failing fast on a real crash.

### Why not exponential backoff

Backoff is the right pattern when probe cost matters (rate-limited APIs, fragile services, distributed coordination). For "wait for a local process to bind a port," the probe is a 1-second-timeout HTTP `GET /doc` against an in-cluster IP — failure is an instant TCP-RST. Polling every 0.5s for 60s = 120 probes, cost negligible. Backoff would actively hurt first-bind detection latency for the common-case warm path.

### Other change

Added a periodic progress log every 10s during the wait. 60s of silence in CI logs makes "wedged" indistinguishable from "still loading"; the progress line shows last_err so we know what the probe is seeing.

## How Has This Been Tested?

- Syntax-checked the edit locally.
- The original 30s value triggered the failure in #11403 CI run https://github.com/onyx-dot-app/onyx/actions/runs/26602203127 ; this PR re-runs `craft-k8s-tests` against the bumped value.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increases the opencode-serve readiness timeout from 30s to 60s to reduce flaky CI failures on cold pods, and adds periodic progress logs so waits are visible in CI.

- **Bug Fixes**
  - Set `OPENCODE_SERVE_READY_TIMEOUT_SECONDS` to 60; polling stays at 0.5s.
  - Log a progress line every 10s with elapsed time and last error; log time-to-ready on success.

<sup>Written for commit f602ab98be992c882dbf1609810d0d4bd2bb07e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11503?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

