### PR TITLE
chore(devcontainer): set UV_LINK_MODE=copy container-wide

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,6 +27,7 @@
     "REDIS_HOST": "cache",
     "S3_ENDPOINT_URL": "http://minio:9000",
     "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
+    "UV_LINK_MODE": "copy",
     "VESPA_HOST": "index"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_REMOTE_USER:dev}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,10 +7,7 @@
       "command": "uv",
       "args": ["run", "--with", "onyx-devtools", "ods", "compose", "dev", "--infra"],
       "options": {
-        "cwd": "${workspaceFolder}",
-        "env": {
-          "UV_LINK_MODE": "copy"
-        }
+        "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
@@ -20,10 +17,7 @@
       "command": "uv",
       "args": ["run", "--with", "onyx-devtools", "ods", "env"],
       "options": {
-        "cwd": "${workspaceFolder}",
-        "env": {
-          "UV_LINK_MODE": "copy"
-        }
+        "cwd": "${workspaceFolder}"
       },
       "problemMatcher": []
     },
@@ -31,10 +25,7 @@
       "type": "shell",
       "label": "start backend",
       "options": {
-        "cwd": "${workspaceFolder}",
-        "env": {
-          "UV_LINK_MODE": "copy"
-        }
+        "cwd": "${workspaceFolder}"
       },
       "command": "uv",
       "args": ["run", "--with", "onyx-devtools", "ods", "backend", "api"]
@@ -43,10 +34,7 @@
       "type": "shell",
       "label": "start frontend",
       "options": {
-        "cwd": "${workspaceFolder}",
-        "env": {
-          "UV_LINK_MODE": "copy"
-        }
+        "cwd": "${workspaceFolder}"
       },
       "command": "uv",
       "args": ["run", "--with", "onyx-devtools", "ods", "web", "dev"]
@@ -58,8 +46,7 @@
         "cwd": "${workspaceFolder}",
         "env": {
           "INTERNAL_URL": "http://api_server:8080",
-          "PORT": "3001",
-          "UV_LINK_MODE": "copy"
+          "PORT": "3001"
         }
       },
       "command": "uv",


### PR DESCRIPTION
## What

Set `UV_LINK_MODE=copy` once in the devcontainer's `containerEnv`, and remove the five duplicated copies that were scattered across `.vscode/tasks.json`.

## Why

The venv lives at `/workspace/.venv` (on the bind-mounted workspace) while uv's cache defaults to `/home/dev/.cache/uv` (on the `onyx-devcontainer-cache` named volume). Those are **separate filesystems**, so uv's default `hardlink` mode can't link cache → venv — it warns on every install and falls back to copy anyway.

### Why not avoid it via volume mounts?

Hardlinking needs the cache *and* venv on the same filesystem. The ways to get there are all worse:

- **Cache onto the bind mount** (`UV_CACHE_DIR=/workspace/...`) — bind mounts are slow (esp. macOS/Windows) and we'd lose the persistent named-volume cache.
- **Separate volumes for venv and cache** — still two filesystems; relying on Docker volumes sharing a device id is brittle and storage-driver-dependent.
- **One shared volume for both** — forces the cache inside `.venv`, or moves `.venv` off its conventional `/workspace/.venv` path, breaking the zshrc auto-activation and the `${workspaceFolder}/.venv` references in `tasks.json`.

uv's own docs recommend `UV_LINK_MODE=copy` for exactly this container scenario. The cost is a one-time copy at install — negligible. Setting it in `containerEnv` covers every shell, task, and agent in the container, so the per-task copies are now redundant.

## Changes

- `.devcontainer/devcontainer.json`: add `UV_LINK_MODE=copy` to `containerEnv`.
- `.vscode/tasks.json`: drop the five now-redundant `UV_LINK_MODE` env entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `UV_LINK_MODE=copy` in the devcontainer so all tasks use copy mode and stop uv’s hardlink warnings. This centralizes the setting and removes duplicated task-level env config.

- **Refactors**
  - Add `UV_LINK_MODE=copy` to `containerEnv` in `.devcontainer/devcontainer.json`.
  - Remove five redundant `UV_LINK_MODE` entries from `.vscode/tasks.json`.

<sup>Written for commit 5c2898ad790aff9de04019fd99805b42fd0482ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

