### PR TITLE
refactor(opal): fix styling for `InputTypein`

### DIFF
--- a/web/lib/opal/src/components/inputs/input-typein/styles.css
+++ b/web/lib/opal/src/components/inputs/input-typein/styles.css
@@ -21,6 +21,5 @@
 }
 
 .opal-input-field::placeholder {
-  @apply !font-main-ui-muted;
-  color: var(--text-02);
+  @apply font-main-ui-muted text-text-02;
 }

--- a/web/lib/opal/src/components/inputs/shared.css
+++ b/web/lib/opal/src/components/inputs/shared.css
@@ -15,8 +15,8 @@
    ========================================================================== */
 
 .opal-input {
-  /* `--interactive-duration` (150ms) was too laggy, so we're using 50ms instead. */
-  @apply flex flex-row items-center justify-between flex-1 h-fit p-1.5 rounded-08 relative w-full transition-all duration-[50ms] ease-(--interactive-easing);
+  /* `--interactive-duration` (150ms) felt too laggy, so we're using 100ms instead. */
+  @apply flex flex-row items-center justify-between flex-1 h-fit p-1.5 rounded-08 relative w-full transition-all duration-100 ease-(--interactive-easing);
 }
 
 .opal-input[data-variant="primary"] {


### PR DESCRIPTION
## Description

Two small CSS fixes to the Opal input components:

- **`shared.css`**: Changed input transition duration from `50ms` to `100ms` (`duration-100`) — the 50ms felt too abrupt; 100ms is snappier than the default 150ms while still feeling smooth. Also switched from the arbitrary `duration-[50ms]` syntax to the standard Tailwind `duration-100` class.
- **`input-typein/styles.css`**: Fixed placeholder styling to use Tailwind utilities exclusively (`font-main-ui-muted text-text-02`) instead of mixing `@apply` with a raw `color:` declaration and an `!important` override.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths Opal input interactions by increasing the transition from 50ms to 100ms using Tailwind `duration-100`. Fixes placeholder styling to use only Tailwind utilities (`font-main-ui-muted text-text-02`), removing the raw color and `!important` override for consistent theming.

<sup>Written for commit d99c107321959268d27efdabacd35e5abf5f3058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11519?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->