### PR TITLE
test(e2e): pre-set admin display name to dismiss onboarding prompt

### DIFF
--- a/web/tests/e2e/chat/scroll_behavior.spec.ts
+++ b/web/tests/e2e/chat/scroll_behavior.spec.ts
@@ -59,10 +59,6 @@ test.describe("Chat Scroll Behavior", () => {
     await page.context().clearCookies();
     await loginAsRandomUser(page);
     await page.goto("/app");
-    const nameInput = page.getByPlaceholder("Your name");
-    await nameInput.waitFor();
-    await nameInput.fill("Playwright Tester");
-    await page.getByText("Save").click();
     await Promise.all([
       // Wait for sidebar navigation to be visible to indicate page is loaded
       page.getByText("Agents").first().waitFor(),

--- a/web/tests/e2e/chat/scroll_behavior.spec.ts
+++ b/web/tests/e2e/chat/scroll_behavior.spec.ts
@@ -148,10 +148,6 @@ test.describe("Dynamic Bottom Spacer - Fresh Chat Effect", () => {
     await page.context().clearCookies();
     await loginAsRandomUser(page);
     await page.goto("/app");
-    const nameInput = page.getByPlaceholder("Your name");
-    await nameInput.waitFor();
-    await nameInput.fill("Playwright Tester");
-    await page.getByText("Save").click();
     await Promise.all([
       page.getByText("Agents").first().waitFor(),
       page.getByText("Projects").first().waitFor(),

--- a/web/tests/e2e/global-setup.ts
+++ b/web/tests/e2e/global-setup.ts
@@ -123,6 +123,34 @@ async function apiLoginAndSaveState(
 }
 
 /**
+ * Set the user's display name via the personalization API. This dismisses the
+ * first-time "What should Onyx call you?" prompt that otherwise covers the
+ * chat UI and silently breaks tests that interact with the action popover.
+ */
+async function setDisplayName(
+  baseURL: string,
+  storageStatePath: string,
+  name: string
+): Promise<void> {
+  const ctx = await request.newContext({
+    baseURL,
+    storageState: storageStatePath,
+  });
+  try {
+    const res = await ctx.patch("/api/user/personalization", {
+      data: { name },
+    });
+    if (!res.ok()) {
+      console.warn(
+        `[global-setup] Failed to set display name for ${storageStatePath}: ${res.status()}`
+      );
+    }
+  } finally {
+    await ctx.dispose();
+  }
+}
+
+/**
  * Promote a user to admin via the manage API.
  * Requires an authenticated context (admin storage state).
  */
@@ -199,6 +227,8 @@ async function globalSetup(config: FullConfig) {
     "admin_auth.json"
   );
 
+  await setDisplayName(baseURL, "admin_auth.json", "Admin");
+
   // Promote admin2 now that we have an admin session
   await promoteToAdmin(
     baseURL,
@@ -212,28 +242,13 @@ async function globalSetup(config: FullConfig) {
     TEST_ADMIN2_CREDENTIALS.password,
     "admin2_auth.json"
   );
+  await setDisplayName(baseURL, "admin2_auth.json", "Admin 2");
 
   for (let i = 0; i < WORKER_USER_POOL_SIZE; i++) {
     const { email, password } = workerUserCredentials(i);
     const storageStatePath = `worker${i}_auth.json`;
     await apiLoginAndSaveState(baseURL, email, password, storageStatePath);
-
-    const workerCtx = await request.newContext({
-      baseURL,
-      storageState: storageStatePath,
-    });
-    try {
-      const res = await workerCtx.patch("/api/user/personalization", {
-        data: { name: "worker" },
-      });
-      if (!res.ok()) {
-        console.warn(
-          `[global-setup] Failed to set display name for ${email}: ${res.status()}`
-        );
-      }
-    } finally {
-      await workerCtx.dispose();
-    }
+    await setDisplayName(baseURL, storageStatePath, "worker");
   }
 
   // ── Ensure a public LLM provider exists ───────────────────────────

--- a/web/tests/e2e/onboarding/onboarding_flow.spec.ts
+++ b/web/tests/e2e/onboarding/onboarding_flow.spec.ts
@@ -34,7 +34,9 @@ async function createFreshAdmin(
 ): Promise<{ email: string; password: string }> {
   // First, log in as the existing admin so we can promote the new user
   await page.context().clearCookies();
-  const { email, password } = await loginAsRandomUser(page);
+  const { email, password } = await loginAsRandomUser(page, {
+    setDisplayName: false,
+  });
 
   // Now promote the new user to admin via the existing admin
   await page.context().clearCookies();
@@ -53,7 +55,7 @@ async function createFreshUser(
   page: Page
 ): Promise<{ email: string; password: string }> {
   await page.context().clearCookies();
-  return await loginAsRandomUser(page);
+  return await loginAsRandomUser(page, { setDisplayName: false });
 }
 
 test.describe("Onboarding Flow @exclusive", () => {

--- a/web/tests/e2e/utils/auth.ts
+++ b/web/tests/e2e/utils/auth.ts
@@ -69,8 +69,13 @@ const generateRandomCredentials = () => {
   };
 };
 
-// Register and log in as a new random user via the API.
-export async function loginAsRandomUser(page: Page): Promise<{
+// Register and log in as a new random user via the API. Also sets a display
+// name by default so the onboarding prompt doesn't block subsequent UI; opt
+// out via `setDisplayName: false` from tests that need the prompt to appear.
+export async function loginAsRandomUser(
+  page: Page,
+  options?: { setDisplayName?: boolean }
+): Promise<{
   email: string;
   password: string;
 }> {
@@ -87,6 +92,18 @@ export async function loginAsRandomUser(page: Page): Promise<{
   }
 
   await apiLogin(page, email, password);
+
+  if (options?.setDisplayName !== false) {
+    const personalizationRes = await page.request.patch(
+      "/api/user/personalization",
+      { data: { name: "Test User" } }
+    );
+    if (!personalizationRes.ok()) {
+      console.warn(
+        `Failed to set display name for ${email}: ${personalizationRes.status()}`
+      );
+    }
+  }
 
   // Navigate to the app so the page is ready for test interactions
   await page.goto("/app?new_team=true");


### PR DESCRIPTION
## Description

The admin Playwright job (~9m27s) is dominated by a ~3m18s serial retry tail in `mcp_oauth_flow.spec.ts`. Root cause: `admin_user@example.com` has no display name set, so the first time a test lands on a chat URL the "What should Onyx call you?" prompt overlays the UI and breaks the action popover. The OAuth test (which exercises the chat popover heavily) trips this; other MCP specs work around it with a per-test `ensureOnboardingComplete()` helper.

This PR sets the admin and admin2 personalization name in `global-setup.ts`, mirroring the existing worker-user pattern. The duplicated inline personalization block is refactored into a small `setDisplayName` helper.

Expected impact: admin job ~9m27s → ~6m once the OAuth retries stop firing.

## How Has This Been Tested?

- `bunx tsc --noEmit` — pass
- `bunx oxlint tests/e2e/global-setup.ts` — pass
- Audited every other Playwright spec that touches admin credentials or onboarding prompts; none assert that the admin user lacks a display name. The dedicated `onboarding/onboarding_flow.spec.ts` uses fresh random users via `createFreshAdmin`/`createFreshUser` and is unaffected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-set display names via the API to dismiss the onboarding prompt that blocked chat popovers in OAuth and other e2e specs, reducing flaky retries and admin job time. Also default random test users to have a display name so most specs never see the overlay.

- **Bug Fixes**
  - Set display names for admin and admin2 in `global-setup.ts` to bypass the overlay impacting `mcp_oauth_flow.spec.ts` (admin job ~9m27s → ~6m).
  - Default `loginAsRandomUser()` to set a display name; removed manual prompt-fill in `chat/scroll_behavior.spec.ts` (including Dynamic Bottom Spacer); `onboarding_flow.spec.ts` opts out with `setDisplayName: false`.

- **Refactors**
  - Extracted a `setDisplayName` helper and reused it for worker users, replacing duplicated personalization calls.

<sup>Written for commit dc65bc44ab1c5b73d6bfb8223e1c21aae718baac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

