### PR TITLE
feat(craft): inject LLM provider key via egress proxy, remove from sandbox pod

### DIFF
--- a/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
+++ b/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
@@ -1,0 +1,72 @@
+"""LLM provider-key credential resolver.
+
+Claims requests bound for the canonical Craft LLM provider hosts (OpenAI,
+Anthropic, OpenRouter) and injects the sandbox owner's real, access-scoped
+provider key read fresh from ``llm_provider``. The pod ships only a placeholder
+apiKey, so the live key never lands in the sandbox. Custom ``api_base`` hosts
+are out of scope; only the canonical hosts are claimed.
+"""
+
+from __future__ import annotations
+
+from mitmproxy import http
+
+from onyx.auth.constants import API_KEY_HEADER_NAME
+from onyx.auth.constants import BEARER_PREFIX
+from onyx.db.users import fetch_user_by_id
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.server.features.build.db.build_session import (
+    fetch_all_supported_build_llm_providers,
+)
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Canonical host -> (provider type, auth header, value prefix). Only the named
+# header is set, so the SDK's anthropic-version etc. survive.
+_HOST_TO_PROVIDER: dict[str, tuple[str, str, str]] = {
+    "api.openai.com": ("openai", API_KEY_HEADER_NAME, BEARER_PREFIX),
+    "api.anthropic.com": ("anthropic", "x-api-key", ""),
+    "openrouter.ai": ("openrouter", API_KEY_HEADER_NAME, BEARER_PREFIX),
+}
+
+
+class LLMProviderKeyResolver(CredentialResolver):
+    """Injects the sandbox owner's LLM provider key on canonical provider hosts."""
+
+    def claims(
+        self,
+        request: http.Request,
+        ctx: InjectionContext,  # noqa: ARG002
+    ) -> bool:
+        return request.host.lower() in _HOST_TO_PROVIDER
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        provider_type, header, prefix = _HOST_TO_PROVIDER[request.host.lower()]
+        user_id = ctx.sandbox.user_id
+        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+            user = fetch_user_by_id(db, user_id)
+            if user is None:
+                raise CredentialUnavailableError(f"sandbox user {user_id} not found")
+            providers = fetch_all_supported_build_llm_providers(db, user)
+
+        # First accessible provider of the type, matching how provisioning picks
+        # the key (get_all_build_mode_llm_configs dedups by type, first wins).
+        provider = next((p for p in providers if p.provider == provider_type), None)
+        if provider is None:
+            raise CredentialUnavailableError(
+                f"no accessible {provider_type} provider for user {user_id}"
+            )
+        if not provider.api_key:
+            raise CredentialUnavailableError(
+                f"{provider_type} provider for user {user_id} has no api_key"
+            )
+
+        logger.info(
+            "llm_provider_key_resolver.resolved provider=%s host=%s",
+            provider_type,
+            request.host,
+        )
+        return {header: f"{prefix}{provider.api_key}"}

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -25,6 +25,7 @@ from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.identity_k8s import K8sInformerLookup
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
+from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
 from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
