### PR TITLE
feat(craft): skill tiles + always-on paste tiles in input bar

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -59,6 +59,7 @@ export {
 /* Tag */
 export {
   Tag,
+  TAG_COLORS,
   type TagProps,
   type TagColor,
 } from "@opal/components/tag/components";

--- a/web/lib/opal/src/components/tag/colors.ts
+++ b/web/lib/opal/src/components/tag/colors.ts
@@ -1,0 +1,13 @@
+// Tag color tints. Kept in a standalone, import-free module so non-React
+// surfaces (e.g. the raw-DOM skill tile in richInputTile.ts) can source the same
+// classes without pulling in the component/CSS barrel.
+
+export type TagColor = "green" | "purple" | "blue" | "gray" | "amber";
+
+export const TAG_COLORS: Record<TagColor, { bg: string; text: string }> = {
+  green: { bg: "bg-theme-green-01", text: "text-theme-green-05" },
+  blue: { bg: "bg-theme-blue-01", text: "text-theme-blue-05" },
+  purple: { bg: "bg-theme-purple-01", text: "text-theme-purple-05" },
+  amber: { bg: "bg-theme-amber-01", text: "text-theme-amber-05" },
+  gray: { bg: "bg-background-tint-02", text: "text-text-03" },
+};

--- a/web/lib/opal/src/components/tag/components.tsx
+++ b/web/lib/opal/src/components/tag/components.tsx
@@ -2,12 +2,11 @@ import "@opal/components/tag/styles.css";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { Text } from "@opal/components";
 import { cn } from "@opal/utils";
+import { TAG_COLORS, type TagColor } from "@opal/components/tag/colors";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-type TagColor = "green" | "purple" | "blue" | "gray" | "amber";
 
 type TagSize = "sm" | "md";
 
@@ -26,23 +25,11 @@ interface TagProps {
 }
 
 // ---------------------------------------------------------------------------
-// Color config
-// ---------------------------------------------------------------------------
-
-const COLOR_CONFIG: Record<TagColor, { bg: string; text: string }> = {
-  green: { bg: "bg-theme-green-01", text: "text-theme-green-05" },
-  blue: { bg: "bg-theme-blue-01", text: "text-theme-blue-05" },
-  purple: { bg: "bg-theme-purple-01", text: "text-theme-purple-05" },
-  amber: { bg: "bg-theme-amber-01", text: "text-theme-amber-05" },
-  gray: { bg: "bg-background-tint-02", text: "text-text-03" },
-};
-
-// ---------------------------------------------------------------------------
 // Tag
 // ---------------------------------------------------------------------------
 
 function Tag({ icon: Icon, title, color = "gray", size = "sm" }: TagProps) {
-  const config = COLOR_CONFIG[color];
+  const config = TAG_COLORS[color];
 
   return (
     <div
@@ -65,4 +52,5 @@ function Tag({ icon: Icon, title, color = "gray", size = "sm" }: TagProps) {
   );
 }
 
-export { Tag, type TagProps, type TagColor, type TagSize };
+export { Tag, type TagProps, type TagSize };
+export { TAG_COLORS, type TagColor } from "@opal/components/tag/colors";

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -44,7 +44,14 @@ import Keycap from "@/refresh-components/Keycap";
 import { useDoubleEscapeInterrupt } from "@/hooks/useDoubleEscapeInterrupt";
 import { useContentEditable } from "@/hooks/useContentEditable";
 import useUserSkills from "@/hooks/useUserSkills";
-import { detectSlashTrigger, toPickerSkills } from "@/lib/skills/picker";
+import { toPickerSkills } from "@/lib/skills/picker";
+import {
+  reduceOnInput,
+  reduceOnSelection,
+  reduceOnDismiss,
+  INITIAL_PICKER_SESSION,
+  type PickerSession,
+} from "@/lib/skills/pickerSession";
 import { getTextContent } from "@/lib/contentEditable";
 import { isSkillTile } from "@/lib/richInputTile";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
@@ -226,15 +233,10 @@ const InputBar = memo(
         () => toPickerSkills(skillsData),
         [skillsData]
       );
-      const [skillPicker, setSkillPicker] = useState<{
-        open: boolean;
-        anchorRect: DOMRect | null;
-        query: string;
-      }>({ open: false, anchorRect: null, query: "" });
-      // `sessionSlash` is the `/` index of the tracked token; `suppressed` hides
-      // the picker within it after Esc. Both reset when that slash is gone.
-      const suppressedRef = useRef(false);
-      const sessionSlashRef = useRef<number | null>(null);
+      const [session, setSession] = useState<PickerSession>(
+        INITIAL_PICKER_SESSION
+      );
+      const [anchorRect, setAnchorRect] = useState<DOMRect | null>(null);
 
       const [skillInfo, setSkillInfo] = useState<{
         tile: HTMLElement;
@@ -282,77 +284,46 @@ const InputBar = memo(
         return rect;
       }, [inputRef]);
 
-      const closeSkillPicker = useCallback(() => {
-        sessionSlashRef.current = null;
-        suppressedRef.current = false;
-        setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
-      }, []);
+      const closeSkillPicker = useCallback(
+        () => setSession(INITIAL_PICKER_SESSION),
+        []
+      );
 
-      // Esc keeps the picker closed within this token until its slash is gone.
-      const dismissSkillPicker = useCallback(() => {
-        suppressedRef.current = true;
-        setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
-      }, []);
+      const dismissSkillPicker = useCallback(
+        () => setSession(reduceOnDismiss),
+        []
+      );
 
       const handleEnhancedInput = useCallback(
         (event: SyntheticEvent<HTMLDivElement>) => {
           onInput(event);
-          const textBefore = getTextBeforeCursor();
-          const trigger =
-            textBefore === null ? null : detectSlashTrigger(textBefore);
-          if (!trigger) {
-            // Keep a dismissed session alive while its slash survives (so deleting
-            // back into the token doesn't reopen it); reset once the slash is gone.
-            const slash = sessionSlashRef.current;
-            if (slash === null || textBefore?.[slash] !== "/") {
-              closeSkillPicker();
-            } else {
-              setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
-            }
-            return;
-          }
-          if (trigger.slashIndex !== sessionSlashRef.current) {
-            sessionSlashRef.current = trigger.slashIndex;
-            suppressedRef.current = false;
-          }
-          if (suppressedRef.current) return;
-          setSkillPicker({
-            open: true,
-            anchorRect: getCaretRect(),
-            query: trigger.query,
-          });
+          const next = reduceOnInput(session, getTextBeforeCursor());
+          if (next.open) setAnchorRect(getCaretRect());
+          setSession(next);
         },
-        [onInput, getTextBeforeCursor, getCaretRect, closeSkillPicker]
+        [onInput, session, getTextBeforeCursor, getCaretRect]
       );
 
-      // Caret moves never open the picker; they only close it or sync its query.
       const handleSelectionChange = useCallback(() => {
-        if (!skillPicker.open) return;
+        if (!session.open) return;
         const textBefore = getTextBeforeCursor();
-        const trigger =
-          textBefore === null ? null : detectSlashTrigger(textBefore);
-        if (!trigger || trigger.slashIndex !== sessionSlashRef.current) {
-          closeSkillPicker();
-          return;
-        }
-        if (trigger.query !== skillPicker.query) {
-          setSkillPicker((s) => ({ ...s, query: trigger.query }));
-        }
-      }, [
-        skillPicker.open,
-        skillPicker.query,
-        getTextBeforeCursor,
-        closeSkillPicker,
-      ]);
+        setSession((prev) => reduceOnSelection(prev, textBefore));
+      }, [session.open, getTextBeforeCursor]);
 
       const handleSkillPickerSelect = useCallback(
         (slug: string) => {
-          if (!skillPicker.open) return;
-          const beforeToken = `/${skillPicker.query}`;
+          if (!session.open) return;
+          const beforeToken = `/${session.query}`;
           const name = pickerSkills.find((s) => s.slug === slug)?.name ?? slug;
           if (insertSkillTile(slug, name, beforeToken)) closeSkillPicker();
         },
-        [skillPicker, pickerSkills, insertSkillTile, closeSkillPicker]
+        [
+          session.open,
+          session.query,
+          pickerSkills,
+          insertSkillTile,
+          closeSkillPicker,
+        ]
       );
 
       const openSkillInfo = useCallback(
@@ -391,6 +362,7 @@ const InputBar = memo(
         reset: () => {
           clearMessage();
           clearFiles();
+          closeSkillPicker();
         },
         focus: () => {
           inputRef.current?.focus();
@@ -432,12 +404,20 @@ const InputBar = memo(
           const skill = slug && pickerSkills.find((s) => s.slug === slug);
           if (skill) {
             insertSkillTile(skill.slug, skill.name, "");
+            closeSkillPicker();
             return;
           }
 
           pasteText(text);
         },
-        [disabled, uploadFiles, pasteText, pickerSkills, insertSkillTile]
+        [
+          disabled,
+          uploadFiles,
+          pasteText,
+          pickerSkills,
+          insertSkillTile,
+          closeSkillPicker,
+        ]
       );
 
       const handleSubmit = useCallback(() => {
@@ -534,7 +514,7 @@ const InputBar = memo(
         enabled:
           interruptible &&
           !isInterrupting &&
-          !skillPicker.open &&
+          !session.open &&
           !tilePopover &&
           !skillInfo,
         onInterrupt: handleInterrupt,
@@ -718,9 +698,9 @@ const InputBar = memo(
             />
           )}
           <SkillPickerPopover
-            open={skillPicker.open}
-            anchorRect={skillPicker.anchorRect}
-            query={skillPicker.query}
+            open={session.open}
+            anchorRect={anchorRect}
+            query={session.query}
             skills={pickerSkills}
             onSelect={handleSkillPickerSelect}
             onClose={dismissSkillPicker}

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -11,12 +11,14 @@ import {
   type ChangeEvent,
   type ClipboardEvent,
   type KeyboardEvent,
+  type MouseEvent,
   type SyntheticEvent,
 } from "react";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { isImageFile } from "@/lib/utils";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
 import SkillPickerPopover from "@/sections/input/SkillPickerPopover";
+import SkillInfoPopover from "@/sections/input/SkillInfoPopover";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
 import {
@@ -41,10 +43,10 @@ import InterruptHint from "@/app/craft/components/InterruptHint";
 import Keycap from "@/refresh-components/Keycap";
 import { useDoubleEscapeInterrupt } from "@/hooks/useDoubleEscapeInterrupt";
 import { useContentEditable } from "@/hooks/useContentEditable";
-import { useUser } from "@/providers/UserProvider";
 import useUserSkills from "@/hooks/useUserSkills";
 import { detectSlashTrigger, toPickerSkills } from "@/lib/skills/picker";
 import { getTextContent } from "@/lib/contentEditable";
+import { isSkillTile } from "@/lib/richInputTile";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
 import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
 import {
@@ -181,7 +183,6 @@ const InputBar = memo(
       // Queueing is enabled only when the parent wires up the callbacks.
       const queueEnabled = !!onQueueMessage;
       const queue = queuedMessages ?? EMPTY_QUEUED_MESSAGES;
-      const { user } = useUser();
       const inputWrapperRef = useRef<HTMLDivElement>(null);
       const {
         ref: inputRef,
@@ -192,6 +193,7 @@ const InputBar = memo(
         handleCompositionStart,
         handleCompositionEnd,
         pasteText,
+        insertSkillTile,
         handleCopy,
         handleCut,
         setCursorToEnd,
@@ -203,7 +205,9 @@ const InputBar = memo(
         updateTileText,
       } = useContentEditable({
         wrapperRef: inputWrapperRef,
-        pasteTilesEnabled: user?.preferences?.paste_as_tile ?? false,
+        // Craft always collapses large pastes into tiles, regardless of the
+        // user's paste_as_tile preference.
+        pasteTilesEnabled: true,
       });
 
       const containerRef = useRef<HTMLDivElement>(null);
@@ -217,9 +221,6 @@ const InputBar = memo(
         hasUploadingFiles,
       } = useUploadFilesContext();
 
-      // `/` skill picker state. The picker watches contentEditable input,
-      // shows accessible skills, and on select replaces the `/<query>` token
-      // with `/<slug> `.
       const { data: skillsData } = useUserSkills();
       const pickerSkills = useMemo(
         () => toPickerSkills(skillsData),
@@ -229,8 +230,15 @@ const InputBar = memo(
         open: boolean;
         anchorRect: DOMRect | null;
         query: string;
-        slashIndex: number;
-      }>({ open: false, anchorRect: null, query: "", slashIndex: -1 });
+      }>({ open: false, anchorRect: null, query: "" });
+
+      const [skillInfo, setSkillInfo] = useState<{
+        tile: HTMLElement;
+        name: string;
+        description: string;
+      } | null>(null);
+      // Stable so SkillInfoPopover's observers/listeners don't rebuild each render.
+      const dismissSkillInfo = useCallback(() => setSkillInfo(null), []);
 
       // Shared queued-message keyboard navigation + highlight state.
       const queueNav = useQueuedMessageNavigation({
@@ -254,6 +262,21 @@ const InputBar = memo(
         tmp.appendChild(cloned.cloneContents());
         return getTextContent(tmp);
       }, [inputRef]);
+
+      // The remaining slash-token characters in the caret's OWN text node (when
+      // a skill is picked mid-token). Scoped to the text node so it never spans
+      // into a following tile's serialized text.
+      const getTokenRemainderAfterCursor = useCallback((): string => {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return "";
+        const { endContainer, endOffset } = sel.getRangeAt(0);
+        if (endContainer.nodeType !== Node.TEXT_NODE) return "";
+        return (
+          (endContainer.textContent ?? "")
+            .slice(endOffset)
+            .match(/^\S*/)?.[0] ?? ""
+        );
+      }, []);
 
       const getCaretRect = useCallback((): DOMRect | null => {
         const sel = window.getSelection();
@@ -287,7 +310,6 @@ const InputBar = memo(
           open: true,
           anchorRect: getCaretRect(),
           query: trigger.query,
-          slashIndex: trigger.slashIndex,
         });
       }, [getCaretRect, getTextBeforeCursor]);
 
@@ -299,10 +321,7 @@ const InputBar = memo(
         [onInput, evaluateSkillPicker]
       );
 
-      // Re-evaluate the slash trigger when the caret moves without input
-      // (arrow keys, Home/End, mouse clicks). Without this, the picker can
-      // hold a stale `slashIndex`/`query` from a previous position and
-      // replace the wrong text on select.
+      // Re-evaluate the trigger when the caret moves without input (arrows/click).
       const handleSelectionChange = useCallback(() => {
         evaluateSkillPicker();
       }, [evaluateSkillPicker]);
@@ -313,18 +332,54 @@ const InputBar = memo(
 
       const handleSkillPickerSelect = useCallback(
         (slug: string) => {
-          setSkillPicker((prev) => {
-            if (!prev.open) return prev;
-            const replacement = `/${slug} `;
-            const newText =
-              message.slice(0, prev.slashIndex) +
-              replacement +
-              message.slice(prev.slashIndex + 1 + prev.query.length);
-            setMessage(newText);
-            return { ...prev, open: false };
+          if (!skillPicker.open) return;
+          // `beforeToken` is `/<query>`; `afterText` is the token remainder past
+          // the caret (when clicking mid-token).
+          const beforeToken = `/${skillPicker.query}`;
+          const afterText = getTokenRemainderAfterCursor();
+          const name = pickerSkills.find((s) => s.slug === slug)?.name ?? slug;
+          insertSkillTile(slug, name, beforeToken, afterText);
+          closeSkillPicker();
+        },
+        [
+          skillPicker,
+          pickerSkills,
+          insertSkillTile,
+          closeSkillPicker,
+          getTokenRemainderAfterCursor,
+        ]
+      );
+
+      const openSkillInfo = useCallback(
+        (tile: HTMLElement) => {
+          const slug = tile.getAttribute("data-skill-slug") ?? "";
+          const skill = pickerSkills.find((s) => s.slug === slug);
+          setSkillInfo({
+            tile,
+            name: skill?.name ?? slug,
+            description: skill?.description ?? "",
           });
         },
-        [message, setMessage]
+        [pickerSkills]
+      );
+
+      // Clicking a skill tile opens an info popover with its name + description.
+      // Other clicks fall through to the paste-tile handler.
+      const handleInputClick = useCallback(
+        (event: MouseEvent<HTMLDivElement>) => {
+          const target = event.target as HTMLElement;
+          const tile = target.closest("[data-rich-tile]") as HTMLElement | null;
+          if (
+            tile &&
+            isSkillTile(tile) &&
+            !target.closest("[data-rich-tile-remove]")
+          ) {
+            openSkillInfo(tile);
+            return;
+          }
+          handleTileClick(event);
+        },
+        [openSkillInfo, handleTileClick]
       );
 
       useImperativeHandle(ref, () => ({
@@ -419,20 +474,32 @@ const InputBar = memo(
 
       const handleKeyDown = useCallback(
         (event: KeyboardEvent<HTMLDivElement>) => {
+          // Shift+Enter falls through to browser default (inserts <br>).
+          const isSubmitEnter =
+            event.key === "Enter" &&
+            !event.shiftKey &&
+            !event.nativeEvent.isComposing;
+
+          // Enter on an arrow-selected skill tile opens its info popover.
+          if (isSubmitEnter) {
+            const selected = inputRef.current?.querySelector(
+              '[data-rich-tile][data-tile-type="skill"].rich-input-tile-selected'
+            ) as HTMLElement | null;
+            if (selected) {
+              event.preventDefault();
+              openSkillInfo(selected);
+              return;
+            }
+          }
           if (handleTileKeyDown(event)) return;
           if (queueEnabled && queueNav.handleKeyDown(event)) return;
 
-          // Shift+Enter falls through to browser default: inserts <br>
-          if (
-            event.key === "Enter" &&
-            !event.shiftKey &&
-            !(event.nativeEvent as any).isComposing
-          ) {
+          if (isSubmitEnter) {
             event.preventDefault();
             handleSubmit();
           }
         },
-        [handleSubmit, handleTileKeyDown, queueEnabled, queueNav]
+        [handleSubmit, handleTileKeyDown, queueEnabled, queueNav, openSkillInfo]
       );
 
       const canSubmit =
@@ -538,7 +605,7 @@ const InputBar = memo(
                 onCopy={handleCopy}
                 onCut={handleCut}
                 onMouseDown={handleTileMouseDown}
-                onClick={handleTileClick}
+                onClick={handleInputClick}
               />
             </div>
 
@@ -640,6 +707,14 @@ const InputBar = memo(
             onSelect={handleSkillPickerSelect}
             onClose={closeSkillPicker}
           />
+          {skillInfo && (
+            <SkillInfoPopover
+              name={skillInfo.name}
+              description={skillInfo.description}
+              tileElement={skillInfo.tile}
+              onDismiss={dismissSkillInfo}
+            />
+          )}
         </Disabled>
       );
     }

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -306,9 +306,10 @@ const InputBar = memo(
 
       const handleSelectionChange = useCallback(() => {
         if (!session.open) return;
-        const textBefore = getTextBeforeCursor();
-        setSession((prev) => reduceOnSelection(prev, textBefore));
-      }, [session.open, getTextBeforeCursor]);
+        const next = reduceOnSelection(session, getTextBeforeCursor());
+        if (next.open) setAnchorRect(getCaretRect());
+        setSession(next);
+      }, [session, getTextBeforeCursor, getCaretRect]);
 
       const handleSkillPickerSelect = useCallback(
         (slug: string) => {

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -231,16 +231,18 @@ const InputBar = memo(
         anchorRect: DOMRect | null;
         query: string;
       }>({ open: false, anchorRect: null, query: "" });
+      // `sessionSlash` is the `/` index of the tracked token; `suppressed` hides
+      // the picker within it after Esc. Both reset when that slash is gone.
+      const suppressedRef = useRef(false);
+      const sessionSlashRef = useRef<number | null>(null);
 
       const [skillInfo, setSkillInfo] = useState<{
         tile: HTMLElement;
         name: string;
         description: string;
       } | null>(null);
-      // Stable so SkillInfoPopover's observers/listeners don't rebuild each render.
       const dismissSkillInfo = useCallback(() => setSkillInfo(null), []);
 
-      // Shared queued-message keyboard navigation + highlight state.
       const queueNav = useQueuedMessageNavigation({
         messages: queue,
         inputIsEmpty: !message,
@@ -263,21 +265,6 @@ const InputBar = memo(
         return getTextContent(tmp);
       }, [inputRef]);
 
-      // The remaining slash-token characters in the caret's OWN text node (when
-      // a skill is picked mid-token). Scoped to the text node so it never spans
-      // into a following tile's serialized text.
-      const getTokenRemainderAfterCursor = useCallback((): string => {
-        const sel = window.getSelection();
-        if (!sel || sel.rangeCount === 0) return "";
-        const { endContainer, endOffset } = sel.getRangeAt(0);
-        if (endContainer.nodeType !== Node.TEXT_NODE) return "";
-        return (
-          (endContainer.textContent ?? "")
-            .slice(endOffset)
-            .match(/^\S*/)?.[0] ?? ""
-        );
-      }, []);
-
       const getCaretRect = useCallback((): DOMRect | null => {
         const sel = window.getSelection();
         if (!sel || sel.rangeCount === 0) return null;
@@ -295,59 +282,77 @@ const InputBar = memo(
         return rect;
       }, [inputRef]);
 
-      const evaluateSkillPicker = useCallback(() => {
-        const textBefore = getTextBeforeCursor();
-        if (textBefore === null) {
-          setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
-          return;
-        }
-        const trigger = detectSlashTrigger(textBefore);
-        if (!trigger) {
-          setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
-          return;
-        }
-        setSkillPicker({
-          open: true,
-          anchorRect: getCaretRect(),
-          query: trigger.query,
-        });
-      }, [getCaretRect, getTextBeforeCursor]);
+      const closeSkillPicker = useCallback(() => {
+        sessionSlashRef.current = null;
+        suppressedRef.current = false;
+        setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
+      }, []);
+
+      // Esc keeps the picker closed within this token until its slash is gone.
+      const dismissSkillPicker = useCallback(() => {
+        suppressedRef.current = true;
+        setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
+      }, []);
 
       const handleEnhancedInput = useCallback(
         (event: SyntheticEvent<HTMLDivElement>) => {
           onInput(event);
-          evaluateSkillPicker();
+          const textBefore = getTextBeforeCursor();
+          const trigger =
+            textBefore === null ? null : detectSlashTrigger(textBefore);
+          if (!trigger) {
+            // Keep a dismissed session alive while its slash survives (so deleting
+            // back into the token doesn't reopen it); reset once the slash is gone.
+            const slash = sessionSlashRef.current;
+            if (slash === null || textBefore?.[slash] !== "/") {
+              closeSkillPicker();
+            } else {
+              setSkillPicker((s) => (s.open ? { ...s, open: false } : s));
+            }
+            return;
+          }
+          if (trigger.slashIndex !== sessionSlashRef.current) {
+            sessionSlashRef.current = trigger.slashIndex;
+            suppressedRef.current = false;
+          }
+          if (suppressedRef.current) return;
+          setSkillPicker({
+            open: true,
+            anchorRect: getCaretRect(),
+            query: trigger.query,
+          });
         },
-        [onInput, evaluateSkillPicker]
+        [onInput, getTextBeforeCursor, getCaretRect, closeSkillPicker]
       );
 
-      // Re-evaluate the trigger when the caret moves without input (arrows/click).
+      // Caret moves never open the picker; they only close it or sync its query.
       const handleSelectionChange = useCallback(() => {
-        evaluateSkillPicker();
-      }, [evaluateSkillPicker]);
-
-      const closeSkillPicker = useCallback(() => {
-        setSkillPicker((s) => ({ ...s, open: false }));
-      }, []);
+        if (!skillPicker.open) return;
+        const textBefore = getTextBeforeCursor();
+        const trigger =
+          textBefore === null ? null : detectSlashTrigger(textBefore);
+        if (!trigger || trigger.slashIndex !== sessionSlashRef.current) {
+          closeSkillPicker();
+          return;
+        }
+        if (trigger.query !== skillPicker.query) {
+          setSkillPicker((s) => ({ ...s, query: trigger.query }));
+        }
+      }, [
+        skillPicker.open,
+        skillPicker.query,
+        getTextBeforeCursor,
+        closeSkillPicker,
+      ]);
 
       const handleSkillPickerSelect = useCallback(
         (slug: string) => {
           if (!skillPicker.open) return;
-          // `beforeToken` is `/<query>`; `afterText` is the token remainder past
-          // the caret (when clicking mid-token).
           const beforeToken = `/${skillPicker.query}`;
-          const afterText = getTokenRemainderAfterCursor();
           const name = pickerSkills.find((s) => s.slug === slug)?.name ?? slug;
-          insertSkillTile(slug, name, beforeToken, afterText);
-          closeSkillPicker();
+          if (insertSkillTile(slug, name, beforeToken)) closeSkillPicker();
         },
-        [
-          skillPicker,
-          pickerSkills,
-          insertSkillTile,
-          closeSkillPicker,
-          getTokenRemainderAfterCursor,
-        ]
+        [skillPicker, pickerSkills, insertSkillTile, closeSkillPicker]
       );
 
       const openSkillInfo = useCallback(
@@ -421,9 +426,18 @@ const InputBar = memo(
           const text = event.clipboardData.getData("text/plain");
           if (!text) return;
 
+          // Recreate a skill tile when pasting a lone `/<slug>` for a known
+          // skill (e.g. copied from another tile), mirroring the picker flow.
+          const slug = text.trim().match(/^\/(\S+)$/)?.[1];
+          const skill = slug && pickerSkills.find((s) => s.slug === slug);
+          if (skill) {
+            insertSkillTile(skill.slug, skill.name, "");
+            return;
+          }
+
           pasteText(text);
         },
-        [disabled, uploadFiles, pasteText]
+        [disabled, uploadFiles, pasteText, pickerSkills, insertSkillTile]
       );
 
       const handleSubmit = useCallback(() => {
@@ -518,7 +532,11 @@ const InputBar = memo(
       }, [interruptible, isInterrupting, onInterrupt]);
       const { armed } = useDoubleEscapeInterrupt({
         enabled:
-          interruptible && !isInterrupting && !skillPicker.open && !tilePopover,
+          interruptible &&
+          !isInterrupting &&
+          !skillPicker.open &&
+          !tilePopover &&
+          !skillInfo,
         onInterrupt: handleInterrupt,
       });
 
@@ -705,7 +723,7 @@ const InputBar = memo(
             query={skillPicker.query}
             skills={pickerSkills}
             onSelect={handleSkillPickerSelect}
-            onClose={closeSkillPicker}
+            onClose={dismissSkillPicker}
           />
           {skillInfo && (
             <SkillInfoPopover

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -486,8 +486,10 @@ const InputBar = memo(
               return;
             }
           }
-          if (handleTileKeyDown(event)) return;
+          // Queue nav owns keys while a message is highlighted, so it must run
+          // before tile handling (whose Backspace guard would otherwise win).
           if (queueEnabled && queueNav.handleKeyDown(event)) return;
+          if (handleTileKeyDown(event)) return;
 
           if (isSubmitEnter) {
             event.preventDefault();

--- a/web/src/app/css/content-editable.css
+++ b/web/src/app/css/content-editable.css
@@ -80,3 +80,16 @@
   background: var(--background-neutral-02);
   color: var(--text-05);
 }
+
+/* Skill tile — colors come from the Opal Tag (TAG_COLORS.blue), applied as
+   classes in richInputTile.ts. Only layout lives here. */
+.rich-input-tile[data-tile-type="skill"] {
+  border-color: transparent;
+  align-items: baseline;
+}
+
+/* Keep icon + remove button centered while the label sets the baseline. */
+.rich-input-tile[data-tile-type="skill"] .rich-input-tile-icon,
+.rich-input-tile[data-tile-type="skill"] .rich-input-tile-remove {
+  align-self: center;
+}

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -7,7 +7,6 @@ import {
   insertNodeAtCursor as insertNodeAtCursorUtil,
   getTextContent,
   deleteTokenBeforeCursor,
-  deleteTextAfterCursor,
   stripLeadingBr,
 } from "@/lib/contentEditable";
 import {
@@ -40,17 +39,8 @@ export interface UseContentEditableReturn {
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
   insertTileAtCursor: (text: string) => void;
-  /**
-   * Insert a skill tile, removing the slash token around the caret: `beforeToken`
-   * (the `/<query>` before the caret) and `afterText` (any remaining token
-   * characters after the caret).
-   */
-  insertSkillTile: (
-    slug: string,
-    name: string,
-    beforeToken: string,
-    afterText: string
-  ) => void;
+  /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
+  insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
@@ -288,13 +278,14 @@ export function useContentEditable({
   );
 
   const insertSkillTile = useCallback(
-    (slug: string, name: string, beforeToken: string, afterText: string) => {
+    (slug: string, name: string, beforeToken: string): boolean => {
       const el = ref.current;
-      if (!el) return;
-      // Bail if the `/<query>` can't be removed — the tile serializes back to
-      // `/<slug> `, so inserting over a surviving `/<query>` would duplicate it.
-      if (!deleteTokenBeforeCursor(el, beforeToken)) return;
-      deleteTextAfterCursor(el, afterText);
+      if (!el) return false;
+      // Replacing a typed `/<query>`: bail if it can't be verifiably removed,
+      // since the tile serializes back to `/<slug> ` and would duplicate it. An
+      // empty `beforeToken` (e.g. paste) just inserts at the caret.
+      if (beforeToken && !deleteTokenBeforeCursor(el, beforeToken))
+        return false;
       const tile = createRichInputTileNode({
         type: SKILL_TILE_TYPE,
         text: `/${slug} `,
@@ -302,10 +293,10 @@ export function useContentEditable({
         meta: "",
         skillSlug: slug,
       });
-      insertNodeAtCursorUtil(el, tile);
-      setCursorAfterNode(tile);
+      insertNodeAtCursorUtil(el, tile); // also places the caret after the tile
       syncFromDOM();
       resize();
+      return true;
     },
     [syncFromDOM, resize]
   );
@@ -462,22 +453,11 @@ export function useContentEditable({
         const selected = selectedTileRef.current;
 
         if (isNav) {
-          // Arrow on selected tile → deselect and move cursor past it
-          event.preventDefault();
+          // Deselect; let the native arrow collapse the selection to the right
+          // edge (it renders the caret correctly, unlike a manual tile-boundary
+          // range, which had no caret rect and needed a second press).
           clearTileSelection();
-          if (event.key === "ArrowRight") {
-            setCursorAfterNode(selected);
-          } else {
-            const s = window.getSelection();
-            if (s) {
-              const r = document.createRange();
-              r.setStartBefore(selected);
-              r.collapse(true);
-              s.removeAllRanges();
-              s.addRange(r);
-            }
-          }
-          return true;
+          return false;
         }
 
         if (isDelete) {

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -6,6 +6,9 @@ import {
   insertTextAtCursor as insertTextAtCursorUtil,
   insertNodeAtCursor as insertNodeAtCursorUtil,
   getTextContent,
+  deleteTokenBeforeCursor,
+  deleteTextAfterCursor,
+  stripLeadingBr,
 } from "@/lib/contentEditable";
 import {
   createRichInputTileNode,
@@ -13,6 +16,8 @@ import {
   shouldCreatePasteTile,
   getPasteTilePreview,
   getPasteTileMeta,
+  isSkillTile,
+  SKILL_TILE_TYPE,
 } from "@/lib/richInputTile";
 
 export interface UseContentEditableOptions {
@@ -35,6 +40,17 @@ export interface UseContentEditableReturn {
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
   insertTileAtCursor: (text: string) => void;
+  /**
+   * Insert a skill tile, removing the slash token around the caret: `beforeToken`
+   * (the `/<query>` before the caret) and `afterText` (any remaining token
+   * characters after the caret).
+   */
+  insertSkillTile: (
+    slug: string,
+    name: string,
+    beforeToken: string,
+    afterText: string
+  ) => void;
   pasteText: (text: string) => void;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
@@ -164,6 +180,18 @@ export function useContentEditable({
     (_event: React.SyntheticEvent<HTMLDivElement>): string => {
       if (isComposingRef.current) return messageRef.current;
       clearTileSelection();
+      const el = ref.current;
+      if (el && stripLeadingBr(el)) {
+        // The stray <br> sat before the caret-at-start; collapse to the start.
+        const s = window.getSelection();
+        if (s) {
+          const r = document.createRange();
+          r.setStart(el, 0);
+          r.collapse(true);
+          s.removeAllRanges();
+          s.addRange(r);
+        }
+      }
       const text = syncFromDOM();
       resize();
       return text;
@@ -259,6 +287,29 @@ export function useContentEditable({
     [syncFromDOM, resize]
   );
 
+  const insertSkillTile = useCallback(
+    (slug: string, name: string, beforeToken: string, afterText: string) => {
+      const el = ref.current;
+      if (!el) return;
+      // Bail if the `/<query>` can't be removed — the tile serializes back to
+      // `/<slug> `, so inserting over a surviving `/<query>` would duplicate it.
+      if (!deleteTokenBeforeCursor(el, beforeToken)) return;
+      deleteTextAfterCursor(el, afterText);
+      const tile = createRichInputTileNode({
+        type: SKILL_TILE_TYPE,
+        text: `/${slug} `,
+        preview: `Skill: ${name}`,
+        meta: "",
+        skillSlug: slug,
+      });
+      insertNodeAtCursorUtil(el, tile);
+      setCursorAfterNode(tile);
+      syncFromDOM();
+      resize();
+    },
+    [syncFromDOM, resize]
+  );
+
   const pasteText = useCallback(
     (text: string) => {
       if (pasteTilesEnabled && shouldCreatePasteTile(text)) {
@@ -300,6 +351,9 @@ export function useContentEditable({
 
       const tile = target.closest("[data-rich-tile]") as HTMLElement | null;
       if (tile) {
+        // Skill tiles don't use the paste-edit popover; their click handling
+        // (re-pick) lives in the host input bar.
+        if (isSkillTile(tile)) return;
         const text = tile.getAttribute("data-text") ?? "";
         setTilePopover({ text, tile });
       } else {
@@ -374,10 +428,12 @@ export function useContentEditable({
       const isNav = event.key === "ArrowLeft" || event.key === "ArrowRight";
       const isDelete = event.key === "Backspace" || event.key === "Delete";
 
-      // Enter on selected tile → open popover
+      // Enter on selected tile → open popover (paste tiles only; skill tiles
+      // have no editable text, so Enter is a no-op that keeps them selected).
       if (event.key === "Enter" && selectedTileRef.current) {
         event.preventDefault();
         const tile = selectedTileRef.current;
+        if (isSkillTile(tile)) return true;
         const text = tile.getAttribute("data-text") ?? "";
         setTilePopover({ text, tile });
         return true;
@@ -444,6 +500,27 @@ export function useContentEditable({
       }
 
       const range = sel.getRangeAt(0);
+
+      // Chrome deletes a leading contentEditable=false tile when Backspace is
+      // pressed with nothing before the caret. That deletion is a no-op anyway
+      // (nothing to the left), so block it — otherwise it eats the tile or
+      // leaves an empty first line above it.
+      const el = ref.current;
+      if (
+        event.key === "Backspace" &&
+        el &&
+        el.contains(range.startContainer)
+      ) {
+        const before = document.createRange();
+        before.selectNodeContents(el);
+        before.setEnd(range.startContainer, range.startOffset);
+        // Collapsed ⇒ nothing precedes the caret.
+        if (before.collapsed) {
+          event.preventDefault();
+          return true;
+        }
+      }
+
       let direction: "before" | "after";
       if (isDelete) {
         direction = event.key === "Backspace" ? "before" : "after";
@@ -530,6 +607,7 @@ export function useContentEditable({
     handleCompositionEnd,
     insertTextAtCursor,
     insertTileAtCursor,
+    insertSkillTile,
     pasteText,
     handleCopy,
     handleCut,

--- a/web/src/lib/__tests__/contentEditable.test.ts
+++ b/web/src/lib/__tests__/contentEditable.test.ts
@@ -276,6 +276,38 @@ describe("deleteTokenBeforeCursor", () => {
     expect(deleteTokenBeforeCursor(el, "")).toBe(false);
     el.remove();
   });
+
+  it("returns false when fewer chars than the token precede the caret", () => {
+    const el = mount("/x");
+    caretAt(el.firstChild as Text, 1);
+    expect(deleteTokenBeforeCursor(el, "/x")).toBe(false);
+    expect(getTextContent(el)).toBe("/x");
+    el.remove();
+  });
+
+  it("returns false (no mutation) for a non-collapsed selection", () => {
+    const el = mount("hi /pptx");
+    const text = el.firstChild as Text;
+    const sel = window.getSelection()!;
+    const r = document.createRange();
+    r.setStart(text, 3);
+    r.setEnd(text, text.length);
+    sel.removeAllRanges();
+    sel.addRange(r);
+    expect(deleteTokenBeforeCursor(el, "/pptx")).toBe(false);
+    expect(getTextContent(el)).toBe("hi /pptx");
+    el.remove();
+  });
+
+  it("returns false when the caret is outside the element", () => {
+    const el = mount("hi /pptx");
+    const outside = mount("/pptx");
+    caretAt(outside.firstChild as Text, 5);
+    expect(deleteTokenBeforeCursor(el, "/pptx")).toBe(false);
+    expect(getTextContent(el)).toBe("hi /pptx");
+    el.remove();
+    outside.remove();
+  });
 });
 
 describe("stripLeadingBr", () => {
@@ -300,6 +332,13 @@ describe("stripLeadingBr", () => {
   it("returns false when the first child is not a <br>", () => {
     const el = mount(`${tileHtml()}`);
     expect(stripLeadingBr(el)).toBe(false);
+    el.remove();
+  });
+
+  it("leaves a leading <br> that precedes a non-tile element untouched", () => {
+    const el = mount("<br><span>text</span>");
+    expect(stripLeadingBr(el)).toBe(false);
+    expect(el.firstChild?.nodeName).toBe("BR");
     el.remove();
   });
 });

--- a/web/src/lib/__tests__/contentEditable.test.ts
+++ b/web/src/lib/__tests__/contentEditable.test.ts
@@ -2,11 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { getTextContent } from "@/lib/contentEditable";
+import {
+  getTextContent,
+  deleteTokenBeforeCursor,
+  deleteTextAfterCursor,
+  stripLeadingBr,
+} from "@/lib/contentEditable";
 import {
   shouldCreatePasteTile,
   getPasteTilePreview,
   getPasteTileMeta,
+  createRichInputTileNode,
   PASTE_TILE_THRESHOLD_CHARS,
 } from "@/lib/richInputTile";
 
@@ -176,5 +182,143 @@ describe("getTextContent", () => {
     el.appendChild(p2);
     el.appendChild(p3);
     expect(getTextContent(el)).toBe("line1\nline2\nline3");
+  });
+});
+
+describe("createRichInputTileNode — skill tiles", () => {
+  // Skill tiles are built with a "Skill: <name>" preview and an empty meta.
+  it("marks the tile type and stores the skill slug", () => {
+    const tile = createRichInputTileNode({
+      type: "skill",
+      text: "/pptx ",
+      preview: "Skill: Slides",
+      meta: "",
+      skillSlug: "pptx",
+    });
+    expect(tile.getAttribute("data-tile-type")).toBe("skill");
+    expect(tile.getAttribute("data-skill-slug")).toBe("pptx");
+  });
+
+  it("serializes to the legacy `/<slug> ` literal via getTextContent", () => {
+    // This is the contract that keeps the submitted payload identical to the
+    // pre-tile behavior, so the backend needs no changes.
+    const el = document.createElement("div");
+    el.appendChild(document.createTextNode("make me "));
+    el.appendChild(
+      createRichInputTileNode({
+        type: "skill",
+        text: "/pptx ",
+        preview: "Skill: Slides",
+        meta: "",
+        skillSlug: "pptx",
+      })
+    );
+    el.appendChild(document.createTextNode("about cats"));
+    expect(getTextContent(el)).toBe("make me /pptx about cats");
+  });
+
+  it("renders the 'Skill: <name>' preview and omits the meta when empty", () => {
+    const tile = createRichInputTileNode({
+      type: "skill",
+      text: "/pptx ",
+      preview: "Skill: Slides",
+      meta: "",
+      skillSlug: "pptx",
+    });
+    expect(tile.querySelector(".rich-input-tile-preview")?.textContent).toBe(
+      "Skill: Slides"
+    );
+    expect(tile.querySelector(".rich-input-tile-meta")).toBeNull();
+  });
+});
+
+// Caret/selection helpers — only the text-node fast paths are exercised here;
+// the Selection.modify node-boundary fallback isn't implemented by jsdom and is
+// left to e2e (the helpers guard on `typeof sel.modify !== "function"`).
+function caretAt(node: Node, offset: number): void {
+  const sel = window.getSelection()!;
+  const r = document.createRange();
+  r.setStart(node, offset);
+  r.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(r);
+}
+
+function mount(html: string): HTMLDivElement {
+  const el = document.createElement("div");
+  el.contentEditable = "true";
+  el.innerHTML = html;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe("deleteTokenBeforeCursor", () => {
+  it("removes the exact token before the caret and returns true", () => {
+    const el = mount("hi /pptx");
+    const text = el.firstChild as Text;
+    caretAt(text, text.length);
+    expect(deleteTokenBeforeCursor(el, "/pptx")).toBe(true);
+    expect(getTextContent(el)).toBe("hi ");
+    el.remove();
+  });
+
+  it("returns false (and deletes nothing) when the chars don't match", () => {
+    const el = mount("hello");
+    const text = el.firstChild as Text;
+    caretAt(text, text.length);
+    expect(deleteTokenBeforeCursor(el, "/x")).toBe(false);
+    expect(getTextContent(el)).toBe("hello");
+    el.remove();
+  });
+
+  it("returns false for an empty token", () => {
+    const el = mount("hi");
+    caretAt(el.firstChild as Text, 2);
+    expect(deleteTokenBeforeCursor(el, "")).toBe(false);
+    el.remove();
+  });
+});
+
+describe("deleteTextAfterCursor", () => {
+  it("removes the exact text after the caret and returns true", () => {
+    const el = mount("/pptx hi");
+    caretAt(el.firstChild as Text, 0);
+    expect(deleteTextAfterCursor(el, "/pptx")).toBe(true);
+    expect(getTextContent(el)).toBe(" hi");
+    el.remove();
+  });
+
+  it("returns false when the text would overrun the node", () => {
+    const el = mount("ab");
+    caretAt(el.firstChild as Text, 0);
+    expect(deleteTextAfterCursor(el, "abc")).toBe(false);
+    expect(getTextContent(el)).toBe("ab");
+    el.remove();
+  });
+});
+
+describe("stripLeadingBr", () => {
+  function tileHtml(): string {
+    return '<span data-rich-tile data-tile-type="skill">Skill: X</span>';
+  }
+
+  it("removes a leading <br> that precedes a rich tile", () => {
+    const el = mount(`<br>${tileHtml()}`);
+    expect(stripLeadingBr(el)).toBe(true);
+    expect(el.firstChild?.nodeName).toBe("SPAN");
+    el.remove();
+  });
+
+  it("leaves a leading <br> that precedes text (user newline) untouched", () => {
+    const el = mount("<br>hello");
+    expect(stripLeadingBr(el)).toBe(false);
+    expect(el.firstChild?.nodeName).toBe("BR");
+    el.remove();
+  });
+
+  it("returns false when the first child is not a <br>", () => {
+    const el = mount(`${tileHtml()}`);
+    expect(stripLeadingBr(el)).toBe(false);
+    el.remove();
   });
 });

--- a/web/src/lib/__tests__/contentEditable.test.ts
+++ b/web/src/lib/__tests__/contentEditable.test.ts
@@ -5,7 +5,6 @@
 import {
   getTextContent,
   deleteTokenBeforeCursor,
-  deleteTextAfterCursor,
   stripLeadingBr,
 } from "@/lib/contentEditable";
 import {
@@ -275,24 +274,6 @@ describe("deleteTokenBeforeCursor", () => {
     const el = mount("hi");
     caretAt(el.firstChild as Text, 2);
     expect(deleteTokenBeforeCursor(el, "")).toBe(false);
-    el.remove();
-  });
-});
-
-describe("deleteTextAfterCursor", () => {
-  it("removes the exact text after the caret and returns true", () => {
-    const el = mount("/pptx hi");
-    caretAt(el.firstChild as Text, 0);
-    expect(deleteTextAfterCursor(el, "/pptx")).toBe(true);
-    expect(getTextContent(el)).toBe(" hi");
-    el.remove();
-  });
-
-  it("returns false when the text would overrun the node", () => {
-    const el = mount("ab");
-    caretAt(el.firstChild as Text, 0);
-    expect(deleteTextAfterCursor(el, "abc")).toBe(false);
-    expect(getTextContent(el)).toBe("ab");
     el.remove();
   });
 });

--- a/web/src/lib/__tests__/skillTileSync.test.ts
+++ b/web/src/lib/__tests__/skillTileSync.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createElement } from "react";
+import { render } from "@testing-library/react";
+import SvgSparkle from "@opal/icons/sparkle";
+import { TAG_COLORS } from "@opal/components/tag/colors";
+import { createRichInputTileNode } from "@/lib/richInputTile";
+
+// Guards the raw-DOM skill tile against drift from its source of truth (the Opal
+// Tag + sparkle icon): the mirrored path must equal the real icon, and the
+// fill/text colors must come from TAG_COLORS.blue.
+describe("skill tile stays in sync with the Opal Tag + sparkle icon", () => {
+  function skillTile() {
+    return createRichInputTileNode({
+      type: "skill",
+      text: "/pptx ",
+      preview: "Skill: Slides",
+      meta: "",
+      skillSlug: "pptx",
+    });
+  }
+
+  it("mirrors the real SvgSparkle path", () => {
+    const { container } = render(createElement(SvgSparkle));
+    const realPath = container.querySelector("path")?.getAttribute("d");
+    expect(realPath).toBeTruthy();
+    const tilePath = skillTile()
+      .querySelector(".rich-input-tile-icon path")
+      ?.getAttribute("d");
+    expect(tilePath).toBe(realPath);
+  });
+
+  it("sources fill + text colors from TAG_COLORS.blue", () => {
+    const tile = skillTile();
+    for (const cls of TAG_COLORS.blue.bg.split(" ")) {
+      expect(tile.classList.contains(cls)).toBe(true);
+    }
+    const iconClass =
+      tile.querySelector(".rich-input-tile-icon")?.getAttribute("class") ?? "";
+    for (const cls of TAG_COLORS.blue.text.split(" ")) {
+      expect(iconClass).toContain(cls);
+    }
+  });
+});

--- a/web/src/lib/__tests__/skillTileSync.test.ts
+++ b/web/src/lib/__tests__/skillTileSync.test.ts
@@ -21,14 +21,18 @@ describe("skill tile stays in sync with the Opal Tag + sparkle icon", () => {
     });
   }
 
-  it("mirrors the real SvgSparkle path", () => {
+  it("mirrors the real SvgSparkle path + stroke-linecap", () => {
     const { container } = render(createElement(SvgSparkle));
     const realPath = container.querySelector("path")?.getAttribute("d");
+    const realCap = container
+      .querySelector("[stroke-linecap]")
+      ?.getAttribute("stroke-linecap");
     expect(realPath).toBeTruthy();
-    const tilePath = skillTile()
-      .querySelector(".rich-input-tile-icon path")
-      ?.getAttribute("d");
-    expect(tilePath).toBe(realPath);
+    expect(realCap).toBeTruthy();
+
+    const tileIcon = skillTile().querySelector(".rich-input-tile-icon");
+    expect(tileIcon?.querySelector("path")?.getAttribute("d")).toBe(realPath);
+    expect(tileIcon?.getAttribute("stroke-linecap")).toBe(realCap);
   });
 
   it("sources fill + text colors from TAG_COLORS.blue", () => {

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -126,3 +126,90 @@ export function getTextContent(element: HTMLElement): string {
   }
   return parts.join("");
 }
+
+/**
+ * Remove the stray leading `<br>` Chrome inserts when the last text on the
+ * first "line" is deleted ahead of an inline contentEditable=false tile,
+ * leaving a blank line above it. Scoped to a `<br>` immediately followed by a
+ * rich tile so it never touches a user-authored leading newline. Returns
+ * whether anything was removed.
+ */
+export function stripLeadingBr(el: HTMLElement): boolean {
+  const first = el.firstChild;
+  const next = first?.nextSibling;
+  if (
+    first?.nodeName === "BR" &&
+    next instanceof HTMLElement &&
+    next.hasAttribute("data-rich-tile")
+  ) {
+    el.removeChild(first);
+    return true;
+  }
+  return false;
+}
+
+// ─── Token Deletion (rich-tile insertion) ───────────────────────────────────
+
+/**
+ * Delete `text` immediately before (`direction: "before"`) or after the
+ * collapsed cursor, but only after verifying the characters to remove equal
+ * `text` (else bail + restore the caret). Returns whether they were removed.
+ */
+function deleteAdjacentText(
+  el: HTMLElement,
+  text: string,
+  direction: "before" | "after"
+): boolean {
+  const n = text.length;
+  if (n <= 0) return false;
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return false;
+  const range = sel.getRangeAt(0);
+  if (!range.collapsed || !el.contains(range.startContainer)) return false;
+
+  const { startContainer, startOffset } = range;
+  const before = direction === "before";
+
+  // Fast path: the text lives entirely within the caret's text node.
+  if (startContainer.nodeType === Node.TEXT_NODE) {
+    const tc = startContainer.textContent ?? "";
+    const start = before ? startOffset - n : startOffset;
+    const end = before ? startOffset : startOffset + n;
+    if (start >= 0 && end <= tc.length && tc.slice(start, end) === text) {
+      if (before) range.setStart(startContainer, start);
+      else range.setEnd(startContainer, end);
+      range.deleteContents();
+      sel.removeAllRanges();
+      sel.addRange(range);
+      return true;
+    }
+  }
+
+  // Fallback for node-spanning text; modify is absent in jsdom.
+  if (typeof sel.modify !== "function") return false;
+  const steps = Array.from(text).length; // code points, not UTF-16 units
+  for (let i = 0; i < steps; i++) {
+    sel.modify("extend", before ? "backward" : "forward", "character");
+  }
+  if (sel.toString() === text) {
+    sel.deleteFromDocument();
+    return true;
+  }
+  const restored = document.createRange();
+  restored.setStart(startContainer, startOffset);
+  restored.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(restored);
+  return false;
+}
+
+export function deleteTokenBeforeCursor(
+  el: HTMLElement,
+  token: string
+): boolean {
+  return deleteAdjacentText(el, token, "before");
+}
+
+export function deleteTextAfterCursor(el: HTMLElement, text: string): boolean {
+  return deleteAdjacentText(el, text, "after");
+}

--- a/web/src/lib/contentEditable.ts
+++ b/web/src/lib/contentEditable.ts
@@ -128,11 +128,10 @@ export function getTextContent(element: HTMLElement): string {
 }
 
 /**
- * Remove the stray leading `<br>` Chrome inserts when the last text on the
- * first "line" is deleted ahead of an inline contentEditable=false tile,
- * leaving a blank line above it. Scoped to a `<br>` immediately followed by a
- * rich tile so it never touches a user-authored leading newline. Returns
- * whether anything was removed.
+ * Remove the stray leading `<br>` Chrome inserts when the last char before a
+ * leading inline tile is deleted. Scoped to a `<br>` immediately followed by a
+ * rich tile so a normal leading newline (followed by text) is preserved.
+ * Returns whether anything was removed.
  */
 export function stripLeadingBr(el: HTMLElement): boolean {
   const first = el.firstChild;
@@ -151,16 +150,15 @@ export function stripLeadingBr(el: HTMLElement): boolean {
 // ─── Token Deletion (rich-tile insertion) ───────────────────────────────────
 
 /**
- * Delete `text` immediately before (`direction: "before"`) or after the
- * collapsed cursor, but only after verifying the characters to remove equal
- * `text` (else bail + restore the caret). Returns whether they were removed.
+ * Delete `token` immediately before the collapsed cursor, but only after
+ * verifying the characters to remove equal it (else bail + restore the caret).
+ * Returns whether the token was removed.
  */
-function deleteAdjacentText(
+export function deleteTokenBeforeCursor(
   el: HTMLElement,
-  text: string,
-  direction: "before" | "after"
+  token: string
 ): boolean {
-  const n = text.length;
+  const n = token.length;
   if (n <= 0) return false;
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return false;
@@ -168,30 +166,25 @@ function deleteAdjacentText(
   if (!range.collapsed || !el.contains(range.startContainer)) return false;
 
   const { startContainer, startOffset } = range;
-  const before = direction === "before";
 
-  // Fast path: the text lives entirely within the caret's text node.
-  if (startContainer.nodeType === Node.TEXT_NODE) {
-    const tc = startContainer.textContent ?? "";
-    const start = before ? startOffset - n : startOffset;
-    const end = before ? startOffset : startOffset + n;
-    if (start >= 0 && end <= tc.length && tc.slice(start, end) === text) {
-      if (before) range.setStart(startContainer, start);
-      else range.setEnd(startContainer, end);
-      range.deleteContents();
-      sel.removeAllRanges();
-      sel.addRange(range);
-      return true;
-    }
+  // Fast path: the token lives entirely within the caret's text node.
+  if (
+    startContainer.nodeType === Node.TEXT_NODE &&
+    startOffset >= n &&
+    startContainer.textContent?.slice(startOffset - n, startOffset) === token
+  ) {
+    range.setStart(startContainer, startOffset - n);
+    range.deleteContents();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return true;
   }
 
-  // Fallback for node-spanning text; modify is absent in jsdom.
+  // Fallback for node-spanning tokens; modify is absent in jsdom.
   if (typeof sel.modify !== "function") return false;
-  const steps = Array.from(text).length; // code points, not UTF-16 units
-  for (let i = 0; i < steps; i++) {
-    sel.modify("extend", before ? "backward" : "forward", "character");
-  }
-  if (sel.toString() === text) {
+  const steps = Array.from(token).length; // code points, not UTF-16 units
+  for (let i = 0; i < steps; i++) sel.modify("extend", "backward", "character");
+  if (sel.toString() === token) {
     sel.deleteFromDocument();
     return true;
   }
@@ -201,15 +194,4 @@ function deleteAdjacentText(
   sel.removeAllRanges();
   sel.addRange(restored);
   return false;
-}
-
-export function deleteTokenBeforeCursor(
-  el: HTMLElement,
-  token: string
-): boolean {
-  return deleteAdjacentText(el, token, "before");
-}
-
-export function deleteTextAfterCursor(el: HTMLElement, text: string): boolean {
-  return deleteAdjacentText(el, text, "after");
 }

--- a/web/src/lib/richInputTile.ts
+++ b/web/src/lib/richInputTile.ts
@@ -54,6 +54,8 @@ interface IconSpec {
   viewBox: string;
   size: number;
   strokeWidth: number;
+  /** Mirror the source icon's linecap (e.g. SvgSparkle uses "square"). */
+  strokeLinecap: "round" | "square";
 }
 
 // Icon per tile type. Keyed by RichTileConfig.type; falls back to "paste".
@@ -63,12 +65,14 @@ const TILE_ICONS: Record<string, IconSpec> = {
     viewBox: "0 0 16 16",
     size: 14,
     strokeWidth: 1.5,
+    strokeLinecap: "round",
   },
   skill: {
     paths: [SPARKLE_PATH],
     viewBox: "0 0 16 16",
     size: 14,
     strokeWidth: 1.5,
+    strokeLinecap: "square",
   },
 };
 
@@ -76,7 +80,8 @@ function createSvgIcon(
   paths: string[],
   viewBox: string,
   size: number,
-  strokeWidth: number
+  strokeWidth: number,
+  strokeLinecap: "round" | "square" = "round"
 ): SVGSVGElement {
   const ns = "http://www.w3.org/2000/svg";
   const svg = document.createElementNS(ns, "svg");
@@ -86,7 +91,7 @@ function createSvgIcon(
   svg.setAttribute("fill", "none");
   svg.setAttribute("stroke", "currentColor");
   svg.setAttribute("stroke-width", String(strokeWidth));
-  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linecap", strokeLinecap);
   svg.setAttribute("stroke-linejoin", "round");
   for (const path of paths) {
     const pathEl = document.createElementNS(ns, "path");
@@ -138,7 +143,8 @@ export function createRichInputTileNode(
     iconSpec.paths,
     iconSpec.viewBox,
     iconSpec.size,
-    iconSpec.strokeWidth
+    iconSpec.strokeWidth,
+    iconSpec.strokeLinecap
   );
   icon.classList.add("rich-input-tile-icon");
   if (isSkill) icon.classList.add(...TAG_COLORS.blue.text.split(" "));

--- a/web/src/lib/richInputTile.ts
+++ b/web/src/lib/richInputTile.ts
@@ -1,3 +1,13 @@
+import { TAG_COLORS } from "@opal/components/tag/colors";
+
+/** Value stored in a tile's `data-tile-type` for slash-command skill tiles. */
+export const SKILL_TILE_TYPE = "skill";
+
+/** Whether `el` is a skill rich tile. */
+export function isSkillTile(el: Element | null): boolean {
+  return el?.getAttribute("data-tile-type") === SKILL_TILE_TYPE;
+}
+
 export const PASTE_TILE_THRESHOLD_CHARS = 200;
 export const PASTE_TILE_THRESHOLD_LINES = 3;
 
@@ -33,10 +43,37 @@ export function getPasteTileMeta(text: string): string {
 const CLIPBOARD_PATH =
   "M10.6667 2.66665H12C12.3536 2.66665 12.6927 2.80712 12.9428 3.05717C13.1928 3.30722 13.3333 3.64636 13.3333 3.99998V13.3333C13.3333 13.6869 13.1928 14.0261 12.9428 14.2761C12.6927 14.5262 12.3536 14.6666 12 14.6666H3.99999C3.64637 14.6666 3.30723 14.5262 3.05718 14.2761C2.80713 14.0261 2.66666 13.6869 2.66666 13.3333V3.99998C2.66666 3.64636 2.80713 3.30722 3.05718 3.05717C3.30723 2.80712 3.64637 2.66665 3.99999 2.66665H5.33332M10.6667 2.66665V1.99998C10.6667 1.63179 10.3682 1.33331 9.99999 1.33331H5.99999C5.6318 1.33331 5.33332 1.63179 5.33332 1.99998V2.66665M10.6667 2.66665V3.33331C10.6667 3.7015 10.3682 3.99998 9.99999 3.99998H5.99999C5.6318 3.99998 5.33332 3.7015 5.33332 3.33331V2.66665";
 
+// Mirrored from @opal/icons sparkle.tsx (viewBox 0 0 16 16) — four-pointed star.
+const SPARKLE_PATH =
+  "M1.5 8C5.11111 6.91667 6.91667 5.11111 8 1.5C9.08333 5.11111 10.8889 6.91667 14.5 8C10.8889 9.08333 9.08333 10.8889 8 14.5C6.91667 10.8889 5.11111 9.08333 1.5 8Z";
+
 const X_PATH = "M21 7L7 21M7 7L21 21";
 
+interface IconSpec {
+  paths: string[];
+  viewBox: string;
+  size: number;
+  strokeWidth: number;
+}
+
+// Icon per tile type. Keyed by RichTileConfig.type; falls back to "paste".
+const TILE_ICONS: Record<string, IconSpec> = {
+  paste: {
+    paths: [CLIPBOARD_PATH],
+    viewBox: "0 0 16 16",
+    size: 14,
+    strokeWidth: 1.5,
+  },
+  skill: {
+    paths: [SPARKLE_PATH],
+    viewBox: "0 0 16 16",
+    size: 14,
+    strokeWidth: 1.5,
+  },
+};
+
 function createSvgIcon(
-  path: string,
+  paths: string[],
   viewBox: string,
   size: number,
   strokeWidth: number
@@ -51,9 +88,11 @@ function createSvgIcon(
   svg.setAttribute("stroke-width", String(strokeWidth));
   svg.setAttribute("stroke-linecap", "round");
   svg.setAttribute("stroke-linejoin", "round");
-  const pathEl = document.createElementNS(ns, "path");
-  pathEl.setAttribute("d", path);
-  svg.appendChild(pathEl);
+  for (const path of paths) {
+    const pathEl = document.createElementNS(ns, "path");
+    pathEl.setAttribute("d", path);
+    svg.appendChild(pathEl);
+  }
   return svg;
 }
 
@@ -62,44 +101,72 @@ export interface RichTileConfig {
   text: string;
   preview: string;
   meta: string;
+  /** Skill slug, set for skill tiles. Stored as data-skill-slug. */
+  skillSlug?: string;
 }
 
 export function createRichInputTileNode(
   config: RichTileConfig
 ): HTMLSpanElement {
+  const isSkill = config.type === SKILL_TILE_TYPE;
+
   const tile = document.createElement("span");
   tile.contentEditable = "false";
   tile.setAttribute("data-rich-tile", "");
   tile.setAttribute("data-tile-type", config.type);
   tile.setAttribute("data-text", config.text);
+  if (config.skillSlug !== undefined) {
+    tile.setAttribute("data-skill-slug", config.skillSlug);
+  }
   tile.className = "rich-input-tile";
-  tile.title =
-    config.text.length > 200 ? config.text.slice(0, 200) + "…" : config.text;
+  // Skill tile fill comes from the Opal Tag's blue tint (single source of truth).
+  if (isSkill) tile.classList.add(...TAG_COLORS.blue.bg.split(" "));
+  tile.title = isSkill
+    ? config.preview
+    : config.text.length > 200
+      ? config.text.slice(0, 200) + "…"
+      : config.text;
   tile.setAttribute(
     "aria-label",
-    "Pasted text: " + config.preview + ", " + config.meta
+    isSkill
+      ? config.preview
+      : "Pasted text: " + config.preview + ", " + config.meta
   );
 
-  const icon = createSvgIcon(CLIPBOARD_PATH, "0 0 16 16", 14, 1.5);
+  const iconSpec = TILE_ICONS[config.type] ?? TILE_ICONS.paste!;
+  const icon = createSvgIcon(
+    iconSpec.paths,
+    iconSpec.viewBox,
+    iconSpec.size,
+    iconSpec.strokeWidth
+  );
   icon.classList.add("rich-input-tile-icon");
+  if (isSkill) icon.classList.add(...TAG_COLORS.blue.text.split(" "));
   tile.appendChild(icon);
 
   const previewSpan = document.createElement("span");
   previewSpan.className = "rich-input-tile-preview";
+  if (isSkill) previewSpan.classList.add(...TAG_COLORS.blue.text.split(" "));
   previewSpan.textContent = config.preview;
   tile.appendChild(previewSpan);
 
-  const metaSpan = document.createElement("span");
-  metaSpan.className = "rich-input-tile-meta";
-  metaSpan.textContent = config.meta;
-  tile.appendChild(metaSpan);
+  // Skill tiles pass an empty meta — only render it when present.
+  if (config.meta) {
+    const metaSpan = document.createElement("span");
+    metaSpan.className = "rich-input-tile-meta";
+    metaSpan.textContent = config.meta;
+    tile.appendChild(metaSpan);
+  }
 
   const removeBtn = document.createElement("span");
   removeBtn.className = "rich-input-tile-remove";
   removeBtn.setAttribute("data-rich-tile-remove", "");
   removeBtn.setAttribute("role", "button");
-  removeBtn.setAttribute("aria-label", "Remove pasted text");
-  removeBtn.appendChild(createSvgIcon(X_PATH, "0 0 28 28", 10, 2.5));
+  removeBtn.setAttribute(
+    "aria-label",
+    isSkill ? "Remove skill" : "Remove pasted text"
+  );
+  removeBtn.appendChild(createSvgIcon([X_PATH], "0 0 28 28", 10, 2.5));
   tile.appendChild(removeBtn);
 
   return tile;

--- a/web/src/lib/skills/__tests__/picker.test.ts
+++ b/web/src/lib/skills/__tests__/picker.test.ts
@@ -1,0 +1,69 @@
+import { detectSlashTrigger, filterPickerSkills } from "@/lib/skills/picker";
+import type { PickerSkill } from "@/lib/skills/picker";
+
+// detectSlashTrigger is the contract that the Craft skill picker + skill-tile
+// insertion depend on: the `/<query>` token it reports drives how many
+// characters get consumed when a tile is dropped. Pin the spec with hardcoded
+// expectations (do not derive from the implementation).
+describe("detectSlashTrigger", () => {
+  it("returns null when there is no slash", () => {
+    expect(detectSlashTrigger("")).toBeNull();
+    expect(detectSlashTrigger("hello world")).toBeNull();
+  });
+
+  it("returns null for a slash that is not at start or after whitespace", () => {
+    expect(detectSlashTrigger("a/b")).toBeNull();
+    expect(detectSlashTrigger("http://x")).toBeNull();
+    expect(detectSlashTrigger("/a b/c")).toBeNull();
+  });
+
+  it("returns null when the query contains whitespace", () => {
+    expect(detectSlashTrigger("/foo bar")).toBeNull();
+  });
+
+  it("matches a bare slash at the start", () => {
+    expect(detectSlashTrigger("/")).toEqual({ slashIndex: 0, query: "" });
+  });
+
+  it("matches a slash query at the start", () => {
+    expect(detectSlashTrigger("/pp")).toEqual({ slashIndex: 0, query: "pp" });
+  });
+
+  it("matches a slash query after preceding text + whitespace", () => {
+    expect(detectSlashTrigger("make me /pp")).toEqual({
+      slashIndex: 8,
+      query: "pp",
+    });
+  });
+
+  it("uses the last eligible slash when several are present", () => {
+    expect(detectSlashTrigger("/a /b")).toEqual({ slashIndex: 3, query: "b" });
+  });
+});
+
+describe("filterPickerSkills", () => {
+  const skills: PickerSkill[] = [
+    { slug: "pptx", name: "Slides", description: "Make slide decks" },
+    { slug: "pdf", name: "PDF", description: "Work with PDF files" },
+  ];
+
+  it("returns all skills for an empty query", () => {
+    expect(filterPickerSkills(skills, "")).toEqual(skills);
+  });
+
+  it("matches against slug, name, and description (case-insensitive)", () => {
+    expect(filterPickerSkills(skills, "PPT").map((s) => s.slug)).toEqual([
+      "pptx",
+    ]);
+    expect(filterPickerSkills(skills, "slide").map((s) => s.slug)).toEqual([
+      "pptx",
+    ]);
+    expect(filterPickerSkills(skills, "files").map((s) => s.slug)).toEqual([
+      "pdf",
+    ]);
+  });
+
+  it("returns nothing when no field matches", () => {
+    expect(filterPickerSkills(skills, "zzz")).toEqual([]);
+  });
+});

--- a/web/src/lib/skills/__tests__/pickerSession.test.ts
+++ b/web/src/lib/skills/__tests__/pickerSession.test.ts
@@ -1,0 +1,172 @@
+import {
+  reduceOnInput,
+  reduceOnSelection,
+  reduceOnDismiss,
+  INITIAL_PICKER_SESSION,
+  type PickerSession,
+} from "@/lib/skills/pickerSession";
+
+const open = (slashIndex: number, query: string): PickerSession => ({
+  slashIndex,
+  suppressed: false,
+  open: true,
+  query,
+});
+
+describe("reduceOnInput", () => {
+  it("opens a session when a slash trigger is typed", () => {
+    expect(reduceOnInput(INITIAL_PICKER_SESSION, "/")).toEqual({
+      slashIndex: 0,
+      suppressed: false,
+      open: true,
+      query: "",
+    });
+  });
+
+  it("extends the query as the token grows", () => {
+    expect(reduceOnInput(open(0, "comp"), "/company")).toEqual(
+      open(0, "company")
+    );
+  });
+
+  it("returns the same reference when the open token is unchanged", () => {
+    const state = open(0, "comp");
+    expect(reduceOnInput(state, "/comp")).toBe(state);
+  });
+
+  it("does not open while typing plain text (no churn)", () => {
+    expect(reduceOnInput(INITIAL_PICKER_SESSION, "hello")).toBe(
+      INITIAL_PICKER_SESSION
+    );
+  });
+
+  it("keeps a suppressed session closed while typing more of the token", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "comp",
+    };
+    expect(reduceOnInput(suppressed, "/company")).toBe(suppressed);
+  });
+
+  it("keeps a suppressed session alive across a space while its slash survives", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "company",
+    };
+    // "/company " has no active trigger (whitespace in the query) but the slash
+    // at index 0 survives, so the session is preserved (not reset).
+    expect(reduceOnInput(suppressed, "/company ")).toBe(suppressed);
+  });
+
+  it("does NOT reopen when backspacing from a space into a suppressed token", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "company",
+    };
+    // The regression: space then backspace must not re-arm the same slash.
+    expect(reduceOnInput(suppressed, "/company")).toBe(suppressed);
+  });
+
+  it("fully resets once the tracked slash is deleted", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "comp",
+    };
+    expect(reduceOnInput(suppressed, "comp")).toBe(INITIAL_PICKER_SESSION);
+  });
+
+  it("re-arms (clears suppression) when a NEW slash token is typed", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "company",
+    };
+    expect(reduceOnInput(suppressed, "/company /pp")).toEqual({
+      slashIndex: 9,
+      suppressed: false,
+      open: true,
+      query: "pp",
+    });
+  });
+
+  it("treats a slash shifted by leading edits as a new token", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "comp",
+    };
+    // Prepending text pushes the slash to index 2; that's a different token.
+    expect(reduceOnInput(suppressed, "x /comp")).toEqual({
+      slashIndex: 2,
+      suppressed: false,
+      open: true,
+      query: "comp",
+    });
+  });
+
+  it("treats null text-before-cursor as no trigger and resets", () => {
+    expect(reduceOnInput(open(0, "comp"), null)).toBe(INITIAL_PICKER_SESSION);
+  });
+});
+
+describe("reduceOnSelection", () => {
+  it("never opens the picker from a caret move", () => {
+    expect(reduceOnSelection(INITIAL_PICKER_SESSION, "/comp")).toBe(
+      INITIAL_PICKER_SESSION
+    );
+  });
+
+  it("syncs the query when the caret stays within the open token", () => {
+    expect(reduceOnSelection(open(0, "company"), "/comp")).toEqual(
+      open(0, "comp")
+    );
+  });
+
+  it("returns the same reference when the query is unchanged", () => {
+    const state = open(0, "comp");
+    expect(reduceOnSelection(state, "/comp")).toBe(state);
+  });
+
+  it("closes when the caret leaves the tracked token", () => {
+    expect(reduceOnSelection(open(0, "comp"), "/comp other")).toBe(
+      INITIAL_PICKER_SESSION
+    );
+  });
+
+  it("closes when the caret moves to a different slash token", () => {
+    expect(reduceOnSelection(open(0, "comp"), "/comp /pp")).toBe(
+      INITIAL_PICKER_SESSION
+    );
+  });
+});
+
+describe("reduceOnDismiss", () => {
+  it("hides the picker and marks the token suppressed", () => {
+    expect(reduceOnDismiss(open(0, "comp"))).toEqual({
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "comp",
+    });
+  });
+
+  it("is a no-op when already closed and suppressed", () => {
+    const suppressed: PickerSession = {
+      slashIndex: 0,
+      suppressed: true,
+      open: false,
+      query: "comp",
+    };
+    expect(reduceOnDismiss(suppressed)).toBe(suppressed);
+  });
+});

--- a/web/src/lib/skills/pickerSession.ts
+++ b/web/src/lib/skills/pickerSession.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure state machine for the `/` skill-picker session in the chat input.
+ *
+ * The picker is a typing session keyed on the active "/" character, not a
+ * reflection of the caret. `slashIndex` tracks that "/"; `suppressed` hides the
+ * picker within the token after Esc; both reset once the slash is gone. Caret
+ * movement never opens the picker — only typing a slash trigger does.
+ *
+ * These reducers are pure (no DOM): the host reads the text-before-cursor and
+ * the caret rect, then feeds the text in here and applies the result.
+ */
+
+import { detectSlashTrigger } from "@/lib/skills/picker";
+
+export interface PickerSession {
+  /** Index of the tracked "/" in the input text, or null when no session. */
+  slashIndex: number | null;
+  /** Whether the picker is hidden within the tracked token (Esc). */
+  suppressed: boolean;
+  /** Whether the picker is currently visible. */
+  open: boolean;
+  /** The query typed after the tracked "/". */
+  query: string;
+}
+
+export const INITIAL_PICKER_SESSION: PickerSession = {
+  slashIndex: null,
+  suppressed: false,
+  open: false,
+  query: "",
+};
+
+function hidden(state: PickerSession): PickerSession {
+  return state.open ? { ...state, open: false } : state;
+}
+
+/** Typing: the only event that can open the picker. */
+export function reduceOnInput(
+  state: PickerSession,
+  textBeforeCursor: string | null
+): PickerSession {
+  const trigger =
+    textBeforeCursor === null ? null : detectSlashTrigger(textBeforeCursor);
+
+  if (!trigger) {
+    // No active trigger. Keep a dismissed session alive while its slash
+    // survives (so deleting back into the token doesn't reopen it); fully
+    // reset once that slash is gone, letting a fresh "/" re-arm later.
+    const slash = state.slashIndex;
+    if (slash === null || textBeforeCursor?.[slash] !== "/") {
+      return INITIAL_PICKER_SESSION;
+    }
+    return hidden(state);
+  }
+
+  if (trigger.slashIndex !== state.slashIndex) {
+    return {
+      slashIndex: trigger.slashIndex,
+      suppressed: false,
+      open: true,
+      query: trigger.query,
+    };
+  }
+
+  if (state.suppressed) return hidden(state);
+
+  return state.open && state.query === trigger.query
+    ? state
+    : { ...state, open: true, query: trigger.query };
+}
+
+/** Caret moved (arrows/click): never opens; closes or syncs the query. */
+export function reduceOnSelection(
+  state: PickerSession,
+  textBeforeCursor: string | null
+): PickerSession {
+  if (!state.open) return state;
+  const trigger =
+    textBeforeCursor === null ? null : detectSlashTrigger(textBeforeCursor);
+  if (!trigger || trigger.slashIndex !== state.slashIndex) {
+    return INITIAL_PICKER_SESSION;
+  }
+  return state.query === trigger.query
+    ? state
+    : { ...state, query: trigger.query };
+}
+
+/** Esc / outside-click: hide within the current token until its slash is gone. */
+export function reduceOnDismiss(state: PickerSession): PickerSession {
+  return state.open || !state.suppressed
+    ? { ...state, suppressed: true, open: false }
+    : state;
+}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -866,8 +866,11 @@ const AppInputBar = React.memo(
                       }
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
-                        if (handleTileKeyDown(event)) return;
+                        // Queue nav owns keys while a message is highlighted, so
+                        // it must run before tile handling (whose Backspace guard
+                        // would otherwise win).
                         if (queueNav.handleKeyDown(event)) return;
+                        if (handleTileKeyDown(event)) return;
 
                         // Enter to submit or queue (Shift+Enter falls through to browser default: inserts <br>)
                         if (

--- a/web/src/sections/input/SkillInfoPopover.tsx
+++ b/web/src/sections/input/SkillInfoPopover.tsx
@@ -21,6 +21,15 @@ function SkillInfoPopover({
 }: SkillInfoPopoverProps) {
   const [rect, setRect] = useState(() => tileElement.getBoundingClientRect());
   const rafId = useRef<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Move focus into the popover on open so screen readers announce it and it's
+  // reachable by keyboard, then restore focus (to the input) on dismiss.
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null;
+    containerRef.current?.focus();
+    return () => previous?.focus?.();
+  }, []);
 
   const updateRect = useCallback(() => {
     if (rafId.current !== null) return;
@@ -97,12 +106,16 @@ function SkillInfoPopover({
         onClick={onDismiss}
       />
       <div
+        ref={containerRef}
         role="note"
         aria-label={`Skill: ${name}`}
+        tabIndex={-1}
         data-testid="skill-info-popover"
-        className="fixed z-50 flex flex-col gap-1 bg-background-neutral-00 border border-border-01 rounded-08 shadow-02 p-3 max-w-[320px] max-h-[15rem] overflow-y-auto"
+        className="fixed z-50 flex flex-col gap-1 bg-background-neutral-00 border border-border-01 rounded-08 shadow-02 p-3 overflow-y-auto outline-hidden"
         style={{
           left: Math.max(GAP, left),
+          maxWidth: POPOVER_MAX_W,
+          maxHeight: POPOVER_MAX_H,
           ...(fitsBelow
             ? { top: rect.bottom + GAP }
             : { bottom: window.innerHeight - rect.top + GAP }),

--- a/web/src/sections/input/SkillInfoPopover.tsx
+++ b/web/src/sections/input/SkillInfoPopover.tsx
@@ -107,7 +107,8 @@ function SkillInfoPopover({
       />
       <div
         ref={containerRef}
-        role="note"
+        role="dialog"
+        aria-modal="true"
         aria-label={`Skill: ${name}`}
         tabIndex={-1}
         data-testid="skill-info-popover"

--- a/web/src/sections/input/SkillInfoPopover.tsx
+++ b/web/src/sections/input/SkillInfoPopover.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Text } from "@opal/components";
+
+interface SkillInfoPopoverProps {
+  name: string;
+  description: string;
+  tileElement: HTMLElement;
+  onDismiss: () => void;
+}
+
+// Read-only popover anchored to a skill tile, showing its name + description.
+// Raw container (anchors to a raw DOM tile node) but renders text via Opal Text.
+function SkillInfoPopover({
+  name,
+  description,
+  tileElement,
+  onDismiss,
+}: SkillInfoPopoverProps) {
+  const [rect, setRect] = useState(() => tileElement.getBoundingClientRect());
+  const rafId = useRef<number | null>(null);
+
+  const updateRect = useCallback(() => {
+    if (rafId.current !== null) return;
+    rafId.current = requestAnimationFrame(() => {
+      rafId.current = null;
+      setRect(tileElement.getBoundingClientRect());
+    });
+  }, [tileElement]);
+
+  useEffect(() => {
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onDismiss();
+      }
+    }
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onDismiss]);
+
+  useEffect(() => {
+    window.addEventListener("resize", updateRect);
+    document.addEventListener("scroll", updateRect, true);
+    return () => {
+      window.removeEventListener("resize", updateRect);
+      document.removeEventListener("scroll", updateRect, true);
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+      }
+    };
+  }, [updateRect]);
+
+  // Dismiss if the tile is removed from the DOM (Backspace, cut, reset, …),
+  // otherwise the popover would anchor to a detached node (rect 0,0).
+  useEffect(() => {
+    const parent = tileElement.parentNode;
+    if (!parent) return;
+    const observer = new MutationObserver(() => {
+      if (!tileElement.isConnected) onDismiss();
+    });
+    observer.observe(parent, { childList: true });
+    return () => observer.disconnect();
+  }, [tileElement, onDismiss]);
+
+  // When opened from an arrow-selected tile, dismiss once it loses the
+  // highlight (e.g. the user arrowed away). Click-opened popovers (tile not
+  // selected at open) are unaffected.
+  useEffect(() => {
+    if (!tileElement.classList.contains("rich-input-tile-selected")) return;
+    const observer = new MutationObserver(() => {
+      if (!tileElement.classList.contains("rich-input-tile-selected")) {
+        onDismiss();
+      }
+    });
+    observer.observe(tileElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, [tileElement, onDismiss]);
+
+  const POPOVER_MAX_H = 240;
+  const POPOVER_MAX_W = 320;
+  const GAP = 4;
+  const fitsBelow = rect.bottom + GAP + POPOVER_MAX_H < window.innerHeight;
+  const left = Math.min(rect.left, window.innerWidth - POPOVER_MAX_W - GAP);
+
+  return createPortal(
+    <>
+      <div
+        data-testid="skill-info-backdrop"
+        className="fixed inset-0 z-40"
+        aria-hidden
+        onClick={onDismiss}
+      />
+      <div
+        role="note"
+        aria-label={`Skill: ${name}`}
+        data-testid="skill-info-popover"
+        className="fixed z-50 flex flex-col gap-1 bg-background-neutral-00 border border-border-01 rounded-08 shadow-02 p-3 max-w-[320px] max-h-[15rem] overflow-y-auto"
+        style={{
+          left: Math.max(GAP, left),
+          ...(fitsBelow
+            ? { top: rect.bottom + GAP }
+            : { bottom: window.innerHeight - rect.top + GAP }),
+        }}
+      >
+        <Text font="main-ui-action" color="text-05">
+          {name}
+        </Text>
+        {description && (
+          <Text font="secondary-body" color="text-03">
+            {description}
+          </Text>
+        )}
+      </div>
+    </>,
+    document.body
+  );
+}
+
+export type { SkillInfoPopoverProps };
+export default SkillInfoPopover;

--- a/web/src/sections/input/SkillInfoPopover.tsx
+++ b/web/src/sections/input/SkillInfoPopover.tsx
@@ -108,7 +108,6 @@ function SkillInfoPopover({
       <div
         ref={containerRef}
         role="dialog"
-        aria-modal="true"
         aria-label={`Skill: ${name}`}
         tabIndex={-1}
         data-testid="skill-info-popover"

--- a/web/src/sections/input/SkillPickerPopover.tsx
+++ b/web/src/sections/input/SkillPickerPopover.tsx
@@ -115,6 +115,11 @@ function SkillPickerPopover({
         data-testid="skill-picker-popover"
         aria-label="Skill picker"
       >
+        <div className="px-2 pt-1.5 pb-1">
+          <Text font="secondary-action" color="text-04">
+            Skills
+          </Text>
+        </div>
         <Popover.Menu scrollContainerRef={scrollContainerRef}>
           {filtered.length === 0
             ? [


### PR DESCRIPTION
## Description
<img width="720" height="293" alt="image" src="https://github.com/user-attachments/assets/2671cb45-6dfb-4813-8072-6016fbf0b01a" />

Adds skill tiles to the Craft input bar, and makes large-paste tiles always-on there.

- Large pastes always collapse into a tile in the Craft input (ignores the `paste_as_tile` user setting).
- Typing `/` opens the skill picker (now with a "Skills" header); selecting a skill inserts a distinct blue rich tile labeled "Skill: \<name\>" with a sparkle icon. The tile serializes back to the legacy `/<slug> ` text, so the submitted message (and backend) is unchanged.
- Selecting consumes the whole `/<query>` token around the caret (before *and* after it), so picking mid-token doesn't leave a stray tail.
- Clicking a skill tile opens a read-only popover with its name + description; remove via ✕ or Backspace.

## How Has This Been Tested?

- Jest unit tests for tile serialization/rendering and the `/` trigger parser (`detectSlashTrigger`).
- Manual testing in the Craft input against a live backend (insert, mid-token insert, click-for-info, remove).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds skill tiles and always-on paste tiles to the Craft input bar to make commands and large pastes clearer. Includes a slash-keyed picker, a read-only Skill Info popover, and support for pasting `/<slug>` to recreate a skill tile.

- **New Features**
  - Always-on paste tiles in the Craft input (ignores the `paste_as_tile` user setting).
  - Typing `/` opens the Skills picker; selecting inserts a blue “Skill: <name>” tile that replaces the whole `/<query>` and serializes to `/<slug> `.
  - Pasting a lone `/<slug>` for a known skill inserts a matching skill tile.
  - Skill Info popover shows name + description; open by click or Enter on a selected tile; dismiss via Escape, backdrop, tile deselection, or removal.
  - Skill tiles mirror Opal Tag styling via `TAG_COLORS.blue` with a sparkle icon.

- **Bug Fixes**
  - Slash picker is keyed to the specific `/` and managed by a session reducer: caret moves never open it; Esc suppresses within the token until that slash is removed; re-evaluates on selection change.
  - Safe replacement of the typed `/<query>` when inserting a skill tile to prevent duplicate text; block Chrome from deleting a leading tile or leaving a blank first line; strip stray leading `<br>` before a tile.
  - Queued-message keyboard navigation now takes priority over tile handling in both Craft and Chat inputs.

<sup>Written for commit 33375517274fec32ca7d00b63f70e13c8a9b8c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



