### PR TITLE
feat(craft): inject Onyx PAT via egress proxy, remove from sandbox pod

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -129,9 +129,9 @@ K8S_CONTEXT=kind-onyx-dev
 #   kind load docker-image onyxdotapp/sandbox:dev --name onyx-dev
 SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev
 
-# How sandboxes reach the api_server *from inside the cluster* (sandbox pods
-# always run in-cluster even in local dev; this is the URL they call back to).
-SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080
+# How sandboxes reach the api_server: out through the egress proxy to the host
+# gateway, not internal cluster DNS. Linux-kind devs sub their own host gateway.
+SANDBOX_API_SERVER_URL=http://host.docker.internal:3000
 
 SANDBOX_NAMESPACE=onyx-sandboxes
 

--- a/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
+++ b/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
@@ -1,0 +1,65 @@
+"""Onyx-API PAT credential resolver.
+
+Claims requests bound for the Onyx API host (the host of
+``SANDBOX_API_SERVER_URL``) and sets both auth headers to the sandbox's real
+per-sandbox PAT, read encrypted off ``Sandbox.encrypted_pat``. The tenant is
+embedded in the PAT itself, so no separate tenant header is injected.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from mitmproxy import http
+
+from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
+from onyx.auth.constants import API_KEY_HEADER_NAME
+from onyx.auth.constants import BEARER_PREFIX
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.server.features.build.configs import SANDBOX_API_SERVER_URL
+from onyx.server.features.build.db.sandbox import get_sandbox_by_id
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class OnyxPatResolver(CredentialResolver):
+    """`CredentialResolver` brokering the sandbox's Onyx API PAT by host."""
+
+    def __init__(self) -> None:
+        host = (
+            urlparse(SANDBOX_API_SERVER_URL).hostname
+            if SANDBOX_API_SERVER_URL
+            else None
+        )
+        self._api_host = host.lower() if host else None
+
+    def claims(
+        self,
+        request: http.Request,
+        ctx: InjectionContext,  # noqa: ARG002
+    ) -> bool:
+        return self._api_host is not None and request.host.lower() == self._api_host
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        sandbox_id = ctx.sandbox.sandbox_id
+        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+            sandbox = get_sandbox_by_id(db, sandbox_id)
+            if sandbox is None:
+                raise CredentialUnavailableError(f"sandbox {sandbox_id} not found")
+            if sandbox.encrypted_pat is None:
+                raise CredentialUnavailableError(f"sandbox {sandbox_id} has no PAT")
+            try:
+                raw_token = sandbox.encrypted_pat.get_value(apply_mask=False)
+            except Exception as e:
+                raise CredentialUnavailableError(
+                    f"failed to decrypt PAT for sandbox {sandbox_id}"
+                ) from e
+
+        logger.info(
+            "onyx_pat_resolver.resolved sandbox_id=%s host=%s", sandbox_id, request.host
+        )
+        bearer = f"{BEARER_PREFIX}{raw_token}"
+        return {API_KEY_HEADER_NAME: bearer, API_KEY_HEADER_ALTERNATIVE_NAME: bearer}

--- a/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
+++ b/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
@@ -26,22 +26,27 @@ logger = setup_logger()
 
 
 class OnyxPatResolver(CredentialResolver):
-    """`CredentialResolver` brokering the sandbox's Onyx API PAT by host."""
+    """Injects the sandbox's Onyx API PAT on requests to the configured API host."""
 
     def __init__(self) -> None:
-        host = (
-            urlparse(SANDBOX_API_SERVER_URL).hostname
-            if SANDBOX_API_SERVER_URL
-            else None
-        )
+        parsed = urlparse(SANDBOX_API_SERVER_URL) if SANDBOX_API_SERVER_URL else None
+        host = parsed.hostname if parsed else None
         self._api_host = host.lower() if host else None
+        if parsed is not None and host:
+            self._api_port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        else:
+            self._api_port = None
 
     def claims(
         self,
         request: http.Request,
         ctx: InjectionContext,  # noqa: ARG002
     ) -> bool:
