### PR TITLE
feat(craft): CredentialInjectionDispatcher + ExternalAppResolver

### DIFF
--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -56,7 +56,7 @@ def resolve_app_for_url(
     return None
 
 
-class ExternalAppActionMatcher:
+class ExternalAppActionMatcher(ActionMatcher):
     """Matches a request against the tenant's connected external apps.
 
     Opens its own short tenant-scoped DB session (mirrors ``IdentityResolver``):

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -20,10 +20,12 @@ from onyx.configs.constants import NotificationType
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
-from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.sandbox_proxy import approval_cache
-from onyx.sandbox_proxy.action_matcher import ActionMatch
 from onyx.sandbox_proxy.action_matcher import ActionMatcher
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
@@ -41,7 +43,13 @@ PARSER_MAX_BODY_BYTES = 1_048_576
 _SNAPSHOT_STREAM_FLAG = "onyx_snapshot_stream"
 
 
-class _Resolver(Protocol):
+class _IdentityResolverProto(Protocol):
+    """Subset of `IdentityResolver` the gate uses.
+
+    Kept distinct from `CredentialResolver` (a different protocol in
+    `credential_injection.py`) to keep the two namespaces separate.
+    """
+
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox | None: ...
 
     def resolve_session_by_id(
@@ -98,11 +106,12 @@ class GateAddon:
 
     def __init__(
         self,
-        identity: _Resolver,
+        identity: _IdentityResolverProto,
         action_matcher: ActionMatcher,
         db_session_factory: DBSessionFactory,
         cache_factory: CacheFactory,
         proxy_instance_id: str,
+        credential_dispatcher: CredentialInjectionDispatcher,
         snapshot_policy: SnapshotEgressPolicy | None = None,
         stream_responses: bool = True,
     ) -> None:
@@ -111,6 +120,7 @@ class GateAddon:
         self._db_session_factory = db_session_factory
         self._cache_factory = cache_factory
         self._proxy_instance_id = proxy_instance_id
+        self._credential_dispatcher = credential_dispatcher
         self._snapshot_policy = snapshot_policy
         self._stream_responses = stream_responses
         # Invariant: `_persist_approval_row` is the only writer;
@@ -237,12 +247,10 @@ class GateAddon:
         try:
             approval_id = self._persist_approval_row(ctx, match)
             decision = await self._await_decision(approval_id, ctx, match)
-            # APPROVED → forward (no 403) WITH credential injection; REJECTED /
-            # EXPIRED → `_write_response_for_decision` sets a 403 (stop here).
             self._write_response_for_decision(flow, decision)
             if decision == ApprovalDecision.APPROVED:
-                self._inject_credentials_or_block(
-                    flow, match, user_id=ctx.user_id, tenant_id=ctx.tenant_id
+                self._dispatch_injection_or_block(
+                    flow, sandbox=ctx.without_session(), match=match
                 )
         except Exception:
             logger.exception(
@@ -325,12 +333,13 @@ class GateAddon:
             match.policy.value if match is not None else "off_catalog",
         )
 
-        # Path per verdict (see _inject_credentials for the injection contract):
-        #   off-catalog -> forward, no credentials
-        #   DENY        -> block
-        #   ALWAYS      -> forward + inject credentials (auto-approved)
-        #   ASK         -> approval pipeline (forward+inject or block, in request())
+        # ALWAYS / DENY / off-catalog terminate here; ASK falls through to the
+        # approval pipeline in `request()`. Strip the in-band session tag
+        # before any dispatcher sees the flow — the dispatcher logs headers,
+        # and forwarded requests must not carry the tag.
         if match is None:
+            flow.request.headers.pop("Proxy-Authorization", None)
+            self._dispatch_injection_or_block(flow, sandbox=sandbox, match=None)
             return None
 
         if match.policy is EndpointPolicy.DENY:
@@ -338,9 +347,8 @@ class GateAddon:
             return None
 
         if match.policy is EndpointPolicy.ALWAYS:
-            self._inject_credentials_or_block(
-                flow, match, user_id=sandbox.user_id, tenant_id=sandbox.tenant_id
-            )
+            flow.request.headers.pop("Proxy-Authorization", None)
+            self._dispatch_injection_or_block(flow, sandbox=sandbox, match=match)
             return None
 
         # ASK: resolve the originating session before prompting. An
@@ -522,75 +530,21 @@ class GateAddon:
         )
         flow.response = _http_403(code)
 
-    def _inject_credentials_or_block(
+    def _dispatch_injection_or_block(
         self,
         flow: http.HTTPFlow,
-        match: ActionMatch,
         *,
-        user_id: UUID,
-        tenant_id: str,
+        sandbox: ResolvedSandbox,
+        match: ActionMatch | None,
     ) -> None:
-        """Inject credentials onto a verified forward, or block it with a 403.
-
-        Wraps ``_inject_credentials`` for the verdict paths: if resolution fails,
-        the request is blocked rather than forwarded with the sandbox's own
-        headers (which would bypass the proxy-only credential boundary).
-        """
-        if not self._inject_credentials(
-            flow, match, user_id=user_id, tenant_id=tenant_id
-        ):
-            flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
-
-    def _inject_credentials(
-        self,
-        flow: http.HTTPFlow,
-        match: ActionMatch,
-        *,
-        user_id: UUID,
-        tenant_id: str,
-    ) -> bool:
-        """Attach the connected app's credentials to a verified forward.
-
-        The sole credential-injection seam: called only on ALWAYS (auto-approved)
-        and ASK-approved requests, never on off-catalog or blocked ones. Renders
-        the app's ``auth_template`` from the org + per-user (``user_id``)
-        credentials and sets the resulting headers on the outbound request, so
-        the real secret lives only here — never in the sandbox.
-
-        Returns ``False`` only when resolution raises — the caller blocks rather
-        than forward the request with the sandbox's own headers. Any successful
-        resolution returns ``True`` (including when there are no headers to
-        inject, e.g. an allowlist-only app).
-        """
-        try:
-            with self._db_session_factory(tenant_id) as db:
-                headers = resolve_injection_headers(db, match.external_app_id, user_id)
-        except Exception:
-            logger.exception(
-                "gate.inject_error external_app_id=%s host=%s",
-                match.external_app_id,
-                flow.request.host,
-            )
-            return False
-
-        if not headers:
-            logger.info(
-                "gate.inject_skipped external_app_id=%s host=%s (no credentials)",
-                match.external_app_id,
-                flow.request.host,
-            )
-            return True
-
-        for name, value in headers.items():
-            flow.request.headers[name] = value
-        # Log header NAMES only — never the injected secret values.
-        logger.info(
-            "gate.inject external_app_id=%s host=%s headers=%s",
-            match.external_app_id,
-            flow.request.host,
-            sorted(headers),
+        """Maps `InjectionOutcome.BLOCKED` to the sandbox-visible 403."""
+        ctx = InjectionContext(
+            sandbox=sandbox,
+            match=match,
+            db_session_factory=self._db_session_factory,
         )
-        return True
+        if self._credential_dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
+            flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
 
     def _terminalize_after_unhandled_error(
         self, approval_id: UUID, tenant_id: str

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -25,7 +25,6 @@ from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import InjectionContext
-from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
@@ -44,11 +43,7 @@ _SNAPSHOT_STREAM_FLAG = "onyx_snapshot_stream"
 
 
 class _IdentityResolverProto(Protocol):
-    """Subset of `IdentityResolver` the gate uses.
-
-    Kept distinct from `CredentialResolver` (a different protocol in
-    `credential_injection.py`) to keep the two namespaces separate.
-    """
+    """Subset of `IdentityResolver` the gate uses."""
 
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox | None: ...
 
@@ -61,6 +56,7 @@ CacheFactory = Callable[[str], CacheBackend]
 
 
 # 403 codes exposed to the sandbox-side caller (distinct from `OnyxError`).
+# `credential_error` lives on `CredentialInjectionDispatcher` as `CODE_CREDENTIAL_ERROR`.
 _CODE_UNIDENTIFIED_SANDBOX = "unidentified_sandbox"
 _CODE_NO_ACTIVE_SESSION = "no_active_session"
 _CODE_BODY_TOO_LARGE = "body_too_large"
@@ -68,7 +64,6 @@ _CODE_USER_REJECTED = "user_rejected"
 _CODE_NOT_AUTHORIZED = "not_authorized"
 _CODE_INTERNAL_ERROR = "internal_error"
 _CODE_POLICY_DENIED = "policy_denied"
-_CODE_CREDENTIAL_ERROR = "credential_error"
 
 # Relative deep link routed through the Next router by NotificationsPopover.tsx;
 # must mirror the frontend's CRAFT_PATH + sessionId search param.
@@ -232,10 +227,11 @@ class GateAddon:
             return
 
         gate_target = self._resolve_and_match(flow)
-        # Strip the session tag so it never reaches the origin. mitmproxy does
-        # NOT strip `Proxy-Authorization` from plain-HTTP requests in regular
-        # mode (no-op for HTTPS, which carries it on the already-consumed
-        # CONNECT). Safe here: `_resolve_and_match` has already read it.
+        # Strip the in-band session tag so it never reaches the origin (it
+        # carries the BuildSession id). mitmproxy does NOT strip
+        # `Proxy-Authorization` from plain-HTTP requests in regular mode (and
+        # for HTTPS the tag rides on the already-consumed CONNECT). The single
+        # strip point: `_resolve_and_match` has read whatever it needs by now.
         flow.request.headers.pop("Proxy-Authorization", None)
         if gate_target is None:
             return
@@ -313,12 +309,15 @@ class GateAddon:
         try:
             match = self._action_matcher.match(flow.request, sandbox.tenant_id)
         except Exception as e:
+            # Matcher crash falls through as off-catalog: host-only resolvers
+            # (Plans 2/3) still get a chance to inject so the request doesn't
+            # forward with a placeholder credential.
             logger.exception(
                 "gate.matcher_error host=%s error=%s",
                 flow.request.host,
                 str(e),
             )
-            return None
+            match = None
 
         # Audit every evaluated request. session_id is the unvalidated claimed
         # tag (the ASK path validates it below); off_catalog = nothing matched.
@@ -334,11 +333,8 @@ class GateAddon:
         )
 
         # ALWAYS / DENY / off-catalog terminate here; ASK falls through to the
-        # approval pipeline in `request()`. Strip the in-band session tag
-        # before any dispatcher sees the flow — the dispatcher logs headers,
-        # and forwarded requests must not carry the tag.
+        # approval pipeline in `request()`.
         if match is None:
-            flow.request.headers.pop("Proxy-Authorization", None)
             self._dispatch_injection_or_block(flow, sandbox=sandbox, match=None)
             return None
 
@@ -347,7 +343,6 @@ class GateAddon:
             return None
 
         if match.policy is EndpointPolicy.ALWAYS:
-            flow.request.headers.pop("Proxy-Authorization", None)
             self._dispatch_injection_or_block(flow, sandbox=sandbox, match=match)
             return None
 
@@ -537,14 +532,15 @@ class GateAddon:
         sandbox: ResolvedSandbox,
         match: ActionMatch | None,
     ) -> None:
-        """Maps `InjectionOutcome.BLOCKED` to the sandbox-visible 403."""
-        ctx = InjectionContext(
-            sandbox=sandbox,
-            match=match,
-            db_session_factory=self._db_session_factory,
+        """Run the credential dispatcher; fail closed with a 403 on BLOCKED."""
+        self._credential_dispatcher.apply_or_block(
+            flow,
+            InjectionContext(
+                sandbox=sandbox,
+                match=match,
+                db_session_factory=self._db_session_factory,
+            ),
         )
-        if self._credential_dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
-            flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
 
     def _terminalize_after_unhandled_error(
         self, approval_id: UUID, tenant_id: str

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -7,7 +7,6 @@ Fail-open: `ActionMatcher` exceptions and non-matching action types.
 import asyncio
 import base64
 import binascii
-import json
 from collections.abc import Callable
 from typing import Protocol
 from uuid import UUID
@@ -25,6 +24,8 @@ from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.errors import http_403
+from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
@@ -42,7 +43,7 @@ PARSER_MAX_BODY_BYTES = 1_048_576
 _SNAPSHOT_STREAM_FLAG = "onyx_snapshot_stream"
 
 
-class _IdentityResolverProto(Protocol):
+class _IdentityResolver(Protocol):
     """Subset of `IdentityResolver` the gate uses."""
 
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox | None: ...
@@ -54,16 +55,6 @@ class _IdentityResolverProto(Protocol):
 
 CacheFactory = Callable[[str], CacheBackend]
 
-
-# 403 codes exposed to the sandbox-side caller (distinct from `OnyxError`).
-# `credential_error` lives on `CredentialInjectionDispatcher` as `CODE_CREDENTIAL_ERROR`.
-_CODE_UNIDENTIFIED_SANDBOX = "unidentified_sandbox"
-_CODE_NO_ACTIVE_SESSION = "no_active_session"
-_CODE_BODY_TOO_LARGE = "body_too_large"
-_CODE_USER_REJECTED = "user_rejected"
-_CODE_NOT_AUTHORIZED = "not_authorized"
-_CODE_INTERNAL_ERROR = "internal_error"
-_CODE_POLICY_DENIED = "policy_denied"
 
 # Relative deep link routed through the Next router by NotificationsPopover.tsx;
 # must mirror the frontend's CRAFT_PATH + sessionId search param.
@@ -101,7 +92,7 @@ class GateAddon:
 
     def __init__(
         self,
-        identity: _IdentityResolverProto,
+        identity: _IdentityResolver,
         action_matcher: ActionMatcher,
         db_session_factory: DBSessionFactory,
         cache_factory: CacheFactory,
@@ -227,11 +218,7 @@ class GateAddon:
             return
 
         gate_target = self._resolve_and_match(flow)
-        # Strip the in-band session tag so it never reaches the origin (it
-        # carries the BuildSession id). mitmproxy does NOT strip
-        # `Proxy-Authorization` from plain-HTTP requests in regular mode (and
-        # for HTTPS the tag rides on the already-consumed CONNECT). The single
-        # strip point: `_resolve_and_match` has read whatever it needs by now.
+        # Strip the in-band session tag so it never reaches the origin
         flow.request.headers.pop("Proxy-Authorization", None)
         if gate_target is None:
             return
@@ -257,7 +244,7 @@ class GateAddon:
                 approval_id,
                 match.action_type,
             )
-            flow.response = _http_403(_CODE_INTERNAL_ERROR)
+            flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             if approval_id is not None:
                 self._terminalize_after_unhandled_error(approval_id, ctx.tenant_id)
 
@@ -281,7 +268,7 @@ class GateAddon:
         """
         src_ip = self._extract_src_ip(flow)
         if src_ip is None:
-            flow.response = _http_403(_CODE_UNIDENTIFIED_SANDBOX)
+            flow.response = http_403(SandboxProxyError.UNIDENTIFIED_SANDBOX)
             return None
 
         try:
@@ -293,25 +280,25 @@ class GateAddon:
                 src_ip,
                 flow.request.host,
             )
-            flow.response = _http_403(_CODE_UNIDENTIFIED_SANDBOX)
+            flow.response = http_403(SandboxProxyError.UNIDENTIFIED_SANDBOX)
             return None
         if sandbox is None:
-            flow.response = _http_403(_CODE_UNIDENTIFIED_SANDBOX)
+            flow.response = http_403(SandboxProxyError.UNIDENTIFIED_SANDBOX)
             return None
 
         # raw_content is None for streamed bodies; treat None as oversize so a
         # future stream opt-in can't silently bypass the cap.
         raw = flow.request.raw_content
         if raw is None or len(raw) > PARSER_MAX_BODY_BYTES:
-            flow.response = _http_403(_CODE_BODY_TOO_LARGE)
+            flow.response = http_403(SandboxProxyError.BODY_TOO_LARGE)
             return None
 
         try:
             match = self._action_matcher.match(flow.request, sandbox.tenant_id)
         except Exception as e:
             # Matcher crash falls through as off-catalog: host-only resolvers
-            # (Plans 2/3) still get a chance to inject so the request doesn't
-            # forward with a placeholder credential.
+            # still get a chance to inject so the request doesn't forward with
+            # a placeholder credential.
             logger.exception(
                 "gate.matcher_error host=%s error=%s",
                 flow.request.host,
@@ -339,7 +326,7 @@ class GateAddon:
             return None
 
         if match.policy is EndpointPolicy.DENY:
-            flow.response = _http_403(_CODE_POLICY_DENIED)
+            flow.response = http_403(SandboxProxyError.POLICY_DENIED)
             return None
 
         if match.policy is EndpointPolicy.ALWAYS:
@@ -357,7 +344,7 @@ class GateAddon:
                 sandbox.user_id,
                 flow.request.host,
             )
-            flow.response = _http_403(_CODE_NO_ACTIVE_SESSION)
+            flow.response = http_403(SandboxProxyError.NO_ACTIVE_SESSION)
             return None
         if session_id is None:
             logger.info(
@@ -369,7 +356,7 @@ class GateAddon:
                 match.action_type,
                 flow.request.host,
             )
-            flow.response = _http_403(_CODE_NO_ACTIVE_SESSION)
+            flow.response = http_403(SandboxProxyError.NO_ACTIVE_SESSION)
             return None
 
         ctx = sandbox.with_session(session_id)
@@ -519,11 +506,11 @@ class GateAddon:
         if decision == ApprovalDecision.APPROVED:
             return
         code = (
-            _CODE_USER_REJECTED
+            SandboxProxyError.USER_REJECTED
             if decision == ApprovalDecision.REJECTED
-            else _CODE_NOT_AUTHORIZED
+            else SandboxProxyError.NOT_AUTHORIZED
         )
