### PR TITLE
fix(craft): deny opencode built-in customize-opencode skill

### DIFF
--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -79,7 +79,10 @@ _PERMISSIONS_TEMPLATE: dict[str, Any] = {
     "list": "allow",
     "lsp": "allow",
     "patch": "allow",
-    "skill": "allow",
+    # Deny opencode's built-in customize-opencode skill (edits opencode.json
+    # via the skill tool, bypassing our edit/write denies). "*" must precede
+    # the named deny — opencode evaluates skill rules with findLast().
+    "skill": {"*": "allow", "customize-opencode": "deny"},
     "question": "allow",
     "webfetch": "allow",
 }

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -185,6 +185,21 @@ def test_disabled_tools_become_deny_entries() -> None:
     assert config["permission"]["webfetch"] == "deny"
 
 
+def test_skill_permission_denies_builtin_customize_opencode() -> None:
+    """The built-in customize-opencode skill must be denied by name, with
+    "*" before the deny since opencode evaluates skill rules via findLast()."""
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-7")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-7",
+    )
+    skill_perm = config["permission"]["skill"]
+    assert skill_perm["customize-opencode"] == "deny"
+    assert skill_perm["*"] == "allow"
+    keys = list(skill_perm.keys())
+    assert keys.index("*") < keys.index("customize-opencode")
+
+
 def test_plugins_omitted_by_default() -> None:
     """No `plugin` key unless plugins are explicitly requested, so the
     default config stays byte-identical to pre-plugin behavior."""


### PR DESCRIPTION
## Description

opencode bundles a built-in skill named **`customize-opencode`** that lets the agent edit `opencode.json` (agents, MCP servers, permissions, themes, etc.). It is auto-registered for every session, so it showed up as an available skill in Craft sandboxes alongside our own pushed skills.

We already deny *file-level* access to `opencode.json` (`edit`/`write`/`read`/`grep`/`glob` denies in `_PERMISSIONS_TEMPLATE`), but `customize-opencode` reaches the config through the **skill tool**, not the edit/write tools — so our existing guard didn't stop it.

The `OPENCODE_DISABLE_EXTERNAL_SKILLS` env var doesn't help: it only suppresses external skill directories and leaves this built-in registered unconditionally (sst/opencode#27526). The supported way to suppress it is a `skill` permission deny by name:

```json
"skill": { "*": "allow", "customize-opencode": "deny" }
```

Order matters — opencode evaluates skill rules with `findLast()`, so the `"*"` allow must precede the named deny. This change makes that one-line edit in `_PERMISSIONS_TEMPLATE`, which flows through both the Docker and K8s sandbox paths (both build config via `build_multi_provider_opencode_config`) and is rebuilt each session, so it survives snapshot/restore.

## How Has This Been Tested?

Added a unit test (`test_skill_permission_denies_builtin_customize_opencode`) asserting the rendered `skill` permission denies `customize-opencode`, allows `*`, and orders the catch-all allow before the named deny. Full `test_opencode_config.py` suite passes (13 passed).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks the built-in `customize-opencode` skill in `opencode` so agents can’t edit `opencode.json` via the skill tool. Applies to Docker and K8s sandboxes and persists across sessions.

- **Bug Fixes**
  - Set `permission.skill` to `{"*": "allow", "customize-opencode": "deny"}` (order matters: `*` before the named deny).
  - Added a unit test for the deny and key order.

<sup>Written for commit 94e46de4acecfc4d64809800ddcccb78a35dd19c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11506?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

