### PR TITLE
fix(llm): omit sampling params + use adaptive thinking for Claude Opus 4.8 (backport #11524)

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -69,11 +69,15 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
 )
 
 # Anthropic models that require the adaptive thinking API (thinking.type.adaptive
 # + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
-_ANTHROPIC_ADAPTIVE_THINKING_MODELS = ("claude-opus-4-7",)
+_ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+)
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
 # top_p, top_k). For these models we must omit these params entirely from the
@@ -86,6 +90,10 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.7",
     "claude-4-7-opus",
     "claude-4.7-opus",
+    "claude-opus-4-8",
+    "claude-opus-4.8",
+    "claude-4-8-opus",
+    "claude-4.8-opus",
 )
 
 
@@ -523,8 +531,8 @@ class LitellmLLM(LLM):
 
         # Temperature
         # Some models reject any non-default sampling parameter (e.g. Claude
-        # Opus 4.7 returns a 400 invalid_request_error if temperature is set to
-        # anything). For those models we must omit the param entirely —
+        # Opus 4.7/4.8 return a 400 invalid_request_error if temperature is set
+        # to anything). For those models we must omit the param entirely —
         # LiteLLM's drop_params is not reliable here because the upstream
         # provider config can still claim the param is supported.
         # https://github.com/BerriAI/litellm/issues/26444

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -30,6 +30,7 @@ VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
     "claude-opus-4-5@20251101",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
 ]
 
 
@@ -431,6 +432,11 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.7",
     "claude-4-7-opus",
     "claude-4.7-opus",
+    "claude-opus-4-8",
+    "claude-opus-4-8@20260101",
+    "claude-opus-4.8",
+    "claude-4-8-opus",
+    "claude-4.8-opus",
 ]
 
 
@@ -455,6 +461,37 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
 
         kwargs = mock_completion.call_args.kwargs
         assert "temperature" not in kwargs
+
+
+@pytest.mark.parametrize("model_name", ["claude-opus-4-7", "claude-opus-4-8"])
+def test_claude_adaptive_thinking_uses_output_config(model_name: str) -> None:
+    # Non-Vertex providers must use the adaptive thinking API for these models
+    # (thinking.type=adaptive + output_config.effort) rather than the legacy
+    # thinking.type.enabled + budget_tokens path, which they reject with a 400.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name=model_name,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name=model_name,
+        ),
+    )
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "output_config" in kwargs
+        assert "budget_tokens" not in kwargs["thinking"]
 
 
 def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> None:


### PR DESCRIPTION
## Description

Backport of #11524 to `release/v3.3`.

Claude Opus 4.8 has the same provider constraints as Opus 4.7, but only 4.7 was registered in the relevant model lists in `multi_llm.py`, so Opus 4.8 chats fail with `400 invalid_request_error` (e.g. `` `temperature` is deprecated for this model `` on Vertex). Adds the 4.8 name variants to all three lists so it gets the same known-good handling as 4.7:

- `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS` — omit `temperature`/`top_p`/`top_k`
- `_VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG` — skip `output_config` on Vertex
- `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` — use adaptive thinking on non-Vertex

Clean cherry-pick of the merged commit (`1a42b3d439`), no conflicts.

## How Has This Been Tested?

`pytest tests/unit/onyx/llm/test_multi_llm.py` — 55 passing on this branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports support for Claude Opus 4.8 to v3.3 so chats don’t fail with 400 errors. Treats 4.8 like 4.7 by omitting sampling params, using adaptive thinking, and handling Vertex quirks.

- **Bug Fixes**
  - Added 4.8 name variants to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`, `_ANTHROPIC_ADAPTIVE_THINKING_MODELS`, and `_VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG`.
  - Updated logic to omit `temperature`/`top_p`/`top_k`, use adaptive thinking on non-Vertex, and skip `output_config` on Vertex.
  - Added tests for 4.8 ensuring sampling params are omitted and adaptive thinking uses `output_config`.

<sup>Written for commit 84ba29e71f83c3a659aaf7de6a06651b87646703. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

