### PR TITLE
test(craft): amortize pod provisioning in K8s tests

### DIFF
--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -17,6 +17,9 @@ import zipfile
 from collections.abc import Callable
 from collections.abc import Generator
 from collections.abc import Iterable
+from collections.abc import Sequence
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field
@@ -647,6 +650,71 @@ class SandboxHandle:
             _sandbox_id=sandbox_id,
         )
         return sandbox_row, workspace
+
+    def provision_for_many(
+        self,
+        users: Sequence[User],
+        status: SandboxStatus = SandboxStatus.RUNNING,
+    ) -> list[tuple[Sandbox, WorkspaceProxy]]:
+        """Parallel ``provision_for``; preserves input order.
+
+        ContextVars don't propagate to ThreadPoolExecutor workers, so each
+        worker re-pins the tenant id before touching the DB. Each
+        successfully-provisioned pod is registered for teardown
+        immediately so a partial failure still cleans up.
+        """
+        if not users:
+            return []
+
+        tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
+
+        def _worker(user: User) -> UUID:
+            token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+            try:
+                return _provision_sandbox_via_app(user.id)
+            finally:
+                CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        sandbox_ids: dict[User, UUID] = {}
+        worker_error: Exception | None = None
+        with ThreadPoolExecutor(max_workers=min(len(users), 8)) as pool:
+            futures = {pool.submit(_worker, user): user for user in users}
+            for fut in as_completed(futures):
+                user = futures[fut]
+                try:
+                    sandbox_id = fut.result()
+                except Exception as e:
+                    if worker_error is None:
+                        worker_error = e
+                    continue
+                sandbox_ids[user] = sandbox_id
+                self._register_extra(sandbox_id)
+
+        if worker_error is not None:
+            raise worker_error
+
+        self._db_session.expire_all()
+
+        results: list[tuple[Sandbox, WorkspaceProxy]] = []
+        for user in users:
+            sandbox_id = sandbox_ids[user]
+            sandbox_row = self._db_session.get(Sandbox, sandbox_id)
+            assert sandbox_row is not None
+
+            if status != SandboxStatus.RUNNING:
+                sandbox_row.status = status
+
+            workspace = WorkspaceProxy(
+                _k8s_client=self._k8s_client,
+                _pod_name=self.manager._get_pod_name(sandbox_id),
+                _sandbox_id=sandbox_id,
+            )
+            results.append((sandbox_row, workspace))
+
+        if status != SandboxStatus.RUNNING:
+            self._db_session.commit()
+
+        return results
 
 
 def _create_committed_craft_user() -> UUID:

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -82,9 +82,19 @@ from tests.external_dependency_unit.craft.stubs import StubSandboxManager
 _DEV_PUSH_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 
-@pytest.fixture(autouse=True)
-def _sandbox_push_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("ONYX_SANDBOX_PUSH_PRIVATE_KEY", _DEV_PUSH_KEY)
+@pytest.fixture(scope="module", autouse=True)
+def _sandbox_push_key() -> Generator[None, None, None]:
+    # Module-scoped so it's set before ``_pool_pod`` (also module-scoped)
+    # provisions its pod — the K8s manager reads the env var at pod-spec
+    # build time. Function-scoped ``monkeypatch`` runs *after* higher-scoped
+    # fixtures, which is what triggered the CI breakage when the first
+    # test in the file moved onto ``pool_session``.
+    mp = pytest.MonkeyPatch()
+    mp.setenv("ONYX_SANDBOX_PUSH_PRIVATE_KEY", _DEV_PUSH_KEY)
+    try:
+        yield
+    finally:
+        mp.undo()
 
 
 # ---------------------------------------------------------------------------
@@ -690,10 +700,19 @@ class SandboxHandle:
                 sandbox_ids[user] = sandbox_id
                 self._register_extra(sandbox_id)
 
+        # Apply the requested status to every pod that came up — including
+        # on partial failure — so teardown sees consistent DB state before
+        # the error propagates.
+        self._db_session.expire_all()
+        if status != SandboxStatus.RUNNING and sandbox_ids:
+            for sandbox_id in sandbox_ids.values():
+                row = self._db_session.get(Sandbox, sandbox_id)
+                assert row is not None
+                row.status = status
+            self._db_session.commit()
+
         if worker_error is not None:
             raise worker_error