-        return self._api_host is not None and request.host.lower() == self._api_host
+        return (
+            self._api_host is not None
+            and request.host.lower() == self._api_host
+            and request.port == self._api_port
+        )
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         sandbox_id = ctx.sandbox.sandbox_id

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -27,6 +27,7 @@ from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.identity_k8s import K8sInformerLookup
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
+from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_HEALTHZ_PORT
@@ -140,7 +141,7 @@ def build_resolvers() -> list[CredentialResolver]:
     canonical hosts). Order is a safety net against accidental overlap, not a
     designed-in priority.
     """
-    return [ExternalAppResolver()]
+    return [OnyxPatResolver(), ExternalAppResolver()]
 
 
 def _build_cache_factory() -> "Callable[[str], CacheBackend]":

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -182,6 +182,15 @@ def _resolve_proxy_ip() -> str:
     )
 
 
+# Loopback only: the firewall permits nothing else to bypass the proxy, and the
+# Onyx API host must transit the proxy so the PAT can be injected on the wire.
+_NO_PROXY = "127.0.0.1,localhost"
+
+# Placeholder shipped in ONYX_PAT; the egress proxy injects the real PAT on the
+# wire (the pod never holds the token).
+_ONYX_PAT_PLACEHOLDER = "onyx_pat_placeholder_replaced_by_proxy"
+
+
 def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
     if not SANDBOX_PROXY_HOST:
         return []
@@ -202,15 +211,6 @@ def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
         client.V1EnvVar(name="CURL_CA_BUNDLE", value=_PROXY_CA_BUNDLE_FILE),
         client.V1EnvVar(name="GIT_SSL_CAINFO", value=_PROXY_CA_BUNDLE_FILE),
     ]
-
-
-# Loopback only: the firewall permits nothing else to bypass the proxy, and the
-# Onyx API host must transit the proxy so the PAT can be injected on the wire.
-_NO_PROXY = "127.0.0.1,localhost"
-
-# Placeholder shipped in ONYX_PAT; the egress proxy injects the real PAT on the
-# wire (the pod never holds the token).
-_ONYX_PAT_PLACEHOLDER = "onyx_pat_placeholder_replaced_by_proxy"
 
 
 def _proxy_init_container() -> client.V1Container:

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1215,9 +1215,9 @@ class KubernetesSandboxManager(SandboxManager):
             user_id: User identifier who owns this sandbox
             tenant_id: Tenant identifier for multi-tenant isolation
             llm_config: LLM provider configuration
-            onyx_pat: Guards that the per-sandbox PAT was minted and persisted
-                to Sandbox.encrypted_pat before pod startup; the pod ships only a
-                placeholder.
+            onyx_pat: Required by the interface and the Docker backend; on K8s
+                the pod ships a placeholder and the proxy injects the real PAT,
+                so this is only checked as a provisioning precondition.
 
         Returns:
             SandboxInfo with the provisioned sandbox details

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -49,7 +49,6 @@ import threading
 import time
 from collections.abc import Iterator
 from pathlib import Path
-from urllib.parse import urlparse
 from uuid import UUID
 from uuid import uuid4
 
@@ -187,7 +186,7 @@ def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
     if not SANDBOX_PROXY_HOST:
         return []
     proxy_url = f"http://{_PROXY_ALIAS}:{SANDBOX_PROXY_PORT}"
-    no_proxy = _compute_no_proxy_list()
+    no_proxy = _NO_PROXY
     return [
         client.V1EnvVar(name="HTTPS_PROXY", value=proxy_url),
         client.V1EnvVar(name="HTTP_PROXY", value=proxy_url),
@@ -205,13 +204,13 @@ def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
     ]
 
 
-def _compute_no_proxy_list() -> str:
-    entries = ["127.0.0.1", "localhost"]
-    if SANDBOX_API_SERVER_URL:
-        parsed = urlparse(SANDBOX_API_SERVER_URL)
-        if parsed.hostname:
-            entries.append(parsed.hostname)
-    return ",".join(entries)
+# Loopback only: the firewall permits nothing else to bypass the proxy, and the
+# Onyx API host must transit the proxy so the PAT can be injected on the wire.
+_NO_PROXY = "127.0.0.1,localhost"
+
+# Placeholder shipped in ONYX_PAT; the egress proxy injects the real PAT on the
+# wire (the pod never holds the token).
+_ONYX_PAT_PLACEHOLDER = "onyx_pat_placeholder_replaced_by_proxy"
 
 
 def _proxy_init_container() -> client.V1Container:
@@ -576,7 +575,6 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         sandbox_id: str,
         tenant_id: str,
-        onyx_pat: str,
     ) -> client.V1Pod:
         """Create Pod specification for sandbox (user-level).
 
