### PR TITLE
feat(craft): External app refresh tokens

### DIFF
--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -2,7 +2,9 @@ import os
 import re
 import threading
 import time
+from collections.abc import Callable
 from collections.abc import Generator
+from contextlib import AbstractContextManager
 from contextlib import contextmanager
 from typing import Any
 
@@ -437,6 +439,10 @@ def _safe_close_session(session: Session) -> None:
         logger.warning(
             "DB connection lost during session cleanup — the connection will be invalidated and recycled by the pool."
         )
+
+
+# Canonical type for a tenant-id -> tenant-scoped DB session context manager
+DBSessionFactory = Callable[[str], AbstractContextManager[Session]]
 
 
 @contextmanager

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -416,3 +416,20 @@ def upsert_external_app_user_credential(
     cred = db_session.scalars(stmt).one()
     db_session.commit()
     return cred
+
+
+def delete_external_app_user_credential(
+    db_session: Session,
+    *,
+    external_app_id: int,
+    user_id: UUID,
+) -> None:
+    """Delete the user's stored credentials for one app, and commit (no-op if
+    absent). Used when a refresh terminally fails so the user reconnects."""
+    db_session.execute(
+        delete(ExternalAppUserCredential).where(
+            ExternalAppUserCredential.external_app_id == external_app_id,
+            ExternalAppUserCredential.user_id == user_id,
+        )
+    )
+    db_session.commit()

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -160,10 +160,9 @@ class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
     # Bounded so a slow token endpoint can't pin the refresh (and the gate).
     refresh_http_timeout_seconds: ClassVar[float] = 20.0
 
-    # Error codes meaning the grant is dead (reconnect). Else: transient.
-    terminal_refresh_errors: ClassVar[frozenset[str]] = frozenset(
-        {"invalid_grant", "invalid_client", "unauthorized_client", "invalid_request"}
-    )
+    # Error codes meaning the grant itself is dead, so the user must reconnect
+    # (RFC 6749 §5.2).
+    terminal_refresh_errors: ClassVar[frozenset[str]] = frozenset({"invalid_grant"})
 
     @abstractmethod
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -208,10 +208,22 @@ class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
                 raise TokenRefreshTerminalError(error)
             raise TokenRefreshTransientError(error)
 
-        refreshed = self.extract_credentials(body)
-        # Carry the existing refresh token forward when the provider didn't rotate.
-        refreshed.setdefault("refresh_token", refresh_token)
-        return refreshed
+        try:
+            mapped = self.extract_credentials(body)
+        except TokenRefreshError:
+            raise
+        except Exception as exc:
+            # A 2xx body we can't map (unexpected shape) isn't a dead grant —
+            # transient, so the caller keeps the existing token, not clears it.
+            # Keeps this method's contract: it raises only TokenRefreshError.
+            raise TokenRefreshTransientError(
+                f"could not map refresh response: {exc}"
+            ) from exc
+
+        # Merge onto the stored creds (response wins) rather than replace, so
+        # connect-time-only fields (Slack's team_id, a prior id_token, …) and the
+        # refresh token survive a refresh that returns only the rotated subset.
+        return {**stored, **mapped}
 
     def build_refresh_request(
         self, refresh_token: str, client_id: str, client_secret: str

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -26,13 +26,25 @@ class TokenRefreshTransientError(TokenRefreshError):
     token should be left in place and the refresh retried on a later request."""
 
 
-def token_response_error(
-    http_response: requests.Response, body: dict[str, Any]
-) -> str | None:
+def token_response_error(http_response: requests.Response, body: Any) -> str | None:
     """Slack returns 200 + ``{"ok": false}`` on failure; everyone else uses
-    non-2xx. Returns the error string or ``None`` on success."""
+    non-2xx. Returns the error string or ``None`` on success.
+
+    ``body`` is whatever ``response.json()`` produced, so it may not be a JSON
+    object (a gateway can return a bare array / string / number / ``null``). A
+    non-object can't carry an OAuth error code, so a non-2xx is reported as a
+    generic failure and a 2xx falls through to credential mapping — never an
+    unguarded ``.get()`` that would escape the refresh error handling."""
+    if not isinstance(body, dict):
+        if http_response.status_code >= 400:
+            return f"unexpected token response (status={http_response.status_code})"
+        return None
     if http_response.status_code >= 400:
-        return body.get("error_description") or body.get("error") or "unknown"
+        # Prefer the machine-readable `error` code over the human-readable
+        # `error_description`: terminal-vs-transient classification matches against
+        # OAuth error codes (e.g. `invalid_grant`), so returning the prose would
+        # misclassify a dead grant as transient and skip required reconnect handling.
+        return body.get("error") or body.get("error_description") or "unknown"
     if body.get("ok") is False:
         return body.get("error") or "unknown"
     return None

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -3,11 +3,39 @@ from abc import abstractmethod
 from typing import Any
 from typing import ClassVar
 
+import requests
 from pydantic import BaseModel
 from pydantic import ConfigDict
 
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.providers.actions import EndpointSpec
+
+
+class TokenRefreshError(Exception):
+    """Base class for OAuth access-token refresh failures."""
+
+
+class TokenRefreshTerminalError(TokenRefreshError):
+    """The refresh token is dead (revoked / invalid_grant / missing). The stored
+    credential should be cleared and the user prompted to reconnect — retrying
+    cannot succeed."""
+
+
+class TokenRefreshTransientError(TokenRefreshError):
+    """A transient failure (network, 5xx, non-JSON, rate-limit). The existing
+    token should be left in place and the refresh retried on a later request."""
+
+
+def token_response_error(
+    http_response: requests.Response, body: dict[str, Any]
+) -> str | None:
+    """Slack returns 200 + ``{"ok": false}`` on failure; everyone else uses
+    non-2xx. Returns the error string or ``None`` on success."""
+    if http_response.status_code >= 400:
+        return body.get("error_description") or body.get("error") or "unknown"
+    if body.get("ok") is False:
+        return body.get("error") or "unknown"
+    return None
 
 
 class OrgCredentialField(BaseModel):
@@ -104,16 +132,103 @@ class ExternalAppProvider(ABC):
 
 
 class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
-    """A provider whose users authenticate via an OAuth 2.0 flow. Concrete
-    subclasses MUST supply an :class:`OAuthProviderSpec` (so ``spec.oauth`` is
-    always present) and implement :meth:`extract_credentials`."""
+    """A provider whose users authenticate via OAuth 2.0. Subclasses supply an
+    :class:`OAuthProviderSpec` and implement :meth:`extract_credentials`.
+
+    :meth:`refresh_credentials` is a template method: a divergent provider
+    overrides one hook (`build_refresh_request`, `classify_token_response`) or
+    class property below, not the whole POST/error-handling flow.
+    """
 
     spec: ClassVar[OAuthProviderSpec]
     _spec_type: ClassVar[type[ProviderSpec]] = OAuthProviderSpec
 
+    # --- Refresh configuration (override per provider as needed) ---
+
+    # Bounded so a slow token endpoint can't pin the refresh (and the gate).
+    refresh_http_timeout_seconds: ClassVar[float] = 20.0
+
+    # Error codes meaning the grant is dead (reconnect). Else: transient.
+    terminal_refresh_errors: ClassVar[frozenset[str]] = frozenset(
+        {"invalid_grant", "invalid_client", "unauthorized_client", "invalid_request"}
+    )
+
     @abstractmethod
     def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
-        """Map a successful token-exchange response to the credentials to
-        persist for the user (e.g. pull the user access token out of Slack's
-        nested ``authed_user``). Raise ``OnyxError`` if the expected token is
-        absent."""
+        """Map a successful token response (initial grant *or* refresh) to the
+        credentials to persist for the user (e.g. pull the user access token out
+        of Slack's nested ``authed_user``). Raise ``OnyxError`` if the expected
+        token is absent."""
+
+    # --- Refresh template method (override a hook below, not this) ---
+
+    def refresh_credentials(
+        self,
+        stored: dict[str, Any],
+        client_id: str,
+        client_secret: str,
+    ) -> dict[str, Any]:
+        """Exchange the stored refresh token for a fresh access token (RFC-6749).
+
+        Clockless (the caller stamps ``expires_at``), mirroring
+        :meth:`extract_credentials`. Override `build_refresh_request` /
+        `classify_token_response` for a divergent provider.
+
+        Raises:
+            TokenRefreshTerminalError: the grant is dead (reconnect required).
+            TokenRefreshTransientError: a retryable failure (network / 5xx / …).
+        """
+        refresh_token = stored.get("refresh_token")
+        if not refresh_token:
+            raise TokenRefreshTerminalError(
+                "No refresh token stored; the user must reconnect."
+            )
+
+        try:
+            response = requests.post(
+                self.spec.oauth.token_url,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                data=self.build_refresh_request(
+                    refresh_token, client_id, client_secret
+                ),
+                timeout=self.refresh_http_timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise TokenRefreshTransientError(f"network error: {exc}") from exc
+        try:
+            body = response.json()
+        except ValueError as exc:
+            raise TokenRefreshTransientError(
+                f"non-JSON token response (status={response.status_code})"
+            ) from exc
+
+        error = self.classify_token_response(response, body)
+        if error is not None:
+            if error in self.terminal_refresh_errors:
+                raise TokenRefreshTerminalError(error)
+            raise TokenRefreshTransientError(error)
+
+        refreshed = self.extract_credentials(body)
+        # Carry the existing refresh token forward when the provider didn't rotate.
+        refreshed.setdefault("refresh_token", refresh_token)
+        return refreshed
+
+    def build_refresh_request(
+        self, refresh_token: str, client_id: str, client_secret: str
+    ) -> dict[str, str]:
+        """The refresh POST form body. Override to add provider-specific params
+        (scope, resource, audience, …) or change the grant."""
+        return {
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        }
+
+    def classify_token_response(
+        self, response: requests.Response, body: dict[str, Any]
+    ) -> str | None:
+        """Error code from a token response, or ``None`` on success. Override for
+        providers whose failure signalling isn't covered by
+        :func:`token_response_error`."""
+        return token_response_error(response, body)

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -11,6 +11,7 @@ from datetime import timezone
 from typing import Any
 from uuid import UUID
 
+from redis.exceptions import RedisError
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import DBSessionFactory
@@ -76,6 +77,17 @@ def ensure_fresh_credentials(
             "ea_token_refresh.lock_contended external_app_id=%s user_id=%s",
             external_app_id,
             user_id,
+        )
+    except RedisError as exc:
+        # Redis unreachable (outage, or lite deployments where it's disabled):
+        # a transient infra failure, not a refresh outcome. Keep the existing
+        # token and let the request proceed rather than hard-blocking it (matches
+        # this function's "never raises for a refresh outcome" contract).
+        logger.warning(
+            "ea_token_refresh.redis_unavailable external_app_id=%s user_id=%s error=%s",
+            external_app_id,
+            user_id,
+            exc,
         )
 
 

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -30,10 +30,10 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Held long enough for the POST + DB steps; short wait so a request never blocks
-# long (a timed-out waiter proceeds while the lock winner refreshes).
+# Held long enough for the POST + DB steps; short wait so a waiter doesn't hold a
+# worker thread for long (a timed-out waiter proceeds while the winner refreshes).
 _LOCK_HELD_S = 30.0
-_LOCK_WAIT_S = 8.0
+_LOCK_WAIT_S = 5.0
 
 # Gathered inside a session for the POST: provider, stored creds, client id/secret.
 _RefreshInputs = tuple[OAuthExternalAppProvider, dict[str, Any], str, str]

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -6,6 +6,8 @@ behind :func:`ensure_fresh_credentials`. Each step takes its own short session, 
 no connection is held across the lock wait or the POST.
 """
 
+from datetime import datetime
+from datetime import timezone
 from typing import Any
 from uuid import UUID
 
@@ -23,7 +25,6 @@ from onyx.external_apps.providers.base import TokenRefreshTransientError
 from onyx.external_apps.providers.registry import get_provider_for_app
 from onyx.external_apps.token_utils import needs_refresh
 from onyx.external_apps.token_utils import stamp_expires_at
-from onyx.external_apps.token_utils import utcnow
 from onyx.redis.lock_context import redis_shared_lock
 from onyx.redis.lock_context import RedisSharedLockAcquisitionError
 from onyx.utils.logger import setup_logger
@@ -53,9 +54,12 @@ def ensure_fresh_credentials(
     (app reads disconnected), a transient failure keeps the existing token, and
     lock contention yields to the concurrent refresher.
     """
+    # Cheap pre-check: just the staleness decision (one cred read), no provider
+    # or client-cred resolution — those happen under the lock, only when stale.
     with db_session_factory(tenant_id) as db:
-        if _load_refresh_inputs(db, external_app_id, user_id) is None:
-            return  # fresh / non-OAuth / no creds → nothing to do
+        stored = _read_stored_credentials(db, external_app_id, user_id)
+    if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
+        return
 
     lock_name = f"ea_token_refresh:{tenant_id}:{external_app_id}:{user_id}"
     try:
@@ -118,7 +122,7 @@ def _refresh_under_lock(
             db,
             external_app_id=external_app_id,
             user_id=user_id,
-            user_credentials=stamp_expires_at(refreshed, utcnow()),
+            user_credentials=stamp_expires_at(refreshed, datetime.now(timezone.utc)),
         )
     logger.info(
         "ea_token_refresh.refreshed external_app_id=%s user_id=%s",
@@ -139,13 +143,8 @@ def _load_refresh_inputs(
     if not isinstance(provider, OAuthExternalAppProvider):
         return None
 
-    user_cred = get_external_app_user_credential(
-        db, external_app_id=external_app_id, user_id=user_id
-    )
-    if user_cred is None:
-        return None
-    stored = user_cred.user_credentials.get_value(apply_mask=False)
-    if not needs_refresh(stored, utcnow()):
+    stored = _read_stored_credentials(db, external_app_id, user_id)
+    if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
         return None
 
     client = _client_credentials(app)
@@ -156,6 +155,18 @@ def _load_refresh_inputs(
         return None
     client_id, client_secret = client
     return provider, stored, client_id, client_secret
+
+
+def _read_stored_credentials(
+    db: Session, external_app_id: int, user_id: UUID
+) -> dict[str, Any] | None:
+    """The user's stored credential dict for an app, or None if unset."""
+    user_cred = get_external_app_user_credential(
+        db, external_app_id=external_app_id, user_id=user_id
+    )
+    if user_cred is None:
+        return None
+    return user_cred.user_credentials.get_value(apply_mask=False)
 
 
 def _client_credentials(app: ExternalApp) -> tuple[str, str] | None:

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -1,0 +1,168 @@
+"""Lazy, single-flighted OAuth token refresh, called by the egress gate.
+
+The caller passes a tenant-scoped session *factory* (not a session) and ids;
+everything else — staleness, the Redis lock, the token POST, persistence — lives
+behind :func:`ensure_fresh_credentials`. Each step takes its own short session, so
+no connection is held across the lock wait or the POST.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import DBSessionFactory
+from onyx.db.external_app import delete_external_app_user_credential
+from onyx.db.external_app import get_external_app_by_id
+from onyx.db.external_app import get_external_app_user_credential
+from onyx.db.external_app import upsert_external_app_user_credential
+from onyx.db.models import ExternalApp
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
+from onyx.external_apps.providers.registry import get_provider_for_app
+from onyx.external_apps.token_utils import needs_refresh
+from onyx.external_apps.token_utils import stamp_expires_at
+from onyx.external_apps.token_utils import utcnow
+from onyx.redis.lock_context import redis_shared_lock
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Held long enough for the POST + DB steps; short wait so a request never blocks
+# long (a timed-out waiter proceeds while the lock winner refreshes).
+_LOCK_HELD_S = 30.0
+_LOCK_WAIT_S = 8.0
+
+# Gathered inside a session for the POST: provider, stored creds, client id/secret.
+_RefreshInputs = tuple[OAuthExternalAppProvider, dict[str, Any], str, str]
+
+
+def ensure_fresh_credentials(
+    db_session_factory: DBSessionFactory,
+    tenant_id: str,
+    external_app_id: int,
+    user_id: UUID,
+) -> None:
+    """Refresh the user's stored access token if it's expired/expiring; a fast
+    no-op otherwise. Opens its own short sessions, single-flights via a Redis
+    lock, and persists the result.
+
+    Never raises for a refresh outcome: a revoked grant clears the credential
+    (app reads disconnected), a transient failure keeps the existing token, and
+    lock contention yields to the concurrent refresher.
+    """
+    with db_session_factory(tenant_id) as db:
+        if _load_refresh_inputs(db, external_app_id, user_id) is None:
+            return  # fresh / non-OAuth / no creds → nothing to do
+
+    lock_name = f"ea_token_refresh:{tenant_id}:{external_app_id}:{user_id}"
+    try:
+        with redis_shared_lock(
+            lock_name,
+            max_time_lock_held_s=_LOCK_HELD_S,
+            wait_for_lock_s=_LOCK_WAIT_S,
+            logger=logger,
+        ):
+            _refresh_under_lock(db_session_factory, tenant_id, external_app_id, user_id)
+    except RedisSharedLockAcquisitionError:
+        # Lock winner is refreshing; proceed with the current token.
+        logger.info(
+            "ea_token_refresh.lock_contended external_app_id=%s user_id=%s",
+            external_app_id,
+            user_id,
+        )
+
+
+def _refresh_under_lock(
+    db_session_factory: DBSessionFactory,
+    tenant_id: str,
+    external_app_id: int,
+    user_id: UUID,
+) -> None:
+    # Re-read in a fresh session — double-check after the lock wait, in case a
+    # concurrent process already refreshed — then release before the POST.
+    with db_session_factory(tenant_id) as db:
+        inputs = _load_refresh_inputs(db, external_app_id, user_id)
+    if inputs is None:
+        return
+    provider, stored, client_id, client_secret = inputs
+
+    # POST with no DB connection held.
+    try:
+        refreshed = provider.refresh_credentials(stored, client_id, client_secret)
+    except TokenRefreshTransientError as exc:
+        # Keep the existing token; retry on a later request.
+        logger.warning(
+            "ea_token_refresh.transient external_app_id=%s error=%s",
+            external_app_id,
+            exc,
+        )
+        return
+    except TokenRefreshTerminalError:
+        # Dead grant: drop the credential so the app reads as disconnected.
+        with db_session_factory(tenant_id) as db:
+            delete_external_app_user_credential(
+                db, external_app_id=external_app_id, user_id=user_id
+            )
+        logger.warning(
+            "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s",
+            external_app_id,
+            user_id,
+        )
+        return
+
+    with db_session_factory(tenant_id) as db:
+        upsert_external_app_user_credential(
+            db,
+            external_app_id=external_app_id,
+            user_id=user_id,
+            user_credentials=stamp_expires_at(refreshed, utcnow()),
+        )
+    logger.info(
+        "ea_token_refresh.refreshed external_app_id=%s user_id=%s",
+        external_app_id,
+        user_id,
+    )
+
+
+def _load_refresh_inputs(
+    db: Session, external_app_id: int, user_id: UUID
+) -> _RefreshInputs | None:
+    """The POST inputs, or ``None`` when there's nothing to do (app gone /
+    non-OAuth / no stored creds / token still fresh / no client creds)."""
+    app = get_external_app_by_id(db, external_app_id)
+    if app is None:
+        return None
+    provider = get_provider_for_app(app)
+    if not isinstance(provider, OAuthExternalAppProvider):
+        return None
+
+    user_cred = get_external_app_user_credential(
+        db, external_app_id=external_app_id, user_id=user_id
+    )
+    if user_cred is None:
+        return None
+    stored = user_cred.user_credentials.get_value(apply_mask=False)
+    if not needs_refresh(stored, utcnow()):
+        return None
+
+    client = _client_credentials(app)
+    if client is None:
+        logger.warning(
+            "ea_token_refresh.missing_client_creds external_app_id=%s", external_app_id
+        )
+        return None
+    client_id, client_secret = client
+    return provider, stored, client_id, client_secret
+
+
+def _client_credentials(app: ExternalApp) -> tuple[str, str] | None:
+    """The app's OAuth client_id/client_secret, or None if an admin hasn't set them."""
+    org_credentials = app.organization_credentials.get_value(apply_mask=False)
+    client_id = org_credentials.get("client_id")
+    client_secret = org_credentials.get("client_secret")
+    if not client_id or not client_secret:
+        return None
+    return client_id, client_secret

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -12,6 +12,7 @@ from typing import Any
 from uuid import UUID
 
 from redis.exceptions import RedisError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import DBSessionFactory
@@ -55,15 +56,15 @@ def ensure_fresh_credentials(
     (app reads disconnected), a transient failure keeps the existing token, and
     lock contention yields to the concurrent refresher.
     """
-    # Cheap pre-check: just the staleness decision (one cred read), no provider
-    # or client-cred resolution — those happen under the lock, only when stale.
-    with db_session_factory(tenant_id) as db:
-        stored = _read_stored_credentials(db, external_app_id, user_id)
-    if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
-        return
-
     lock_name = f"ea_token_refresh:{tenant_id}:{external_app_id}:{user_id}"
     try:
+        # Cheap pre-check: just the staleness decision (one cred read), no provider
+        # or client-cred resolution — those happen under the lock, only when stale.
+        with db_session_factory(tenant_id) as db:
+            stored = _read_stored_credentials(db, external_app_id, user_id)
+        if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
+            return
+
         with redis_shared_lock(
             lock_name,
             max_time_lock_held_s=_LOCK_HELD_S,
@@ -78,13 +79,10 @@ def ensure_fresh_credentials(
             external_app_id,
             user_id,
         )
-    except RedisError as exc:
-        # Redis unreachable (outage, or lite deployments where it's disabled):
-        # a transient infra failure, not a refresh outcome. Keep the existing
-        # token and let the request proceed rather than hard-blocking it (matches
-        # this function's "never raises for a refresh outcome" contract).
+    except (RedisError, SQLAlchemyError) as exc:
+        # Transient infra failure — Keep existing tokens and let requests through
         logger.warning(
-            "ea_token_refresh.redis_unavailable external_app_id=%s user_id=%s error=%s",
+            "ea_token_refresh.infra_unavailable external_app_id=%s user_id=%s error=%s",
             external_app_id,
             user_id,
             exc,
@@ -116,16 +114,17 @@ def _refresh_under_lock(
             exc,
         )
         return
-    except TokenRefreshTerminalError:
+    except TokenRefreshTerminalError as exc:
         # Dead grant: drop the credential so the app reads as disconnected.
         with db_session_factory(tenant_id) as db:
             delete_external_app_user_credential(
                 db, external_app_id=external_app_id, user_id=user_id
             )
         logger.warning(
-            "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s",
+            "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s error=%s",
             external_app_id,
             user_id,
+            exc,
         )
         return
 

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -47,16 +47,16 @@ def needs_refresh(
 ) -> bool:
     """True iff the stored token is expired or within the skew window.
 
-    A *missing* ``expires_at`` → ``False``: a legitimately non-expiring token
-    (e.g. Slack/Linear), never refreshed. A *present-but-unparseable*
-    ``expires_at`` is instead a corrupt value (the only writer, ``stamp_expires_at``,
-    always emits a valid ISO instant) → ``True``, so the refresh path heals it
-    rather than silently keeping a token of unknown — likely expired — validity."""
-    raw = credentials.get("expires_at")
-    if not raw:
+    A *missing* ``expires_at`` key → ``False``: a legitimately non-expiring token
+    (e.g. Slack/Linear), never refreshed. A *present* ``expires_at`` that is empty,
+    the wrong type, or otherwise unparseable is a corrupt value, not a non-expiring
+    token (the only writer, ``stamp_expires_at``, always emits a valid ISO instant)
+    → ``True``, so the refresh path heals it rather than silently keeping a token of
+    unknown — likely expired — validity."""
+    if "expires_at" not in credentials:
         return False
     try:
-        expires_at = datetime.fromisoformat(raw)
+        expires_at = datetime.fromisoformat(credentials["expires_at"])
     except (TypeError, ValueError):
         return True
     if expires_at.tzinfo is None:

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -1,0 +1,56 @@
+"""Pure, clockless helpers for OAuth token expiry. A leaf module (imports nothing
+from providers/orchestrator) so callers can use it without an import cycle.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import Any
+
+# Refresh slightly early so no in-flight request reaches upstream with a just-
+# expired token.
+DEFAULT_REFRESH_SKEW_SECONDS = 120
+
+
+def utcnow() -> datetime:
+    """Timezone-aware UTC now. Single source so tests can monkeypatch one symbol."""
+    return datetime.now(timezone.utc)
+
+
+def stamp_expires_at(credentials: dict[str, Any], now: datetime) -> dict[str, Any]:
+    """Return a *new* creds dict with an absolute ``expires_at`` derived from the
+    response's relative ``expires_in`` (unchanged if no ``expires_in`` — "no
+    ``expires_at``" means "never expires").
+
+    New dict, not a mutation — the input may be a ``SensitiveValue`` cache.
+    """
+    expires_in = credentials.get("expires_in")
+    if expires_in is None:
+        return dict(credentials)
+    try:
+        seconds = int(expires_in)
+    except (TypeError, ValueError):
+        return dict(credentials)
+
+    stamped = dict(credentials)
+    stamped["expires_at"] = (now + timedelta(seconds=seconds)).isoformat()
+    return stamped
+
+
+def needs_refresh(
+    credentials: dict[str, Any],
+    now: datetime,
+    skew_s: int = DEFAULT_REFRESH_SKEW_SECONDS,
+) -> bool:
+    """True iff the stored token is expired or within the skew window. Missing or
+    unparseable ``expires_at`` → ``False`` (treat as never-expiring)."""
+    raw = credentials.get("expires_at")
+    if not raw:
+        return False
+    try:
+        expires_at = datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return False
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return (expires_at - now).total_seconds() <= skew_s

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -14,8 +14,14 @@ DEFAULT_REFRESH_SKEW_SECONDS = 120
 
 def stamp_expires_at(credentials: dict[str, Any], now: datetime) -> dict[str, Any]:
     """Return a *new* creds dict with an absolute ``expires_at`` derived from the
-    response's relative ``expires_in`` (unchanged if no ``expires_in`` — "no
-    ``expires_at``" means "never expires").
+    response's relative ``expires_in``.
+
+    A *missing* ``expires_in`` is left unstamped — "no ``expires_at``" means a
+    non-expiring token (e.g. Slack/Linear). A *present-but-unparseable*
+    ``expires_in`` is a corrupt value, not a non-expiring token, so it's stamped
+    as already-expired (``now``): ``needs_refresh`` then treats it as stale and the
+    refresh path heals it, rather than silently never refreshing a token that the
+    provider said *does* expire.
 
     New dict, not a mutation — the input may be a ``SensitiveValue`` cache.
     """
@@ -25,7 +31,9 @@ def stamp_expires_at(credentials: dict[str, Any], now: datetime) -> dict[str, An
     try:
         seconds = int(expires_in)
     except (TypeError, ValueError):
-        return dict(credentials)
+        # Corrupt expiry → stamp as already-expired so it refreshes, rather than
+        # dropping it (which would read downstream as a non-expiring token).
+        seconds = 0
 
     stamped = dict(credentials)
     stamped["expires_at"] = (now + timedelta(seconds=seconds)).isoformat()

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -12,11 +12,6 @@ from typing import Any
 DEFAULT_REFRESH_SKEW_SECONDS = 120
 
 
-def utcnow() -> datetime:
-    """Timezone-aware UTC now. Single source so tests can monkeypatch one symbol."""
-    return datetime.now(timezone.utc)
-
-
 def stamp_expires_at(credentials: dict[str, Any], now: datetime) -> dict[str, Any]:
     """Return a *new* creds dict with an absolute ``expires_at`` derived from the
     response's relative ``expires_in`` (unchanged if no ``expires_in`` — "no

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -37,15 +37,20 @@ def needs_refresh(
     now: datetime,
     skew_s: int = DEFAULT_REFRESH_SKEW_SECONDS,
 ) -> bool:
-    """True iff the stored token is expired or within the skew window. Missing or
-    unparseable ``expires_at`` → ``False`` (treat as never-expiring)."""
+    """True iff the stored token is expired or within the skew window.
+
+    A *missing* ``expires_at`` → ``False``: a legitimately non-expiring token
+    (e.g. Slack/Linear), never refreshed. A *present-but-unparseable*
+    ``expires_at`` is instead a corrupt value (the only writer, ``stamp_expires_at``,
+    always emits a valid ISO instant) → ``True``, so the refresh path heals it
+    rather than silently keeping a token of unknown — likely expired — validity."""
     raw = credentials.get("expires_at")
     if not raw:
         return False
     try:
         expires_at = datetime.fromisoformat(raw)
     except (TypeError, ValueError):
-        return False
+        return True
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
     return (expires_at - now).total_seconds() <= skew_s

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -14,12 +14,12 @@ from urllib.parse import parse_qs
 
 from mitmproxy import http
 
+from onyx.db.engine.sql_engine import DBSessionFactory
 from onyx.db.external_app import get_external_apps
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.external_apps.matching.request import ProxiedRequest
-from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -16,6 +16,7 @@ from mitmproxy import http
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
 from onyx.configs.constants import NotificationType
+from onyx.db.engine.sql_engine import DBSessionFactory
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
@@ -26,7 +27,6 @@ from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatche
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
-from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -217,7 +217,7 @@ class GateAddon:
             # Already validated in `requestheaders`; body is streaming.
             return
 
-        gate_target = self._resolve_and_match(flow)
+        gate_target = await self._resolve_and_match(flow)
         # Strip the in-band session tag so it never reaches the origin
         flow.request.headers.pop("Proxy-Authorization", None)
         if gate_target is None:
@@ -232,8 +232,15 @@ class GateAddon:
             decision = await self._await_decision(approval_id, ctx, match)
             self._write_response_for_decision(flow, decision)
             if decision == ApprovalDecision.APPROVED:
-                self._dispatch_injection_or_block(
-                    flow, sandbox=ctx.without_session(), match=match
+                # Off-thread: the external-app resolver may refresh an expiring
+                # OAuth token (token POST + Redis lock) before rendering headers;
+                # keep that off the proxy event loop so a slow token endpoint
+                # stalls only this request, not every in-flight flow.
+                await asyncio.to_thread(
+                    self._dispatch_injection_or_block,
+                    flow,
+                    sandbox=ctx.without_session(),
+                    match=match,
                 )
         except Exception:
             logger.exception(
@@ -252,7 +259,7 @@ class GateAddon:
     # request() helpers
     # ------------------------------------------------------------------
 
-    def _resolve_and_match(
+    async def _resolve_and_match(
         self, flow: http.HTTPFlow
     ) -> tuple[SessionContext, RequestMatch] | None:
         """Identity → matcher → (only if gated) in-band session resolution.
@@ -330,7 +337,11 @@ class GateAddon:
             return None
 
         if match.decisive.policy is EndpointPolicy.ALWAYS:
-            self._dispatch_injection_or_block(flow, sandbox=sandbox, match=match)
+            # Off-thread: see the ASK path in `request` — the resolver may refresh
+            # an expiring OAuth token before injecting on this auto-approved call.
+            await asyncio.to_thread(
+                self._dispatch_injection_or_block, flow, sandbox=sandbox, match=match
+            )
             return None
 
         # ASK: resolve the originating session before prompting. An

--- a/backend/onyx/sandbox_proxy/identity.py
+++ b/backend/onyx/sandbox_proxy/identity.py
@@ -14,7 +14,6 @@ with no verifiable session tag fails closed rather than routing to a
 guessed session.
 """
 
-from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Protocol
@@ -23,6 +22,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.db.engine.sql_engine import DBSessionFactory
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
@@ -98,11 +98,6 @@ class SandboxIPLookup(Protocol):
     def is_synced(self) -> bool: ...
 
     def stop(self) -> None: ...
-
-
-# Canonical type for the proxy's tenant-id -> DB-session factory. Imported by
-# action_matcher and the gate addon so the signature has a single source.
-DBSessionFactory = Callable[[str], AbstractContextManager[Session]]
 
 
 def default_session_factory(tenant_id: str) -> AbstractContextManager[Session]:

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from mitmproxy import http
 
 from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.external_apps.token_refresh import ensure_fresh_credentials
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
@@ -38,6 +39,18 @@ class ExternalAppResolver(CredentialResolver):
             raise CredentialUnavailableError(
                 "ExternalAppResolver invoked without a matched request"
             )
+
+        # Lazily refresh an expired/expiring OAuth token before rendering, so the
+        # injected `Bearer` is live. A no-op for fresh or non-OAuth credentials,
+        # and single-flighted across the fleet via a Redis lock; it opens its own
+        # short sessions and never raises for a refresh outcome (a dead grant
+        # clears the credential, which renders as empty headers below).
+        ensure_fresh_credentials(
+            ctx.db_session_factory,
+            ctx.sandbox.tenant_id,
+            match.external_app_id,
+            ctx.sandbox.user_id,
+        )
 
         with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
             headers = resolve_injection_headers(

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -1,6 +1,5 @@
 import base64
 import uuid
-from typing import Any
 from urllib.parse import urlencode
 
 import requests
@@ -20,7 +19,10 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import token_response_error
 from onyx.external_apps.providers.registry import get_provider_or_raise
+from onyx.external_apps.token_utils import stamp_expires_at
+from onyx.external_apps.token_utils import utcnow
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.models import OAuthCallbackRequest
 from onyx.server.features.build.api.models import OAuthCallbackResponse
@@ -68,18 +70,6 @@ def _oauth_provider_or_raise(app: ExternalApp) -> OAuthExternalAppProvider:
             f"App '{app.skill.name}' does not use an OAuth flow.",
         )
     return provider
-
-
-def _token_response_is_error(
-    http_response: requests.Response, body: dict[str, Any]
-) -> str | None:
-    """Slack returns 200 + `{"ok": false}` on failure; everyone else
-    uses non-2xx. Returns the error string or None on success."""
-    if http_response.status_code >= 400:
-        return body.get("error_description") or body.get("error") or "unknown"
-    if body.get("ok") is False:
-        return body.get("error") or "unknown"
-    return None
 
 
 class _OAuthStateRecord(BaseModel):
@@ -219,7 +209,7 @@ def handle_external_app_oauth_callback(
             status_code_override=response.status_code,
         )
 
-    error = _token_response_is_error(response, response_data)
+    error = token_response_error(response, response_data)
     if error:
         logger.warning(
             "%s OAuth token exchange failed for user %s, app %d: %s",
@@ -233,7 +223,11 @@ def handle_external_app_oauth_callback(
             f"{app.skill.name} OAuth failed: {error}",
         )
 
-    stored_credentials = provider.extract_credentials(response_data)
+    # Stamp an absolute `expires_at` now so the lazy-refresh path can later
+    # decide staleness without "when was this written" bookkeeping.
+    stored_credentials = stamp_expires_at(
+        provider.extract_credentials(response_data), utcnow()
+    )
 
     upsert_external_app_user_credential(
         db_session,

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -1,5 +1,7 @@
 import base64
 import uuid
+from datetime import datetime
+from datetime import timezone
 from urllib.parse import urlencode
 
 import requests
@@ -22,7 +24,6 @@ from onyx.external_apps.providers.base import OAuthExternalAppProvider
 from onyx.external_apps.providers.base import token_response_error
 from onyx.external_apps.providers.registry import get_provider_or_raise
 from onyx.external_apps.token_utils import stamp_expires_at
-from onyx.external_apps.token_utils import utcnow
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.models import OAuthCallbackRequest
 from onyx.server.features.build.api.models import OAuthCallbackResponse
@@ -226,7 +227,7 @@ def handle_external_app_oauth_callback(
     # Stamp an absolute `expires_at` now so the lazy-refresh path can later
     # decide staleness without "when was this written" bookkeeping.
     stored_credentials = stamp_expires_at(
-        provider.extract_credentials(response_data), utcnow()
+        provider.extract_credentials(response_data), datetime.now(timezone.utc)
     )
 
     upsert_external_app_user_credential(

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -1,0 +1,286 @@
+import json
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+import requests
+
+from onyx.external_apps import token_refresh as tr
+from onyx.external_apps.providers.base import TokenRefreshTerminalError
+from onyx.external_apps.providers.base import TokenRefreshTransientError
+from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
+
+# ---------------------------------------------------------------------------
+# Provider.refresh_credentials (RFC-6749 default on OAuthExternalAppProvider)
+# ---------------------------------------------------------------------------
+
+
+def _response(status_code: int, body: dict[str, Any]) -> requests.Response:
+    """A real `requests.Response` (the `OAuthTokenResponse` model validates the
+    type), with `status_code` set and `.json()` returning `body`."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode()
+    return response
+
+
+def _patch_post(monkeypatch: pytest.MonkeyPatch, response: object) -> None:
+    monkeypatch.setattr(
+        "onyx.external_apps.providers.base.requests.post",
+        lambda *_a, **_k: response,
+    )
+
+
+def test_refresh_maps_response_and_carries_refresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_post(
+        monkeypatch,
+        _response(200, {"access_token": "new", "expires_in": 3600}),
+    )
+    result = GoogleCalendarProvider().refresh_credentials(
+        {"access_token": "old", "refresh_token": "rt"}, "cid", "secret"
+    )
+    assert result["access_token"] == "new"
+    assert result["expires_in"] == 3600
+    # No new refresh token in the response → carry the old one forward.
+    assert result["refresh_token"] == "rt"
+    # Clockless: the orchestrator stamps the absolute expiry, not the provider.
+    assert "expires_at" not in result
+
+
+def test_refresh_uses_rotated_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_post(
+        monkeypatch,
+        _response(200, {"access_token": "new", "refresh_token": "rt2"}),
+    )
+    result = GoogleCalendarProvider().refresh_credentials(
+        {"refresh_token": "rt"}, "cid", "secret"
+    )
+    assert result["refresh_token"] == "rt2"
+
+
+def test_refresh_missing_refresh_token_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = MagicMock()
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", called)
+    with pytest.raises(TokenRefreshTerminalError):
+        GoogleCalendarProvider().refresh_credentials({"access_token": "a"}, "c", "s")
+    called.assert_not_called()
+
+
+def test_refresh_invalid_grant_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_post(monkeypatch, _response(400, {"error": "invalid_grant"}))
+    with pytest.raises(TokenRefreshTerminalError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+def test_refresh_5xx_is_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_post(monkeypatch, _response(503, {"error": "server_error"}))
+    with pytest.raises(TokenRefreshTransientError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+def test_refresh_network_error_is_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*_a: Any, **_k: Any) -> None:
+        raise requests.RequestException("connection reset")
+
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", _boom)
+    with pytest.raises(TokenRefreshTransientError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+# ---------------------------------------------------------------------------
+# Template-method extensibility: a provider overrides one hook, reuses the rest
+# ---------------------------------------------------------------------------
+
+
+def _capturing_post(
+    monkeypatch: pytest.MonkeyPatch, response: object
+) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def _post(url: str, **kwargs: Any) -> object:
+        captured["url"] = url
+        captured["data"] = kwargs.get("data")
+        return response
+
+    monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", _post)
+    return captured
+
+
+def test_provider_overrides_only_the_refresh_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider needing an extra refresh param overrides `build_refresh_request`
+    alone — the POST, error handling, and response mapping are inherited."""
+
+    class _ResourceProvider(GoogleCalendarProvider, abstract=True):
+        def build_refresh_request(
+            self, refresh_token: str, client_id: str, client_secret: str
+        ) -> dict[str, str]:
+            base = super().build_refresh_request(
+                refresh_token, client_id, client_secret
+            )
+            return {**base, "resource": "r"}
+
+    captured = _capturing_post(monkeypatch, _response(200, {"access_token": "new"}))
+    result = _ResourceProvider().refresh_credentials(
+        {"refresh_token": "rt"}, "cid", "secret"
+    )
+    assert captured["data"]["resource"] == "r"  # the override took effect
+    assert captured["data"]["grant_type"] == "refresh_token"  # inherited default
+    assert result["access_token"] == "new"  # inherited mapping
+
+
+def test_provider_overrides_only_the_terminal_error_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider with different failure semantics overrides
+    `terminal_refresh_errors` alone."""
+
+    class _StrictProvider(GoogleCalendarProvider, abstract=True):
+        terminal_refresh_errors = frozenset({"consent_required"})
+
+    _patch_post(monkeypatch, _response(400, {"error": "consent_required"}))
+    with pytest.raises(TokenRefreshTerminalError):
+        _StrictProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+    # `invalid_grant` is no longer terminal for this provider → transient.
+    _patch_post(monkeypatch, _response(400, {"error": "invalid_grant"}))
+    with pytest.raises(TokenRefreshTransientError):
+        _StrictProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+# ---------------------------------------------------------------------------
+# ensure_fresh_credentials orchestration (own short sessions, single-flight)
+# ---------------------------------------------------------------------------
+
+
+def _stale_creds() -> dict[str, Any]:
+    return {
+        "access_token": "old",
+        "refresh_token": "rt",
+        "expires_at": "2000-01-01T00:00:00+00:00",
+    }
+
+
+def _fresh_creds() -> dict[str, Any]:
+    return {
+        "access_token": "ok",
+        "refresh_token": "rt",
+        "expires_at": "2999-01-01T00:00:00+00:00",
+    }
+
+
+def _cred(values: dict[str, Any]) -> MagicMock:
+    cred = MagicMock()
+    cred.user_credentials.get_value.return_value = values
+    return cred
+
+
+@contextmanager
+def _noop_cm(*_a: Any, **_k: Any):  # type: ignore[no-untyped-def]
+    yield MagicMock()
+
+
+def _setup(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    creds_sequence: list[dict[str, Any]],
+) -> dict[str, MagicMock]:
+    """Patch token_refresh's DB + provider + lock seams. `creds_sequence` is the
+    stored credentials returned on successive reads (pre-check, then re-read under
+    the lock)."""
+    provider = GoogleCalendarProvider()
+    app = MagicMock()
+    app.skill.name = "Google Calendar"
+
+    monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(tr, "get_external_app_by_id", lambda *_a, **_k: app)
+    monkeypatch.setattr(tr, "get_provider_for_app", lambda *_a, **_k: provider)
+    monkeypatch.setattr(
+        tr,
+        "get_external_app_user_credential",
+        MagicMock(side_effect=[_cred(c) for c in creds_sequence]),
+    )
+    monkeypatch.setattr(tr, "_client_credentials", lambda _app: ("cid", "secret"))
+    upsert = MagicMock()
+    delete = MagicMock()
+    refresh = MagicMock()
+    monkeypatch.setattr(tr, "upsert_external_app_user_credential", upsert)
+    monkeypatch.setattr(tr, "delete_external_app_user_credential", delete)
+    monkeypatch.setattr(provider, "refresh_credentials", refresh)
+    return {"upsert": upsert, "delete": delete, "refresh": refresh}
+
+
+def _run() -> None:
+    # The factory: any callable returning a context manager yielding a session.
+    tr.ensure_fresh_credentials(_noop_cm, "public", 1, uuid4())
+
+
+def test_ensure_fresh_noop_when_token_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    spies = _setup(monkeypatch, creds_sequence=[_fresh_creds()])
+    _run()
+    spies["refresh"].assert_not_called()
+    spies["upsert"].assert_not_called()
+
+
+def test_ensure_fresh_double_checked_skips_when_winner_refreshed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pre-check sees stale; the re-read under the lock sees the winner's fresh
+    # token → no network call.
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _fresh_creds()])
+    _run()
+    spies["refresh"].assert_not_called()
+    spies["upsert"].assert_not_called()
+
+
+def test_ensure_fresh_refreshes_and_upserts_stamped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
+    spies["refresh"].return_value = {
+        "access_token": "new",
+        "refresh_token": "rt",
+        "expires_in": 3600,
+    }
+    _run()
+    spies["upsert"].assert_called_once()
+    stored = spies["upsert"].call_args.kwargs["user_credentials"]
+    assert stored["access_token"] == "new"
+    assert "expires_at" in stored  # stamped from expires_in
+
+
+def test_ensure_fresh_terminal_clears_credential_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
+    spies["refresh"].side_effect = TokenRefreshTerminalError("invalid_grant")
+    _run()  # does not raise — the app simply reads as disconnected afterwards
+    spies["delete"].assert_called_once()
+    spies["upsert"].assert_not_called()
+
+
+def test_ensure_fresh_transient_keeps_existing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
+    spies["refresh"].side_effect = TokenRefreshTransientError("503")
+    _run()  # does not raise
+    spies["upsert"].assert_not_called()
+    spies["delete"].assert_not_called()
+
+
+def test_ensure_fresh_noop_for_non_oauth_app(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(tr, "get_external_app_by_id", lambda *_a, **_k: MagicMock())
+    monkeypatch.setattr(tr, "get_provider_for_app", lambda *_a, **_k: None)
+    cred_reader = MagicMock()
+    monkeypatch.setattr(tr, "get_external_app_user_credential", cred_reader)
+    _run()
+    cred_reader.assert_not_called()  # bailed before reading credentials

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -62,6 +62,21 @@ def test_refresh_uses_rotated_refresh_token(monkeypatch: pytest.MonkeyPatch) -> 
     assert result["refresh_token"] == "rt2"
 
 
+def test_refresh_preserves_connect_time_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh returning only the rotated subset keeps connect-time-only fields
+    (e.g. team_id) by merging onto the stored creds — response wins on conflicts."""
+    _patch_post(
+        monkeypatch, _response(200, {"access_token": "new", "expires_in": 3600})
+    )
+    stored = {"access_token": "old", "refresh_token": "rt", "team_id": "T1"}
+    result = GoogleCalendarProvider().refresh_credentials(stored, "cid", "secret")
+    assert result["access_token"] == "new"  # response wins
+    assert result["team_id"] == "T1"  # connect-time-only field preserved
+    assert result["refresh_token"] == "rt"  # carried forward via the merge
+
+
 def test_refresh_missing_refresh_token_is_terminal(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -277,10 +292,10 @@ def test_ensure_fresh_transient_keeps_existing_token(
 
 
 def test_ensure_fresh_noop_for_non_oauth_app(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
-    monkeypatch.setattr(tr, "get_external_app_by_id", lambda *_a, **_k: MagicMock())
+    # Stale creds pass the pre-check, but a non-OAuth provider has no refresh
+    # flow → bail under the lock, no refresh/upsert.
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
     monkeypatch.setattr(tr, "get_provider_for_app", lambda *_a, **_k: None)
-    cred_reader = MagicMock()
-    monkeypatch.setattr(tr, "get_external_app_user_credential", cred_reader)
     _run()
-    cred_reader.assert_not_called()  # bailed before reading credentials
+    spies["refresh"].assert_not_called()
+    spies["upsert"].assert_not_called()

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 import requests
+from redis.exceptions import ConnectionError as RedisConnectionError
 
 from onyx.external_apps import token_refresh as tr
 from onyx.external_apps.providers.base import TokenRefreshTerminalError
@@ -93,6 +94,26 @@ def test_refresh_invalid_grant_is_terminal(monkeypatch: pytest.MonkeyPatch) -> N
         GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
 
 
+def test_refresh_invalid_grant_with_description_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead grant must classify on the `error` code even when a human-readable
+    `error_description` is also present — preferring the prose would misclassify
+    it as transient and never clear the credential / prompt a reconnect."""
+    _patch_post(
+        monkeypatch,
+        _response(
+            400,
+            {
+                "error": "invalid_grant",
+                "error_description": "Token has been expired or revoked.",
+            },
+        ),
+    )
+    with pytest.raises(TokenRefreshTerminalError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
 def test_refresh_5xx_is_transient(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_post(monkeypatch, _response(503, {"error": "server_error"}))
     with pytest.raises(TokenRefreshTransientError):
@@ -104,6 +125,27 @@ def test_refresh_network_error_is_transient(monkeypatch: pytest.MonkeyPatch) -> 
         raise requests.RequestException("connection reset")
 
     monkeypatch.setattr("onyx.external_apps.providers.base.requests.post", _boom)
+    with pytest.raises(TokenRefreshTransientError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+def _raw_response(status_code: int, raw_body: Any) -> requests.Response:
+    """A `requests.Response` whose `.json()` returns a possibly-non-object body,
+    e.g. a gateway error page encoded as a JSON array / string."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(raw_body).encode()
+    return response
+
+
+@pytest.mark.parametrize("raw_body", [["err"], "bad gateway", 500, None])
+def test_refresh_non_object_error_body_is_transient(
+    monkeypatch: pytest.MonkeyPatch, raw_body: Any
+) -> None:
+    """A non-2xx with a non-object JSON body must surface as a clean transient
+    error, not an unguarded `.get()` `AttributeError` that escapes the
+    terminal/transient handling."""
+    _patch_post(monkeypatch, _raw_response(502, raw_body))
     with pytest.raises(TokenRefreshTransientError):
         GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
 
@@ -287,6 +329,25 @@ def test_ensure_fresh_transient_keeps_existing_token(
     spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
     spies["refresh"].side_effect = TokenRefreshTransientError("503")
     _run()  # does not raise
+    spies["upsert"].assert_not_called()
+    spies["delete"].assert_not_called()
+
+
+def test_ensure_fresh_redis_unavailable_keeps_existing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redis unreachable (outage / lite deployments where it's disabled) is a
+    transient infra failure, not a refresh outcome: keep the existing token and
+    return, never raise — a raised error would hard-block the request as a 403 at
+    the credential dispatcher instead of proceeding with the current credential."""
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds()])
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise RedisConnectionError("Error connecting to Redis.")
+
+    monkeypatch.setattr(tr, "redis_shared_lock", _boom)
+    _run()  # must not raise
+    spies["refresh"].assert_not_called()
     spies["upsert"].assert_not_called()
     spies["delete"].assert_not_called()
 

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 import requests
 from redis.exceptions import ConnectionError as RedisConnectionError
+from sqlalchemy.exc import SQLAlchemyError
 
 from onyx.external_apps import token_refresh as tr
 from onyx.external_apps.providers.base import TokenRefreshTerminalError
@@ -91,6 +92,21 @@ def test_refresh_missing_refresh_token_is_terminal(
 def test_refresh_invalid_grant_is_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_post(monkeypatch, _response(400, {"error": "invalid_grant"}))
     with pytest.raises(TokenRefreshTerminalError):
+        GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
+
+
+@pytest.mark.parametrize(
+    "error_code", ["invalid_client", "unauthorized_client", "invalid_request"]
+)
+def test_refresh_client_and_request_errors_are_transient(
+    monkeypatch: pytest.MonkeyPatch, error_code: str
+) -> None:
+    """Client-config (`invalid_client`/`unauthorized_client`) and malformed-request
+    (`invalid_request`) errors are NOT a dead user grant: they must stay transient
+    so the existing credential is kept, not cleared — re-auth can't fix a
+    misconfigured client, and clearing would force every affected user to reconnect."""
+    _patch_post(monkeypatch, _response(400, {"error": error_code}))
+    with pytest.raises(TokenRefreshTransientError):
         GoogleCalendarProvider().refresh_credentials({"refresh_token": "rt"}, "c", "s")
 
 
@@ -346,6 +362,25 @@ def test_ensure_fresh_redis_unavailable_keeps_existing_token(
         raise RedisConnectionError("Error connecting to Redis.")
 
     monkeypatch.setattr(tr, "redis_shared_lock", _boom)
+    _run()  # must not raise
+    spies["refresh"].assert_not_called()
+    spies["upsert"].assert_not_called()
+    spies["delete"].assert_not_called()
+
+
+def test_ensure_fresh_db_error_keeps_existing_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A DB blip during refresh (here, the pre-check read) is a transient infra
+    failure, not a refresh outcome: keep the existing token and return, never
+    raise — a raised error would hard-block the request as a 403 at the
+    credential dispatcher instead of proceeding with the current credential."""
+    spies = _setup(monkeypatch, creds_sequence=[_stale_creds()])
+
+    def _boom(*_a: Any, **_k: Any) -> Any:
+        raise SQLAlchemyError("db connection reset")
+
+    monkeypatch.setattr(tr, "_read_stored_credentials", _boom)
     _run()  # must not raise
     spies["refresh"].assert_not_called()
     spies["upsert"].assert_not_called()

--- a/backend/tests/unit/external_apps/test_token_utils.py
+++ b/backend/tests/unit/external_apps/test_token_utils.py
@@ -63,8 +63,15 @@ def test_needs_refresh_missing_expires_at_is_false() -> None:
     assert needs_refresh({"access_token": "a"}, _NOW) is False
 
 
-def test_needs_refresh_unparseable_expires_at_is_false() -> None:
-    assert needs_refresh({"expires_at": "not-a-date"}, _NOW) is False
+def test_needs_refresh_unparseable_expires_at_is_true() -> None:
+    # A present-but-corrupt expiry isn't a non-expiring token: refresh (heal it)
+    # rather than silently keep a token of unknown validity in use.
+    assert needs_refresh({"expires_at": "not-a-date"}, _NOW) is True
+
+
+def test_needs_refresh_non_string_expires_at_is_true() -> None:
+    # A truthy non-string value also fails parsing → treat as needing refresh.
+    assert needs_refresh({"expires_at": 1234567890}, _NOW) is True
 
 
 def test_needs_refresh_naive_expires_at_treated_as_utc() -> None:

--- a/backend/tests/unit/external_apps/test_token_utils.py
+++ b/backend/tests/unit/external_apps/test_token_utils.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from onyx.external_apps.token_utils import needs_refresh
+from onyx.external_apps.token_utils import stamp_expires_at
+
+_NOW = datetime(2026, 5, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# stamp_expires_at
+# ---------------------------------------------------------------------------
+
+
+def test_stamp_expires_at_computes_absolute_instant() -> None:
+    stamped = stamp_expires_at({"access_token": "a", "expires_in": 3600}, _NOW)
+    assert stamped["expires_at"] == (_NOW + timedelta(seconds=3600)).isoformat()
+    # original fields preserved
+    assert stamped["access_token"] == "a"
+
+
+def test_stamp_expires_at_no_expires_in_is_passthrough() -> None:
+    creds = {"access_token": "a"}
+    stamped = stamp_expires_at(creds, _NOW)
+    assert "expires_at" not in stamped
+
+
+def test_stamp_expires_at_does_not_mutate_input() -> None:
+    creds = {"access_token": "a", "expires_in": 60}
+    stamp_expires_at(creds, _NOW)
+    assert "expires_at" not in creds  # built a new dict
+
+
+def test_stamp_expires_at_bad_expires_in_is_passthrough() -> None:
+    stamped = stamp_expires_at({"access_token": "a", "expires_in": "soon"}, _NOW)
+    assert "expires_at" not in stamped
+
+
+# ---------------------------------------------------------------------------
+# needs_refresh
+# ---------------------------------------------------------------------------
+
+
+def test_needs_refresh_fresh_token_is_false() -> None:
+    expires_at = (_NOW + timedelta(hours=1)).isoformat()
+    assert needs_refresh({"expires_at": expires_at}, _NOW) is False
+
+
+def test_needs_refresh_expired_token_is_true() -> None:
+    expires_at = (_NOW - timedelta(minutes=5)).isoformat()
+    assert needs_refresh({"expires_at": expires_at}, _NOW) is True
+
+
+def test_needs_refresh_within_skew_is_true() -> None:
+    # 60s left, default skew is 120s → refresh early.
+    expires_at = (_NOW + timedelta(seconds=60)).isoformat()
+    assert needs_refresh({"expires_at": expires_at}, _NOW) is True
+
+
+def test_needs_refresh_missing_expires_at_is_false() -> None:
+    # Slack / Linear / static-credential apps never expire.
+    assert needs_refresh({"access_token": "a"}, _NOW) is False
+
+
+def test_needs_refresh_unparseable_expires_at_is_false() -> None:
+    assert needs_refresh({"expires_at": "not-a-date"}, _NOW) is False
+
+
+def test_needs_refresh_naive_expires_at_treated_as_utc() -> None:
+    naive = (_NOW.replace(tzinfo=None) - timedelta(minutes=1)).isoformat()
+    assert needs_refresh({"expires_at": naive}, _NOW) is True

--- a/backend/tests/unit/external_apps/test_token_utils.py
+++ b/backend/tests/unit/external_apps/test_token_utils.py
@@ -62,8 +62,16 @@ def test_needs_refresh_within_skew_is_true() -> None:
 
 
 def test_needs_refresh_missing_expires_at_is_false() -> None:
-    # Slack / Linear / static-credential apps never expire.
+    # Slack / Linear / static-credential apps never expire (key absent).
     assert needs_refresh({"access_token": "a"}, _NOW) is False
+
+
+def test_needs_refresh_present_but_falsy_expires_at_is_true() -> None:
+    # A present-but-empty/null value is corrupt, NOT a non-expiring token: it must
+    # be distinguished from the missing key and routed to refresh, not treated as
+    # never-expiring (which would leave an invalid token un-refreshed forever).
+    assert needs_refresh({"expires_at": ""}, _NOW) is True
+    assert needs_refresh({"expires_at": None}, _NOW) is True
 
 
 def test_needs_refresh_unparseable_expires_at_is_true() -> None:

--- a/backend/tests/unit/external_apps/test_token_utils.py
+++ b/backend/tests/unit/external_apps/test_token_utils.py
@@ -32,9 +32,12 @@ def test_stamp_expires_at_does_not_mutate_input() -> None:
     assert "expires_at" not in creds  # built a new dict
 
 
-def test_stamp_expires_at_bad_expires_in_is_passthrough() -> None:
+def test_stamp_expires_at_bad_expires_in_stamps_already_expired() -> None:
+    # A corrupt expiry must not read as a non-expiring token: stamp it as
+    # already-expired so the refresh path heals it on next use.
     stamped = stamp_expires_at({"access_token": "a", "expires_in": "soon"}, _NOW)
-    assert "expires_at" not in stamped
+    assert stamped["expires_at"] == _NOW.isoformat()
+    assert needs_refresh(stamped, _NOW) is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -25,6 +25,16 @@ from tests.unit.sandbox_proxy.conftest import make_request_match
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 
 
+@pytest.fixture(autouse=True)
+def _noop_token_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default `ensure_fresh_credentials` to a no-op so these tests pin the
+    claim rule and rendering contract; the refresh-seam test re-patches it.
+    The refresh mechanics live in `tests/unit/external_apps/test_token_refresh.py`."""
+    monkeypatch.setattr(
+        external_app_mod, "ensure_fresh_credentials", lambda *_a, **_k: None
+    )
+
+
 def _recorder_db_factory(ops: list[str]) -> Any:
     @contextmanager
     def factory(tenant_id: str) -> Iterator[Any]:
@@ -81,6 +91,35 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
     assert captured["external_app_id"] == 99
     assert captured["user_id"] == ctx.sandbox.user_id
     assert ops == ["session:tenant-7"]
+
+
+def test_resolve_refreshes_token_before_rendering(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolver refreshes an expiring OAuth token (via `ensure_fresh_credentials`,
+    handed the session factory + ids) before rendering headers, so the injected
+    `Bearer` is live. The refresh mechanics themselves are pinned in
+    `tests/unit/external_apps/test_token_refresh.py`."""
+    calls: list[tuple[Any, str, int, Any]] = []
+
+    def _ensure(factory: Any, tenant_id: str, app_id: int, user_id: Any) -> None:
+        calls.append((factory, tenant_id, app_id, user_id))
+
+    monkeypatch.setattr(external_app_mod, "ensure_fresh_credentials", _ensure)
+    monkeypatch.setattr(
+        external_app_mod,
+        "resolve_injection_headers",
+        lambda *_a, **_k: {"Authorization": "Bearer real"},
+    )
+
+    factory = _recorder_db_factory([])
+    match = make_request_match(external_app_id=99)
+    ctx = _ctx(match=match, db_factory=factory)
+
+    headers = ExternalAppResolver().resolve(_flow().request, ctx)
+
+    assert headers == {"Authorization": "Bearer real"}
+    assert calls == [(factory, "tenant-7", 99, ctx.sandbox.user_id)]
 
 
 def test_resolve_raises_when_match_is_none() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -135,13 +135,14 @@ _MATCH_DENY = make_request_match(payload={"text": "hi"}, policy=EndpointPolicy.D
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_no_source_ip_fails_closed() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_no_source_ip_fails_closed() -> None:
     resolver = _StubResolver()
     matcher = _StubMatcher(result=_MATCH)
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _flow(peername=None)
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.UNIDENTIFIED_SANDBOX)
@@ -158,7 +159,8 @@ def test_resolve_and_match_no_source_ip_fails_closed() -> None:
     ],
     ids=["returns_none", "raises"],
 )
-def test_resolve_and_match_sandbox_resolution_fails_closed(
+@pytest.mark.asyncio
+async def test_resolve_and_match_sandbox_resolution_fails_closed(
     resolver_kwargs: dict[str, Any],
 ) -> None:
     """Absent pod and DB blip during resolution both fail closed."""
@@ -167,7 +169,7 @@ def test_resolve_and_match_sandbox_resolution_fails_closed(
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _flow()
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.UNIDENTIFIED_SANDBOX)
@@ -184,7 +186,8 @@ _OVERSIZE_BODY = b"\x00" * 1_048_577
     [None, _OVERSIZE_BODY],
     ids=["streamed", "oversize"],
 )
-def test_resolve_and_match_body_too_large_fails_closed(
+@pytest.mark.asyncio
+async def test_resolve_and_match_body_too_large_fails_closed(
     raw_content: bytes | None,
 ) -> None:
     """Streamed (None) and oversize bodies both fail closed."""
@@ -193,7 +196,7 @@ def test_resolve_and_match_body_too_large_fails_closed(
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _flow(raw_content=raw_content)
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.BODY_TOO_LARGE)
@@ -205,7 +208,8 @@ def test_parser_max_body_bytes_constant_matches_spec() -> None:
     assert PARSER_MAX_BODY_BYTES == 1_048_576
 
 
-def test_resolve_and_match_no_tag_fails_closed() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_no_tag_fails_closed() -> None:
     """Identified pod, no session tag: fail closed with no fallback, so
     the session lookup is never attempted."""
     resolver = _StubResolver(sandbox=_sandbox())
@@ -213,7 +217,7 @@ def test_resolve_and_match_no_tag_fails_closed() -> None:
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _flow()  # no proxy_auth
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
@@ -225,7 +229,8 @@ def test_resolve_and_match_no_tag_fails_closed() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     """Non-gated traffic: matcher returns None → forwarded; the off-catalog
     dispatcher invocation runs with `match=None` so host-only resolvers can
     still claim by host."""
@@ -236,7 +241,7 @@ def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
     flow = _flow()
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     assert flow.response is None  # forwarded
@@ -248,7 +253,8 @@ def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     assert ctx.sandbox is sandbox
 
 
-def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None:
     """Matcher exception falls through to off-catalog dispatch — otherwise
     the request would forward with placeholder credentials, surfacing as a
     fingerprintable upstream 401 once host-only resolvers exist."""
@@ -258,7 +264,7 @@ def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None
     addon = _build(resolver=resolver, matcher=matcher, credential_resolvers=[spy])
     flow = _flow()
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     assert flow.response is None  # forwarded
@@ -273,7 +279,8 @@ def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -> None
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_always_forwards_without_session() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_always_forwards_without_session() -> None:
     """ALWAYS auto-approves: forward (with credentials injected), no approval
     row, and (since it's not gated) no session lookup — even when a tag is
     present."""
@@ -288,20 +295,21 @@ def test_resolve_and_match_always_forwards_without_session() -> None:
     )
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None  # forwarded, not promoted to an approval
     assert flow.response is None
     assert resolver.resolve_session_by_id_calls == []
 
 
-def test_resolve_and_match_deny_blocks_with_403() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_deny_blocks_with_403() -> None:
     """DENY blocks outright with a policy_denied 403, no session needed."""
     resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH_DENY))
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.POLICY_DENIED)
@@ -462,7 +470,8 @@ async def test_ask_denied_blocks(
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_happy_path_promotes_session() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_happy_path_promotes_session() -> None:
     user_id = uuid4()
     session_id = UUID(_TAG_UUID)
     sandbox = _sandbox(user_id=user_id)
@@ -471,7 +480,7 @@ def test_resolve_and_match_happy_path_promotes_session() -> None:
     addon = _build(resolver=resolver, matcher=matcher)
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is not None
     ctx, match = result
@@ -539,7 +548,8 @@ def test_http_connect_ignores_missing_or_garbled_header() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_and_match_exact_tag_on_http_request() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_exact_tag_on_http_request() -> None:
     """Plain-HTTP: Proxy-Authorization rides on the request; a verified
     tag routes to that exact session."""
     user_id = uuid4()
@@ -549,7 +559,7 @@ def test_resolve_and_match_exact_tag_on_http_request() -> None:
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is not None
     ctx, _match = result
@@ -559,7 +569,8 @@ def test_resolve_and_match_exact_tag_on_http_request() -> None:
     ]
 
 
-def test_resolve_and_match_exact_tag_on_https_connect() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_exact_tag_on_https_connect() -> None:
     """HTTPS: the tag rode on the CONNECT (captured via http_connect)
     and is read back off the connection, not the MITM'd request."""
     user_id = uuid4()
@@ -573,14 +584,15 @@ def test_resolve_and_match_exact_tag_on_https_connect() -> None:
     # Decrypted request has no Proxy-Authorization of its own.
     request_flow = _flow(conn_id="conn-1")
 
-    result = addon._resolve_and_match(request_flow)
+    result = await addon._resolve_and_match(request_flow)
 
     assert result is not None
     ctx, _match = result
     assert ctx.session_id == tagged_id
 
 
-def test_resolve_and_match_unverified_tag_fails_closed() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_unverified_tag_fails_closed() -> None:
     """Tag doesn't resolve to one of this user's sessions (stale /
     foreign / tampered): fail closed, no fallback."""
     sandbox = _sandbox()
@@ -588,27 +600,29 @@ def test_resolve_and_match_unverified_tag_fails_closed() -> None:
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert len(resolver.resolve_session_by_id_calls) == 1
 
 
-def test_resolve_and_match_malformed_tag_fails_closed() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_malformed_tag_fails_closed() -> None:
     """A non-UUID username fails closed without hitting the DB."""
     resolver = _StubResolver(sandbox=_sandbox())
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     flow = _flow(proxy_auth=_basic_auth("not-a-uuid"))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
     assert resolver.resolve_session_by_id_calls == []
 
 
-def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
+@pytest.mark.asyncio
+async def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
     """A DB blip validating the tag fails closed, not silently forward."""
     resolver = _StubResolver(
         sandbox=_sandbox(), session_by_id_exc=RuntimeError("db down")
@@ -616,7 +630,7 @@ def test_resolve_and_match_session_by_id_db_error_fails_closed() -> None:
     addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
     flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
 
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
 
     assert result is None
     _assert_403(flow, SandboxProxyError.NO_ACTIVE_SESSION)
@@ -716,7 +730,7 @@ async def test_requestheaders_rejects_cross_tenant_prefix() -> None:
     assert gate_mod._SNAPSHOT_STREAM_FLAG not in flow.metadata
 
     # Unmarked oversize flow now hits the fail-closed cap.
-    result = addon._resolve_and_match(flow)
+    result = await addon._resolve_and_match(flow)
     assert result is None
     _assert_403(flow, SandboxProxyError.BODY_TOO_LARGE)
 

--- a/docs/craft/features/external-apps/oauth-token-refresh.md
+++ b/docs/craft/features/external-apps/oauth-token-refresh.md
@@ -51,7 +51,8 @@ expiry.
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| Trigger | Lazy, at the injection seam (`GateAddon._inject_credentials`) | Two calls — `ensure_fresh_credentials(...)` then `resolve_injection_headers(...)`. |
+| Trigger | Lazy, at the injection seam (`GateAddon._inject_credentials`) | Two steps — refresh (`ensure_fresh_credentials`) then render (`resolve_injection_headers`). |
+| Event-loop safety | The refresh runs via `await asyncio.to_thread(...)` | It can block (token POST + Redis lock); off-thread it stalls only the triggering request, not the whole proxy loop. The injection seam and `_resolve_and_match` are `async` so both verdict paths await the refresh inline (no `flow.metadata` side channel). |
 | Interface boundary | The seam passes the **session factory + ids**; the helper abstracts read + refresh + store entirely | The gate stays ignorant of refresh mechanics (no DB calls, no lock, no token POST, no session handling at the seam). |
 | `ensure_fresh_credentials` shape | `(db_session_factory, tenant_id, external_app_id, user_id) -> None` | Self-contained: opens its own short sessions, single-flights, persists. Returns nothing — the caller just renders next. |
 | Single-flight | Fleet-wide Redis lock (`redis_shared_lock`) with double-checked re-read | Dedupes a stampede across processes/pods and is safe for token-rotating providers; fully hidden inside the helper. |
@@ -61,12 +62,13 @@ expiry.
 | `expires_at` stamping | At the callback and inside the refresh helper, not the provider | `extract_credentials` / `refresh_credentials` stay clockless and trivially testable. |
 | Refresh-token-only rows backfill | Self-heal (treat missing `expires_at` as never-expire) | The pre-change population is tiny and transient; one extra 401 then a reconnect. |
 
-**Event-loop note.** The refresh runs synchronously on the proxy event loop
-(matching the sync DB I/O already there); it is rare (once per token lifetime per
-user), single-flighted, and the token POST is tightly timed out. If a slow token
-endpoint blocking the loop becomes a problem, the seam can wrap the one
-`ensure_fresh_credentials(...)` call in `asyncio.to_thread` — its internals don't
-change.
+**Event-loop note.** `gate.request` runs on the mitmproxy event loop, which
+multiplexes egress for many sessions/tenants. The refresh's blocking work (token
+POST up to `refresh_http_timeout_seconds`, Redis-lock wait up to `_LOCK_WAIT_S`)
+therefore runs in a worker thread via `await asyncio.to_thread(...)`, so a slow
+or hung token endpoint stalls only the triggering request — not every concurrent
+proxied flow. Because refreshes now run on threads (no longer serialized by the
+loop), the Redis lock is the real in-process single-flight, not redundant.
 
 ## Changes (file-by-file — the PR review map)
 
@@ -123,19 +125,23 @@ change.
     in (not a live session); **persistence stays in `db/external_app.py`**.
 
 ### 4. Wire into the egress seam
-- **`backend/onyx/sandbox_proxy/addons/gate.py`** — `_inject_credentials` makes
-  two calls inside its existing `try`/`except`:
+- **`backend/onyx/sandbox_proxy/addons/gate.py`** — `_inject_credentials` (now
+  `async`) refreshes off the event loop, then renders:
   ```python
-  ensure_fresh_credentials(self._db_session_factory, tenant_id, app_id, user_id)
+  await asyncio.to_thread(
+      ensure_fresh_credentials, self._db_session_factory, tenant_id, app_id, user_id
+  )
   with self._db_session_factory(tenant_id) as db:
       headers = resolve_injection_headers(db, app_id, user_id)
   ```
   The gate imports only `ensure_fresh_credentials` + `resolve_injection_headers`
-  — no DB functions, no lock, no refresh exceptions. A revoked grant is cleared
-  inside the helper, so the render finds no creds and forwards unauthenticated
-  (upstream 401), the same as a never-connected app. Unexpected errors hit the
-  existing broad `except` → `False` (fail closed). Both ALWAYS and ASK-approved
-  go through `_inject_credentials_or_block` → `_inject_credentials` unchanged.
+  — no DB functions, no lock, no refresh exceptions. `_inject_credentials_or_block`
+  → `_inject_credentials` and `_resolve_and_match` are all `async`, so both verdict
+  paths await injection inline: the ALWAYS path in `_resolve_and_match`, the
+  ASK-approved path in `request` (no `flow.metadata` hand-off). A revoked grant is
+  cleared inside the helper → render finds no creds → forwards unauthenticated
+  (upstream 401), same as a never-connected app. Unexpected errors hit the broad
+  `except` → `False` (fail closed).
 
 ## Failure handling
 
@@ -196,8 +202,11 @@ exception:
 - [ ] Refresh format lives on `OAuthExternalAppProvider` as overridable
       properties/hooks (template method), not in free functions/constants — a new
       provider's divergence is a one-method override, not a reimplementation.
-- [ ] The gate seam is two calls and imports only `ensure_fresh_credentials` +
+- [ ] The gate seam imports only `ensure_fresh_credentials` +
       `resolve_injection_headers` — no DB functions, lock, or refresh exceptions.
+- [ ] The (blocking) refresh runs via `await asyncio.to_thread(...)` — never
+      synchronously on the mitmproxy event loop. `_LOCK_WAIT_S` is bounded so a
+      waiter doesn't hold a worker thread long.
 - [ ] `ensure_fresh_credentials` takes the session **factory** (not a live
       session); each step's session is short — none spans the lock wait or POST.
 - [ ] `stamp_expires_at` builds a new dict — the `get_value(apply_mask=False)`

--- a/docs/craft/features/external-apps/oauth-token-refresh.md
+++ b/docs/craft/features/external-apps/oauth-token-refresh.md
@@ -85,8 +85,10 @@ loop), the Redis lock is the real in-process single-flight, not redundant.
   provider class (not in free functions) and a divergent provider overrides only
   the piece that differs — it never re-implements the POST + error boilerplate:
   - **`refresh_credentials(stored, client_id, client_secret)`** — the template:
-    read the refresh token → build request → POST → classify error → map + carry
-    the refresh token forward. Clockless (caller stamps `expires_at`).
+    read the refresh token → build request → POST → classify error → map, then
+    **merge onto the stored creds** (`{**stored, **mapped}`) so connect-time-only
+    fields and the (un-rotated) refresh token survive. Clockless (caller stamps
+    `expires_at`).
   - **Class properties** (override per provider): `refresh_http_timeout_seconds`,
     `terminal_refresh_errors` (which OAuth error codes are fatal vs. retryable).
   - **Hooks** (override per provider): `build_refresh_request(...) -> dict` (the
@@ -104,16 +106,18 @@ loop), the Redis lock is the real in-process single-flight, not redundant.
   ```
   ensure_fresh_credentials(db_session_factory, tenant_id, external_app_id, user_id) -> None
   ```
-  - **Pre-check** (own short session, then closed): resolve app + provider; bail
-    if non-OAuth; read creds; `needs_refresh(stored, now)`? If not → return (the
-    common path — no lock, no network, connection released).
+  - **Pre-check** (own short session, then closed): read creds, `needs_refresh`?
+    If not → return (the common path — just one cred read, no lock, no network,
+    no provider/client-cred resolution).
   - Acquire `redis_shared_lock("ea_token_refresh:{tenant}:{app}:{user}", …)`.
-  - **Re-read** (own short session, then closed): a fresh session sees a
-    concurrent winner's committed refresh (read-committed); if no longer stale,
-    return. Otherwise gather the POST inputs (provider, stored creds,
-    `client_id`/`client_secret`) and close the session.
+  - **Re-read + gather** (own short session, then closed): a fresh session sees a
+    concurrent winner's committed refresh (read-committed); bail if no longer
+    stale, non-OAuth, or missing client creds. Otherwise gather the POST inputs
+    (provider, stored creds, `client_id`/`client_secret`) and close the session.
   - `provider.refresh_credentials(...)` — the token POST runs with **no DB
-    connection held**.
+    connection held**. `refresh_credentials` raises **only `TokenRefreshError`**
+    (a 2xx body it can't map is reclassified transient), so a refresh outcome
+    never escapes the helper.
   - **Persist** (own short session): `upsert_external_app_user_credential` with
     the `stamp_expires_at`-stamped creds.
   - **Never raises for a refresh outcome:** transient → log + return (keep the
@@ -180,8 +184,9 @@ exception:
   - `needs_refresh`: fresh → no-op; within-skew / expired → refresh; no
     `expires_at` → no-op. (`test_token_utils.py`)
   - `refresh_credentials` mapping: success maps fields; rotation persists a new
-    `refresh_token`; no-rotation carries the old one forward; `invalid_grant` →
-    terminal; 5xx / network → transient. (`test_token_refresh.py`)
+    `refresh_token`; no-rotation carries the old one forward; the merge preserves
+    connect-time-only fields (e.g. `team_id`); `invalid_grant` → terminal; 5xx /
+    network → transient. (`test_token_refresh.py`)
   - Template-method extensibility: a subclass overriding one hook
     (`build_refresh_request`, `terminal_refresh_errors`) changes only that
     behavior and inherits the rest. (`test_token_refresh.py`)

--- a/docs/craft/features/external-apps/oauth-token-refresh.md
+++ b/docs/craft/features/external-apps/oauth-token-refresh.md
@@ -1,0 +1,219 @@
+# External-App OAuth Token Refresh — Implementation Plan
+
+> **Scope.** This plan implements **lazy, just-in-time refresh** of a connected
+> external app's OAuth access token at the egress credential-injection seam. It
+> builds on [action policies](./action-policies.md) (which decides *whether* a
+> request is forwarded) and the egress proxy's credential injection — this plan
+> only ensures the token injected on an approved forward is **live**.
+>
+> **Why lazy / why this shape.** The approach trade-offs (lazy vs. background vs.
+> on-401, and the three ways to single-flight a lazy refresh) are argued in
+> `plans/external-app-lazy-token-refresh-design.md`. This doc is the
+> implementation contract for the chosen path — **Approach 2: offloaded refresh
+> via `asyncio.to_thread`, single-flighted by a system-wide Redis lock** — and
+> exists so a reviewer can map the PR diff to an agreed design.
+
+## Summary
+
+OAuth access tokens for connected apps are captured once at connect time and
+never refreshed. Google Calendar tokens expire ~1 hour later, after which the
+egress proxy injects a dead `Bearer` token, the upstream 401s, and the agent's
+request fails until the user manually reconnects. The `refresh_token` is already
+stored — it is simply never used.
+
+This change refreshes the access token transparently, the first time it is
+needed after it goes stale, using the stored `refresh_token`. A burst of
+concurrent sandbox requests is single-flighted through a Redis lock so the
+provider's token endpoint is hit at most once per (tenant, app, user) per
+expiry.
+
+## Problem
+
+- `extract_credentials` persists `refresh_token` + `expires_in` at connect time
+  (`backend/onyx/external_apps/providers/{google_calendar,slack,linear}.py`), but
+  nothing ever calls the token endpoint again and no absolute expiry is stored.
+- The sole injection seam, `GateAddon._inject_credentials`
+  (`backend/onyx/sandbox_proxy/addons/gate.py`) → `resolve_injection_headers`
+  (`backend/onyx/external_apps/credentials.py`), renders whatever is stored —
+  including an expired token. It already opens a synchronous DB session here, so
+  the refresh is a natural in-line addition at this one seam.
+
+## What is already in place (not part of this PR)
+
+- **Encryption at rest** (PR #11514): `ExternalAppUserCredential.user_credentials`
+  and `ExternalApp.organization_credentials` are `EncryptedJson()` /
+  `SensitiveValue[dict]`, read via `.get_value(apply_mask=False)`. No encryption
+  migration is needed here.
+- **Refresh token + `expires_in` capture**: providers already store both. This
+  PR adds only the absolute `expires_at` and the refresh machinery.
+
+## Design decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Trigger | Lazy, at the injection seam (`GateAddon._inject_credentials`) | Two calls — `ensure_fresh_credentials(...)` then `resolve_injection_headers(...)`. |
+| Interface boundary | The seam passes the **session factory + ids**; the helper abstracts read + refresh + store entirely | The gate stays ignorant of refresh mechanics (no DB calls, no lock, no token POST, no session handling at the seam). |
+| `ensure_fresh_credentials` shape | `(db_session_factory, tenant_id, external_app_id, user_id) -> None` | Self-contained: opens its own short sessions, single-flights, persists. Returns nothing — the caller just renders next. |
+| Single-flight | Fleet-wide Redis lock (`redis_shared_lock`) with double-checked re-read | Dedupes a stampede across processes/pods and is safe for token-rotating providers; fully hidden inside the helper. |
+| Session lifetime | The helper takes its own **short** sessions per step (pre-check, re-read, persist) | No connection held across the Redis-lock wait or the token POST. The factory is passed in (not a live session, not threaded through call after call). |
+| Terminal handling | Helper **clears** the credential and **returns** (does not raise) | A revoked grant becomes "disconnected" — the same path as a never-connected app (render finds no creds → forwards unauthenticated → upstream 401 + UI reconnect). Keeps the gate free of refresh-specific error handling. |
+| Expiry storage | Absolute UTC `expires_at` instant | No "when was this written" bookkeeping on read. |
+| `expires_at` stamping | At the callback and inside the refresh helper, not the provider | `extract_credentials` / `refresh_credentials` stay clockless and trivially testable. |
+| Refresh-token-only rows backfill | Self-heal (treat missing `expires_at` as never-expire) | The pre-change population is tiny and transient; one extra 401 then a reconnect. |
+
+**Event-loop note.** The refresh runs synchronously on the proxy event loop
+(matching the sync DB I/O already there); it is rare (once per token lifetime per
+user), single-flighted, and the token POST is tightly timed out. If a slow token
+endpoint blocking the loop becomes a problem, the seam can wrap the one
+`ensure_fresh_credentials(...)` call in `asyncio.to_thread` — its internals don't
+change.
+
+## Changes (file-by-file — the PR review map)
+
+### 1. Stamp absolute `expires_at` at write time
+- **`backend/onyx/server/features/build/api/external_apps_oauth_api.py`** — after
+  `provider.extract_credentials(...)` in the callback, compute `expires_at` (UTC,
+  from the response's `expires_in`) and merge it into the stored dict before
+  `upsert_external_app_user_credential`. `extract_credentials` stays a pure
+  response→dict mapper (no clock).
+
+### 2. Provider refresh capability (template method)
+- **`backend/onyx/external_apps/providers/base.py`** — `OAuthExternalAppProvider`
+  owns refresh as a **template method**, so the format knowledge lives on the
+  provider class (not in free functions) and a divergent provider overrides only
+  the piece that differs — it never re-implements the POST + error boilerplate:
+  - **`refresh_credentials(stored, client_id, client_secret)`** — the template:
+    read the refresh token → build request → POST → classify error → map + carry
+    the refresh token forward. Clockless (caller stamps `expires_at`).
+  - **Class properties** (override per provider): `refresh_http_timeout_seconds`,
+    `terminal_refresh_errors` (which OAuth error codes are fatal vs. retryable).
+  - **Hooks** (override per provider): `build_refresh_request(...) -> dict` (the
+    refresh POST form body — add `scope`/`resource`/etc.), `classify_token_response(...)`
+    (failure detection), and `extract_credentials` (response → creds, shared with
+    the initial grant).
+  - All built-ins use the default RFC-6749 path today; the hooks exist so the next
+    built-in or a (future, config-driven) custom OAuth provider slots in by
+    overriding one method. Slack/Linear return no `expires_in`, so they're never
+    refreshed regardless.
+
+### 3. Refresh-and-persist helper (new)
+- **`backend/onyx/external_apps/token_refresh.py`** (new) — the one call the gate
+  makes; everything about keeping the token fresh lives behind it:
+  ```
+  ensure_fresh_credentials(db_session_factory, tenant_id, external_app_id, user_id) -> None
+  ```
+  - **Pre-check** (own short session, then closed): resolve app + provider; bail
+    if non-OAuth; read creds; `needs_refresh(stored, now)`? If not → return (the
+    common path — no lock, no network, connection released).
+  - Acquire `redis_shared_lock("ea_token_refresh:{tenant}:{app}:{user}", …)`.
+  - **Re-read** (own short session, then closed): a fresh session sees a
+    concurrent winner's committed refresh (read-committed); if no longer stale,
+    return. Otherwise gather the POST inputs (provider, stored creds,
+    `client_id`/`client_secret`) and close the session.
+  - `provider.refresh_credentials(...)` — the token POST runs with **no DB
+    connection held**.
+  - **Persist** (own short session): `upsert_external_app_user_credential` with
+    the `stamp_expires_at`-stamped creds.
+  - **Never raises for a refresh outcome:** transient → log + return (keep the
+    existing token); terminal → `delete_external_app_user_credential` + return
+    (app reads disconnected); lock contention → yield to the winner + return.
+  - `needs_refresh(stored, now, skew_s=120)`: no `expires_at` → `False`; else
+    `expires_at - now <= skew`. `stamp_expires_at` builds a new dict, so the
+    `get_value(apply_mask=False)` cache is never mutated. The factory is passed
+    in (not a live session); **persistence stays in `db/external_app.py`**.
+
+### 4. Wire into the egress seam
+- **`backend/onyx/sandbox_proxy/addons/gate.py`** — `_inject_credentials` makes
+  two calls inside its existing `try`/`except`:
+  ```python
+  ensure_fresh_credentials(self._db_session_factory, tenant_id, app_id, user_id)
+  with self._db_session_factory(tenant_id) as db:
+      headers = resolve_injection_headers(db, app_id, user_id)
+  ```
+  The gate imports only `ensure_fresh_credentials` + `resolve_injection_headers`
+  — no DB functions, no lock, no refresh exceptions. A revoked grant is cleared
+  inside the helper, so the render finds no creds and forwards unauthenticated
+  (upstream 401), the same as a never-connected app. Unexpected errors hit the
+  existing broad `except` → `False` (fail closed). Both ALWAYS and ASK-approved
+  go through `_inject_credentials_or_block` → `_inject_credentials` unchanged.
+
+## Failure handling
+
+All inside `ensure_fresh_credentials` — the gate never sees a refresh-specific
+exception:
+
+- **`invalid_grant` / revoked (terminal):** clear the credential row
+  (`delete_external_app_user_credential`) and return. The render then finds no
+  creds → forwards unauthenticated → upstream 401 + the app reads as
+  disconnected (UI prompts reconnect). No retry loop.
+- **Transient network / 5xx:** log and return the existing token in place; the
+  request proceeds (may 401) and the next request retries. Never destroy a
+  possibly-valid token on a blip.
+- **Lock contention (`RedisSharedLockAcquisitionError`):** yield to the
+  concurrent refresher and return; this request proceeds with the current token.
+- **Unexpected (DB down, etc.):** propagates to the gate's broad `except` →
+  `False` → block (fail closed).
+
+## Concurrency & edge cases
+
+- **Stampede:** N parallel stale requests → one wins the Redis lock and
+  refreshes; the rest re-read (fresh session) and see the committed token.
+- **Skew:** the 120s window refreshes early so no in-flight request reaches
+  upstream with a just-expired token.
+- **Slack / Linear / static-credential apps:** no `expires_at` → `needs_refresh`
+  is `False` → `ensure_fresh_credentials` is a no-op; behaviour unchanged.
+- **Lock scope:** `redis_shared_lock` is on the shared (not tenant) Redis client,
+  so the lock name encodes `tenant_id:app_id:user_id`.
+- **No connection across the POST:** each step takes its own short session; the
+  token POST holds none.
+- **Clock:** compare against UTC `now`; store/parse absolute instants.
+
+## Tests
+
+- **Unit** (`backend/tests/unit/external_apps/`):
+  - `needs_refresh`: fresh → no-op; within-skew / expired → refresh; no
+    `expires_at` → no-op. (`test_token_utils.py`)
+  - `refresh_credentials` mapping: success maps fields; rotation persists a new
+    `refresh_token`; no-rotation carries the old one forward; `invalid_grant` →
+    terminal; 5xx / network → transient. (`test_token_refresh.py`)
+  - Template-method extensibility: a subclass overriding one hook
+    (`build_refresh_request`, `terminal_refresh_errors`) changes only that
+    behavior and inherits the rest. (`test_token_refresh.py`)
+  - `ensure_fresh_credentials` orchestration (mocked DB factory + lock +
+    provider): fresh → no-op; double-checked re-read skips when the winner
+    refreshed; stale → upserts a `stamp_expires_at`-stamped dict; terminal clears
+    the row **without raising**; transient keeps the existing token; non-OAuth →
+    no-op. (`test_token_refresh.py`)
+- **Gate** (`backend/tests/unit/sandbox_proxy/test_gate.py`):
+  - `_inject_credentials` calls `ensure_fresh_credentials(factory, tenant, app,
+    user)` before rendering. An autouse fixture defaults the refresh to a no-op so
+    the other gate tests pin injection/approval only.
+
+## Reviewer checklist
+
+- [ ] `extract_credentials` remains a pure mapper; `expires_at` is stamped by the
+      callback and the refresh helper — never the provider.
+- [ ] Refresh format lives on `OAuthExternalAppProvider` as overridable
+      properties/hooks (template method), not in free functions/constants — a new
+      provider's divergence is a one-method override, not a reimplementation.
+- [ ] The gate seam is two calls and imports only `ensure_fresh_credentials` +
+      `resolve_injection_headers` — no DB functions, lock, or refresh exceptions.
+- [ ] `ensure_fresh_credentials` takes the session **factory** (not a live
+      session); each step's session is short — none spans the lock wait or POST.
+- [ ] `stamp_expires_at` builds a new dict — the `get_value(apply_mask=False)`
+      cache is never mutated.
+- [ ] All DB calls go through `db/external_app.py`; the provider token POST has a
+      bounded HTTP timeout; lock name includes tenant + app + user.
+- [ ] Failure paths (all inside the helper, never raised to the gate): terminal
+      clears the row; transient/lock-contention keep the existing token; only
+      unexpected errors propagate (gate blocks).
+- [ ] Slack/Linear (no `expires_in`) and static-credential apps are provably
+      no-ops.
+- [ ] Refresh tokens never logged; injection logging stays header-names-only.
+
+## References
+
+- Approach comparison & rationale: `plans/external-app-lazy-token-refresh-design.md`
+- Original problem framing & option pitches: `plans/external-app-token-refresh.md`
+- Policy layer (what gates the forward): [`action-policies.md`](./action-policies.md)
+- Egress enforcement: [`egress-proxy-action-policy-enforcement.md`](./egress-proxy-action-policy-enforcement.md)


### PR DESCRIPTION
## Description
Adds lazy, single-flighted OAuth token refresh for connected external apps: the egress proxy's ExternalAppResolver refreshes an expired/expiring access token just-in-time (off the event loop via asyncio.to_thread) before injecting credentials, transparently to the agent. A revoked grant clears the credential to prompt reconnect, while transient failures (network/5xx, malformed expiry, Redis unavailable) keep the existing token and fail safe. Includes provider refresh_credentials hooks, absolute expires_at stamping at connect time, and unit coverage for the refresh, staleness, and error-classification paths.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lazy, single-flighted OAuth token refresh for external apps at injection time to prevent 401s from expired tokens. Refresh runs off the proxy event loop, and we persist an absolute `expires_at` at connect and on refresh.

- **New Features**
  - Template method on `OAuthExternalAppProvider` (`refresh_credentials`) with terminal vs. transient errors via `token_response_error`; merges onto stored creds and uses a bounded HTTP timeout.
  - `ensure_fresh_credentials(db_session_factory, tenant_id, external_app_id, user_id)` uses short DB sessions, Redis single-flight with double-checked read; terminal clears creds via `delete_external_app_user_credential`, transient keeps existing tokens; handles Redis/DB outages; never raises.
  - `ExternalAppResolver` refreshes before rendering headers; gate injection runs via `asyncio.to_thread` for ASK and ALWAYS paths.
  - OAuth callback stamps `expires_at` from `expires_in` and now uses `token_response_error`; refresh path stamps via `stamp_expires_at` and early-refresh uses `needs_refresh` with a 120s skew. Added unit tests and docs at `docs/craft/features/external-apps/oauth-token-refresh.md`.

- **Refactors**
  - Centralized `DBSessionFactory` in `onyx.db.engine.sql_engine`; gate, matcher, and identity import it. `_resolve_and_match` is now async.

<sup>Written for commit 90dfa6d5246563a3a07065601f1f11549775e11c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



