### PR TITLE
chore(craft): bump default onyx-cli version for longer search timeout

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/initial-requirements.txt
@@ -6,7 +6,7 @@ lxml==6.1.0
 matplotlib==3.9.1
 matplotlib-inline==0.2.2
 numpy==1.26.4
-onyx-cli==1.0.3
+onyx-cli==1.0.4
 openpyxl==3.1.5
 pandas==2.2.2
 pdfplumber==0.11.9


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped default `onyx-cli` to 1.0.4 in sandbox build requirements to improve search reliability.

- **Dependencies**
  - Upgrade `onyx-cli` from 1.0.3 to 1.0.4, which enables a longer search timeout.

<sup>Written for commit 068d7776a7939c6e2753733c93d70199e9bdc36d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