@@ -604,7 +602,7 @@ class KubernetesSandboxManager(SandboxManager):
             command=["/workspace/entrypoint.sh"],
             ports=sandbox_ports,
             env=[
-                client.V1EnvVar(name="ONYX_PAT", value=onyx_pat),
+                client.V1EnvVar(name="ONYX_PAT", value=_ONYX_PAT_PLACEHOLDER),
                 client.V1EnvVar(name="ONYX_SERVER_URL", value=SANDBOX_API_SERVER_URL),
                 client.V1EnvVar(
                     name=OPENCODE_SERVER_PASSWORD,
@@ -1217,7 +1215,9 @@ class KubernetesSandboxManager(SandboxManager):
             user_id: User identifier who owns this sandbox
             tenant_id: Tenant identifier for multi-tenant isolation
             llm_config: LLM provider configuration
-            onyx_pat: Raw PAT token to inject as ONYX_PAT env var in the pod
+            onyx_pat: Guards that the per-sandbox PAT was minted and persisted
+                to Sandbox.encrypted_pat before pod startup; the pod ships only a
+                placeholder.
 
         Returns:
             SandboxInfo with the provisioned sandbox details
@@ -1304,7 +1304,6 @@ class KubernetesSandboxManager(SandboxManager):
             pod = self._create_sandbox_pod(
                 sandbox_id=str(sandbox_id),
                 tenant_id=tenant_id,
-                onyx_pat=onyx_pat,
             )
             try:
                 self._core_api.create_namespaced_pod(

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -1,0 +1,63 @@
+"""External-dependency-unit test for `OnyxPatResolver` against a real DB.
+
+Pins the full claim->resolve contract the unit test mocks: `ensure_sandbox_pat`
+mints a PAT and persists it (encrypted) on the sandbox row, the resolver claims
+the configured Onyx API host, and reads the token back — through real
+`EncryptedString` — as the same value on both auth headers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
+from onyx.auth.constants import API_KEY_HEADER_NAME
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.resolvers import onyx_pat as onyx_pat_mod
+from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
+from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
+from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
+from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
+from tests.external_dependency_unit.conftest import create_test_user
+
+_API_HOST = "api.example.com"
+
+
+def test_claims_then_resolve_round_trips_minted_pat(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "onyx_pat_resolver")
+    sandbox = create_sandbox__no_commit(db_session, user.id)
+    raw_token = ensure_sandbox_pat(db_session, sandbox, user)
+    db_session.commit()
+
+    ctx = InjectionContext(
+        sandbox=ResolvedSandbox(
+            sandbox_id=sandbox.id,
+            user_id=user.id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            sandbox_name="sandbox-test",
+            sandbox_ip="127.0.0.1",
+        ),
+        match=None,
+        db_session_factory=lambda tenant_id: get_session_with_tenant(
+            tenant_id=tenant_id
+        ),
+    )
+
+    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", f"https://{_API_HOST}")
+    resolver = OnyxPatResolver()
+    assert resolver.claims(MagicMock(host=_API_HOST), ctx) is True
+    assert resolver.claims(MagicMock(host="slack.com"), ctx) is False
+
+    headers = resolver.resolve(MagicMock(host=_API_HOST), ctx)
+
+    assert headers[API_KEY_HEADER_NAME] == f"Bearer {raw_token}"
+    assert headers[API_KEY_HEADER_ALTERNATIVE_NAME] == f"Bearer {raw_token}"

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -54,10 +54,10 @@ def test_claims_then_resolve_round_trips_minted_pat(
 
     monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", f"https://{_API_HOST}")
     resolver = OnyxPatResolver()
-    assert resolver.claims(MagicMock(host=_API_HOST), ctx) is True
-    assert resolver.claims(MagicMock(host="slack.com"), ctx) is False
+    assert resolver.claims(MagicMock(host=_API_HOST, port=443), ctx) is True
+    assert resolver.claims(MagicMock(host="slack.com", port=443), ctx) is False
 
-    headers = resolver.resolve(MagicMock(host=_API_HOST), ctx)
+    headers = resolver.resolve(MagicMock(host=_API_HOST, port=443), ctx)
 
     assert headers[API_KEY_HEADER_NAME] == f"Bearer {raw_token}"
     assert headers[API_KEY_HEADER_ALTERNATIVE_NAME] == f"Bearer {raw_token}"

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -59,7 +59,6 @@ def pod() -> client.V1Pod:
     return mgr._create_sandbox_pod(  # type: ignore[attr-defined]
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
-        onyx_pat="test-pat",
     )
 
 
@@ -161,3 +160,32 @@ def test_share_process_namespace_is_disabled(pod: client.V1Pod) -> None:
     """PID-sharing would expose the sidecar's IRSA env via /proc to the
     agent. Pin explicitly False (not just None / unset)."""
     assert pod.spec.share_process_namespace is False
+
+
+# ---------------------------------------------------------------------------
+# Credential rip-out: the real PAT never lives in the pod
+# ---------------------------------------------------------------------------
+
+
+def test_onyx_pat_env_is_placeholder_not_real(pod: client.V1Pod) -> None:
+    """The pod ships a placeholder; the egress proxy injects the real PAT."""
+    env = {e.name: e.value for e in _container(pod, "sandbox").env}
+    assert env["ONYX_PAT"] == ksm._ONYX_PAT_PLACEHOLDER
+
+
+def test_no_proxy_is_loopback_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only loopback may bypass the proxy; the Onyx API host must route through
+    it so the PAT can be injected on the wire."""
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "sandbox-proxy")
+    env = {e.name: e.value for e in ksm._proxy_main_container_env_vars()}
+    assert set(env["NO_PROXY"].split(",")) == {"127.0.0.1", "localhost"}
+    assert env["no_proxy"] == env["NO_PROXY"]
+
+
+def test_proxy_env_absent_when_proxy_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No proxy host means no proxy/NO_PROXY env at all — pinning that the pod
+    can't silently fall back to a direct, un-injected path."""
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "")
+    assert ksm._proxy_main_container_env_vars() == []

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -48,9 +48,7 @@ def _push_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ksm, "_push_public_key_b64", None, raising=False)
 
 
-@pytest.fixture
-def pod() -> client.V1Pod:
-    """A freshly-built pod spec. Each test gets its own — no cross-test state."""
+def _build_pod() -> client.V1Pod:
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
     mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
     mgr._image = "onyxdotapp/sandbox:test"  # type: ignore[attr-defined]
@@ -60,6 +58,12 @@ def pod() -> client.V1Pod:
         sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
         tenant_id="t-1",
     )
+
+
+@pytest.fixture
+def pod() -> client.V1Pod:
+    """A freshly-built pod spec. Each test gets its own — no cross-test state."""
+    return _build_pod()
 
 
 def _container(pod: client.V1Pod, name: str) -> client.V1Container:
@@ -182,10 +186,21 @@ def test_no_proxy_is_loopback_only(monkeypatch: pytest.MonkeyPatch) -> None:
     assert env["no_proxy"] == env["NO_PROXY"]
 
 
