### PR TITLE
fix(craft): seed default LLM provider for ext-dep tests; drop dead _get_llm_config

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -383,17 +383,6 @@ class SessionManager:
         )
         return default, get_all_build_mode_llm_configs(providers, default)
 
-    def _get_llm_config(
-        self,
-        requested_provider_type: str | None,
-        requested_model_name: str | None,
-        user: User,
-    ) -> LLMProviderConfig:
-        """The default Craft LLM config only (see ``build_llm_configs``)."""
-        return self.build_llm_configs(
-            user, requested_provider_type, requested_model_name
-        )[0]
-
     @staticmethod
     def _select_default_llm_config(
         providers: list[LLMProviderView],

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -226,16 +226,9 @@ def _isolate_skill_tables(
 def _seed_default_llm_provider() -> Generator[None, None, None]:
     """Seed a default LLM provider so the real provisioning path resolves one.
 
-    No-op (and no teardown) if the DB already has a default, so it never
-    clobbers a dev database. K8s lane only.
+    No-op (and no teardown) if the DB already has a default. The fake key is
+    never invoked — tests forward the resolved config to ``provision()`` only.
     """
-    from onyx.server.features.build.configs import SANDBOX_BACKEND
-    from onyx.server.features.build.configs import SandboxBackend
-
-    if SANDBOX_BACKEND != SandboxBackend.KUBERNETES:
-        yield
-        return
-
     SqlEngine.init_engine(pool_size=10, max_overflow=5)
     token = CURRENT_TENANT_ID_CONTEXTVAR.set(TEST_TENANT_ID)
     seeded_name: str | None = None
@@ -1186,9 +1179,8 @@ def session_manager_with_stub(
     Patches both ``session.manager.get_sandbox_manager`` (which
     ``SessionManager.__init__`` captures into ``self._sandbox_manager`` at
     construction time) AND ``sandbox.base._sandbox_manager_instance`` so any
-    deferred lookup also lands on the stub. The LLM provider lookup is
-    short-circuited to ``default_llm_config()`` so tests don't need a real
-    provider configured in the DB.
+    deferred lookup also lands on the stub. The LLM lookup runs for real
+    against the provider from ``_seed_default_llm_provider``.
     """
     monkeypatch.setattr(
         "onyx.server.features.build.session.manager.get_sandbox_manager",
@@ -1199,11 +1191,6 @@ def session_manager_with_stub(
         stub_sandbox_manager,
     )
     sm = SessionManager(db_session)
-    monkeypatch.setattr(
-        sm,
-        "_get_llm_config",
-        lambda *args, **kwargs: default_llm_config(),  # noqa: ARG005
-    )
     # Sanity: SessionManager captured the stub at construction.
     assert sm._sandbox_manager is stub_sandbox_manager
     return sm

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -7,10 +7,7 @@ timeout).
 
 Uses the real Postgres DB (via the ``db_session`` fixture) and the real
 ``KubernetesSandboxManager`` against a kind cluster. Each test cleans
-up its sandbox via ``mgr.terminate()`` so consecutive runs stay
-hermetic. ``_get_llm_config`` is stubbed because the wake state machine
-forwards the config opaquely to ``provision()`` and the test DB doesn't
-seed a default LLM provider.
+up its sandbox via ``mgr.terminate()`` so consecutive runs stay hermetic.
 
 Gated to the K8s CI lane (``pr-craft-k8s-tests.yml``) since the local
 sandbox backend was removed in
@@ -45,21 +42,8 @@ pytestmark = pytest.mark.skipif(
 
 
 def _make_session_manager(db_session: Session) -> SessionManager:
-    """Construct a SessionManager wired to the env's real SandboxManager.
-
-    ``_get_llm_config`` is stubbed because the wake state machine just
-    forwards the config to ``provision()`` and the external-dependency
-    test DB doesn't seed a default LLM provider.
-    """
-    sm = SessionManager(db_session)
-    stub_config = LLMProviderConfig(
-        provider="test",
-        model_name="test-model",
-        api_key="test-key",
-        api_base=None,
-    )
-    setattr(sm, "_get_llm_config", lambda *_args, **_kwargs: stub_config)
-    return sm
+    """Construct a SessionManager wired to the env's real SandboxManager."""
+    return SessionManager(db_session)
 
 
 @pytest.fixture

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -213,11 +213,6 @@ class TestHealthCheckFailureRecovery:
             "onyx.server.features.build.api.sessions_api.get_sandbox_manager",
             lambda: stub_sandbox_manager,
         )
-        # Bypass LLM provider lookup (no real provider in ext-dep CI).
-        monkeypatch.setattr(
-            "onyx.server.features.build.session.manager.SessionManager._get_llm_config",
-            lambda _self, *_a, **_kw: default_llm_config(),
-        )
 
         restore_session(
             session_id=session_id,

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -37,7 +37,6 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
-from tests.external_dependency_unit.craft._test_helpers import default_llm_config
 from tests.external_dependency_unit.craft._test_helpers import make_sandbox
 from tests.external_dependency_unit.craft._test_helpers import make_user
 from tests.external_dependency_unit.craft.conftest import (
@@ -600,11 +599,6 @@ class TestSandboxReset:
             failing_stub,
         )
         sm_fail = SessionManager(db_session)
-        monkeypatch.setattr(
-            sm_fail,
-            "_get_llm_config",
-            lambda *args, **kwargs: default_llm_config(),  # noqa: ARG005
-        )
         with pytest.raises(RuntimeError):
             sm_fail.terminate_user_sandbox(user_id=other_user.id)
         # Caller would rollback; mirror that here.

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -213,9 +213,10 @@ class TestGetAllBuildModeLlmConfigs:
 
 
 class TestGetLlmConfigFallback:
-    """``SessionManager._get_llm_config(None, None, user)`` resolves to the
-    highest-priority accessible provider of a supported type (anthropic >
-    openai > openrouter), using that provider's first visible model."""
+    """``SessionManager.build_llm_configs(user)[0]`` (the default config)
+    resolves to the highest-priority accessible provider of a supported type
+    (anthropic > openai > openrouter), using that provider's first visible
+    model."""
 
     @staticmethod
     def _manager() -> SessionManager:
@@ -245,7 +246,7 @@ class TestGetLlmConfigFallback:
             api_key="k-anthropic",
         )
         with self._patch_providers([provider]):
-            config = self._manager()._get_llm_config(None, None, self._user())
+            config = self._manager().build_llm_configs(self._user(), None, None)[0]
         assert (config.provider, config.model_name) == (
             "anthropic",
             "claude-opus-4-7",
@@ -263,7 +264,7 @@ class TestGetLlmConfigFallback:
                 ),
             ]
         ):
