### PR TITLE
perf(craft): async webapp proxy with connection pooling and per-asset DB caching

### DIFF
--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from uuid import UUID
 
 import httpx
-from cachetools import TTLCache
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
@@ -16,6 +15,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import optional_user
+from onyx.cache.factory import get_cache_backend
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
@@ -65,12 +65,19 @@ def _get_proxy_client() -> httpx.AsyncClient:
     return _ASYNC_PROXY_CLIENT
 
 
-# Per-asset DB-skip caches. Only GRANTs cached; 30s TTL = max stale access
-# after un-sharing. Concurrent misses hit the DB redundantly (not a bug).
-_SANDBOX_URL_CACHE: TTLCache[UUID, str] = TTLCache(maxsize=10_000, ttl=60.0)
-_WEBAPP_ACCESS_CACHE: TTLCache[tuple[UUID, UUID], bool] = TTLCache(
-    maxsize=50_000, ttl=30.0
-)
+# Per-asset DB-skip caches, backed by the shared cache (Redis) so the entry is
+# shared across api_server pods rather than per-process. Only GRANTs are cached;
+# the access TTL bounds how long a grant outlives an un-share.
+_SANDBOX_URL_TTL = 60
+_WEBAPP_ACCESS_TTL = 30
+
+
+def _sandbox_url_cache_key(session_id: UUID) -> str:
+    return f"craft:webapp:url:{session_id}"
+
+
+def _webapp_access_cache_key(session_id: UUID, user_id: UUID) -> str:
+    return f"craft:webapp:access:{session_id}:{user_id}"
 
 
 def require_onyx_craft_enabled(
@@ -275,9 +282,10 @@ REWRITABLE_CONTENT_TYPES = {
 
 async def _get_sandbox_url(session_id: UUID) -> str:
     """Resolve a session's Next.js server URL; cache hits open no DB connection."""
-    cached = _SANDBOX_URL_CACHE.get(session_id)
+    cache = get_cache_backend()
+    cached = cache.get(_sandbox_url_cache_key(session_id))
     if cached is not None:
-        return cached
+        return cached.decode()
 
     async with get_async_session_context_manager() as db_session:
         target = await get_webapp_target_async(db_session, session_id)
@@ -291,7 +299,7 @@ async def _get_sandbox_url(session_id: UUID) -> str:
         raise HTTPException(status_code=404, detail="Sandbox not found")
 
     url = get_sandbox_manager().get_webapp_url(sandbox_id, nextjs_port)
-    _SANDBOX_URL_CACHE[session_id] = url
+    cache.set(_sandbox_url_cache_key(session_id), url, ex=_SANDBOX_URL_TTL)
     return url
 
 
@@ -398,7 +406,8 @@ async def _proxy_request(
 async def _check_webapp_access(session_id: UUID, user: User | None) -> None:
     # Cached grants short-circuit before the DB fetch; 404 (missing session)
     # must still beat 401 (unauthenticated), so only grants are cached.
-    if user is not None and _WEBAPP_ACCESS_CACHE.get((session_id, user.id)):
+    cache = get_cache_backend()
+    if user is not None and cache.get(_webapp_access_cache_key(session_id, user.id)):
         return
 
     async with get_async_session_context_manager() as db_session:
@@ -412,7 +421,9 @@ async def _check_webapp_access(session_id: UUID, user: User | None) -> None:
     if sharing_scope == SharingScope.PRIVATE and owner_id != user.id:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    _WEBAPP_ACCESS_CACHE[(session_id, user.id)] = True
+    cache.set(
+        _webapp_access_cache_key(session_id, user.id), b"1", ex=_WEBAPP_ACCESS_TTL
+    )
 
 
 _OFFLINE_HTML = (_TEMPLATES_DIR / "webapp_offline.html").read_text()
@@ -452,7 +463,7 @@ async def get_webapp(
         if e.status_code in (502, 503, 504):
             # The cached URL may point at a dead/recreated pod; drop it so the
             # next request re-resolves from the DB.
-            _SANDBOX_URL_CACHE.pop(session_id, None)
+            get_cache_backend().delete(_sandbox_url_cache_key(session_id))
             return _offline_html_response()
         raise
 

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -49,8 +49,7 @@ logger = setup_logger()
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _WEBAPP_HMR_FIXER_TEMPLATE = (_TEMPLATES_DIR / "webapp_hmr_fixer.js").read_text()
 
-# Shared pooled async client. Lazy init so importing this module in tests
-# doesn't leave an unclosed client.
+# Lazy-init so importing this module (e.g. in tests) doesn't leak an open client.
 _ASYNC_PROXY_CLIENT: httpx.AsyncClient | None = None
 
 
@@ -65,9 +64,7 @@ def _get_proxy_client() -> httpx.AsyncClient:
     return _ASYNC_PROXY_CLIENT
 
 
-# Per-asset DB-skip caches, backed by the shared cache (Redis) so the entry is
-# shared across api_server pods rather than per-process. Only GRANTs are cached;
-# the access TTL bounds how long a grant outlives an un-share.
+# Redis-backed so cache entries are shared across pods. Only grants are cached.
 _SANDBOX_URL_TTL = 60
 _WEBAPP_ACCESS_TTL = 30
 
@@ -304,8 +301,7 @@ async def _get_sandbox_url(session_id: UUID) -> str:
 
 
 async def _aiter_and_close(response: httpx.Response) -> AsyncGenerator[bytes, None]:
-    # finally runs on client disconnect (GeneratorExit) too, so a cancelled
-    # stream can't leak its pooled connection — a BackgroundTask wouldn't.
+    # Runs on client disconnect (GeneratorExit) too, so the connection can't leak.
     try:
         async for chunk in response.aiter_bytes(chunk_size=8192):
             yield chunk
@@ -345,9 +341,8 @@ async def _proxy_request(
         logger.error("Error proxying request to %s: %s", target_url, e)
         raise HTTPException(status_code=502, detail="Bad gateway")
 
-    # aclose() is idempotent, so one guarded finally covers every pre-handoff exit
-    # (buffered success/failure, header-building errors). Only a successful handoff to
-    # StreamingResponse transfers ownership to _aiter_and_close, which then closes.
+    # aclose() is idempotent: one guarded finally covers every exit except a
+    # successful StreamingResponse handoff, which passes ownership to _aiter_and_close.
     handed_off = False
     try:
         response_headers = {
@@ -359,10 +354,8 @@ async def _proxy_request(
             response_headers, str(session_id)
         )
 
-        # Only /_next/static/media/* (fonts, images) has content-hashed filenames safe
-        # to cache forever. In dev, chunk/CSS URLs are path-stable but their content
-        # changes on every edit, so the dev server marks them no-cache — overriding that
-        # to immutable serves stale code after an edit + full reload. Preserve it.
+        # Only /_next/static/media/* is content-hashed (safe forever). Dev chunk/CSS
+        # URLs are stable but mutable, so immutable would serve stale code after edits.
         if path.lstrip("/").startswith("_next/static/media/"):
             response_headers["cache-control"] = "public, max-age=31536000, immutable"
             response_headers.pop("pragma", None)
@@ -370,8 +363,7 @@ async def _proxy_request(
 
         content_type = response.headers.get("content-type", "")
 
-        # Buffer and rewrite /_next/ refs. Idempotent: already-proxied URLs
-        # (new sandboxes with assetPrefix) are not double-rewritten.
+        # Buffer to rewrite /_next/ refs; idempotent for assetPrefix-prefixed URLs.
         if any(ct in content_type for ct in REWRITABLE_CONTENT_TYPES):
             try:
                 raw = await response.aread()
@@ -404,8 +396,7 @@ async def _proxy_request(
 
 
 async def _check_webapp_access(session_id: UUID, user: User | None) -> None:
-    # Cached grants short-circuit before the DB fetch; 404 (missing session)
-    # must still beat 401 (unauthenticated), so only grants are cached.
+    # Only grants are cached — a 404 (missing session) must still beat 401 (unauth).
     cache = get_cache_backend()
     if user is not None and cache.get(_webapp_access_cache_key(session_id, user.id)):
         return
@@ -461,8 +452,7 @@ async def get_webapp(
         return await _proxy_request(path, request, session_id)
     except HTTPException as e:
         if e.status_code in (502, 503, 504):
-            # The cached URL may point at a dead/recreated pod; drop it so the
-            # next request re-resolves from the DB.
+            # Cached URL may point at a dead/recreated pod; drop it to force re-resolve.
             get_cache_backend().delete(_sandbox_url_cache_key(session_id))
             return _offline_html_response()
         raise

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -280,7 +280,8 @@ REWRITABLE_CONTENT_TYPES = {
 async def _get_sandbox_url(session_id: UUID) -> str:
     """Resolve a session's Next.js server URL; cache hits open no DB connection."""
     cache = get_cache_backend()
-    cached = cache.get(_sandbox_url_cache_key(session_id))
+    key = _sandbox_url_cache_key(session_id)
+    cached = cache.get(key)
     if cached is not None:
         return cached.decode()
 
@@ -296,7 +297,7 @@ async def _get_sandbox_url(session_id: UUID) -> str:
         raise HTTPException(status_code=404, detail="Sandbox not found")
 
     url = get_sandbox_manager().get_webapp_url(sandbox_id, nextjs_port)
-    cache.set(_sandbox_url_cache_key(session_id), url, ex=_SANDBOX_URL_TTL)
+    cache.set(key, url, ex=_SANDBOX_URL_TTL)
     return url
 
 
@@ -313,9 +314,11 @@ async def _proxy_request(
     path: str, request: Request, session_id: UUID
 ) -> StreamingResponse | Response:
     """Proxy a request to the sandbox's Next.js server."""
+    session_str = str(session_id)
+    rel_path = path.lstrip("/")
     base_url = await _get_sandbox_url(session_id)
 
-    target_url = f"{base_url}/{path.lstrip('/')}"
+    target_url = f"{base_url}/{rel_path}"
     if request.query_params:
         target_url = f"{target_url}?{request.query_params}"
 
@@ -351,12 +354,12 @@ async def _proxy_request(
             if key.lower() not in EXCLUDED_HEADERS
         }
         response_headers = _rewrite_proxy_response_headers(
-            response_headers, str(session_id)
+            response_headers, session_str
         )
 
         # Only /_next/static/media/* is content-hashed (safe forever). Dev chunk/CSS
         # URLs are stable but mutable, so immutable would serve stale code after edits.
-        if path.lstrip("/").startswith("_next/static/media/"):
+        if rel_path.startswith("_next/static/media/"):
             response_headers["cache-control"] = "public, max-age=31536000, immutable"
             response_headers.pop("pragma", None)
             response_headers.pop("expires", None)
@@ -371,9 +374,9 @@ async def _proxy_request(
                 # Surface as 502 so the caller falls back to the offline page.
                 logger.error("Error reading proxied body from %s: %s", target_url, e)
                 raise HTTPException(status_code=502, detail="Bad gateway")
-            content = _rewrite_asset_paths(raw, str(session_id))
+            content = _rewrite_asset_paths(raw, session_str)
             if "text/html" in content_type:
-                content = _inject_hmr_fixer(content, str(session_id))
+                content = _inject_hmr_fixer(content, session_str)
             return Response(
                 content=content,
                 status_code=response.status_code,

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -348,8 +348,11 @@ async def _proxy_request(
             response_headers, str(session_id)
         )
 
-        # Override dev server's no-store so hashed static assets cache in the browser.
-        if path.lstrip("/").startswith("_next/static/"):
+        # Only /_next/static/media/* (fonts, images) has content-hashed filenames safe
+        # to cache forever. In dev, chunk/CSS URLs are path-stable but their content
+        # changes on every edit, so the dev server marks them no-cache — overriding that
+        # to immutable serves stale code after an edit + full reload. Preserve it.
+        if path.lstrip("/").startswith("_next/static/media/"):
             response_headers["cache-control"] = "public, max-age=31536000, immutable"
             response_headers.pop("pragma", None)
             response_headers.pop("expires", None)

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -50,17 +50,28 @@ _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _WEBAPP_HMR_FIXER_TEMPLATE = (_TEMPLATES_DIR / "webapp_hmr_fixer.js").read_text()
 
 # Shared pooled client: async so a slow sandbox suspends its coroutine rather
-# than holding one of the ~40 shared sync threads. Lives for the process
-# lifetime (no shared-lifespan close hook, to keep Craft out of all images).
-_ASYNC_PROXY_CLIENT = httpx.AsyncClient(
-    timeout=30.0,
-    follow_redirects=True,
-    limits=httpx.Limits(max_keepalive_connections=50, max_connections=200),
-)
+# than holding one of the ~40 shared sync threads. Initialised lazily on first
+# use so tests that import this module don't inherit an unclosed client.
+_ASYNC_PROXY_CLIENT: httpx.AsyncClient | None = None
 
-# Per-asset DB-skip caches. Lock-free: only touched from the event loop with no
-# await between read and write. Only GRANTS are cached; the 30s access TTL is
+
+def _get_proxy_client() -> httpx.AsyncClient:
+    global _ASYNC_PROXY_CLIENT
+    if _ASYNC_PROXY_CLIENT is None:
+        _ASYNC_PROXY_CLIENT = httpx.AsyncClient(
+            timeout=30.0,
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=50, max_connections=200),
+        )
+    return _ASYNC_PROXY_CLIENT
+
+
+# Per-asset DB-skip caches. Only GRANTS are cached; the 30s access TTL is
 # the max window a viewer keeps access after a session is un-shared.
+# Cache reads and writes are not atomic under concurrent awaits (there may be
+# awaits between a miss check and the subsequent write), so concurrent misses
+# on the same key will each hit the DB — a minor thundering-herd on cold start,
+# not a correctness issue.
 _SANDBOX_URL_CACHE: TTLCache[UUID, str] = TTLCache(maxsize=10_000, ttl=60.0)
 _WEBAPP_ACCESS_CACHE: TTLCache[tuple[UUID, UUID], bool] = TTLCache(
     maxsize=50_000, ttl=30.0
@@ -323,11 +334,10 @@ async def _proxy_request(
     # Stream mode: headers arrive before the body, so we can choose to
     # buffer-and-rewrite (HTML/CSS/JS) or stream through (binary) without
     # reading the whole body.
-    req = _ASYNC_PROXY_CLIENT.build_request(
-        "GET", target_url, headers=forwarded_headers
-    )
+    client = _get_proxy_client()
+    req = client.build_request("GET", target_url, headers=forwarded_headers)
     try:
-        response = await _ASYNC_PROXY_CLIENT.send(req, stream=True)
+        response = await client.send(req, stream=True)
     except httpx.TimeoutException:
         logger.error("Timeout while proxying request to %s", target_url)
         raise HTTPException(status_code=504, detail="Gateway timeout")
@@ -356,8 +366,10 @@ async def _proxy_request(
 
         content_type = response.headers.get("content-type", "")
 
-        # HTML/CSS/JS: buffer and rewrite asset paths. With assetPrefix on, JS/CSS
-        # already point at the proxy, so skip the rewrite and only handle HTML.
+        # HTML/CSS/JS: buffer and rewrite asset paths. _rewrite_asset_paths is
+        # idempotent (already-prefixed URLs are not double-rewritten), so it is
+        # safe for both new sandboxes (assetPrefix emits pre-proxied URLs) and
+        # sandboxes started before this deploy (bare /_next/ refs).
         if any(ct in content_type for ct in REWRITABLE_CONTENT_TYPES):
             try:
                 raw = await response.aread()
@@ -367,13 +379,9 @@ async def _proxy_request(
                 raise HTTPException(status_code=502, detail="Bad gateway")
             finally:
                 await response.aclose()
+            content = _rewrite_asset_paths(raw, str(session_id))
             if "text/html" in content_type:
-                content = _inject_hmr_fixer(
-                    _rewrite_asset_paths(raw, str(session_id)), str(session_id)
-                )
-            else:
-                # JS/CSS: sandbox emits assetPrefix-prefixed URLs, no rewrite needed.
-                content = raw
+                content = _inject_hmr_fixer(content, str(session_id))
             return Response(
                 content=content,
                 status_code=response.status_code,

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -49,9 +49,8 @@ logger = setup_logger()
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _WEBAPP_HMR_FIXER_TEMPLATE = (_TEMPLATES_DIR / "webapp_hmr_fixer.js").read_text()
 
-# Shared pooled client: async so a slow sandbox suspends its coroutine rather
-# than holding one of the ~40 shared sync threads. Initialised lazily on first
-# use so tests that import this module don't inherit an unclosed client.
+# Shared pooled async client. Lazy init so importing this module in tests
+# doesn't leave an unclosed client.
 _ASYNC_PROXY_CLIENT: httpx.AsyncClient | None = None
 
 
@@ -66,12 +65,8 @@ def _get_proxy_client() -> httpx.AsyncClient:
     return _ASYNC_PROXY_CLIENT
 
 
-# Per-asset DB-skip caches. Only GRANTS are cached; the 30s access TTL is
-# the max window a viewer keeps access after a session is un-shared.
-# Cache reads and writes are not atomic under concurrent awaits (there may be
-# awaits between a miss check and the subsequent write), so concurrent misses
-# on the same key will each hit the DB — a minor thundering-herd on cold start,
-# not a correctness issue.
+# Per-asset DB-skip caches. Only GRANTs cached; 30s TTL = max stale access
+# after un-sharing. Concurrent misses hit the DB redundantly (not a bug).
 _SANDBOX_URL_CACHE: TTLCache[UUID, str] = TTLCache(maxsize=10_000, ttl=60.0)
 _WEBAPP_ACCESS_CACHE: TTLCache[tuple[UUID, UUID], bool] = TTLCache(
     maxsize=50_000, ttl=30.0
@@ -331,9 +326,6 @@ async def _proxy_request(
         )
     }
 
-    # Stream mode: headers arrive before the body, so we can choose to
-    # buffer-and-rewrite (HTML/CSS/JS) or stream through (binary) without
-    # reading the whole body.
     client = _get_proxy_client()
     req = client.build_request("GET", target_url, headers=forwarded_headers)
     try:
@@ -345,8 +337,7 @@ async def _proxy_request(
         logger.error("Error proxying request to %s: %s", target_url, e)
         raise HTTPException(status_code=502, detail="Bad gateway")
 
-    # Stream is open: close it on any failure before handoff to StreamingResponse
-    # (which then owns it), or the pooled connection leaks.
+    # Close on any failure before handing off to StreamingResponse, or the connection leaks.
     try:
         response_headers = {
             key: value
@@ -357,8 +348,7 @@ async def _proxy_request(
             response_headers, str(session_id)
         )
 
-        # Hashed /_next/static/ assets are immutable; the dev server's no-store
-        # would force a re-proxy on every reload, so cache them in the browser.
+        # Override dev server's no-store so hashed static assets cache in the browser.
         if path.lstrip("/").startswith("_next/static/"):
             response_headers["cache-control"] = "public, max-age=31536000, immutable"
             response_headers.pop("pragma", None)
@@ -366,10 +356,8 @@ async def _proxy_request(
 
         content_type = response.headers.get("content-type", "")
 
-        # HTML/CSS/JS: buffer and rewrite asset paths. _rewrite_asset_paths is
-        # idempotent (already-prefixed URLs are not double-rewritten), so it is
-        # safe for both new sandboxes (assetPrefix emits pre-proxied URLs) and
-        # sandboxes started before this deploy (bare /_next/ refs).
+        # Buffer and rewrite /_next/ refs. Idempotent: already-proxied URLs
+        # (new sandboxes with assetPrefix) are not double-rewritten.
         if any(ct in content_type for ct in REWRITABLE_CONTENT_TYPES):
             try:
                 raw = await response.aread()
@@ -389,8 +377,7 @@ async def _proxy_request(
                 media_type=content_type,
             )
 
-        # Binary assets stream straight through; the generator closes the
-        # upstream when drained or when the client disconnects.
+        # Binary assets: stream through; generator closes upstream on drain or disconnect.
         return StreamingResponse(
             _aiter_and_close(response),
             status_code=response.status_code,

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from uuid import UUID
 
@@ -295,7 +295,7 @@ async def _get_sandbox_url(session_id: UUID) -> str:
     return url
 
 
-async def _aiter_and_close(response: httpx.Response) -> AsyncIterator[bytes]:
+async def _aiter_and_close(response: httpx.Response) -> AsyncGenerator[bytes, None]:
     # finally runs on client disconnect (GeneratorExit) too, so a cancelled
     # stream can't leak its pooled connection — a BackgroundTask wouldn't.
     try:

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -1,8 +1,10 @@
 import re
+from collections.abc import AsyncIterator
 from pathlib import Path
 from uuid import UUID
 
 import httpx
+from cachetools import TTLCache
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
@@ -14,10 +16,10 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import optional_user
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.enums import SharingScope
-from onyx.db.models import BuildSession
 from onyx.db.models import User
 from onyx.server.features.build.api.debug_api import router as debug_router
 from onyx.server.features.build.api.external_apps_api import (
@@ -32,7 +34,8 @@ from onyx.server.features.build.api.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.api.sessions_api import router as sessions_router
 from onyx.server.features.build.api.user_library import router as user_library_router
 from onyx.server.features.build.approvals.api import router as approvals_router
-from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
+from onyx.server.features.build.db.build_session import get_webapp_access_async
+from onyx.server.features.build.db.build_session import get_webapp_target_async
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
 from onyx.server.features.build.scheduled_tasks.api import (
     router as scheduled_tasks_router,
@@ -46,14 +49,27 @@ logger = setup_logger()
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _WEBAPP_HMR_FIXER_TEMPLATE = (_TEMPLATES_DIR / "webapp_hmr_fixer.js").read_text()
 
+# Shared pooled client: async so a slow sandbox suspends its coroutine rather
+# than holding one of the ~40 shared sync threads. Lives for the process
+# lifetime (no shared-lifespan close hook, to keep Craft out of all images).
+_ASYNC_PROXY_CLIENT = httpx.AsyncClient(
+    timeout=30.0,
+    follow_redirects=True,
+    limits=httpx.Limits(max_keepalive_connections=50, max_connections=200),
+)
+
+# Per-asset DB-skip caches. Lock-free: only touched from the event loop with no
+# await between read and write. Only GRANTS are cached; the 30s access TTL is
+# the max window a viewer keeps access after a session is un-shared.
+_SANDBOX_URL_CACHE: TTLCache[UUID, str] = TTLCache(maxsize=10_000, ttl=60.0)
+_WEBAPP_ACCESS_CACHE: TTLCache[tuple[UUID, UUID], bool] = TTLCache(
+    maxsize=50_000, ttl=30.0
+)
+
 
 def require_onyx_craft_enabled(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> User:
-    """
-    Dependency that checks if Onyx Craft is enabled for the user.
-    Raises HTTP 403 if Onyx Craft is disabled via feature flag.
-    """
     if not is_onyx_craft_enabled(user):
         raise HTTPException(
             status_code=403,
@@ -251,49 +267,45 @@ REWRITABLE_CONTENT_TYPES = {
 }
 
 
-def _get_sandbox_url(session_id: UUID, db_session: Session) -> str:
-    """Get the internal URL for a session's Next.js server.
+async def _get_sandbox_url(session_id: UUID) -> str:
+    """Resolve a session's Next.js server URL; cache hits open no DB connection."""
+    cached = _SANDBOX_URL_CACHE.get(session_id)
+    if cached is not None:
+        return cached
 
-    Uses the sandbox manager to get the correct URL for both local and
-    Kubernetes environments.
+    async with get_async_session_context_manager() as db_session:
+        target = await get_webapp_target_async(db_session, session_id)
 
-    Args:
-        session_id: The build session ID
-        db_session: Database session
-
-    Returns:
-        Internal URL to proxy requests to
-
-    Raises:
-        HTTPException: If session not found, port not allocated, or sandbox not found
-    """
-
-    session = db_session.get(BuildSession, session_id)
-    if not session:
+    if target is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    if session.nextjs_port is None:
+    sandbox_id, nextjs_port = target
+    if nextjs_port is None:
         raise HTTPException(status_code=503, detail="Session port not allocated")
-    if session.user_id is None:
-        raise HTTPException(status_code=404, detail="User not found")
-
-    sandbox = get_sandbox_by_user_id(db_session, session.user_id)
-    if sandbox is None:
+    if sandbox_id is None:
         raise HTTPException(status_code=404, detail="Sandbox not found")
 
-    sandbox_manager = get_sandbox_manager()
-    return sandbox_manager.get_webapp_url(sandbox.id, session.nextjs_port)
+    url = get_sandbox_manager().get_webapp_url(sandbox_id, nextjs_port)
+    _SANDBOX_URL_CACHE[session_id] = url
+    return url
 
 
-def _proxy_request(
-    path: str, request: Request, session_id: UUID, db_session: Session
+async def _aiter_and_close(response: httpx.Response) -> AsyncIterator[bytes]:
+    # finally runs on client disconnect (GeneratorExit) too, so a cancelled
+    # stream can't leak its pooled connection — a BackgroundTask wouldn't.
+    try:
+        async for chunk in response.aiter_bytes(chunk_size=8192):
+            yield chunk
+    finally:
+        await response.aclose()
+
+
+async def _proxy_request(
+    path: str, request: Request, session_id: UUID
 ) -> StreamingResponse | Response:
     """Proxy a request to the sandbox's Next.js server."""
-    base_url = _get_sandbox_url(session_id, db_session)
+    base_url = await _get_sandbox_url(session_id)
 
-    # Build the target URL
     target_url = f"{base_url}/{path.lstrip('/')}"
-
-    # Include query params if present
     if request.query_params:
         target_url = f"{target_url}?{request.query_params}"
 
@@ -308,42 +320,14 @@ def _proxy_request(
         )
     }
 
+    # Stream mode: headers arrive before the body, so we can choose to
+    # buffer-and-rewrite (HTML/CSS/JS) or stream through (binary) without
+    # reading the whole body.
+    req = _ASYNC_PROXY_CLIENT.build_request(
+        "GET", target_url, headers=forwarded_headers
+    )
     try:
-        # Make the request to the target URL
-        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
-            response = client.get(target_url, headers=forwarded_headers)
-
-            # Build response headers, excluding hop-by-hop headers
-            response_headers = {
-                key: value
-                for key, value in response.headers.items()
-                if key.lower() not in EXCLUDED_HEADERS
-            }
-            response_headers = _rewrite_proxy_response_headers(
-                response_headers, str(session_id)
-            )
-
-            content_type = response.headers.get("content-type", "")
-
-            # For HTML/CSS/JS responses, rewrite asset paths
-            if any(ct in content_type for ct in REWRITABLE_CONTENT_TYPES):
-                content = _rewrite_asset_paths(response.content, str(session_id))
-                if "text/html" in content_type:
-                    content = _inject_hmr_fixer(content, str(session_id))
-                return Response(
-                    content=content,
-                    status_code=response.status_code,
-                    headers=response_headers,
-                    media_type=content_type,
-                )
-
-            return StreamingResponse(
-                content=response.iter_bytes(chunk_size=8192),
-                status_code=response.status_code,
-                headers=response_headers,
-                media_type=content_type or None,
-            )
-
+        response = await _ASYNC_PROXY_CLIENT.send(req, stream=True)
     except httpx.TimeoutException:
         logger.error("Timeout while proxying request to %s", target_url)
         raise HTTPException(status_code=504, detail="Gateway timeout")
@@ -351,37 +335,92 @@ def _proxy_request(
         logger.error("Error proxying request to %s: %s", target_url, e)
         raise HTTPException(status_code=502, detail="Bad gateway")
 
+    # Stream is open: close it on any failure before handoff to StreamingResponse
+    # (which then owns it), or the pooled connection leaks.
+    try:
+        response_headers = {
+            key: value
+            for key, value in response.headers.items()
+            if key.lower() not in EXCLUDED_HEADERS
+        }
+        response_headers = _rewrite_proxy_response_headers(
+            response_headers, str(session_id)
+        )
 
-def _check_webapp_access(
-    session_id: UUID, user: User | None, db_session: Session
-) -> BuildSession:
-    """Check if user can access a session's webapp.
+        # Hashed /_next/static/ assets are immutable; the dev server's no-store
+        # would force a re-proxy on every reload, so cache them in the browser.
+        if path.lstrip("/").startswith("_next/static/"):
+            response_headers["cache-control"] = "public, max-age=31536000, immutable"
+            response_headers.pop("pragma", None)
+            response_headers.pop("expires", None)
 
-    - private: only accessible by the session owner
-    - public_org: accessible by any authenticated user
-    """
-    session = db_session.get(BuildSession, session_id)
-    if not session:
+        content_type = response.headers.get("content-type", "")
+
+        # HTML/CSS/JS: buffer and rewrite asset paths. With assetPrefix on, JS/CSS
+        # already point at the proxy, so skip the rewrite and only handle HTML.
+        if any(ct in content_type for ct in REWRITABLE_CONTENT_TYPES):
+            try:
+                raw = await response.aread()
+            except httpx.RequestError as e:
+                # Surface as 502 so the caller falls back to the offline page.
+                logger.error("Error reading proxied body from %s: %s", target_url, e)
+                raise HTTPException(status_code=502, detail="Bad gateway")
+            finally:
+                await response.aclose()
+            if "text/html" in content_type:
+                content = _inject_hmr_fixer(
+                    _rewrite_asset_paths(raw, str(session_id)), str(session_id)
+                )
+            else:
+                # JS/CSS: sandbox emits assetPrefix-prefixed URLs, no rewrite needed.
+                content = raw
+            return Response(
+                content=content,
+                status_code=response.status_code,
+                headers=response_headers,
+                media_type=content_type,
+            )
+
+        # Binary assets stream straight through; the generator closes the
+        # upstream when drained or when the client disconnects.
+        return StreamingResponse(
+            _aiter_and_close(response),
+            status_code=response.status_code,
+            headers=response_headers,
+            media_type=content_type or None,
+        )
+    except HTTPException:
+        raise  # buffered branch already closed; nothing to clean up
+    except BaseException:
+        await response.aclose()  # failure after open, before handoff
+        raise
+
+
+async def _check_webapp_access(session_id: UUID, user: User | None) -> None:
+    # Cached grants short-circuit before the DB fetch; 404 (missing session)
+    # must still beat 401 (unauthenticated), so only grants are cached.
+    if user is not None and _WEBAPP_ACCESS_CACHE.get((session_id, user.id)):
+        return
+
+    async with get_async_session_context_manager() as db_session:
+        access = await get_webapp_access_async(db_session, session_id)
+
+    if access is None:
         raise HTTPException(status_code=404, detail="Session not found")
     if user is None:
         raise HTTPException(status_code=401, detail="Authentication required")
-    if session.sharing_scope == SharingScope.PRIVATE and session.user_id != user.id:
+    sharing_scope, owner_id = access
+    if sharing_scope == SharingScope.PRIVATE and owner_id != user.id:
         raise HTTPException(status_code=404, detail="Session not found")
-    return session
+
+    _WEBAPP_ACCESS_CACHE[(session_id, user.id)] = True
 
 
-_OFFLINE_HTML_PATH = _TEMPLATES_DIR / "webapp_offline.html"
+_OFFLINE_HTML = (_TEMPLATES_DIR / "webapp_offline.html").read_text()
 
 
 def _offline_html_response() -> Response:
-    """Return a branded Craft HTML page when the sandbox is not reachable.
-
-    Design mirrors the default Craft web template (outputs/web/app/page.tsx):
-    terminal window aesthetic with Minecraft-themed typing animation.
-
-    """
-    html = _OFFLINE_HTML_PATH.read_text()
-    return Response(content=html, status_code=503, media_type="text/html")
+    return Response(content=_OFFLINE_HTML, status_code=503, media_type="text/html")
 
 
 # Router for the webapp proxy. The route is exempted from the global auth
@@ -396,29 +435,25 @@ public_build_router = APIRouter(prefix="/build")
 @public_build_router.get(
     "/sessions/{session_id}/webapp/{path:path}", response_model=None
 )
-def get_webapp(
+async def get_webapp(
     session_id: UUID,
     request: Request,
     path: str = "",
     user: User | None = Depends(optional_user),
-    db_session: Session = Depends(get_session),
 ) -> StreamingResponse | Response:
-    """Proxy the webapp for a specific session (root and subpaths).
-
-    Requires authentication; access is further gated by the session's
-    sharing_scope (private = owner only, public_org = any org member).
-    Returns a friendly offline page when the sandbox is not running.
-    """
     try:
-        _check_webapp_access(session_id, user, db_session)
+        await _check_webapp_access(session_id, user)
     except HTTPException as e:
         if e.status_code == 401:
             return RedirectResponse(url="/auth/login", status_code=302)
         raise
     try:
-        return _proxy_request(path, request, session_id, db_session)
+        return await _proxy_request(path, request, session_id)
     except HTTPException as e:
         if e.status_code in (502, 503, 504):
+            # The cached URL may point at a dead/recreated pod; drop it so the
+            # next request re-resolves from the DB.
+            _SANDBOX_URL_CACHE.pop(session_id, None)
             return _offline_html_response()
         raise
 

--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -337,7 +337,10 @@ async def _proxy_request(
         logger.error("Error proxying request to %s: %s", target_url, e)
         raise HTTPException(status_code=502, detail="Bad gateway")
 
-    # Close on any failure before handing off to StreamingResponse, or the connection leaks.
+    # aclose() is idempotent, so one guarded finally covers every pre-handoff exit
+    # (buffered success/failure, header-building errors). Only a successful handoff to
+    # StreamingResponse transfers ownership to _aiter_and_close, which then closes.
+    handed_off = False
     try:
         response_headers = {
             key: value
@@ -368,8 +371,6 @@ async def _proxy_request(
                 # Surface as 502 so the caller falls back to the offline page.
                 logger.error("Error reading proxied body from %s: %s", target_url, e)
                 raise HTTPException(status_code=502, detail="Bad gateway")
-            finally:
-                await response.aclose()
             content = _rewrite_asset_paths(raw, str(session_id))
             if "text/html" in content_type:
                 content = _inject_hmr_fixer(content, str(session_id))
@@ -380,18 +381,18 @@ async def _proxy_request(
                 media_type=content_type,
             )
 
-        # Binary assets: stream through; generator closes upstream on drain or disconnect.
+        # Binary assets: stream through; _aiter_and_close now owns the connection.
+        stream = _aiter_and_close(response)
+        handed_off = True
         return StreamingResponse(
-            _aiter_and_close(response),
+            stream,
             status_code=response.status_code,
             headers=response_headers,
             media_type=content_type or None,
         )
-    except HTTPException:
-        raise  # buffered branch already closed; nothing to clean up
-    except BaseException:
-        await response.aclose()  # failure after open, before handoff
-        raise
+    finally:
+        if not handed_off:
+            await response.aclose()
 
 
 async def _check_webapp_access(session_id: UUID, user: User | None) -> None:

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from sqlalchemy import desc
 from sqlalchemy import exists
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
@@ -81,6 +82,37 @@ def get_build_session(
         )
         .one_or_none()
     )
+
+
+async def get_webapp_access_async(
+    db_session: AsyncSession,
+    session_id: UUID,
+) -> tuple[SharingScope, UUID] | None:
+    """(sharing_scope, owner_user_id) for the proxy access check; None if absent."""
+    row = (
+        await db_session.execute(
+            select(BuildSession.sharing_scope, BuildSession.user_id).where(
+                BuildSession.id == session_id
+            )
+        )
+    ).first()
+    return (row[0], row[1]) if row is not None else None
+
+
+async def get_webapp_target_async(
+    db_session: AsyncSession,
+    session_id: UUID,
+) -> tuple[UUID | None, int | None] | None:
+    """(sandbox_id, nextjs_port) in one round-trip; None if the session is absent."""
+    row = (
+        await db_session.execute(
+            select(Sandbox.id, BuildSession.nextjs_port)
+            .select_from(BuildSession)
+            .outerjoin(Sandbox, Sandbox.user_id == BuildSession.user_id)
+            .where(BuildSession.id == session_id)
+        )
+    ).first()
+    return (row[0], row[1]) if row is not None else None
 
 
 def get_user_build_sessions(

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -165,6 +165,7 @@ fi
 set -e
 cd {session_path}/outputs/web
 {install_check}
+export WEBAPP_ASSET_PREFIX="/api/build/sessions/$(basename {session_path})/webapp"
 echo "Starting Next.js dev server on port {nextjs_port}..."
 nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
 NEXTJS_PID=$!

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
+// The preview is served through the Onyx proxy at
+// /api/build/sessions/<id>/webapp. When WEBAPP_ASSET_PREFIX is set (by the
+// dev-server start script), emit /_next/ asset URLs already prefixed with it so
+// the proxy doesn't have to rewrite them on every request.
+const assetPrefix = process.env.WEBAPP_ASSET_PREFIX || undefined;
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  ...(assetPrefix ? { assetPrefix } : {}),
 };
 
 export default nextConfig;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web/next.config.ts
@@ -1,9 +1,6 @@
 import type { NextConfig } from "next";
 
-// The preview is served through the Onyx proxy at
-// /api/build/sessions/<id>/webapp. When WEBAPP_ASSET_PREFIX is set (by the
-// dev-server start script), emit /_next/ asset URLs already prefixed with it so
-// the proxy doesn't have to rewrite them on every request.
+// When set by the dev-server start script, emits pre-proxied /_next/ URLs.
 const assetPrefix = process.env.WEBAPP_ASSET_PREFIX || undefined;
 
 const nextConfig: NextConfig = {

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -354,6 +354,7 @@ fi
 set -e
 cd {session_path}/outputs/web
 {install_check}
+export WEBAPP_ASSET_PREFIX="/api/build/sessions/$(basename {session_path})/webapp"
 echo "Starting Next.js dev server on port {nextjs_port}..."
 nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
 NEXTJS_PID=$!

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -1,15 +1,18 @@
 """Unit tests for webapp proxy path rewriting/injection."""
 
+from collections.abc import AsyncGenerator
+from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import cast
-from typing import Literal
 from uuid import UUID
 
 import httpx
 import pytest
+from fastapi import HTTPException
 from fastapi import Request
-from sqlalchemy.orm import Session
+from starlette.responses import StreamingResponse
 
+from onyx.db.enums import SharingScope
 from onyx.server.features.build.api import api
 from onyx.server.features.build.api.api import _inject_hmr_fixer
 from onyx.server.features.build.api.api import _rewrite_asset_paths
@@ -155,80 +158,101 @@ class TestProxyHeaderRewriting:
         assert f"<{BASE}/_next/static/media/font.woff2>" in result["link"]
 
 
+class _FakeUpstream:
+    """Stand-in for httpx's streaming response in the async proxy path."""
+
+    def __init__(
+        self, status_code: int, headers: dict[str, str], content: bytes
+    ) -> None:
+        self.status_code = status_code
+        self.headers = httpx.Headers(headers)
+        self._content = content
+        self.close_count = 0
+
+    async def aread(self) -> bytes:
+        return self._content
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+    async def aiter_bytes(self, **_kwargs: object) -> AsyncIterator[bytes]:
+        for i in range(0, len(self._content), 4):
+            yield self._content[i : i + 4]
+
+
+class _FakeAsyncClient:
+    """Captures the forwarded request headers and returns a canned upstream."""
+
+    def __init__(
+        self, upstream: _FakeUpstream, captured: dict[str, str] | None = None
+    ) -> None:
+        self._upstream = upstream
+        self._captured = captured
+
+    def build_request(
+        self, method: str, url: str, headers: dict[str, str]
+    ) -> SimpleNamespace:
+        if self._captured is not None:
+            self._captured.update(headers)
+        return SimpleNamespace(method=method, url=url, headers=headers)
+
+    async def send(self, _request: object, **_kwargs: object) -> _FakeUpstream:
+        return self._upstream
+
+
+async def _fake_sandbox_url(_session_id: UUID) -> str:
+    return "http://sandbox"
+
+
+class _FakeACM:
+    """No-op async context manager standing in for an async DB session."""
+
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *_args: object) -> bool:
+        return False
+
+
 class TestProxyRequestWiring:
-    def test_proxy_request_rewrites_link_header_on_html_response(
+    @pytest.mark.asyncio
+    async def test_proxy_request_rewrites_link_header_on_html_response(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        html = b"<html><head></head><body>ok</body></html>"
-        upstream = httpx.Response(
+        upstream = _FakeUpstream(
             200,
-            headers={
+            {
                 "content-type": "text/html; charset=utf-8",
                 "link": '</_next/static/media/font.woff2>; rel=preload; as="font"',
             },
-            content=html,
+            b"<html><head></head><body>ok</body></html>",
         )
-
-        monkeypatch.setattr(api, "_get_sandbox_url", lambda *_args: "http://sandbox")
-
-        class FakeClient:
-            def __init__(self, *_args: object, **_kwargs: object) -> None:
-                pass
-
-            def __enter__(self) -> "FakeClient":
-                return self
-
-            def __exit__(self, *_args: object) -> Literal[False]:
-                return False
-
-            def get(self, _url: str, headers: dict[str, str]) -> httpx.Response:
-                assert "host" not in {key.lower() for key in headers}
-                return upstream
-
-        monkeypatch.setattr(api.httpx, "Client", FakeClient)
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
 
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
-        response = api._proxy_request(
-            "", request, UUID(SESSION_ID), cast(Session, SimpleNamespace())
-        )
+        response = await api._proxy_request("", request, UUID(SESSION_ID))
 
         assert response.headers["link"] == (
             f'<{BASE}/_next/static/media/font.woff2>; rel=preload; as="font"'
         )
 
-    def test_proxy_request_injects_hmr_fixer_for_html_response(
+    @pytest.mark.asyncio
+    async def test_proxy_request_injects_hmr_fixer_for_html_response(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        upstream = httpx.Response(
+        upstream = _FakeUpstream(
             200,
-            headers={"content-type": "text/html; charset=utf-8"},
-            content=b"<html><head><title>x</title></head><body></body></html>",
+            {"content-type": "text/html; charset=utf-8"},
+            b"<html><head><title>x</title></head><body></body></html>",
         )
-
-        monkeypatch.setattr(api, "_get_sandbox_url", lambda *_args: "http://sandbox")
-
-        class FakeClient:
-            def __init__(self, *_args: object, **_kwargs: object) -> None:
-                pass
-
-            def __enter__(self) -> "FakeClient":
-                return self
-
-            def __exit__(self, *_args: object) -> Literal[False]:
-                return False
-
-            def get(self, _url: str, headers: dict[str, str]) -> httpx.Response:
-                assert "host" not in {key.lower() for key in headers}
-                return upstream
-
-        monkeypatch.setattr(api.httpx, "Client", FakeClient)
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
 
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
-        response = api._proxy_request(
-            "", request, UUID(SESSION_ID), cast(Session, SimpleNamespace())
-        )
+        response = await api._proxy_request("", request, UUID(SESSION_ID))
         body = cast(bytes, response.body).decode("utf-8")
 
         assert "window.WebSocket = function (url, protocols)" in body
@@ -236,32 +260,18 @@ class TestProxyRequestWiring:
             "<title>x</title>"
         )
 
-    def test_proxy_request_strips_sensitive_viewer_headers(
+    @pytest.mark.asyncio
+    async def test_proxy_request_strips_sensitive_viewer_headers(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Credential, CSRF, and forwarded-identity headers must not reach the sandbox."""
-        upstream = httpx.Response(
-            200, headers={"content-type": "text/plain"}, content=b"ok"
-        )
+        upstream = _FakeUpstream(200, {"content-type": "text/plain"}, b"ok")
         forwarded_headers: dict[str, str] = {}
 
-        monkeypatch.setattr(api, "_get_sandbox_url", lambda *_args: "http://sandbox")
-
-        class FakeClient:
-            def __init__(self, *_args: object, **_kwargs: object) -> None:
-                pass
-
-            def __enter__(self) -> "FakeClient":
-                return self
-
-            def __exit__(self, *_args: object) -> Literal[False]:
-                return False
-
-            def get(self, _url: str, headers: dict[str, str]) -> httpx.Response:
-                forwarded_headers.update(headers)
-                return upstream
-
-        monkeypatch.setattr(api.httpx, "Client", FakeClient)
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(
+            api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream, forwarded_headers)
+        )
 
         # Security spec: every header here must never reach the sandbox,
         # regardless of how EXCLUDED_REQUEST_HEADERS evolves. Removing a key
@@ -322,9 +332,7 @@ class TestProxyRequestWiring:
             ),
         )
 
-        api._proxy_request(
-            "", request, UUID(SESSION_ID), cast(Session, SimpleNamespace())
-        )
+        await api._proxy_request("", request, UUID(SESSION_ID))
 
         lower = {key.lower(): value for key, value in forwarded_headers.items()}
         # Exact match: no sensitive header survives, no extra header leaks
@@ -342,3 +350,160 @@ class TestProxyRequestWiring:
         result = _rewrite_proxy_response_headers(headers, SESSION_ID)
 
         assert f"<{BASE}/_next/static/media/font.woff2>" in result["link"]
+
+    @pytest.mark.asyncio
+    async def test_proxy_sets_immutable_cache_control_on_next_static(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hashed /_next/static/ assets get a long immutable cache, overriding
+        the dev server's no-store so the browser skips re-proxying on reload."""
+        upstream = _FakeUpstream(
+            200,
+            {
+                "content-type": "application/javascript",
+                "cache-control": "no-store, must-revalidate",
+                "pragma": "no-cache",
+            },
+            b"console.log(1)",
+        )
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        response = await api._proxy_request(
+            "_next/static/chunks/main.js", request, UUID(SESSION_ID)
+        )
+
+        assert (
+            response.headers["cache-control"] == "public, max-age=31536000, immutable"
+        )
+        assert "pragma" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_proxy_passes_js_through_unrewritten(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """JS bundles pass through unrewritten; the sandbox emits assetPrefix URLs."""
+        js = b'fetch("/_next/static/chunks/x.js")'
+        upstream = _FakeUpstream(200, {"content-type": "application/javascript"}, js)
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        response = await api._proxy_request(
+            "_next/static/chunks/x.js", request, UUID(SESSION_ID)
+        )
+
+        assert cast(bytes, response.body) == js
+
+    @pytest.mark.asyncio
+    async def test_proxy_streams_binary_assets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-rewritable assets stream straight through, byte-for-byte."""
+        body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+        upstream = _FakeUpstream(200, {"content-type": "image/png"}, body)
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        response = await api._proxy_request("logo.png", request, UUID(SESSION_ID))
+
+        assert isinstance(response, StreamingResponse)
+        chunks = [chunk async for chunk in response.body_iterator]
+        assert b"".join(cast(list[bytes], chunks)) == body
+        assert upstream.close_count == 1  # released after full drain
+
+    @pytest.mark.asyncio
+    async def test_streaming_closes_upstream_on_early_disconnect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the client disconnects mid-stream, the pooled connection is still
+        released (the generator's finally runs on GeneratorExit)."""
+        upstream = _FakeUpstream(200, {"content-type": "image/png"}, b"abcdefghijkl")
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        response = await api._proxy_request("logo.png", request, UUID(SESSION_ID))
+        assert isinstance(response, StreamingResponse)
+
+        body_iter = cast(AsyncGenerator[bytes, None], response.body_iterator)
+        first = await body_iter.__anext__()
+        assert first == b"abcd"
+        await body_iter.aclose()
+
+        assert upstream.close_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_buffered_response_closes_upstream(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The buffer-and-rewrite branch releases the upstream after reading."""
+        upstream = _FakeUpstream(
+            200, {"content-type": "text/html"}, b"<html><head></head></html>"
+        )
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        await api._proxy_request("", request, UUID(SESSION_ID))
+
+        assert upstream.close_count == 1
+
+
+class TestWebappAccessCache:
+    @pytest.mark.asyncio
+    async def test_grant_is_cached_skipping_db_on_repeat(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A granted (session, viewer) pair skips the DB on subsequent assets."""
+        api._WEBAPP_ACCESS_CACHE.clear()
+        viewer = SimpleNamespace(id=UUID("11111111-1111-1111-1111-111111111111"))
+        calls = {"n": 0}
+
+        async def fake_access(
+            _db: object, _sid: UUID
+        ) -> tuple[SharingScope, UUID] | None:
+            calls["n"] += 1
+            # Owner == viewer, so a PRIVATE session is granted.
+            return (SharingScope.PRIVATE, viewer.id)
+
+        monkeypatch.setattr(api, "get_webapp_access_async", fake_access)
+        monkeypatch.setattr(
+            api, "get_async_session_context_manager", lambda: _FakeACM()
+        )
+
+        await api._check_webapp_access(UUID(SESSION_ID), cast(api.User, viewer))
+        await api._check_webapp_access(UUID(SESSION_ID), cast(api.User, viewer))
+
+        assert calls["n"] == 1  # second call served from cache
+
+    @pytest.mark.asyncio
+    async def test_private_session_denies_non_owner_and_is_not_cached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-owner gets 404 on a private session, and the denial is re-queried
+        (denials are never cached, so re-sharing takes effect immediately)."""
+        api._WEBAPP_ACCESS_CACHE.clear()
+        owner_id = UUID("22222222-2222-2222-2222-222222222222")
+        viewer = SimpleNamespace(id=UUID("33333333-3333-3333-3333-333333333333"))
+        calls = {"n": 0}
+
+        async def fake_access(
+            _db: object, _sid: UUID
+        ) -> tuple[SharingScope, UUID] | None:
+            calls["n"] += 1
+            return (SharingScope.PRIVATE, owner_id)
+
+        monkeypatch.setattr(api, "get_webapp_access_async", fake_access)
+        monkeypatch.setattr(
+            api, "get_async_session_context_manager", lambda: _FakeACM()
+        )
+
+        for _ in range(2):
+            with pytest.raises(HTTPException) as exc:
+                await api._check_webapp_access(UUID(SESSION_ID), cast(api.User, viewer))
+            assert exc.value.status_code == 404
+
+        assert calls["n"] == 2  # denial hit the DB both times

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -358,17 +358,49 @@ class TestProxyRequestWiring:
         assert f"<{BASE}/_next/static/media/font.woff2>" in result["link"]
 
     @pytest.mark.asyncio
-    async def test_proxy_sets_immutable_cache_control_on_next_static(
+    async def test_proxy_sets_immutable_cache_control_on_next_static_media(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Hashed /_next/static/ assets get a long immutable cache, overriding
-        the dev server's no-store so the browser skips re-proxying on reload."""
+        """Content-hashed /_next/static/media/* assets (fonts, images) get a long
+        immutable cache, overriding the dev server's no-store so the browser skips
+        re-proxying on reload."""
+        upstream = _FakeUpstream(
+            200,
+            {
+                "content-type": "font/woff2",
+                "cache-control": "no-store, must-revalidate",
+                "pragma": "no-cache",
+            },
+            b"\x00\x01font",
+        )
+        monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
+        request = cast(Request, SimpleNamespace(headers={}, query_params=""))
+
+        response = await api._proxy_request(
+            "_next/static/media/font.woff2", request, UUID(SESSION_ID)
+        )
+
+        assert (
+            response.headers["cache-control"] == "public, max-age=31536000, immutable"
+        )
+        assert "pragma" not in response.headers
+
+    @pytest.mark.asyncio
+    async def test_proxy_preserves_no_cache_on_next_static_chunks(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dev chunk/CSS URLs are path-stable but content-volatile, so the dev server
+        marks them no-cache. The proxy must NOT override that to immutable — doing so
+        serves stale code after an edit + full reload (Turbopack dev does not
+        content-hash chunk filenames)."""
         upstream = _FakeUpstream(
             200,
             {
                 "content-type": "application/javascript",
-                "cache-control": "no-store, must-revalidate",
-                "pragma": "no-cache",
+                "cache-control": "no-cache, must-revalidate",
             },
             b"console.log(1)",
         )
@@ -382,10 +414,8 @@ class TestProxyRequestWiring:
             "_next/static/chunks/main.js", request, UUID(SESSION_ID)
         )
 
-        assert (
-            response.headers["cache-control"] == "public, max-age=31536000, immutable"
-        )
-        assert "pragma" not in response.headers
+        assert response.headers["cache-control"] == "no-cache, must-revalidate"
+        assert "immutable" not in response.headers["cache-control"]
 
     @pytest.mark.asyncio
     async def test_proxy_passes_js_through_unrewritten(

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -500,13 +500,28 @@ class TestProxyRequestWiring:
         assert upstream.close_count == 1
 
 
+class _FakeCacheBackend:
+    """In-memory stand-in for the Redis-backed CacheBackend (get/set/delete)."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, bytes] = {}
+
+    def get(self, key: str) -> bytes | None:
+        return self._store.get(key)
+
+    def set(self, key: str, value: str | bytes, **_kwargs: object) -> None:
+        self._store[key] = value.encode() if isinstance(value, str) else value
+
+    def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
 class TestWebappAccessCache:
     @pytest.mark.asyncio
     async def test_grant_is_cached_skipping_db_on_repeat(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A granted (session, viewer) pair skips the DB on subsequent assets."""
-        api._WEBAPP_ACCESS_CACHE.clear()
         viewer = SimpleNamespace(id=UUID("11111111-1111-1111-1111-111111111111"))
         calls = {"n": 0}
 
@@ -522,6 +537,10 @@ class TestWebappAccessCache:
             api, "get_async_session_context_manager", lambda: _FakeACM()
         )
 
+        # Shared backend across both calls so the grant persists like Redis would.
+        shared = _FakeCacheBackend()
+        monkeypatch.setattr(api, "get_cache_backend", lambda: shared)
+
         await api._check_webapp_access(UUID(SESSION_ID), cast(api.User, viewer))
         await api._check_webapp_access(UUID(SESSION_ID), cast(api.User, viewer))
 
@@ -533,7 +552,8 @@ class TestWebappAccessCache:
     ) -> None:
         """Non-owner gets 404 on a private session, and the denial is re-queried
         (denials are never cached, so re-sharing takes effect immediately)."""
-        api._WEBAPP_ACCESS_CACHE.clear()
+        shared = _FakeCacheBackend()
+        monkeypatch.setattr(api, "get_cache_backend", lambda: shared)
         owner_id = UUID("22222222-2222-2222-2222-222222222222")
         viewer = SimpleNamespace(id=UUID("33333333-3333-3333-3333-333333333333"))
         calls = {"n": 0}

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -418,7 +418,7 @@ class TestProxyRequestWiring:
         assert "immutable" not in response.headers["cache-control"]
 
     @pytest.mark.asyncio
-    async def test_proxy_passes_js_through_unrewritten(
+    async def test_proxy_rewrites_js_asset_paths(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """JS bundles are rewritten; idempotent for new sandboxes (assetPrefix),

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -228,7 +228,9 @@ class TestProxyRequestWiring:
             b"<html><head></head><body>ok</body></html>",
         )
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
 
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
@@ -248,7 +250,9 @@ class TestProxyRequestWiring:
             b"<html><head><title>x</title></head><body></body></html>",
         )
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
 
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
@@ -270,7 +274,9 @@ class TestProxyRequestWiring:
 
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
         monkeypatch.setattr(
-            api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream, forwarded_headers)
+            api,
+            "_get_proxy_client",
+            lambda: _FakeAsyncClient(upstream, forwarded_headers),
         )
 
         # Security spec: every header here must never reach the sandbox,
@@ -367,7 +373,9 @@ class TestProxyRequestWiring:
             b"console.log(1)",
         )
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
         response = await api._proxy_request(
@@ -383,18 +391,22 @@ class TestProxyRequestWiring:
     async def test_proxy_passes_js_through_unrewritten(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """JS bundles pass through unrewritten; the sandbox emits assetPrefix URLs."""
-        js = b'fetch("/_next/static/chunks/x.js")'
+        """JS bundles are rewritten; idempotent for new sandboxes (assetPrefix),
+        and corrects bare /_next/ refs for sandboxes started before this deploy."""
+        js = b'import x from "/_next/static/chunks/dep.js"'
         upstream = _FakeUpstream(200, {"content-type": "application/javascript"}, js)
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
         response = await api._proxy_request(
             "_next/static/chunks/x.js", request, UUID(SESSION_ID)
         )
 
-        assert cast(bytes, response.body) == js
+        body = cast(bytes, response.body).decode()
+        assert f'"/{BASE.lstrip("/")}/_next/static/chunks/dep.js"' in body
 
     @pytest.mark.asyncio
     async def test_proxy_streams_binary_assets(
@@ -404,7 +416,9 @@ class TestProxyRequestWiring:
         body = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
         upstream = _FakeUpstream(200, {"content-type": "image/png"}, body)
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
         response = await api._proxy_request("logo.png", request, UUID(SESSION_ID))
@@ -422,7 +436,9 @@ class TestProxyRequestWiring:
         released (the generator's finally runs on GeneratorExit)."""
         upstream = _FakeUpstream(200, {"content-type": "image/png"}, b"abcdefghijkl")
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
         response = await api._proxy_request("logo.png", request, UUID(SESSION_ID))
@@ -444,7 +460,9 @@ class TestProxyRequestWiring:
             200, {"content-type": "text/html"}, b"<html><head></head></html>"
         )
         monkeypatch.setattr(api, "_get_sandbox_url", _fake_sandbox_url)
-        monkeypatch.setattr(api, "_ASYNC_PROXY_CLIENT", _FakeAsyncClient(upstream))
+        monkeypatch.setattr(
+            api, "_get_proxy_client", lambda: _FakeAsyncClient(upstream)
+        )
         request = cast(Request, SimpleNamespace(headers={}, query_params=""))
 
         await api._proxy_request("", request, UUID(SESSION_ID))


### PR DESCRIPTION
## Description

Speeds up the Craft webapp preview proxy, which forwards browser requests (HTML + JS/CSS/font/image fan-out) from the user's iframe to the Next.js dev server inside the sandbox pod.

**Changes:**

- **Async endpoint** (`get_webapp`, `_proxy_request`, helpers): converted from sync `def` (ran in the 40-thread shared pool) to `async def` with `httpx.AsyncClient`. Slow sandbox upstreams now suspend a coroutine rather than parking a threadpool worker, so preview load can no longer starve unrelated API endpoints. Binary assets stream via `aiter_bytes` with a `finally`-guarded generator so client disconnects can't leak pooled connections.

- **Connection pooling**: replaced the per-request `httpx.Client(...)` with a module-level `httpx.AsyncClient` (keepalive, 50/200 limits). Eliminates TCP setup/teardown on every proxied asset.

- **Per-asset DB caching**: `_SANDBOX_URL_CACHE` (session_id → upstream URL, 60s TTL) and `_WEBAPP_ACCESS_CACHE` ((session_id, viewer_id) → grant, 30s TTL) — both bounded `TTLCache`s. On the warm path (every asset after the first), zero DB connections are opened. Two new async DB helpers (`get_webapp_target_async`, `get_webapp_access_async`) collapse what was 3 sync round-trips per asset into a single async join on cache miss.

- **Immutable cache headers**: `/_next/static/` assets get `Cache-Control: public, max-age=31536000, immutable`, overriding the dev server's `no-store` so the browser skips re-proxying on reload.

- **assetPrefix on the sandbox dev server**: `next.config.ts` reads `WEBAPP_ASSET_PREFIX` (exported by the dev-server start scripts at launch), so Next.js emits already-proxied URLs. The proxy then only rewrites HTML (small, single doc); JS/CSS bundles pass through as-is.

## How Has This Been Tested?

- **Unit tests** (`tests/unit/build/test_rewrite_asset_paths.py`): 34 pass. Added async wiring tests (HTML rewrite, HMR injection, header stripping, immutable cache override, JS pass-through, upstream connection closed on full drain and on early client disconnect, auth grant cached / denial not cached).
- **Live benchmark** against the running local dev environment (telepresence → cluster sandbox):
  - Sync baseline (main): **p50 = 10,214 ms** per page-load (HTML + 20 assets)
  - Async (this PR): **p50 = 183 ms** — ~56× faster on loopback (amplified by telepresence round-trips; production gains are smaller in absolute terms but the same overheads are removed)
  - Static `Cache-Control` confirmed `public, max-age=31536000, immutable` on live assets

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Craft webapp preview proxy async with pooled connections and shared Redis caching to speed up previews and prevent API thread starvation. Adds immutable caching for content‑hashed media and asset prefixing to cut rewrites and round trips; local p50 page load dropped from ~10s to ~183ms.

- **Refactors**
  - Converted `get_webapp` and proxy helpers to `async` with `httpx.AsyncClient` streaming and a lazily initialized pooled client (keepalive; 50/200 limits).
  - Replaced per-process caches with a shared Redis backend via `get_cache_backend()` for sandbox URL (session → URL, 60s) and access grants ((session, viewer) → grant, 30s; grants only). New async DB helpers (`get_webapp_target_async`, `get_webapp_access_async`) collapse lookups; evict cached sandbox URL on 502/503/504.
  - Always rewrite HTML/CSS/JS bodies (idempotent with asset prefix). Stream binary assets and ensure upstream connections are closed on drain or early client disconnect using a single guarded finally; `_aiter_and_close` is typed as `AsyncGenerator[bytes, None]`.
  - Hoisted repeated `str(session_id)`, relative path, and cache-key computation in the proxy (no behavior change).

- **New Features**
  - Set `Cache-Control: public, max-age=31536000, immutable` for `/_next/static/media/` only; preserve the dev server’s no-cache for chunks/CSS; strip `pragma`/`expires` on media responses.
  - `next.config.ts` reads `WEBAPP_ASSET_PREFIX` (set by dev‑server start scripts) so JS/CSS URLs are pre‑prefixed; proxy rewrites remain safe for old and new sandboxes.

<sup>Written for commit f560a5d7c467e88a6b8ecd0b52e10acac1b3f904. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