-def test_proxy_env_absent_when_proxy_not_configured(
+def test_no_proxy_env_on_sandbox_container_when_proxy_unconfigured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No proxy host means no proxy/NO_PROXY env at all — pinning that the pod
-    can't silently fall back to a direct, un-injected path."""
+    """With no proxy host, the built pod's sandbox container must carry no proxy
+    env at all — pinning the actual spec, not just the helper, so a hardcoded or
+    misplaced proxy var can't create a silent direct-egress (un-injected) path."""
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "")
-    assert ksm._proxy_main_container_env_vars() == []
+    env = {e.name for e in _container(_build_pod(), "sandbox").env}
+    assert env.isdisjoint(
+        {
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "NO_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "no_proxy",
+        }
+    )

--- a/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -69,15 +69,31 @@ def resolver(monkeypatch: pytest.MonkeyPatch) -> OnyxPatResolver:
     return OnyxPatResolver()
 
 
-def test_claims_true_only_for_api_host(resolver: OnyxPatResolver) -> None:
-    assert resolver.claims(_flow(host=_API_HOST).request, _ctx()) is True
-    assert resolver.claims(_flow(host=_API_HOST.upper()).request, _ctx()) is True
-    assert resolver.claims(_flow(host="api.slack.com").request, _ctx()) is False
+def test_claims_requires_matching_host_and_port(resolver: OnyxPatResolver) -> None:
+    # _API_URL is https with no explicit port, so the effective port is 443.
+    assert resolver.claims(_flow(host=_API_HOST, port=443).request, _ctx()) is True
+    assert (
+        resolver.claims(_flow(host=_API_HOST.upper(), port=443).request, _ctx()) is True
+    )
+    assert resolver.claims(_flow(host=_API_HOST, port=8080).request, _ctx()) is False
+    assert (
+        resolver.claims(_flow(host="api.slack.com", port=443).request, _ctx()) is False
+    )
+
+
+def test_claims_matches_explicit_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", "http://internal:8080")
+    resolver = OnyxPatResolver()
+    assert resolver.claims(_flow(host="internal", port=8080).request, _ctx()) is True
+    assert resolver.claims(_flow(host="internal", port=443).request, _ctx()) is False
 
 
 def test_inert_when_api_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", "")
