### PR TITLE
fix(craft): harden sandbox restore against conflicts, transient failures, and unreachable pods

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -355,7 +355,6 @@ def restore_session(
         )
 
     try:
-        # Re-read: another request may have restored while we waited.
         db_session.refresh(sandbox)
 
         if sandbox.status == SandboxStatus.RUNNING:
@@ -381,14 +380,12 @@ def restore_session(
                 )
                 db_session.commit()
                 db_session.refresh(sandbox)
-                # Fall through to the TERMINATED branch below.
 
         session_manager = SessionManager(db_session)
         llm_config, all_llm_configs = session_manager.build_llm_configs(user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            # PAT before PROVISIONING so a failure here stays retriable. The
-            # sandbox needs it to reach Onyx via onyx-cli.
+            # Mint the PAT before flipping to PROVISIONING so a failure is retriable.
             onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
 
             update_sandbox_status__no_commit(
@@ -418,7 +415,6 @@ def restore_session(
             if not workspace_exists:
                 if not session.nextjs_port:
                     session.nextjs_port = allocate_nextjs_port(db_session)
-                    # Commit before the long-running restore below.
                     db_session.commit()
 
                 snapshot = get_latest_snapshot_for_session(db_session, session_id)
@@ -481,8 +477,7 @@ def restore_session(
             db_session.rollback()
             stuck = get_sandbox_by_user_id(db_session, user.id)
             if stuck is not None and stuck.status == SandboxStatus.PROVISIONING:
-                # provision() failed — back to SLEEPING so the next attempt
-                # re-provisions instead of staying stuck PROVISIONING forever.
+                # provision() failed — back to SLEEPING so it isn't stuck.
                 update_sandbox_status__no_commit(
                     db_session, stuck.id, SandboxStatus.SLEEPING
                 )
@@ -492,10 +487,8 @@ def restore_session(
                     stuck.id,
                 )
             elif stuck is not None and stuck.status == SandboxStatus.RUNNING:
-                # Provision succeeded but the workspace load failed, possibly
-                # leaving a partial sessions/$id/ dir. Remove it so the next
-                # attempt redoes the load (else session_workspace_exists() sees
-                # the partial dir and falsely reports the session restored).
+                # Workspace load failed after provision — drop the partial dir
+                # so session_workspace_exists() doesn't later report it restored.
                 failed_session = get_build_session(session_id, user.id, db_session)
                 failed_port = (
                     failed_session.nextjs_port if failed_session is not None else None

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -328,18 +328,9 @@ def restore_session(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> DetailedSessionResponse:
-    """Restore sandbox and load session snapshot. Blocks until complete.
-
-    Uses Redis lock to ensure only one restore runs per sandbox at a time.
-    If another restore is in progress, waits for it to complete.
-
-    Handles two cases:
-    1. Sandbox is SLEEPING: Re-provision pod, then load session snapshot
-    2. Sandbox is RUNNING but session not loaded: Just load session snapshot
-
-    Returns immediately if session workspace already exists in pod.
-    Always returns session_loaded_in_sandbox=True on success.
-    """
+    """Restore the sandbox (re-provisioning if asleep) and load the session
+    workspace. Serialized per-sandbox via a Redis lock; returns 409 if another
+    restore holds it."""
     session = get_build_session(session_id, user.id, db_session)
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -348,17 +339,14 @@ def restore_session(
     if not sandbox:
         raise HTTPException(status_code=404, detail="Sandbox not found")
 
-    # If sandbox is already running, check if session workspace exists
     sandbox_manager = get_sandbox_manager()
     tenant_id = get_current_tenant_id()
 
-    # Need to do some work - acquire Redis lock
     redis_client = get_redis_client(tenant_id=tenant_id)
     lock_key = f"sandbox_restore:{sandbox.id}"
     lock = redis_client.lock(lock_key, timeout=RESTORE_LOCK_TIMEOUT_SECONDS)
 
-    # Non-blocking: if another restore is already running, return 409 immediately
-    # instead of making the user wait. The frontend will retry.
+    # 409 instead of blocking — the frontend retries.
     acquired = lock.acquire(blocking=False)
     if not acquired:
         raise HTTPException(
@@ -367,11 +355,9 @@ def restore_session(
         )
 
     try:
-        # Re-fetch sandbox status (may have changed while waiting for lock)
+        # Re-read: another request may have restored while we waited.
         db_session.refresh(sandbox)
 
-        # Also re-check if session workspace exists (another request may have
-        # restored it while we were waiting)
         if sandbox.status == SandboxStatus.RUNNING:
             is_healthy = sandbox_manager.health_check(sandbox.id, timeout=10.0)
             if is_healthy and sandbox_manager.session_workspace_exists(
@@ -389,29 +375,22 @@ def restore_session(
                     "Sandbox %s marked as RUNNING but pod is unhealthy/missing. Entering recovery mode.",
                     sandbox.id,
                 )
-                # Terminate to clean up any lingering K8s resources
                 sandbox_manager.terminate(sandbox.id)
-
                 update_sandbox_status__no_commit(
                     db_session, sandbox.id, SandboxStatus.TERMINATED
                 )
                 db_session.commit()
                 db_session.refresh(sandbox)
-                # Fall through to TERMINATED handling below
+                # Fall through to the TERMINATED branch below.
 
         session_manager = SessionManager(db_session)
-        # One access-scoped read → default config + all pre-registered configs.
         llm_config, all_llm_configs = session_manager.build_llm_configs(user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            # Mint/look up the PAT before flipping to PROVISIONING so that a
-            # failure here can be retried without the sandbox getting stuck.
-            # Docker (and Kubernetes) require the PAT at provision time so
-            # the sandbox can talk back to Onyx via onyx-cli.
+            # PAT before PROVISIONING so a failure here stays retriable. The
+            # sandbox needs it to reach Onyx via onyx-cli.
             onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
 
-            # Mark as PROVISIONING before the long-running provision() call
-            # so other requests know work is in progress
             update_sandbox_status__no_commit(
                 db_session, sandbox.id, SandboxStatus.PROVISIONING
             )
@@ -426,27 +405,22 @@ def restore_session(
                 all_llm_configs=all_llm_configs,
             )
 
-            # Mark as RUNNING after successful provision
             update_sandbox_status__no_commit(
                 db_session, sandbox.id, SandboxStatus.RUNNING
             )
             db_session.commit()
 
-        # 2. Check if session workspace needs to be loaded
         if sandbox.status == SandboxStatus.RUNNING:
             workspace_exists = sandbox_manager.session_workspace_exists(
                 sandbox.id, session_id
             )
 
             if not workspace_exists:
-                # Allocate port if not already set (needed for both snapshot restore and fresh setup)
                 if not session.nextjs_port:
                     session.nextjs_port = allocate_nextjs_port(db_session)
-                    # Commit port allocation before long-running operations
+                    # Commit before the long-running restore below.
                     db_session.commit()
 
-                # All supported backends snapshot session state to durable
-                # storage (S3 for kubernetes, host disk for docker).
                 snapshot = get_latest_snapshot_for_session(db_session, session_id)
 
                 skills_section, skills_files = build_user_skills_payload(
@@ -473,7 +447,6 @@ def restore_session(
                         db_session.commit()
                         raise
                 else:
-                    # No snapshot - set up fresh workspace
                     sandbox_manager.setup_session_workspace(
                         sandbox_id=sandbox.id,
                         session_id=session_id,
@@ -503,16 +476,13 @@ def restore_session(
 
     except Exception as e:
         logger.error("Failed to restore session %s: %s", session_id, e, exc_info=True)
-        # Roll the sandbox out of ``PROVISIONING`` so the frontend's
-        # ``needsRestore`` check picks it back up and the next attempt isn't
-        # blocked by a stuck status. Without this, an api_server restart
-        # mid-provision (or any other transient failure) leaves the sandbox
-        # marked PROVISIONING forever and the user has to manually unstick it
-        # in the DB. Re-fetch the sandbox in case the session was rolled back.
+        # Recover so the next attempt isn't blocked by a half-finished state.
         try:
             db_session.rollback()
             stuck = get_sandbox_by_user_id(db_session, user.id)
             if stuck is not None and stuck.status == SandboxStatus.PROVISIONING:
+                # provision() failed — back to SLEEPING so the next attempt
+                # re-provisions instead of staying stuck PROVISIONING forever.
                 update_sandbox_status__no_commit(
                     db_session, stuck.id, SandboxStatus.SLEEPING
                 )
@@ -521,9 +491,25 @@ def restore_session(
                     "Rolled sandbox %s back to SLEEPING after failed restore",
                     stuck.id,
                 )
+            elif stuck is not None and stuck.status == SandboxStatus.RUNNING:
+                # Provision succeeded but the workspace load failed, possibly
+                # leaving a partial sessions/$id/ dir. Remove it so the next
+                # attempt redoes the load (else session_workspace_exists() sees
+                # the partial dir and falsely reports the session restored).
+                failed_session = get_build_session(session_id, user.id, db_session)
+                failed_port = (
+                    failed_session.nextjs_port if failed_session is not None else None
+                )
+                sandbox_manager.cleanup_session_workspace(
+                    stuck.id, session_id, failed_port
+                )
+                logger.info(
+                    "Cleaned up partial workspace for session %s after failed restore",
+                    session_id,
+                )
         except Exception as rollback_err:
             logger.warning(
-                "Failed to roll sandbox status back after restore failure: %s",
+                "Failed to recover sandbox state after restore failure: %s",
                 rollback_err,
             )
         raise HTTPException(

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -2361,9 +2361,7 @@ class SessionManager:
             # outputs/ doesn't exist yet — no artifacts.
             return artifacts
         except Exception:
-            # The sandbox can be transiently unreachable (pod still coming up
-            # after a restore). Degrade to "no artifacts yet" rather than 500;
-            # the frontend re-fetches via SWR.
+            # Sandbox transiently unreachable — degrade to no artifacts, not 500.
             logger.warning(
                 "Could not list artifacts for session %s; sandbox not reachable",
                 session_id,

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -2351,7 +2351,6 @@ class SessionManager:
         artifacts: list[dict[str, Any]] = []
         now = datetime.now(timezone.utc)
 
-        # Check for outputs directory using sandbox manager
         try:
             output_entries = self._sandbox_manager.list_directory(
                 sandbox_id=sandbox.id,
@@ -2359,7 +2358,17 @@ class SessionManager:
                 path="outputs",
             )
         except ValueError:
-            # Directory doesn't exist
+            # outputs/ doesn't exist yet — no artifacts.
+            return artifacts
+        except Exception:
+            # The sandbox can be transiently unreachable (pod still coming up
+            # after a restore). Degrade to "no artifacts yet" rather than 500;
+            # the frontend re-fetches via SWR.
+            logger.warning(
+                "Could not list artifacts for session %s; sandbox not reachable",
+                session_id,
+                exc_info=True,
+            )
             return artifacts
 
         # Check for webapp (web directory in outputs)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -18,6 +18,7 @@ from typing import Callable
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import BuildSessionStatus
@@ -28,7 +29,9 @@ from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.api.sessions_api import restore_session
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
+from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import get_idle_sandboxes
+from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
@@ -226,6 +229,145 @@ class TestHealthCheckFailureRecovery:
         # cycle (TERMINATED -> PROVISIONING -> RUNNING).
         assert refreshed is not None
         assert refreshed.status == SandboxStatus.RUNNING
+
+
+class TestRestoreFailureRecovery:
+    def test_workspace_load_failure_cleans_up_partial_workspace(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        stub_sandbox_manager: StubSandboxManager,
+        session_manager_with_stub: SessionManager,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # provision() succeeds (the row flips SLEEPING -> RUNNING and commits),
+        # but loading the session workspace then fails. The recovery branch
+        # must leave the healthy pod RUNNING and remove the half-written
+        # workspace so the next attempt redoes the load cleanly — otherwise
+        # session_workspace_exists() returns True for the partial dir and the
+        # session is falsely reported as restored.
+        row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
+
+        idle_session = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="restore-fails",
+            status=BuildSessionStatus.IDLE,
+        )
+        db_session.add(idle_session)
+        db_session.commit()
+        session_id = idle_session.id
+
+        # A snapshot exists, so restore takes the restore_snapshot branch.
+        create_snapshot__no_commit(
+            db_session,
+            session_id,
+            f"{TEST_TENANT_ID}/snapshots/{session_id}/snap.tar.gz",
+            size_bytes=123,
+        )
+        db_session.commit()
+
+        stub_sandbox_manager.provision_returns = SandboxInfo(
+            sandbox_id=row.id,
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+        stub_sandbox_manager.session_workspace_exists_returns = False
+        # restore_snapshot left unconfigured -> raises, simulating a failed
+        # workspace load after a successful provision.
+        stub_sandbox_manager.cleanup_session_workspace_silent = True
+
+        monkeypatch.setattr(
+            "onyx.server.features.build.api.sessions_api.get_sandbox_manager",
+            lambda: stub_sandbox_manager,
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.build.session.manager.SessionManager._get_llm_config",
+            lambda _self, *_a, **_kw: default_llm_config(),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            restore_session(
+                session_id=session_id,
+                user=test_user,
+                db_session=db_session,
+            )
+        assert exc_info.value.status_code == 500
+
+        # The partial workspace was cleaned up for this exact session...
+        assert stub_sandbox_manager.cleanup_session_workspace_count == 1
+        assert stub_sandbox_manager.last_cleanup_session_workspace_payload is not None
+        assert (
+            stub_sandbox_manager.last_cleanup_session_workspace_payload["session_id"]
+            == session_id
+        )
+
+        # ...and the healthy pod stays RUNNING (no needless re-provision).
+        db_session.expire_all()
+        refreshed = db_session.get(Sandbox, row.id)
+        assert refreshed is not None
+        assert refreshed.status == SandboxStatus.RUNNING
+
+
+class TestListArtifacts:
+    def _seed_session(self, db_session: Session, user: User) -> BuildSession:
+        session = BuildSession(
+            id=uuid4(),
+            user_id=user.id,
+            name="artifacts",
+            status=BuildSessionStatus.ACTIVE,
+        )
+        db_session.add(session)
+        db_session.commit()
+        return session
+
+    def test_transient_sandbox_error_degrades_to_empty(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        stub_sandbox_manager: StubSandboxManager,
+        session_manager_with_stub: SessionManager,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # list_directory reaches into the sandbox and can fail transiently
+        # while the pod is still coming up after a restore. list_artifacts must
+        # degrade to [] (200) rather than propagating a 500.
+        sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        session = self._seed_session(db_session, test_user)
+
+        def _raise_transient(**_kwargs: object) -> list[FilesystemEntry]:
+            raise RuntimeError("Failed to list directory: pod not ready")
+
+        monkeypatch.setattr(stub_sandbox_manager, "list_directory", _raise_transient)
+
+        result = session_manager_with_stub.list_artifacts(session.id, test_user.id)
+
+        assert result == []
+
+    def test_lists_webapp_when_sandbox_reachable(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        stub_sandbox_manager: StubSandboxManager,
+        session_manager_with_stub: SessionManager,
+    ) -> None:
+        # Sanity: when the sandbox is reachable and outputs/web exists, the
+        # web_app artifact is still surfaced (no regression from the new guard).
+        sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        session = self._seed_session(db_session, test_user)
+
+        stub_sandbox_manager.list_directory_returns = [
+            FilesystemEntry(name="web", path="outputs/web", is_directory=True),
+        ]
+
+        result = session_manager_with_stub.list_artifacts(session.id, test_user.id)
+
+        assert result is not None
+        assert [a["type"] for a in result] == ["web_app"]
 
 
 class TestIdleCleanupSelection:

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -283,10 +283,6 @@ class TestRestoreFailureRecovery:
             "onyx.server.features.build.api.sessions_api.get_sandbox_manager",
             lambda: stub_sandbox_manager,
         )
-        monkeypatch.setattr(
-            "onyx.server.features.build.session.manager.SessionManager._get_llm_config",
-            lambda _self, *_a, **_kw: default_llm_config(),
-        )
 
         with pytest.raises(HTTPException) as exc_info:
             restore_session(

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -1,0 +1,63 @@
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+import * as api from "@/app/craft/services/apiServices";
+
+jest.mock("@/app/craft/services/apiServices");
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const SESSION_ID = "11111111-1111-1111-1111-111111111111";
+
+// Minimal DetailedSessionResponse shapes — loadSession only reads status,
+// session_loaded_in_sandbox, and sandbox.{status,nextjs_port}.
+function sleepingSession(): unknown {
+  return {
+    id: SESSION_ID,
+    status: "idle",
+    session_loaded_in_sandbox: false,
+    sandbox: { id: "sb1", status: "sleeping", nextjs_port: null },
+  };
+}
+
+function runningSession(): unknown {
+  return {
+    id: SESSION_ID,
+    status: "active",
+    session_loaded_in_sandbox: true,
+    sandbox: { id: "sb1", status: "running", nextjs_port: null },
+  };
+}
+
+describe("loadSession restore status", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useBuildSessionStore.setState({
+      sessions: new Map(),
+      currentSessionId: null,
+    } as never);
+    mockedApi.fetchMessages.mockResolvedValue([] as never);
+    mockedApi.fetchArtifacts.mockResolvedValue([] as never);
+  });
+
+  it("keeps the sandbox running when the post-restore artifact fetch fails", async () => {
+    mockedApi.fetchSession.mockResolvedValue(sleepingSession() as never);
+    mockedApi.restoreSession.mockResolvedValue(runningSession() as never);
+    // Artifacts list the sandbox via opencode-serve and can fail right after
+    // the pod comes up — this must NOT flip the sandbox to "failed".
+    mockedApi.fetchArtifacts.mockRejectedValue(new Error("opencode not ready"));
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.sandbox?.status).toBe("running");
+  });
+
+  it("marks the sandbox failed when restore itself fails", async () => {
+    mockedApi.fetchSession.mockResolvedValue(sleepingSession() as never);
+    mockedApi.restoreSession.mockRejectedValue(new Error("restore boom"));
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.sandbox?.status).toBe("failed");
+  });
+});

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -1,4 +1,7 @@
-import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+import {
+  useBuildSessionStore,
+  waitForWebappReady,
+} from "@/app/craft/hooks/useBuildSessionStore";
 import * as api from "@/app/craft/services/apiServices";
 
 jest.mock("@/app/craft/services/apiServices");
@@ -27,6 +30,10 @@ function runningSession(): unknown {
   };
 }
 
+function webappInfo(has_webapp: boolean, ready: boolean): unknown {
+  return { has_webapp, webapp_url: null, status: "running", ready };
+}
+
 describe("loadSession restore status", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,6 +43,10 @@ describe("loadSession restore status", () => {
     } as never);
     mockedApi.fetchMessages.mockResolvedValue([] as never);
     mockedApi.fetchArtifacts.mockResolvedValue([] as never);
+    // Default: webapp already serving, so the readiness gate is a no-op.
+    mockedApi.fetchWebappInfo.mockResolvedValue(
+      webappInfo(true, true) as never
+    );
   });
 
   it("keeps the sandbox running when the post-restore artifact fetch fails", async () => {
@@ -59,5 +70,66 @@ describe("loadSession restore status", () => {
 
     const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
     expect(session?.sandbox?.status).toBe("failed");
+  });
+
+  it("waits for the webapp before flipping to running, then shows running", async () => {
+    mockedApi.fetchSession.mockResolvedValue(sleepingSession() as never);
+    mockedApi.restoreSession.mockResolvedValue(runningSession() as never);
+    // Webapp not ready on the first poll, ready on the second.
+    mockedApi.fetchWebappInfo
+      .mockResolvedValueOnce(webappInfo(true, false) as never)
+      .mockResolvedValue(webappInfo(true, true) as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    // It consulted webapp readiness, and the final state is running.
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalled();
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.sandbox?.status).toBe("running");
+  });
+});
+
+describe("waitForWebappReady", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("returns immediately when the session has no webapp", async () => {
+    mockedApi.fetchWebappInfo.mockResolvedValue(
+      webappInfo(false, false) as never
+    );
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns immediately when the webapp is already ready", async () => {
+    mockedApi.fetchWebappInfo.mockResolvedValue(
+      webappInfo(true, true) as never
+    );
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls until the webapp reports ready", async () => {
+    mockedApi.fetchWebappInfo
+      .mockResolvedValueOnce(webappInfo(true, false) as never)
+      .mockResolvedValueOnce(webappInfo(true, false) as never)
+      .mockResolvedValue(webappInfo(true, true) as never);
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(3);
+  });
+
+  it("gives up after maxAttempts when the webapp never comes up", async () => {
+    mockedApi.fetchWebappInfo.mockResolvedValue(
+      webappInfo(true, false) as never
+    );
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0, maxAttempts: 3 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps polling through transient fetch errors", async () => {
+    mockedApi.fetchWebappInfo
+      .mockRejectedValueOnce(new Error("sandbox not reachable"))
+      .mockResolvedValue(webappInfo(true, true) as never);
+    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
+    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -750,11 +750,8 @@ const createInitialSessionData = (
 // Store
 // =============================================================================
 
-// Restore re-launches the Next.js dev server fire-and-forget, so the backend
-// reports the sandbox RUNNING before the webapp actually serves. Poll
-// webapp-info until it reports ready (or the session has no webapp), so the
-// caller can keep showing "Restoring…" until the preview is live. Bounded by
-// maxAttempts so a webapp that never comes up doesn't pin the chip forever.
+// The dev server is started fire-and-forget, so the backend reports RUNNING
+// before the webapp serves. Poll webapp-info until ready (bounded by maxAttempts).
 export async function waitForWebappReady(
   sessionId: string,
   { intervalMs = 1500, maxAttempts = 20 }: WaitForWebappReadyOptions = {}
@@ -764,10 +761,9 @@ export async function waitForWebappReady(
     try {
       info = await fetchWebappInfo(sessionId);
     } catch {
-      // Transient (sandbox not reachable yet) — keep polling.
+      // keep polling
     }
-    // Done once we get a definitive answer: no webapp, or it's serving. A
-    // transient error (info null) falls through and we keep polling.
+    // Done on a definitive answer (no webapp or serving); errors keep polling.
     if (info && (!info.has_webapp || info.ready)) return;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
@@ -1581,10 +1577,8 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           return;
         }
 
-        // Restore relaunched the webapp dev server fire-and-forget. Keep the
-        // chip on "restoring" and bump webappNeedsRefresh so OutputPanel
-        // refetches webapp-info, then wait for the webapp to actually serve
-        // before flipping the sandbox to its real (running) status.
+        // Hold the chip on "restoring" (and refresh the preview) until the
+        // webapp actually serves, then flip to the real status below.
         updateSessionData(sessionId, {
           status: sessionData.status === "active" ? "active" : "idle",
           sandbox: sessionData.sandbox
@@ -1595,12 +1589,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         });
 
         await waitForWebappReady(sessionId);
-
-        // Webapp is serving (or we timed out) — show the real sandbox status.
         updateSessionData(sessionId, { sandbox: sessionData.sandbox });
 
-        // Artifacts hit the sandbox and can fail transiently right after the
-        // pod comes up — that must NOT flip the sandbox to "failed". SWR retries.
+        // An artifact-fetch failure must NOT flip the sandbox to "failed".
         try {
           const restoredArtifacts = await fetchArtifacts(sessionId);
           updateSessionData(sessionId, { artifacts: restoredArtifacts });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1537,26 +1537,11 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         isLoaded: true,
       });
 
-      // Now restore the sandbox if needed (messages are already visible).
-      // The backend enforces a timeout and returns an error if restore
-      // takes too long, so no frontend timeout needed here.
       if (needsRestore) {
         try {
           sessionData = await restoreSession(sessionId);
-
-          // Sandbox is now running - fetch artifacts
-          const restoredArtifacts = await fetchArtifacts(sessionId);
-
-          updateSessionData(sessionId, {
-            status: sessionData.status === "active" ? "active" : "idle",
-            artifacts: restoredArtifacts,
-            sandbox: sessionData.sandbox,
-            // Bump so OutputPanel's SWR refetches webapp-info (which
-            // derives the actual webappUrl from the backend).
-            webappNeedsRefresh:
-              (get().sessions.get(sessionId)?.webappNeedsRefresh || 0) + 1,
-          });
         } catch (restoreErr) {
+          // Only a genuine restore failure marks the sandbox failed.
           console.error("Sandbox restore failed:", restoreErr);
           updateSessionData(sessionId, {
             status: "idle",
@@ -1564,6 +1549,28 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
               ? { ...sessionData.sandbox, status: "failed" }
               : null,
           });
+          return;
+        }
+
+        // Restore succeeded — reflect the real status; bump webappNeedsRefresh
+        // so OutputPanel's SWR refetches webapp-info.
+        updateSessionData(sessionId, {
+          status: sessionData.status === "active" ? "active" : "idle",
+          sandbox: sessionData.sandbox,
+          webappNeedsRefresh:
+            (get().sessions.get(sessionId)?.webappNeedsRefresh || 0) + 1,
+        });
+
+        // Artifacts hit the sandbox and can fail transiently right after the
+        // pod comes up — that must NOT flip the sandbox to "failed". SWR retries.
+        try {
+          const restoredArtifacts = await fetchArtifacts(sessionId);
+          updateSessionData(sessionId, { artifacts: restoredArtifacts });
+        } catch (artifactsErr) {
+          console.warn(
+            "Failed to fetch artifacts after restore:",
+            artifactsErr
+          );
         }
       }
     } catch (err) {

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -42,6 +42,7 @@ import {
   deleteSession as apiDeleteSession,
   fetchMessages,
   fetchArtifacts,
+  fetchWebappInfo,
   restoreSession,
 } from "@/app/craft/services/apiServices";
 
@@ -748,6 +749,34 @@ const createInitialSessionData = (
 // =============================================================================
 // Store
 // =============================================================================
+
+// Restore re-launches the Next.js dev server fire-and-forget, so the backend
+// reports the sandbox RUNNING before the webapp actually serves. Poll
+// webapp-info until it reports ready (or the session has no webapp), so the
+// caller can keep showing "Restoring…" until the preview is live. Bounded by
+// maxAttempts so a webapp that never comes up doesn't pin the chip forever.
+export async function waitForWebappReady(
+  sessionId: string,
+  { intervalMs = 1500, maxAttempts = 20 }: WaitForWebappReadyOptions = {}
+): Promise<void> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    let info: Awaited<ReturnType<typeof fetchWebappInfo>> | null = null;
+    try {
+      info = await fetchWebappInfo(sessionId);
+    } catch {
+      // Transient (sandbox not reachable yet) — keep polling.
+    }
+    // Done once we get a definitive answer: no webapp, or it's serving. A
+    // transient error (info null) falls through and we keep polling.
+    if (info && (!info.has_webapp || info.ready)) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+interface WaitForWebappReadyOptions {
+  intervalMs?: number;
+  maxAttempts?: number;
+}
 
 export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
   currentSessionId: null,
@@ -1552,14 +1581,23 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           return;
         }
 
-        // Restore succeeded — reflect the real status; bump webappNeedsRefresh
-        // so OutputPanel's SWR refetches webapp-info.
+        // Restore relaunched the webapp dev server fire-and-forget. Keep the
+        // chip on "restoring" and bump webappNeedsRefresh so OutputPanel
+        // refetches webapp-info, then wait for the webapp to actually serve
+        // before flipping the sandbox to its real (running) status.
         updateSessionData(sessionId, {
           status: sessionData.status === "active" ? "active" : "idle",
-          sandbox: sessionData.sandbox,
+          sandbox: sessionData.sandbox
+            ? { ...sessionData.sandbox, status: "restoring" }
+            : sessionData.sandbox,
           webappNeedsRefresh:
             (get().sessions.get(sessionId)?.webappNeedsRefresh || 0) + 1,
         });
+
+        await waitForWebappReady(sessionId);
+
+        // Webapp is serving (or we timed out) — show the real sandbox status.
+        updateSessionData(sessionId, { sandbox: sessionData.sandbox });
 
         // Artifacts hit the sandbox and can fail transiently right after the
         // pod comes up — that must NOT flip the sandbox to "failed". SWR retries.

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -211,32 +211,41 @@ export async function deleteSession(sessionId: string): Promise<void> {
   }
 }
 
-/**
- * Restore a sleeping sandbox and load the session's snapshot.
- * This is a blocking call that waits until the restore is complete.
- *
- * Handles two cases:
- * 1. Sandbox is SLEEPING: Re-provisions pod, then loads session snapshot
- * 2. Sandbox is RUNNING but session not loaded: Just loads session snapshot
- *
- * Returns immediately if session workspace already exists in pod.
- */
-export async function restoreSession(
-  sessionId: string
-): Promise<ApiDetailedSessionResponse> {
-  const res = await fetch(`${BUILD_API_BASE}/sessions/${sessionId}/restore`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-  });
+// ~2 min of retries — covers a concurrent provision + snapshot restore; the
+// backend's per-sandbox lock itself expires at 300s.
+const RESTORE_CONFLICT_RETRY_DELAY_MS = 2000;
+const RESTORE_CONFLICT_MAX_RETRIES = 60;
 
-  if (!res.ok) {
+export async function restoreSession(
+  sessionId: string,
+  // Overridable for tests; production callers use the module defaults.
+  opts: { retryDelayMs?: number; maxRetries?: number } = {}
+): Promise<ApiDetailedSessionResponse> {
+  const retryDelayMs = opts.retryDelayMs ?? RESTORE_CONFLICT_RETRY_DELAY_MS;
+  const maxRetries = opts.maxRetries ?? RESTORE_CONFLICT_MAX_RETRIES;
+
+  for (let attempt = 0; ; attempt++) {
+    const res = await fetch(`${BUILD_API_BASE}/sessions/${sessionId}/restore`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (res.ok) {
+      return res.json();
+    }
+
+    // 409 = another tab/request holds the restore lock; it's transient, so
+    // retry until that restore finishes rather than surfacing it as a failure.
+    if (res.status === 409 && attempt < maxRetries) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      continue;
+    }
+
     const errorData = await res.json().catch(() => ({}));
     throw new Error(
       errorData.detail || `Failed to restore session: ${res.status}`
     );
   }
-
-  return res.json();
 }
 
 /**

--- a/web/src/app/craft/services/restoreSession.test.ts
+++ b/web/src/app/craft/services/restoreSession.test.ts
@@ -1,0 +1,70 @@
+import { restoreSession } from "./apiServices";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("restoreSession", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("returns the session on a 200", async () => {
+    const session = { id: "s1" };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(jsonResponse(200, session));
+
+    await expect(restoreSession("s1", { retryDelayMs: 0 })).resolves.toEqual(
+      session
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on a transient 409 and resolves once the lock frees", async () => {
+    const session = { id: "s1" };
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse(409, { detail: "Restore already in progress" })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(409, { detail: "Restore already in progress" })
+      )
+      .mockResolvedValueOnce(jsonResponse(200, session));
+
+    await expect(restoreSession("s1", { retryDelayMs: 0 })).resolves.toEqual(
+      session
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after exhausting retries on persistent 409", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(
+        jsonResponse(409, { detail: "Restore already in progress" })
+      );
+
+    await expect(
+      restoreSession("s1", { retryDelayMs: 0, maxRetries: 2 })
+    ).rejects.toThrow("Restore already in progress");
+    // initial attempt + 2 retries
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on a non-409 error", async () => {
+    const fetchMock = jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(jsonResponse(500, { detail: "boom" }));
+
+    await expect(restoreSession("s1", { retryDelayMs: 0 })).rejects.toThrow(
+      "boom"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Fixes a cluster of issues that surfaced as "Failed to provision sandbox" (and a transient `restoring → failed → running` flicker) when restoring a Craft sandbox, plus a related status-accuracy fix. Root causes were confirmed from production logs and verified end-to-end against a live kind cluster.

- **Retry transient 409 on restore.** `restore_session` returns `409 "Restore already in progress"` when a concurrent restore (second tab / double render) holds the per-sandbox Redis lock. The frontend treated this as a hard failure; `restoreSession()` now retries the 409 with backoff (~2 min, under the 300s lock TTL) until the in-flight restore finishes. Non-409 errors still throw.
- **Don't fail the sandbox on a post-restore artifact error.** `loadSession` fetched artifacts in the same `try` as the restore, so an artifact failure (the listing hits opencode-serve, which can 500 right after the pod comes up) flipped the sandbox to `failed` even though restore succeeded. The real status is now set as soon as restore returns; artifacts are fetched separately and a failure only warns.
- **Recover a partial workspace after a failed restore.** If `provision()` succeeded (sandbox committed `RUNNING`) but the workspace load then failed, the sandbox was left `RUNNING` with a half-written `sessions/$id/` dir that `session_workspace_exists()` would later report as restored. The recovery branch now cleans up that dir so the next attempt redoes the load; the pre-existing `PROVISIONING → SLEEPING` rollback is unchanged.
- **Degrade gracefully when the sandbox is unreachable.** `list_artifacts` only caught `ValueError` from `list_directory`; transient pod-exec/opencode failures (`RuntimeError`, connection errors) 500'd the endpoint. It now returns an empty list (200) and logs a warning when the sandbox is transiently unreachable.
- **Hold status on "restoring" until the webapp serves.** Restore relaunches the Next.js dev server fire-and-forget, so the backend reports `RUNNING` before the preview is actually serving and the chip flipped to "Sandbox running" while it was still cold-compiling. After restore, the sandbox is held on `restoring` and `waitForWebappReady` polls `webapp-info` until it reports ready (or the session has no webapp), then flips to `running` — bounded by `maxAttempts` so a webapp that never comes up can't pin the chip forever.
- Trimmed verbose comments in the restore path.

## How Has This Been Tested?

- **Frontend unit (jest):** `restoreSession.test.ts` (200 passthrough, retry-then-succeed on 409, throw after exhausting 409 retries, no-retry on non-409) and `loadSessionRestore.test.ts` (artifact failure keeps sandbox `running`; restore failure marks it `failed`; `waitForWebappReady` returns on no-webapp/ready, polls until ready, gives up after `maxAttempts`, survives transient errors; `loadSession` waits for readiness then shows `running`). 12/12 pass.
- **Backend external-dependency unit (pytest, real Postgres + Redis):** `test_sandbox_lifecycle.py` — `TestRestoreFailureRecovery` (post-provision load failure cleans up the workspace, sandbox stays `RUNNING`) and `TestListArtifacts` (transient error degrades to `[]`; reachable sandbox still lists the web_app). Full file 10/10 pass.
- **Live kind cluster (end-to-end):**
  - Deleted a real sandbox pod → `GET /artifacts` returned `200 []` with the warning log (pre-fix: 500).
  - `POST /restore` against the dead pod re-provisioned a fresh pod and returned 200.
  - Two concurrent restores returned one `200` and one `409`, confirming the contention the retry now absorbs.
  - Slept a real sandbox (idle cleanup) and restored: the status chip held on "Restoring sandbox…" through the dev-server cold compile and only flipped to "Sandbox running" once the preview served.
- `ruff format`/`ruff check` and `oxfmt` clean on changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
