### PR TITLE
fix(ods): tolerate externally-occupied ports in portutil test

### DIFF
--- a/tools/ods/internal/portutil/portutil_test.go
+++ b/tools/ods/internal/portutil/portutil_test.go
@@ -71,7 +71,10 @@ func TestFindAvailable_errorWhenAllOccupied(t *testing.T) {
 	for i := 0; i < maxRange; i++ {
 		ln, err := net.Listen("tcp", ":"+strconv.Itoa(base+i))
 		if err != nil {
-			t.Fatalf("failed to occupy port %d: %v", base+i, err)
+			// The port is already held by another process. That still
+			// counts as occupied for the purposes of this test, so leave
+			// it be rather than failing.
+			continue
 		}
 		listeners = append(listeners, ln)
 	}


### PR DESCRIPTION
## Summary

`TestFindAvailable_errorWhenAllOccupied` in `tools/ods/internal/portutil` was flaky. It picked a random base port and assumed all 100 consecutive ports starting from it were free to bind. When another process already held one of those ports, the test's own setup loop fataled on the bind failure:

```
--- FAIL: TestFindAvailable_errorWhenAllOccupied (0.00s)
    portutil_test.go:74: failed to occupy port 40126: listen tcp :40126: bind: address already in use
```

A port already held by another process is still "occupied" for the purposes of this test (which verifies `FindAvailable` returns an error when no port in the range is bindable). So the setup loop now skips ports it can't bind rather than failing — the assertion still holds because such ports are occupied either way.

## Testing

```
$ go test ./internal/portutil/ -v -run TestFindAvailable
--- PASS: TestFindAvailable_returnsBaseWhenFree (0.00s)
--- PASS: TestFindAvailable_skipsOccupiedPort (0.00s)
--- PASS: TestFindAvailable_skipsClaimedPort (0.00s)
--- PASS: TestFindAvailable_errorWhenAllOccupied (0.02s)
PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flakiness in `tools/ods/internal/portutil` by updating `TestFindAvailable_errorWhenAllOccupied` to tolerate ports already in use by other processes. The setup now skips unbindable ports and still asserts `FindAvailable` errors when the whole range is occupied.

<sup>Written for commit 59db5cc025221ec0a41489dc882910f1069e7f59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

