### PR TITLE
fix(llm): omit sampling params + use adaptive thinking for Claude Opus 4.8

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -72,11 +72,15 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
 )
 
 # Anthropic models that require the adaptive thinking API (thinking.type.adaptive
 # + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
-_ANTHROPIC_ADAPTIVE_THINKING_MODELS = ("claude-opus-4-7",)
+_ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
 # top_p, top_k). For these models we must omit these params entirely from the
@@ -89,6 +93,10 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.7",
     "claude-4-7-opus",
     "claude-4.7-opus",
+    "claude-opus-4-8",
+    "claude-opus-4.8",
+    "claude-4-8-opus",
+    "claude-4.8-opus",
 )
 
 
@@ -541,8 +549,8 @@ class LitellmLLM(LLM):
 
         # Temperature
         # Some models reject any non-default sampling parameter (e.g. Claude
-        # Opus 4.7 returns a 400 invalid_request_error if temperature is set to
-        # anything). For those models we must omit the param entirely —
+        # Opus 4.7/4.8 return a 400 invalid_request_error if temperature is set
+        # to anything). For those models we must omit the param entirely —
         # LiteLLM's drop_params is not reliable here because the upstream
         # provider config can still claim the param is supported.
         # https://github.com/BerriAI/litellm/issues/26444

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -30,6 +30,7 @@ VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
     "claude-opus-4-5@20251101",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
 ]
 
 
@@ -431,6 +432,11 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.7",
     "claude-4-7-opus",
     "claude-4.7-opus",
+    "claude-opus-4-8",
+    "claude-opus-4-8@20260101",
+    "claude-opus-4.8",
+    "claude-4-8-opus",
+    "claude-4.8-opus",
 ]
 
 
@@ -455,6 +461,37 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
 
         kwargs = mock_completion.call_args.kwargs
         assert "temperature" not in kwargs
+
+
+@pytest.mark.parametrize("model_name", ["claude-opus-4-7", "claude-opus-4-8"])
+def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
+    # Non-Vertex providers must use the adaptive thinking API for these models
+    # (thinking.type=adaptive + output_config.effort) rather than the legacy
+    # thinking.type.enabled + budget_tokens path, which they reject with a 400.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name=model_name,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name=model_name,
+        ),
+    )
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "output_config" in kwargs
+        assert "budget_tokens" not in kwargs["thinking"]
 
 
 def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> None:


### PR DESCRIPTION
## Description

Claude Opus 4.8 has the same provider constraints as Opus 4.7, but only 4.7 was registered in the relevant model lists in `multi_llm.py`. As a result, Opus 4.8 chats fail with `400 invalid_request_error` from the provider (e.g. `` `temperature` is deprecated for this model `` on Vertex).

This PR adds the Opus 4.8 name variants to all three lists so 4.8 gets the same known-good handling as 4.7:

- **`_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`** — omit `temperature`/`top_p`/`top_k` (these are rejected).
- **`_VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG`** — on Vertex, skip the reasoning/`output_config` block (Vertex rejects `output_config` for these models).
- **`_ANTHROPIC_ADAPTIVE_THINKING_MODELS`** — on non-Vertex providers, use the adaptive thinking API (`thinking.type=adaptive` + `output_config.effort`) instead of the legacy `thinking.type.enabled` + `budget_tokens` path, which 4.6+ reject.

Substring matching already covers proxy/Vertex naming variants (e.g. `vertex_ai/claude-opus-4-8`) and date-suffixed names.

## How Has This Been Tested?

`pytest tests/unit/onyx/llm/test_multi_llm.py` — 55 passing. Extended the parametrized sampling-params and Vertex-output-config tests with the 4.8 variants, and added a test asserting the adaptive thinking path is used for both 4.7 and 4.8.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check