### PR TITLE
refactor(chat): extract shared queued-message navigation hook

### DIFF
--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -13,6 +13,15 @@ export interface QueuedMessage {
   text: string;
 }
 
+/**
+ * Maximum number of messages that can be queued while a response streams.
+ * Shared by both the main chat and Craft input bars / stores.
+ */
+export const MAX_QUEUED_MESSAGES = 5;
+
+/** Stable empty reference for selectors/props; `readonly` guards the singleton. */
+export const EMPTY_QUEUED_MESSAGES: readonly QueuedMessage[] = [];
+
 export type ChatState =
   | "input"
   | "loading"

--- a/web/src/hooks/useQueuedMessageNavigation.ts
+++ b/web/src/hooks/useQueuedMessageNavigation.ts
@@ -1,0 +1,132 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type Dispatch,
+  type KeyboardEvent,
+  type SetStateAction,
+} from "react";
+import { QueuedMessage } from "@/app/app/interfaces";
+
+interface UseQueuedMessageNavigationParams {
+  /** The messages currently queued for the active session. */
+  messages: readonly QueuedMessage[];
+  /**
+   * Whether the text input is empty. Up-arrow only enters navigation mode
+   * when there is no text to move the caret within.
+   */
+  inputIsEmpty: boolean;
+  /** Remove the queued message at `index`. */
+  onRemove: (index: number) => void;
+  /** Pull a queued message's text back into the input for editing. */
+  onEdit: (text: string) => void;
+}
+
+export interface QueuedMessageNavigation {
+  /** Index of the queued message focused for keyboard editing, or null. */
+  highlightedIndex: number | null;
+  setHighlightedIndex: Dispatch<SetStateAction<number | null>>;
+  /**
+   * Handle a keydown for queue navigation. Returns true if the event was
+   * consumed (the caller should stop processing it). Returns false when the
+   * key should fall through to normal input handling — including the case
+   * where an arbitrary key exits navigation mode and types as usual.
+   */
+  handleKeyDown: (event: KeyboardEvent<HTMLDivElement>) => boolean;
+}
+
+/**
+ * Keyboard navigation for the queued-message bar, shared by the main chat and
+ * Craft input bars. Owns the highlight state and translates key presses into
+ * remove / edit / navigate actions, leaving the store wiring to the caller.
+ *
+ * Behavior:
+ * - ↑ on an empty input enters navigation mode at the last queued message.
+ * - In navigation mode: ↑/↓ move (↓ past the end exits), Enter edits (pulls
+ *   the message into the input), Delete/Backspace removes (staying in
+ *   navigation mode so items can be pruned in a row), Escape exits.
+ * - Any other key exits navigation mode and falls through so it types.
+ */
+export function useQueuedMessageNavigation({
+  messages,
+  inputIsEmpty,
+  onRemove,
+  onEdit,
+}: UseQueuedMessageNavigationParams): QueuedMessageNavigation {
+  const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null);
+
+  // Keep the highlight in range as the queue shrinks (auto-send or prune),
+  // and clear it once the queue empties.
+  useEffect(() => {
+    setHighlightedIndex((prev) => {
+      if (prev === null) return null;
+      if (messages.length === 0) return null;
+      return Math.min(prev, messages.length - 1);
+    });
+  }, [messages.length]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>): boolean => {
+      // Navigation mode: keys act on the highlighted queued message.
+      if (highlightedIndex !== null) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          const queued = messages[highlightedIndex];
+          if (queued) {
+            onRemove(highlightedIndex);
+            onEdit(queued.text);
+          }
+          setHighlightedIndex(null);
+          return true;
+        }
+        if (event.key === "ArrowUp") {
+          event.preventDefault();
+          setHighlightedIndex((prev) => Math.max((prev ?? 0) - 1, 0));
+          return true;
+        }
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          setHighlightedIndex((prev) => {
+            const next = (prev ?? 0) + 1;
+            return next >= messages.length ? null : next;
+          });
+          return true;
+        }
+        if (event.key === "Delete" || event.key === "Backspace") {
+          event.preventDefault();
+          // Stay in nav mode (clamp effect re-points the index) to prune in a row.
+          onRemove(highlightedIndex);
+          return true;
+        }
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setHighlightedIndex(null);
+          return true;
+        }
+        if (
+          event.key === "Shift" ||
+          event.key === "Alt" ||
+          event.key === "Control" ||
+          event.key === "Meta" ||
+          event.key === "Tab"
+        ) {
+          return true;
+        }
+        // Any other key exits navigation mode and falls through to type.
+        setHighlightedIndex(null);
+      }
+
+      // Up arrow on an empty input enters navigation mode.
+      if (event.key === "ArrowUp" && inputIsEmpty && messages.length > 0) {
+        event.preventDefault();
+        setHighlightedIndex(messages.length - 1);
+        return true;
+      }
+
+      return false;
+    },
+    [highlightedIndex, messages, inputIsEmpty, onRemove, onEdit]
+  );
+
+  return { highlightedIndex, setHighlightedIndex, handleKeyDown };
+}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -17,7 +17,8 @@ import { useContentEditable } from "@/hooks/useContentEditable";
 import useFilter from "@/hooks/useFilter";
 import useCCPairs from "@/hooks/useCCPairs";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
