### PR TITLE
ci: always run all backend unit tests even on failures

### DIFF
--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -74,4 +74,4 @@ jobs:
 
     - name: Run Tests
       shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
-      run: py.test -o junit_family=xunit2 -v --ff --maxfail=1 -n auto backend/tests/unit
+      run: py.test -o junit_family=xunit2 -v -n auto backend/tests/unit


### PR DESCRIPTION
Not sure if this was introduced in https://github.com/onyx-dot-app/onyx/commit/9ea0d8a5d0e68e2fe442e0eb142c3a677d69ebaa, but I don't like it.

## Summary

Updates `.github/workflows/pr-python-tests.yml` so the backend unit test job runs the **entire** suite and reports every failure, instead of bailing out after the first one.

- Removed `--maxfail=1`, which previously aborted the run on the first failing test.
- Removed `--ff` (failed-first ordering), which only provides value when combined with early-exit — with all tests now running, it no longer affects the outcome.

## Test plan

- CI workflow change only; verified by the `Python Unit Tests` check running to completion on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)