### PR TITLE
refactor(craft): Remove DBSessionFactory pattern

### DIFF
--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -2,9 +2,7 @@ import os
 import re
 import threading
 import time
-from collections.abc import Callable
 from collections.abc import Generator
-from contextlib import AbstractContextManager
 from contextlib import contextmanager
 from typing import Any
 
@@ -439,10 +437,6 @@ def _safe_close_session(session: Session) -> None:
         logger.warning(
             "DB connection lost during session cleanup — the connection will be invalidated and recycled by the pool."
         )
-
-
-# Canonical type for a tenant-id -> tenant-scoped DB session context manager
-DBSessionFactory = Callable[[str], AbstractContextManager[Session]]
 
 
 @contextmanager

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -15,7 +15,7 @@ from redis.exceptions import RedisError
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import DBSessionFactory
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.external_app import delete_external_app_user_credential
 from onyx.db.external_app import get_external_app_by_id
 from onyx.db.external_app import get_external_app_user_credential
@@ -43,7 +43,6 @@ _RefreshInputs = tuple[OAuthExternalAppProvider, dict[str, Any], str, str]
 
 
 def ensure_fresh_credentials(
-    db_session_factory: DBSessionFactory,
     tenant_id: str,
     external_app_id: int,
     user_id: UUID,
@@ -60,7 +59,7 @@ def ensure_fresh_credentials(
     try:
         # Cheap pre-check: just the staleness decision (one cred read), no provider
         # or client-cred resolution — those happen under the lock, only when stale.
-        with db_session_factory(tenant_id) as db:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
             stored = _read_stored_credentials(db, external_app_id, user_id)
         if stored is None or not needs_refresh(stored, datetime.now(timezone.utc)):
             return
@@ -71,7 +70,7 @@ def ensure_fresh_credentials(
             wait_for_lock_s=_LOCK_WAIT_S,
             logger=logger,
         ):
-            _refresh_under_lock(db_session_factory, tenant_id, external_app_id, user_id)
+            _refresh_under_lock(tenant_id, external_app_id, user_id)
     except RedisSharedLockAcquisitionError:
         # Lock winner is refreshing; proceed with the current token.
         logger.info(
@@ -90,14 +89,13 @@ def ensure_fresh_credentials(
 
 
 def _refresh_under_lock(
-    db_session_factory: DBSessionFactory,
     tenant_id: str,
     external_app_id: int,
     user_id: UUID,
 ) -> None:
     # Re-read in a fresh session — double-check after the lock wait, in case a
     # concurrent process already refreshed — then release before the POST.
-    with db_session_factory(tenant_id) as db:
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
         inputs = _load_refresh_inputs(db, external_app_id, user_id)
     if inputs is None:
         return
@@ -116,7 +114,7 @@ def _refresh_under_lock(
         return
     except TokenRefreshTerminalError as exc:
         # Dead grant: drop the credential so the app reads as disconnected.
-        with db_session_factory(tenant_id) as db:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
             delete_external_app_user_credential(
                 db, external_app_id=external_app_id, user_id=user_id
             )
@@ -128,7 +126,7 @@ def _refresh_under_lock(
         )
         return
 
-    with db_session_factory(tenant_id) as db:
+    with get_session_with_tenant(tenant_id=tenant_id) as db:
         upsert_external_app_user_credential(
             db,
             external_app_id=external_app_id,

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -14,7 +14,7 @@ from urllib.parse import parse_qs
 
 from mitmproxy import http
 
-from onyx.db.engine.sql_engine import DBSessionFactory
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.external_app import get_external_apps
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import match_action
@@ -63,11 +63,8 @@ class ExternalAppActionMatcher(ActionMatcher):
     the pre-written ``match_action`` for the policy verdict.
     """
 
-    def __init__(self, db_session_factory: DBSessionFactory) -> None:
-        self._db_session_factory = db_session_factory
-
     def match(self, request: http.Request, tenant_id: str) -> RequestMatch | None:
-        with self._db_session_factory(tenant_id) as db:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
             apps = get_external_apps(db)
             app = resolve_app_for_url(request.url, apps)
             if app is None:

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -16,7 +16,7 @@ from mitmproxy import http
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
 from onyx.configs.constants import NotificationType
-from onyx.db.engine.sql_engine import DBSessionFactory
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
@@ -94,7 +94,6 @@ class GateAddon:
         self,
         identity: _IdentityResolver,
         action_matcher: ActionMatcher,
-        db_session_factory: DBSessionFactory,
         cache_factory: CacheFactory,
         proxy_instance_id: str,
         credential_dispatcher: CredentialInjectionDispatcher,
@@ -103,7 +102,6 @@ class GateAddon:
     ) -> None:
         self._identity = identity
         self._action_matcher = action_matcher
-        self._db_session_factory = db_session_factory
         self._cache_factory = cache_factory
         self._proxy_instance_id = proxy_instance_id
         self._credential_dispatcher = credential_dispatcher
@@ -389,7 +387,7 @@ class GateAddon:
         card on the next `/live` refetch, so we don't fail the request.
         """
         actions_payload = [a.model_dump(mode="json") for a in match.actions]
-        with self._db_session_factory(ctx.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             row = action_approval.insert_action_approval(
                 db,
                 session_id=ctx.session_id,
@@ -493,7 +491,7 @@ class GateAddon:
         """Conditionally claim EXPIRED; if the API already wrote a decision,
         return that winner instead so the caller forwards/rejects correctly.
         """
-        with self._db_session_factory(tenant_id) as db:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
             claimed = action_approval.try_record_decision(
                 db,
                 approval_id=approval_id,
@@ -539,7 +537,6 @@ class GateAddon:
             InjectionContext(
                 sandbox=sandbox,
                 match=match,
-                db_session_factory=self._db_session_factory,
             ),
         )
 
@@ -638,7 +635,7 @@ class GateAddon:
         Body carries no PII; the full payload lives on the action_approval
         row, which the popover fetches when the chat loads.
         """
-        with self._db_session_factory(ctx.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             create_notification(
                 user_id=ctx.user_id,
                 notif_type=NotificationType.APPROVAL_REQUESTED,

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -21,7 +21,6 @@ from mitmproxy import http
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
-from onyx.sandbox_proxy.identity import DBSessionFactory
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.utils.logger import setup_logger
 
@@ -43,7 +42,6 @@ class InjectionContext:
 
     sandbox: ResolvedSandbox
     match: RequestMatch | None
-    db_session_factory: DBSessionFactory
 
 
 class CredentialResolver(Protocol):

--- a/backend/onyx/sandbox_proxy/identity.py
+++ b/backend/onyx/sandbox_proxy/identity.py
@@ -14,15 +14,12 @@ with no verifiable session tag fails closed rather than routing to a
 guessed session.
 """
 
-from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import DBSessionFactory
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
@@ -100,26 +97,9 @@ class SandboxIPLookup(Protocol):
     def stop(self) -> None: ...
 
 
-def default_session_factory(tenant_id: str) -> AbstractContextManager[Session]:
-    """tenant_id -> a tenant-scoped DB session context manager. The single
-    production factory: the gate (approval-row writes), the action matcher (app
-    + policy reads), and ``IdentityResolver`` all share it so they resolve the
-    same tenant schema."""
-    return get_session_with_tenant(tenant_id=tenant_id)
-
-
 class IdentityResolver:
-    def __init__(
-        self,
-        ip_lookup: SandboxIPLookup,
-        db_session_factory: DBSessionFactory | None = None,
-    ) -> None:
+    def __init__(self, ip_lookup: SandboxIPLookup) -> None:
         self._ip_lookup = ip_lookup
-        self._session_factory = (
-            db_session_factory
-            if db_session_factory is not None
-            else default_session_factory
-        )
 
     def resolve_sandbox(self, src_ip: str) -> ResolvedSandbox | None:
         """Pod IP → owning user + tenant; `None` if IP unknown or sandbox has no owner.
@@ -130,7 +110,7 @@ class IdentityResolver:
         if identity is None:
             return None
 
-        with self._session_factory(identity.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=identity.tenant_id) as db:
             user_id = db.scalar(
                 select(Sandbox.user_id).where(Sandbox.id == identity.sandbox_id)
             )
@@ -159,7 +139,7 @@ class IdentityResolver:
         Status is intentionally not filtered: this is the session that
         originated the egress regardless of its current status.
         """
-        with self._session_factory(tenant_id) as db:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
             stmt = (
                 select(BuildSession.id)
                 .where(BuildSession.id == session_id)

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from mitmproxy import http
 
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.external_apps.credentials import resolve_injection_headers
 from onyx.external_apps.token_refresh import ensure_fresh_credentials
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
@@ -46,13 +47,12 @@ class ExternalAppResolver(CredentialResolver):
         # short sessions and never raises for a refresh outcome (a dead grant
         # clears the credential, which renders as empty headers below).
         ensure_fresh_credentials(
-            ctx.db_session_factory,
             ctx.sandbox.tenant_id,
             match.external_app_id,
             ctx.sandbox.user_id,
         )
 
-        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             headers = resolve_injection_headers(
                 db, match.external_app_id, ctx.sandbox.user_id
             )

--- a/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
+++ b/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
@@ -13,6 +13,7 @@ from mitmproxy import http
 
 from onyx.auth.constants import API_KEY_HEADER_NAME
 from onyx.auth.constants import BEARER_PREFIX
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import fetch_user_by_id
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
@@ -46,7 +47,7 @@ class LLMProviderKeyResolver(CredentialResolver):
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         provider_type, header, prefix = _HOST_TO_PROVIDER[request.host.lower()]
         user_id = ctx.sandbox.user_id
-        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             user = fetch_user_by_id(db, user_id)
             if user is None:
                 raise CredentialUnavailableError(f"sandbox user {user_id} not found")

--- a/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
+++ b/backend/onyx/sandbox_proxy/resolvers/onyx_pat.py
@@ -15,6 +15,7 @@ from mitmproxy import http
 from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
 from onyx.auth.constants import API_KEY_HEADER_NAME
 from onyx.auth.constants import BEARER_PREFIX
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
@@ -50,7 +51,7 @@ class OnyxPatResolver(CredentialResolver):
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         sandbox_id = ctx.sandbox.sandbox_id
-        with ctx.db_session_factory(ctx.sandbox.tenant_id) as db:
+        with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             sandbox = get_sandbox_by_id(db, sandbox_id)
             if sandbox is None:
                 raise CredentialUnavailableError(f"sandbox {sandbox_id} not found")

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -20,7 +20,6 @@ from onyx.sandbox_proxy.ca import CABootstrap
 from onyx.sandbox_proxy.ca_k8s import K8sSecretCAStore
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
-from onyx.sandbox_proxy.identity import default_session_factory
 from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
 from onyx.sandbox_proxy.identity_k8s import K8sInformerLookup
@@ -198,7 +197,6 @@ def main() -> int:
                 snapshot_policy.bucket,
                 snapshot_policy.endpoint_host,
             )
-        db_session_factory = default_session_factory
         resolvers = build_resolvers()
         logger.info(
             "credential resolvers registered: %s",
@@ -206,10 +204,7 @@ def main() -> int:
         )
         gate = GateAddon(
             identity=identity,
-            action_matcher=ExternalAppActionMatcher(
-                db_session_factory=db_session_factory
-            ),
-            db_session_factory=db_session_factory,
+            action_matcher=ExternalAppActionMatcher(),
             cache_factory=lambda tid: get_cache_backend(tenant_id=tid),
             proxy_instance_id=proxy_instance_id,
             credential_dispatcher=CredentialInjectionDispatcher(resolvers),

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from contextlib import contextmanager
-from typing import Any
+from typing import Callable
 
 import pytest
 from mitmproxy import http
@@ -198,7 +199,9 @@ def test_graphql_batched_sorts_strictest_first(
 # ── ExternalAppActionMatcher: full proxy-request → verdict bridge ───
 
 
-def _session_factory(db_session: Session) -> Any:
+def _session_factory(
+    db_session: Session,
+) -> "Callable[[str], AbstractContextManager[Session]]":
     """A ``get_session_with_tenant`` stand-in that hands the matcher the test's
     own session so flushed-but-uncommitted rows are visible; never closes it."""
 

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Any
 
 import pytest
 from mitmproxy import http
@@ -22,7 +23,7 @@ from onyx.external_apps.matching.engine import ActionMatch
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.external_apps.matching.request import ProxiedRequest
-from onyx.sandbox_proxy.action_matcher import DBSessionFactory
+from onyx.sandbox_proxy import action_matcher as action_matcher_mod
 from onyx.sandbox_proxy.action_matcher import ExternalAppActionMatcher
 from tests.external_dependency_unit.craft._test_helpers import make_external_app
 from tests.external_dependency_unit.craft._test_helpers import make_skill
@@ -197,9 +198,9 @@ def test_graphql_batched_sorts_strictest_first(
 # ── ExternalAppActionMatcher: full proxy-request → verdict bridge ───
 
 
-def _session_factory(db_session: Session) -> DBSessionFactory:
-    """A ``DBSessionFactory`` that hands the matcher the test's own session
-    so flushed-but-uncommitted rows are visible; never closes it."""
+def _session_factory(db_session: Session) -> Any:
+    """A ``get_session_with_tenant`` stand-in that hands the matcher the test's
+    own session so flushed-but-uncommitted rows are visible; never closes it."""
 
     @contextmanager
     def factory(tenant_id: str) -> Iterator[Session]:  # noqa: ARG001
@@ -221,6 +222,7 @@ def _slack_request(
 def test_external_app_matcher_resolves_app_and_verdict(
     db_session: Session,
     test_user: object,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     skill = make_skill(db_session)
     app = make_external_app(
@@ -232,7 +234,10 @@ def test_external_app_matcher_resolves_app_and_verdict(
     )
     _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.DENY)
 
-    matcher = ExternalAppActionMatcher(db_session_factory=_session_factory(db_session))
+    monkeypatch.setattr(
+        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+    )
+    matcher = ExternalAppActionMatcher()
     matched = matcher.match(_slack_request(), "public")
 
     assert matched is not None
@@ -246,8 +251,12 @@ def test_external_app_matcher_resolves_app_and_verdict(
 def test_external_app_matcher_unconnected_host_returns_none(
     db_session: Session,
     test_user: object,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    matcher = ExternalAppActionMatcher(db_session_factory=_session_factory(db_session))
+    monkeypatch.setattr(
+        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+    )
+    matcher = ExternalAppActionMatcher()
     request = http.Request.make("GET", "https://example.com/", headers={})
     assert matcher.match(request, "public") is None
 
@@ -255,6 +264,7 @@ def test_external_app_matcher_unconnected_host_returns_none(
 def test_external_app_matcher_off_catalog_on_connected_host_returns_none(
     db_session: Session,
     test_user: object,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     skill = make_skill(db_session)
     make_external_app(
@@ -265,6 +275,9 @@ def test_external_app_matcher_off_catalog_on_connected_host_returns_none(
         upstream_url_patterns=["https://slack\\.com/api/.*"],
     )
 
-    matcher = ExternalAppActionMatcher(db_session_factory=_session_factory(db_session))
+    monkeypatch.setattr(
+        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+    )
+    matcher = ExternalAppActionMatcher()
     request = _slack_request(url="https://slack.com/api/some.unknownMethod")
     assert matcher.match(request, "public") is None

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -14,7 +14,6 @@ from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import ActionApproval
@@ -92,8 +91,9 @@ class _UnusedMatcher(ActionMatcher):
 
 
 def _build_addon() -> GateAddon:
-    """`GateAddon` with only `db_session_factory` wired; the arbiter doesn't
-    touch the others, so they're obvious-fail stubs."""
+    """`GateAddon` for the claim arbiter; it opens its own tenant session via
+    `get_session_with_tenant`, so the identity/matcher/cache deps are
+    obvious-fail stubs the arbiter never touches."""
 
     def _factory_raises(tenant_id: str) -> Any:  # noqa: ARG001
         raise AssertionError("cache_factory unexpectedly used")
@@ -101,9 +101,6 @@ def _build_addon() -> GateAddon:
     return GateAddon(
         identity=_UnusedResolver(),
         action_matcher=_UnusedMatcher(),
-        db_session_factory=lambda tenant_id: get_session_with_tenant(
-            tenant_id=tenant_id
-        ),
         cache_factory=_factory_raises,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher([]),

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_identity_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_identity_resolver.py
@@ -13,7 +13,6 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
@@ -25,12 +24,7 @@ from tests.unit.sandbox_proxy.conftest import StaticLookup
 
 
 def _resolver_with(identity: SandboxIdentity | None) -> IdentityResolver:
-    return IdentityResolver(
-        ip_lookup=StaticLookup.single(identity),
-        db_session_factory=lambda tenant_id: get_session_with_tenant(
-            tenant_id=tenant_id
-        ),
-    )
+    return IdentityResolver(ip_lookup=StaticLookup.single(identity))
 
 
 @pytest.fixture

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -13,7 +13,6 @@ from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import upsert_llm_provider
 from onyx.sandbox_proxy.credential_injection import InjectionContext
@@ -49,9 +48,6 @@ def test_claims_then_resolve_round_trips_encrypted_key(
             sandbox_ip="127.0.0.1",
         ),
         match=None,
-        db_session_factory=lambda tenant_id: get_session_with_tenant(
-            tenant_id=tenant_id
-        ),
     )
 
     try:

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.constants import API_KEY_HEADER_ALTERNATIVE_NAME
 from onyx.auth.constants import API_KEY_HEADER_NAME
-from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.resolvers import onyx_pat as onyx_pat_mod
@@ -47,9 +46,6 @@ def test_claims_then_resolve_round_trips_minted_pat(
             sandbox_ip="127.0.0.1",
         ),
         match=None,
-        db_session_factory=lambda tenant_id: get_session_with_tenant(
-            tenant_id=tenant_id
-        ),
     )
 
     monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", f"https://{_API_HOST}")

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -273,6 +273,7 @@ def _setup(
     app.skill.name = "Google Calendar"
 
     monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
+    monkeypatch.setattr(tr, "get_session_with_tenant", _noop_cm)
     monkeypatch.setattr(tr, "get_external_app_by_id", lambda *_a, **_k: app)
     monkeypatch.setattr(tr, "get_provider_for_app", lambda *_a, **_k: provider)
     monkeypatch.setattr(
@@ -291,8 +292,7 @@ def _setup(
 
 
 def _run() -> None:
-    # The factory: any callable returning a context manager yielding a session.
-    tr.ensure_fresh_credentials(_noop_cm, "public", 1, uuid4())
+    tr.ensure_fresh_credentials("public", 1, uuid4())
 
 
 def test_ensure_fresh_noop_when_token_fresh(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -10,8 +10,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -225,14 +223,3 @@ def make_request_match(
         external_app_id=external_app_id,
         payload=payload if payload is not None else {},
     )
-
-
-@contextmanager
-def _noop_session(tenant_id: str) -> Iterator[Any]:  # noqa: ARG001
-    raise AssertionError("db factory unexpectedly used")
-    yield  # pragma: no cover
-
-
-def noop_db_factory(tenant_id: str) -> Any:
-    """`DBSessionFactory` whose session never opens."""
-    return _noop_session(tenant_id)

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -19,14 +19,11 @@ from onyx.sandbox_proxy.errors import SandboxProxyError
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_request_match
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
-from tests.unit.sandbox_proxy.conftest import noop_db_factory
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 
 
 def _ctx(*, match: RequestMatch | None = None) -> InjectionContext:
-    return InjectionContext(
-        sandbox=_sandbox(), match=match, db_session_factory=noop_db_factory
-    )
+    return InjectionContext(sandbox=_sandbox(), match=match)
 
 
 def test_no_resolver_claims_returns_pass_through() -> None:
@@ -169,9 +166,7 @@ def test_resolver_receives_request_and_full_context() -> None:
     match = make_request_match()
     resolver = RecordingCredentialResolver(claims_result=True)
     flow = _flow(host="api.anthropic.com")
-    ctx = InjectionContext(
-        sandbox=sandbox, match=match, db_session_factory=noop_db_factory
-    )
+    ctx = InjectionContext(sandbox=sandbox, match=match)
 
     CredentialInjectionDispatcher([resolver]).apply(flow, ctx)
 

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -44,18 +44,8 @@ def _recorder_db_factory(ops: list[str]) -> Any:
     return factory
 
 
-def _ctx(
-    *,
-    match: RequestMatch | None = None,
-    db_factory: Any = None,
-) -> InjectionContext:
-    return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"),
-        match=match,
-        db_session_factory=db_factory
-        if db_factory is not None
-        else _recorder_db_factory([]),
-    )
+def _ctx(*, match: RequestMatch | None = None) -> InjectionContext:
+    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=match)
 
 
 def test_claims_true_iff_match_present() -> None:
@@ -80,10 +70,13 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
         return {"Authorization": "Bearer real"}
 
     monkeypatch.setattr(external_app_mod, "resolve_injection_headers", _fake)
+    ops: list[str] = []
+    monkeypatch.setattr(
+        external_app_mod, "get_session_with_tenant", _recorder_db_factory(ops)
+    )
 
     match = make_request_match(external_app_id=99)
-    ops: list[str] = []
-    ctx = _ctx(match=match, db_factory=_recorder_db_factory(ops))
+    ctx = _ctx(match=match)
 
     headers = ExternalAppResolver().resolve(_flow().request, ctx)
 
@@ -97,13 +90,13 @@ def test_resolve_refreshes_token_before_rendering(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The resolver refreshes an expiring OAuth token (via `ensure_fresh_credentials`,
-    handed the session factory + ids) before rendering headers, so the injected
-    `Bearer` is live. The refresh mechanics themselves are pinned in
+    handed the tenant + ids) before rendering headers, so the injected `Bearer` is
+    live. The refresh mechanics themselves are pinned in
     `tests/unit/external_apps/test_token_refresh.py`."""
-    calls: list[tuple[Any, str, int, Any]] = []
+    calls: list[tuple[str, int, Any]] = []
 
-    def _ensure(factory: Any, tenant_id: str, app_id: int, user_id: Any) -> None:
-        calls.append((factory, tenant_id, app_id, user_id))
+    def _ensure(tenant_id: str, app_id: int, user_id: Any) -> None:
+        calls.append((tenant_id, app_id, user_id))
 
     monkeypatch.setattr(external_app_mod, "ensure_fresh_credentials", _ensure)
     monkeypatch.setattr(
@@ -111,15 +104,17 @@ def test_resolve_refreshes_token_before_rendering(
         "resolve_injection_headers",
         lambda *_a, **_k: {"Authorization": "Bearer real"},
     )
+    monkeypatch.setattr(
+        external_app_mod, "get_session_with_tenant", _recorder_db_factory([])
+    )
 
-    factory = _recorder_db_factory([])
     match = make_request_match(external_app_id=99)
-    ctx = _ctx(match=match, db_factory=factory)
+    ctx = _ctx(match=match)
 
     headers = ExternalAppResolver().resolve(_flow().request, ctx)
 
     assert headers == {"Authorization": "Bearer real"}
-    assert calls == [(factory, "tenant-7", 99, ctx.sandbox.user_id)]
+    assert calls == [("tenant-7", 99, ctx.sandbox.user_id)]
 
 
 def test_resolve_raises_when_match_is_none() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1,7 +1,8 @@
 """Unit tests for the GateAddon mitmproxy addon.
 
-External dependencies (`_IdentityResolver`, `ActionMatcher`, `CacheFactory`,
-`DBSessionFactory`) are stubbed via small Protocol implementations.
+External dependencies (`_IdentityResolver`, `ActionMatcher`, `CacheFactory`)
+are stubbed via small Protocol implementations; `get_session_with_tenant` is
+patched per test.
 
 The race arbiter (`_claim_expired_or_read_winner`) is covered against a
 real Postgres row in
@@ -43,7 +44,6 @@ from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_request_match
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
-from tests.unit.sandbox_proxy.conftest import noop_db_factory
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 
@@ -94,18 +94,24 @@ def _ctx(
     )
 
 
+@pytest.fixture(autouse=True)
+def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate opens tenant sessions via `gate_mod.get_session_with_tenant`.
+    Default it to a dummy MagicMock-yielding session; tests asserting on
+    session-open ordering re-patch it with `_recorder_db_factory(ops)`."""
+    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory([]))
+
+
 def _build(
     *,
     resolver: _StubResolver,
     matcher: _StubMatcher,
-    db_factory: Any = noop_db_factory,
     cache_factory: Any = _noop_cache_factory,
     credential_resolvers: list[CredentialResolver] | None = None,
 ) -> GateAddon:
     return GateAddon(
         identity=resolver,
         action_matcher=matcher,
-        db_session_factory=db_factory,
         cache_factory=cache_factory,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher(
@@ -288,7 +294,6 @@ async def test_resolve_and_match_always_forwards_without_session() -> None:
     addon = _build(
         resolver=resolver,
         matcher=_StubMatcher(result=_MATCH_ALWAYS),
-        db_factory=_recorder_db_factory([]),
         # No-claim resolver -> dispatcher returns PASS_THROUGH, leaves the
         # flow forwarded with no response.
         credential_resolvers=[RecordingCredentialResolver(claims_result=False)],
@@ -821,9 +826,6 @@ def test_dispatch_injection_writes_resolved_headers() -> None:
     seen = spy.resolve_calls[0]
     assert seen.sandbox is sandbox
     assert seen.match is _MATCH_ALWAYS
-    # The dispatcher must receive the gate's own session factory — a resolver
-    # that opens its own session would see the wrong tenant schema.
-    assert seen.db_session_factory is addon._db_session_factory
 
 
 def test_dispatch_injection_pass_through_forwards_untouched() -> None:
@@ -1048,10 +1050,10 @@ def test_persist_approval_row_commits_announces_notifies(
     )
 
     cache = _RecorderCache(ops)
+    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory(ops))
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory(ops),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
@@ -1101,10 +1103,10 @@ def test_persist_approval_row_announce_failure_is_swallowed(
     )
 
     cache = _RecorderCache(ops, rpush_raises=RedisError("connection refused"))
+    monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory(ops))
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory(ops),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
@@ -1154,7 +1156,6 @@ async def test_await_decision_wake_received_returns_decision(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
     addon._parked.add(ctx.tenant_id, approval_id)
@@ -1184,7 +1185,6 @@ async def test_await_decision_timeout_claims_expired(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
     addon._parked.add(ctx.tenant_id, approval_id)
@@ -1224,7 +1224,6 @@ async def test_await_decision_cancelled_claims_expired_and_reraises(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
     addon._parked.add(ctx.tenant_id, approval_id)
@@ -1266,7 +1265,6 @@ async def test_drain_inflight_walks_parked_per_tenant(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: per_tenant_caches[tenant_id],
     )
 
@@ -1320,7 +1318,6 @@ async def test_drain_inflight_completes_when_inflight_set_empty() -> None:
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=_tracking_cache_factory,
     )
 
@@ -1352,7 +1349,6 @@ def test_terminalize_happy_path_writes_wake(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
@@ -1384,7 +1380,6 @@ def test_terminalize_db_failure_skips_wake(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
@@ -1417,7 +1412,6 @@ def test_terminalize_wake_failure_swallowed(
     addon = _build(
         resolver=_StubResolver(),
         matcher=_StubMatcher(),
-        db_factory=_recorder_db_factory([]),
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 

--- a/backend/tests/unit/sandbox_proxy/test_identity.py
+++ b/backend/tests/unit/sandbox_proxy/test_identity.py
@@ -4,6 +4,9 @@ from typing import Any
 from uuid import UUID
 from uuid import uuid4
 
+import pytest
+
+from onyx.sandbox_proxy import identity as identity_mod
 from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SandboxIdentity
@@ -46,13 +49,14 @@ def _identity(ip: str = "10.0.0.1") -> SandboxIdentity:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_sandbox_happy_path() -> None:
+def test_resolve_sandbox_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
     sandbox_user_id = uuid4()
     stub = _StubSession([sandbox_user_id])
     lookup = StaticLookup({"10.0.0.1": _identity()})
     factory = _factory(stub)
 
-    resolver = IdentityResolver(ip_lookup=lookup, db_session_factory=factory)
+    monkeypatch.setattr(identity_mod, "get_session_with_tenant", factory)
+    resolver = IdentityResolver(ip_lookup=lookup)
     sandbox = resolver.resolve_sandbox("10.0.0.1")
 
     assert sandbox is not None
@@ -66,24 +70,28 @@ def test_resolve_sandbox_happy_path() -> None:
     assert stub.scalar_calls == 1
 
 
-def test_resolve_sandbox_unknown_ip_skips_db() -> None:
+def test_resolve_sandbox_unknown_ip_skips_db(monkeypatch: pytest.MonkeyPatch) -> None:
     stub = _StubSession([])
     lookup = StaticLookup({})
     factory = _factory(stub)
 
-    resolver = IdentityResolver(ip_lookup=lookup, db_session_factory=factory)
+    monkeypatch.setattr(identity_mod, "get_session_with_tenant", factory)
+    resolver = IdentityResolver(ip_lookup=lookup)
 
     assert resolver.resolve_sandbox("203.0.113.10") is None
     assert stub.scalar_calls == 0
     assert factory.last_tenant_id is None
 
 
-def test_resolve_sandbox_missing_sandbox_row_returns_none() -> None:
+def test_resolve_sandbox_missing_sandbox_row_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     stub = _StubSession([None])
     lookup = StaticLookup({"10.0.0.1": _identity()})
     factory = _factory(stub)
 
-    resolver = IdentityResolver(ip_lookup=lookup, db_session_factory=factory)
+    monkeypatch.setattr(identity_mod, "get_session_with_tenant", factory)
+    resolver = IdentityResolver(ip_lookup=lookup)
 
     assert resolver.resolve_sandbox("10.0.0.1") is None
     assert stub.scalar_calls == 1
@@ -94,13 +102,16 @@ def test_resolve_sandbox_missing_sandbox_row_returns_none() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_session_by_id_propagates_scalar() -> None:
+def test_resolve_session_by_id_propagates_scalar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Pin both the verified (id returned) and unverified (None) cases so a
     change like wrapping the scalar in a default would fail here."""
     found_id = uuid4()
     stub = _StubSession([found_id, None])
     factory = _factory(stub)
-    resolver = IdentityResolver(ip_lookup=StaticLookup({}), db_session_factory=factory)
+    monkeypatch.setattr(identity_mod, "get_session_with_tenant", factory)
+    resolver = IdentityResolver(ip_lookup=StaticLookup({}))
 
     assert resolver.resolve_session_by_id(found_id, uuid4(), "public") == found_id
     assert resolver.resolve_session_by_id(uuid4(), uuid4(), "public") is None

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -39,12 +39,15 @@ def _noop_db_factory() -> Any:
     return factory
 
 
+@pytest.fixture(autouse=True)
+def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolver opens its own tenant session via `get_session_with_tenant`;
+    yield a dummy so the patched DB-access functions receive it."""
+    monkeypatch.setattr(mod, "get_session_with_tenant", _noop_db_factory())
+
+
 def _ctx() -> InjectionContext:
-    return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"),
-        match=None,
-        db_session_factory=_noop_db_factory(),
-    )
+    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=None)
 
 
 @pytest.fixture

--- a/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -54,12 +54,15 @@ def _noop_db_factory() -> Any:
     return factory
 
 
+@pytest.fixture(autouse=True)
+def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The resolver opens its own tenant session via `get_session_with_tenant`;
+    yield a dummy so the patched DB-access functions receive it."""
+    monkeypatch.setattr(onyx_pat_mod, "get_session_with_tenant", _noop_db_factory())
+
+
 def _ctx() -> InjectionContext:
-    return InjectionContext(
-        sandbox=_sandbox(tenant_id="tenant-7"),
-        match=None,
-        db_session_factory=_noop_db_factory(),
-    )
+    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=None)
 
 
 @pytest.fixture

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -166,7 +166,6 @@ def _start_proxy(
     gate = GateAddon(
         identity=_StubResolver(),
         action_matcher=_NonGatingMatcher(),
-        db_session_factory=_unused_factory,
         cache_factory=_unused_factory,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher([]),


### PR DESCRIPTION
## Description
Removes the DBSessionFactory pattern from the craft code which is just a wrapper around `get_session_with_tenant`. Replaces it with `get_session_with_tenant`

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `DBSessionFactory` pattern across craft; all code now opens tenant-scoped sessions via `get_session_with_tenant`. This simplifies the sandbox proxy, resolvers, and token refresh flow.

- **Refactors**
  - Deleted `DBSessionFactory` and `default_session_factory`; all DB access now uses `get_session_with_tenant(tenant_id=...)`.
  - API changes:
    - `ExternalAppActionMatcher()` no longer accepts a session factory.
    - `GateAddon(...)` drops the session factory arg.
    - `IdentityResolver(ip_lookup)` no longer accepts a session factory.
    - `InjectionContext` no longer carries a session factory.
    - `ensure_fresh_credentials(tenant_id, external_app_id, user_id)`; sessions opened internally.
  - Resolvers now open sessions directly and use the new refresh call (`external_app`, `llm_provider_key`, `onyx_pat`); `sandbox_proxy/server.py` wiring updated.
  - Tests patch `get_session_with_tenant` at call sites; removed factory helpers and updated fixtures.

<sup>Written for commit f0332f1a21dea7af18da1945c341a1312a98e3f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

