### PR TITLE
fix(craft): keep chat column on-screen for long conversations

### DIFF
--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -27,7 +27,7 @@ interface BuildMessageListProps {
    * Scrollable container wrapping this list. Auto-scroll moves it directly
    * rather than via scrollIntoView, which scrolls every ancestor.
    */
-  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
   /**
    * Trailing content attached to the last assistant block — either the
    * in-progress streaming area (if visible) or the last saved assistant
@@ -55,7 +55,7 @@ export default function BuildMessageList({
   trailingAssistantSlot,
 }: BuildMessageListProps) {
   useEffect(() => {
-    const container = scrollContainerRef?.current;
+    const container = scrollContainerRef.current;
     if (autoScrollEnabled && container) {
       container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
     }

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { cn } from "@opal/utils";
 import Logo from "@/refresh-components/Logo";
 import TextChunk from "@/app/craft/components/TextChunk";
@@ -23,8 +23,11 @@ interface BuildMessageListProps {
   isStreaming?: boolean;
   /** Whether auto-scroll is enabled (user is at bottom) */
   autoScrollEnabled?: boolean;
-  /** Ref to the end marker div for scroll detection */
-  messagesEndRef?: React.RefObject<HTMLDivElement>;
+  /**
+   * Scrollable container wrapping this list. Auto-scroll moves it directly
+   * rather than via scrollIntoView, which scrolls every ancestor.
+   */
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
   /**
    * Trailing content attached to the last assistant block — either the
    * in-progress streaming area (if visible) or the last saved assistant
@@ -48,17 +51,20 @@ export default function BuildMessageList({
   streamItems,
   isStreaming = false,
   autoScrollEnabled = true,
-  messagesEndRef: externalMessagesEndRef,
+  scrollContainerRef,
   trailingAssistantSlot,
 }: BuildMessageListProps) {
-  const internalMessagesEndRef = useRef<HTMLDivElement>(null);
-  const messagesEndRef = externalMessagesEndRef ?? internalMessagesEndRef;
-
   useEffect(() => {
-    if (autoScrollEnabled && messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    const container = scrollContainerRef?.current;
+    if (autoScrollEnabled && container) {
+      container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
     }
-  }, [messages.length, streamItems.length, autoScrollEnabled, messagesEndRef]);
+  }, [
+    messages.length,
+    streamItems.length,
+    autoScrollEnabled,
+    scrollContainerRef,
+  ]);
 
   const hasStreamItems = streamItems.length > 0;
   const lastMessage = messages[messages.length - 1];
@@ -295,8 +301,6 @@ export default function BuildMessageList({
             </div>
           </div>
         )}
-
-        <div ref={messagesEndRef} />
       </div>
     </div>
   );

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -390,7 +390,9 @@ export default function BuildChatPanel({
         <div
           ref={scrollContainerRef}
           onScroll={handleScroll}
-          className="flex-1 overflow-auto"
+          // min-h-0 lets this flex child scroll internally instead of growing
+          // the column past the page bounds.
+          className="flex-1 min-h-0 overflow-auto"
         >
           {!hasSession && !existingSessionId ? (
             <BuildWelcome
@@ -404,6 +406,7 @@ export default function BuildChatPanel({
               streamItems={session?.streamItems ?? []}
               isStreaming={isRunning}
               autoScrollEnabled={isAtBottom}
+              scrollContainerRef={scrollContainerRef}
               trailingAssistantSlot={
                 <LiveApprovalsRegion
                   sessionId={sessionId ?? existingSessionId ?? null}

--- a/web/src/app/craft/v1/page.tsx
+++ b/web/src/app/craft/v1/page.tsx
@@ -27,7 +27,9 @@ export default function BuildV1Page() {
   useBuildSessionController({ existingSessionId: sessionId });
 
   return (
-    <div className="relative flex-1 h-full overflow-hidden">
+    // overflow-clip, not overflow-hidden: a hidden box is still programmatically
+    // scrollable, which would shove the chat column off-screen.
+    <div className="relative flex-1 h-full overflow-clip">
       {/* Chat panel - always full width for background */}
       <BuildChatPanel existingSessionId={sessionId} />
 


### PR DESCRIPTION
## Description
<img width="2258" height="1282" alt="image" src="https://github.com/user-attachments/assets/9893ad63-625a-4f2c-8dd9-25991d54f180" />

Long assistant messages on `craft/v1` shoved the chat column off the top of the viewport on load (input bar near the top, empty space below). Cause: `BuildMessageList`'s `scrollIntoView` auto-scroll scrolled the `overflow-hidden` page wrapper — which is still programmatically scrollable — pushing the whole column off-screen.

Fix:
- `page.tsx`: `overflow-hidden` → `overflow-clip` (can't be programmatically scrolled).
- `ChatPanel.tsx`: add `min-h-0` so the messages container scrolls internally.
- `BuildMessageList.tsx`: scroll the container directly instead of `scrollIntoView`.

## How Has This Been Tested?

`tsc`, `oxfmt`, `oxlint`, and pre-commit all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
