### PR TITLE
fix(auth): allow dotted Gmail to sign in via Google OAuth

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -877,7 +877,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                         raise exceptions.UserNotExists()
 
                 except exceptions.UserNotExists:
-                    verify_email_domain(account_email, is_registration=True)
+                    # OAuth-created accounts are not subject to the dotted-Gmail
+                    # signup block: the provider vouches for one canonical email
+                    # per account, so dot-alias abuse isn't possible here.
+                    verify_email_domain(account_email)
 
                     # Lock + check on the same session that does the insert.
                     await self.user_db.session.run_sync(

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from fastapi_users import exceptions
 
 from onyx.auth.schemas import UserCreate
 from onyx.auth.users import UserManager
@@ -594,3 +595,70 @@ class TestCaseInsensitiveEmailMatching:
             mock_user_create.email, is_registration=True
         )
         mock_verify_invited.assert_called_once()  # Existing tenant = invite needed
+
+
+class TestOAuthDottedGmail:
+    """OAuth account creation must not apply the dotted-Gmail signup block.
+
+    Regression guard for the redirect loop where a dotted-Gmail Google account
+    could never be created (verify_email_domain(is_registration=True) rejected
+    it on every first login), so the user never became "existing".
+    """
+
+    @pytest.mark.asyncio
+    @patch("onyx.auth.users.MULTI_TENANT", False)
+    @patch("onyx.auth.users.verify_email_in_whitelist")
+    @patch("onyx.auth.users.verify_email_domain")
+    @patch("onyx.auth.users.fetch_ee_implementation_or_noop")
+    @patch("onyx.auth.users.get_async_session_context_manager")
+    @patch("onyx.auth.users.remove_user_from_invited_users")
+    async def test_oauth_create_does_not_block_dotted_gmail(
+        self,
+        mock_remove_invited: MagicMock,  # noqa: ARG002
+        mock_session_manager: MagicMock,
+        mock_fetch_ee: MagicMock,
+        mock_verify_domain: MagicMock,
+        mock_verify_whitelist: MagicMock,  # noqa: ARG002
+        mock_async_session: MagicMock,
+    ) -> None:
+        dotted_email = "first.last@gmail.com"
+
+        mock_session_manager.return_value = _AsyncSessionContextManager(
+            mock_async_session
+        )
+        mock_fetch_ee.return_value = AsyncMock(return_value="test_tenant")
+        mock_verify_domain.return_value = None
+
+        user_manager = UserManager(MagicMock())
+        _mock_user_manager_methods(user_manager)
+        setattr(user_manager, "on_after_register", AsyncMock())
+        setattr(
+            user_manager,
+            "get_by_oauth_account",
+            AsyncMock(side_effect=exceptions.UserNotExists()),
+        )
+
+        created_user = MagicMock(id="test-id", email=dotted_email)
+        created_user.oidc_expiry = None
+
+        mock_user_db = MagicMock()
+        mock_user_db.get_by_email = AsyncMock(side_effect=exceptions.UserNotExists())
+        mock_user_db.create = AsyncMock(return_value=created_user)
+        mock_user_db.add_oauth_account = AsyncMock(return_value=MagicMock())
+        mock_user_db.session = MagicMock()
+        mock_user_db.session.run_sync = AsyncMock()
+        user_manager.user_db = mock_user_db
+
+        await user_manager.oauth_callback(
+            oauth_name="google",
+            access_token="token",
+            account_id="acct-123",
+            account_email=dotted_email,
+        )
+
+        # The user was actually created (creation branch reached, not blocked).
+        mock_user_db.create.assert_awaited_once()
+        # No verify_email_domain call on the OAuth path used the signup block.
+        assert mock_verify_domain.call_args_list
+        for call in mock_verify_domain.call_args_list:
+            assert call.kwargs.get("is_registration") is not True


### PR DESCRIPTION
## Description

**Bug:** Google accounts whose email contains a dot (e.g. `first.last@gmail.com`) hit a permanent redirect-to-login loop on cloud.

**Cause:** In `oauth_callback`, the user-creation branch called `verify_email_domain(account_email, is_registration=True)`, which rejects dotted Gmail. The user was therefore never created, so every subsequent OAuth login was again "first login" and hit the same block — forever.

**Fix:** Drop `is_registration=True` at the OAuth creation site. The dotted-Gmail block exists to stop dot-alias free-trial abuse on *manual* signup; OAuth providers vouch for one canonical email per account, so that vector doesn't exist via OAuth. Manual email/password signup keeps the block unchanged.

Adds a regression test guarding the call site.

## How Has This Been Tested?

<!--- The user will fill this in --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check