@@ -120,7 +121,7 @@ def build_resolvers() -> list[CredentialResolver]:
     canonical hosts). Order is a safety net against accidental overlap, not a
     designed-in priority.
     """
-    return [OnyxPatResolver(), ExternalAppResolver()]
+    return [OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]
 
 
 def _install_signal_handlers(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -186,9 +186,22 @@ def _resolve_proxy_ip() -> str:
 # Onyx API host must transit the proxy so the PAT can be injected on the wire.
 _NO_PROXY = "127.0.0.1,localhost"
 
-# Placeholder shipped in ONYX_PAT; the egress proxy injects the real PAT on the
-# wire (the pod never holds the token).
-_ONYX_PAT_PLACEHOLDER = "onyx_pat_placeholder_replaced_by_proxy"
+# Non-empty sentinel for every proxy-injected credential (ONYX_PAT + each
+# opencode apiKey); the proxy overwrites the real value on the wire.
+_PROXY_INJECTED_PLACEHOLDER = "replaced_by_egress_proxy"
+
+
+def _placeholder_llm_configs(
+    configs: list[LLMProviderConfig],
+) -> list[LLMProviderConfig]:
+    """Swap real LLM keys for the proxy placeholder before the opencode config
+    reaches the pod; provider/model/api_base stay so routing is unchanged."""
+    return [
+        c.model_copy(update={"api_key": _PROXY_INJECTED_PLACEHOLDER})
+        if c.api_key
+        else c
+        for c in configs
+    ]
 
 
 def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
@@ -602,7 +615,7 @@ class KubernetesSandboxManager(SandboxManager):
             command=["/workspace/entrypoint.sh"],
             ports=sandbox_ports,
             env=[
-                client.V1EnvVar(name="ONYX_PAT", value=_ONYX_PAT_PLACEHOLDER),
+                client.V1EnvVar(name="ONYX_PAT", value=_PROXY_INJECTED_PLACEHOLDER),
                 client.V1EnvVar(name="ONYX_SERVER_URL", value=SANDBOX_API_SERVER_URL),
                 client.V1EnvVar(
                     name=OPENCODE_SERVER_PASSWORD,
@@ -1278,11 +1291,10 @@ class KubernetesSandboxManager(SandboxManager):
                 self._terminated_sandboxes.discard(sandbox_id)
             self._invalidate_serve_connection_info(sandbox_id)
 
-            # Secret must exist before the Pod (env references it via
-            # secretKeyRef). Pre-load every configured provider so
-            # cross-provider per-prompt model overrides work without a
-            # pod restart.
-            providers = all_llm_configs or [llm_config]
+            # Secret must exist before the Pod (secretKeyRef). Pre-load every
+            # provider for cross-provider model overrides; keys are swapped for
+            # the proxy placeholder so the pod never holds them.
+            providers = _placeholder_llm_configs(all_llm_configs or [llm_config])
             # Only register the egress-tagging plugin when the proxy is
             # deployed; otherwise it would no-op (no HTTP(S)_PROXY to re-tag).
             session_tag_plugins = (

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -1,0 +1,66 @@
+"""External-dependency-unit test for `LLMProviderKeyResolver` against a real DB.
+
+Pins the claim->resolve contract the unit test mocks: an access-scoped
+`llm_provider` row's key, stored encrypted, is read back — through real
+`EncryptedString` and the build-mode access scoping — onto the provider's wire
+auth header for a request to its canonical host.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import upsert_llm_provider
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def test_claims_then_resolve_round_trips_encrypted_key(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "llm_key_resolver")
+    provider = upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=f"craft-anthropic-{uuid4().hex[:8]}",
+            provider="anthropic",
+            api_key="sk-ant-round-trip",
+            api_key_changed=True,
+        ),
+        db_session=db_session,
+    )
+    db_session.commit()
+
+    ctx = InjectionContext(
+        sandbox=ResolvedSandbox(
+            sandbox_id=uuid4(),
+            user_id=user.id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            sandbox_name="sandbox-test",
+            sandbox_ip="127.0.0.1",
+        ),
+        match=None,
+        db_session_factory=lambda tenant_id: get_session_with_tenant(
+            tenant_id=tenant_id
+        ),
+    )
+
+    try:
+        resolver = LLMProviderKeyResolver()
+        assert resolver.claims(MagicMock(host="api.anthropic.com"), ctx) is True
+        assert resolver.claims(MagicMock(host="slack.com"), ctx) is False
+
+        headers = resolver.resolve(MagicMock(host="api.anthropic.com"), ctx)
+        assert headers == {"x-api-key": "sk-ant-round-trip"}
+    finally:
+        remove_llm_provider(db_session, provider.id)
+        db_session.commit()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_key_ripout.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_key_ripout.py
@@ -1,0 +1,61 @@
+"""The opencode config the K8s manager ships must never carry a real LLM key.
+
+On Kubernetes the egress proxy injects the live per-tenant key on the wire, so
+`_placeholder_llm_configs` strips every real key before the config reaches the
+pod. These pin that swap and that the rendered opencode.json leaks no real key.
+"""
+
+from __future__ import annotations
+
+import json
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.util.opencode_config import (
+    build_multi_provider_opencode_config,
+)
+
+_REAL_KEY = "sk-real-secret-do-not-ship"
+
+
+def _config(
+    provider: str, api_key: str | None, api_base: str | None = None
+) -> LLMProviderConfig:
+    return LLMProviderConfig(
+        provider=provider, model_name="m", api_key=api_key, api_base=api_base
+    )
+
+
+def test_placeholder_swap_replaces_real_keys_keeps_routing() -> None:
+    swapped = ksm._placeholder_llm_configs(
+        [
+            _config("openai", _REAL_KEY),
+            _config("anthropic", _REAL_KEY, api_base="https://gw.example/v1"),
+        ]
+    )
+    assert [c.api_key for c in swapped] == [ksm._PROXY_INJECTED_PLACEHOLDER] * 2
+    # provider / model / api_base (non-secret routing inputs) are untouched.
+    assert [c.provider for c in swapped] == ["openai", "anthropic"]
+    assert swapped[1].api_base == "https://gw.example/v1"
+
+
+def test_keyless_provider_stays_keyless() -> None:
+    # No real key to strip, so no placeholder is injected either.
+    assert ksm._placeholder_llm_configs([_config("openai", None)])[0].api_key is None
+
+
+def test_rendered_opencode_config_leaks_no_real_key() -> None:
+    swapped = ksm._placeholder_llm_configs(
+        [_config("openai", _REAL_KEY), _config("anthropic", _REAL_KEY)]
+    )
+    config = build_multi_provider_opencode_config(
+        providers=swapped,
+        default_provider="openai",
+        default_model="m",
+    )
+    assert _REAL_KEY not in json.dumps(config)
+    for provider in ("openai", "anthropic"):
+        assert (
+            config["provider"][provider]["options"]["apiKey"]
+            == ksm._PROXY_INJECTED_PLACEHOLDER
+        )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -174,7 +174,7 @@ def test_share_process_namespace_is_disabled(pod: client.V1Pod) -> None:
 def test_onyx_pat_env_is_placeholder_not_real(pod: client.V1Pod) -> None:
     """The pod ships a placeholder; the egress proxy injects the real PAT."""
     env = {e.name: e.value for e in _container(pod, "sandbox").env}