-import { ChatState } from "@/app/app/interfaces";
+import { ChatState, MAX_QUEUED_MESSAGES } from "@/app/app/interfaces";
+import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
 import { useForcedTools } from "@/lib/hooks/useForcedTools";
 import useAppFocus from "@/hooks/useAppFocus";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
@@ -141,9 +142,6 @@ const AppInputBar = React.memo(
     const removeCurrentQueuedMessage = useChatSessionStore(
       (state) => state.removeCurrentQueuedMessage
     );
-    const [highlightedQueueIndex, setHighlightedQueueIndex] = useState<
-      number | null
-    >(null);
     const { user, isAdmin } = useUser();
     const isAutoSending = useRef(false);
     const inputWrapperRef = useRef<HTMLDivElement>(null);
@@ -169,6 +167,15 @@ const AppInputBar = React.memo(
       initialContent: initialMessage,
       wrapperRef: inputWrapperRef,
       pasteTilesEnabled: user?.preferences?.paste_as_tile ?? false,
+    });
+
+    // Keyboard navigation + highlight state for the queued-message bar
+    // (shared with the Craft input bar).
+    const queueNav = useQueuedMessageNavigation({
+      messages: queuedMessages,
+      inputIsEmpty: !message,
+      onRemove: removeCurrentQueuedMessage,
+      onEdit: setMessage,
     });
 
     const filesWrapperRef = useRef<HTMLDivElement>(null);
@@ -341,14 +348,6 @@ const AppInputBar = React.memo(
       stopTTS,
       onSubmit,
     ]);
-
-    useEffect(() => {
-      setHighlightedQueueIndex((prev) => {
-        if (prev === null) return null;
-        if (queuedMessages.length === 0) return null;
-        return Math.min(prev, queuedMessages.length - 1);
-      });
-    }, [queuedMessages]);
 
     // Animate attached files wrapper to its content height so CSS transitions
     // can interpolate between concrete pixel values (0px ↔ Npx).
