### PR TITLE
perf(ci): scope playwright install to chromium, skip redundant --with-deps

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -337,7 +337,7 @@ jobs:
 
       - name: Install playwright browsers
         working-directory: ./web
-        run: bunx playwright install --with-deps
+        run: bunx playwright install chromium
 
       - name: Setup test license
         uses: ./.github/actions/setup-test-license
@@ -582,7 +582,7 @@ jobs:
 
       - name: Install playwright browsers
         working-directory: ./web
-        run: bunx playwright install --with-deps
+        run: bunx playwright install chromium
 
       - name: Setup test license
         uses: ./.github/actions/setup-test-license


### PR DESCRIPTION
## What

The `Install playwright browsers` step in `pr-playwright-tests.yml` (both the `playwright-tests` matrix job and `playwright-tests-lite`) ran:

```
bunx playwright install --with-deps
```

This change scopes it to the only browser the suite uses and drops the apt step:

```
bunx playwright install chromium
```

## Why

Timing of a recent run ([job 78566889649](https://github.com/onyx-dot-app/onyx/actions/runs/26655939580/job/78566889649)) showed the step taking ~45s, but the log makes clear where it went:

```
18:56:29  Cache restored from key: Linux-playwright-bun-...   ← browser binary already cached
18:56:30  Installing dependencies... / Switching to root user...
18:56:30  Get:1 ... Get:13 http://.../ubuntu-ports noble ...  ← apt-get, the slow part
18:57:14  step ends
```

So:
- The browser binary is **already a cache hit** (`~/.cache/ms-playwright`), so "installing the browser" is essentially free.
- The ~45s was almost entirely `--with-deps` re-running `apt-get` to install system libraries that the `runs-on-v2.2-ubuntu24-full-arm64` ("full") runner AMI already ships.
- `--with-deps` with no browser arg also pulls deps + binaries for **all three** browsers; the suite only drives **Chromium** (`devices["Desktop Chrome"]` in `web/playwright.config.ts`).

Scoping to `chromium` and dropping `--with-deps` recovers most of that time at no networking risk and with no new image to maintain.

## Validation

This bet — that the full runner AMI already has Chromium's system libs — needs a real CI run to confirm. **This PR's `playwright-tests` run is that validation.** Blast radius is contained: if Chromium can't launch (missing `.so`), this run fails and nothing merges.

**Fallback if it fails:** `bunx playwright install --with-deps chromium` — still scoped to chromium-only deps (fewer packages than the original all-browsers form), so still faster than before.

## Context

This started as an exploration of running the suite in the devcontainer / sharing its Playwright. That turned out not to apply:
- The devcontainer's Playwright is the **Python** package; the e2e suite needs the **JS** `@playwright/test` runner — not interchangeable.
- A job-level `container:` would break the MCP specs that spawn servers on the runner and reach them via `host.docker.internal`.
- Provisioning (~1 min) isn't the long pole regardless — the ~9-min `admin` test execution is, which a follow-up sharding change can target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up Playwright CI by installing only Chromium and skipping redundant dependency installs. Cuts ~45s from the "Install playwright browsers" step in both Playwright jobs with no change to test coverage.

- **Performance**
  - Switch to `bunx playwright install chromium` in `playwright-tests` and `playwright-tests-lite`.
  - Drop `--with-deps` to avoid apt work on the full runner AMI; fallback if needed: `bunx playwright install --with-deps chromium`.

<sup>Written for commit 9d55f1a63be2e982981d071eeb8d6200092c3a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