-            config = self._manager()._get_llm_config(None, None, self._user())
+            config = self._manager().build_llm_configs(self._user(), None, None)[0]
         assert config.provider == "anthropic"
 
     def test_ignores_unsupported_provider_type(self) -> None:
@@ -272,7 +273,7 @@ class TestGetLlmConfigFallback:
             [_provider(name="az", provider="azure", models=[_model("gpt-5.5")])]
         ):
             try:
-                self._manager()._get_llm_config(None, None, self._user())
+                self._manager().build_llm_configs(self._user(), None, None)[0]
             except OnyxError as e:
                 assert e.status_code == 400
             else:
@@ -289,13 +290,13 @@ class TestGetLlmConfigFallback:
                 _provider(name="o", provider="openai", models=[_model("gpt-5.5")]),
             ]
         ):
-            config = self._manager()._get_llm_config(None, None, self._user())
+            config = self._manager().build_llm_configs(self._user(), None, None)[0]
         assert (config.provider, config.model_name) == ("openai", "gpt-5.5")
 
     def test_raises_onyx_error_when_no_supported_provider(self) -> None:
         with self._patch_providers([]):
             try:
-                self._manager()._get_llm_config(None, None, self._user())
+                self._manager().build_llm_configs(self._user(), None, None)[0]
             except OnyxError as e:
                 assert e.status_code == 400
             else:
@@ -311,9 +312,9 @@ class TestGetLlmConfigFallback:
             api_key="k-anthropic",
         )
         with self._patch_providers([provider]):
-            config = self._manager()._get_llm_config(
-                "anthropic", "claude-sonnet-4-6", self._user()
-            )
+            config = self._manager().build_llm_configs(
+                self._user(), "anthropic", "claude-sonnet-4-6"
+            )[0]
         assert (config.provider, config.model_name) == (
             "anthropic",
             "claude-sonnet-4-6",
@@ -329,9 +330,9 @@ class TestGetLlmConfigFallback:
                 )
             ]
         ):
-            config = self._manager()._get_llm_config(
-                "azure", "some-azure-model", self._user()
-            )
+            config = self._manager().build_llm_configs(
+                self._user(), "azure", "some-azure-model"
+            )[0]
         assert (config.provider, config.model_name) == (
             "anthropic",
             "claude-opus-4-7",


### PR DESCRIPTION
## Description

`#11502` rewired Craft provisioning to call `build_llm_configs` directly, leaving `_get_llm_config` as a dead delegator. Several ext-dep tests still monkeypatched `_get_llm_config`, so the patch silently no-op'd and the real resolution ran — raising `OnyxError: No accessible LLM provider...` in the stub lane (`TestIdempotentProvision`). The k8s lane masked it via the `_seed_default_llm_provider` fixture.

Instead of re-pointing the patches at `build_llm_configs` (re-coupling tests to an internal method — the brittleness that caused this), this seeds a real provider so tests run the actual path against the DB:

- Ungate `_seed_default_llm_provider` so it seeds in every craft ext-dep lane (no-op if a default exists; fake key never invoked; `is_public=True` so test users can access it).
- Remove the now-dead `_get_llm_config` monkeypatches (fixture, `TestHealthCheckFailureRecovery`, `_make_session_manager`, and an unused one on `terminate_user_sandbox`).
- Delete `_get_llm_config`; migrate its unit tests to `build_llm_configs(user, ...)[0]`.

## How Has This Been Tested?

- `test_get_all_build_mode_llm_configs.py` — 18 passed; `ruff`/`ty`/pre-commit pass.
- DB-backed ext-dep suite not run locally (no local Postgres) — relies on CI. Seeding code is unchanged and already runs in the k8s lane; this only broadens where it runs.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check