### PR TITLE
perf(build): split backend image into builder + runtime stages

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -194,26 +194,25 @@ jobs:
             -e SHAREPOINT_SITE \
             -e BITBUCKET_EMAIL \
             "${PROD_IMAGE}" sleep infinity
-          # --no-config: ignore the workspace pyproject.toml / uv.toml. Running
-          # from /workspace, uv would otherwise pick up [tool.uv]
-          # override-dependencies (unpinned ranges like brotli>=1.2.0,<2.0),
-          # which conflict with --require-hashes. The prod Dockerfile's
-          # identical install avoids this only by running from /tmp.
+          # The prod image no longer ships uv, so install the test-only deps
+          # (pytest, etc.) with the image's own pip against the system
+          # interpreter, where the image's deps already live. pip ignores
+          # pyproject.toml's [tool.uv] overrides, so --require-hashes resolves
+          # directly without uv's --no-config workaround.
           docker exec onyx-connector-tests bash -c '
             set -euo pipefail
-            uv pip install --system --no-config --no-deps --require-hashes \
+            python -m pip install --no-deps --require-hashes \
               -r backend/requirements/default.txt \
               -r backend/requirements/dev.txt
           '
 
-      # --no-project: don't discover/sync the workspace uv project (the prod
-      # image has no .venv and is stripped of build tools). uv runs against the
-      # system interpreter, where the deps above were installed.
+      # The prod image has no uv or .venv; run pytest with the system
+      # interpreter directly, where the deps installed above live.
       - name: Run Tests (excluding HubSpot, Salesforce, GitHub, and Coda)
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         run: |
           docker exec onyx-connector-tests bash -c '
-            uv run --no-config --no-project python -m pytest \
+            python -m pytest \
               -n 8 \
               --dist loadfile \
               --durations=8 \
@@ -232,7 +231,7 @@ jobs:
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         run: |
           docker exec onyx-connector-tests bash -c '
-            uv run --no-config --no-project python -m pytest \
+            python -m pytest \
               -n 8 \
               --dist loadfile \
               --durations=8 \
@@ -247,7 +246,7 @@ jobs:
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         run: |
           docker exec onyx-connector-tests bash -c '
-            uv run --no-config --no-project python -m pytest \
+            python -m pytest \
               -n 8 \
               --dist loadfile \
               --durations=8 \
@@ -262,7 +261,7 @@ jobs:
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         run: |
           docker exec onyx-connector-tests bash -c '
-            uv run --no-config --no-project python -m pytest \
+            python -m pytest \
               -n 8 \
               --dist loadfile \
               --durations=8 \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,61 @@
-FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
+####################################################################################################
+# Builder stage
+#
+# Installs the full build toolchain and compiles/installs all Python dependencies. Nothing from this
+# stage survives into the final image except the resulting site-packages + console scripts, which are
+# copied into the runtime stage below. This is what keeps the GCC/cmake toolchain (~190MB) out of the
+# shipped image: it lives only here and is discarded.
+####################################################################################################
+FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2 AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
+
+# Install the full set of system dependencies present during the original single-stage build so the
+# pip install behaves identically. Build-only tools (cmake, gcc, libxmlsec1-dev, pkg-config) live
+# here and never reach the runtime image.
+# cmake/libxmlsec1-dev/pkg-config/gcc needed to compile native wheels (e.g. xmlsec)
+# ca-certificates for HTTPS when fetching from PyPI
+RUN apt-get update && \
+    apt-get install -y \
+        cmake \
+        curl \
+        zip \
+        ca-certificates \
+        libgnutls30 \
+        libblkid1 \
+        libmount1 \
+        libsmartcols1 \
+        libuuid1 \
+        libxmlsec1-dev \
+        pkg-config \
+        gcc \
+        libjemalloc2 \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean
+
+# Install Python dependencies
+# Remove py which is pulled in by retry, py is not needed and is a CVE
+COPY ./requirements/default.txt /tmp/requirements.txt
+COPY ./requirements/ee.txt /tmp/ee-requirements.txt
+# TODO: drop --no-deps once we upgrade to a litellm version with looser dependencies.
+RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
+        -r /tmp/requirements.txt \
+        -r /tmp/ee-requirements.txt && \
+    pip uninstall -y py && \
+    # https://github.com/tornadoweb/tornado/issues/3107
+    rm -f /usr/local/lib/python3.11/site-packages/tornado/test/test.key && \
+    rm -rf ~/.cache/uv /tmp/*.txt
+
+
+####################################################################################################
+# Runtime stage
+#
+# The actual shipped image. Installs only runtime system libraries and copies the already-built
+# Python packages from the builder stage. The runtime apt set is exactly the set that survived the
+# install/remove dance in the original single-stage Dockerfile.
+####################################################################################################
+FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2 AS runtime
 
 LABEL com.danswer.maintainer="founders@onyx.app"
 LABEL com.danswer.description="This image is the web/frontend container of Onyx which \
@@ -9,6 +66,7 @@ founders@onyx.app for more information. Please visit https://github.com/onyx-dot
 
 # Build argument for Craft support (disabled by default)
 # Use --build-arg ENABLE_CRAFT=true to include Node.js and opencode CLI
+# ARGs do not cross build stages, so it must be redeclared here.
 ARG ENABLE_CRAFT=false
 
 # DO_NOT_TRACK is used to disable telemetry for Unstructured
@@ -25,15 +83,17 @@ RUN groupadd -g 1001 onyx && \
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 
-# Install system dependencies
-# cmake needed for psycopg (postgres)
-# libpq-dev needed for psycopg (postgres)
+# Install runtime system dependencies only (no build toolchain).
 # curl included just for users' convenience
-# zip for Vespa step futher down
+# zip for Vespa step further down
 # ca-certificates for HTTPS
+# libxmlsec1-openssl is the runtime counterpart to the build-time libxmlsec1-dev
+# postgresql-client for easy manual tests
+# procps so kubernetes exec sessions can use ps aux for debugging
+# perl-base is part of the base Python Debian image but not needed for Onyx functionality;
+# removed for CVE surface reduction (requires --allow-remove-essential)
 RUN apt-get update && \
     apt-get install -y \
-        cmake \
         curl \
         zip \
         ca-certificates \
@@ -42,15 +102,15 @@ RUN apt-get update && \
         libmount1 \
         libsmartcols1 \
         libuuid1 \
-        libxmlsec1-dev \
-        pkg-config \
-        gcc \
         nano \
         vim \
-        # Install procps so kubernetes exec sessions can use ps aux for debugging
         procps \
         libjemalloc2 \
+        libxmlsec1-openssl \
+        postgresql-client \
         && \
+    apt-get remove -y --allow-remove-essential perl-base && \
+    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -72,43 +132,18 @@ RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
     fi
 ENV PATH="/root/.opencode/bin:${PATH}"
 
-# Install Python dependencies
-# Remove py which is pulled in by retry, py is not needed and is a CVE
-COPY ./requirements/default.txt /tmp/requirements.txt
-COPY ./requirements/ee.txt /tmp/ee-requirements.txt
-# TODO: drop --no-deps once we upgrade to a litellm version with looser dependencies.
-RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
-        -r /tmp/requirements.txt \
-        -r /tmp/ee-requirements.txt && \
-    pip uninstall -y py && \
+# Copy the Python packages + console scripts built in the builder stage. Both stages derive from the
+# same base image digest, so paths and ABI match exactly.
+COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Install the Chromium browser used by Playwright and its OS-level runtime libraries. Must run after
+# the site-packages copy above so the playwright CLI is available.
+RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     playwright install chromium && \
     playwright install-deps chromium && \
-    chown -R onyx:onyx /app && \
-    ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
-    # Cleanup for CVEs and size reduction
-    # https://github.com/tornadoweb/tornado/issues/3107
-    # xserver-common and xvfb included by playwright installation but not needed after
-    # perl-base is part of the base Python Debian image but not needed for Onyx functionality
-    # perl-base could only be removed with --allow-remove-essential
-    apt-get update && \
-    apt-get remove -y --allow-remove-essential \
-        perl-base \
-        cmake \
-        libxmlsec1-dev \
-        pkg-config \
-        gcc && \
-    # Install here to avoid some packages being cleaned up above
-    apt-get install -y \
-        libxmlsec1-openssl \
-        # Install postgresql-client for easy manual tests
-        postgresql-client && \
-    apt-get autoremove -y && \
-    # Re-run after autoremove to restore any chromium runtime libs
-    # (libnss3, libnspr4, etc.) that got swept up by the cascade.
-    playwright install-deps chromium && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf ~/.cache/uv /tmp/*.txt && \
-    rm -f /usr/local/lib/python3.11/site-packages/tornado/test/test.key
+    apt-get clean
 
 # Pre-downloading models for setups with limited egress
 RUN python -c "from tokenizers import Tokenizer; \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -90,8 +90,6 @@ COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 # libxmlsec1-openssl is the runtime counterpart to the build-time libxmlsec1-dev
 # postgresql-client for easy manual tests
 # procps so kubernetes exec sessions can use ps aux for debugging
-# perl-base is part of the base Python Debian image but not needed for Onyx functionality;
-# removed for CVE surface reduction (requires --allow-remove-essential)
 RUN apt-get update && \
     apt-get install -y \
         curl \
@@ -109,8 +107,6 @@ RUN apt-get update && \
         libxmlsec1-openssl \
         postgresql-client \
         && \
-    apt-get remove -y --allow-remove-essential perl-base && \
-    apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -139,8 +135,17 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Install the Chromium browser used by Playwright and its OS-level runtime libraries. Must run after
 # the site-packages copy above so the playwright CLI is available.
+#
+# perl-base is part of the base Python Debian image but not needed for Onyx functionality; it is
+# removed for CVE surface reduction (requires --allow-remove-essential). It must be removed AFTER the
+# first `playwright install-deps`, because the font/X11 packages that install-deps pulls in run perl
+# scripts in their dpkg configure step. The second `playwright install-deps` then restores any
+# chromium runtime libs (libnss3, libnspr4, etc.) that autoremove swept up in the cascade.
 RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     playwright install chromium && \
+    playwright install-deps chromium && \
+    apt-get remove -y --allow-remove-essential perl-base && \
+    apt-get autoremove -y && \
     playwright install-deps chromium && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,18 +1,15 @@
 ####################################################################################################
 # Builder stage
 #
-# Installs the full build toolchain and compiles/installs all Python dependencies. Nothing from this
-# stage survives into the final image except the resulting site-packages + console scripts, which are
-# copied into the runtime stage below. This is what keeps the GCC/cmake toolchain (~190MB) out of the
-# shipped image: it lives only here and is discarded.
+# Installs the build toolchain and compiles/installs all Python dependencies. Only the resulting
+# site-packages + console scripts are copied into the runtime stage; the build toolchain never
+# reaches the shipped image.
 ####################################################################################################
 FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2 AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
 
-# Install the full set of system dependencies present during the original single-stage build so the
-# pip install behaves identically. Build-only tools (cmake, gcc, libxmlsec1-dev, pkg-config) live
-# here and never reach the runtime image.
+# System dependencies for compiling the Python wheels.
 # cmake/libxmlsec1-dev/pkg-config/gcc needed to compile native wheels (e.g. xmlsec)
 # ca-certificates for HTTPS when fetching from PyPI
 RUN apt-get update && \
@@ -29,7 +26,6 @@ RUN apt-get update && \
         libxmlsec1-dev \
         pkg-config \
         gcc \
-        libjemalloc2 \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
@@ -52,8 +48,7 @@ RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
 # Runtime stage
 #
 # The actual shipped image. Installs only runtime system libraries and copies the already-built
-# Python packages from the builder stage. The runtime apt set is exactly the set that survived the
-# install/remove dance in the original single-stage Dockerfile.
+# Python packages from the builder stage.
 ####################################################################################################
 FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2 AS runtime
 
@@ -128,10 +123,19 @@ RUN if [ "$ENABLE_CRAFT" = "true" ]; then \
     fi
 ENV PATH="/root/.opencode/bin:${PATH}"
 
-# Copy the Python packages + console scripts built in the builder stage. Both stages derive from the
-# same base image digest, so paths and ABI match exactly.
+# Copy the compiled Python packages and only the console scripts our services launch (api server,
+# celery workers/beat, alembic migrations, supervisord, Playwright). Both stages share the same base
+# image digest, so paths and ABI match. Listing the scripts explicitly keeps the base interpreter
+# binaries and any build-stage executables out of the shipped /usr/local/bin.
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder \
+    /usr/local/bin/alembic \
+    /usr/local/bin/celery \
+    /usr/local/bin/uvicorn \
+    /usr/local/bin/supervisord \
+    /usr/local/bin/supervisorctl \
+    /usr/local/bin/playwright \
+    /usr/local/bin/
 
 # Install the Chromium browser used by Playwright and its OS-level runtime libraries. Must run after
 # the site-packages copy above so the playwright CLI is available.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,7 +34,10 @@ RUN apt-get update && \
 # Remove py which is pulled in by retry, py is not needed and is a CVE
 COPY ./requirements/default.txt /tmp/requirements.txt
 COPY ./requirements/ee.txt /tmp/ee-requirements.txt
-# TODO: drop --no-deps once we upgrade to a litellm version with looser dependencies.
+# requirements/*.txt are a complete, pre-resolved lock export, so --no-deps installs them as-is
+# without re-resolving. It is also required, not just an optimization: mitmproxy pins tight
+# transitive caps (e.g. hyperframe<=6.0.1) that are only loosened by [tool.uv] override-dependencies
+# in pyproject.toml, which is absent from this build context — a resolving install would fail.
 RUN uv pip install --system --no-cache-dir --no-deps --require-hashes \
         -r /tmp/requirements.txt \
         -r /tmp/ee-requirements.txt && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -79,8 +79,6 @@ RUN groupadd -g 1001 onyx && \
     chmod 755 /var/log/onyx && \
     chown onyx:onyx /var/log/onyx
 
-COPY --from=ghcr.io/astral-sh/uv:0.9.9 /uv /uvx /bin/
-
 # Install runtime system dependencies only (no build toolchain).
 # curl included just for users' convenience
 # zip for Vespa step further down


### PR DESCRIPTION
## What

Splits `backend/Dockerfile` into a throwaway **builder** stage and a clean **runtime** stage to eliminate ~190MB of wasted space that `dive` flags in the current single-stage image.

dive overview now,

<img width="2880" height="1920" alt="20260529_21h14m18s_grim" src="https://github.com/user-attachments/assets/465d40e1-eea1-40ad-9636-72cd55d17c91" />


## Why

The single-stage Dockerfile installs the build toolchain (`cmake`, `gcc`, `libxmlsec1-dev`, `pkg-config`) in one layer (needed to compile native wheels like `xmlsec`) and removes it in a *later* layer. Docker layers are append-only — removing a file in a later layer only writes a whiteout; the bytes stay in the earlier layer forever. So the toolchain ships in the image regardless of the `apt-get remove`. `dive` reports this as ~193MB wasted / 95% efficiency.

## How

- **Builder stage** installs only the build toolchain (`cmake`, `gcc`, `libxmlsec1-dev`, `pkg-config`) and runs the *identical* `uv pip install` as before, so compile behavior is unchanged. Nothing from this stage ships. `--no-deps` is required here: the `requirements/*.txt` are a complete, pre-resolved lock export, and a resolving install would fail on `mitmproxy`'s tight transitive caps (e.g. `hyperframe<=6.0.1`), which are only loosened by `[tool.uv] override-dependencies` in `pyproject.toml` — absent from the build context.
- **Runtime stage** installs only the runtime system libraries (`libxmlsec1-openssl`, `postgresql-client`, `libjemalloc2`, chromium runtime libs, etc. — `libjemalloc2` is a runtime `LD_PRELOAD`, so it lives here, not in the builder), then `COPY --from=builder` the built `site-packages` plus only the console scripts our services launch (`alembic`, `celery`, `uvicorn`, `supervisord`, `supervisorctl`, `playwright`) — keeping the base interpreter binaries and any build-stage executables out of the shipped `/usr/local/bin`. Both stages share the same base image digest, so paths/ABI match exactly.
- Playwright browser install + model/NLTK/tiktoken predownloads + all app file copies are unchanged, just relocated to the runtime stage.
- `perl-base` removal for CVE surface reduction is preserved.

The resulting runtime filesystem is equivalent to today's working image, minus the discarded toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the `backend` image into `builder` and `runtime` stages to keep the toolchain out of the final image and cut wasted layers. Runtime behavior is unchanged; the CVE surface is smaller, only required console scripts are shipped, and CI tests no longer rely on `uv` inside the prod image.

- **Refactors**
  - Add `builder` stage with `uv` to install Python deps and build tools (`cmake`, `gcc`, `libxmlsec1-dev`, `pkg-config`); exclude `libjemalloc2`. Remove `py` and the `tornado` test key during build.
  - Add `runtime` stage with only runtime libs (`libxmlsec1-openssl`, `libjemalloc2`, `postgresql-client`, `procps`) and copy `site-packages` plus scripts only: `alembic`, `celery`, `uvicorn`, `supervisord`, `supervisorctl`, `playwright`. Both stages share the same base image digest; redeclare `ARG ENABLE_CRAFT`.
  - Drop `uv` from the runtime stage (builder-only), reducing the image by ~30MB.
  - Update connector test workflow to use `python -m pip` and `python -m pytest` instead of `uv`, since the prod image no longer ships `uv`.

- **Bug Fixes**
  - Remove `perl-base` after the first `playwright install-deps chromium`, then rerun `install-deps`, to prevent dpkg configure failures from font/X11 packages.

<sup>Written for commit 250e916b68fb01fb03f2240814eb462dcbcfcfa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