-        flow.response = _http_403(code)
+        flow.response = http_403(code)
 
     def _dispatch_injection_or_block(
         self,
@@ -765,21 +752,3 @@ def _parse_proxy_auth_username(header_value: str | None) -> str | None:
         return None
     username = decoded.split(":", 1)[0]
     return username or None
-
-
-# -----------------------------------------------------------------------
-# Sandbox-facing 403 helper
-# -----------------------------------------------------------------------
-
-
-def _http_403(code: str) -> http.Response:
-    """Build a 403 response visible to the sandbox.
-
-    `code` is a stable string the SDK / curl wrapper matches on.
-    """
-    body = json.dumps({"error": code}).encode()
-    return http.Response.make(
-        403,
-        content=body,
-        headers={"content-type": "application/json"},
-    )

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -12,7 +12,6 @@ to inspect the outcome directly.
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol
@@ -20,16 +19,13 @@ from typing import Protocol
 from mitmproxy import http
 
 from onyx.external_apps.matching.engine import ActionMatch
+from onyx.sandbox_proxy.errors import http_403
+from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-
-# Sandbox-visible 403 code emitted on `BLOCKED`. Exported so the gate's test
-# suite can pin the value end-to-end.
-CODE_CREDENTIAL_ERROR = "credential_error"
 
 
 class CredentialUnavailableError(Exception):
@@ -122,11 +118,7 @@ class CredentialInjectionDispatcher:
         outcome directly call `apply` instead.
         """
         if self.apply(flow, ctx) is InjectionOutcome.BLOCKED:
-            flow.response = http.Response.make(
-                403,
-                content=json.dumps({"error": CODE_CREDENTIAL_ERROR}).encode(),
-                headers={"content-type": "application/json"},
-            )
+            flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
 
     def _pick(
         self, request: http.Request, ctx: InjectionContext

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -1,0 +1,116 @@
+"""Host-claim dispatcher for sandbox-proxy credential injection.
+
+`CredentialInjectionDispatcher` walks a registered list of `CredentialResolver`s
+and asks each in turn whether it owns the request. The first one that claims
+renders its auth headers; the dispatcher writes them onto `flow.request` so the
+real secret never has to live in the sandbox pod. Resolution outcomes are
+explicit (`PASS_THROUGH` / `INJECTED` / `BLOCKED`) and the dispatcher never
+raises — fail-closed mapping to a 403 is the caller's job.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Protocol
+
+from mitmproxy import http
+
+from onyx.external_apps.matching.engine import ActionMatch
+from onyx.sandbox_proxy.identity import DBSessionFactory
+from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class CredentialUnavailableError(Exception):
+    """A resolver claimed a request but couldn't produce its credential."""
+
+
+@dataclass(frozen=True)
+class InjectionContext:
+    """Per-request inputs every resolver receives.
+
+    `match` is `None` on off-catalog forwards. `sandbox.tenant_id` is what
+    resolvers key their per-tenant lookups by.
+    """
+
+    sandbox: ResolvedSandbox
+    match: ActionMatch | None
+    db_session_factory: DBSessionFactory
+
+
+class CredentialResolver(Protocol):
+    """One credential source: claims a request by host, then renders headers."""
+
+    def claims(self, host: str, ctx: InjectionContext) -> bool:
+        """Cheap, no-DB predicate: does this resolver own this request?"""
+        ...
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        """Render auth headers; raise `CredentialUnavailableError` to fail closed."""
+        ...
+
+
+class InjectionOutcome(Enum):
+    PASS_THROUGH = "pass_through"
+    INJECTED = "injected"
+    BLOCKED = "blocked"
+
+
+class CredentialInjectionDispatcher:
+    """First-claim-wins dispatch across a fixed list of resolvers."""
+
+    def __init__(self, resolvers: list[CredentialResolver]) -> None:
+        self._resolvers = list(resolvers)
+
+    def apply(self, flow: http.HTTPFlow, ctx: InjectionContext) -> InjectionOutcome:
+        host = flow.request.host
+        resolver = self._pick(host, ctx)
+        if resolver is None:
+            return InjectionOutcome.PASS_THROUGH
+
+        resolver_name = type(resolver).__name__
+        try:
+            headers = resolver.resolve(flow.request, ctx)
+        except CredentialUnavailableError as e:
+            logger.warning(
+                "credential_injection.unavailable resolver=%s host=%s error=%s",
+                resolver_name,
+                host,
+                str(e),
+            )
+            return InjectionOutcome.BLOCKED
+        except Exception:
+            logger.exception(
+                "credential_injection.resolver_error resolver=%s host=%s",
+                resolver_name,
+                host,
+            )
+            return InjectionOutcome.BLOCKED
+
+        for name, value in headers.items():
+            flow.request.headers[name] = value
+        # Header NAMES only — never log the injected secret values.
+        logger.info(
+            "credential_injection.applied resolver=%s host=%s headers=%s",
+            resolver_name,
+            host,
+            sorted(headers),
+        )
+        return InjectionOutcome.INJECTED
+
+    def _pick(self, host: str, ctx: InjectionContext) -> CredentialResolver | None:
+        for resolver in self._resolvers:
+            try:
+                if resolver.claims(host, ctx):
+                    return resolver
+            except Exception:
+                # One buggy resolver must not deny the others a chance.
+                logger.exception(
+                    "credential_injection.claims_error resolver=%s host=%s",
+                    type(resolver).__name__,
+                    host,
+                )
+        return None

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -5,11 +5,14 @@ and asks each in turn whether it owns the request. The first one that claims
 renders its auth headers; the dispatcher writes them onto `flow.request` so the
 real secret never has to live in the sandbox pod. Resolution outcomes are
 explicit (`PASS_THROUGH` / `INJECTED` / `BLOCKED`) and the dispatcher never
-raises — fail-closed mapping to a 403 is the caller's job.
+raises. The high-level `apply_or_block(flow, ctx)` does both the dispatch and
+the fail-closed 403 in one call; tests use `apply(flow, ctx)` when they want
+to inspect the outcome directly.
 """
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Protocol
@@ -22,6 +25,11 @@ from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+# Sandbox-visible 403 code emitted on `BLOCKED`. Exported so the gate's test
+# suite can pin the value end-to-end.
+CODE_CREDENTIAL_ERROR = "credential_error"
 
 
 class CredentialUnavailableError(Exception):
@@ -42,10 +50,15 @@ class InjectionContext:
 
 
 class CredentialResolver(Protocol):
-    """One credential source: claims a request by host, then renders headers."""
+    """One credential source: claims a request, then renders headers."""
 
-    def claims(self, host: str, ctx: InjectionContext) -> bool:
-        """Cheap, no-DB predicate: does this resolver own this request?"""
+    def claims(self, request: http.Request, ctx: InjectionContext) -> bool:
+        """Cheap predicate: does this resolver own this request?
+
+        Implementations should key off `request.host` (and `ctx.match` /
+        `ctx.sandbox.tenant_id` for per-context routing); they MUST NOT open
+        a DB session — that's `resolve()`'s job.
+        """
         ...
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
@@ -67,7 +80,7 @@ class CredentialInjectionDispatcher:
 
     def apply(self, flow: http.HTTPFlow, ctx: InjectionContext) -> InjectionOutcome:
         host = flow.request.host
-        resolver = self._pick(host, ctx)
+        resolver = self._pick(flow.request, ctx)
         if resolver is None:
             return InjectionOutcome.PASS_THROUGH
 
@@ -101,16 +114,32 @@ class CredentialInjectionDispatcher:
         )
         return InjectionOutcome.INJECTED
 
-    def _pick(self, host: str, ctx: InjectionContext) -> CredentialResolver | None:
+    def apply_or_block(self, flow: http.HTTPFlow, ctx: InjectionContext) -> None:
+        """Run `apply`; on `BLOCKED`, write a sandbox-visible 403 to `flow`.
+
+        The single seam most call sites want — they don't need to inspect the
+        outcome, just to fail closed on it. Tests that need to assert on the
+        outcome directly call `apply` instead.
+        """
+        if self.apply(flow, ctx) is InjectionOutcome.BLOCKED:
+            flow.response = http.Response.make(
+                403,
+                content=json.dumps({"error": CODE_CREDENTIAL_ERROR}).encode(),
+                headers={"content-type": "application/json"},
+            )
+
+    def _pick(
+        self, request: http.Request, ctx: InjectionContext
+    ) -> CredentialResolver | None:
         for resolver in self._resolvers:
             try:
-                if resolver.claims(host, ctx):
+                if resolver.claims(request, ctx):
                     return resolver
             except Exception:
                 # One buggy resolver must not deny the others a chance.
                 logger.exception(
                     "credential_injection.claims_error resolver=%s host=%s",
                     type(resolver).__name__,
-                    host,
+                    request.host,
                 )
         return None

--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -1,0 +1,37 @@
+"""Sandbox-facing 403 error codes and response builder.
+
+Every 403 the proxy returns to the sandbox carries a stable `error` code that
+the sandbox-side SDK / curl wrapper matches on. Keeping the codes and the
+response shape in one place keeps the gate and the credential dispatcher
+emitting the same contract.
+"""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+
+from mitmproxy import http
+
+
+class SandboxProxyError(str, Enum):
+    """Stable `error` codes returned to the sandbox in a 403 body."""
+
+    UNIDENTIFIED_SANDBOX = "unidentified_sandbox"
+    NO_ACTIVE_SESSION = "no_active_session"
+    BODY_TOO_LARGE = "body_too_large"
+    USER_REJECTED = "user_rejected"
+    NOT_AUTHORIZED = "not_authorized"
+    INTERNAL_ERROR = "internal_error"
+    POLICY_DENIED = "policy_denied"
+    CREDENTIAL_ERROR = "credential_error"
+
+
+def http_403(code: SandboxProxyError) -> http.Response:
+    """Build a sandbox-visible 403 whose JSON body is `{"error": <code>}`."""
+    body = json.dumps({"error": code.value}).encode()
+    return http.Response.make(
+        403,
+        content=body,
+        headers={"content-type": "application/json"},
+    )

--- a/backend/onyx/sandbox_proxy/identity.py
+++ b/backend/onyx/sandbox_proxy/identity.py
@@ -71,6 +71,16 @@ class SessionContext:
     sandbox_name: str
     sandbox_ip: str
 
+    def without_session(self) -> ResolvedSandbox:
+        """Inverse of `ResolvedSandbox.with_session(...)` — drops the session id."""
+        return ResolvedSandbox(
+            sandbox_id=self.sandbox_id,
+            user_id=self.user_id,
+            tenant_id=self.tenant_id,
+            sandbox_name=self.sandbox_name,
+            sandbox_ip=self.sandbox_ip,
+        )
+
 
 class SandboxIPLookup(Protocol):
     """Backend-specific IP → SandboxIdentity resolver.

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -1,0 +1,52 @@
+"""External-app credential resolver.
+
+Claims a request iff the matcher has attributed it to a connected `ExternalApp`
+(`ctx.match is not None`) and renders the app's `auth_template` from the org +
+per-user credentials via `resolve_injection_headers`. Per-header fail-open
+behaviour for missing placeholders lives in `build_auth_headers`.
+"""
+
+from __future__ import annotations
+
+from mitmproxy import http
+
+from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class ExternalAppResolver:
+    """`CredentialResolver` for matcher-attributed external-app requests."""
+
+    def claims(self, host: str, ctx: InjectionContext) -> bool:  # noqa: ARG002
+        # Host is irrelevant: the matcher has already proven this request
+        # belongs to a connected app.
+        return ctx.match is not None
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        match = ctx.match
+        if match is None:
+            # `claims` guarantees this is unreachable; runtime check so a
+            # broken Protocol contract surfaces as a 403, not a NoneType crash.
+            raise CredentialUnavailableError(
+                "ExternalAppResolver invoked without an ActionMatch"
+            )
+
+        try:
+            with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+                return resolve_injection_headers(
+                    db, match.external_app_id, ctx.sandbox.user_id
+                )
+        except Exception as e:
+            logger.exception(
+                "external_app_resolver.error external_app_id=%s host=%s",
+                match.external_app_id,
+                request.host,
+            )
+            raise CredentialUnavailableError(
+                f"external_app_id={match.external_app_id} resolution failed: "
+                f"{type(e).__name__}"
+            ) from e

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -21,32 +21,36 @@ logger = setup_logger()
 class ExternalAppResolver:
     """`CredentialResolver` for matcher-attributed external-app requests."""
 
-    def claims(self, host: str, ctx: InjectionContext) -> bool:  # noqa: ARG002
-        # Host is irrelevant: the matcher has already proven this request
-        # belongs to a connected app.
+    def claims(
+        self,
+        request: http.Request,  # noqa: ARG002
+        ctx: InjectionContext,
+    ) -> bool:
+        # The matcher has already proven URL→app attribution; host is unused.
         return ctx.match is not None
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         match = ctx.match
         if match is None:
-            # `claims` guarantees this is unreachable; runtime check so a
+            # `claims` guarantees this is unreachable; explicit raise so a
             # broken Protocol contract surfaces as a 403, not a NoneType crash.
             raise CredentialUnavailableError(
                 "ExternalAppResolver invoked without an ActionMatch"
             )
 
-        try:
-            with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
-                return resolve_injection_headers(
-                    db, match.external_app_id, ctx.sandbox.user_id
-                )
-        except Exception as e:
-            logger.exception(
-                "external_app_resolver.error external_app_id=%s host=%s",
-                match.external_app_id,
-                request.host,
+        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+            headers = resolve_injection_headers(
+                db, match.external_app_id, ctx.sandbox.user_id
             )
-            raise CredentialUnavailableError(
-                f"external_app_id={match.external_app_id} resolution failed: "
-                f"{type(e).__name__}"
-            ) from e
+
+        # Per-app audit line so `external_app_id` survives in logs even when
+        # the dispatcher's `credential_injection.applied` log groups by resolver.
+        # Empty `headers` means "app disabled / deleted / placeholders unfillable" —
+        # the request still forwards (upstream 401 surfaces to the user).
+        logger.info(
+            "external_app_resolver.resolved external_app_id=%s host=%s headers=%s",
+            match.external_app_id,
+            request.host,
+            sorted(headers),
+        )
+        return headers

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from mitmproxy import http
 
 from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.utils.logger import setup_logger
@@ -18,7 +19,7 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
-class ExternalAppResolver:
+class ExternalAppResolver(CredentialResolver):
     """`CredentialResolver` for matcher-attributed external-app requests."""
 
     def claims(

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -20,10 +20,13 @@ from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.ca import CABootstrap
 from onyx.sandbox_proxy.ca import MaterializedCA
 from onyx.sandbox_proxy.ca_k8s import K8sSecretCAStore
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.identity import default_session_factory
 from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.identity_k8s import K8sInformerLookup
+from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_HEALTHZ_PORT
@@ -128,6 +131,17 @@ def _build_lookup() -> K8sInformerLookup:
     return lookup
 
 
+def build_resolvers() -> list[CredentialResolver]:
+    """The registered credential resolvers, in first-claim-wins order.
+
+    Host-claim sets are designed to be disjoint (external-app hosts come from
+    the matcher; the Onyx PAT and LLM-key resolvers from Plans 2/3 will claim
+    their own canonical hosts). Order is a safety net against accidental
+    overlap, not a designed-in priority.
+    """
+    return [ExternalAppResolver()]
+
+
 def _build_cache_factory() -> "Callable[[str], CacheBackend]":
     """tenant_id → CacheBackend; must match the API side's namespace to share keys."""
     from onyx.cache.factory import get_cache_backend
@@ -218,6 +232,11 @@ def main() -> int:
                 snapshot_policy.endpoint_host,
             )
         db_session_factory = default_session_factory
+        resolvers = build_resolvers()
+        logger.info(
+            "credential resolvers registered: %s",
+            [type(r).__name__ for r in resolvers],
+        )
         gate = GateAddon(
             identity=identity,
             action_matcher=ExternalAppActionMatcher(
@@ -226,6 +245,7 @@ def main() -> int:
             db_session_factory=db_session_factory,
             cache_factory=_build_cache_factory(),
             proxy_instance_id=proxy_instance_id,
+            credential_dispatcher=CredentialInjectionDispatcher(resolvers),
             snapshot_policy=snapshot_policy,
         )
 

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -134,10 +134,10 @@ def _build_lookup() -> K8sInformerLookup:
 def build_resolvers() -> list[CredentialResolver]:
     """The registered credential resolvers, in first-claim-wins order.
 
-    Host-claim sets are designed to be disjoint (external-app hosts come from
-    the matcher; the Onyx PAT and LLM-key resolvers from Plans 2/3 will claim
-    their own canonical hosts). Order is a safety net against accidental
-    overlap, not a designed-in priority.
+    Host-claim sets are designed to be disjoint (external-app requests are
+    attributed by the matcher; host-only resolvers added later claim their own
+    canonical hosts). Order is a safety net against accidental overlap, not a
+    designed-in priority.
     """
     return [ExternalAppResolver()]
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -19,6 +19,8 @@ from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import ActionApproval
 from onyx.db.models import BuildSession
+from onyx.sandbox_proxy.action_matcher import ActionMatcher
+from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
@@ -61,7 +63,7 @@ def _seed_action_approval(
     return row
 
 
-class _UnusedResolver:
+class _UnusedResolver(_IdentityResolver):
     """Obvious-fail stub for the arbiter tests; none of these are called."""
 
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox | None:  # noqa: ARG002
@@ -76,7 +78,7 @@ class _UnusedResolver:
         raise AssertionError("identity.resolve_session_by_id unexpectedly used")
 
 
-class _UnusedMatcher:
+class _UnusedMatcher(ActionMatcher):
     def match(self, request: Any, tenant_id: str) -> Any:  # noqa: ARG002
         raise AssertionError("action_matcher.match unexpectedly used")
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -20,6 +20,7 @@ from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import ActionApproval
 from onyx.db.models import BuildSession
 from onyx.sandbox_proxy.addons.gate import GateAddon
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
 from tests.external_dependency_unit.conftest import create_test_user
@@ -95,6 +96,7 @@ def _build_addon() -> GateAddon:
         ),
         cache_factory=_factory_raises,
         proxy_instance_id="proxy-test",
+        credential_dispatcher=CredentialInjectionDispatcher([]),
     )
 
 

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -166,7 +166,7 @@ class StubResolver:
 class RecordingCredentialResolver:
     """`CredentialResolver` stub: configurable claim + canned headers/exception.
 
-    Records every `(host, ctx)` claim probe and every `ctx` it was asked to
+    Records every `(request, ctx)` claim probe and every `ctx` it was asked to
     resolve so tests can assert the dispatcher routed correctly.
     """
 
@@ -180,11 +180,11 @@ class RecordingCredentialResolver:
         self._claims_result = claims_result
         self._headers = headers if headers is not None else {}
         self._exc = exc
-        self.claims_calls: list[tuple[str, InjectionContext]] = []
+        self.claims_calls: list[tuple[http.Request, InjectionContext]] = []
         self.resolve_calls: list[InjectionContext] = []
 
-    def claims(self, host: str, ctx: InjectionContext) -> bool:
-        self.claims_calls.append((host, ctx))
+    def claims(self, request: http.Request, ctx: InjectionContext) -> bool:
+        self.claims_calls.append((request, ctx))
         return self._claims_result
 
     def resolve(
@@ -205,7 +205,7 @@ def make_action_match(
     policy: EndpointPolicy = EndpointPolicy.ASK,
     external_app_id: int = 42,
 ) -> ActionMatch:
-    """Factory for `ActionMatch` test rows. Override the few fields each test cares about."""
+    """Factory for `ActionMatch` test rows."""
     return ActionMatch(
         action_type=action_type,
         payload=payload if payload is not None else {},
@@ -221,5 +221,5 @@ def _noop_session(tenant_id: str) -> Iterator[Any]:  # noqa: ARG001
 
 
 def noop_db_factory(tenant_id: str) -> Any:
-    """`DBSessionFactory` whose session never opens — fails the test if it does."""
+    """`DBSessionFactory` whose session never opens."""
     return _noop_session(tenant_id)

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -1,18 +1,27 @@
 """Shared stubs and factories for sandbox_proxy unit tests.
 
 - `StaticLookup` — `SandboxIPLookup` stub keyed by source IP.
-- `make_resolved_sandbox` / `make_flow` — value + mitmproxy-flow factories.
+- `make_resolved_sandbox` / `make_flow` / `make_action_match` — value
+  + mitmproxy-flow factories.
 - `StubResolver` — identity resolver stub (sandbox + session) for the gate.
+- `RecordingCredentialResolver` — `CredentialResolver` stub recording the
+  claim/resolve calls a dispatcher made on it.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID
 from uuid import uuid4
 
 from mitmproxy import http
 
+from onyx.db.enums import EndpointPolicy
+from onyx.external_apps.matching.engine import ActionMatch
+from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SandboxIdentity
 from onyx.sandbox_proxy.identity import SandboxIPLookup
@@ -152,3 +161,65 @@ class StubResolver:
         if self._session_by_id_exc is not None:
             raise self._session_by_id_exc
         return self._session_by_id
+
+
+class RecordingCredentialResolver:
+    """`CredentialResolver` stub: configurable claim + canned headers/exception.
+
+    Records every `(host, ctx)` claim probe and every `ctx` it was asked to
+    resolve so tests can assert the dispatcher routed correctly.
+    """
+
+    def __init__(
+        self,
+        *,
+        claims_result: bool = True,
+        headers: dict[str, str] | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self._claims_result = claims_result
+        self._headers = headers if headers is not None else {}
+        self._exc = exc
+        self.claims_calls: list[tuple[str, InjectionContext]] = []
+        self.resolve_calls: list[InjectionContext] = []
+
+    def claims(self, host: str, ctx: InjectionContext) -> bool:
+        self.claims_calls.append((host, ctx))
+        return self._claims_result
+
+    def resolve(
+        self,
+        request: http.Request,  # noqa: ARG002
+        ctx: InjectionContext,
+    ) -> dict[str, str]:
+        self.resolve_calls.append(ctx)
+        if self._exc is not None:
+            raise self._exc
+        return dict(self._headers)
+
+
+def make_action_match(
+    *,
+    action_type: str = "slack.messages.write",
+    payload: dict[str, Any] | None = None,
+    policy: EndpointPolicy = EndpointPolicy.ASK,
+    external_app_id: int = 42,
+) -> ActionMatch:
+    """Factory for `ActionMatch` test rows. Override the few fields each test cares about."""
+    return ActionMatch(
+        action_type=action_type,
+        payload=payload if payload is not None else {},
+        policy=policy,
+        external_app_id=external_app_id,
+    )
+
+
+@contextmanager
+def _noop_session(tenant_id: str) -> Iterator[Any]:  # noqa: ARG001
+    raise AssertionError("db factory unexpectedly used")
+    yield  # pragma: no cover
+
+
+def noop_db_factory(tenant_id: str) -> Any:
+    """`DBSessionFactory` whose session never opens — fails the test if it does."""
+    return _noop_session(tenant_id)

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -21,6 +21,8 @@ from mitmproxy import http
 
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import ActionMatch
+from onyx.sandbox_proxy.addons.gate import _IdentityResolver
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SandboxIdentity
@@ -124,8 +126,8 @@ def make_flow(
     return flow
 
 
-class StubResolver:
-    """`SessionResolver` stub with canned returns (resolves sandbox + session)."""
+class StubResolver(_IdentityResolver):
+    """`_IdentityResolver` stub with canned returns (resolves sandbox + session)."""
 
     def __init__(
         self,
@@ -163,7 +165,7 @@ class StubResolver:
         return self._session_by_id
 
 
-class RecordingCredentialResolver:
+class RecordingCredentialResolver(CredentialResolver):
     """`CredentialResolver` stub: configurable claim + canned headers/exception.
 
     Records every `(request, ctx)` claim probe and every `ctx` it was asked to

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock
 
-from onyx.sandbox_proxy.credential_injection import CODE_CREDENTIAL_ERROR
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.credential_injection import InjectionOutcome
+from onyx.sandbox_proxy.errors import SandboxProxyError
 from tests.unit.sandbox_proxy.conftest import make_action_match
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
@@ -22,7 +23,7 @@ from tests.unit.sandbox_proxy.conftest import noop_db_factory
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 
 
-def _ctx(*, match=None) -> InjectionContext:  # type: ignore[no-untyped-def]
+def _ctx(*, match: ActionMatch | None = None) -> InjectionContext:
     return InjectionContext(
         sandbox=_sandbox(), match=match, db_session_factory=noop_db_factory
     )
@@ -143,7 +144,7 @@ def test_apply_or_block_writes_403_on_blocked() -> None:
     assert flow.response.status_code == 403
     content = flow.response.content
     assert content is not None
-    assert json.loads(content) == {"error": CODE_CREDENTIAL_ERROR}
+    assert json.loads(content) == {"error": SandboxProxyError.CREDENTIAL_ERROR.value}
 
 
 def test_apply_or_block_leaves_response_unset_on_inject_or_pass_through() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -1,0 +1,159 @@
+"""Unit tests for `CredentialInjectionDispatcher`.
+
+The dispatcher is the single seam between the gate and any concrete
+`CredentialResolver`; per-resolver behaviour is tested separately.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.credential_injection import InjectionOutcome
+from tests.unit.sandbox_proxy.conftest import make_action_match
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import noop_db_factory
+from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
+
+
+def _ctx(*, match=None) -> InjectionContext:  # type: ignore[no-untyped-def]
+    return InjectionContext(
+        sandbox=_sandbox(), match=match, db_session_factory=noop_db_factory
+    )
+
+
+def test_no_resolver_claims_returns_pass_through() -> None:
+    a = RecordingCredentialResolver(claims_result=False)
+    b = RecordingCredentialResolver(claims_result=False)
+    dispatcher = CredentialInjectionDispatcher([a, b])
+    flow = _flow()
+    flow.request.headers["X-Existing"] = "preserve"
+
+    outcome = dispatcher.apply(flow, _ctx())
+
+    assert outcome is InjectionOutcome.PASS_THROUGH
+    assert flow.request.headers["X-Existing"] == "preserve"
+    assert a.claims_calls and b.claims_calls
+    assert a.resolve_calls == [] and b.resolve_calls == []
+
+
+def test_first_claim_wins() -> None:
+    """Registered order is priority order; later resolvers are not even queried."""
+    first = RecordingCredentialResolver(
+        claims_result=True, headers={"Authorization": "from-first"}
+    )
+    second = RecordingCredentialResolver(
+        claims_result=True, headers={"Authorization": "from-second"}
+    )
+    dispatcher = CredentialInjectionDispatcher([first, second])
+    flow = _flow()
+
+    outcome = dispatcher.apply(flow, _ctx())
+
+    assert outcome is InjectionOutcome.INJECTED
+    assert flow.request.headers["Authorization"] == "from-first"
+    assert first.resolve_calls != []
+    assert second.resolve_calls == []
+    assert second.claims_calls == []
+
+
+def test_injected_headers_overwrite_existing() -> None:
+    """Pod ships placeholders; the dispatcher overwrites them set/replace."""
+    resolver = RecordingCredentialResolver(
+        claims_result=True, headers={"Authorization": "Bearer real"}
+    )
+    dispatcher = CredentialInjectionDispatcher([resolver])
+    flow = _flow()
+    flow.request.headers["Authorization"] = "placeholder"
+
+    dispatcher.apply(flow, _ctx())
+
+    assert flow.request.headers["Authorization"] == "Bearer real"
+
+
+def test_resolver_claiming_but_returning_no_headers_is_injected() -> None:
+    """The claim is the contract — empty header set is INJECTED, not PASS_THROUGH."""
+    resolver = RecordingCredentialResolver(claims_result=True, headers={})
+    dispatcher = CredentialInjectionDispatcher([resolver])
+
+    outcome = dispatcher.apply(_flow(), _ctx())
+
+    assert outcome is InjectionOutcome.INJECTED
+
+
+def test_credential_unavailable_returns_blocked() -> None:
+    resolver = RecordingCredentialResolver(
+        claims_result=True, exc=CredentialUnavailableError("no PAT for sandbox")
+    )
+    dispatcher = CredentialInjectionDispatcher([resolver])
+    flow = _flow()
+
+    outcome = dispatcher.apply(flow, _ctx())
+
+    assert outcome is InjectionOutcome.BLOCKED
+    assert "Authorization" not in flow.request.headers
+
+
+def test_unexpected_exception_returns_blocked() -> None:
+    """Any non-Credential-Unavailable resolver error is also fail-closed."""
+    resolver = RecordingCredentialResolver(
+        claims_result=True, exc=RuntimeError("db down mid-resolve")
+    )
+    dispatcher = CredentialInjectionDispatcher([resolver])
+
+    outcome = dispatcher.apply(_flow(), _ctx())
+
+    assert outcome is InjectionOutcome.BLOCKED
+
+
+def test_claims_exception_falls_through_to_next_resolver() -> None:
+    """A buggy `claims` predicate must not deny later resolvers a chance."""
+    bad = MagicMock(spec=CredentialResolver)
+    bad.claims.side_effect = RuntimeError("claims is buggy")
+    good = RecordingCredentialResolver(claims_result=True, headers={"X-Hdr": "val"})
+    dispatcher = CredentialInjectionDispatcher([bad, good])
+    flow = _flow()
+
+    outcome = dispatcher.apply(flow, _ctx())
+
+    assert outcome is InjectionOutcome.INJECTED
+    assert flow.request.headers["X-Hdr"] == "val"
+
+
+def test_all_claims_raise_returns_pass_through() -> None:
+    """No usable resolver: fail OPEN — the dispatcher itself never blocks."""
+    a = MagicMock(spec=CredentialResolver)
+    a.claims.side_effect = RuntimeError("a")
+    b = MagicMock(spec=CredentialResolver)
+    b.claims.side_effect = RuntimeError("b")
+
+    outcome = CredentialInjectionDispatcher([a, b]).apply(_flow(), _ctx())
+
+    assert outcome is InjectionOutcome.PASS_THROUGH
+
+
+def test_dispatcher_passes_full_context_to_resolver() -> None:
+    """The `InjectionContext` reaches `resolve()` unchanged (sandbox, match,
+    db_session_factory all forwarded), and `claims()` sees the host + ctx."""
+    sandbox = _sandbox(tenant_id="tenant-xyz", user_id=uuid4())
+    match = make_action_match()
+    resolver = RecordingCredentialResolver(claims_result=True)
+    dispatcher = CredentialInjectionDispatcher([resolver])
+    flow = _flow(host="api.anthropic.com")
+    ctx = InjectionContext(
+        sandbox=sandbox, match=match, db_session_factory=noop_db_factory
+    )
+
+    dispatcher.apply(flow, ctx)
+
+    assert resolver.claims_calls == [("api.anthropic.com", ctx)]
+    assert resolver.resolve_calls == [ctx]
+    seen = resolver.resolve_calls[0]
+    assert seen.sandbox is sandbox
+    assert seen.match is match
+    assert seen.db_session_factory is noop_db_factory

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -6,9 +6,10 @@ The dispatcher is the single seam between the gate and any concrete
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
-from uuid import uuid4
 
+from onyx.sandbox_proxy.credential_injection import CODE_CREDENTIAL_ERROR
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
@@ -30,11 +31,10 @@ def _ctx(*, match=None) -> InjectionContext:  # type: ignore[no-untyped-def]
 def test_no_resolver_claims_returns_pass_through() -> None:
     a = RecordingCredentialResolver(claims_result=False)
     b = RecordingCredentialResolver(claims_result=False)
-    dispatcher = CredentialInjectionDispatcher([a, b])
     flow = _flow()
     flow.request.headers["X-Existing"] = "preserve"
 
-    outcome = dispatcher.apply(flow, _ctx())
+    outcome = CredentialInjectionDispatcher([a, b]).apply(flow, _ctx())
 
     assert outcome is InjectionOutcome.PASS_THROUGH
     assert flow.request.headers["X-Existing"] == "preserve"
@@ -43,19 +43,17 @@ def test_no_resolver_claims_returns_pass_through() -> None:
 
 
 def test_first_claim_wins() -> None:
-    """Registered order is priority order; later resolvers are not even queried."""
+    """Registered order is priority order; later resolvers are not queried."""
     first = RecordingCredentialResolver(
         claims_result=True, headers={"Authorization": "from-first"}
     )
     second = RecordingCredentialResolver(
         claims_result=True, headers={"Authorization": "from-second"}
     )
-    dispatcher = CredentialInjectionDispatcher([first, second])
     flow = _flow()
 
-    outcome = dispatcher.apply(flow, _ctx())
+    CredentialInjectionDispatcher([first, second]).apply(flow, _ctx())
 
-    assert outcome is InjectionOutcome.INJECTED
     assert flow.request.headers["Authorization"] == "from-first"
     assert first.resolve_calls != []
     assert second.resolve_calls == []
@@ -67,21 +65,19 @@ def test_injected_headers_overwrite_existing() -> None:
     resolver = RecordingCredentialResolver(
         claims_result=True, headers={"Authorization": "Bearer real"}
     )
-    dispatcher = CredentialInjectionDispatcher([resolver])
     flow = _flow()
     flow.request.headers["Authorization"] = "placeholder"
 
-    dispatcher.apply(flow, _ctx())
+    CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
 
     assert flow.request.headers["Authorization"] == "Bearer real"
 
 
 def test_resolver_claiming_but_returning_no_headers_is_injected() -> None:
-    """The claim is the contract — empty header set is INJECTED, not PASS_THROUGH."""
+    """Claim is the contract — empty header set is INJECTED, not PASS_THROUGH."""
     resolver = RecordingCredentialResolver(claims_result=True, headers={})
-    dispatcher = CredentialInjectionDispatcher([resolver])
 
-    outcome = dispatcher.apply(_flow(), _ctx())
+    outcome = CredentialInjectionDispatcher([resolver]).apply(_flow(), _ctx())
 
     assert outcome is InjectionOutcome.INJECTED
 
@@ -90,23 +86,21 @@ def test_credential_unavailable_returns_blocked() -> None:
     resolver = RecordingCredentialResolver(
         claims_result=True, exc=CredentialUnavailableError("no PAT for sandbox")
     )
-    dispatcher = CredentialInjectionDispatcher([resolver])
     flow = _flow()
 
-    outcome = dispatcher.apply(flow, _ctx())
+    outcome = CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
 
     assert outcome is InjectionOutcome.BLOCKED
     assert "Authorization" not in flow.request.headers
 
 
 def test_unexpected_exception_returns_blocked() -> None:
-    """Any non-Credential-Unavailable resolver error is also fail-closed."""
+    """Non-CredentialUnavailable resolver errors also fail closed."""
     resolver = RecordingCredentialResolver(
         claims_result=True, exc=RuntimeError("db down mid-resolve")
     )
-    dispatcher = CredentialInjectionDispatcher([resolver])
 
-    outcome = dispatcher.apply(_flow(), _ctx())
+    outcome = CredentialInjectionDispatcher([resolver]).apply(_flow(), _ctx())
 
     assert outcome is InjectionOutcome.BLOCKED
 
@@ -116,10 +110,9 @@ def test_claims_exception_falls_through_to_next_resolver() -> None:
     bad = MagicMock(spec=CredentialResolver)
     bad.claims.side_effect = RuntimeError("claims is buggy")
     good = RecordingCredentialResolver(claims_result=True, headers={"X-Hdr": "val"})
-    dispatcher = CredentialInjectionDispatcher([bad, good])
     flow = _flow()
 
-    outcome = dispatcher.apply(flow, _ctx())
+    outcome = CredentialInjectionDispatcher([bad, good]).apply(flow, _ctx())
 
     assert outcome is InjectionOutcome.INJECTED
     assert flow.request.headers["X-Hdr"] == "val"
@@ -137,23 +130,51 @@ def test_all_claims_raise_returns_pass_through() -> None:
     assert outcome is InjectionOutcome.PASS_THROUGH
 
 
-def test_dispatcher_passes_full_context_to_resolver() -> None:
-    """The `InjectionContext` reaches `resolve()` unchanged (sandbox, match,
-    db_session_factory all forwarded), and `claims()` sees the host + ctx."""
-    sandbox = _sandbox(tenant_id="tenant-xyz", user_id=uuid4())
+def test_apply_or_block_writes_403_on_blocked() -> None:
+    """The high-level seam: BLOCKED → sandbox-visible 403 with the documented body."""
+    resolver = RecordingCredentialResolver(
+        claims_result=True, exc=CredentialUnavailableError("no creds")
+    )
+    flow = _flow()
+
+    CredentialInjectionDispatcher([resolver]).apply_or_block(flow, _ctx())
+
+    assert flow.response is not None
+    assert flow.response.status_code == 403
+    content = flow.response.content
+    assert content is not None
+    assert json.loads(content) == {"error": CODE_CREDENTIAL_ERROR}
+
+
+def test_apply_or_block_leaves_response_unset_on_inject_or_pass_through() -> None:
+    """INJECTED and PASS_THROUGH both leave `flow.response` untouched so the
+    request forwards through mitmproxy."""
+    claiming = RecordingCredentialResolver(claims_result=True, headers={"X": "y"})
+    not_claiming = RecordingCredentialResolver(claims_result=False)
+
+    flow_a = _flow()
+    CredentialInjectionDispatcher([claiming]).apply_or_block(flow_a, _ctx())
+    assert flow_a.response is None
+
+    flow_b = _flow()
+    CredentialInjectionDispatcher([not_claiming]).apply_or_block(flow_b, _ctx())
+    assert flow_b.response is None
+
+
+def test_resolver_receives_request_and_full_context() -> None:
+    """Sanity: `claims` and `resolve` both see the same request + ctx the
+    dispatcher was handed, unchanged."""
+    sandbox = _sandbox(tenant_id="tenant-xyz")
     match = make_action_match()
     resolver = RecordingCredentialResolver(claims_result=True)
-    dispatcher = CredentialInjectionDispatcher([resolver])
     flow = _flow(host="api.anthropic.com")
     ctx = InjectionContext(
         sandbox=sandbox, match=match, db_session_factory=noop_db_factory
     )
 
-    dispatcher.apply(flow, ctx)
+    CredentialInjectionDispatcher([resolver]).apply(flow, ctx)
 
-    assert resolver.claims_calls == [("api.anthropic.com", ctx)]
+    [(claim_request, claim_ctx)] = resolver.claims_calls
+    assert claim_request is flow.request
+    assert claim_ctx is ctx
     assert resolver.resolve_calls == [ctx]
-    seen = resolver.resolve_calls[0]
-    assert seen.sandbox is sandbox
-    assert seen.match is match
-    assert seen.db_session_factory is noop_db_factory

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -1,0 +1,98 @@
+"""Unit tests for `ExternalAppResolver`.
+
+The resolver is a thin wrapper around `resolve_injection_headers`; coverage
+focuses on the dispatcher seam — the claim rule and the exception
+translation. The renderer's per-header fail-open behaviour lives in
+`tests/external_dependency_unit/craft/test_credential_injection.py`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.resolvers import external_app as external_app_mod
+from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
+from tests.unit.sandbox_proxy.conftest import make_action_match
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+
+
+def _recorder_db_factory(ops: list[str]) -> Any:
+    @contextmanager
+    def factory(tenant_id: str) -> Iterator[Any]:
+        ops.append(f"session:{tenant_id}")
+        yield MagicMock()
+
+    return factory
+
+
+def _ctx(
+    *,
+    match=make_action_match(),
+    db_factory: Any = None,  # type: ignore[no-untyped-def]
+) -> InjectionContext:
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"),
+        match=match,
+        db_session_factory=db_factory
+        if db_factory is not None
+        else _recorder_db_factory([]),
+    )
+
+
+def test_claims_true_iff_match_present() -> None:
+    """Host is irrelevant — the matcher has already attributed the request."""
+    resolver = ExternalAppResolver()
+    assert resolver.claims("api.slack.com", _ctx()) is True
+    assert resolver.claims("anything.example", _ctx()) is True
+    assert resolver.claims("api.slack.com", _ctx(match=None)) is False
+
+
+def test_resolve_delegates_to_resolve_injection_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opens a tenant-scoped session and forwards `(external_app_id, user_id)`
+    to the renderer; returns whatever the renderer returned."""
+    captured: dict[str, Any] = {}
+
+    def _fake(db: Any, external_app_id: int, user_id: Any) -> dict[str, str]:
+        captured["db"] = db
+        captured["external_app_id"] = external_app_id
+        captured["user_id"] = user_id
+        return {"Authorization": "Bearer real"}
+
+    monkeypatch.setattr(external_app_mod, "resolve_injection_headers", _fake)
+
+    match = make_action_match(external_app_id=99)
+    ops: list[str] = []
+    ctx = _ctx(match=match, db_factory=_recorder_db_factory(ops))
+    flow = _flow()
+
+    headers = ExternalAppResolver().resolve(flow.request, ctx)
+
+    assert headers == {"Authorization": "Bearer real"}
+    assert captured["external_app_id"] == 99
+    assert captured["user_id"] == ctx.sandbox.user_id
+    assert ops == ["session:tenant-7"]
+
+
+def test_resolve_translates_db_error_to_credential_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB blip becomes the explicit fail-closed signal so the dispatcher
+    renders a 403, not a silent forward."""
+
+    def _boom(_db: Any, _aid: int, _uid: Any) -> dict[str, str]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(external_app_mod, "resolve_injection_headers", _boom)
+
+    with pytest.raises(CredentialUnavailableError):
+        ExternalAppResolver().resolve(_flow().request, _ctx())

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -1,9 +1,9 @@
 """Unit tests for `ExternalAppResolver`.
 
 The resolver is a thin wrapper around `resolve_injection_headers`; coverage
-focuses on the dispatcher seam — the claim rule and the exception
-translation. The renderer's per-header fail-open behaviour lives in
-`tests/external_dependency_unit/craft/test_credential_injection.py`.
+focuses on the claim rule and the contract violations the dispatcher relies
+on. The renderer's per-header fail-open behaviour is pinned against a real
+DB in `tests/external_dependency_unit/craft/test_credential_injection.py`.
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.resolvers import external_app as external_app_mod
@@ -35,8 +36,8 @@ def _recorder_db_factory(ops: list[str]) -> Any:
 
 def _ctx(
     *,
-    match=make_action_match(),
-    db_factory: Any = None,  # type: ignore[no-untyped-def]
+    match: ActionMatch | None = None,
+    db_factory: Any = None,
 ) -> InjectionContext:
     return InjectionContext(
         sandbox=_sandbox(tenant_id="tenant-7"),
@@ -50,16 +51,16 @@ def _ctx(
 def test_claims_true_iff_match_present() -> None:
     """Host is irrelevant — the matcher has already attributed the request."""
     resolver = ExternalAppResolver()
-    assert resolver.claims("api.slack.com", _ctx()) is True
-    assert resolver.claims("anything.example", _ctx()) is True
-    assert resolver.claims("api.slack.com", _ctx(match=None)) is False
+    req = _flow(host="api.slack.com").request
+    assert resolver.claims(req, _ctx(match=make_action_match())) is True
+    assert resolver.claims(req, _ctx(match=None)) is False
 
 
-def test_resolve_delegates_to_resolve_injection_headers(
+def test_resolve_forwards_external_app_id_user_id_and_tenant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Opens a tenant-scoped session and forwards `(external_app_id, user_id)`
-    to the renderer; returns whatever the renderer returned."""
+    """The resolver opens a tenant-scoped session and forwards
+    `(external_app_id, user_id)` to the renderer."""
     captured: dict[str, Any] = {}
 
     def _fake(db: Any, external_app_id: int, user_id: Any) -> dict[str, str]:
@@ -73,9 +74,8 @@ def test_resolve_delegates_to_resolve_injection_headers(
     match = make_action_match(external_app_id=99)
     ops: list[str] = []
     ctx = _ctx(match=match, db_factory=_recorder_db_factory(ops))
-    flow = _flow()
 
-    headers = ExternalAppResolver().resolve(flow.request, ctx)
+    headers = ExternalAppResolver().resolve(_flow().request, ctx)
 
     assert headers == {"Authorization": "Bearer real"}
     assert captured["external_app_id"] == 99
@@ -83,16 +83,9 @@ def test_resolve_delegates_to_resolve_injection_headers(
     assert ops == ["session:tenant-7"]
 
 
-def test_resolve_translates_db_error_to_credential_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A DB blip becomes the explicit fail-closed signal so the dispatcher
-    renders a 403, not a silent forward."""
-
-    def _boom(_db: Any, _aid: int, _uid: Any) -> dict[str, str]:
-        raise RuntimeError("db down")
-
-    monkeypatch.setattr(external_app_mod, "resolve_injection_headers", _boom)
-
+def test_resolve_raises_when_match_is_none() -> None:
+    """Contract violation safety net: `claims` guarantees `match` is set, but
+    a Protocol bug must surface as a 403, not a NoneType crash inside SQL code."""
+    resolver = ExternalAppResolver()
     with pytest.raises(CredentialUnavailableError):
-        ExternalAppResolver().resolve(_flow().request, _ctx())
+        resolver.resolve(_flow().request, _ctx(match=None))

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -28,6 +28,7 @@ from redis.exceptions import RedisError
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import ActionMatch
+from onyx.sandbox_proxy import credential_injection as credential_injection_mod
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
@@ -38,8 +39,10 @@ from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
+from tests.unit.sandbox_proxy.conftest import make_action_match
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import noop_db_factory
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 
@@ -70,17 +73,6 @@ class _StubMatcher:
         return self._result
 
 
-def _noop_db_factory(tenant_id: str) -> Any:  # noqa: ARG001
-    """`DBSessionFactory` that must never be called."""
-
-    @contextmanager
-    def cm() -> Iterator[Any]:
-        raise AssertionError("db factory unexpectedly used")
-        yield  # pragma: no cover
-
-    return cm()
-
-
 def _noop_cache_factory(tenant_id: str) -> Any:  # noqa: ARG001
     raise AssertionError("cache factory unexpectedly used")
 
@@ -105,7 +97,7 @@ def _build(
     *,
     resolver: _StubResolver,
     matcher: _StubMatcher,
-    db_factory: Any = _noop_db_factory,
+    db_factory: Any = noop_db_factory,
     cache_factory: Any = _noop_cache_factory,
     credential_resolvers: list[CredentialResolver] | None = None,
 ) -> GateAddon:
@@ -130,24 +122,11 @@ def _assert_403(flow: http.HTTPFlow, expected_code: str) -> None:
     assert body == {"error": expected_code}
 
 
-_MATCH = ActionMatch(
-    action_type="slack.messages.write",
-    payload={"text": "hi"},
-    policy=EndpointPolicy.ASK,
-    external_app_id=42,
+_MATCH = make_action_match(payload={"text": "hi"})
+_MATCH_ALWAYS = make_action_match(
+    action_type="slack.channels.read", policy=EndpointPolicy.ALWAYS
 )
-_MATCH_ALWAYS = ActionMatch(
-    action_type="slack.channels.read",
-    payload={},
-    policy=EndpointPolicy.ALWAYS,
-    external_app_id=42,
-)
-_MATCH_DENY = ActionMatch(
-    action_type="slack.messages.write",
-    payload={"text": "hi"},
-    policy=EndpointPolicy.DENY,
-    external_app_id=42,
-)
+_MATCH_DENY = make_action_match(payload={"text": "hi"}, policy=EndpointPolicy.DENY)
 
 
 # ---------------------------------------------------------------------------
@@ -263,26 +242,29 @@ def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     assert resolver.resolve_session_by_id_calls == []
     # The off-catalog dispatch IS wired — the resolver was probed with match=None.
     assert len(spy.claims_calls) == 1
-    _host, ctx = spy.claims_calls[0]
+    _request, ctx = spy.claims_calls[0]
     assert ctx.match is None
     assert ctx.sandbox is sandbox
 
 
-def test_resolve_and_match_matcher_raises_fails_open() -> None:
-    """Matcher exception: no off-catalog dispatch — would risk leaking
-    credentials onto a request whose attribution failed."""
+def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None:
+    """Matcher exception falls through to off-catalog dispatch — otherwise
+    the request would forward with placeholder credentials, surfacing as a
+    fingerprintable upstream 401 once Plans 2/3 add host-only resolvers."""
     resolver = _StubResolver(sandbox=_sandbox())
     matcher = _StubMatcher(exc=RuntimeError("matcher boom"))
-    spy = RecordingCredentialResolver(claims_result=True)
+    spy = RecordingCredentialResolver(claims_result=False)
     addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
     flow = _flow()
 
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    assert flow.response is None
+    assert flow.response is None  # forwarded
     assert resolver.resolve_session_by_id_calls == []
-    assert spy.claims_calls == []  # matcher exception aborts before dispatch
+    # Dispatcher was invoked with match=None (same as a real off-catalog).
+    assert len(spy.claims_calls) == 1
+    assert spy.claims_calls[0][1].match is None
 
 
 # ---------------------------------------------------------------------------
@@ -409,27 +391,6 @@ async def test_always_goes_straight_through(monkeypatch: pytest.MonkeyPatch) -> 
     assert flow.response is None  # forwarded
     assert not spy.approval_ran  # straight through — no prompt
     assert spy.dispatched == [(_MATCH_ALWAYS, sandbox.user_id, sandbox.tenant_id)]
-
-
-@pytest.mark.asyncio
-async def test_off_catalog_dispatches_with_match_none(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No matching rule: forwarded, dispatcher runs with match=None so
-    host-only resolvers (Onyx PAT, LLM keys) get a chance to claim."""
-    sandbox = _sandbox()
-    addon = _build(
-        resolver=_StubResolver(sandbox=sandbox),
-        matcher=_StubMatcher(result=None),
-    )
-    spy = _spy_pipeline(addon, monkeypatch)
-    flow = _flow()
-
-    await addon.request(flow)
-
-    assert flow.response is None  # forwarded
-    assert not spy.approval_ran
-    assert spy.dispatched == [(None, sandbox.user_id, sandbox.tenant_id)]
 
 
 @pytest.mark.asyncio
@@ -883,7 +844,7 @@ def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
 
     addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
 
-    _assert_403(flow, gate_mod._CODE_CREDENTIAL_ERROR)
+    _assert_403(flow, credential_injection_mod.CODE_CREDENTIAL_ERROR)
 
 
 def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
@@ -899,26 +860,7 @@ def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
 
     addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
 
-    _assert_403(flow, gate_mod._CODE_CREDENTIAL_ERROR)
-
-
-def test_dispatch_injection_off_catalog_passes_match_none_to_resolvers() -> None:
-    """Off-catalog forwards reach the dispatcher with match=None so host-only
-    resolvers (Onyx PAT, LLM keys) can still claim by host."""
-    spy = RecordingCredentialResolver(
-        claims_result=True, headers={"Authorization": "Bearer x"}
-    )
-    addon = _build(
-        resolver=_StubResolver(),
-        matcher=_StubMatcher(),
-        credential_resolvers=[spy],
-    )
-    flow = _flow()
-
-    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=None)
-
-    assert flow.response is None
-    assert spy.resolve_calls[0].match is None
+    _assert_403(flow, credential_injection_mod.CODE_CREDENTIAL_ERROR)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1,6 +1,6 @@
 """Unit tests for the GateAddon mitmproxy addon.
 
-External dependencies (`_Resolver`, `ActionMatcher`, `CacheFactory`,
+External dependencies (`_IdentityResolverProto`, `ActionMatcher`, `CacheFactory`,
 `DBSessionFactory`) are stubbed via small Protocol implementations.
 
 The race arbiter (`_claim_expired_or_read_winner`) is covered against a
@@ -27,15 +27,20 @@ from redis.exceptions import RedisError
 
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
-from onyx.sandbox_proxy.action_matcher import ActionMatch
+from onyx.external_apps.matching.engine import ActionMatch
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
 from onyx.sandbox_proxy.addons.gate import PARSER_MAX_BODY_BYTES
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 
 # ---------------------------------------------------------------------------
@@ -102,6 +107,7 @@ def _build(
     matcher: _StubMatcher,
     db_factory: Any = _noop_db_factory,
     cache_factory: Any = _noop_cache_factory,
+    credential_resolvers: list[CredentialResolver] | None = None,
 ) -> GateAddon:
     return GateAddon(
         identity=resolver,
@@ -109,6 +115,9 @@ def _build(
         db_session_factory=db_factory,
         cache_factory=cache_factory,
         proxy_instance_id="proxy-test",
+        credential_dispatcher=CredentialInjectionDispatcher(
+            credential_resolvers if credential_resolvers is not None else []
+        ),
     )
 
 
@@ -237,24 +246,35 @@ def test_resolve_and_match_no_tag_fails_closed() -> None:
 
 
 def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
-    """Non-gated traffic: matcher returns None → mitmproxy forwards."""
-    resolver = _StubResolver(sandbox=_sandbox())
+    """Non-gated traffic: matcher returns None → forwarded; the off-catalog
+    dispatcher invocation runs with `match=None` so host-only resolvers
+    (Onyx PAT, LLM keys from plans 2/3) can still claim by host."""
+    sandbox = _sandbox()
+    resolver = _StubResolver(sandbox=sandbox)
     matcher = _StubMatcher(result=None)
-    addon = _build(resolver=resolver, matcher=matcher)
+    spy = RecordingCredentialResolver(claims_result=False)
+    addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
     flow = _flow()
 
     result = addon._resolve_and_match(flow)
 
     assert result is None
     assert flow.response is None  # forwarded
-    # Non-gated traffic must not trigger a session lookup.
     assert resolver.resolve_session_by_id_calls == []
+    # The off-catalog dispatch IS wired — the resolver was probed with match=None.
+    assert len(spy.claims_calls) == 1
+    _host, ctx = spy.claims_calls[0]
+    assert ctx.match is None
+    assert ctx.sandbox is sandbox
 
 
 def test_resolve_and_match_matcher_raises_fails_open() -> None:
+    """Matcher exception: no off-catalog dispatch — would risk leaking
+    credentials onto a request whose attribution failed."""
     resolver = _StubResolver(sandbox=_sandbox())
     matcher = _StubMatcher(exc=RuntimeError("matcher boom"))
-    addon = _build(resolver=resolver, matcher=matcher)
+    spy = RecordingCredentialResolver(claims_result=True)
+    addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
     flow = _flow()
 
     result = addon._resolve_and_match(flow)
@@ -262,6 +282,7 @@ def test_resolve_and_match_matcher_raises_fails_open() -> None:
     assert result is None
     assert flow.response is None
     assert resolver.resolve_session_by_id_calls == []
+    assert spy.claims_calls == []  # matcher exception aborts before dispatch
 
 
 # ---------------------------------------------------------------------------
@@ -269,9 +290,7 @@ def test_resolve_and_match_matcher_raises_fails_open() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_always_forwards_without_session(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_resolve_and_match_always_forwards_without_session() -> None:
     """ALWAYS auto-approves: forward (with credentials injected), no approval
     row, and (since it's not gated) no session lookup — even when a tag is
     present."""
@@ -280,8 +299,10 @@ def test_resolve_and_match_always_forwards_without_session(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH_ALWAYS),
         db_factory=_recorder_db_factory([]),
+        # No-claim resolver -> dispatcher returns PASS_THROUGH, leaves the
+        # flow forwarded with no response.
+        credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
     )
-    _patch_headers(monkeypatch, {})
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
     result = addon._resolve_and_match(flow)
@@ -321,11 +342,13 @@ def test_resolve_and_match_deny_blocks_with_403() -> None:
 
 @dataclass
 class _PipelineSpy:
-    """Records the approval pipeline + injection so a test can read the path."""
+    """Records the approval pipeline + dispatcher so a test can read the path."""
 
     persisted: list[tuple[SessionContext, ActionMatch]]
     awaited: list[ActionMatch]
-    injected: list[tuple[ActionMatch, UUID, str]]
+    # (match, sandbox_user_id, sandbox_tenant_id) — captured off the
+    # InjectionContext the dispatcher was handed.
+    dispatched: list[tuple[ActionMatch | None, UUID, str]]
 
     @property
     def approval_ran(self) -> bool:
@@ -338,12 +361,13 @@ def _spy_pipeline(
     *,
     decision: ApprovalDecision | None = None,
 ) -> _PipelineSpy:
-    """Stub the approval pipeline (persist + await) and the injection seam.
+    """Stub the approval pipeline (persist + await) and capture dispatch
+    invocations so each verdict path can be read end-to-end.
 
     `decision` is what the (stubbed) approval wait resolves to — only the ASK
     path reaches it.
     """
-    spy = _PipelineSpy(persisted=[], awaited=[], injected=[])
+    spy = _PipelineSpy(persisted=[], awaited=[], dispatched=[])
 
     def _persist(ctx: SessionContext, match: ActionMatch) -> UUID:
         spy.persisted.append((ctx, match))
@@ -355,19 +379,17 @@ def _spy_pipeline(
         spy.awaited.append(match)
         return decision
 
-    def _inject(
+    def _dispatch(
         flow: http.HTTPFlow,  # noqa: ARG001
-        match: ActionMatch,
         *,
-        user_id: UUID,
-        tenant_id: str,
-    ) -> bool:
-        spy.injected.append((match, user_id, tenant_id))
-        return True
+        sandbox: ResolvedSandbox,
+        match: ActionMatch | None,
+    ) -> None:
+        spy.dispatched.append((match, sandbox.user_id, sandbox.tenant_id))
 
     monkeypatch.setattr(addon, "_persist_approval_row", _persist)
     monkeypatch.setattr(addon, "_await_decision", _await)
-    monkeypatch.setattr(addon, "_inject_credentials", _inject)
+    monkeypatch.setattr(addon, "_dispatch_injection_or_block", _dispatch)
     return spy
 
 
@@ -386,16 +408,18 @@ async def test_always_goes_straight_through(monkeypatch: pytest.MonkeyPatch) -> 
 
     assert flow.response is None  # forwarded
     assert not spy.approval_ran  # straight through — no prompt
-    assert spy.injected == [(_MATCH_ALWAYS, sandbox.user_id, sandbox.tenant_id)]
+    assert spy.dispatched == [(_MATCH_ALWAYS, sandbox.user_id, sandbox.tenant_id)]
 
 
 @pytest.mark.asyncio
-async def test_off_catalog_goes_straight_through(
+async def test_off_catalog_dispatches_with_match_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No matching rule: forwarded as-is, no approval prompt, NO injection."""
+    """No matching rule: forwarded, dispatcher runs with match=None so
+    host-only resolvers (Onyx PAT, LLM keys) get a chance to claim."""
+    sandbox = _sandbox()
     addon = _build(
-        resolver=_StubResolver(sandbox=_sandbox()),
+        resolver=_StubResolver(sandbox=sandbox),
         matcher=_StubMatcher(result=None),
     )
     spy = _spy_pipeline(addon, monkeypatch)
@@ -405,12 +429,12 @@ async def test_off_catalog_goes_straight_through(
 
     assert flow.response is None  # forwarded
     assert not spy.approval_ran
-    assert spy.injected == []
+    assert spy.dispatched == [(None, sandbox.user_id, sandbox.tenant_id)]
 
 
 @pytest.mark.asyncio
 async def test_deny_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DENY: blocked with a 403, no approval prompt, NO injection."""
+    """DENY: blocked with a 403, no approval prompt, NO dispatch."""
     addon = _build(
         resolver=_StubResolver(sandbox=_sandbox()),
         matcher=_StubMatcher(result=_MATCH_DENY),
@@ -422,14 +446,14 @@ async def test_deny_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
 
     _assert_403(flow, gate_mod._CODE_POLICY_DENIED)
     assert not spy.approval_ran
-    assert spy.injected == []
+    assert spy.dispatched == []
 
 
 @pytest.mark.asyncio
 async def test_ask_approved_forwards_after_approval(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """ASK: runs the approval pipeline; on APPROVED forwards + injects."""
+    """ASK: runs the approval pipeline; on APPROVED forwards + dispatches."""
     user_id = uuid4()
     sandbox = _sandbox(user_id=user_id)
     resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
@@ -442,7 +466,7 @@ async def test_ask_approved_forwards_after_approval(
     assert spy.approval_ran  # required approval
     assert spy.awaited == [_MATCH]
     assert flow.response is None  # forwarded after approval
-    assert spy.injected == [(_MATCH, user_id, sandbox.tenant_id)]
+    assert spy.dispatched == [(_MATCH, user_id, sandbox.tenant_id)]
 
 
 @pytest.mark.asyncio
@@ -458,7 +482,7 @@ async def test_ask_denied_blocks(
     decision: ApprovalDecision,
     expected_code: str,
 ) -> None:
-    """ASK: runs the approval pipeline; on REJECTED/EXPIRED blocks, no inject."""
+    """ASK: runs the approval pipeline; on REJECTED/EXPIRED blocks, no dispatch."""
     resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     spy = _spy_pipeline(addon, monkeypatch, decision=decision)
@@ -468,7 +492,7 @@ async def test_ask_denied_blocks(
 
     assert spy.approval_ran  # required approval before blocking
     _assert_403(flow, expected_code)
-    assert spy.injected == []
+    assert spy.dispatched == []
 
 
 # ---------------------------------------------------------------------------
@@ -794,119 +818,107 @@ def test_responseheaders_no_response_is_noop() -> None:
 
 
 # ---------------------------------------------------------------------------
-# _inject_credentials — apply resolved auth headers to a verified forward
+# _dispatch_injection_or_block — credential dispatcher wired into the gate
 # ---------------------------------------------------------------------------
 
 
-def _patch_headers(monkeypatch: pytest.MonkeyPatch, headers: dict[str, str]) -> None:
-    monkeypatch.setattr(
-        gate_mod, "resolve_injection_headers", lambda _db, _aid, _uid: headers
+def test_dispatch_injection_writes_resolved_headers() -> None:
+    """A claiming resolver's headers overwrite whatever the sandbox shipped —
+    the real secret lives only in the proxy."""
+    spy = RecordingCredentialResolver(
+        claims_result=True, headers={"Authorization": "Bearer real-secret"}
     )
-
-
-def test_inject_credentials_sets_resolved_headers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Resolved headers are written onto the request, overwriting any value the
-    sandbox supplied (the real secret lives only in the proxy)."""
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
+        credential_resolvers=[spy],
     )
-    _patch_headers(monkeypatch, {"Authorization": "Bearer real-secret"})
     flow = _flow()
     flow.request.headers["Authorization"] = "sandbox-placeholder"
+    sandbox = _sandbox()
 
-    assert addon._inject_credentials(
-        flow, _MATCH_ALWAYS, user_id=uuid4(), tenant_id="public"
-    )
+    addon._dispatch_injection_or_block(flow, sandbox=sandbox, match=_MATCH_ALWAYS)
+
+    assert flow.response is None  # forwarded
     assert flow.request.headers["Authorization"] == "Bearer real-secret"
+    assert len(spy.resolve_calls) == 1
+    seen = spy.resolve_calls[0]
+    assert seen.sandbox is sandbox
+    assert seen.match is _MATCH_ALWAYS
+    # The dispatcher must receive the gate's own session factory — a resolver
+    # that opens its own session would see the wrong tenant schema.
+    assert seen.db_session_factory is addon._db_session_factory
 
 
-def test_inject_credentials_succeeds_with_no_headers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """No resolvable credentials -> nothing injected, but still a success (the
-    request forwards; a missing credential just means upstream answers 401)."""
+def test_dispatch_injection_pass_through_forwards_untouched() -> None:
+    """No resolver claims: forward, don't 403, don't modify headers."""
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
+        credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
     )
-    _patch_headers(monkeypatch, {})
-    flow = _flow()  # headers default to {}
+    flow = _flow()
+    flow.request.headers["X-Pod-Side"] = "preserve"
 
-    assert addon._inject_credentials(
-        flow, _MATCH_ALWAYS, user_id=uuid4(), tenant_id="public"
-    )
-    assert dict(flow.request.headers) == {}
+    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
+
+    assert flow.response is None
+    assert flow.request.headers["X-Pod-Side"] == "preserve"
 
 
-def test_inject_credentials_fails_on_error(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A resolution error must not raise, must not inject, and reports failure
-    so the caller can block."""
+def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
+    """A claiming resolver that can't render fails closed at the gate boundary
+    — the request never forwards with the sandbox's own headers."""
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
+        credential_resolvers=[
+            RecordingCredentialResolver(
+                claims_result=True,
+                exc=CredentialUnavailableError("no PAT for sandbox"),
+            )
+        ],
     )
-
-    def _boom(_db: Any, _aid: int, _uid: UUID) -> dict[str, str]:
-        raise RuntimeError("db down")
-
-    monkeypatch.setattr(gate_mod, "resolve_injection_headers", _boom)
-    flow = _flow()  # headers default to {}
-
-    assert not addon._inject_credentials(
-        flow, _MATCH_ALWAYS, user_id=uuid4(), tenant_id="public"
-    )
-    assert "Authorization" not in flow.request.headers
-
-
-def test_inject_credentials_or_block_sets_403_on_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The wrapper blocks a verified forward with a 403 when injection fails,
-    rather than forwarding it with the sandbox's own headers."""
-    addon = _build(
-        resolver=_StubResolver(),
-        matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
-    )
-
-    def _boom(_db: Any, _aid: int, _uid: UUID) -> dict[str, str]:
-        raise RuntimeError("db down")
-
-    monkeypatch.setattr(gate_mod, "resolve_injection_headers", _boom)
     flow = _flow()
 
-    addon._inject_credentials_or_block(
-        flow, _MATCH_ALWAYS, user_id=uuid4(), tenant_id="public"
-    )
+    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
 
     _assert_403(flow, gate_mod._CODE_CREDENTIAL_ERROR)
 
 
-def test_inject_credentials_or_block_forwards_on_success(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The wrapper leaves the response unset (forwards) when injection succeeds."""
+def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
+    """Any other resolver error is also fail-closed — never a silent forward."""
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
+        credential_resolvers=[
+            RecordingCredentialResolver(claims_result=True, exc=RuntimeError("db blip"))
+        ],
     )
-    _patch_headers(monkeypatch, {"Authorization": "Bearer real-secret"})
     flow = _flow()
 
-    addon._inject_credentials_or_block(
-        flow, _MATCH_ALWAYS, user_id=uuid4(), tenant_id="public"
+    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
+
+    _assert_403(flow, gate_mod._CODE_CREDENTIAL_ERROR)
+
+
+def test_dispatch_injection_off_catalog_passes_match_none_to_resolvers() -> None:
+    """Off-catalog forwards reach the dispatcher with match=None so host-only
+    resolvers (Onyx PAT, LLM keys) can still claim by host."""
+    spy = RecordingCredentialResolver(
+        claims_result=True, headers={"Authorization": "Bearer x"}
     )
+    addon = _build(
+        resolver=_StubResolver(),
+        matcher=_StubMatcher(),
+        credential_resolvers=[spy],
+    )
+    flow = _flow()
+
+    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=None)
 
     assert flow.response is None
+    assert spy.resolve_calls[0].match is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1,6 +1,6 @@
 """Unit tests for the GateAddon mitmproxy addon.
 
-External dependencies (`_IdentityResolverProto`, `ActionMatcher`, `CacheFactory`,
+External dependencies (`_IdentityResolver`, `ActionMatcher`, `CacheFactory`,
 `DBSessionFactory`) are stubbed via small Protocol implementations.
 
 The race arbiter (`_claim_expired_or_read_winner`) is covered against a
@@ -28,7 +28,7 @@ from redis.exceptions import RedisError
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import ActionMatch
-from onyx.sandbox_proxy import credential_injection as credential_injection_mod
+from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
@@ -36,6 +36,7 @@ from onyx.sandbox_proxy.addons.gate import PARSER_MAX_BODY_BYTES
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
@@ -51,7 +52,7 @@ from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 # ---------------------------------------------------------------------------
 
 
-class _StubMatcher:
+class _StubMatcher(ActionMatcher):
     def __init__(
         self,
         *,
@@ -103,7 +104,7 @@ def _build(
 ) -> GateAddon:
     return GateAddon(
         identity=resolver,
-        action_matcher=matcher,  # type: ignore[arg-type]
+        action_matcher=matcher,
         db_session_factory=db_factory,
         cache_factory=cache_factory,
         proxy_instance_id="proxy-test",
@@ -113,13 +114,13 @@ def _build(
     )
 
 
-def _assert_403(flow: http.HTTPFlow, expected_code: str) -> None:
+def _assert_403(flow: http.HTTPFlow, expected_code: SandboxProxyError) -> None:
     assert flow.response is not None
     assert flow.response.status_code == 403
     content = flow.response.content
     assert content is not None
     body = json.loads(content)
-    assert body == {"error": expected_code}
+    assert body == {"error": expected_code.value}
 
 
 _MATCH = make_action_match(payload={"text": "hi"})
@@ -143,7 +144,7 @@ def test_resolve_and_match_no_source_ip_fails_closed() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_UNIDENTIFIED_SANDBOX)
+    _assert_403(flow, SandboxProxyError.UNIDENTIFIED_SANDBOX)
     # Short-circuited before resolver / matcher ran.
     assert resolver.resolve_sandbox_calls == 0
     assert matcher.calls == 0
@@ -169,7 +170,7 @@ def test_resolve_and_match_sandbox_resolution_fails_closed(
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_UNIDENTIFIED_SANDBOX)
+    _assert_403(flow, SandboxProxyError.UNIDENTIFIED_SANDBOX)
     assert matcher.calls == 0
 
 
@@ -195,7 +196,7 @@ def test_resolve_and_match_body_too_large_fails_closed(
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_BODY_TOO_LARGE)
+    _assert_403(flow, SandboxProxyError.BODY_TOO_LARGE)
     assert matcher.calls == 0
 
 
@@ -215,7 +216,7 @@ def test_resolve_and_match_no_tag_fails_closed() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_NO_ACTIVE_SESSION)
+    _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert resolver.resolve_session_by_id_calls == []
 
 
@@ -226,8 +227,8 @@ def test_resolve_and_match_no_tag_fails_closed() -> None:
 
 def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     """Non-gated traffic: matcher returns None → forwarded; the off-catalog
-    dispatcher invocation runs with `match=None` so host-only resolvers
-    (Onyx PAT, LLM keys from plans 2/3) can still claim by host."""
+    dispatcher invocation runs with `match=None` so host-only resolvers can
+    still claim by host."""
     sandbox = _sandbox()
     resolver = _StubResolver(sandbox=sandbox)
     matcher = _StubMatcher(result=None)
@@ -250,7 +251,7 @@ def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
 def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None:
     """Matcher exception falls through to off-catalog dispatch — otherwise
     the request would forward with placeholder credentials, surfacing as a
-    fingerprintable upstream 401 once Plans 2/3 add host-only resolvers."""
+    fingerprintable upstream 401 once host-only resolvers exist."""
     resolver = _StubResolver(sandbox=_sandbox())
     matcher = _StubMatcher(exc=RuntimeError("matcher boom"))
     spy = RecordingCredentialResolver(claims_result=False)
@@ -303,7 +304,7 @@ def test_resolve_and_match_deny_blocks_with_403() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_POLICY_DENIED)
+    _assert_403(flow, SandboxProxyError.POLICY_DENIED)
     assert resolver.resolve_session_by_id_calls == []
 
 
@@ -405,7 +406,7 @@ async def test_deny_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
 
     await addon.request(flow)
 
-    _assert_403(flow, gate_mod._CODE_POLICY_DENIED)
+    _assert_403(flow, SandboxProxyError.POLICY_DENIED)
     assert not spy.approval_ran
     assert spy.dispatched == []
 
@@ -434,14 +435,14 @@ async def test_ask_approved_forwards_after_approval(
 @pytest.mark.parametrize(
     "decision, expected_code",
     [
-        (ApprovalDecision.REJECTED, gate_mod._CODE_USER_REJECTED),
-        (ApprovalDecision.EXPIRED, gate_mod._CODE_NOT_AUTHORIZED),
+        (ApprovalDecision.REJECTED, SandboxProxyError.USER_REJECTED),
+        (ApprovalDecision.EXPIRED, SandboxProxyError.NOT_AUTHORIZED),
     ],
 )
 async def test_ask_denied_blocks(
     monkeypatch: pytest.MonkeyPatch,
     decision: ApprovalDecision,
-    expected_code: str,
+    expected_code: SandboxProxyError,
 ) -> None:
     """ASK: runs the approval pipeline; on REJECTED/EXPIRED blocks, no dispatch."""
     resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
@@ -590,7 +591,7 @@ def test_resolve_and_match_unverified_tag_fails_closed() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_NO_ACTIVE_SESSION)
+    _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert len(resolver.resolve_session_by_id_calls) == 1
 
 
@@ -603,7 +604,7 @@ def test_resolve_and_match_malformed_tag_fails_closed() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_NO_ACTIVE_SESSION)
+    _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert resolver.resolve_session_by_id_calls == []
 
 
@@ -618,7 +619,7 @@ def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
     result = addon._resolve_and_match(flow)
 
     assert result is None
-    _assert_403(flow, gate_mod._CODE_NO_ACTIVE_SESSION)
+    _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert len(resolver.resolve_session_by_id_calls) == 1
 
 
@@ -717,7 +718,7 @@ async def test_requestheaders_rejects_cross_tenant_prefix() -> None:
     # Unmarked oversize flow now hits the fail-closed cap.
     result = addon._resolve_and_match(flow)
     assert result is None
-    _assert_403(flow, gate_mod._CODE_BODY_TOO_LARGE)
+    _assert_403(flow, SandboxProxyError.BODY_TOO_LARGE)
 
 
 @pytest.mark.asyncio
@@ -844,7 +845,7 @@ def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
 
     addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
 
-    _assert_403(flow, credential_injection_mod.CODE_CREDENTIAL_ERROR)
+    _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
 
 
 def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
@@ -860,7 +861,7 @@ def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
 
     addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
 
-    _assert_403(flow, credential_injection_mod.CODE_CREDENTIAL_ERROR)
+    _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
 
 
 # ---------------------------------------------------------------------------
@@ -883,7 +884,7 @@ def test_write_response_rejected_sets_user_rejected_403() -> None:
 
     addon._write_response_for_decision(flow, ApprovalDecision.REJECTED)
 
-    _assert_403(flow, gate_mod._CODE_USER_REJECTED)
+    _assert_403(flow, SandboxProxyError.USER_REJECTED)
 
 
 def test_write_response_expired_sets_not_authorized_403() -> None:
@@ -892,7 +893,7 @@ def test_write_response_expired_sets_not_authorized_403() -> None:
 
     addon._write_response_for_decision(flow, ApprovalDecision.EXPIRED)
 
-    _assert_403(flow, gate_mod._CODE_NOT_AUTHORIZED)
+    _assert_403(flow, SandboxProxyError.NOT_AUTHORIZED)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_healthz.py
+++ b/backend/tests/unit/sandbox_proxy/test_healthz.py
@@ -5,11 +5,12 @@ from http.server import HTTPServer
 
 import pytest
 
+from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.server import _build_healthz_handler
 from onyx.sandbox_proxy.server import _Readiness
 
 
-class _FakeLookup:
+class _FakeLookup(SandboxIPLookup):
     def __init__(self, synced: bool) -> None:
         self._synced = synced
 

--- a/backend/tests/unit/sandbox_proxy/test_identity.py
+++ b/backend/tests/unit/sandbox_proxy/test_identity.py
@@ -115,8 +115,8 @@ def test_resolve_session_by_id_propagates_scalar() -> None:
 
 
 def test_with_session_then_without_session_round_trips() -> None:
-    """A regression that drops any field would silently break the ASK→APPROVED
-    credential injection — `OnyxPatResolver` (plan 2) reads `sandbox_id`."""
+    """A regression that drops any field would silently break ASK→APPROVED
+    credential injection, where resolvers key off `sandbox_id` and `user_id`."""
     sandbox = ResolvedSandbox(
         sandbox_id=uuid4(),
         user_id=uuid4(),

--- a/backend/tests/unit/sandbox_proxy/test_identity.py
+++ b/backend/tests/unit/sandbox_proxy/test_identity.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from uuid import uuid4
 
 from onyx.sandbox_proxy.identity import IdentityResolver
+from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SandboxIdentity
 from tests.unit.sandbox_proxy.conftest import StaticLookup
 
@@ -105,3 +106,24 @@ def test_resolve_session_by_id_propagates_scalar() -> None:
     assert resolver.resolve_session_by_id(uuid4(), uuid4(), "public") is None
     assert factory.last_tenant_id == "public"
     assert stub.scalar_calls == 2
+
+
+# ---------------------------------------------------------------------------
+# `with_session` / `without_session` round-trip (the credential-injection seam
+# unpacks the SessionContext back to a ResolvedSandbox on ASK→APPROVED).
+# ---------------------------------------------------------------------------
+
+
+def test_with_session_then_without_session_round_trips() -> None:
+    """A regression that drops any field would silently break the ASK→APPROVED
+    credential injection — `OnyxPatResolver` (plan 2) reads `sandbox_id`."""
+    sandbox = ResolvedSandbox(
+        sandbox_id=uuid4(),
+        user_id=uuid4(),
+        tenant_id="tenant-xyz",
+        sandbox_name="sandbox-1",
+        sandbox_ip="10.0.0.99",
+    )
+    session_id = uuid4()
+
+    assert sandbox.with_session(session_id).without_session() == sandbox

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -32,6 +32,8 @@ from mitmproxy import http as mitm_http
 from mitmproxy.options import Options
 from mitmproxy.tools.dump import DumpMaster
 
+from onyx.sandbox_proxy.action_matcher import ActionMatcher
+from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
@@ -90,7 +92,7 @@ class _UpstreamHandler(BaseHTTPRequestHandler):
         self.wfile.flush()
 
 
-class _StubResolver:
+class _StubResolver(_IdentityResolver):
     """Resolves any source IP to one sandbox so the request is forwarded."""
 
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox:  # noqa: ARG002
@@ -111,7 +113,7 @@ class _StubResolver:
         return None
 
 
-class _NonGatingMatcher:
+class _NonGatingMatcher(ActionMatcher):
     """Never matches, so every request fails open and is forwarded."""
 
     def match(self, request: mitm_http.Request, tenant_id: str) -> None:  # noqa: ARG002

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -33,6 +33,7 @@ from mitmproxy.options import Options
 from mitmproxy.tools.dump import DumpMaster
 
 from onyx.sandbox_proxy.addons.gate import GateAddon
+from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 
 # Inter-chunk delay on the upstream. The whole stream takes
@@ -166,6 +167,7 @@ def _start_proxy(
         db_session_factory=_unused_factory,
         cache_factory=_unused_factory,
         proxy_instance_id="proxy-test",
+        credential_dispatcher=CredentialInjectionDispatcher([]),
         stream_responses=stream_responses,
     )
 

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -1,137 +1,172 @@
-# Plan 1 — Egress Credential-Injection Seam
+# Plan 1 — Unified Credential-Injection Seam
 
-This is the foundation of the Craft secret-injection workstream: keep long-lived secrets (LLM
-provider keys, the Onyx PAT) **out of the sandbox pod** and hold them only in the egress proxy.
-The sandbox is a low-trust environment that runs agent-authored code, so it shouldn't hold
-credentials at rest; the proxy (`backend/onyx/sandbox_proxy/`) is a separate, locked-down
-Deployment that already forces all egress through itself, MITMs TLS with a CA the sandbox trusts,
-and resolves sandbox identity by source IP — the natural place to broker secrets.
+Replaces the original Phase 1 (a host-keyed dispatcher run in `requestheaders`). Defines a single
+host-claim seam, run from the gate's post-verdict path, that hosts three credential sources — Dane's
+user-connected external apps, the per-sandbox Onyx PAT ([Plan 2](./02-onyx-pat.md)), and the
+per-tenant LLM provider keys ([Plan 3](./03-llm-key.md)) — so long-lived secrets live only in the
+proxy and never in the sandbox pod.
 
-It defines **one** egress credential-injection seam, **shared with the external-apps work**
-(Danelegend, PRs #11033–#11413). External-app credentials, LLM keys, and the Onyx PAT all inject
-through it. The workstream is three plans: this seam, then the [Onyx PAT resolver](./02-onyx-pat.md)
-and [LLM provider-key resolver](./03-llm-key.md), which plug into it and are independent of each
-other.
+## Status after Dane's PRs land
 
-## Landing plan (PRs)
+Dane's `dane/ea-matcher` + `dane/ea-inject-creds` deliver credential injection for one source — user-
+connected external apps — through `GateAddon._inject_credentials`, called on `ALWAYS` and
+`ASK → APPROVED`. `DENY` blocks; off-catalog forwards uncredentialed.
 
-Roughly one PR per plan, flag-gated and independently revertible:
+That covers external apps but not the two system credentials this project must broker:
 
-1. **Prerequisite** — wire `ENCRYPTION_KEY_SECRET` into the proxy Deployment.
-2. **This seam** — interface + dispatcher + rendering helper + config + observability; lands inert
-  (no resolvers registered).
-3. **[Onyx PAT resolver](./02-onyx-pat.md)** and 4. **[LLM key resolver](./03-llm-key.md)** — each one
-  atomic, flag-gated PR (placeholder + resolver + routing together). Independent; land in parallel.
+| Source | Key scope | Why Dane's API doesn't fit |
+|---|---|---|
+| External-app credentials | `(external_app_id, user_id)` | What Dane built. |
+| Onyx PAT ([Plan 2](./02-onyx-pat.md)) | `sandbox_id` | API takes `user_id`; one user can own multiple sandboxes. The PAT lives on the `Sandbox` row, not in any `ExternalApp`. The Onyx API isn't an external app. |
+| LLM provider keys ([Plan 3](./03-llm-key.md)) | `tenant_id` (per provider) | Per-tenant infrastructure, not user-connected. Keys live in `llm_provider` rows; modelling them as `ExternalApp`s would duplicate the LLM-admin data model. |
 
-Sequence: 1 + 2 first, then 3 and 4 in parallel. Each migration must ship atomically behind its
-flag — the pod-side placeholder only takes effect once its resolver is live. The external-apps
-convergence (retire `action_matcher.py`, register Dane's resolver) is a separate PR in that track.
+And: off-catalog hosts (the Onyx API, LLM providers) forward uncredentialed today.
 
 ## Issues to Address
 
-Two secrets are currently provisioned into the pod: the LLM key in `OPENCODE_CONFIG_CONTENT`, and
-the Onyx PAT in the `ONYX_PAT` env var (both in `kubernetes_sandbox_manager.py`). This seam relocates
-them to the proxy so they no longer reside in the sandbox. Separately, the external-apps work already resolves per-user app
-credentials server-side — `get_external_app_credentials(db, user_id, url)` (added in the open PR
-#11086) matches the outbound URL against an app's `upstream_url_patterns` and renders its
-`auth_template`; the skill wrappers send no auth — and expects the proxy to inject them. **But the
-proxy injection step doesn't exist yet, for anyone.** Both efforts need the same primitive; building
-them as separate request-hook paths would collide over the same headers. This plan builds the one
-seam; the LLM/PAT resolvers (plans 2 & 3) and Dane's external-app resolver plug into it. It can land
-with zero resolvers (pure substrate).
+1. The credential-injection seam is hard-wired to one source. No plug-in point for additional sources.
+2. Off-catalog flows forward uncredentialed — fine for arbitrary traffic, wrong for known system
+   endpoints.
+3. Dane's fail-open semantic is right for user-in-the-loop apps but wrong for system credentials:
+   a missing PAT or LLM key is a configuration error, and a Craft 403 is safer than fingerprinting
+   the upstream's response.
+4. The Onyx API host is on `NO_PROXY` (`_compute_no_proxy_list()`); its traffic bypasses the proxy
+   entirely.
 
 ## Important Notes
 
-**Trust boundary, already in place.** All egress is iptables-forced through the proxy
-(`firewall-init.sh`); its NetworkPolicy only admits the sandbox namespace; it MITMs TLS; and
-`IdentityResolver.resolve_sandbox(src_ip)` (`identity.py`) yields `ResolvedSandbox` (`sandbox_id`,
-`user_id`, `tenant_id`, …). `GateAddon` already has a `db_session_factory` (`server.py`).
+**Two orthogonal concerns at the gate.** Action *gating* (matcher) decides whether a request needs
+user approval. Credential *injection* (dispatcher) decides what auth headers go on the wire. They
+compose at the gate but are independent — a request can need injection without gating (the Onyx API,
+LLM calls).
 
-**One dispatcher, many resolvers.** Define `CredentialResolver.resolve(request, identity) -> Injection | None`: return rendered auth headers to set; `None` if the host doesn't match (pass
-through); or signal **block** (fail-closed) if the host matches but the secret can't be resolved.
-Three resolvers plug in:
+**Disjoint host responsibilities.** External-app hosts come from `ExternalApp.upstream_url_patterns`;
+the Onyx API host is `SANDBOX_API_SERVER_URL`; LLM provider hosts are the canonical provider hosts
+plus each tenant's `LLMProvider.api_base`. The dispatcher logs at startup if two resolvers' claim
+predicates overlap; the dispatcher unit test fails on overlap.
 
-- **ExternalAppResolver** — Dane's, per-**user** (creds are per-user), from `external_app` rows.
-- **LLMProviderKeyResolver** — per-**tenant** (sandboxes share the tenant's keys), from `llm_provider`.
-- **OnyxPatResolver** — per-**sandbox** (each sandbox has its own PAT).
+**Placeholder/overwrite contract.** The pod ships a non-empty placeholder for each credential header
+(opencode's AI SDK throws on unset keys; onyx-cli treats empty as unconfigured). The proxy
+overwrites only the named header.
 
-The dispatcher resolves identity once, passes the full `ResolvedSandbox`, and tries resolvers
-first-match-by-host. Hosts are disjoint (external-app hosts vs LLM provider hosts vs the Onyx API
-host), so this is conflict-free; if an overlap ever surfaces, fix the order explicitly.
+**Decryption.** `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment (#11451), so
+`LLMProviderView.from_model()` and the encrypted per-sandbox PAT both decrypt in-process.
 
-**Reuse the external-apps matching + rendering contract.** An `external_app` models
-`upstream_url_patterns` (regex) + `auth_template` (a `{header: "Bearer {token}"}` dict rendered via
-`format_map`, fail-closed on any missing placeholder). LLM/PAT resolvers supply their templates and
-values from code rather than DB rows, but the render-and-overwrite step is identical. Don't build a
-parallel matcher — the current `sandbox_proxy/action_matcher.py` is a stopgap to be retired (step 6).
+**Supersedes the existing scaffold.** `onyx/sandbox_proxy/credential_injection.py` on
+`whuang/craft-proxy-secrets-injection-scaffold` defines an early host-only dispatcher run in
+`requestheaders`. This plan re-shapes it: post-verdict call site, `InjectionContext` that carries the
+matcher's output, and `_inject_credentials` becomes a delegation to it.
 
-**Placeholder/overwrite contract (single source — referenced by plans 2 & 3).** Clients need a
-*non-empty* credential to build a request (onyx-cli treats empty as "unconfigured"; opencode's AI
-SDK throws if the key is unset). So the pod ships a fixed, non-secret **placeholder constant** in
-place of each real credential, and the proxy **overwrites** the auth header(s) named in the resolved
-template — set/replace, never append; all other headers (e.g. Anthropic's `anthropic-version`) left
-intact. Overwrite is unconditional for matched hosts; the proxy doesn't need to recognize the
-placeholder value. A resolver may match one host or several.
+## The seam
 
-**Decryption: `ENCRYPTION_KEY_SECRET` on the proxy (prerequisite, step 1).** The proxy decrypts DB
-columns with the same machinery as the api_server (`EncryptedString`, `LLMProviderView.from_model`);
-no-op in MIT, real in EE/cloud. Trade-off: it can now decrypt any encrypted column it can reach, so
-its access surface matters more. **Coordination flag:** external-app creds are stored plaintext
-today (unlike `llm_provider.api_key` and the PAT) — encrypt them with Dane if we're hardening this.
+```python
+@dataclass(frozen=True)
+class InjectionContext:
+    sandbox: ResolvedSandbox
+    match: ActionMatch | None      # None for off-catalog flows
+    db_session_factory: DBSessionFactory
 
-**Inject at `requestheaders` (single source for streaming-safety).** Injection only rewrites a
-request header, so the dispatcher runs in `requestheaders` — headers and source IP are available
-before the body. It never reads the request body or the response, so large prompts and SSE
-responses pass through untouched. A matched+injected flow is flagged in `flow.metadata` (mirroring
-the snapshot stream flag) so the `request` hook skips the stopgap gating path.
 
-**Compose with policy/approval gating.** Hook order: resolve identity → policy decision → inject
-(only if allowed) → forward. Dane's #11366 adds `ALWAYS`/`ASK`/`DENY` policy + an action catalog
-the proxy will consume, routing `ASK` through the existing approval flow. Injection and policy are
-separate concerns at the same hook.
+class CredentialUnavailableError(Exception):
+    """A resolver claimed a request but couldn't produce its credential."""
 
-**Coordination / ownership.** The seam lives in `sandbox_proxy/` (ours): we own the dispatcher, the
-`CredentialResolver` interface, the fail-closed/ordering contract, and the LLM/PAT resolvers; Dane
-owns the ExternalAppResolver. Agree the interface before either side builds the injection step.
+
+class CredentialResolver(Protocol):
+    def claims(self, host: str, match: ActionMatch | None) -> bool:
+        """Cheap, no-DB: does this resolver claim this request? First claim wins."""
+        ...
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        """Render auth headers; raise CredentialUnavailableError to fail closed."""
+        ...
+```
+
+`CredentialInjectionDispatcher.apply(flow, ctx)` iterates resolvers in registered order, picks the
+first whose `claims(host, match)` returns True, calls `resolve`, and sets the returned headers on
+`flow.request` (set/replace, never append). Outcome:
+
+- No resolver claims → `PASS_THROUGH`.
+- Resolver returns headers → `INJECTED`.
+- Resolver raises `CredentialUnavailableError` (or any other exception) → `BLOCKED`; the gate maps
+  it to `_http_403(_CODE_CREDENTIAL_UNAVAILABLE)`.
+
+`apply` never raises.
 
 ## Implementation Strategy
 
-1. **Wire `ENCRYPTION_KEY_SECRET` into the proxy Deployment (prerequisite — land first).** From the
-  same K8s Secret the api_server uses.
-2. **Define `CredentialResolver` + the dispatcher** in a new module `sandbox_proxy/injection/`. The
-  dispatcher holds an ordered resolver list, is constructed in `server.py`, and is passed to
-   `GateAddon` like `snapshot_policy`. It runs in `requestheaders`: first host match wins → render +
-   overwrite headers → flag the flow to skip gating. Matched-but-unresolvable → block via the
-   existing 403 helper; unmatched → pass through. Reuse the resolved `ResolvedSandbox`; keep
-   injection independent of gating.
-3. **Shared rendering helper** — `auth_template` `format_map`, fail-closed — used by all resolvers.
-4. **Config.** A seam enable flag plus per-resolver flags (e.g. `*_INJECTION_ENABLED`), read at
-  startup like `SnapshotEgressPolicy.from_env()`, so plans 2 & 3 and Dane's apps roll out
-   independently.
-5. **Observability.** A structured log per injection (host, sandbox_id, tenant_id, resolver, result)
-  — never the secret value.
-6. **Converge with external apps.** Support Dane adapting `get_external_app_credentials` into a
-  `CredentialResolver`; retire `sandbox_proxy/action_matcher.py` for his #11366 catalog.
+1. **Refactor `GateAddon._inject_credentials`** to delegate:
+
+   ```python
+   ctx = InjectionContext(
+       sandbox=sandbox, match=match, db_session_factory=self._db_session_factory
+   )
+   if self._dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
+       flow.response = _http_403(_CODE_CREDENTIAL_UNAVAILABLE)
+   ```
+
+   Move the call so it fires on `OFF_CATALOG` forwards too (today: only `ALWAYS` +
+   `ASK → APPROVED`). `DENY` and `ASK → REJECTED` still skip injection. Pass `match=None` on
+   `OFF_CATALOG`.
+
+2. **`ExternalAppResolver`** — wraps Dane's existing logic.
+   - `claims`: True iff `match is not None and match.external_app_id is not None`. The matcher
+     already did URL→app resolution; the resolver delegates rather than redoing it.
+   - `resolve`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and calls Dane's
+     existing `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
+     Returns `{}` rather than raising on Dane's existing error paths — preserves the per-header
+     fail-open contract he ships.
+
+3. **`OnyxPatResolver`** ([Plan 2](./02-onyx-pat.md)) — claims by host.
+
+4. **`LLMProviderKeyResolver`** ([Plan 3](./03-llm-key.md)) — claims by host (canonical + each
+   tenant's `api_base`).
+
+5. **Route the Onyx API through the proxy.** Remove `SANDBOX_API_SERVER_URL` from
+   `_compute_no_proxy_list()` (keep loopback). Verify in CI that the proxy reaches the API.
+
+6. **Remove sandbox-side credentials** atomically with each resolver's flag:
+   - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` (and the docker manager) → non-empty
+     placeholder. `ensure_sandbox_pat` keeps minting and persisting the PAT on the `Sandbox` row.
+   - LLM keys in `OPENCODE_CONFIG_CONTENT` (`opencode_config.py`) → non-empty placeholders. While
+     here, fix the existing `block["api"]` → `provider.<id>.options.baseURL` mismatch
+     ([[project_craft_beta_no_backcompat]]).
+
+7. **Wire in `server.py`.** `build_resolvers()` returns
+   `[OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]`. The dispatcher is
+   constructed once at startup and passed into `GateAddon`.
 
 ## Tests
 
-External-dependency unit tests (proxy + DB real, sandbox mocked — matches the existing
-`sandbox_proxy/` suite):
+- **Dispatcher unit** (mocked resolvers): first-claim-wins; unclaimed → `PASS_THROUGH`; resolver
+  raises `CredentialUnavailableError` → `BLOCKED` → 403; the `InjectionContext` passed to `resolve`
+  carries the right `sandbox` and `match`. Two resolvers that both claim the same `(host, match)`
+  fail the test.
+- **`ExternalAppResolver` regression**: Dane's existing external-dependency
+  `test_credential_injection.py` passes unchanged — behaviour preserved.
+- **Gate integration**: dispatcher runs on `ALWAYS` / `OFF_CATALOG` / `ASK → APPROVED`; skipped on
+  `DENY` / `ASK → REJECTED`.
+- **`NO_PROXY`**: the computed list no longer contains the Onyx API host.
 
-- Matched request → target header **overwritten** (not duplicated), other headers intact; unmatched
-host passes through.
-- Fail-closed: matched host with an unresolvable secret → 403, not forwarded.
-- Multiple resolvers registered → first host match wins; an injected flow skips the gating path.
-- Identity: the resolver receives the correct `ResolvedSandbox` for the source IP.
-- Feature-flag off → no-op.
+Per-resolver tests live in [Plan 2](./02-onyx-pat.md) and [Plan 3](./03-llm-key.md).
 
-Don't test mitmproxy's header API or Pydantic ([[feedback_dont_test_framework_validation]]).
-Per-resolver behavior is exercised by plans 2/3 and Dane's tests.
+## Landing plan (PRs)
+
+Four PRs, in order; each flag-gated where behavioural and independently revertible.
+
+1. **Seam extraction (refactor only).** Protocol + dispatcher + `ExternalAppResolver`.
+   `_inject_credentials` becomes a delegation. Call site moves to fire on `OFF_CATALOG`. With only
+   `ExternalAppResolver` registered, off-catalog stays a no-op. Dane's external-dep tests unchanged.
+2. **Route the Onyx API through the proxy.** Remove the API host from `_compute_no_proxy_list()`.
+   Independently revertible.
+3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)).
+4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)).
+
+(1) and (2) first, in either order; (3) and (4) parallel after.
 
 ## Out of scope
 
-- Removing `ONYX_PAT` / the LLM key from the pod — plans 2 and 3.
-- The ExternalAppResolver and external-app credential encryption — Dane's, coordinated.
-- Policy enforcement (#11366) — composes at the same hook but is separate.
-- PAT scopes (`plans/whuang/pat_system/SCOPES.md`, unimplemented).
-
+- Action gating (matcher) — unchanged.
+- Migrating `llm_provider` rows into the `ExternalApp` data model.
+- PAT scopes; a CRAFT PAT grants full user access today.
+- The pre-body `requestheaders` injection seam and its `INJECTION_HANDLED_FLAG`. Both abandoned;
+  injection runs post-verdict in the same `request` task as the gate.

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -8,17 +8,18 @@ proxy and never in the sandbox pod.
 
 ## Status after Dane's PRs land
 
-Dane's `dane/ea-matcher` + `dane/ea-inject-creds` deliver credential injection for one source — user-
-connected external apps — through `GateAddon._inject_credentials`, called on `ALWAYS` and
-`ASK → APPROVED`. `DENY` blocks; off-catalog forwards uncredentialed.
+Dane's stack delivers credential injection for one source — user-connected external apps:
+`dane/ea-matcher` adds the matcher and the `DENY` / off-catalog gate paths; `dane/ea-inject-creds`
+adds `GateAddon._inject_credentials`, called on `ALWAYS` and `ASK → APPROVED`. `DENY` blocks;
+off-catalog forwards uncredentialed.
 
 That covers external apps but not the two system credentials this project must broker:
 
-| Source | Key scope | Why Dane's API doesn't fit |
+| Source | Lives in | Why Dane's API doesn't fit |
 |---|---|---|
-| External-app credentials | `(external_app_id, user_id)` | What Dane built. |
-| Onyx PAT ([Plan 2](./02-onyx-pat.md)) | `sandbox_id` | API takes `user_id`; one user can own multiple sandboxes. The PAT lives on the `Sandbox` row, not in any `ExternalApp`. The Onyx API isn't an external app. |
-| LLM provider keys ([Plan 3](./03-llm-key.md)) | `tenant_id` (per provider) | Per-tenant infrastructure, not user-connected. Keys live in `llm_provider` rows; modelling them as `ExternalApp`s would duplicate the LLM-admin data model. |
+| External-app credentials | `external_app_user_credentials` (per user × app) | What Dane built. |
+| Onyx PAT ([Plan 2](./02-onyx-pat.md)) | `Sandbox.encrypted_pat` | The PAT lives on the `Sandbox` row, not on any `ExternalApp`; the Onyx API isn't a third-party app a user "connected". |
+| LLM provider keys ([Plan 3](./03-llm-key.md)) | `llm_provider` rows (per tenant schema) | Per-tenant infrastructure, not user-connected. Modelling them as `ExternalApp`s would duplicate the LLM-admin data model. |
 
 And: off-catalog hosts (the Onyx API, LLM providers) forward uncredentialed today.
 
@@ -51,6 +52,11 @@ overwrites only the named header.
 
 **Decryption.** `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment (#11451), so
 `LLMProviderView.from_model()` and the encrypted per-sandbox PAT both decrypt in-process.
+
+**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend; the docker
+self-hosted backend has no proxy wiring (`docker_sandbox_manager.py` has no `HTTPS_PROXY` /
+`NO_PROXY` / CA env vars). This seam is a no-op on docker, which keeps injecting real credentials
+via env vars. Step 6 below scopes pod-side changes to K8s.
 
 **Supersedes the existing scaffold.** `onyx/sandbox_proxy/credential_injection.py` on
 `whuang/craft-proxy-secrets-injection-scaffold` defines an early host-only dispatcher run in
@@ -109,8 +115,9 @@ first whose `claims(host, match)` returns True, calls `resolve`, and sets the re
    `OFF_CATALOG`.
 
 2. **`ExternalAppResolver`** — wraps Dane's existing logic.
-   - `claims`: True iff `match is not None and match.external_app_id is not None`. The matcher
-     already did URL→app resolution; the resolver delegates rather than redoing it.
+   - `claims`: True iff `match is not None` (`ActionMatch.external_app_id` is non-Optional on the
+     matcher today). The matcher already did URL→app resolution; the resolver delegates rather
+     than redoing it.
    - `resolve`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and calls Dane's
      existing `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
      Returns `{}` rather than raising on Dane's existing error paths — preserves the per-header
@@ -121,14 +128,21 @@ first whose `claims(host, match)` returns True, calls `resolve`, and sets the re
 4. **`LLMProviderKeyResolver`** ([Plan 3](./03-llm-key.md)) — claims by host (canonical + each
    tenant's `api_base`).
 
-5. **Route the Onyx API through the proxy.** Remove `SANDBOX_API_SERVER_URL` from
-   `_compute_no_proxy_list()` (keep loopback). Verify in CI that the proxy reaches the API.
+5. **Route the Onyx API through the proxy.** Today `_compute_no_proxy_list()` appends
+   `SANDBOX_API_SERVER_URL`'s host to `NO_PROXY`, but `firewall-init.sh` drops everything except
+   loopback and TCP to `sandbox-proxy:8080` — so clients honour `NO_PROXY`, try direct DNS, and
+   get `EPERM`. Replace the function with a `_NO_PROXY = "127.0.0.1,localhost"` constant (loopback
+   is the only thing the firewall permits to bypass the proxy) and a comment naming the firewall
+   constraint; pin the value with a regression test so non-loopback entries can't be added by
+   accident.
 
-6. **Remove sandbox-side credentials** atomically with each resolver's flag:
-   - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` (and the docker manager) → non-empty
-     placeholder. `ensure_sandbox_pat` keeps minting and persisting the PAT on the `Sandbox` row.
-   - LLM keys in `OPENCODE_CONFIG_CONTENT` (`opencode_config.py`) → non-empty placeholders. While
-     here, fix the existing `block["api"]` → `provider.<id>.options.baseURL` mismatch
+6. **Remove sandbox-side credentials** atomically with each resolver's flag (K8s only — see Note):
+   - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` → non-empty placeholder.
+     `ensure_sandbox_pat` keeps minting and persisting the PAT on the `Sandbox` row. The docker
+     manager continues to inject the real PAT.
+   - LLM keys in `OPENCODE_CONFIG_CONTENT` (built by `opencode_config.py`) → non-empty placeholders
+     for the K8s manager only; the docker manager keeps the real keys. While here, fix the existing
+     `block["api"]` → `provider.<provider_name>.options.baseURL` mismatch
      ([[project_craft_beta_no_backcompat]]).
 
 7. **Wire in `server.py`.** `build_resolvers()` returns
@@ -156,8 +170,9 @@ Four PRs, in order; each flag-gated where behavioural and independently revertib
 1. **Seam extraction (refactor only).** Protocol + dispatcher + `ExternalAppResolver`.
    `_inject_credentials` becomes a delegation. Call site moves to fire on `OFF_CATALOG`. With only
    `ExternalAppResolver` registered, off-catalog stays a no-op. Dane's external-dep tests unchanged.
-2. **Route the Onyx API through the proxy.** Remove the API host from `_compute_no_proxy_list()`.
-   Independently revertible.
+2. **Route the Onyx API through the proxy.** Per step 5: replace `_compute_no_proxy_list()` with a
+   loopback-only constant and pin it with a regression test. Independently revertible. Also fixes
+   a pre-existing `EPERM` on outbound calls to the Onyx API from inside a Craft sandbox.
 3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)).
 4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)).
 

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -6,18 +6,19 @@ user-connected external apps, the per-sandbox Onyx PAT ([Plan 2](./02-onyx-pat.m
 per-tenant LLM provider keys ([Plan 3](./03-llm-key.md)) — so long-lived secrets live only in the
 proxy and never in the sandbox pod.
 
-## Status after Dane's PRs land
+## Status on main
 
-Dane's stack delivers credential injection for one source — user-connected external apps:
-`dane/ea-matcher` adds the matcher and the `DENY` / off-catalog gate paths; `dane/ea-inject-creds`
-adds `GateAddon._inject_credentials`, called on `ALWAYS` and `ASK → APPROVED`. `DENY` blocks;
-off-catalog forwards uncredentialed.
+`main` delivers credential injection for one source — user-connected external apps (PRs
+#11366, #11457, #11471, plus follow-up #11403). `GateAddon._inject_credentials_or_block` wraps
+`_inject_credentials` and is called on `ALWAYS` (`gate.py` line ~341) and `ASK → APPROVED`
+(`gate.py` line ~244); the wrapper fails closed with `_http_403(_CODE_CREDENTIAL_ERROR)` on a
+resolver exception. `DENY` blocks with `_CODE_POLICY_DENIED`; off-catalog forwards uncredentialed.
 
 That covers external apps but not the two system credentials this project must broker:
 
-| Source | Lives in | Why Dane's API doesn't fit |
+| Source | Lives in | Why the existing API doesn't fit |
 |---|---|---|
-| External-app credentials | `external_app_user_credentials` (per user × app) | What Dane built. |
+| External-app credentials | `external_app_user_credentials` (per user × app) | Already wired through `resolve_injection_headers(db, external_app_id, user_id)`. |
 | Onyx PAT ([Plan 2](./02-onyx-pat.md)) | `Sandbox.encrypted_pat` | The PAT lives on the `Sandbox` row, not on any `ExternalApp`; the Onyx API isn't a third-party app a user "connected". |
 | LLM provider keys ([Plan 3](./03-llm-key.md)) | `llm_provider` rows (per tenant schema) | Per-tenant infrastructure, not user-connected. Modelling them as `ExternalApp`s would duplicate the LLM-admin data model. |
 
@@ -28,9 +29,12 @@ And: off-catalog hosts (the Onyx API, LLM providers) forward uncredentialed toda
 1. The credential-injection seam is hard-wired to one source. No plug-in point for additional sources.
 2. Off-catalog flows forward uncredentialed — fine for arbitrary traffic, wrong for known system
    endpoints.
-3. Dane's fail-open semantic is right for user-in-the-loop apps but wrong for system credentials:
-   a missing PAT or LLM key is a configuration error, and a Craft 403 is safer than fingerprinting
-   the upstream's response.
+3. The existing fail policy mixes two behaviours: `_inject_credentials_or_block` fails *closed* on
+   resolver exceptions (`_CODE_CREDENTIAL_ERROR`), but `build_auth_headers` silently *drops* an
+   individual header whose placeholder won't render. That per-header drop is right for
+   user-in-the-loop apps (the upstream's 401 surfaces to the user) but wrong for system credentials:
+   a missing PAT or LLM key is a configuration error, and we want it surfaced as a Craft 403, not as
+   a (drop → upstream 401 → fingerprintable response).
 4. The Onyx API host is on `NO_PROXY` (`_compute_no_proxy_list()`); its traffic bypasses the proxy
    entirely.
 
@@ -94,34 +98,37 @@ first whose `claims(host, match)` returns True, calls `resolve`, and sets the re
 - No resolver claims → `PASS_THROUGH`.
 - Resolver returns headers → `INJECTED`.
 - Resolver raises `CredentialUnavailableError` (or any other exception) → `BLOCKED`; the gate maps
-  it to `_http_403(_CODE_CREDENTIAL_UNAVAILABLE)`.
+  it to `_http_403(_CODE_CREDENTIAL_ERROR)` (reusing main's existing constant; see `gate.py:63`).
 
 `apply` never raises.
 
 ## Implementation Strategy
 
-1. **Refactor `GateAddon._inject_credentials`** to delegate:
+1. **Refactor `_inject_credentials` + `_inject_credentials_or_block`** so the wrapper delegates to
+   the dispatcher:
 
    ```python
    ctx = InjectionContext(
        sandbox=sandbox, match=match, db_session_factory=self._db_session_factory
    )
    if self._dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
-       flow.response = _http_403(_CODE_CREDENTIAL_UNAVAILABLE)
+       flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
    ```
 
-   Move the call so it fires on `OFF_CATALOG` forwards too (today: only `ALWAYS` +
-   `ASK → APPROVED`). `DENY` and `ASK → REJECTED` still skip injection. Pass `match=None` on
-   `OFF_CATALOG`.
+   The wrapper today calls `_inject_credentials` on `ALWAYS` (`gate.py:341`) and `ASK → APPROVED`
+   (`gate.py:244`); add a third invocation for `OFF_CATALOG` forwards inside `_resolve_and_match`
+   just before the off-catalog `return None` (`gate.py:333-334`). `DENY` and `ASK → REJECTED` still
+   skip injection. Pass `match=None` on `OFF_CATALOG`.
 
-2. **`ExternalAppResolver`** — wraps Dane's existing logic.
-   - `claims`: True iff `match is not None` (`ActionMatch.external_app_id` is non-Optional on the
-     matcher today). The matcher already did URL→app resolution; the resolver delegates rather
-     than redoing it.
-   - `resolve`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and calls Dane's
-     existing `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
-     Returns `{}` rather than raising on Dane's existing error paths — preserves the per-header
-     fail-open contract he ships.
+2. **`ExternalAppResolver`** — wraps the existing logic on main, no new DB helpers needed.
+   - `claims`: True iff `match is not None` (`ActionMatch.external_app_id` is non-Optional;
+     `external_apps/matching/engine.py:46`). The matcher already did URL→app resolution; the
+     resolver delegates rather than redoing it.
+   - `resolve`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and calls
+     main's existing `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`
+     (`external_apps/credentials.py:36`). Returns whatever it returns — including `{}` on missing
+     app / disabled skill / unrenderable headers. Behaviour preserved: per-header drop inside
+     `build_auth_headers` stays, the wrapper still 403s on exceptions.
 
 3. **`OnyxPatResolver`** ([Plan 2](./02-onyx-pat.md)) — claims by host.
 
@@ -151,15 +158,20 @@ first whose `claims(host, match)` returns True, calls `resolve`, and sets the re
 
 ## Tests
 
+Reuse `backend/tests/unit/sandbox_proxy/conftest.py` (shared helpers landed in #11467):
+`make_flow`, `make_resolved_sandbox`, `StubResolver`. Don't re-roll fixtures.
+
 - **Dispatcher unit** (mocked resolvers): first-claim-wins; unclaimed → `PASS_THROUGH`; resolver
   raises `CredentialUnavailableError` → `BLOCKED` → 403; the `InjectionContext` passed to `resolve`
   carries the right `sandbox` and `match`. Two resolvers that both claim the same `(host, match)`
   fail the test.
-- **`ExternalAppResolver` regression**: Dane's existing external-dependency
-  `test_credential_injection.py` passes unchanged — behaviour preserved.
+- **`ExternalAppResolver` regression**: the existing external-dependency
+  `backend/tests/external_dependency_unit/craft/test_credential_injection.py` passes unchanged —
+  behaviour preserved.
 - **Gate integration**: dispatcher runs on `ALWAYS` / `OFF_CATALOG` / `ASK → APPROVED`; skipped on
   `DENY` / `ASK → REJECTED`.
-- **`NO_PROXY`**: the computed list no longer contains the Onyx API host.
+- **`NO_PROXY`**: the computed list no longer contains the Onyx API host (regression test on the
+  `_NO_PROXY` constant; see step 5).
 
 Per-resolver tests live in [Plan 2](./02-onyx-pat.md) and [Plan 3](./03-llm-key.md).
 

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -32,7 +32,7 @@ class CredentialUnavailableError(Exception):
 
 
 class CredentialResolver(Protocol):
-    def claims(self, host: str, match: ActionMatch | None) -> bool:
+    def claims(self, request: http.Request, ctx: InjectionContext) -> bool:
         """Cheap, no-DB: does this resolver own this request? First claim wins."""
         ...
 
@@ -42,7 +42,7 @@ class CredentialResolver(Protocol):
 ```
 
 `CredentialInjectionDispatcher.apply(flow, ctx)` iterates resolvers in registered order, calls the
-first whose `claims(host, match)` returns True, and sets the returned headers on `flow.request`
+first whose `claims(request, ctx)` returns True, and sets the returned headers on `flow.request`
 (set/replace, never append). The dispatcher never raises:
 
 - No resolver claims → `PASS_THROUGH`.

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -1,79 +1,29 @@
 # Plan 1 — Unified Credential-Injection Seam
 
-Replaces the original Phase 1 (a host-keyed dispatcher run in `requestheaders`). Defines a single
-host-claim seam, run from the gate's post-verdict path, that hosts three credential sources — Dane's
-user-connected external apps, the per-sandbox Onyx PAT ([Plan 2](./02-onyx-pat.md)), and the
-per-tenant LLM provider keys ([Plan 3](./03-llm-key.md)) — so long-lived secrets live only in the
-proxy and never in the sandbox pod.
+A single host-claim dispatcher in the egress proxy, run from the gate's post-verdict path, hosts
+three credential sources behind one Protocol: user-connected external apps, the per-sandbox Onyx
+PAT ([Plan 2](./02-onyx-pat.md)), and per-tenant LLM provider keys ([Plan 3](./03-llm-key.md)).
+Long-lived secrets live only in the proxy; the sandbox pod ships placeholders that the proxy
+overwrites on the wire. Action gating (matcher) and credential injection (dispatcher) compose at
+the gate but are independent — a request can need injection without gating (the Onyx API, LLM
+calls).
 
-## Status on main
+## How it works
 
-`main` delivers credential injection for one source — user-connected external apps (PRs
-#11366, #11457, #11471, plus follow-up #11403). `GateAddon._inject_credentials_or_block` wraps
-`_inject_credentials` and is called on `ALWAYS` (`gate.py` line ~341) and `ASK → APPROVED`
-(`gate.py` line ~244); the wrapper fails closed with `_http_403(_CODE_CREDENTIAL_ERROR)` on a
-resolver exception. `DENY` blocks with `_CODE_POLICY_DENIED`; off-catalog forwards uncredentialed.
+The gate's verdict ladder is unchanged: `_resolve_and_match` produces one of four outcomes —
+off-catalog forward, `DENY` block, `ALWAYS` auto-approved forward, or `ASK` (which becomes
+`APPROVED` / `REJECTED` / `EXPIRED` via the approval pipeline). Today only the two
+forward-with-credentials paths (`ALWAYS` and `ASK → APPROVED`) call `_inject_credentials_or_block`,
+which 403s with `_CODE_CREDENTIAL_ERROR` on a resolver exception and forwards otherwise.
+Off-catalog forwards uncredentialed, even when it shouldn't (the Onyx API, LLM providers).
 
-That covers external apps but not the two system credentials this project must broker:
-
-| Source | Lives in | Why the existing API doesn't fit |
-|---|---|---|
-| External-app credentials | `external_app_user_credentials` (per user × app) | Already wired through `resolve_injection_headers(db, external_app_id, user_id)`. |
-| Onyx PAT ([Plan 2](./02-onyx-pat.md)) | `Sandbox.encrypted_pat` | The PAT lives on the `Sandbox` row, not on any `ExternalApp`; the Onyx API isn't a third-party app a user "connected". |
-| LLM provider keys ([Plan 3](./03-llm-key.md)) | `llm_provider` rows (per tenant schema) | Per-tenant infrastructure, not user-connected. Modelling them as `ExternalApp`s would duplicate the LLM-admin data model. |
-
-And: off-catalog hosts (the Onyx API, LLM providers) forward uncredentialed today.
-
-## Issues to Address
-
-1. The credential-injection seam is hard-wired to one source. No plug-in point for additional sources.
-2. Off-catalog flows forward uncredentialed — fine for arbitrary traffic, wrong for known system
-   endpoints.
-3. The existing fail policy mixes two behaviours: `_inject_credentials_or_block` fails *closed* on
-   resolver exceptions (`_CODE_CREDENTIAL_ERROR`), but `build_auth_headers` silently *drops* an
-   individual header whose placeholder won't render. That per-header drop is right for
-   user-in-the-loop apps (the upstream's 401 surfaces to the user) but wrong for system credentials:
-   a missing PAT or LLM key is a configuration error, and we want it surfaced as a Craft 403, not as
-   a (drop → upstream 401 → fingerprintable response).
-4. The Onyx API host is on `NO_PROXY` (`_compute_no_proxy_list()`); its traffic bypasses the proxy
-   entirely.
-
-## Important Notes
-
-**Two orthogonal concerns at the gate.** Action *gating* (matcher) decides whether a request needs
-user approval. Credential *injection* (dispatcher) decides what auth headers go on the wire. They
-compose at the gate but are independent — a request can need injection without gating (the Onyx API,
-LLM calls).
-
-**Disjoint host responsibilities.** External-app hosts come from `ExternalApp.upstream_url_patterns`;
-the Onyx API host is `SANDBOX_API_SERVER_URL`; LLM provider hosts are the canonical provider hosts
-plus each tenant's `LLMProvider.api_base`. The dispatcher logs at startup if two resolvers' claim
-predicates overlap; the dispatcher unit test fails on overlap.
-
-**Placeholder/overwrite contract.** The pod ships a non-empty placeholder for each credential header
-(opencode's AI SDK throws on unset keys; onyx-cli treats empty as unconfigured). The proxy
-overwrites only the named header.
-
-**Decryption.** `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment (#11451), so
-`LLMProviderView.from_model()` and the encrypted per-sandbox PAT both decrypt in-process.
-
-**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend; the docker
-self-hosted backend has no proxy wiring (`docker_sandbox_manager.py` has no `HTTPS_PROXY` /
-`NO_PROXY` / CA env vars). This seam is a no-op on docker, which keeps injecting real credentials
-via env vars. Step 6 below scopes pod-side changes to K8s.
-
-**Supersedes the existing scaffold.** `onyx/sandbox_proxy/credential_injection.py` on
-`whuang/craft-proxy-secrets-injection-scaffold` defines an early host-only dispatcher run in
-`requestheaders`. This plan re-shapes it: post-verdict call site, `InjectionContext` that carries the
-matcher's output, and `_inject_credentials` becomes a delegation to it.
-
-## The seam
+This plan generalises that single call site into a dispatcher with a uniform contract:
 
 ```python
 @dataclass(frozen=True)
 class InjectionContext:
     sandbox: ResolvedSandbox
-    match: ActionMatch | None      # None for off-catalog flows
+    match: ActionMatch | None      # None on off-catalog flows
     db_session_factory: DBSessionFactory
 
 
@@ -83,7 +33,7 @@ class CredentialUnavailableError(Exception):
 
 class CredentialResolver(Protocol):
     def claims(self, host: str, match: ActionMatch | None) -> bool:
-        """Cheap, no-DB: does this resolver claim this request? First claim wins."""
+        """Cheap, no-DB: does this resolver own this request? First claim wins."""
         ...
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
@@ -91,21 +41,56 @@ class CredentialResolver(Protocol):
         ...
 ```
 
-`CredentialInjectionDispatcher.apply(flow, ctx)` iterates resolvers in registered order, picks the
-first whose `claims(host, match)` returns True, calls `resolve`, and sets the returned headers on
-`flow.request` (set/replace, never append). Outcome:
+`CredentialInjectionDispatcher.apply(flow, ctx)` iterates resolvers in registered order, calls the
+first whose `claims(host, match)` returns True, and sets the returned headers on `flow.request`
+(set/replace, never append). The dispatcher never raises:
 
 - No resolver claims → `PASS_THROUGH`.
 - Resolver returns headers → `INJECTED`.
 - Resolver raises `CredentialUnavailableError` (or any other exception) → `BLOCKED`; the gate maps
-  it to `_http_403(_CODE_CREDENTIAL_ERROR)` (reusing main's existing constant; see `gate.py:63`).
+  it to `_http_403(_CODE_CREDENTIAL_ERROR)`, reusing the existing constant.
 
-`apply` never raises.
+The dispatch points are the three verdicts that forward: `ALWAYS`, `ASK → APPROVED`, and
+`OFF_CATALOG`. `DENY` and `ASK → REJECTED` still skip injection. The off-catalog path is the new
+one — today's gate returns uncredentialed, and the dispatcher now runs there with `match=None` so
+the Onyx PAT and LLM resolvers get a chance to claim.
 
-## Implementation Strategy
+**Fail policy.** Two layers, deliberately distinct. A resolver that raises
+`CredentialUnavailableError` blocks the request (system credentials are configuration errors;
+surfacing them as Craft 403s beats a fingerprintable upstream 401). Within the external-app
+resolver, the existing `build_auth_headers` continues to silently drop an individual header whose
+placeholder can't be rendered — that's correct for user-in-the-loop apps where the upstream 401
+surfaces to the user. The dispatcher's outer `BLOCKED` and the renderer's per-header drop coexist.
 
-1. **Refactor `_inject_credentials` + `_inject_credentials_or_block`** so the wrapper delegates to
-   the dispatcher:
+**Claim disjointness.** External-app hosts come from `ExternalApp.upstream_url_patterns`; the Onyx
+API host is `SANDBOX_API_SERVER_URL`; LLM hosts are the canonical provider hosts plus each tenant's
+`LLMProvider.api_base`. These sets are disjoint by construction. The dispatcher's unit test fails
+the build on overlap, and startup logs any predicate collision.
+
+**Placeholder / overwrite contract.** The pod ships a non-empty placeholder for each credential
+header — opencode's AI SDK throws on unset keys and onyx-cli treats empty as unconfigured. The
+proxy overwrites only the named header. The real secret never leaves the proxy.
+
+## Resolvers
+
+- **`ExternalAppResolver`** — claims iff `match is not None`. The matcher has already done URL→app
+  resolution; the resolver opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and
+  delegates to `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
+  Behaviour identical to the current `_inject_credentials`.
+- **`OnyxPatResolver`** — claims the `SANDBOX_API_SERVER_URL` host; reads `Sandbox.encrypted_pat`.
+  See [Plan 2](./02-onyx-pat.md).
+- **`LLMProviderKeyResolver`** — claims canonical LLM provider hosts plus each tenant's `api_base`;
+  reads `llm_provider` rows. See [Plan 3](./03-llm-key.md).
+
+In-proxy decryption works because the proxy Deployment already has `ENCRYPTION_KEY_SECRET` wired.
+
+**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend. The docker
+self-hosted manager has no `HTTPS_PROXY` / `NO_PROXY` / CA env vars and keeps injecting real
+credentials via env vars. Every pod-side placeholder swap below is scoped to the K8s manager.
+
+## Implementation
+
+1. **Refactor the gate call site.** `_inject_credentials_or_block` delegates to the dispatcher:
 
    ```python
    ctx = InjectionContext(
@@ -115,76 +100,60 @@ first whose `claims(host, match)` returns True, calls `resolve`, and sets the re
        flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
    ```
 
-   The wrapper today calls `_inject_credentials` on `ALWAYS` (`gate.py:341`) and `ASK → APPROVED`
-   (`gate.py:244`); add a third invocation for `OFF_CATALOG` forwards inside `_resolve_and_match`
-   just before the off-catalog `return None` (`gate.py:333-334`). `DENY` and `ASK → REJECTED` still
-   skip injection. Pass `match=None` on `OFF_CATALOG`.
+   Add the third invocation for off-catalog forwards inside `_resolve_and_match`, just before its
+   off-catalog `return None`, with `match=None`. `_inject_credentials` collapses into the
+   `ExternalAppResolver`.
 
-2. **`ExternalAppResolver`** — wraps the existing logic on main, no new DB helpers needed.
-   - `claims`: True iff `match is not None` (`ActionMatch.external_app_id` is non-Optional;
-     `external_apps/matching/engine.py:46`). The matcher already did URL→app resolution; the
-     resolver delegates rather than redoing it.
-   - `resolve`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and calls
-     main's existing `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`
-     (`external_apps/credentials.py:36`). Returns whatever it returns — including `{}` on missing
-     app / disabled skill / unrenderable headers. Behaviour preserved: per-header drop inside
-     `build_auth_headers` stays, the wrapper still 403s on exceptions.
-
-3. **`OnyxPatResolver`** ([Plan 2](./02-onyx-pat.md)) — claims by host.
-
-4. **`LLMProviderKeyResolver`** ([Plan 3](./03-llm-key.md)) — claims by host (canonical + each
-   tenant's `api_base`).
-
-5. **Route the Onyx API through the proxy.** Today `_compute_no_proxy_list()` appends
+2. **Route the Onyx API through the proxy.** `_compute_no_proxy_list()` currently appends
    `SANDBOX_API_SERVER_URL`'s host to `NO_PROXY`, but `firewall-init.sh` drops everything except
    loopback and TCP to `sandbox-proxy:8080` — so clients honour `NO_PROXY`, try direct DNS, and
    get `EPERM`. Replace the function with a `_NO_PROXY = "127.0.0.1,localhost"` constant (loopback
    is the only thing the firewall permits to bypass the proxy) and a comment naming the firewall
-   constraint; pin the value with a regression test so non-loopback entries can't be added by
-   accident.
+   constraint. Pin the value with a regression test.
 
-6. **Remove sandbox-side credentials** atomically with each resolver's flag (K8s only — see Note):
-   - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` → non-empty placeholder.
-     `ensure_sandbox_pat` keeps minting and persisting the PAT on the `Sandbox` row. The docker
-     manager continues to inject the real PAT.
+3. **Add `OnyxPatResolver` and `LLMProviderKeyResolver`** per Plans 2 and 3.
+
+4. **Swap pod-side credentials for placeholders** (K8s manager only), atomically with each
+   resolver's config flag:
+   - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` → non-empty placeholder. `ensure_sandbox_pat`
+     keeps minting and persisting the PAT on the `Sandbox` row.
    - LLM keys in `OPENCODE_CONFIG_CONTENT` (built by `opencode_config.py`) → non-empty placeholders
-     for the K8s manager only; the docker manager keeps the real keys. While here, fix the existing
-     `block["api"]` → `provider.<provider_name>.options.baseURL` mismatch
-     ([[project_craft_beta_no_backcompat]]).
+     for each `options.apiKey`. While in `_build_provider_block`, fix the pre-existing
+     `block["api"]` → `provider.<provider_name>.options.baseURL` field-name bug.
 
-7. **Wire in `server.py`.** `build_resolvers()` returns
+   The docker manager continues to inject real credentials in both cases.
+
+5. **Wire in `server.py`.** `build_resolvers()` returns
    `[OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]`. The dispatcher is
    constructed once at startup and passed into `GateAddon`.
 
 ## Tests
 
-Reuse `backend/tests/unit/sandbox_proxy/conftest.py` (shared helpers landed in #11467):
-`make_flow`, `make_resolved_sandbox`, `StubResolver`. Don't re-roll fixtures.
+Reuse the shared helpers in `backend/tests/unit/sandbox_proxy/conftest.py` (`make_flow`,
+`make_resolved_sandbox`, `StubResolver`).
 
-- **Dispatcher unit** (mocked resolvers): first-claim-wins; unclaimed → `PASS_THROUGH`; resolver
+- **Dispatcher unit (mocked resolvers).** First-claim-wins; unclaimed → `PASS_THROUGH`; resolver
   raises `CredentialUnavailableError` → `BLOCKED` → 403; the `InjectionContext` passed to `resolve`
   carries the right `sandbox` and `match`. Two resolvers that both claim the same `(host, match)`
-  fail the test.
-- **`ExternalAppResolver` regression**: the existing external-dependency
-  `backend/tests/external_dependency_unit/craft/test_credential_injection.py` passes unchanged —
-  behaviour preserved.
-- **Gate integration**: dispatcher runs on `ALWAYS` / `OFF_CATALOG` / `ASK → APPROVED`; skipped on
-  `DENY` / `ASK → REJECTED`.
-- **`NO_PROXY`**: the computed list no longer contains the Onyx API host (regression test on the
-  `_NO_PROXY` constant; see step 5).
+  fail the build.
+- **`ExternalAppResolver` regression.** The existing
+  `backend/tests/external_dependency_unit/craft/test_credential_injection.py` passes unchanged.
+- **Gate integration.** Dispatcher fires on `ALWAYS`, `OFF_CATALOG`, and `ASK → APPROVED`; skipped
+  on `DENY` and `ASK → REJECTED`.
+- **`NO_PROXY` regression.** Pins the `_NO_PROXY` constant so non-loopback entries can't be added
+  by accident.
 
 Per-resolver tests live in [Plan 2](./02-onyx-pat.md) and [Plan 3](./03-llm-key.md).
 
-## Landing plan (PRs)
+## Landing plan
 
-Four PRs, in order; each flag-gated where behavioural and independently revertible.
+Four PRs, each flag-gated where behavioural and independently revertible:
 
 1. **Seam extraction (refactor only).** Protocol + dispatcher + `ExternalAppResolver`.
-   `_inject_credentials` becomes a delegation. Call site moves to fire on `OFF_CATALOG`. With only
-   `ExternalAppResolver` registered, off-catalog stays a no-op. Dane's external-dep tests unchanged.
-2. **Route the Onyx API through the proxy.** Per step 5: replace `_compute_no_proxy_list()` with a
-   loopback-only constant and pin it with a regression test. Independently revertible. Also fixes
-   a pre-existing `EPERM` on outbound calls to the Onyx API from inside a Craft sandbox.
+   `_inject_credentials` becomes a delegation; the off-catalog call site is added but, with only
+   the external-app resolver registered, off-catalog stays a no-op.
+2. **Route the Onyx API through the proxy.** Loopback-only `NO_PROXY`; independently fixes a
+   pre-existing `EPERM` on outbound Onyx API calls from the sandbox.
 3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)).
 4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)).
 
@@ -192,8 +161,8 @@ Four PRs, in order; each flag-gated where behavioural and independently revertib
 
 ## Out of scope
 
-- Action gating (matcher) — unchanged.
+- Action gating (matcher).
 - Migrating `llm_provider` rows into the `ExternalApp` data model.
-- PAT scopes; a CRAFT PAT grants full user access today.
-- The pre-body `requestheaders` injection seam and its `INJECTION_HANDLED_FLAG`. Both abandoned;
+- PAT scopes — a CRAFT PAT grants full user access today.
+- The pre-body `requestheaders` injection seam and its `INJECTION_HANDLED_FLAG`. Abandoned;
   injection runs post-verdict in the same `request` task as the gate.

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -14,32 +14,35 @@ dispatcher.
 
 ## Important Notes
 
-**Per-sandbox key scope, not per-user.** Plan 1's `InjectionContext` carries
-`sandbox: ResolvedSandbox`, so the resolver keys off `ctx.sandbox.sandbox_id` — it does not
-re-resolve identity. A user can own multiple sandboxes; the dispatcher has already pinned the
-request to one.
+**The PAT is materialized on the `Sandbox` row.** The `PersonalAccessToken` row stores only a
+SHA-256 `hashed_token` (lookup-only); the raw token is recoverable from `Sandbox.encrypted_pat`
+(`SensitiveValue[str]` over `EncryptedString`), written by `ensure_sandbox_pat` at provisioning
+and read back with `get_value(apply_mask=False)`. The resolver loads it via
+`ctx.sandbox.sandbox_id` (Plan 1's `InjectionContext` already pins the sandbox; `Sandbox.user_id`
+is `unique=True`, so there's no ambiguity to resolve). The proxy decrypts in-process via
+`ENCRYPTION_KEY_SECRET` (wired by Plan 1).
+
+**PAT lifecycle.** `ensure_sandbox_pat` enforces exactly one non-expired `CRAFT` PAT per user with a
+30-day expiry (`_PAT_EXPIRATION_DAYS`); on any state drift (no row, hash mismatch, multiple rows)
+it revokes the existing PATs and mints a new one, updating `Sandbox.encrypted_pat`. The proxy
+always reads the current materialized PAT.
 
 **Depends on Plan 1's NO_PROXY change.** `_compute_no_proxy_list()` in
-`kubernetes_sandbox_manager.py` currently adds the API host so the pod talks to the API directly.
+`kubernetes_sandbox_manager.py` currently adds the API host, so the pod talks to the API directly.
 [Plan 1](./01-framework.md) (step 5) removes that entry; until it lands, the resolver claims a host
 the proxy never sees.
 
-**MITM TLS contract for onyx-cli (Go).** Once the API host is off `NO_PROXY`, onyx-cli must trust
-the proxy MITM CA. It clones `http.DefaultTransport` (so it honors `HTTPS_PROXY`/`NO_PROXY`), and
-Go's TLS stack reads `SSL_CERT_FILE` (it ignores `REQUESTS_CA_BUNDLE`); `firewall-init.sh` also
-installs the CA into the system trust store. Both paths are already wired in
-`_proxy_main_container_env_vars()`. This route isn't exercised today — integration test required.
+**MITM TLS trust.** Once the API host is off `NO_PROXY`, onyx-cli (Python, pip-installed via
+`onyx-cli==1.0.3`) must trust the proxy MITM CA. The K8s sandbox already wires the bundle through
+the standard env vars — `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`,
+`NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE` — in `_proxy_main_container_env_vars()`,
+and `firewall-init.sh` additionally installs the CA into the system trust store via
+`update-ca-certificates`. This route isn't exercised today — integration test required.
 
-**Pod-side placeholder is non-empty.** onyx-cli's Go `IsConfigured()` checks the token is non-empty
-only (no format validation); the client sets the same value on `Authorization` and
-`X-Onyx-Authorization`. Per Plan 1's placeholder/overwrite contract, `ONYX_PAT` ships as a non-empty
-placeholder and the resolver overwrites both headers.
-
-**PAT storage is already recoverable.** `Sandbox.encrypted_pat` is a `SensitiveValue[str]` over an
-`EncryptedString` column — `ensure_sandbox_pat` stores the raw token encrypted at provisioning and
-reads it back with `get_value(apply_mask=False)`. No schema or provisioning change needed.
-(`PersonalAccessToken.hashed_token` is the API-side lookup hash, not what the proxy reads.) The
-proxy decrypts in-process via `ENCRYPTION_KEY_SECRET` (already wired by Plan 1).
+**Pod-side placeholder is non-empty.** onyx-cli treats an empty token as unconfigured and the
+client sets the same value on `Authorization` and `X-Onyx-Authorization` (the server accepts
+either; see `API_KEY_HEADER_*` and `auth/utils.py`). Per Plan 1's placeholder/overwrite contract,
+`ONYX_PAT` ships as a non-empty placeholder and the resolver overwrites both headers.
 
 **Fail closed.** Per Plan 1, a missing or undecryptable PAT raises `CredentialUnavailableError`,
 and the dispatcher serves `_http_403(_CODE_CREDENTIAL_UNAVAILABLE)`.
@@ -65,8 +68,9 @@ The server resolves the PAT via the standard auth path and the tenant via
      headers above. Raises `CredentialUnavailableError` if the row is missing, `encrypted_pat` is
      `None`, or decryption fails.
 
-2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py` and `docker_sandbox_manager.py`:
-   set `ONYX_PAT` to the Plan 1 placeholder constant. `ensure_sandbox_pat` is unchanged.
+2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py`: set `ONYX_PAT` to the Plan 1
+   placeholder constant. `ensure_sandbox_pat` is unchanged. The docker manager continues to inject
+   the real PAT (docker self-hosted has no proxy wiring; see Plan 1's "Kubernetes-only" note).
 
 3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
    `LLMProviderKeyResolver`. Hosts are disjoint; order is for clarity.

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -1,74 +1,103 @@
 # Plan 2 — Onyx PAT Resolver
 
-Reference: [Plan 1](./01-framework.md) for project context and the shared seam this plugs into.
+Reference: [Plan 1](./01-framework.md) for the shared dispatcher and `InjectionContext` this plugs
+into.
 
 ## Issues to Address
 
-The sandbox authenticates back to the Onyx API server with a CRAFT-type Personal Access Token,
-currently provisioned into the pod as the `ONYX_PAT` env var (`kubernetes_sandbox_manager.py`;
-docker manager too). It's a 30-day token scoped to the owning user (`ensure_sandbox_pat`,
-`sandbox.py`). This plan moves it out of the pod so it lives only in the proxy: an `OnyxPatResolver`
-behind the [Plan 1](./01-framework.md) seam injects auth on requests to the Onyx API host.
+The sandbox authenticates back to the Onyx API with a CRAFT-type Personal Access Token, currently
+provisioned into the pod as the `ONYX_PAT` env var (`kubernetes_sandbox_manager.py` and the docker
+manager). It's a 30-day per-user token minted by `ensure_sandbox_pat` (`onyx/server/features/build/
+db/sandbox.py`). This plan removes the real PAT from the pod and injects it from the proxy via an
+`OnyxPatResolver` that claims the `SANDBOX_API_SERVER_URL` host on the [Plan 1](./01-framework.md)
+dispatcher.
 
 ## Important Notes
 
-**Blocker — the Onyx API host is on `NO_PROXY`, so the proxy never sees that traffic.**
-`_compute_no_proxy_list()` (`kubernetes_sandbox_manager.py`) adds the `SANDBOX_API_SERVER_URL`
-hostname. Routing it through the proxy (step 2) is the central change of this plan; the external-app
-and LLM hosts already traverse the proxy.
+**Per-sandbox key scope, not per-user.** Plan 1's `InjectionContext` carries
+`sandbox: ResolvedSandbox`, so the resolver keys off `ctx.sandbox.sandbox_id` — it does not
+re-resolve identity. A user can own multiple sandboxes; the dispatcher has already pinned the
+request to one.
 
-**onyx-cli works with a non-empty placeholder (confirmed against v1.0.3 Go source).** `IsConfigured()`
-only checks the token is non-empty (no format validation), and the client sets it on **both**
-`Authorization` and `X-Onyx-Authorization` — so per Plan 1's placeholder/overwrite contract, keep
-`ONYX_PAT` a non-empty placeholder and have the resolver overwrite both headers. onyx-cli honors
-`HTTPS_PROXY`/`NO_PROXY` (it clones `http.DefaultTransport`) and trusts the proxy MITM CA via
-`SSL_CERT_FILE` (which Go honors; it ignores `REQUESTS_CA_BUNDLE`) plus the system-store install in
-`firewall-init.sh` — so it routes through the proxy once off `NO_PROXY`. That path isn't exercised
-today, so cover it with an integration test. `ONYX_SERVER_URL` stays set (onyx-cli appends `/api`).
+**Depends on Plan 1's NO_PROXY change.** `_compute_no_proxy_list()` in
+`kubernetes_sandbox_manager.py` currently adds the API host so the pod talks to the API directly.
+[Plan 1](./01-framework.md) (step 5) removes that entry; until it lands, the resolver claims a host
+the proxy never sees.
 
-**How the resolver obtains the PAT: read + decrypt the stored per-sandbox PAT (chosen).** The proxy
-has `ENCRYPTION_KEY_SECRET` (Plan 1), so `OnyxPatResolver` reuses the PAT provisioning already mints
-and stores encrypted on the `Sandbox` row (`ensure_sandbox_pat`): resolve `sandbox_id` from source
-IP, read the row, decrypt. Provisioning is unchanged except the pod gets the placeholder; lifecycle
-is unchanged (30-day, rotated on re-provision).
+**MITM TLS contract for onyx-cli (Go).** Once the API host is off `NO_PROXY`, onyx-cli must trust
+the proxy MITM CA. It clones `http.DefaultTransport` (so it honors `HTTPS_PROXY`/`NO_PROXY`), and
+Go's TLS stack reads `SSL_CERT_FILE` (it ignores `REQUESTS_CA_BUNDLE`); `firewall-init.sh` also
+installs the CA into the system trust store. Both paths are already wired in
+`_proxy_main_container_env_vars()`. This route isn't exercised today — integration test required.
 
-> **Pre-implementation check.** Confirm the `Sandbox` PAT column stores the *raw token encrypted*
-> (recoverable), not just the SHA-256 lookup hash. If only the hash, persist the raw token encrypted
-> at provisioning — acceptable under [[project_craft_beta_no_backcompat]]. This gates the chosen path.
+**Pod-side placeholder is non-empty.** onyx-cli's Go `IsConfigured()` checks the token is non-empty
+only (no format validation); the client sets the same value on `Authorization` and
+`X-Onyx-Authorization`. Per Plan 1's placeholder/overwrite contract, `ONYX_PAT` ships as a non-empty
+placeholder and the resolver overwrites both headers.
 
-*Alternative (not chosen):* the resolver mints + caches its own session PAT (`create_pat`), revoked
-on teardown — tighter lifecycle, more machinery. Revisit only if we want per-session revocation.
+**PAT storage is already recoverable.** `Sandbox.encrypted_pat` is a `SensitiveValue[str]` over an
+`EncryptedString` column — `ensure_sandbox_pat` stores the raw token encrypted at provisioning and
+reads it back with `get_value(apply_mask=False)`. No schema or provisioning change needed.
+(`PersonalAccessToken.hashed_token` is the API-side lookup hash, not what the proxy reads.) The
+proxy decrypts in-process via `ENCRYPTION_KEY_SECRET` (already wired by Plan 1).
 
-**What the resolver injects.** `Authorization: Bearer <pat>` + `X-Onyx-Authorization: Bearer <pat>`,
-and `X-Onyx-Tenant-ID = resolved.tenant_id` (the server resolves the PAT via the standard auth path
-and the tenant via `add_onyx_tenant_id_middleware`).
+**Fail closed.** Per Plan 1, a missing or undecryptable PAT raises `CredentialUnavailableError`,
+and the dispatcher serves `_http_403(_CODE_CREDENTIAL_UNAVAILABLE)`.
 
-Scopes are out of scope — see Plan 1 (a CRAFT PAT grants full user access today).
+**Headers injected:**
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <pat>` |
+| `X-Onyx-Authorization` | `Bearer <pat>` |
+| `X-Onyx-Tenant-ID` | `ctx.sandbox.tenant_id` |
+
+The server resolves the PAT via the standard auth path and the tenant via
+`add_onyx_tenant_id_middleware`.
 
 ## Implementation Strategy
 
-1. **Stop pre-populating the real PAT.** In `kubernetes_sandbox_manager.py` and the docker manager,
-   set `ONYX_PAT` to the Plan 1 placeholder. `ensure_sandbox_pat` keeps minting and storing the
-   encrypted PAT on the `Sandbox` row — the resolver reads from there.
+1. **`OnyxPatResolver`** implementing Plan 1's `CredentialResolver` Protocol.
+   - `claims(host, match)`: returns True iff `host` is the host of `SANDBOX_API_SERVER_URL`. Ignores
+     `match` (the Onyx API is never an external app).
+   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
+     loads `Sandbox` by `ctx.sandbox.sandbox_id`, decrypts `encrypted_pat`. Returns the three
+     headers above. Raises `CredentialUnavailableError` if the row is missing, `encrypted_pat` is
+     `None`, or decryption fails.
 
-2. **Route API traffic through the proxy.** Remove the `SANDBOX_API_SERVER_URL` hostname from
-   `_compute_no_proxy_list()` (keep `127.0.0.1`/`localhost`); verify the proxy can reach the API host.
+2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py` and `docker_sandbox_manager.py`:
+   set `ONYX_PAT` to the Plan 1 placeholder constant. `ensure_sandbox_pat` is unchanged.
 
-3. **Implement `OnyxPatResolver`** for the Onyx API host: read + decrypt the `Sandbox` PAT, overwrite
-   both `Authorization` and `X-Onyx-Authorization`, set `X-Onyx-Tenant-ID`; fail closed if identity
-   or token can't be resolved.
+3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
+   `LLMProviderKeyResolver`. Hosts are disjoint; order is for clarity.
 
-4. **Config**: an enable flag for the PAT resolver, separate from the LLM-key resolver.
+4. **Config flag** independent of the LLM-key resolver, so each pod-side placeholder change is
+   atomic with its proxy-side flip.
 
 ## Tests
 
-Integration test (CI only — [[feedback_no_integration_tests_locally]]) in
-`backend/tests/integration/tests/craft/`:
+**Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): given a fake `Sandbox` row
+with a stored `encrypted_pat` and a mock `db_session_factory`, the resolver returns the three
+headers with `Bearer <pat>` on `Authorization` + `X-Onyx-Authorization`. Negative cases — row
+missing, `encrypted_pat is None`, decrypt raises — each raise `CredentialUnavailableError`. `claims`
+returns True for the configured API host and False for others.
 
-- A request with the placeholder, routed through the proxy from a known sandbox IP, reaches the API
-  and authenticates as the owning user (proxy overwrote the headers + set the tenant header).
-- A request from an unidentifiable source IP to the API host is blocked (fail-closed).
+**External-dependency unit** in `backend/tests/external_dependency_unit/sandbox_proxy/`: against a
+real DB, provision a `Sandbox`, run `OnyxPatResolver.resolve` with a real `InjectionContext`, and
+assert the returned `Authorization` token matches what `ensure_sandbox_pat` minted (round-trips
+through real `EncryptedString`).
 
-External-dependency unit test in `sandbox_proxy/`: given a `Sandbox` row with a stored PAT, a request
-from that sandbox's IP gets both auth headers overwritten and the tenant header set; and
-`_compute_no_proxy_list` no longer contains the API host.
+**Integration** (CI only — [[feedback_no_integration_tests_locally]], gated under
+[[feedback_no_local_craft_k8s_tests]]) in `backend/tests/integration/tests/craft/`: onyx-cli inside
+a real sandbox calls the Onyx API. The placeholder leaves the pod; the proxy overwrites both auth
+headers and the tenant header; the API authenticates the request as the sandbox's owning user. This
+exercises the MITM-trust path that isn't exercised today.
+
+## Out of scope
+
+- PAT scopes — a CRAFT PAT grants full user access today; scope work is separate.
+- Per-session PAT minting / revocation. The persistent per-sandbox PAT (30-day, rotated on
+  re-provision) is sufficient.
+- LLM provider keys — see [Plan 3](./03-llm-key.md).
+- Any change to `_inject_credentials`, the matcher, or the gate's verdict paths — owned by
+  [Plan 1](./01-framework.md).

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -1,53 +1,15 @@
 # Plan 2 — Onyx PAT Resolver
 
-Reference: [Plan 1](./01-framework.md) for the shared dispatcher and `InjectionContext` this plugs
-into.
+The Onyx PAT resolver brokers the sandbox's auth back to the Onyx API. It claims the
+`SANDBOX_API_SERVER_URL` host on the [Plan 1](./01-framework.md) dispatcher, reads the sandbox's
+persisted PAT, and sets the `Authorization`, `X-Onyx-Authorization`, and `X-Onyx-Tenant-ID` headers
+on the outbound request — so onyx-cli in the pod runs against a non-secret placeholder while the
+real CRAFT PAT lives only in the proxy.
 
-## Issues to Address
+## How it works
 
-The sandbox authenticates back to the Onyx API with a CRAFT-type Personal Access Token, currently
-provisioned into the pod as the `ONYX_PAT` env var (`kubernetes_sandbox_manager.py` and the docker
-manager). It's a 30-day per-user token minted by `ensure_sandbox_pat` (`onyx/server/features/build/
-db/sandbox.py`). This plan removes the real PAT from the pod and injects it from the proxy via an
-`OnyxPatResolver` that claims the `SANDBOX_API_SERVER_URL` host on the [Plan 1](./01-framework.md)
-dispatcher.
-
-## Important Notes
-
-**The PAT is materialized on the `Sandbox` row.** The `PersonalAccessToken` row stores only a
-SHA-256 `hashed_token` (lookup-only); the raw token is recoverable from `Sandbox.encrypted_pat`
-(`SensitiveValue[str]` over `EncryptedString`), written by `ensure_sandbox_pat` at provisioning
-and read back with `get_value(apply_mask=False)`. The resolver loads it via
-`ctx.sandbox.sandbox_id` (Plan 1's `InjectionContext` already pins the sandbox; `Sandbox.user_id`
-is `unique=True`, so there's no ambiguity to resolve). The proxy decrypts in-process via
-`ENCRYPTION_KEY_SECRET` (wired by Plan 1).
-
-**PAT lifecycle.** `ensure_sandbox_pat` enforces exactly one non-expired `CRAFT` PAT per user with a
-30-day expiry (`_PAT_EXPIRATION_DAYS`); on any state drift (no row, hash mismatch, multiple rows)
-it revokes the existing PATs and mints a new one, updating `Sandbox.encrypted_pat`. The proxy
-always reads the current materialized PAT.
-
-**Depends on Plan 1's NO_PROXY change.** `_compute_no_proxy_list()` in
-`kubernetes_sandbox_manager.py` currently adds the API host, so the pod talks to the API directly.
-[Plan 1](./01-framework.md) (step 5) removes that entry; until it lands, the resolver claims a host
-the proxy never sees.
-
-**MITM TLS trust.** Once the API host is off `NO_PROXY`, onyx-cli (Python, pip-installed via
-`onyx-cli==1.0.3`) must trust the proxy MITM CA. The K8s sandbox already wires the bundle through
-the standard env vars — `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `CURL_CA_BUNDLE`,
-`NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE` — in `_proxy_main_container_env_vars()`,
-and `firewall-init.sh` additionally installs the CA into the system trust store via
-`update-ca-certificates`. This route isn't exercised today — integration test required.
-
-**Pod-side placeholder is non-empty.** onyx-cli treats an empty token as unconfigured and the
-client sets the same value on `Authorization` and `X-Onyx-Authorization` (the server accepts
-either; see `API_KEY_HEADER_*` and `auth/utils.py`). Per Plan 1's placeholder/overwrite contract,
-`ONYX_PAT` ships as a non-empty placeholder and the resolver overwrites both headers.
-
-**Fail closed.** Per Plan 1, a missing or undecryptable PAT raises `CredentialUnavailableError`,
-and the dispatcher serves `_http_403(_CODE_CREDENTIAL_ERROR)` (reusing main's existing constant).
-
-**Headers injected:**
+**What gets injected.** The resolver claims by host (the Onyx API is never an external app, so
+`match` is ignored) and renders three headers:
 
 | Header | Value |
 |---|---|
@@ -55,47 +17,81 @@ and the dispatcher serves `_http_403(_CODE_CREDENTIAL_ERROR)` (reusing main's ex
 | `X-Onyx-Authorization` | `Bearer <pat>` |
 | `X-Onyx-Tenant-ID` | `ctx.sandbox.tenant_id` |
 
-The server resolves the PAT via the standard auth path and the tenant via
+The server accepts the PAT on either auth header (`API_KEY_HEADER_NAME` /
+`API_KEY_HEADER_ALTERNATIVE_NAME` in `auth/constants.py`) and reads the tenant via
 `add_onyx_tenant_id_middleware`.
 
-## Implementation Strategy
+**Where the PAT lives.** `Sandbox.encrypted_pat` (`SensitiveValue[str]` over `EncryptedString`)
+stores the raw token encrypted on the sandbox row. The companion `PersonalAccessToken` row holds
+only a SHA-256 `hashed_token` for the server's lookup path. The resolver loads the sandbox by
+`ctx.sandbox.sandbox_id`, calls `get_value(apply_mask=False)` on `encrypted_pat`, and decrypts
+in-process — `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment by Plan 1.
+`Sandbox.user_id` is `unique=True`, so the one-pod, one-user, one-PAT identity is unambiguous.
 
-1. **`OnyxPatResolver`** implementing Plan 1's `CredentialResolver` Protocol.
-   - `claims(host, match)`: returns True iff `host` is the host of `SANDBOX_API_SERVER_URL`. Ignores
-     `match` (the Onyx API is never an external app).
-   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
-     loads `Sandbox` by `ctx.sandbox.sandbox_id`, decrypts `encrypted_pat`. Returns the three
-     headers above. Raises `CredentialUnavailableError` if the row is missing, `encrypted_pat` is
-     `None`, or decryption fails.
+**PAT lifecycle.** `ensure_sandbox_pat` (in `onyx/server/features/build/db/sandbox.py`) enforces
+exactly one non-expired `CRAFT` PAT per user with a 30-day expiry (`_PAT_EXPIRATION_DAYS = 30`).
+On any drift — no row, hash mismatch, multiple rows — it revokes the existing PATs, mints a fresh
+one, and writes it back to `Sandbox.encrypted_pat`. The resolver always reads the currently
+materialized value, so rotations take effect on the next request.
+
+**NO_PROXY.** Today `_compute_no_proxy_list()` in `kubernetes_sandbox_manager.py` appends the API
+host to `NO_PROXY`, so traffic from the pod to the Onyx API bypasses the proxy. The resolver is
+inert until [Plan 1](./01-framework.md) step 2 collapses `NO_PROXY` to loopback only; until then
+it would claim a host the proxy never sees.
+
+**MITM trust.** Once the API host routes through the proxy, onyx-cli (Python, pip-installed
+`onyx-cli==1.0.3`) must trust the proxy's MITM CA. The K8s sandbox already wires the bundle
+through the standard env vars in `_proxy_main_container_env_vars()` — `REQUESTS_CA_BUNDLE`,
+`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE` — and
+`firewall-init.sh` installs the CA into the system trust store via `update-ca-certificates`. The
+TLS path is in place; the resolver is its first real consumer.
+
+**Pod-side placeholder is non-empty.** onyx-cli treats an empty token as unconfigured, so the
+`ONYX_PAT` env var ships as a non-empty placeholder and the proxy overwrites both auth headers
+per the Plan 1 placeholder/overwrite contract.
+
+**Failure mode.** A missing row, a `None` `encrypted_pat`, or a decrypt failure raises
+`CredentialUnavailableError`; the dispatcher serves `_http_403(_CODE_CREDENTIAL_ERROR)`. The
+sandbox never sees a partial-auth fallback.
+
+**Kubernetes only.** The docker self-hosted backend doesn't route through the proxy and continues
+to inject the real PAT directly as the `ONYX_PAT` env var.
+
+## Implementation
+
+1. **`OnyxPatResolver`** implementing the Plan 1 `CredentialResolver` protocol.
+   - `claims(host, match)`: True iff `host` is the host of `SANDBOX_API_SERVER_URL`.
+   - `resolve(request, ctx)`: open a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
+     load `Sandbox` by `ctx.sandbox.sandbox_id`, decrypt `encrypted_pat`, return the three
+     headers. Raise `CredentialUnavailableError` on missing row, `None` PAT, or decrypt failure.
 
 2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py`: set `ONYX_PAT` to the Plan 1
-   placeholder constant. `ensure_sandbox_pat` is unchanged. The docker manager continues to inject
-   the real PAT (docker self-hosted has no proxy wiring; see Plan 1's "Kubernetes-only" note).
+   placeholder constant. `ensure_sandbox_pat` is unchanged. The docker manager keeps injecting
+   the real PAT.
 
-3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
-   `LLMProviderKeyResolver`. Hosts are disjoint; order is for clarity.
+3. **Register in `build_resolvers()`** (Plan 1 step 5) alongside `ExternalAppResolver` and
+   `LLMProviderKeyResolver`. Hosts are disjoint.
 
-4. **Config flag** independent of the LLM-key resolver, so each pod-side placeholder change is
-   atomic with its proxy-side flip.
+4. **Config flag** independent of the LLM-key resolver, so the pod-side placeholder swap and the
+   proxy-side resolver flip atomically.
 
 ## Tests
 
-**Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): given a fake `Sandbox` row
-with a stored `encrypted_pat` and a mock `db_session_factory`, the resolver returns the three
-headers with `Bearer <pat>` on `Authorization` + `X-Onyx-Authorization`. Negative cases — row
-missing, `encrypted_pat is None`, decrypt raises — each raise `CredentialUnavailableError`. `claims`
-returns True for the configured API host and False for others.
+- **Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): given a fake `Sandbox`
+  row with a stored `encrypted_pat` and a mock `db_session_factory`, the resolver returns the
+  three headers with `Bearer <pat>` on both auth headers. Negative cases — missing row,
+  `encrypted_pat is None`, decrypt raises — each raise `CredentialUnavailableError`. `claims` is
+  True for the API host and False for others.
 
-**External-dependency unit** in `backend/tests/external_dependency_unit/sandbox_proxy/`: against a
-real DB, provision a `Sandbox`, run `OnyxPatResolver.resolve` with a real `InjectionContext`, and
-assert the returned `Authorization` token matches what `ensure_sandbox_pat` minted (round-trips
-through real `EncryptedString`).
+- **External-dependency unit** in `backend/tests/external_dependency_unit/sandbox_proxy/`: against
+  a real DB, provision a `Sandbox`, run `OnyxPatResolver.resolve` with a real `InjectionContext`,
+  assert the returned `Authorization` token matches what `ensure_sandbox_pat` minted — round-trips
+  through real `EncryptedString`.
 
-**Integration** (CI only — [[feedback_no_integration_tests_locally]], gated under
-[[feedback_no_local_craft_k8s_tests]]) in `backend/tests/integration/tests/craft/`: onyx-cli inside
-a real sandbox calls the Onyx API. The placeholder leaves the pod; the proxy overwrites both auth
-headers and the tenant header; the API authenticates the request as the sandbox's owning user. This
-exercises the MITM-trust path that isn't exercised today.
+- **Integration** (CI only) in `backend/tests/integration/tests/craft/`: onyx-cli inside a real
+  sandbox calls the Onyx API. The placeholder leaves the pod; the proxy overwrites both auth
+  headers and the tenant header; the API authenticates the request as the sandbox's owning user.
+  This is the first end-to-end exercise of the MITM-trust path.
 
 ## Out of scope
 

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -45,7 +45,7 @@ either; see `API_KEY_HEADER_*` and `auth/utils.py`). Per Plan 1's placeholder/ov
 `ONYX_PAT` ships as a non-empty placeholder and the resolver overwrites both headers.
 
 **Fail closed.** Per Plan 1, a missing or undecryptable PAT raises `CredentialUnavailableError`,
-and the dispatcher serves `_http_403(_CODE_CREDENTIAL_UNAVAILABLE)`.
+and the dispatcher serves `_http_403(_CODE_CREDENTIAL_ERROR)` (reusing main's existing constant).
 
 **Headers injected:**
 

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -7,27 +7,33 @@ into. Independent of [Plan 2](./02-onyx-pat.md).
 
 LLM provider keys are baked into the sandbox today. `_build_provider_block` in
 `onyx/server/features/build/sandbox/util/opencode_config.py` writes
-`provider.<id>.options.apiKey = <real key>`, and the resulting JSON is mounted as
-`OPENCODE_CONFIG_CONTENT` on the pod. This plan removes the key from the pod and injects it from
-the proxy via an `LLMProviderKeyResolver` that claims the canonical provider hosts plus each
-tenant's `LLMProvider.api_base`.
+`provider.<provider_name>.options.apiKey = <real key>` for each enabled provider, and the resulting
+JSON is mounted as `OPENCODE_CONFIG_CONTENT` on the pod. This plan removes the key from the pod and
+injects it from the proxy via an `LLMProviderKeyResolver` that claims the canonical provider hosts
+plus each tenant's `LLMProvider.api_base`.
 
 While here, fix an existing bug: a tenant's custom endpoint is currently written as `block["api"]`,
-but the opencode schema reads it from `provider.<id>.options.baseURL`. The wrong key silently
-routes to canonical hosts ([[project_craft_beta_no_backcompat]]).
+but the opencode schema reads it from `provider.<provider_name>.options.baseURL` — so the custom
+endpoint silently doesn't take effect and traffic goes to the canonical host
+([[project_craft_beta_no_backcompat]]).
 
 ## Important Notes
 
-**Per-tenant key scope, not per-user.** Plan 1's `InjectionContext` carries
-`sandbox: ResolvedSandbox`, so the resolver keys off `ctx.sandbox.tenant_id` — one key per
-`(tenant_id, provider)` is shared across the tenant's users.
+**Per-tenant key scope, not per-user.** Tenancy is per-PostgreSQL-schema, not a column on
+`llm_provider`. Plan 1's `InjectionContext` carries `sandbox: ResolvedSandbox`, so the resolver
+opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and reads the tenant's rows.
 
-**Keys stay in `llm_provider` rows.** Per Plan 1, LLM keys are not migrated into the `ExternalApp`
-data model. The resolver reads `llm_provider` directly via `fetch_all_build_mode_llm_providers` /
-`fetch_llm_provider_by_type_for_build_mode` (`onyx/server/features/build/db/build_session.py`),
-both of which return `LLMProviderView` with the key already decrypted by
-`LLMProviderView.from_model()`. This works in-proxy because Plan 1 wires `ENCRYPTION_KEY_SECRET`
-into the proxy Deployment.
+**Row resolution rule.** `llm_provider` has no uniqueness constraint, so a tenant can have multiple
+rows of the same `provider` type (e.g. both `build-mode-anthropic` and `anthropic`). The resolver
+reuses `fetch_llm_provider_by_type_for_build_mode` (`onyx/server/features/build/db/build_session.py`),
+which prefers the `build-mode-{type}` named row and falls back to any row of that `provider` type.
+For custom-host matching, it iterates `fetch_all_build_mode_llm_providers` and matches the request's
+host against each row's `api_base`. Both helpers return `LLMProviderView` with the `api_key` already
+decrypted by `LLMProviderView.from_model()`. This works in-proxy because Plan 1 wires
+`ENCRYPTION_KEY_SECRET` into the proxy Deployment.
+
+**Keys stay in `llm_provider`.** Per Plan 1, LLM keys are not migrated into the `ExternalApp` data
+model — no sync surface with the LLM-admin UI.
 
 **Per-provider auth conventions** (overwrite only the named header):
 
@@ -35,17 +41,17 @@ into the proxy Deployment.
 |---|---|---|
 | OpenAI | `api.openai.com` | `Authorization: Bearer {key}` |
 | Anthropic | `api.anthropic.com` | `x-api-key: {key}` — leave `anthropic-version` intact |
-| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}`; strip any `?key=` query param |
+| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}` (defensively strip any `?key=` query param the client may have set) |
 | OpenRouter | `openrouter.ai` | `Authorization: Bearer {key}` |
 
 **Custom `api_base`.** A tenant can configure a per-provider endpoint via `LLMProvider.api_base`.
 The resolver must claim both the canonical host *and* each tenant's configured `api_base` host —
 miss this and the request 401s against the custom gateway.
 
-**Placeholder, not empty.** Opencode's AI SDK throws `LoadAPIKeyError` before sending if
-`options.apiKey` is unset (opencode #21737), so the pod ships a non-empty placeholder for each
-`options.apiKey`. The AI SDK turns that into the wire header per provider convention; the proxy
-overwrites that header. Never set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars in the pod.
+**Placeholder, not empty.** Opencode's AI SDK refuses to send when `options.apiKey` is unset, so
+the pod ships a non-empty placeholder for each provider's `options.apiKey`. The AI SDK turns that
+into the wire header per provider convention; the proxy overwrites that header. Never set
+`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars in the pod.
 
 **Keep opencode pointed at the real provider hosts.** Don't repoint `baseURL` at the proxy;
 traffic already routes and MITMs through the proxy, so host-matching stays simple.
@@ -58,21 +64,22 @@ SSE and long-running streams pass through untouched.
 
 ## Implementation Strategy
 
-1. **Emit placeholders in the opencode config.** In `_build_provider_block` /
-   `build_multi_provider_opencode_config` (`opencode_config.py`), write the Plan 1 placeholder for
-   each `options.apiKey` behind the LLM-key resolver flag. Keep `model`, `enabled_providers`, and
-   provider blocks intact. *Also* fix the custom-endpoint field: `block["api"]` →
-   `block["options"]["baseURL"]`.
+1. **Emit placeholders in the opencode config** for the K8s manager only (the docker manager keeps
+   the real keys — docker self-hosted doesn't route through the proxy; see Plan 1's
+   "Kubernetes-only" note). In `_build_provider_block` / `build_multi_provider_opencode_config`
+   (`opencode_config.py`), write the Plan 1 placeholder for each `options.apiKey` behind the LLM-key
+   resolver flag. Keep `model`, `enabled_providers`, and provider blocks intact. *Also* fix the
+   custom-endpoint field: `block["api"]` → `block["options"]["baseURL"]`.
 
 2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver` Protocol.
-   - `claims(host, match)`: returns True iff `host` is one of the canonical LLM provider hosts or
-     a configured tenant `api_base` host. Ignores `match`. A per-tenant `api_base` cache is
-     populated lazily on first claim for a tenant and refreshed on provider-row updates.
+   - `claims(host, match)`: True iff `host` is one of the canonical LLM provider hosts or a
+     configured tenant `api_base` host. Ignores `match`. A per-tenant `api_base` cache is populated
+     lazily on first claim for a tenant and refreshed on provider-row updates.
    - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
-     finds the matching provider row by host (canonical or `api_base`), pulls the decrypted key
-     off its `LLMProviderView`, and renders the per-provider header. Strips `?key=` from the URL
-     for Gemini. Raises `CredentialUnavailableError` if no provider/key is configured for the
-     matched host+tenant.
+     finds the matching provider row (canonical host → `fetch_llm_provider_by_type_for_build_mode`;
+     custom host → scan `fetch_all_build_mode_llm_providers` by `api_base`), pulls the decrypted
+     key off `LLMProviderView.api_key`, and renders the per-provider header. Strips any `?key=`
+     query param on Gemini requests. Raises `CredentialUnavailableError` if no row / no key.
 
 3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
    `OnyxPatResolver`. Provider hosts are disjoint from the other resolvers; order is for clarity.

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -1,75 +1,107 @@
 # Plan 3 — LLM Provider-Key Resolver
 
-Reference: [Plan 1](./01-framework.md) for project context and the shared seam this plugs into.
-Independent of plan 2.
+Reference: [Plan 1](./01-framework.md) for the shared dispatcher and `InjectionContext` this plugs
+into. Independent of [Plan 2](./02-onyx-pat.md).
 
 ## Issues to Address
 
-The LLM provider key is currently written into the opencode config: `_build_provider_block` sets
-`provider.<id>.options.apiKey = <real key>` (`opencode_config.py`), and the JSON is mounted as
-`OPENCODE_CONFIG_CONTENT` (`kubernetes_sandbox_manager.py`). This plan moves the key out of the pod
-so it lives only in the proxy: an `LLMProviderKeyResolver` behind the [Plan 1](./01-framework.md)
-seam injects the per-tenant provider key on outbound LLM requests. It's the cleanest of the three:
-LLM traffic already traverses and MITMs through the proxy.
+LLM provider keys are baked into the sandbox today. `_build_provider_block` in
+`onyx/server/features/build/sandbox/util/opencode_config.py` writes
+`provider.<id>.options.apiKey = <real key>`, and the resulting JSON is mounted as
+`OPENCODE_CONFIG_CONTENT` on the pod. This plan removes the key from the pod and injects it from
+the proxy via an `LLMProviderKeyResolver` that claims the canonical provider hosts plus each
+tenant's `LLMProvider.api_base`.
+
+While here, fix an existing bug: a tenant's custom endpoint is currently written as `block["api"]`,
+but the opencode schema reads it from `provider.<id>.options.baseURL`. The wrong key silently
+routes to canonical hosts ([[project_craft_beta_no_backcompat]]).
 
 ## Important Notes
 
-**Placeholder.** Per Plan 1's placeholder/overwrite contract, set each provider's `options.apiKey`
-to the placeholder — required because opencode's AI SDK throws `LoadAPIKeyError` before sending if
-the key is unset (opencode #21737). Never set `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` in the pod.
+**Per-tenant key scope, not per-user.** Plan 1's `InjectionContext` carries
+`sandbox: ResolvedSandbox`, so the resolver keys off `ctx.sandbox.tenant_id` — one key per
+`(tenant_id, provider)` is shared across the tenant's users.
 
-**Per-provider auth_templates** (matched by host; overwrite only the named header — Plan 1):
+**Keys stay in `llm_provider` rows.** Per Plan 1, LLM keys are not migrated into the `ExternalApp`
+data model. The resolver reads `llm_provider` directly via `fetch_all_build_mode_llm_providers` /
+`fetch_llm_provider_by_type_for_build_mode` (`onyx/server/features/build/db/build_session.py`),
+both of which return `LLMProviderView` with the key already decrypted by
+`LLMProviderView.from_model()`. This works in-proxy because Plan 1 wires `ENCRYPTION_KEY_SECRET`
+into the proxy Deployment.
 
-| Provider | Host | auth_template |
+**Per-provider auth conventions** (overwrite only the named header):
+
+| Provider | Canonical host | Header convention |
 |---|---|---|
-| OpenAI | `api.openai.com` | `{"Authorization": "Bearer {key}"}` |
-| Anthropic | `api.anthropic.com` | `{"x-api-key": "{key}"}` — leave `anthropic-version` intact |
-| Google Gemini | `generativelanguage.googleapis.com` | `{"x-goog-api-key": "{key}"}`; strip any `?key=` param |
-| OpenRouter | `openrouter.ai` | `{"Authorization": "Bearer {key}"}` |
+| OpenAI | `api.openai.com` | `Authorization: Bearer {key}` |
+| Anthropic | `api.anthropic.com` | `x-api-key: {key}` — leave `anthropic-version` intact |
+| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}`; strip any `?key=` query param |
+| OpenRouter | `openrouter.ai` | `Authorization: Bearer {key}` |
 
-**Key source.** Build-mode `llm_provider` rows: `fetch_all_build_mode_llm_providers` /
-`fetch_llm_provider_by_type_for_build_mode` (`build_session.py`) return `LLMProviderView` with the
-key decrypted via `LLMProviderView.from_model()` (works because the proxy has `ENCRYPTION_KEY_SECRET`
-— Plan 1). The resolver: `tenant_id` from `ResolvedSandbox` → `get_session_with_tenant` → fetch by
-provider/host.
+**Custom `api_base`.** A tenant can configure a per-provider endpoint via `LLMProvider.api_base`.
+The resolver must claim both the canonical host *and* each tenant's configured `api_base` host —
+miss this and the request 401s against the custom gateway.
 
-**Custom `api_base`.** A tenant may set a custom endpoint via `LLMProvider.api_base`
-(`opencode_config.py`), so the host differs from canonical. The resolver loads the tenant's
-build-mode providers (including `api_base`) and matches both canonical and custom hosts — miss this
-and the request 401s.
+**Placeholder, not empty.** Opencode's AI SDK throws `LoadAPIKeyError` before sending if
+`options.apiKey` is unset (opencode #21737), so the pod ships a non-empty placeholder for each
+`options.apiKey`. The AI SDK turns that into the wire header per provider convention; the proxy
+overwrites that header. Never set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars in the pod.
 
-**Keep opencode pointed at the real provider hosts** — don't repoint `baseURL` at the proxy; traffic
-already routes and MITMs through the proxy, so host-matching stays simple.
+**Keep opencode pointed at the real provider hosts.** Don't repoint `baseURL` at the proxy;
+traffic already routes and MITMs through the proxy, so host-matching stays simple.
 
-**Multi-provider sessions** (`enabled_providers`) work for free: matching keys on each request's
-host. **Streaming** is stream-safe via Plan 1 (injection runs at `requestheaders`, never reads body
-or response).
+**Streaming-safe.** Per Plan 1, injection runs at header time without reading body or response, so
+SSE and long-running streams pass through untouched.
+
+**Fail closed.** Per Plan 1, a missing or unreadable LLM key for a claimed host raises
+`CredentialUnavailableError` and the dispatcher serves a Craft 403.
 
 ## Implementation Strategy
 
-1. **Emit placeholders instead of real keys.** In `_build_provider_block` /
+1. **Emit placeholders in the opencode config.** In `_build_provider_block` /
    `build_multi_provider_opencode_config` (`opencode_config.py`), write the Plan 1 placeholder for
-   each `options.apiKey`, behind the LLM-key resolver flag. Keep `model`, `enabled_providers`, base
-   URLs, and `api_base`; ensure the pod never sets the provider env keys. *While here:* the custom
-   endpoint is written as `block["api"]`, but the current opencode schema uses
-   `provider.<id>.options.baseURL` — fix it ([[project_craft_beta_no_backcompat]]).
+   each `options.apiKey` behind the LLM-key resolver flag. Keep `model`, `enabled_providers`, and
+   provider blocks intact. *Also* fix the custom-endpoint field: `block["api"]` →
+   `block["options"]["baseURL"]`.
 
-2. **Implement `LLMProviderKeyResolver`** for the LLM provider hosts (canonical + tenant `api_base`):
-   resolve `tenant_id`, fetch + decrypt the matching build-mode provider's key, render the host's
-   auth_template (leaving `anthropic-version` intact); fail closed if no provider/key for that
-   host+tenant.
+2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver` Protocol.
+   - `claims(host, match)`: returns True iff `host` is one of the canonical LLM provider hosts or
+     a configured tenant `api_base` host. Ignores `match`. A per-tenant `api_base` cache is
+     populated lazily on first claim for a tenant and refreshed on provider-row updates.
+   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
+     finds the matching provider row by host (canonical or `api_base`), pulls the decrypted key
+     off its `LLMProviderView`, and renders the per-provider header. Strips `?key=` from the URL
+     for Gemini. Raises `CredentialUnavailableError` if no provider/key is configured for the
+     matched host+tenant.
 
-3. **Config**: an enable flag, independent of the PAT resolver.
+3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
+   `OnyxPatResolver`. Provider hosts are disjoint from the other resolvers; order is for clarity.
+
+4. **Config flag** independent of the PAT resolver, gating both the proxy-side resolver and the
+   pod-side placeholder swap.
 
 ## Tests
 
-External-dependency unit tests (real DB + provider config, sandbox mocked) extending `sandbox_proxy/`:
+External-dependency unit tests (real Postgres for `llm_provider` rows; sandbox proxy under test;
+upstream HTTP mocked) in `backend/tests/external_dependency_unit/sandbox_proxy/`:
 
-- OpenAI-bound request with the placeholder → `Authorization` overwritten with the decrypted tenant key.
-- Anthropic-bound request → `x-api-key` set, `anthropic-version` left intact.
-- Custom `api_base` provider → resolver host-matches the custom host and injects.
-- Fail-closed: a provider-host request from a tenant with no configured provider is blocked.
-- `opencode_config` output carries only the placeholder, never a real key, with the flag on. Pin
-  against the spec, not the constant ([[feedback_tests_pin_spec_not_impl]]).
+- **One test per provider header convention.** OpenAI / OpenRouter → `Authorization: Bearer`;
+  Anthropic → `x-api-key` with `anthropic-version` preserved; Gemini → `x-goog-api-key` with
+  `?key=` stripped. Assert the header the resolver *produces*.
+- **Custom `api_base`** — a tenant with `LLMProvider.api_base = https://llm.tenant.example/v1`:
+  the resolver claims that host and injects the right key.
+- **Fail closed** — a request to a canonical provider host from a tenant with no configured
+  build-mode provider for that type → `CredentialUnavailableError` → 403.
+- **Opencode config emits placeholder only**, never a real key, with the flag on. Pin against the
+  spec (documented header conventions + placeholder constant), not against the resolver constant
+  under test ([[feedback_tests_pin_spec_not_impl]]); a completeness check asserts the per-provider
+  header table is exhaustive over the configured provider set.
 
-One test per header convention is enough; assert the header the resolver *produces*.
+## Out of scope
+
+- LLM admin UI changes — keys keep being managed through the existing LLM-provider settings.
+- Migrating `llm_provider` rows into the `ExternalApp` data model.
+- Per-user (rather than per-tenant) LLM keys.
+- Per-provider scoping/rotation; lifecycle is unchanged.
+- Changes to the matcher, gating semantics, or anything [Plan 1](./01-framework.md) /
+  [Plan 2](./02-onyx-pat.md) owns.

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -1,120 +1,107 @@
 # Plan 3 — LLM Provider-Key Resolver
 
-Reference: [Plan 1](./01-framework.md) for the shared dispatcher and `InjectionContext` this plugs
-into. Independent of [Plan 2](./02-onyx-pat.md).
+A Craft sandbox calls LLM provider APIs (OpenAI, Anthropic, Gemini, OpenRouter, plus any
+tenant-configured custom endpoint) from `opencode serve`. Today the tenant's real provider keys
+ship inside the pod, written into `OPENCODE_CONFIG_CONTENT` by `_build_provider_block` as
+`provider.<name>.options.apiKey`. This plan moves those keys out of the pod: the pod ships
+non-empty placeholders, and the egress proxy injects the real per-tenant key — read fresh from
+`llm_provider` on each request — via an `LLMProviderKeyResolver` plugged into the
+[Plan 1](./01-framework.md) dispatcher. Independent of [Plan 2](./02-onyx-pat.md).
 
-## Issues to Address
+## How it works
 
-LLM provider keys are baked into the sandbox today. `_build_provider_block` in
-`onyx/server/features/build/sandbox/util/opencode_config.py` writes
-`provider.<provider_name>.options.apiKey = <real key>` for each enabled provider, and the resulting
-JSON is mounted as `OPENCODE_CONFIG_CONTENT` on the pod. This plan removes the key from the pod and
-injects it from the proxy via an `LLMProviderKeyResolver` that claims the canonical provider hosts
-plus each tenant's `LLMProvider.api_base`.
-
-The `block["api"]` → `block["options"]["baseURL"]` mismatch on the same file is owned by
-[Plan 1](./01-framework.md) step 6, atomic with the placeholder swap.
-
-## Important Notes
-
-**Per-tenant key scope, not per-user.** Tenancy is per-PostgreSQL-schema, not a column on
-`llm_provider`. Plan 1's `InjectionContext` carries `sandbox: ResolvedSandbox`, so the resolver
-opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and reads the tenant's rows.
-
-**Row resolution rule.** `llm_provider` has no uniqueness constraint, so a tenant can have multiple
-rows of the same `provider` type (e.g. both `build-mode-anthropic` and `anthropic`). For canonical
-hosts the resolver reuses `fetch_llm_provider_by_type_for_build_mode`
-(`onyx/server/features/build/db/build_session.py`), which prefers the `build-mode-{type}` row and
-falls back to any row of that provider type. For custom-host matching the resolver scans
-`fetch_all_build_mode_llm_providers` — note this function returns only rows whose `name` matches
-`build-mode-%`, so a tenant's custom `api_base` is only routed when configured on a
-`build-mode-{type}` row (the existing build-mode naming convention). Both helpers return
-`LLMProviderView` with the `api_key` decrypted by `LLMProviderView.from_model()`; in-proxy
-decryption works because Plan 1 wires `ENCRYPTION_KEY_SECRET` into the proxy Deployment.
-
-**Keys stay in `llm_provider`.** Per Plan 1, LLM keys are not migrated into the `ExternalApp` data
-model — no sync surface with the LLM-admin UI.
-
-**Opencode-serve loads config once at pod start.** Per #11408, the in-pod `opencode serve` process
-reads `OPENCODE_CONFIG_CONTENT` at startup and does not hot-reload. The placeholder swap therefore
-applies at provisioning; a key rotation that arrives after the pod is running takes effect on the
-next sandbox provision (or on a manual pod recycle). This is acceptable — the proxy still injects
-the *current* tenant key on each request, so a stale placeholder in the pod is fine.
-
-**Per-provider auth conventions** (overwrite only the named header):
+**Hosts the resolver claims.** The four canonical provider hosts plus each tenant's configured
+`LLMProvider.api_base` host:
 
 | Provider | Canonical host | Header convention |
 |---|---|---|
 | OpenAI | `api.openai.com` | `Authorization: Bearer {key}` |
 | Anthropic | `api.anthropic.com` | `x-api-key: {key}` — leave `anthropic-version` intact |
-| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}` (defensively strip any `?key=` query param the client may have set) |
+| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}` (defensively strip any `?key=` query param) |
 | OpenRouter | `openrouter.ai` | `Authorization: Bearer {key}` |
 
-**Custom `api_base`.** A tenant can configure a per-provider endpoint via `LLMProvider.api_base`.
-The resolver must claim both the canonical host *and* each tenant's configured `api_base` host —
-miss this and the request 401s against the custom gateway.
+**Row resolution.** Tenancy is per-PostgreSQL-schema; `llm_provider` has no `tenant_id` column,
+so the resolver opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and reads the
+tenant's rows directly. `llm_provider` has no uniqueness constraint on `provider`, so a tenant
+can have multiple rows of the same type. For canonical hosts the resolver calls
+`fetch_llm_provider_by_type_for_build_mode` (`build/db/build_session.py`), which prefers the
+`build-mode-{type}` row and falls back to any row of that type. For a custom-host match the
+resolver scans `fetch_all_build_mode_llm_providers` by `api_base`; that helper returns only rows
+whose `name` matches `build-mode-%`, so a tenant's custom endpoint is routed only when configured
+on a `build-mode-{type}` row. Both helpers return `LLMProviderView`, which decrypts `api_key`
+through `EncryptedString` in `LLMProviderView.from_model()`. The proxy decrypts in-process via
+the `ENCRYPTION_KEY_SECRET` Plan 1 wires into the Deployment.
 
-**Placeholder, not empty.** Opencode's AI SDK refuses to send when `options.apiKey` is unset, so
-the pod ships a non-empty placeholder for each provider's `options.apiKey`. The AI SDK turns that
-into the wire header per provider convention; the proxy overwrites that header. Never set
-`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars in the pod.
+**Placeholder / overwrite.** Opencode's AI SDK refuses to send when `options.apiKey` is unset, so
+each provider block in `OPENCODE_CONFIG_CONTENT` ships a non-empty placeholder. The AI SDK turns
+that into the per-provider wire header; the proxy overwrites only the named header (set/replace).
+No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars are set in the pod. `baseURL` stays pointed at
+the real provider host — traffic already MITMs through the proxy, so host-matching stays simple.
 
-**Keep opencode pointed at the real provider hosts.** Don't repoint `baseURL` at the proxy;
-traffic already routes and MITMs through the proxy, so host-matching stays simple.
+**Streaming-safe, fail-closed.** Per Plan 1, injection runs at header time without touching the
+body or response, so SSE and long-running streams pass through untouched. A missing row,
+unrenderable header, or undecryptable key raises `CredentialUnavailableError`; the dispatcher
+serves `_http_403(_CODE_CREDENTIAL_ERROR)`.
 
-**Streaming-safe.** Per Plan 1, injection runs at header time without reading body or response, so
-SSE and long-running streams pass through untouched.
+**No hot-reload in the pod.** `opencode serve` reads `OPENCODE_CONFIG_CONTENT` once at startup
+(sst/opencode#22213) and does not reload. The placeholder swap is a provisioning-time concern;
+the proxy still injects the *current* tenant key on every request, so a stale placeholder in a
+running pod is harmless. Key rotation takes effect on the next request, not the next pod.
 
-**Fail closed.** Per Plan 1, a missing or unreadable LLM key for a claimed host raises
-`CredentialUnavailableError` and the dispatcher serves a Craft 403.
+**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend (Plan 1, "Kubernetes
+only"). The docker manager keeps writing real keys into the opencode config.
 
-## Implementation Strategy
+**Keys keep living in `llm_provider`.** No migration into the `ExternalApp` data model; no sync
+surface with the LLM-admin UI.
 
-1. **Emit placeholders in the opencode config** for the K8s manager only (the docker manager keeps
-   the real keys — docker self-hosted doesn't route through the proxy; see Plan 1's
-   "Kubernetes-only" note). In `_build_provider_block` / `build_multi_provider_opencode_config`
-   (`opencode_config.py`), write the Plan 1 placeholder for each `options.apiKey` behind the LLM-key
-   resolver flag. Keep `model`, `enabled_providers`, and provider blocks intact. (Plan 1 step 6
-   handles the adjacent `block["api"]` → `options.baseURL` fix atomically.)
+## Implementation
+
+1. **Emit placeholders in the opencode config** (K8s manager only). In `_build_provider_block` /
+   `build_multi_provider_opencode_config` (`opencode_config.py`), substitute the Plan 1
+   placeholder for each `options.apiKey` behind the LLM-key resolver flag. `model`,
+   `enabled_providers`, and the rest of each provider block are unchanged. The adjacent
+   `block["api"]` → `provider.<name>.options.baseURL` fix is owned by
+   [Plan 1](./01-framework.md) step 4 and lands atomically with this swap.
 
 2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver` Protocol.
-   - `claims(host, match)`: True iff `host` is one of the canonical LLM provider hosts or a
-     configured tenant `api_base` host (on a `build-mode-*` row). Ignores `match`. A per-tenant
-     `api_base` cache is populated lazily on first claim and refreshed on provider-row updates.
-   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
-     finds the matching provider row (canonical host → `fetch_llm_provider_by_type_for_build_mode`;
-     custom host → scan `fetch_all_build_mode_llm_providers` by `api_base`), pulls the decrypted
-     key off `LLMProviderView.api_key`, and renders the per-provider header. Strips any `?key=`
-     query param on Gemini requests. Raises `CredentialUnavailableError` if no row / no key.
+   - `claims(host, match)`: True iff `host` is one of the four canonical hosts or a
+     `build-mode-*` row's `api_base` host. A per-tenant `api_base` cache is populated lazily on
+     first claim and refreshed on provider-row updates.
+   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`;
+     for a canonical host calls `fetch_llm_provider_by_type_for_build_mode`, for a custom host
+     scans `fetch_all_build_mode_llm_providers` by `api_base`; pulls the decrypted key off
+     `LLMProviderView.api_key` and renders the per-provider header; strips `?key=` on Gemini.
+     Raises `CredentialUnavailableError` if no row matches or `api_key is None`.
 
-3. **Register in `build_resolvers()`** (Plan 1, step 7) alongside `ExternalAppResolver` and
-   `OnyxPatResolver`. Provider hosts are disjoint from the other resolvers; order is for clarity.
+3. **Register in `build_resolvers()`** (Plan 1 step 5) alongside `ExternalAppResolver` and
+   `OnyxPatResolver`. Hosts are disjoint; order is for clarity.
 
 4. **Config flag** independent of the PAT resolver, gating both the proxy-side resolver and the
-   pod-side placeholder swap.
+   pod-side placeholder swap atomically.
 
 ## Tests
 
-External-dependency unit tests (real Postgres for `llm_provider` rows; sandbox proxy under test;
+External-dependency unit tests (real Postgres for `llm_provider`; sandbox proxy under test;
 upstream HTTP mocked) in `backend/tests/external_dependency_unit/sandbox_proxy/`:
 
-- **One test per provider header convention.** OpenAI / OpenRouter → `Authorization: Bearer`;
-  Anthropic → `x-api-key` with `anthropic-version` preserved; Gemini → `x-goog-api-key` with
-  `?key=` stripped. Assert the header the resolver *produces*.
-- **Custom `api_base`** — a tenant with `LLMProvider.api_base = https://llm.tenant.example/v1`:
-  the resolver claims that host and injects the right key.
-- **Fail closed** — a request to a canonical provider host from a tenant with no configured
-  build-mode provider for that type → `CredentialUnavailableError` → 403.
-- **Opencode config emits placeholder only**, never a real key, with the flag on. Pin against the
-  spec (documented header conventions + placeholder constant), not against the resolver constant
-  under test ([[feedback_tests_pin_spec_not_impl]]); a completeness check asserts the per-provider
-  header table is exhaustive over the configured provider set.
+- **One test per header convention.** OpenAI / OpenRouter → `Authorization: Bearer`; Anthropic →
+  `x-api-key` with `anthropic-version` preserved; Gemini → `x-goog-api-key` with `?key=` stripped.
+- **Custom `api_base`** — a tenant with `LLMProvider.api_base = https://llm.tenant.example/v1` on
+  a `build-mode-anthropic` row: the resolver claims that host and injects the right key.
+- **Build-mode naming required for custom hosts** — the same `api_base` on a non-`build-mode-*`
+  row is not claimed.
+- **Fail closed** — a canonical-host request from a tenant with no matching build-mode provider
+  raises `CredentialUnavailableError` → 403.
+- **Opencode config emits placeholder only** with the flag on, never a real key. Pin against the
+  spec (documented header conventions + the Plan 1 placeholder constant), not against the
+  resolver's own constants ([[feedback_tests_pin_spec_not_impl]]); a completeness check asserts
+  the header table is exhaustive over the configured provider set.
 
 ## Out of scope
 
 - LLM admin UI changes — keys keep being managed through the existing LLM-provider settings.
 - Migrating `llm_provider` rows into the `ExternalApp` data model.
 - Per-user (rather than per-tenant) LLM keys.
-- Per-provider scoping/rotation; lifecycle is unchanged.
-- Changes to the matcher, gating semantics, or anything [Plan 1](./01-framework.md) /
+- Per-provider scoping or rotation; lifecycle is unchanged.
+- The matcher, gating semantics, or anything [Plan 1](./01-framework.md) /
   [Plan 2](./02-onyx-pat.md) owns.

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -12,10 +12,8 @@ JSON is mounted as `OPENCODE_CONFIG_CONTENT` on the pod. This plan removes the k
 injects it from the proxy via an `LLMProviderKeyResolver` that claims the canonical provider hosts
 plus each tenant's `LLMProvider.api_base`.
 
-While here, fix an existing bug: a tenant's custom endpoint is currently written as `block["api"]`,
-but the opencode schema reads it from `provider.<provider_name>.options.baseURL` — so the custom
-endpoint silently doesn't take effect and traffic goes to the canonical host
-([[project_craft_beta_no_backcompat]]).
+The `block["api"]` → `block["options"]["baseURL"]` mismatch on the same file is owned by
+[Plan 1](./01-framework.md) step 6, atomic with the placeholder swap.
 
 ## Important Notes
 
@@ -24,16 +22,24 @@ endpoint silently doesn't take effect and traffic goes to the canonical host
 opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and reads the tenant's rows.
 
 **Row resolution rule.** `llm_provider` has no uniqueness constraint, so a tenant can have multiple
-rows of the same `provider` type (e.g. both `build-mode-anthropic` and `anthropic`). The resolver
-reuses `fetch_llm_provider_by_type_for_build_mode` (`onyx/server/features/build/db/build_session.py`),
-which prefers the `build-mode-{type}` named row and falls back to any row of that `provider` type.
-For custom-host matching, it iterates `fetch_all_build_mode_llm_providers` and matches the request's
-host against each row's `api_base`. Both helpers return `LLMProviderView` with the `api_key` already
-decrypted by `LLMProviderView.from_model()`. This works in-proxy because Plan 1 wires
-`ENCRYPTION_KEY_SECRET` into the proxy Deployment.
+rows of the same `provider` type (e.g. both `build-mode-anthropic` and `anthropic`). For canonical
+hosts the resolver reuses `fetch_llm_provider_by_type_for_build_mode`
+(`onyx/server/features/build/db/build_session.py`), which prefers the `build-mode-{type}` row and
+falls back to any row of that provider type. For custom-host matching the resolver scans
+`fetch_all_build_mode_llm_providers` — note this function returns only rows whose `name` matches
+`build-mode-%`, so a tenant's custom `api_base` is only routed when configured on a
+`build-mode-{type}` row (the existing build-mode naming convention). Both helpers return
+`LLMProviderView` with the `api_key` decrypted by `LLMProviderView.from_model()`; in-proxy
+decryption works because Plan 1 wires `ENCRYPTION_KEY_SECRET` into the proxy Deployment.
 
 **Keys stay in `llm_provider`.** Per Plan 1, LLM keys are not migrated into the `ExternalApp` data
 model — no sync surface with the LLM-admin UI.
+
+**Opencode-serve loads config once at pod start.** Per #11408, the in-pod `opencode serve` process
+reads `OPENCODE_CONFIG_CONTENT` at startup and does not hot-reload. The placeholder swap therefore
+applies at provisioning; a key rotation that arrives after the pod is running takes effect on the
+next sandbox provision (or on a manual pod recycle). This is acceptable — the proxy still injects
+the *current* tenant key on each request, so a stale placeholder in the pod is fine.
 
 **Per-provider auth conventions** (overwrite only the named header):
 
@@ -68,13 +74,13 @@ SSE and long-running streams pass through untouched.
    the real keys — docker self-hosted doesn't route through the proxy; see Plan 1's
    "Kubernetes-only" note). In `_build_provider_block` / `build_multi_provider_opencode_config`
    (`opencode_config.py`), write the Plan 1 placeholder for each `options.apiKey` behind the LLM-key
-   resolver flag. Keep `model`, `enabled_providers`, and provider blocks intact. *Also* fix the
-   custom-endpoint field: `block["api"]` → `block["options"]["baseURL"]`.
+   resolver flag. Keep `model`, `enabled_providers`, and provider blocks intact. (Plan 1 step 6
+   handles the adjacent `block["api"]` → `options.baseURL` fix atomically.)
 
 2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver` Protocol.
    - `claims(host, match)`: True iff `host` is one of the canonical LLM provider hosts or a
-     configured tenant `api_base` host. Ignores `match`. A per-tenant `api_base` cache is populated
-     lazily on first claim for a tenant and refreshed on provider-row updates.
+     configured tenant `api_base` host (on a `build-mode-*` row). Ignores `match`. A per-tenant
+     `api_base` cache is populated lazily on first claim and refreshed on provider-row updates.
    - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
      finds the matching provider row (canonical host → `fetch_llm_provider_by_type_for_build_mode`;
      custom host → scan `fetch_all_build_mode_llm_providers` by `api_base`), pulls the decrypted


### PR DESCRIPTION
## Description

Generalises the Craft sandbox-proxy gate's single-app credential-injection seam into a first-claim-wins dispatcher with a `CredentialResolver` Protocol. The dispatcher walks a registered list of resolvers, lets the first one that claims a request render its auth headers, and writes them onto `flow.request` so the real secret never has to live in the sandbox pod. The single resolver shipped here, `ExternalAppResolver`, is the matcher-attributed path that the gate already had inline — the refactor is observable-equivalent for the existing external-app flow.

Two follow-up PRs (Plans 2 and 3 in `docs/craft/features/secrets-injection/`) plug additional resolvers into the same seam:
- **`OnyxPatResolver`** — claims the `SANDBOX_API_SERVER_URL` host, brokers `Sandbox.encrypted_pat` so onyx-cli inside the sandbox calls back to the Onyx API without the real PAT ever leaving the proxy
- **`LLMProviderKeyResolver`** — claims canonical LLM-provider hosts (OpenAI / Anthropic / Gemini / OpenRouter) plus each tenant's configured `api_base`, brokers per-tenant LLM keys

This PR adds the framework, the first resolver, and instrumentation:

- `backend/onyx/sandbox_proxy/credential_injection.py` — `CredentialResolver` Protocol + `InjectionContext` + `CredentialInjectionDispatcher` (`apply` for tests, `apply_or_block` for the gate). `BLOCKED → 403` and `CODE_CREDENTIAL_ERROR` live on the dispatcher so resolvers and the gate share one fail-closed mapping.
- `backend/onyx/sandbox_proxy/resolvers/external_app.py` — `ExternalAppResolver` (the only resolver in this PR).
- `backend/onyx/sandbox_proxy/addons/gate.py` — `_inject_credentials` / `_inject_credentials_or_block` collapse into the dispatcher; the gate's verdict ladder (ALWAYS / ASK→APPROVED / off-catalog) calls a single `_dispatch_injection_or_block` helper.
- Matcher-exception path falls through as off-catalog (`match=None`) so the dispatcher still runs — host-only resolvers from Plans 2/3 will inject even when matching crashes, instead of forwarding with a placeholder credential.
- `SessionContext.without_session()` — symmetric inverse of `ResolvedSandbox.with_session(...)` used by the ASK→APPROVED dispatch site.
- `backend/onyx/sandbox_proxy/server.py` — `build_resolvers()` is the registration seam Plans 2/3 will extend. Resolver class names are logged at startup.

The implementation went through two review rounds with three parallel subagents each (production / tests / cross-cutting). Major changes coming out of those reviews:

- `claims(request, ctx)` mirrors `resolve(request, ctx)` so the LLM resolver from Plan 3 can peek at path/query if needed.
- Off-catalog dispatch is wired now (no-op until Plans 2/3 register host-only resolvers).
- `Proxy-Authorization` strips consolidated to one point in `request()`.
- Shared `RecordingCredentialResolver`, `make_action_match`, `noop_db_factory` in `tests/unit/sandbox_proxy/conftest.py` for Plans 2/3 to reuse.

## How Has This Been Tested?

Unit tests (`backend/tests/unit/sandbox_proxy/`):
- `test_credential_injection.py` — dispatcher: first-claim-wins, PASS_THROUGH on no claim, INJECTED with header overwrite, BLOCKED on `CredentialUnavailableError` or generic exception, claims-error fallthrough, `apply_or_block` 403 wiring.
- `test_external_app_resolver.py` — resolver: `claims` rule, arg forwarding to `resolve_injection_headers`, contract-violation safety net.
- `test_gate.py` — refactored: all five verdict paths (ALWAYS / OFF_CATALOG / DENY / ASK→APPROVED / ASK→REJECTED-or-EXPIRED) end-to-end through the dispatcher seam; matcher-exception now falls through as off-catalog; gate-level `_dispatch_injection_or_block` 403 mapping; `Proxy-Authorization` strip pinned at single point.
- `test_identity.py` — `with_session().without_session()` round-trip.

All 141 sandbox_proxy unit tests pass.

External-dependency unit tests in `backend/tests/external_dependency_unit/craft/test_credential_injection.py` continue to pin the renderer's per-header fail-open behaviour against a real DB — no overlap with the unit-level resolver tests.

`pre-commit run --all-files` clean on the changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduced a unified credential injection dispatcher with a `CredentialResolver` Protocol and wired the gate to use it for approved and off-catalog forwards; shipped `ExternalAppResolver` to preserve current external-app behavior while preparing for Onyx PAT and LLM key resolvers. Requests that can’t render credentials now fail closed with a 403 `credential_error`.

- **New Features**
  - `CredentialInjectionDispatcher` with first-claim-wins and `apply_or_block` that injects headers or returns 403 (`CODE_CREDENTIAL_ERROR`).
  - `ExternalAppResolver` claims matcher-attributed requests and renders headers via `resolve_injection_headers`.
  - Off-catalog and matcher-exception paths now dispatch, enabling host-only resolvers to inject instead of forwarding with placeholders.
  - Resolver registration seam (`build_resolvers()` in `server.py`); resolver class names logged at startup.
  - `SessionContext.without_session()` helper for the ASK→APPROVED path.

- **Refactors**
  - Gate injection collapsed into `_dispatch_injection_or_block` using the dispatcher; ALWAYS and ASK-approved paths use it.
  - Single `Proxy-Authorization` strip point in `request()`.
  - Added focused unit tests for the dispatcher and resolver; updated gate tests and docs to match the new seam.

<sup>Written for commit dfb243120f25247b8ea586843a09a5dfb0afb7cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11516?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