-    assert OnyxPatResolver().claims(_flow(host=_API_HOST).request, _ctx()) is False
+    assert (
+        OnyxPatResolver().claims(_flow(host=_API_HOST, port=443).request, _ctx())
+        is False
+    )
 
 
 def test_resolve_renders_pat_on_both_auth_headers(

--- a/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -1,0 +1,125 @@
+"""Unit tests for `OnyxPatResolver`.
+
+Coverage: the host claim rule (incl. inert when `SANDBOX_API_SERVER_URL` is
+unset), header rendering on both auth headers, and the fail-closed cases the
+dispatcher maps to a 403. The encrypt/store/read round-trip against a real DB
+is pinned in `tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
+from onyx.auth.constants import API_KEY_HEADER_NAME
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.resolvers import onyx_pat as onyx_pat_mod
+from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+
+_API_URL = "https://api.onyx.example.com"
+_API_HOST = "api.onyx.example.com"
+
+
+class _FakeEncrypted:
+    def __init__(
+        self, *, value: str | None = None, exc: Exception | None = None
+    ) -> None:
+        self._value = value
+        self._exc = exc
+
+    def get_value(self, apply_mask: bool) -> str | None:  # noqa: ARG002
+        if self._exc is not None:
+            raise self._exc
+        return self._value
+
+
+class _FakeSandbox:
+    def __init__(self, encrypted_pat: _FakeEncrypted | None) -> None:
+        self.encrypted_pat = encrypted_pat
+
+
+def _noop_db_factory() -> Any:
+    @contextmanager
+    def factory(tenant_id: str) -> Iterator[Any]:  # noqa: ARG001
+        yield MagicMock()
+
+    return factory
+
+
+def _ctx() -> InjectionContext:
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"),
+        match=None,
+        db_session_factory=_noop_db_factory(),
+    )
+
+
+@pytest.fixture
+def resolver(monkeypatch: pytest.MonkeyPatch) -> OnyxPatResolver:
+    # __init__ captures the API host, so the patch must precede construction.
+    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", _API_URL)
+    return OnyxPatResolver()
+
+
+def test_claims_true_only_for_api_host(resolver: OnyxPatResolver) -> None:
+    assert resolver.claims(_flow(host=_API_HOST).request, _ctx()) is True
+    assert resolver.claims(_flow(host=_API_HOST.upper()).request, _ctx()) is True
+    assert resolver.claims(_flow(host="api.slack.com").request, _ctx()) is False
+
+
+def test_inert_when_api_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", "")
+    assert OnyxPatResolver().claims(_flow(host=_API_HOST).request, _ctx()) is False
+
+
+def test_resolve_renders_pat_on_both_auth_headers(
+    resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        onyx_pat_mod,
+        "get_sandbox_by_id",
+        lambda *_: _FakeSandbox(_FakeEncrypted(value="onyx_pat_t.secret")),
+    )
+    headers = resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+    assert headers == {
+        API_KEY_HEADER_NAME: "Bearer onyx_pat_t.secret",
+        API_KEY_HEADER_ALTERNATIVE_NAME: "Bearer onyx_pat_t.secret",
+    }
+
+
+def test_resolve_raises_when_sandbox_missing(
+    resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(onyx_pat_mod, "get_sandbox_by_id", lambda *_: None)
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+
+
+def test_resolve_raises_when_pat_unset(
+    resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        onyx_pat_mod, "get_sandbox_by_id", lambda *_: _FakeSandbox(None)
+    )
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host=_API_HOST).request, _ctx())
+
+
+def test_resolve_raises_when_decrypt_fails(
+    resolver: OnyxPatResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        onyx_pat_mod,
+        "get_sandbox_by_id",
+        lambda *_: _FakeSandbox(_FakeEncrypted(exc=ValueError("boom"))),
+    )
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host=_API_HOST).request, _ctx())

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -78,7 +78,8 @@ codeInterpreter:
 
 configMap:
   ENABLE_CRAFT: "true"
-  SANDBOX_API_SERVER_URL: "http://onyx-api-service.onyx.svc.cluster.local:8080"
+  # Host gateway (Docker Desktop), not internal cluster DNS; Linux-kind devs sub their own.
+  SANDBOX_API_SERVER_URL: "http://host.docker.internal:3000"
   ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: "true"
 
 # Can't be disabled when ENABLE_CRAFT=true: sandbox pods won't start

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -14,7 +14,7 @@ The gate's verdict ladder is unchanged: `_resolve_and_match` produces one of fou
 off-catalog forward, `DENY` block, `ALWAYS` auto-approved forward, or `ASK` (which becomes
 `APPROVED` / `REJECTED` / `EXPIRED` via the approval pipeline). Today only the two
 forward-with-credentials paths (`ALWAYS` and `ASK → APPROVED`) call `_inject_credentials_or_block`,
-which 403s with `_CODE_CREDENTIAL_ERROR` on a resolver exception and forwards otherwise.
+which 403s with `SandboxProxyError.CREDENTIAL_ERROR` on a resolver exception and forwards otherwise.
 Off-catalog forwards uncredentialed, even when it shouldn't (the Onyx API, LLM providers).
 
 This plan generalises that single call site into a dispatcher with a uniform contract:
@@ -48,7 +48,7 @@ first whose `claims(request, ctx)` returns True, and sets the returned headers o
 - No resolver claims → `PASS_THROUGH`.
 - Resolver returns headers → `INJECTED`.
 - Resolver raises `CredentialUnavailableError` (or any other exception) → `BLOCKED`; the gate maps
-  it to `_http_403(_CODE_CREDENTIAL_ERROR)`, reusing the existing constant.
+  it to `http_403(SandboxProxyError.CREDENTIAL_ERROR)`.
 
 The dispatch points are the three verdicts that forward: `ALWAYS`, `ASK → APPROVED`, and
 `OFF_CATALOG`. `DENY` and `ASK → REJECTED` still skip injection. The off-catalog path is the new
@@ -97,24 +97,22 @@ credentials via env vars. Every pod-side placeholder swap below is scoped to the
        sandbox=sandbox, match=match, db_session_factory=self._db_session_factory
    )
    if self._dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
-       flow.response = _http_403(_CODE_CREDENTIAL_ERROR)
+       flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
    ```
 
    Add the third invocation for off-catalog forwards inside `_resolve_and_match`, just before its
    off-catalog `return None`, with `match=None`. `_inject_credentials` collapses into the
    `ExternalAppResolver`.
 
-2. **Route the Onyx API through the proxy.** `_compute_no_proxy_list()` currently appends
-   `SANDBOX_API_SERVER_URL`'s host to `NO_PROXY`, but `firewall-init.sh` drops everything except
-   loopback and TCP to `sandbox-proxy:8080` — so clients honour `NO_PROXY`, try direct DNS, and
-   get `EPERM`. Replace the function with a `_NO_PROXY = "127.0.0.1,localhost"` constant (loopback
-   is the only thing the firewall permits to bypass the proxy) and a comment naming the firewall
-   constraint. Pin the value with a regression test.
+2. **Route the Onyx API through the proxy.** `firewall-init.sh` drops everything except loopback
+   and TCP to `sandbox-proxy:8080`, so any host in `NO_PROXY` other than loopback makes clients try
+   direct DNS and hit `EPERM`. The `_compute_no_proxy_list()` helper (which appended the API host)
+   is replaced by a `_NO_PROXY = "127.0.0.1,localhost"` constant — loopback is the only thing the
+   firewall permits to bypass the proxy. Pinned by a regression test.
 
 3. **Add `OnyxPatResolver` and `LLMProviderKeyResolver`** per Plans 2 and 3.
 
-4. **Swap pod-side credentials for placeholders** (K8s manager only), atomically with each
-   resolver's config flag:
+4. **Swap pod-side credentials for placeholders** (K8s manager only):
    - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` → non-empty placeholder. `ensure_sandbox_pat`
      keeps minting and persisting the PAT on the `Sandbox` row.
    - LLM keys in `OPENCODE_CONFIG_CONTENT` (built by `opencode_config.py`) → non-empty placeholders
@@ -124,8 +122,8 @@ credentials via env vars. Every pod-side placeholder swap below is scoped to the
    The docker manager continues to inject real credentials in both cases.
 
 5. **Wire in `server.py`.** `build_resolvers()` returns
-   `[OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]`. The dispatcher is
-   constructed once at startup and passed into `GateAddon`.
+   `[OnyxPatResolver(), ExternalAppResolver()]` (the LLM resolver joins per Plan 3). The dispatcher
+   is constructed once at startup and passed into `GateAddon`.
 
 ## Tests
 
@@ -147,17 +145,15 @@ Per-resolver tests live in [Plan 2](./02-onyx-pat.md) and [Plan 3](./03-llm-key.
 
 ## Landing plan
 
-Four PRs, each flag-gated where behavioural and independently revertible:
+Each step is an independently revertible PR (Craft is beta — no feature flags):
 
 1. **Seam extraction (refactor only).** Protocol + dispatcher + `ExternalAppResolver`.
    `_inject_credentials` becomes a delegation; the off-catalog call site is added but, with only
-   the external-app resolver registered, off-catalog stays a no-op.
-2. **Route the Onyx API through the proxy.** Loopback-only `NO_PROXY`; independently fixes a
-   pre-existing `EPERM` on outbound Onyx API calls from the sandbox.
-3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)).
-4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)).
-
-(1) and (2) first, in either order; (3) and (4) parallel after.
+   the external-app resolver registered, off-catalog stays a no-op. _Shipped._
+2. **Route the Onyx API through the proxy.** Loopback-only `NO_PROXY`; also fixes a pre-existing
+   `EPERM` on outbound Onyx API calls from the sandbox. _Shipped with the Onyx PAT resolver._
+3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)). _Shipped._
+4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)). Remaining.
 
 ## Out of scope
 

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -2,31 +2,34 @@
 
 The Onyx PAT resolver brokers the sandbox's auth back to the Onyx API. It claims the
 `SANDBOX_API_SERVER_URL` host on the [Plan 1](./01-framework.md) dispatcher, reads the sandbox's
-persisted PAT, and sets the `Authorization`, `X-Onyx-Authorization`, and `X-Onyx-Tenant-ID` headers
-on the outbound request — so onyx-cli in the pod runs against a non-secret placeholder while the
-real CRAFT PAT lives only in the proxy.
+persisted PAT, and overwrites the `Authorization` and `X-Onyx-Authorization` headers on the
+outbound request — so onyx-cli in the pod runs against a non-secret placeholder while the real
+CRAFT PAT lives only in the proxy.
 
 ## How it works
 
 **What gets injected.** The resolver claims by host (the Onyx API is never an external app, so
-`match` is ignored) and renders three headers:
+`match` is ignored) and renders two headers:
 
 | Header | Value |
 |---|---|
 | `Authorization` | `Bearer <pat>` |
 | `X-Onyx-Authorization` | `Bearer <pat>` |
-| `X-Onyx-Tenant-ID` | `ctx.sandbox.tenant_id` |
 
-The server accepts the PAT on either auth header (`API_KEY_HEADER_NAME` /
-`API_KEY_HEADER_ALTERNATIVE_NAME` in `auth/constants.py`) and reads the tenant via
-`add_onyx_tenant_id_middleware`.
+No tenant header is injected. The tenant is embedded in the PAT itself
+(`onyx_pat_<tenant>.<random>`), and the server derives it from the token.
+`get_hashed_bearer_token_from_request` checks `X-Onyx-Authorization` first, then `Authorization`
+(`API_KEY_HEADER_ALTERNATIVE_NAME` / `API_KEY_HEADER_NAME` in `auth/constants.py`); both are
+overwritten so whichever the server reads carries the real PAT.
 
 **Where the PAT lives.** `Sandbox.encrypted_pat` (`SensitiveValue[str]` over `EncryptedString`)
 stores the raw token encrypted on the sandbox row. The companion `PersonalAccessToken` row holds
 only a SHA-256 `hashed_token` for the server's lookup path. The resolver loads the sandbox by
 `ctx.sandbox.sandbox_id`, calls `get_value(apply_mask=False)` on `encrypted_pat`, and decrypts
-in-process — `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment by Plan 1.
-`Sandbox.user_id` is `unique=True`, so the one-pod, one-user, one-PAT identity is unambiguous.
+in-process — `ENCRYPTION_KEY_SECRET` is wired into the proxy Deployment by Plan 1. The `Sandbox`
+model has no `tenant_id` column; the resolver opens its session with the tenant carried on
+`ctx.sandbox.tenant_id` (from `ResolvedSandbox`). `Sandbox.user_id` is `unique=True`, so the
+one-pod, one-user, one-PAT identity is unambiguous.
 
 **PAT lifecycle.** `ensure_sandbox_pat` (in `onyx/server/features/build/db/sandbox.py`) enforces
 exactly one non-expired `CRAFT` PAT per user with a 30-day expiry (`_PAT_EXPIRATION_DAYS = 30`).
@@ -34,64 +37,72 @@ On any drift — no row, hash mismatch, multiple rows — it revokes the existin
 one, and writes it back to `Sandbox.encrypted_pat`. The resolver always reads the currently
 materialized value, so rotations take effect on the next request.
 
-**NO_PROXY.** Today `_compute_no_proxy_list()` in `kubernetes_sandbox_manager.py` appends the API
-host to `NO_PROXY`, so traffic from the pod to the Onyx API bypasses the proxy. The resolver is
-inert until [Plan 1](./01-framework.md) step 2 collapses `NO_PROXY` to loopback only; until then
-it would claim a host the proxy never sees.
+**NO_PROXY is loopback only.** `_proxy_main_container_env_vars()` in
+`kubernetes_sandbox_manager.py` sets `NO_PROXY` to the `_NO_PROXY = "127.0.0.1,localhost"`
+constant. Loopback is the only thing `firewall-init.sh` permits to bypass the proxy, so the Onyx
+API host transits the proxy and the PAT is injected on the wire. (Previously a
+`_compute_no_proxy_list()` helper appended the API host, which let clients try direct DNS and hit
+`EPERM`; that helper is gone.)
 
-**MITM trust.** Once the API host routes through the proxy, onyx-cli (Python, pip-installed
-`onyx-cli==1.0.3`) must trust the proxy's MITM CA. The K8s sandbox already wires the bundle
-through the standard env vars in `_proxy_main_container_env_vars()` — `REQUESTS_CA_BUNDLE`,
-`SSL_CERT_FILE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE` — and
-`firewall-init.sh` installs the CA into the system trust store via `update-ca-certificates`. The
-TLS path is in place; the resolver is its first real consumer.
+**MITM trust.** Because the API host routes through the proxy, onyx-cli (pip-installed) trusts
+the proxy's MITM CA. The K8s sandbox wires the bundle through the
+standard env vars in `_proxy_main_container_env_vars()` — `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`,
+`CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `GIT_SSL_CAINFO`, `AWS_CA_BUNDLE` — and `firewall-init.sh`
+installs the CA into the system trust store via `update-ca-certificates`.
 
 **Pod-side placeholder is non-empty.** onyx-cli treats an empty token as unconfigured, so the
-`ONYX_PAT` env var ships as a non-empty placeholder and the proxy overwrites both auth headers
-per the Plan 1 placeholder/overwrite contract.
+pod's `ONYX_PAT` env ships a non-empty placeholder (`_ONYX_PAT_PLACEHOLDER`, a private constant in
+`kubernetes_sandbox_manager.py`) and the proxy overwrites both auth headers per the Plan 1
+placeholder/overwrite contract.
 
 **Failure mode.** A missing row, a `None` `encrypted_pat`, or a decrypt failure raises
-`CredentialUnavailableError`; the dispatcher serves `_http_403(_CODE_CREDENTIAL_ERROR)`. The
-sandbox never sees a partial-auth fallback.
+`CredentialUnavailableError`; the dispatcher serves `http_403(SandboxProxyError.CREDENTIAL_ERROR)`.
+The sandbox never sees a partial-auth fallback.
 
-**Kubernetes only.** The docker self-hosted backend doesn't route through the proxy and continues
-to inject the real PAT directly as the `ONYX_PAT` env var.
+**Inert outside Kubernetes.** When `SANDBOX_API_SERVER_URL` is unset the resolver computes no API
+host and `claims` always returns False. The docker self-hosted backend doesn't route through the
+proxy and continues to inject the real PAT directly as the `ONYX_PAT` env var.
 
 ## Implementation
 
-1. **`OnyxPatResolver`** implementing the Plan 1 `CredentialResolver` protocol.
-   - `claims(host, match)`: True iff `host` is the host of `SANDBOX_API_SERVER_URL`.
+1. **`OnyxPatResolver`** (`onyx/sandbox_proxy/resolvers/onyx_pat.py`) implementing the Plan 1
+   `CredentialResolver` protocol.
+   - `claims(request, ctx)`: True iff `request.host` is the host of `SANDBOX_API_SERVER_URL`
+     (case-insensitive); False when the var is unset.
    - `resolve(request, ctx)`: open a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
-     load `Sandbox` by `ctx.sandbox.sandbox_id`, decrypt `encrypted_pat`, return the three
-     headers. Raise `CredentialUnavailableError` on missing row, `None` PAT, or decrypt failure.
+     load `Sandbox` by `ctx.sandbox.sandbox_id`, decrypt `encrypted_pat`, return the two headers.
+     Raise `CredentialUnavailableError` on missing row, `None` PAT, or decrypt failure.
 
-2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py`: set `ONYX_PAT` to the Plan 1
-   placeholder constant. `ensure_sandbox_pat` is unchanged. The docker manager keeps injecting
-   the real PAT.
+2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py`: the pod's `ONYX_PAT` env is
+   set to `_ONYX_PAT_PLACEHOLDER`, and `_create_sandbox_pod` no longer takes an `onyx_pat`
+   argument. `provision()` still takes and validates `onyx_pat` — it guarantees the PAT was minted
+   and persisted to `Sandbox.encrypted_pat` before the pod starts, even though the pod only ships
+   the placeholder. `ensure_sandbox_pat` is unchanged. The docker manager keeps injecting the real
+   PAT.
 
-3. **Register in `build_resolvers()`** (Plan 1 step 5) alongside `ExternalAppResolver` and
-   `LLMProviderKeyResolver`. Hosts are disjoint.
+3. **`NO_PROXY` collapse** to the `_NO_PROXY = "127.0.0.1,localhost"` constant (replacing
+   `_compute_no_proxy_list()`), so the Onyx API host transits the proxy.
 
-4. **Config flag** independent of the LLM-key resolver, so the pod-side placeholder swap and the
-   proxy-side resolver flip atomically.
+4. **Register in `build_resolvers()`** (`server.py`):
+   `[OnyxPatResolver(), ExternalAppResolver()]`. Hosts are disjoint.
 
 ## Tests
 
-- **Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): given a fake `Sandbox`
-  row with a stored `encrypted_pat` and a mock `db_session_factory`, the resolver returns the
-  three headers with `Bearer <pat>` on both auth headers. Negative cases — missing row,
-  `encrypted_pat is None`, decrypt raises — each raise `CredentialUnavailableError`. `claims` is
-  True for the API host and False for others.
+- **Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): with a fake `Sandbox`
+  row and a mock `db_session_factory`, the resolver returns both auth headers as `Bearer <pat>`.
+  Negative cases — missing row, `encrypted_pat is None`, decrypt raises — each raise
+  `CredentialUnavailableError`. `claims` is True for the API host (case-insensitive), False for
+  others, and False when `SANDBOX_API_SERVER_URL` is unset.
 
-- **External-dependency unit** in `backend/tests/external_dependency_unit/sandbox_proxy/`: against
-  a real DB, provision a `Sandbox`, run `OnyxPatResolver.resolve` with a real `InjectionContext`,
-  assert the returned `Authorization` token matches what `ensure_sandbox_pat` minted — round-trips
+- **External-dependency unit**
+  (`backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py`): against a
+  real DB, provision a `Sandbox`, mint a PAT with `ensure_sandbox_pat`, run `OnyxPatResolver.resolve`
+  with a real `InjectionContext`, and assert both auth headers carry the minted token — round-trips
   through real `EncryptedString`.
 
-- **Integration** (CI only) in `backend/tests/integration/tests/craft/`: onyx-cli inside a real
-  sandbox calls the Onyx API. The placeholder leaves the pod; the proxy overwrites both auth
-  headers and the tenant header; the API authenticates the request as the sandbox's owning user.
-  This is the first end-to-end exercise of the MITM-trust path.
+- **Pod spec** (`backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py`): the
+  pod's `ONYX_PAT` env equals `_ONYX_PAT_PLACEHOLDER` (never the real token); `NO_PROXY` is loopback
+  only.
 
 ## Out of scope
 

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -41,7 +41,7 @@ the real provider host — traffic already MITMs through the proxy, so host-matc
 **Streaming-safe, fail-closed.** Per Plan 1, injection runs at header time without touching the
 body or response, so SSE and long-running streams pass through untouched. A missing row,
 unrenderable header, or undecryptable key raises `CredentialUnavailableError`; the dispatcher
-serves `_http_403(_CODE_CREDENTIAL_ERROR)`.
+serves `http_403(SandboxProxyError.CREDENTIAL_ERROR)`.
 
 **No hot-reload in the pod.** `opencode serve` reads `OPENCODE_CONFIG_CONTENT` once at startup
 (sst/opencode#22213) and does not reload. The placeholder swap is a provisioning-time concern;


### PR DESCRIPTION
## Description

Removes the long-lived Onyx PAT from the Craft sandbox pod. The pod now ships a non-secret placeholder for `ONYX_PAT`; the egress proxy injects the real per-sandbox PAT on the wire (decrypted from `Sandbox.encrypted_pat`), so the token never lives in the sandbox.

- **`OnyxPatResolver`** (new): claims requests to the Onyx API host+port (`SANDBOX_API_SERVER_URL`) and sets `Authorization` + `X-Onyx-Authorization`. The tenant rides in the PAT, so no tenant header is needed. Fails closed (403) on missing row / null PAT / decrypt error; inert when the URL is unset.
- **K8s manager**: `ONYX_PAT` → placeholder; `NO_PROXY` collapsed to loopback-only so API traffic transits the proxy (it previously bypassed it and hit the firewall with `EPERM`). `provision()` still validates `onyx_pat` to guarantee the PAT was minted before the pod starts.
- **Docker self-hosted backend** unchanged (no proxy there — keeps injecting the real PAT).
- **localdev**: `SANDBOX_API_SERVER_URL` → host gateway (`http://host.docker.internal:3000`), so the sandbox round-trips to the web layer like prod's public URL instead of internal cluster DNS.

Out of scope (follow-up): restricting the proxy's own egress to public destinations (SSRF / internal-reachability hardening).

## How Has This Been Tested?

- **Unit**: claim rule (host+port, implicit-443, explicit-port, mismatch, inert), dual-header rendering, fail-closed paths.
- **Pod-spec unit**: pod ships the placeholder not the real PAT; loopback-only `NO_PROXY`; no proxy env when the proxy is unconfigured.
- **External-dependency unit**: mint → encrypt → store → claim → resolve round-trip against real Postgres.
- **Manual (kind)**: confirmed end-to-end that onyx-cli works

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the Onyx PAT out of sandbox pods and injects it at the egress proxy so the token never resides in the pod. Routes sandbox→API traffic through the proxy (host+port aware) and points localdev at the host gateway.

- **New Features**
  - Added `OnyxPatResolver` to claim requests to the `SANDBOX_API_SERVER_URL` host+port and set `Authorization` and `X-Onyx-Authorization` from `Sandbox.encrypted_pat` (fails closed on missing/undecryptable PAT; inert when unset).
  - K8s sandbox pods now ship a non-secret `ONYX_PAT` placeholder and use loopback-only `NO_PROXY`; proxy env is omitted when the proxy is unconfigured.
  - Proxy registers `[OnyxPatResolver(), ExternalAppResolver()]` to ensure PAT injection precedes external-app handling.
  - Localdev points `SANDBOX_API_SERVER_URL` to `http://host.docker.internal:3000`; docker self-hosted remains unchanged and still injects the real PAT directly.

- **Refactors**
  - Moved proxy constants above their use site for clarity.

<sup>Written for commit 0b0b88732973ec711d596bbaba71d4f2c72d96b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



