### PR TITLE
test: deflake pool metrics hold-duration test

### DIFF
--- a/backend/tests/unit/onyx/server/test_pool_metrics.py
+++ b/backend/tests/unit/onyx/server/test_pool_metrics.py
@@ -1,6 +1,5 @@
 """Unit tests for SQLAlchemy connection pool Prometheus metrics."""
 
-import time
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -149,7 +148,11 @@ def test_checkin_event_observes_hold_duration() -> None:
     conn_record = _make_conn_record()
     conn_record.info["_metrics_endpoint"] = "/api/search"
     conn_record.info["_metrics_tenant_id"] = "tenant_abc"
-    conn_record.info["_metrics_checkout_time"] = time.monotonic() - 0.5
+    # Use a deterministic, mocked monotonic clock so the observed hold
+    # duration is exact and not subject to wall-clock timing on slow CI.
+    checkout_time = 1000.0
+    checkin_time = checkout_time + 0.5
+    conn_record.info["_metrics_checkout_time"] = checkout_time
 
     with (
         patch(
@@ -159,6 +162,10 @@ def test_checkin_event_observes_hold_duration() -> None:
             "onyx.server.metrics.postgres_connection_pool._hold_seconds"
         ) as mock_hist,
         patch("onyx.server.metrics.postgres_connection_pool._checkin_total"),
+        patch(
+            "onyx.server.metrics.postgres_connection_pool.time.monotonic",
+            return_value=checkin_time,
+        ),
     ):
         mock_labels = MagicMock()
         mock_gauge.labels.return_value = mock_labels
@@ -173,9 +180,9 @@ def test_checkin_event_observes_hold_duration() -> None:
         mock_labels.dec.assert_called_once()
         mock_hist.labels.assert_called_with(handler="/api/search", engine="sync")
         mock_hist_labels.observe.assert_called_once()
-        # Verify the observed duration is roughly 0.5s
+        # Observed duration is exactly checkin_time - checkout_time == 0.5s
         observed = mock_hist_labels.observe.call_args[0][0]
-        assert 0.4 < observed < 1.0
+        assert observed == 0.5
 
     # conn_record.info should be cleaned up
     assert "_metrics_endpoint" not in conn_record.info


### PR DESCRIPTION
## Problem

`test_checkin_event_observes_hold_duration` is flaky. It relied on real wall-clock time: it set the checkout time to `time.monotonic() - 0.5` and asserted the observed hold duration fell in the loose window `0.4 < observed < 1.0`. On a slow/loaded CI runner, the elapsed time between setting up the record and invoking the `checkin` listener could push the measured duration past the upper bound:

```
assert 1.009985186999998 < 1.0
```

## Fix

Patch `time.monotonic` in the metrics module to a fixed value and set the checkout time to a fixed value exactly `0.5` earlier. The measured duration is now deterministic, so the assertion can be tightened to an exact `observed == 0.5`. Also removed the now-unused `import time`.

## Testing

```
uv run pytest tests/unit/onyx/server/test_pool_metrics.py -q
10 passed in 0.40s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflaked the pool metrics hold-duration test by mocking `time.monotonic` and using fixed checkout/checkin times so the observed duration is exactly 0.5s. CI timing is now deterministic and stable.

- **Bug Fixes**
  - Patched `onyx.server.metrics.postgres_connection_pool.time.monotonic` to a fixed value; set `_metrics_checkout_time` to 1000.0 and assert a 0.5s observation.
  - Removed unused `import time`.

<sup>Written for commit d79d6828250047843f58e61051ce509699f0577c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