-    assert env["ONYX_PAT"] == ksm._ONYX_PAT_PLACEHOLDER
+    assert env["ONYX_PAT"] == ksm._PROXY_INJECTED_PLACEHOLDER
 
 
 def test_no_proxy_is_loopback_only(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -1,0 +1,154 @@
+"""Unit tests for `LLMProviderKeyResolver`.
+
+Coverage: the canonical-host claim rule, the per-provider header conventions
+(pinned against the spec, not the resolver's own table), and the fail-closed
+cases the dispatcher maps to a 403. The encrypt/store/read round-trip against a
+real DB is pinned in
+`tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.resolvers import llm_provider_key as mod
+from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
+from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
+
+
+class _FakeProvider:
+    def __init__(self, provider: str, api_key: str | None) -> None:
+        self.provider = provider
+        self.api_key = api_key
+
+
+def _noop_db_factory() -> Any:
+    @contextmanager
+    def factory(tenant_id: str) -> Iterator[Any]:  # noqa: ARG001
+        yield MagicMock()
+
+    return factory
+
+
+def _ctx() -> InjectionContext:
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"),
+        match=None,
+        db_session_factory=_noop_db_factory(),
+    )
+
+
+@pytest.fixture
+def resolver() -> LLMProviderKeyResolver:
+    return LLMProviderKeyResolver()
+
+
+def _patch_providers(
+    monkeypatch: pytest.MonkeyPatch, providers: list[_FakeProvider]
+) -> None:
+    monkeypatch.setattr(mod, "fetch_user_by_id", lambda *_: object())
+    monkeypatch.setattr(
+        mod, "fetch_all_supported_build_llm_providers", lambda *_: providers
+    )
+
+
+def test_claims_only_canonical_hosts(resolver: LLMProviderKeyResolver) -> None:
+    for host in ("api.openai.com", "api.anthropic.com", "openrouter.ai"):
+        assert resolver.claims(_flow(host=host).request, _ctx()) is True
+        assert resolver.claims(_flow(host=host.upper()).request, _ctx()) is True
+    assert resolver.claims(_flow(host="api.slack.com").request, _ctx()) is False
+    assert resolver.claims(_flow(host="example.com").request, _ctx()) is False
+
+
+def test_openai_and_openrouter_render_bearer(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_providers(
+        monkeypatch,
+        [_FakeProvider("openai", "sk-oai"), _FakeProvider("openrouter", "sk-or")],
+    )
+    assert resolver.resolve(_flow(host="api.openai.com").request, _ctx()) == {
+        "Authorization": "Bearer sk-oai"
+    }
+    assert resolver.resolve(_flow(host="openrouter.ai").request, _ctx()) == {
+        "Authorization": "Bearer sk-or"
+    }
+
+
+def test_anthropic_renders_x_api_key_only(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
+    # x-api-key only — anthropic-version and other SDK headers must survive.
+    assert resolver.resolve(_flow(host="api.anthropic.com").request, _ctx()) == {
+        "x-api-key": "sk-ant"
+    }
+
+
+def test_selects_first_provider_of_claimed_type(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_providers(
+        monkeypatch,
+        [
+            _FakeProvider("openai", "sk-first"),
+            _FakeProvider("openai", "sk-second"),
+            _FakeProvider("anthropic", "sk-ant"),
+        ],
+    )
+    assert resolver.resolve(_flow(host="api.openai.com").request, _ctx()) == {
+        "Authorization": "Bearer sk-first"
+    }
+
+
+def test_resolve_raises_when_user_missing(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(mod, "fetch_user_by_id", lambda *_: None)
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+
+
+def test_resolve_raises_when_no_provider_of_type(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+
+
+def test_resolve_raises_when_provider_has_no_key(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_providers(monkeypatch, [_FakeProvider("openai", None)])
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_flow(host="api.openai.com").request, _ctx())
+
+
+# The wire contract per provider, written out independently of the resolver's
+# own table so a drifted host/header/prefix is caught, not re-derived from impl.
+_EXPECTED_HOST_TABLE = {
+    "api.openai.com": ("openai", "Authorization", "Bearer "),
+    "api.anthropic.com": ("anthropic", "x-api-key", ""),
+    "openrouter.ai": ("openrouter", "Authorization", "Bearer "),
+}
+
+
+def test_host_table_matches_wire_spec() -> None:
+    assert mod._HOST_TO_PROVIDER == _EXPECTED_HOST_TABLE
+
+
+def test_host_table_covers_every_build_mode_provider_type() -> None:
+    """A new allowed provider type without a host rule would silently leave its
+    key in the pod (un-injected), so pin the spec table against the allowed set."""
+    covered = {pt for pt, _, _ in _EXPECTED_HOST_TABLE.values()}
+    assert covered == set(BUILD_MODE_ALLOWED_PROVIDER_TYPES)

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -122,7 +122,7 @@ credentials via env vars. Every pod-side placeholder swap below is scoped to the
    The docker manager continues to inject real credentials in both cases.
 
 5. **Wire in `server.py`.** `build_resolvers()` returns
-   `[OnyxPatResolver(), ExternalAppResolver()]` (the LLM resolver joins per Plan 3). The dispatcher
+   `[OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]`. The dispatcher
    is constructed once at startup and passed into `GateAddon`.
 
 ## Tests

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -23,7 +23,7 @@ This plan generalises that single call site into a dispatcher with a uniform con
 @dataclass(frozen=True)
 class InjectionContext:
     sandbox: ResolvedSandbox
-    match: ActionMatch | None      # None on off-catalog flows
+    match: RequestMatch | None     # None on off-catalog flows
     db_session_factory: DBSessionFactory
 
 
@@ -63,9 +63,9 @@ placeholder can't be rendered — that's correct for user-in-the-loop apps where
 surfaces to the user. The dispatcher's outer `BLOCKED` and the renderer's per-header drop coexist.
 
 **Claim disjointness.** External-app hosts come from `ExternalApp.upstream_url_patterns`; the Onyx
-API host is `SANDBOX_API_SERVER_URL`; LLM hosts are the canonical provider hosts plus each tenant's
-`LLMProvider.api_base`. These sets are disjoint by construction. The dispatcher's unit test fails
-the build on overlap, and startup logs any predicate collision.
+API host is `SANDBOX_API_SERVER_URL`; LLM hosts are the canonical provider hosts. These sets are
+disjoint by construction. The dispatcher's unit test fails the build on overlap, and startup logs
+any predicate collision.
 
 **Placeholder / overwrite contract.** The pod ships a non-empty placeholder for each credential
 header — opencode's AI SDK throws on unset keys and onyx-cli treats empty as unconfigured. The
@@ -79,8 +79,8 @@ proxy overwrites only the named header. The real secret never leaves the proxy.
   Behaviour identical to the current `_inject_credentials`.
 - **`OnyxPatResolver`** — claims the `SANDBOX_API_SERVER_URL` host; reads `Sandbox.encrypted_pat`.
   See [Plan 2](./02-onyx-pat.md).
-- **`LLMProviderKeyResolver`** — claims canonical LLM provider hosts plus each tenant's `api_base`;
-  reads `llm_provider` rows. See [Plan 3](./03-llm-key.md).
+- **`LLMProviderKeyResolver`** — claims the canonical LLM provider hosts (custom `api_base` out of
+  scope); reads `llm_provider` rows. See [Plan 3](./03-llm-key.md).
 
 In-proxy decryption works because the proxy Deployment already has `ENCRYPTION_KEY_SECRET` wired.
 

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -1,107 +1,90 @@
 # Plan 3 — LLM Provider-Key Resolver
 
-A Craft sandbox calls LLM provider APIs (OpenAI, Anthropic, Gemini, OpenRouter, plus any
-tenant-configured custom endpoint) from `opencode serve`. Today the tenant's real provider keys
-ship inside the pod, written into `OPENCODE_CONFIG_CONTENT` by `_build_provider_block` as
-`provider.<name>.options.apiKey`. This plan moves those keys out of the pod: the pod ships
-non-empty placeholders, and the egress proxy injects the real per-tenant key — read fresh from
-`llm_provider` on each request — via an `LLMProviderKeyResolver` plugged into the
-[Plan 1](./01-framework.md) dispatcher. Independent of [Plan 2](./02-onyx-pat.md).
+A Craft sandbox calls LLM provider APIs (OpenAI, Anthropic, OpenRouter — the
+`BUILD_MODE_ALLOWED_PROVIDER_TYPES`) from `opencode serve`. The tenant's real
+provider key used to ship inside the pod, written into `OPENCODE_CONFIG_CONTENT`
+as `provider.<name>.options.apiKey`. This plan moves the key out: the pod ships
+a non-empty placeholder, and the egress proxy injects the real per-tenant key —
+read fresh from `llm_provider` on each request — via an `LLMProviderKeyResolver`
+plugged into the [Plan 1](./01-framework.md) dispatcher. Independent of
+[Plan 2](./02-onyx-pat.md).
 
 ## How it works
 
-**Hosts the resolver claims.** The four canonical provider hosts plus each tenant's configured
-`LLMProvider.api_base` host:
+**Hosts the resolver claims.** The canonical host of each build-mode provider
+type:
 
 | Provider | Canonical host | Header convention |
 |---|---|---|
 | OpenAI | `api.openai.com` | `Authorization: Bearer {key}` |
-| Anthropic | `api.anthropic.com` | `x-api-key: {key}` — leave `anthropic-version` intact |
-| Google Gemini | `generativelanguage.googleapis.com` | `x-goog-api-key: {key}` (defensively strip any `?key=` query param) |
+| Anthropic | `api.anthropic.com` | `x-api-key: {key}` — `anthropic-version` left intact |
 | OpenRouter | `openrouter.ai` | `Authorization: Bearer {key}` |
 
-**Row resolution.** Tenancy is per-PostgreSQL-schema; `llm_provider` has no `tenant_id` column,
-so the resolver opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and reads the
-tenant's rows directly. `llm_provider` has no uniqueness constraint on `provider`, so a tenant
-can have multiple rows of the same type. For canonical hosts the resolver calls
-`fetch_llm_provider_by_type_for_build_mode` (`build/db/build_session.py`), which prefers the
-`build-mode-{type}` row and falls back to any row of that type. For a custom-host match the
-resolver scans `fetch_all_build_mode_llm_providers` by `api_base`; that helper returns only rows
-whose `name` matches `build-mode-%`, so a tenant's custom endpoint is routed only when configured
-on a `build-mode-{type}` row. Both helpers return `LLMProviderView`, which decrypts `api_key`
-through `EncryptedString` in `LLMProviderView.from_model()`. The proxy decrypts in-process via
-the `ENCRYPTION_KEY_SECRET` Plan 1 wires into the Deployment.
+`claims()` matches `request.host` against this table; no DB session is opened.
 
-**Placeholder / overwrite.** Opencode's AI SDK refuses to send when `options.apiKey` is unset, so
-each provider block in `OPENCODE_CONFIG_CONTENT` ships a non-empty placeholder. The AI SDK turns
-that into the per-provider wire header; the proxy overwrites only the named header (set/replace).
-No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env vars are set in the pod. `baseURL` stays pointed at
-the real provider host — traffic already MITMs through the proxy, so host-matching stays simple.
+**Row resolution.** Tenancy is per-PostgreSQL-schema, so the resolver opens a
+session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`, loads the sandbox
+owner (`fetch_user_by_id`), and calls `fetch_all_supported_build_llm_providers`
+— the same access-scoped fetch provisioning uses. It then takes the first
+provider of the claimed type, matching how provisioning picks the key
+(`get_all_build_mode_llm_configs` dedups by type, first wins), so the injected
+key is the one the sandbox was provisioned with, decrypted in-process.
 
-**Streaming-safe, fail-closed.** Per Plan 1, injection runs at header time without touching the
-body or response, so SSE and long-running streams pass through untouched. A missing row,
-unrenderable header, or undecryptable key raises `CredentialUnavailableError`; the dispatcher
-serves `http_403(SandboxProxyError.CREDENTIAL_ERROR)`.
+**Placeholder / overwrite.** Opencode's AI SDK refuses to send when
+`options.apiKey` is unset, so K8s provisioning swaps each provider's real key
+for the shared proxy placeholder (`_PROXY_INJECTED_PLACEHOLDER`, the same
+sentinel `ONYX_PAT` ships) before building `opencode.json`; `provider`, `model`,
+and `api_base` are untouched so opencode still routes to the canonical host. The
+AI SDK renders the placeholder into the per-provider wire header; the proxy
+overwrites only the named header. No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` env
+vars are set in the pod.
 
-**No hot-reload in the pod.** `opencode serve` reads `OPENCODE_CONFIG_CONTENT` once at startup
-(sst/opencode#22213) and does not reload. The placeholder swap is a provisioning-time concern;
-the proxy still injects the *current* tenant key on every request, so a stale placeholder in a
-running pod is harmless. Key rotation takes effect on the next request, not the next pod.
+**Streaming-safe, fail-closed.** Per Plan 1, injection runs at header time
+without touching the body or response, so SSE and long-running streams pass
+through untouched. A missing user, no accessible provider of the type, or an
+unset key raises `CredentialUnavailableError`; the dispatcher serves
+`http_403(SandboxProxyError.CREDENTIAL_ERROR)`.
 
-**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend (Plan 1, "Kubernetes
-only"). The docker manager keeps writing real keys into the opencode config.
+**No hot-reload in the pod.** `opencode serve` reads its config once at startup
+(sst/opencode#22213), but the proxy injects the current tenant key on every
+request — so a stale placeholder in a running pod is harmless and key rotation
+takes effect on the next request, not the next pod.
 
-**Keys keep living in `llm_provider`.** No migration into the `ExternalApp` data model; no sync
-surface with the LLM-admin UI.
+**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend
+(Plan 1, "Kubernetes only"). The docker manager keeps writing real keys into the
+opencode config.
 
 ## Implementation
 
-1. **Emit placeholders in the opencode config** (K8s manager only). In `_build_provider_block` /
-   `build_multi_provider_opencode_config` (`opencode_config.py`), substitute the Plan 1
-   placeholder for each `options.apiKey` behind the LLM-key resolver flag. `model`,
-   `enabled_providers`, and the rest of each provider block are unchanged. The adjacent
-   `block["api"]` → `provider.<name>.options.baseURL` fix is owned by
-   [Plan 1](./01-framework.md) step 4 and lands atomically with this swap.
+1. **Swap keys for the placeholder at provision time** (K8s manager only).
+   Before `build_multi_provider_opencode_config`, replace each
+   `LLMProviderConfig.api_key` with `_PROXY_INJECTED_PLACEHOLDER`.
 
-2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver` Protocol.
-   - `claims(host, match)`: True iff `host` is one of the four canonical hosts or a
-     `build-mode-*` row's `api_base` host. A per-tenant `api_base` cache is populated lazily on
-     first claim and refreshed on provider-row updates.
-   - `resolve(request, ctx)`: opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`;
-     for a canonical host calls `fetch_llm_provider_by_type_for_build_mode`, for a custom host
-     scans `fetch_all_build_mode_llm_providers` by `api_base`; pulls the decrypted key off
-     `LLMProviderView.api_key` and renders the per-provider header; strips `?key=` on Gemini.
-     Raises `CredentialUnavailableError` if no row matches or `api_key is None`.
+2. **`LLMProviderKeyResolver`** implementing Plan 1's `CredentialResolver`
+   Protocol. `claims` matches `request.host` against the canonical-host table;
+   `resolve` opens the tenant session, loads the user, fetches the access-scoped
+   build providers, picks the first of the claimed type, and renders the
+   per-provider header from the decrypted key.
 
-3. **Register in `build_resolvers()`** (Plan 1 step 5) alongside `ExternalAppResolver` and
-   `OnyxPatResolver`. Hosts are disjoint; order is for clarity.
-
-4. **Config flag** independent of the PAT resolver, gating both the proxy-side resolver and the
-   pod-side placeholder swap atomically.
+3. **Register in `build_resolvers()`** alongside `OnyxPatResolver` and
+   `ExternalAppResolver`. Host-claim sets are disjoint; order is for clarity.
 
 ## Tests
 
-External-dependency unit tests (real Postgres for `llm_provider`; sandbox proxy under test;
-upstream HTTP mocked) in `backend/tests/external_dependency_unit/sandbox_proxy/`:
-
-- **One test per header convention.** OpenAI / OpenRouter → `Authorization: Bearer`; Anthropic →
-  `x-api-key` with `anthropic-version` preserved; Gemini → `x-goog-api-key` with `?key=` stripped.
-- **Custom `api_base`** — a tenant with `LLMProvider.api_base = https://llm.tenant.example/v1` on
-  a `build-mode-anthropic` row: the resolver claims that host and injects the right key.
-- **Build-mode naming required for custom hosts** — the same `api_base` on a non-`build-mode-*`
-  row is not claimed.
-- **Fail closed** — a canonical-host request from a tenant with no matching build-mode provider
-  raises `CredentialUnavailableError` → 403.
-- **Opencode config emits placeholder only** with the flag on, never a real key. Pin against the
-  spec (documented header conventions + the Plan 1 placeholder constant), not against the
-  resolver's own constants ([[feedback_tests_pin_spec_not_impl]]); a completeness check asserts
-  the header table is exhaustive over the configured provider set.
+- **Unit** (`tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py`): the
+  canonical-host claim rule, the per-provider header conventions (pinned against
+  the documented spec), first-of-type selection, the fail-closed cases, and a
+  completeness check that the host table covers every
+  `BUILD_MODE_ALLOWED_PROVIDER_TYPES`.
+- **External-dependency unit**
+  (`tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py`):
+  an access-scoped `llm_provider` row's key, stored encrypted, round-trips
+  through real `EncryptedString` onto its wire header for a request to its
+  canonical host.
 
 ## Out of scope
 
-- LLM admin UI changes — keys keep being managed through the existing LLM-provider settings.
-- Migrating `llm_provider` rows into the `ExternalApp` data model.
-- Per-user (rather than per-tenant) LLM keys.
-- Per-provider scoping or rotation; lifecycle is unchanged.
-- The matcher, gating semantics, or anything [Plan 1](./01-framework.md) /
-  [Plan 2](./02-onyx-pat.md) owns.
+- **Custom `api_base` hosts.** Build-mode providers default to `api_base=None`
+  (opencode uses the SDK's built-in base URL), so the canonical-host table
+  covers the standard case. A provider pointed at a custom gateway is not
+  claimed; supporting it would require a per-tenant host cache in `claims()`.


### PR DESCRIPTION
## Description

Final phase of Craft secrets-injection: rip the per-tenant **LLM provider key** out of the sandbox pod, following the egress-proxy pattern from the Onyx PAT phase (#11549).

The K8s sandbox used to ship the real key in `OPENCODE_CONFIG_CONTENT` (`provider.<name>.options.apiKey`). Now the pod ships a placeholder (the shared `_PROXY_INJECTED_PLACEHOLDER`) and a new `LLMProviderKeyResolver` injects the sandbox owner's real, access-scoped key on the wire, read fresh from `llm_provider` per request:

| Provider | Host | Header |
|---|---|---|
| OpenAI | `api.openai.com` | `Authorization: Bearer` |
| Anthropic | `api.anthropic.com` | `x-api-key` |
| OpenRouter | `openrouter.ai` | `Authorization: Bearer` |

Resolution reuses `fetch_all_supported_build_llm_providers` and picks the first provider of the claimed type, matching what provisioning keyed the sandbox with; missing/unset key fails closed (403).

**Scope:** Kubernetes-only; custom `api_base` hosts out of scope (providers default to `api_base=None`); no flag (Craft is beta).

## How Has This Been Tested?

- **Unit:** claim rule + header conventions pinned to a hardcoded spec, first-of-type selection, fail-closed branches; and that the provisioned opencode config carries placeholders, never a real key.
- **External-dependency unit:** an encrypted `llm_provider` key round-trips through real `EncryptedString` onto its wire header.
- `ruff`/`ty` clean; two rounds of multi-agent review applied.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
