### PR TITLE
fix(chat): eliminate ReDoS in citation processor partial-citation regex (#11527) to release v3.3

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -191,7 +191,19 @@ class DynamicCitationProcessor:
         # Citation patterns
         # Matches potential incomplete citations: '[', '[[', '[1', '[[1', '[1,', '[1, ', etc.
         # Also matches unicode bracket variants: 【, ［
-        self.possible_citation_pattern = re.compile(r"([\[【［]+(?:\d+,? ?)*$)")
+        #
+        # NOTE: the inner group is written as `\d+(?:, ?\d+)*` (comma-separated runs of
+        # digits) rather than `(?:\d+,? ?)*`. The latter nests an unbounded quantifier
+        # (`\d+`) inside another unbounded quantifier (`(?:...)*`) with optional
+        # separators, which makes a solid run of digits ambiguous to parse. When the
+        # match ultimately fails the trailing `$` anchor, the engine backtracks through
+        # exponentially many ways of splitting the digits (O(2^n)), pinning a CPU core.
+        # The comma-separated form has exactly one way to parse a digit run, so it stays
+        # linear. This must mirror `citation_pattern` below, which already requires
+        # commas between numbers, so no real (closeable) citation is missed.
+        self.possible_citation_pattern = re.compile(
+            r"([\[【［]+(?:\d+(?:, ?\d+)*(?:, ?)?)?$)"
+        )
 
         # Matches complete citations:
         # group 1: '[[1]]', [[2]], etc. (also matches 【【1】】, ［［1］］, 【1】, ［1］)

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -13,6 +13,7 @@ Key features tested:
 - Edge cases (unicode, code blocks, invalid citations, etc.)
 """
 
+import time
 from datetime import datetime
 
 import pytest
@@ -2419,3 +2420,87 @@ class TestKeepMarkersEdgeCases:
         assert len(citations) == 0
         # Should not be in seen citations
         assert 99 not in processor.get_seen_citations()
+
+
+class TestPossibleCitationPatternReDoS:
+    """Regression tests for catastrophic backtracking (ReDoS) in the
+    `possible_citation_pattern` used to hold back partial citations.
+
+    The original pattern `([\\[【［]+(?:\\d+,? ?)*$)` nested an unbounded `\\d+`
+    inside an unbounded `(?:...)*` with optional separators. A long run of digits
+    that fails the trailing `$` anchor (e.g. an opening bracket followed by many
+    digits and then a non-citation character) forced the engine to backtrack
+    through O(2^n) ways of splitting the digits, pinning a CPU core. An LLM can
+    emit such a token stream, so this is a remotely-triggerable DoS.
+    """
+
+    def test_long_digit_run_does_not_hang(self) -> None:
+        """A bracket followed by a long digit run + trailing junk must match
+        in well under a second. With the vulnerable pattern this took many
+        seconds and grew exponentially with the number of digits."""
+        processor = DynamicCitationProcessor()
+        # Opening bracket, 60 digits, then a char that defeats the `$` anchor.
+        # 60 digits => 2^59 paths for the vulnerable regex (effectively never
+        # finishes); the fixed regex is linear.
+        malicious = "[" + "1" * 60 + "!"
+
+        start = time.perf_counter()
+        match = processor.possible_citation_pattern.search(malicious)
+        elapsed = time.perf_counter() - start
+
+        # The fixed pattern resolves in microseconds; allow generous headroom
+        # for slow CI while still catching exponential blowup.
+        assert elapsed < 1.0, f"regex took {elapsed:.3f}s (possible ReDoS)"
+        # Trailing '!' means this is not a (closeable) partial citation.
+        assert match is None
+
+    def test_long_digit_run_in_token_stream_does_not_hang(self) -> None:
+        """End-to-end: feeding the malicious sequence through process_token
+        (which calls the regex on the accumulated segment) stays fast."""
+        processor = DynamicCitationProcessor()
+        tokens: list[str | None] = ["[" + "9" * 60 + "!"]
+
+        start = time.perf_counter()
+        output, citations = process_tokens(processor, tokens)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0, f"processing took {elapsed:.3f}s (possible ReDoS)"
+        # Not a real citation, so the text passes through unchanged.
+        assert output == "[" + "9" * 60 + "!"
+        assert citations == []
+
+    def test_partial_citations_still_detected(self) -> None:
+        """The fix must not regress detection of genuine partial citations
+        (the ones that could still be completed into a real citation)."""
+        partials = [
+            "text [",
+            "text [[",
+            "text [1",
+            "text [[1",
+            "text [1,",
+            "text [1, ",
+            "text [1, 2",
+            "text [12, 34, 5",
+            "text 【",
+            "text 【1",
+            "text ［1",
+        ]
+        for segment in partials:
+            assert (
+                DynamicCitationProcessor().possible_citation_pattern.search(segment)
+                is not None
+            ), f"expected {segment!r} to be treated as a possible citation"
+
+    def test_non_citations_not_matched(self) -> None:
+        """Text that can never become a citation must not be held back."""
+        non_partials = [
+            "no citation here",
+            "ends with a number 5",
+            "[1]",  # already complete, handled by citation_pattern
+            "[1, 2]",
+        ]
+        for segment in non_partials:
+            assert (
+                DynamicCitationProcessor().possible_citation_pattern.search(segment)
+                is None
+            ), f"expected {segment!r} to NOT be treated as a possible citation"


### PR DESCRIPTION
Cherry-pick of commit a29c5c0a9d8ef470d69153d74f91333c888fa756 to release/v3.3 branch.

Original PR: #11527

Fixes a remotely-triggerable ReDoS (catastrophic backtracking) in `DynamicCitationProcessor`'s partial-citation regex. The vulnerable inner group `(?:\d+,? ?)*` nests an unbounded `\d+` inside an unbounded `(?:...)*`, so a long LLM-emitted bracketed digit run that fails the trailing `$` anchor forces O(2^n) backtracking and pins a CPU core. Replaced with the comma-anchored `\d+(?:, ?\d+)*(?:, ?)?` form (linear time), mirroring the existing complete-citation regex. The vulnerable pattern is identical on this release branch.

Regression tests (`TestPossibleCitationPatternReDoS`) included; full citation-processor suite passes (129 tests).

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a remotely triggerable ReDoS in the chat citation processor by replacing the partial-citation regex with a linear-time, comma-separated pattern. Prevents catastrophic backtracking on long digit runs while preserving valid partial-citation detection.

- **Bug Fixes**
  - Replaced `([\[【［]+(?:\d+,? ?)*$)` with `([\[【［]+(?:\d+(?:, ?\d+)*(?:, ?)?)?$)` in `possible_citation_pattern` to remove nested unbounded quantifiers.
  - Added regression tests (`TestPossibleCitationPatternReDoS`) to guard against hangs and confirm expected matches.

<sup>Written for commit 16db568931c64218308eececf042986728574d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