@@ -722,7 +721,7 @@ const AppInputBar = React.memo(
               const canSubmitNormally =
                 chatState === "input" && !awaitingPreferredSelection;
               if (!canSubmitNormally && message.trim()) {
-                if (queuedMessages.length < 5) {
+                if (queuedMessages.length < MAX_QUEUED_MESSAGES) {
                   enqueueCurrentMessage(message.trim());
                   clearMessage();
                 }
@@ -744,10 +743,10 @@ const AppInputBar = React.memo(
       <>
         <QueuedMessageBar
           messages={queuedMessages}
-          highlightedIndex={highlightedQueueIndex}
+          highlightedIndex={queueNav.highlightedIndex}
           awaitingPreferredSelection={awaitingPreferredSelection}
           onDiscard={removeCurrentQueuedMessage}
-          onHighlight={setHighlightedQueueIndex}
+          onHighlight={queueNav.setHighlightedIndex}
         />
         <Disabled disabled={disabled} allowClick>
           <div
@@ -840,7 +839,7 @@ const AppInputBar = React.memo(
                       onCut={handleCut}
                       onMouseDown={handleTileMouseDown}
                       onClick={handleTileClick}
-                      onBlur={() => setHighlightedQueueIndex(null)}
+                      onBlur={() => queueNav.setHighlightedIndex(null)}
                       onKeyDownCapture={handleKeyDownForPromptShortcuts}
                       onInput={handleContentEditableInput}
                       onCompositionStart={handleCompositionStart}
@@ -868,72 +867,7 @@ const AppInputBar = React.memo(
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
                         if (handleTileKeyDown(event)) return;
-
-                        // Queue navigation mode
-                        if (highlightedQueueIndex !== null) {
-                          if (event.key === "Enter") {
-                            event.preventDefault();
-                            const text =
-                              queuedMessages[highlightedQueueIndex]!.text;
-                            removeCurrentQueuedMessage(highlightedQueueIndex);
-                            setMessage(text);
-                            setHighlightedQueueIndex(null);
-                            return;
-                          }
-                          if (event.key === "ArrowUp") {
-                            event.preventDefault();
-                            setHighlightedQueueIndex((prev) =>
-                              Math.max((prev ?? 0) - 1, 0)
-                            );
-                            return;
-                          }
-                          if (event.key === "ArrowDown") {
-                            event.preventDefault();
-                            setHighlightedQueueIndex((prev) => {
-                              const next = (prev ?? 0) + 1;
-                              if (next >= queuedMessages.length) {
-                                return null; // exit navigation mode
-                              }
-                              return next;
-                            });
-                            return;
-                          }
-                          if (
-                            event.key === "Delete" ||
-                            event.key === "Backspace"
-                          ) {
-                            event.preventDefault();
-                            removeCurrentQueuedMessage(highlightedQueueIndex);
-                            return;
-                          }
-                          if (event.key === "Escape") {
-                            event.preventDefault();
-                            setHighlightedQueueIndex(null);
-                            return;
-                          }
-                          if (
-                            event.key === "Shift" ||
-                            event.key === "Alt" ||
-                            event.key === "Control" ||
-                            event.key === "Meta" ||
-                            event.key === "Tab"
-                          ) {
-                            return;
-                          }
-                          // Any other key: exit navigation mode, let keypress proceed
-                          setHighlightedQueueIndex(null);
-                        }
-
-                        // Up arrow to enter navigation mode
-                        if (
-                          event.key === "ArrowUp" &&
-                          !message &&
-                          queuedMessages.length > 0
-                        ) {
-                          event.preventDefault();
-                          setHighlightedQueueIndex(queuedMessages.length - 1);
-                          return;
-                        }
+                        if (queueNav.handleKeyDown(event)) return;
 
                         // Enter to submit or queue (Shift+Enter falls through to browser default: inserts <br>)
                         if (
@@ -960,7 +894,7 @@ const AppInputBar = React.memo(
                             !disabled &&
                             !isClassifying &&
                             !hasUploadingFiles &&
-                            queuedMessages.length < 5
+                            queuedMessages.length < MAX_QUEUED_MESSAGES
                           ) {
                             enqueueCurrentMessage(message.trim());
                             clearMessage();


### PR DESCRIPTION
## Description

First of a 3-PR stack. Pure refactor, no behavior change: pulls the queued-message keyboard navigation out of the main chat input bar into a reusable, store-agnostic hook so the Craft input can reuse it (next PR).

- New `useQueuedMessageNavigation` hook (`web/src/hooks/`) — owns highlight state, a `handleKeyDown` that reports whether it consumed the event, and the index-clamp effect. Takes `onRemove`/`onEdit` callbacks, so it's store-agnostic.
- New `MAX_QUEUED_MESSAGES` / `EMPTY_QUEUED_MESSAGES` constants in `interfaces.ts`.
- `AppInputBar.tsx` now uses the hook + constant, dropping ~50 lines of inline logic. Navigation behavior is unchanged.

## How Has This Been Tested?

- `tsc --noEmit`: 0 errors; `oxlint` clean; `oxfmt` applied.
- No new tests — pure refactor, covered by the existing main-chat queue flow.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared queued‑message keyboard navigation hook to remove duplicate input logic and keep behavior consistent across the main chat and Craft input bars. Centralizes queue limits and simplifies key handling with no UX changes.

- **Refactors**
  - Added `useQueuedMessageNavigation` to manage highlight state and handle ArrowUp/Down, Enter, Backspace/Delete, Escape, and fallthrough typing.
  - Replaced inline logic in `AppInputBar` with the hook; routed blur and `onKeyDown` to `queueNav`.
  - Introduced `MAX_QUEUED_MESSAGES` and `EMPTY_QUEUED_MESSAGES`; replaced hardcoded `5` in queue checks.
  - Removed local state/effects tied to queue navigation.

<sup>Written for commit 87f55f6a8bc220213546223ae8ca5d6ec6f1490a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

