### PR TITLE
feat(craft): queue messages sent while a response is streaming

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -14,6 +14,7 @@ import {
   useIsPreProvisioning,
   useIsPreProvisioningFailed,
   usePreProvisionedSessionId,
+  useQueuedMessages,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { useBuildStreaming } from "@/app/craft/hooks/useBuildStreaming";
 import { useUsageLimits } from "@/app/craft/hooks/useUsageLimits";
@@ -110,6 +111,11 @@ export default function BuildChatPanel({
     (state) => state.nameBuildSession
   );
   const { streamMessage } = useBuildStreaming();
+  const queuedMessages = useQueuedMessages();
+  const enqueueMessage = useBuildSessionStore((state) => state.enqueueMessage);
+  const removeQueuedMessage = useBuildSessionStore(
+    (state) => state.removeQueuedMessage
+  );
   const isPreProvisioning = useIsPreProvisioning();
   const isPreProvisioningFailed = useIsPreProvisioningFailed();
   const preProvisionedSessionId = usePreProvisionedSessionId();
@@ -339,6 +345,61 @@ export default function BuildChatPanel({
     ]
   );
 
+  const handleQueueMessage = useCallback(
+    (text: string) => {
+      if (sessionId) enqueueMessage(sessionId, text);
+    },
+    [sessionId, enqueueMessage]
+  );
+
+  const handleRemoveQueuedMessage = useCallback(
+    (index: number) => {
+      if (sessionId) removeQueuedMessage(sessionId, index);
+    },
+    [sessionId, removeQueuedMessage]
+  );
+
+  // Auto-send the next queued message FIFO after a run cleanly succeeds (each
+  // send re-arms this for the message after). Only fire on a clean completion
+  // and when the send is actually eligible — otherwise we'd dequeue a message
+  // that a failed/rate-limited run never sends, silently dropping it. The
+  // sessionId guard avoids mistaking a session switch for a run completion.
+  const sessionStatus = session?.status;
+  const sessionError = session?.error;
+  const isLimited = limits?.isLimited ?? false;
+  const prevIsRunningRef = useRef(isRunning);
+  const prevSessionIdRef = useRef(sessionId);
+  useEffect(() => {
+    const wasRunning = prevIsRunningRef.current;
+    const prevSessionId = prevSessionIdRef.current;
+    prevIsRunningRef.current = isRunning;
+    prevSessionIdRef.current = sessionId;
+
+    const runSucceeded =
+      wasRunning &&
+      !isRunning &&
+      sessionId === prevSessionId &&
+      sessionStatus === "active" &&
+      !sessionError &&
+      !isLimited;
+    if (runSucceeded && sessionId && queuedMessages.length > 0) {
+      const next = queuedMessages[0];
+      if (next) {
+        removeQueuedMessage(sessionId, 0);
+        void handleSubmit(next.text, []);
+      }
+    }
+  }, [
+    isRunning,
+    sessionId,
+    sessionStatus,
+    sessionError,
+    isLimited,
+    queuedMessages,
+    handleSubmit,
+    removeQueuedMessage,
+  ]);
+
   return (
     <div className="h-full w-full">
       <UpgradePlanModal
@@ -451,6 +512,9 @@ export default function BuildChatPanel({
                 onSubmit={handleSubmit}
                 isRunning={isRunning}
                 placeholder="Continue the conversation..."
+                queuedMessages={queuedMessages}
+                onQueueMessage={handleQueueMessage}
+                onRemoveQueuedMessage={handleRemoveQueuedMessage}
               />
             </div>
           </div>

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -41,6 +41,13 @@ import { useUser } from "@/providers/UserProvider";
 import useUserSkills from "@/hooks/useUserSkills";
 import { detectSlashTrigger, toPickerSkills } from "@/lib/skills/picker";
 import { getTextContent } from "@/lib/contentEditable";
+import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
+import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
+import {
+  QueuedMessage,
+  MAX_QUEUED_MESSAGES,
+  EMPTY_QUEUED_MESSAGES,
+} from "@/app/app/interfaces";
 
 export interface InputBarHandle {
   reset: () => void;
@@ -55,6 +62,10 @@ export interface InputBarProps {
   placeholder?: string;
   sandboxInitializing?: boolean;
   noBottomRounding?: boolean;
+  /** Queued messages + callbacks; when wired, submitting mid-stream enqueues. */
+  queuedMessages?: readonly QueuedMessage[];
+  onQueueMessage?: (text: string) => void;
+  onRemoveQueuedMessage?: (index: number) => void;
 }
 
 /**
@@ -152,9 +163,15 @@ const InputBar = memo(
         placeholder = "Describe your task...",
         sandboxInitializing = false,
         noBottomRounding = false,
+        queuedMessages,
+        onQueueMessage,
+        onRemoveQueuedMessage,
       },
       ref
     ) => {
+      // Queueing is enabled only when the parent wires up the callbacks.
+      const queueEnabled = !!onQueueMessage;
+      const queue = queuedMessages ?? EMPTY_QUEUED_MESSAGES;
       const { user } = useUser();
       const inputWrapperRef = useRef<HTMLDivElement>(null);
       const {
@@ -205,6 +222,14 @@ const InputBar = memo(
         query: string;
         slashIndex: number;
       }>({ open: false, anchorRect: null, query: "", slashIndex: -1 });
+
+      // Shared queued-message keyboard navigation + highlight state.
+      const queueNav = useQueuedMessageNavigation({
+        messages: queue,
+        inputIsEmpty: !message,
+        onRemove: (index) => onRemoveQueuedMessage?.(index),
+        onEdit: setMessage,
+      });
 
       const getTextBeforeCursor = useCallback((): string | null => {
         const el = inputRef.current;
@@ -338,14 +363,23 @@ const InputBar = memo(
       );
 
       const handleSubmit = useCallback(() => {
-        if (disabled || isRunning || hasUploadingFiles || sandboxInitializing)
+        // File uploads / sandbox init are hard blockers regardless of queueing.
+        if (disabled || hasUploadingFiles || sandboxInitializing) return;
+
+        const text = message.trim();
+
+        // While streaming, queue the message; the parent auto-sends it later.
+        if (isRunning) {
+          if (onQueueMessage && text && queue.length < MAX_QUEUED_MESSAGES) {
+            onQueueMessage(text);
+            clearMessage();
+          }
           return;
+        }
 
-        const hasMessage = message.trim().length > 0;
         const hasFiles = currentMessageFiles.length > 0;
-
-        if (hasMessage) {
-          onSubmit(message.trim(), currentMessageFiles);
+        if (text) {
+          onSubmit(text, currentMessageFiles);
           clearMessage();
           clearFiles({ suppressRefetch: true });
         } else if (hasFiles) {
@@ -358,6 +392,8 @@ const InputBar = memo(
         hasUploadingFiles,
         sandboxInitializing,
         onSubmit,
+        onQueueMessage,
+        queue,
         currentMessageFiles,
         clearFiles,
         clearMessage,
@@ -366,6 +402,7 @@ const InputBar = memo(
       const handleKeyDown = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {
           if (handleTileKeyDown(event)) return;
+          if (queueEnabled && queueNav.handleKeyDown(event)) return;
 
           // Shift+Enter falls through to browser default: inserts <br>
           if (
@@ -377,18 +414,27 @@ const InputBar = memo(
             handleSubmit();
           }
         },
-        [handleSubmit, handleTileKeyDown]
+        [handleSubmit, handleTileKeyDown, queueEnabled, queueNav]
       );
 
       const canSubmit =
         message.trim().length > 0 &&
         !disabled &&
-        !isRunning &&
         !hasUploadingFiles &&
-        !sandboxInitializing;
+        !sandboxInitializing &&
+        (!isRunning || (queueEnabled && queue.length < MAX_QUEUED_MESSAGES));
 
       return (
         <Disabled disabled={disabled}>
+          {queueEnabled && (
+            <QueuedMessageBar
+              messages={queue}
+              highlightedIndex={queueNav.highlightedIndex}
+              awaitingPreferredSelection={false}
+              onDiscard={(index) => onRemoveQueuedMessage?.(index)}
+              onHighlight={queueNav.setHighlightedIndex}
+            />
+          )}
           <div
             ref={containerRef}
             className={cn(
@@ -431,6 +477,7 @@ const InputBar = memo(
                 onKeyDown={handleKeyDown}
                 onKeyUp={handleSelectionChange}
                 onMouseUp={handleSelectionChange}
+                onBlur={() => queueNav.setHighlightedIndex(null)}
                 className={cn(
                   "w-full",
                   "h-full",
@@ -455,7 +502,11 @@ const InputBar = memo(
                 aria-multiline={true}
                 aria-disabled={disabled}
                 aria-placeholder={placeholder}
-                data-placeholder={placeholder}
+                data-placeholder={
+                  !message && queueEnabled && queue.length > 0
+                    ? "Press up to edit queued messages"
+                    : placeholder
+                }
                 data-empty={!message ? "" : undefined}
                 onCopy={handleCopy}
                 onCut={handleCut}

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -23,6 +23,12 @@ import {
 } from "@/app/craft/types/displayTypes";
 
 import {
+  QueuedMessage,
+  MAX_QUEUED_MESSAGES,
+  EMPTY_QUEUED_MESSAGES,
+} from "@/app/app/interfaces";
+
+import {
   createSession as apiCreateSession,
   fetchSession,
   fetchSessionHistory,
@@ -259,6 +265,9 @@ export type PreProvisioningState =
 // Module-level variable to store the provisioning promise (not in Zustand state for serializability)
 let provisioningPromise: Promise<string | null> | null = null;
 
+// Monotonic id for queued messages (kept out of Zustand state for simplicity).
+let nextQueuedMessageId = 1;
+
 /** File preview tab data */
 export interface FilePreviewTab {
   path: string;
@@ -300,6 +309,11 @@ export interface BuildSessionData {
    * Rendered directly without transformation.
    */
   streamItems: StreamItem[];
+  /**
+   * Messages typed while a response is streaming. Auto-sent FIFO once the
+   * current run finishes (see the auto-send effect in BuildChatPanel).
+   */
+  queuedMessages: QueuedMessage[];
   error: string | null;
   webappUrl: string | null;
   /** Sandbox info from backend */
@@ -412,6 +426,10 @@ interface BuildSessionStore {
   ) => void;
   clearStreamItems: (sessionId: string) => void;
 
+  // Actions - Queued Messages
+  enqueueMessage: (sessionId: string, text: string) => void;
+  removeQueuedMessage: (sessionId: string, index: number) => void;
+
   // Actions - Abort Control
   setAbortController: (sessionId: string, controller: AbortController) => void;
   abortSession: (sessionId: string) => void;
@@ -481,6 +499,7 @@ const createInitialSessionData = (
   artifacts: [],
   toolCalls: [],
   streamItems: [],
+  queuedMessages: [],
   error: null,
   webappUrl: null,
   sandbox: null,
@@ -1059,6 +1078,45 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const updatedSession: BuildSessionData = {
         ...session,
         streamItems: [],
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  // ===========================================================================
+  // Queued Messages
+  // ===========================================================================
+
+  enqueueMessage: (sessionId: string, text: string) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session || session.queuedMessages.length >= MAX_QUEUED_MESSAGES) {
+        return state;
+      }
+      const updatedSession: BuildSessionData = {
+        ...session,
+        queuedMessages: [
+          ...session.queuedMessages,
+          { id: nextQueuedMessageId++, text },
+        ],
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  removeQueuedMessage: (sessionId: string, index: number) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+      const updatedSession: BuildSessionData = {
+        ...session,
+        queuedMessages: session.queuedMessages.filter((_, i) => i !== index),
         lastAccessed: new Date(),
       };
       const newSessions = new Map(state.sessions);
@@ -2025,6 +2083,16 @@ export const useStreamItems = () =>
     const { currentSessionId, sessions } = state;
     if (!currentSessionId) return EMPTY_ARRAY;
     return sessions.get(currentSessionId)?.streamItems ?? EMPTY_ARRAY;
+  });
+
+// Queued messages selector
+export const useQueuedMessages = () =>
+  useBuildSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    if (!currentSessionId) return EMPTY_QUEUED_MESSAGES;
+    return (
+      sessions.get(currentSessionId)?.queuedMessages ?? EMPTY_QUEUED_MESSAGES
+    );
   });
 
 // Webapp refresh selector

--- a/web/src/sections/input/QueuedMessageBar.tsx
+++ b/web/src/sections/input/QueuedMessageBar.tsx
@@ -4,7 +4,7 @@ import { cn } from "@opal/utils";
 import { QueuedMessage } from "@/app/app/interfaces";
 
 interface QueuedMessageBarProps {
-  messages: QueuedMessage[];
+  messages: readonly QueuedMessage[];
   highlightedIndex: number | null;
   awaitingPreferredSelection: boolean;
   onDiscard: (index: number) => void;


### PR DESCRIPTION
## Description

Adds **queued messages** to the Craft input bar. Submitting while a response streams used to be a no-op; now the message is queued (shown as a pill above the input) and auto-sent FIFO when the run finishes. Builds on the shared hook/constants from the previous PR.

- **Store** (`useBuildSessionStore.ts`) — per-session `queuedMessages`, `enqueueMessage`/`removeQueuedMessage` (immutable Map-copy pattern), `useQueuedMessages` selector; cap of 5.
- **`InputBar.tsx`** — optional queue props; submit-while-streaming enqueues instead of no-op; renders the reused `QueuedMessageBar` and the shared nav hook.
- **`ChatPanel.tsx`** — auto-send effect, fired once per completed run via the `isRunning` running→idle transition (with a session-switch guard).

UX: ↑ from an empty input highlights a pill; ↑/↓ navigate, Enter edits, Delete/Backspace removes, Esc exits.

Note: the queue is text-only — attached files stay in the input rather than being sent with a queued message (matches main chat).

## How Has This Been Tested?

- `tsc --noEmit`: 0 errors; `oxlint` clean; `oxfmt` applied.
- Exercised by the Storybook story added in the next PR. No new automated tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queue messages submitted while a response is streaming and auto-send them FIFO after a clean run completes. This prevents dropped messages and keeps the chat responsive during long generations.

- **New Features**
  - Per-session `queuedMessages` in `useBuildSessionStore` with `enqueueMessage`/`removeQueuedMessage` and `useQueuedMessages` (capped by `MAX_QUEUED_MESSAGES`).
  - `InputBar` enqueues text on submit while streaming, renders `QueuedMessageBar`, supports keyboard edit/remove via `useQueuedMessageNavigation`, and shows a helpful placeholder; queueing is enabled only when `onQueueMessage` is wired; files are not queued.
  - `BuildChatPanel` wires queue props and auto-sends the next message FIFO only after a clean run completion (no error, not rate-limited, same `sessionId`) to avoid silent drops.

<sup>Written for commit 130a3ae0cf2349e39a8ee0ce12aa02081306f7f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