-
-        self._db_session.expire_all()
 
         results: list[tuple[Sandbox, WorkspaceProxy]] = []
         for user in users:
@@ -701,18 +720,12 @@ class SandboxHandle:
             sandbox_row = self._db_session.get(Sandbox, sandbox_id)
             assert sandbox_row is not None
 
-            if status != SandboxStatus.RUNNING:
-                sandbox_row.status = status
-
             workspace = WorkspaceProxy(
                 _k8s_client=self._k8s_client,
                 _pod_name=self.manager._get_pod_name(sandbox_id),
                 _sandbox_id=sandbox_id,
             )
             results.append((sandbox_row, workspace))
-
-        if status != SandboxStatus.RUNNING:
-            self._db_session.commit()
 
         return results
 

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -110,7 +110,8 @@ def _read_pod_file(k8s: client.CoreV1Api, pod_name: str, path: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Fixtures: k8s_manager and live_pod are provided by conftest.py
+# Fixtures: k8s_manager, pool_session, live_pod, provisioned_sandbox, and
+# k8s_client are provided by conftest.py.
 # ---------------------------------------------------------------------------
 
 
@@ -122,6 +123,7 @@ def _read_pod_file(k8s: client.CoreV1Api, pod_name: str, path: str) -> str:
 def test_provisioned_pod_has_sandbox_image_directories(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
     """After ``provision()``, the baked-in workspace directories exist.
 
@@ -130,38 +132,29 @@ def test_provisioned_pod_has_sandbox_image_directories(
     answer ``health_check``. Also doubles as the merged ``health_check_returns_true``
     coverage per the plan note.
     """
-    sandbox_id = uuid4()
-    try:
-        _provisioned_sandbox(k8s_manager, sandbox_id)
+    sandbox_id, _, pod_name = pool_session
 
-        pod_name = k8s_manager._get_pod_name(sandbox_id)
-        pod = k8s_client.read_namespaced_pod(name=pod_name, namespace=SANDBOX_NAMESPACE)
-        assert pod.status.phase == "Running"
+    pod = k8s_client.read_namespaced_pod(name=pod_name, namespace=SANDBOX_NAMESPACE)
+    assert pod.status.phase == "Running"
 
-        for required in (
-            "/workspace/templates",
-            "/workspace/managed",
-            "/workspace/sessions",
-        ):
-            resp = pod_exec(
-                k8s_client,
-                pod_name,
-                SANDBOX_NAMESPACE,
-                f"test -d {required} && echo OK || echo MISSING",
-            )
-            assert "OK" in resp, (
-                f"{required} should exist in the provisioned pod. Got: {resp!r}"
-            )
-
-        # Health-check verification is merged with this provision test.
-        assert k8s_manager.health_check(sandbox_id, timeout=5.0), (
-            "health_check() should return True for a freshly provisioned pod"
+    for required in (
+        "/workspace/templates",
+        "/workspace/managed",
+        "/workspace/sessions",
+    ):
+        resp = pod_exec(
+            k8s_client,
+            pod_name,
+            SANDBOX_NAMESPACE,
+            f"test -d {required} && echo OK || echo MISSING",
         )
-    finally:
-        k8s_manager.terminate(sandbox_id)
-        wait_for_pod_deletion(
-            k8s_client, k8s_manager._get_pod_name(sandbox_id), SANDBOX_NAMESPACE
+        assert "OK" in resp, (
+            f"{required} should exist in the provisioned pod. Got: {resp!r}"
         )
+
+    assert k8s_manager.health_check(sandbox_id, timeout=5.0), (
+        "health_check() should return True for a freshly provisioned pod"
+    )
 
 
 def test_session_workspace_setup_creates_expected_tree(
@@ -382,34 +375,26 @@ def test_health_check_returns_false_for_missing_pod(
 
 
 def test_pod_runs_sandbox_and_sidecar_containers(
-    k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
     """After provision, the pod has both `sandbox` and `sidecar` containers
     and the sidecar reports ready (its `/health` probe is what gates this).
     """
-    sandbox_id = uuid4()
-    try:
-        _provisioned_sandbox(k8s_manager, sandbox_id)
-        pod_name = k8s_manager._get_pod_name(sandbox_id)
-        pod = k8s_client.read_namespaced_pod(name=pod_name, namespace=SANDBOX_NAMESPACE)
+    _, _, pod_name = pool_session
+    pod = k8s_client.read_namespaced_pod(name=pod_name, namespace=SANDBOX_NAMESPACE)
 
-        statuses = {c.name: c for c in pod.status.container_statuses or []}
-        assert set(statuses) == {"sandbox", "sidecar"}, (
-            f"pod should have exactly 2 containers, got {set(statuses)}"
-        )
-        assert statuses["sidecar"].ready, "sidecar should be ready via /health probe"
-        assert statuses["sandbox"].ready, "sandbox container should be ready"
-    finally:
-        k8s_manager.terminate(sandbox_id)
-        wait_for_pod_deletion(
-            k8s_client, k8s_manager._get_pod_name(sandbox_id), SANDBOX_NAMESPACE
-        )
+    statuses = {c.name: c for c in pod.status.container_statuses or []}
+    assert set(statuses) == {"sandbox", "sidecar"}, (
+        f"pod should have exactly 2 containers, got {set(statuses)}"
+    )
+    assert statuses["sidecar"].ready, "sidecar should be ready via /health probe"
+    assert statuses["sandbox"].ready, "sandbox container should be ready"
 
 
 def test_irsa_credentials_stripped_from_sandbox_container(
-    k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
     """The sandbox container must never see IRSA credentials.
 
@@ -422,51 +407,41 @@ def test_irsa_credentials_stripped_from_sandbox_container(
     IRSA") depends on the EKS pod-identity webhook plus SA annotations
     that don't exist on a kind cluster, so it lives elsewhere.
     """
-    sandbox_id = uuid4()
-    try:
-        _provisioned_sandbox(k8s_manager, sandbox_id)
-        pod_name = k8s_manager._get_pod_name(sandbox_id)
+    _, _, pod_name = pool_session
 
-        # Check each var independently so partial leakage (one set, one unset)
-        # cannot pass as "all unset". The shell expansion ${VAR:-} substitutes
-        # an empty string when the var is unset OR empty; we then explicitly
-        # report which (if any) is non-empty.
-        sandbox_env = pod_exec(
-            k8s_client,
-            pod_name,
-            SANDBOX_NAMESPACE,
-            (
-                "for v in AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; do "
-                '  eval "val=\\${${v}:-}"; '
-                '  if [ -n "$val" ]; then echo "LEAK:$v=$val"; fi; '
-                "done; echo DONE"
-            ),
-            container="sandbox",
-        )
-        assert "LEAK:" not in sandbox_env, (
-            f"sandbox container leaked IRSA env vars: {sandbox_env!r}"
-        )
-        assert "DONE" in sandbox_env, (
-            f"env-leak probe did not run to completion: {sandbox_env!r}"
-        )
+    # Check each var independently so partial leakage (one set, one unset)
+    # cannot pass as "all unset". The shell expansion ${VAR:-} substitutes
+    # an empty string when the var is unset OR empty; we then explicitly
+    # report which (if any) is non-empty.
+    sandbox_env = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        (
+            "for v in AWS_ROLE_ARN AWS_WEB_IDENTITY_TOKEN_FILE; do "
+            '  eval "val=\\${${v}:-}"; '
+            '  if [ -n "$val" ]; then echo "LEAK:$v=$val"; fi; '
+            "done; echo DONE"
+        ),
+        container="sandbox",
+    )
+    assert "LEAK:" not in sandbox_env, (
+        f"sandbox container leaked IRSA env vars: {sandbox_env!r}"
+    )
+    assert "DONE" in sandbox_env, (
+        f"env-leak probe did not run to completion: {sandbox_env!r}"
+    )
 
-        # Belt to the env-var suspenders: confirm the projected token mount
-        # path doesn't exist in the sandbox container.
-        token_mount = pod_exec(
-            k8s_client,
-            pod_name,
-            SANDBOX_NAMESPACE,
-            "[ -d /var/run/secrets/eks.amazonaws.com ] && echo PRESENT || echo MISSING",
-            container="sandbox",
-        )
-        assert "MISSING" in token_mount, (
-            f"IRSA token mount leaked into sandbox container: {token_mount!r}"
-        )
-    finally:
-        k8s_manager.terminate(sandbox_id)
-        wait_for_pod_deletion(
-            k8s_client, k8s_manager._get_pod_name(sandbox_id), SANDBOX_NAMESPACE
-        )
+    token_mount = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        "[ -d /var/run/secrets/eks.amazonaws.com ] && echo PRESENT || echo MISSING",
+        container="sandbox",
+    )
+    assert "MISSING" in token_mount, (
+        f"IRSA token mount leaked into sandbox container: {token_mount!r}"
+    )
 
 
 def test_managed_directory_is_read_only_from_sandbox_container(
@@ -535,33 +510,25 @@ _proxy_required = pytest.mark.skipif(
 
 @_proxy_required
 def test_sandbox_etc_hosts_resolves_proxy_alias(
-    k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
     """The main container's /etc/hosts must contain the `sandbox-proxy` alias.
 
     kubelet manages /etc/hosts per-container so initContainer writes don't
     propagate; host_aliases on the PodSpec is the only path that works.
     """
-    sandbox_id = uuid4()
-    try:
-        _provisioned_sandbox(k8s_manager, sandbox_id)
-        pod_name = k8s_manager._get_pod_name(sandbox_id)
-        hosts = pod_exec(
-            k8s_client,
-            pod_name,
-            SANDBOX_NAMESPACE,
-            "cat /etc/hosts",
-            container="sandbox",
-        )
-        assert "sandbox-proxy" in hosts, (
-            f"main container /etc/hosts missing sandbox-proxy alias: {hosts!r}"
-        )
-    finally:
-        k8s_manager.terminate(sandbox_id)
-        wait_for_pod_deletion(
-            k8s_client, k8s_manager._get_pod_name(sandbox_id), SANDBOX_NAMESPACE
-        )
+    _, _, pod_name = pool_session
+    hosts = pod_exec(
+        k8s_client,
+        pod_name,
+        SANDBOX_NAMESPACE,
+        "cat /etc/hosts",
+        container="sandbox",
+    )
+    assert "sandbox-proxy" in hosts, (
+        f"main container /etc/hosts missing sandbox-proxy alias: {hosts!r}"
+    )
 
 
 @_proxy_required

--- a/backend/tests/external_dependency_unit/craft/test_skill_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push.py
@@ -94,14 +94,16 @@ class TestSkillPush:
         user_c = cohort["noone"][0]
 
         # Delete sandbox rows created by granted_users (they lack FS
-        # provisioning) and re-provision via handle.provision_for.
-        workspaces: dict[UUID, WorkspaceProxy] = {}
-        for user in (user_a, user_b, user_c):
+        # provisioning) and re-provision via the manager.
+        cohort_users = [user_a, user_b, user_c]
+        for user in cohort_users:
             row = db_session.query(Sandbox).filter(Sandbox.user_id == user.id).one()
             db_session.delete(row)
         db_session.commit()
-        for user in (user_a, user_b, user_c):
-            _, workspaces[user.id] = handle.provision_for(user)
+        provisioned = handle.provision_for_many(cohort_users)
+        workspaces: dict[UUID, WorkspaceProxy] = {
+            user.id: ws for user, (_row, ws) in zip(cohort_users, provisioned)
+        }
 
         public_skill = seeded_skill(
             slug=f"public-skill-{uuid4().hex[:6]}",
@@ -137,13 +139,15 @@ class TestSkillPush:
             db_session.query(UserGroup).filter(UserGroup.name == "engineering").one()
         )
 
-        workspaces: dict[UUID, WorkspaceProxy] = {}
-        for user in (user_a, user_b, user_c):
+        cohort_users = [user_a, user_b, user_c]
+        for user in cohort_users:
             row = db_session.query(Sandbox).filter(Sandbox.user_id == user.id).one()
             db_session.delete(row)
         db_session.commit()
-        for user in (user_a, user_b, user_c):
-            _, workspaces[user.id] = handle.provision_for(user)
+        provisioned = handle.provision_for_many(cohort_users)
+        workspaces: dict[UUID, WorkspaceProxy] = {
+            user.id: ws for user, (_row, ws) in zip(cohort_users, provisioned)
+        }
 
         skill = seeded_skill(
             slug=f"eng-only-{uuid4().hex[:6]}",
@@ -258,8 +262,7 @@ class TestSkillPush:
         add_user_to_group(db_session, user_b, group_y)
         db_session.commit()
 
-        _row_a, ws_a = handle.provision_for(user_a)
-        _row_b, ws_b = handle.provision_for(user_b)
+        (_row_a, ws_a), (_row_b, ws_b) = handle.provision_for_many([user_a, user_b])
 
         skill = seeded_skill(
             slug=f"grants-flip-{uuid4().hex[:6]}",
@@ -346,8 +349,7 @@ class TestSkillPush:
         user_a = make_user(db_session)
         user_b = make_user(db_session)
         db_session.commit()
-        _row_a, ws_a = handle.provision_for(user_a)
-        _row_b, ws_b = handle.provision_for(user_b)
+        (_row_a, ws_a), (_row_b, ws_b) = handle.provision_for_many([user_a, user_b])
 
         skill = seeded_skill(
             slug=f"to-delete-{uuid4().hex[:6]}",
@@ -389,9 +391,9 @@ class TestSkillPush:
         user_b = make_user(db_session)
         user_c = make_user(db_session)
         db_session.commit()
-        _row_a, _ = handle.provision_for(user_a)
-        row_b, _ = handle.provision_for(user_b)
-        _row_c, _ = handle.provision_for(user_c)
+        (_row_a, _), (row_b, _), (_row_c, _) = handle.provision_for_many(
+            [user_a, user_b, user_c]
+        )
 
         # Make user_b's push fatally fail; the other two succeed silently.
         stub = failing_sandbox_manager(
@@ -491,8 +493,7 @@ class TestSkillPush:
         add_user_to_group(db_session, user_b, group_b)
         db_session.commit()
 
-        _, ws_a = handle.provision_for(user_a)
-        _, ws_b = handle.provision_for(user_b)
+        (_, ws_a), (_, ws_b) = handle.provision_for_many([user_a, user_b])
         row_a = db_session.query(Sandbox).filter(Sandbox.user_id == user_a.id).one()
         row_b = db_session.query(Sandbox).filter(Sandbox.user_id == user_b.id).one()
 

--- a/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
+++ b/backend/tests/external_dependency_unit/craft/test_snapshot_restore.py
@@ -152,11 +152,12 @@ def _list_archive_members(tar_path: Path) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Fixtures: k8s_manager and live_pod are provided by conftest.py.
-#
-# Note: snapshot S3 cleanup is NOT handled by the shared ``live_pod``
-# fixture. Tests that create snapshots must clean them up individually
-# (see ``_delete_snapshot``).
+# Fixtures: k8s_manager, pool_session, and live_pod are provided by conftest.py.
+# Tests use ``pool_session`` to share the module pod; ``live_pod`` is
+# reserved for the termination test and the traversal-defence test (where
+# isolation matters if the defence ever regresses). Snapshot S3 cleanup
+# is not handled by either fixture — snapshot keys include the per-test
+# session_id so they don't collide.
 # ---------------------------------------------------------------------------
 
 
@@ -168,10 +169,10 @@ def _list_archive_members(tar_path: Path) -> list[str]:
 def test_snapshot_includes_outputs_and_attachments_and_opencode_data(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
     tmp_path: Path,
 ) -> None:
-    sandbox_id, session_id, pod_name = live_pod
+    sandbox_id, session_id, pod_name = pool_session
 
     _populate_session_workspace(k8s_client, pod_name, session_id)
 
@@ -203,10 +204,10 @@ def test_snapshot_includes_outputs_and_attachments_and_opencode_data(
 def test_snapshot_excludes_managed_skills_agents_md_opencode_json(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
     tmp_path: Path,
 ) -> None:
-    sandbox_id, session_id, pod_name = live_pod
+    sandbox_id, session_id, pod_name = pool_session
 
     # ``setup_session_workspace`` already wrote AGENTS.md + opencode.json
     # at the session root. We additionally seed managed/skills/ at the
@@ -244,9 +245,9 @@ def test_snapshot_excludes_managed_skills_agents_md_opencode_json(
 def test_restore_from_snapshot_recreates_workspace(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
-    sandbox_id, session_id, pod_name = live_pod
+    sandbox_id, session_id, pod_name = pool_session
 
     payload = _populate_session_workspace(k8s_client, pod_name, session_id)
     result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
@@ -314,9 +315,9 @@ def test_restore_from_snapshot_recreates_workspace(
 def test_restore_re_pushes_skills(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
-    sandbox_id, session_id, pod_name = live_pod
+    sandbox_id, session_id, pod_name = pool_session
 
     _populate_session_workspace(k8s_client, pod_name, session_id)
     result = k8s_manager.create_snapshot(sandbox_id, session_id, TEST_TENANT_ID)
@@ -384,9 +385,9 @@ def test_restore_re_pushes_skills(
 def test_restore_with_missing_snapshot_creates_fresh_workspace(
     k8s_manager: KubernetesSandboxManager,
     k8s_client: client.CoreV1Api,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
-    sandbox_id, session_id, pod_name = live_pod
+    sandbox_id, session_id, pod_name = pool_session
 
     # Wipe the workspace so we can verify the fresh-setup path.
     k8s_manager.cleanup_session_workspace(sandbox_id, session_id)
@@ -487,6 +488,10 @@ def test_restore_uses_data_filter_to_block_traversal(
     sandbox_id, session_id, pod_name = live_pod
 
     # Wipe the workspace so we can detect any traversal artefacts cleanly.
+    # Stays on ``live_pod`` (not ``pool_session``) so that any regression
+    # which lets ``/workspace/escape.txt`` actually get written is
+    # contained to a fresh pod, not poisoning every later test in the
+    # module.
     k8s_manager.cleanup_session_workspace(sandbox_id, session_id)
 
     # Build a tarball locally with one well-behaved entry plus one traversal
@@ -563,9 +568,9 @@ def test_restore_uses_data_filter_to_block_traversal(
 )
 def test_snapshot_corruption_detected_on_restore(
     k8s_manager: KubernetesSandboxManager,
-    live_pod: tuple[UUID, UUID, str],
+    pool_session: tuple[UUID, UUID, str],
 ) -> None:
-    sandbox_id, session_id, _pod_name = live_pod
+    sandbox_id, session_id, _pod_name = pool_session
 
     # Forge a truncated gzip blob — valid gzip header, garbage body.
     corrupt_bytes = b"\x1f\x8b\x08\x00" + b"\x00" * 8 + b"truncated-mid-stream"


### PR DESCRIPTION
## Description

The Craft K8s CI lane runs ~20 min vs. ~10 min for other lanes. Pod provisioning (~14s kubelet readiness wait per pod) dominates. Two changes:

- **Parallelize cohort provisioning.** New ``SandboxHandle.provision_for_many(users)`` runs each ``provision_for`` on a ``ThreadPoolExecutor`` (capped at 8). Workers re-pin the tenant ``ContextVar`` and register their pod for teardown as soon as they return, so a partial failure doesn't leak pods. Used by 7 multi-pod tests in ``test_skill_push.py``.

- **Move spec-only tests to the module pool pod.** Tests that just inspect pod spec or per-session state move from per-test ``live_pod`` to the existing module-scoped ``pool_session``: 4 tests in ``test_kubernetes_sandbox.py`` and 6 of 8 in ``test_snapshot_restore.py``. Lifecycle tests (``terminate``, RO-mount probe, egress proxy, snapshot-failure-then-terminate) and the traversal-defence test stay isolated.

## How Has This Been Tested?

Pre-commit (ruff, ty) clean locally. K8s tests aren't runnable locally; the ``pr-craft-k8s-tests.yml`` lane exercises both paths.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check