### PR TITLE
feat(craft): interrupt agent in chat turn

### DIFF
--- a/backend/onyx/server/features/build/api/messages_api.py
+++ b/backend/onyx/server/features/build/api/messages_api.py
@@ -15,6 +15,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.server.features.build.api.models import MessageInterruptResponse
 from onyx.server.features.build.api.models import MessageListResponse
 from onyx.server.features.build.api.models import MessageRequest
 from onyx.server.features.build.api.models import MessageResponse
@@ -209,3 +210,19 @@ def send_subagent_message(
             "X-Accel-Buffering": "no",  # Disable nginx buffering
         },
     )
+
+
+@router.post("/sessions/{session_id}/interrupt", tags=PUBLIC_API_TAGS)
+def interrupt_message(
+    session_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> MessageInterruptResponse:
+    """Interrupt the in-flight agent turn for a session.
+
+    Interrupts the opencode-serve turn inside the sandbox; the corresponding
+    /send-message stream then terminates through its normal completion path.
+    """
+    session_manager = SessionManager(db_session)
+    interrupted = session_manager.interrupt_message(session_id, user.id)
+    return MessageInterruptResponse(interrupted=interrupted)

--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -181,6 +181,14 @@ class MessageRequest(BaseModel):
     content: str
 
 
+class MessageInterruptResponse(BaseModel):
+    """Response to an interrupt request. ``interrupted`` is False when there was
+    no directly-interruptible turn (no running sandbox or no opencode session);
+    the interrupt fence is set regardless."""
+
+    interrupted: bool
+
+
 class MessageResponse(BaseModel):
     """Response containing message details.
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -333,6 +333,7 @@ class SandboxManager(_ServeMixin, ABC):
         agent_provider: str | None = None,
         agent_model: str | None = None,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
         """Stream typed sandbox events for one user message via
         opencode-serve.
@@ -353,6 +354,7 @@ class SandboxManager(_ServeMixin, ABC):
             agent_provider,
             agent_model,
             on_opencode_session_resolved=on_opencode_session_resolved,
+            should_interrupt=should_interrupt,
         )
 
     def send_subagent_message(

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -1046,6 +1046,7 @@ class OpencodeServeClient:
         model_provider: str | None = None,
         model_id: str | None = None,
         timeout: float = SANDBOX_TURN_TIMEOUT_SECONDS,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
         """Stream one turn of SandboxEvents via the shared per-pod bus.
 
@@ -1114,6 +1115,7 @@ class OpencodeServeClient:
                 directory=directory,
                 parent_resolver=self._event_bus.parent_of,
                 children_resolver=self._event_bus.list_children,
+                should_interrupt=should_interrupt,
             )
 
         except GeneratorExit:
@@ -1133,13 +1135,29 @@ class OpencodeServeClient:
         directory: str,
         parent_resolver: Callable[[str], str | None] | None = None,
         children_resolver: Callable[[str], list[str]] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
         """Drain the bus queue, translate, yield until a
-        :class:`PromptResponse` is emitted. permission.asked → auto-allow."""
+        :class:`PromptResponse` is emitted. permission.asked → auto-allow.
+
+        ``should_interrupt`` (polled ~1/s) lets the caller end the turn
+        deterministically: we abort opencode and emit our own terminating
+        ``PromptResponse`` rather than waiting on a ``session.idle`` that may
+        never arrive after an abort — otherwise an interrupted, event-less turn
+        would pin its slot until ``timeout``."""
         terminated_locally = False
         start = time.monotonic()
         last_event = start
+        last_interrupt_check = start
         while True:
+            now = time.monotonic()
+            if should_interrupt is not None and now - last_interrupt_check >= 1.0:
+                last_interrupt_check = now
+                if should_interrupt():
+                    self.abort(opencode_session_id, directory=directory)
+                    yield PromptResponse.model_validate({"stopReason": "cancelled"})
+                    return
+
             remaining = timeout - (time.monotonic() - start)
             if remaining <= 0:
                 self.abort(opencode_session_id, directory=directory)

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -47,6 +47,11 @@ _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 OPENCODE_SERVE_READY_TIMEOUT_SECONDS = 30
 OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.25
 
+# How long a new turn waits for the previous turn's slot before giving up.
+# Mostly absorbs the brief window where an interrupted turn is still unwinding
+# (abort → session.idle → terminator) as the next queued message fires.
+PROMPT_SLOT_ACQUIRE_TIMEOUT_SECONDS = 10.0
+
 
 @dataclass(frozen=True)
 class ServeConnectionInfo:
@@ -143,18 +148,21 @@ class _ServeMixin:
         sandbox_id: UUID,
         build_session_id: UUID,
     ) -> Generator[bool, None, None]:
-        """Non-blocking try-acquire of a per-build-session lock; yields True
-        if acquired, False if a turn is already in flight (caller must
-        abort without side effects).
+        """Bounded-blocking acquire of a per-build-session lock; yields True
+        if acquired within ``PROMPT_SLOT_ACQUIRE_TIMEOUT_SECONDS``, False if a
+        turn is still in flight past it (caller must abort without side
+        effects).
 
         opencode-serve's ``prompt_async`` is fire-and-forget and not
         concurrent-safe: a second POST while a turn is in flight is
         silently dropped, the second subscriber catches the *first* turn's
         terminator, and a phantom user_message gets persisted with no
-        assistant reply. Key on ``build_session_id`` (not
-        ``opencode_session_id``) so the lock survives id rotation from
-        ``on_opencode_session_resolved`` and bounds the dict to one entry
-        per build session.
+        assistant reply. The short wait (rather than an instant refusal) lets
+        a queued message that fires while an interrupted turn is still unwinding
+        serialize cleanly behind it instead of erroring. Key on
+        ``build_session_id`` (not ``opencode_session_id``) so the lock
+        survives id rotation from ``on_opencode_session_resolved`` and bounds
+        the dict to one entry per build session.
         """
         key = (sandbox_id, build_session_id)
         with self._prompt_locks_meta:
@@ -163,7 +171,7 @@ class _ServeMixin:
                 lock = threading.Lock()
                 self._prompt_locks[key] = lock
 
-        acquired = lock.acquire(blocking=False)
+        acquired = lock.acquire(timeout=PROMPT_SLOT_ACQUIRE_TIMEOUT_SECONDS)
         try:
             if not acquired:
                 logger.warning(
@@ -359,6 +367,7 @@ class _ServeMixin:
         agent_model: str | None,
         *,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
         """Stream sandbox events via the in-sandbox ``opencode serve``. Preflight
         ``opencode_session_id`` via :meth:`ensure_opencode_session` to avoid
@@ -409,6 +418,7 @@ class _ServeMixin:
                     directory=session_path,
                     model_provider=agent_provider,
                     model_id=agent_model,
+                    should_interrupt=should_interrupt,
                 ):
                     events_count += 1
                     if isinstance(event, PromptResponse):

--- a/backend/onyx/server/features/build/session/interrupt_signal.py
+++ b/backend/onyx/server/features/build/session/interrupt_signal.py
@@ -1,0 +1,37 @@
+"""Cross-replica interrupt fence for build (Craft) sessions.
+
+A direct opencode-serve abort only works once the session's opencode id has
+been minted, which on the first turn happens lazily *inside* the streaming
+request. An interrupt arriving during that window can't abort anything. This
+fence closes that race: the interrupt endpoint sets a flag the streaming flow
+checks at the point the opencode session becomes known and on every event
+thereafter, aborting itself when set. Backed by the tenant-aware cache so it
+works across api_server replicas (mirrors ``onyx.chat.stop_signal_checker``).
+"""
+
+from uuid import UUID
+
+from onyx.cache.interface import CacheBackend
+
+FENCE_PREFIX = "buildsessioninterrupt_fence"
+# Backstop: a turn never outlives this, so a fence can't leak past one.
+FENCE_TTL = 10 * 60
+
+
+def _fence_key(session_id: UUID) -> str:
+    # Tenant isolation is handled by the cache backend's key-prefixing.
+    return f"{FENCE_PREFIX}_{session_id}"
+
+
+def request_interrupt(session_id: UUID, cache: CacheBackend) -> None:
+    """Signal that the in-flight turn for this session should be interrupted."""
+    cache.set(_fence_key(session_id), 0, ex=FENCE_TTL)
+
+
+def is_interrupt_requested(session_id: UUID, cache: CacheBackend) -> bool:
+    return cache.exists(_fence_key(session_id))
+
+
+def clear_interrupt(session_id: UUID, cache: CacheBackend) -> None:
+    """Clear the fence — called at the start and end of each turn."""
+    cache.delete(_fence_key(session_id))

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -14,6 +14,7 @@ import threading
 import time
 import uuid
 import zipfile
+from collections.abc import Callable
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
@@ -25,6 +26,7 @@ import httpx
 from sqlalchemy.orm import Session as DBSession
 
 from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
@@ -93,6 +95,9 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.session.interrupt_signal import clear_interrupt
+from onyx.server.features.build.session.interrupt_signal import is_interrupt_requested
+from onyx.server.features.build.session.interrupt_signal import request_interrupt
 from onyx.server.features.build.session.md_to_docx import markdown_to_docx_bytes
 from onyx.server.features.build.session.prompts import BUILD_NAMING_SYSTEM_PROMPT
 from onyx.server.features.build.session.prompts import BUILD_NAMING_USER_PROMPT
@@ -1427,6 +1432,23 @@ class SessionManager:
             if prompt_slot_cm is not None:
                 prompt_slot_cm.__exit__(None, None, None)
 
+    def interrupt_message(self, session_id: UUID, user_id: UUID) -> bool:
+        """Interrupt the in-flight agent turn for a session.
+
+        Sets the interrupt fence and returns. The active stream's consume loop
+        polls the fence (~1/s) and self-terminates — aborting opencode and
+        emitting its own ``PromptResponse`` rather than waiting on a
+        ``session.idle`` that may never arrive after an abort. Setting a flag
+        (vs. a direct abort) is also what survives the first-turn race, where
+        the opencode session id isn't minted until inside the stream.
+        """
+        session = get_build_session(session_id, user_id, self._db_session)
+        if session is None:
+            raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
+
+        request_interrupt(session_id, get_cache_backend())
+        return True
+
     # ----- Persistence helpers (shared with the headless scheduled-tasks executor) -----
     #
     # `_yield_sandbox_events` is a thin wrapper around the sandbox manager that drives
@@ -1577,6 +1599,8 @@ class SessionManager:
         sandbox_id: UUID,
         session_id: UUID,
         user_message_content: str,
+        opencode_session_id: str | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[Any, None, None]:
         """Drain the CLI agent to completion, yielding raw sandbox events.
 
@@ -1590,7 +1614,10 @@ class SessionManager:
         callers should pass them through (interactive) or drop them
         (headless).
         """
-        opencode_session_id = self._ensure_opencode_session_id(sandbox_id, session_id)
+        if opencode_session_id is None:
+            opencode_session_id = self._ensure_opencode_session_id(
+                sandbox_id, session_id
+            )
         agent_provider, agent_model = self._get_session_agent_selection(session_id)
 
         def _persist_resolved_id(new_id: str) -> None:
@@ -1609,6 +1636,7 @@ class SessionManager:
             agent_provider=agent_provider,
             agent_model=agent_model,
             on_opencode_session_resolved=_persist_resolved_id,
+            should_interrupt=should_interrupt,
         )
 
     def _get_session_agent_selection(
@@ -1948,6 +1976,26 @@ class SessionManager:
             # which releases on every exit path.
             prompt_slot_cm = candidate_cm
 
+            # NB: we deliberately do NOT clear the fence here. The finally clears
+            # it before releasing the slot, so a prior turn's fence can never
+            # leak to this one. Clearing at turn start instead would wipe an
+            # interrupt that landed while we were blocked acquiring the slot —
+            # losing the very first-turn interrupt this feature must honor.
+            cache = get_cache_backend()
+
+            def interrupt_requested() -> bool:
+                # A cache blip must never fail a healthy turn — fail open.
+                try:
+                    return is_interrupt_requested(session_id, cache)
+                except CACHE_TRANSIENT_ERRORS:
+                    logger.warning(
+                        "[SANDBOX-SERVE] interrupt fence check failed for "
+                        "session %s; treating as not-interrupted",
+                        session_id,
+                        exc_info=True,
+                    )
+                    return False
+
             # Calculate turn_index BEFORE saving user message
             # turn_index = count of existing USER messages (this will be the Nth user message)
 
@@ -1998,12 +2046,41 @@ class SessionManager:
                 },
             )
 
+            # Resolve the opencode session id up front (a slow create on the
+            # first turn). Honoring the interrupt fence here means an interrupt
+            # that arrived during that creation window stops us before we ever
+            # drive the agent — closing the first-turn race a direct interrupt
+            # can't.
+            opencode_session_id = self._ensure_opencode_session_id(
+                sandbox_id, session_id
+            )
+            if interrupt_requested():
+                clear_interrupt(session_id, cache)
+                logger.info(
+                    "[SANDBOX-SERVE] turn interrupted before start: session=%s",
+                    session_id,
+                )
+                yield self._serialize_sandbox_event(
+                    PromptResponse.model_validate({"stopReason": "cancelled"}),
+                    "prompt_response",
+                )
+                return
+
             # Drive the agent. sandbox events are merged with proxy approval
             # announces onto one SSE stream. `_persist_sandbox_event` applies
             # persistence; SSE formatting + packet-logger book-keeping happen here.
+            # `should_interrupt` lets the consume loop self-terminate on the
+            # fence (abort + its own PromptResponse) within ~1s, even on an
+            # event-less turn — so an interrupt never depends on opencode
+            # emitting session.idle, which can leave the turn (and its slot)
+            # hung until the wall-clock timeout.
             merged_events = self._merge_events_with_announces(
                 self._yield_sandbox_events(
-                    sandbox_id, session_id, user_message_content
+                    sandbox_id,
+                    session_id,
+                    user_message_content,
+                    opencode_session_id=opencode_session_id,
+                    should_interrupt=interrupt_requested,
                 ),
                 session_id=session_id,
                 tenant_id=get_current_tenant_id(),
@@ -2202,6 +2279,20 @@ class SessionManager:
             # and exception flow — without this a long-running turn would
             # leak the lock and permanently block follow-up turns on the
             # same session.
+            # Clear the fence BEFORE releasing the slot: while we still hold it
+            # no next turn can start, so we can't clobber a fence legitimately
+            # set for that turn. Don't let a fence outlive its turn either.
+            # Guard the cache call — a raise here would skip the slot release
+            # below and leak the lock for the rest of the process's life.
+            try:
+                clear_interrupt(session_id, get_cache_backend())
+            except CACHE_TRANSIENT_ERRORS:
+                logger.warning(
+                    "[SANDBOX-SERVE] failed to clear interrupt fence for "
+                    "session %s; releasing slot anyway",
+                    session_id,
+                    exc_info=True,
+                )
             if prompt_slot_cm is not None:
                 prompt_slot_cm.__exit__(None, None, None)
 

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -377,6 +377,7 @@ class StubSandboxManager(SandboxManager):
         agent_provider: str | None = None,
         agent_model: str | None = None,
         on_opencode_session_resolved: Callable[[str], None] | None = None,
+        should_interrupt: Callable[[], bool] | None = None,
     ) -> Generator[SandboxEvent, None, None]:
         self.send_message_count += 1
         self.last_send_message_payload = {
@@ -387,6 +388,7 @@ class StubSandboxManager(SandboxManager):
             "agent_provider": agent_provider,
             "agent_model": agent_model,
             "on_opencode_session_resolved": on_opencode_session_resolved,
+            "should_interrupt": should_interrupt,
         }
         if self._send_message_events is None:
             raise _not_configured("send_message")

--- a/docs/craft/issues/opencode-serve-deploy-gotchas.md
+++ b/docs/craft/issues/opencode-serve-deploy-gotchas.md
@@ -40,8 +40,25 @@ the Role in your deployment system.
 ```yaml
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["create", "get", "list", "watch", "delete", "patch"]
+  verbs: ["create", "get", "update", "delete"]
 ```
+
+These are exactly the four verbs the api server exercises — and no more.
+Map each to the `_core_api.` call that needs it:
+
+| call (`kubernetes_sandbox_manager.py`) | HTTP method | RBAC verb |
+| -------------------------------------- | ----------- | --------- |
+| `create_namespaced_secret`             | POST        | `create`  |
+| `read_namespaced_secret`               | GET         | `get`     |
+| `replace_namespaced_secret`            | PUT         | `update`  |
+| `delete_namespaced_secret`             | DELETE      | `delete`  |
+
+Watch out: `replace_namespaced_secret` is a **PUT**, which maps to the
+`update` verb — **not** `patch`. If you grant `patch` instead of
+`update`, the happy path still works but the 409-race re-provision
+branch (see §1.3 — the path that calls `replace_namespaced_secret` after
+a create conflict) will intermittently 403. `list`/`watch` are not used
+on secrets at all.
 
 `backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py`
 is the source of truth for which k8s resources the api server touches —

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -8,6 +8,7 @@ import {
   useSessionId,
   useHasSession,
   useIsRunning,
+  useIsInterrupting,
   useOutputPanelOpen,
   useToggleOutputPanel,
   useBuildSessionStore,
@@ -103,7 +104,8 @@ export default function BuildChatPanel({
   const nameBuildSession = useBuildSessionStore(
     (state) => state.nameBuildSession
   );
-  const { streamMessage } = useBuildStreaming();
+  const { streamMessage, interruptStreaming } = useBuildStreaming();
+  const isInterrupting = useIsInterrupting();
   const queuedMessages = useQueuedMessages();
   const enqueueMessage = useBuildSessionStore((state) => state.enqueueMessage);
   const removeQueuedMessage = useBuildSessionStore(
@@ -353,6 +355,10 @@ export default function BuildChatPanel({
     ]
   );
 
+  const handleInterrupt = useCallback(() => {
+    if (sessionId) void interruptStreaming(sessionId);
+  }, [sessionId, interruptStreaming]);
+
   const handleQueueMessage = useCallback(
     (text: string) => {
       if (sessionId) enqueueMessage(sessionId, text);
@@ -545,6 +551,8 @@ export default function BuildChatPanel({
                 ref={inputBarRef}
                 onSubmit={handleSubmit}
                 isRunning={isRunning}
+                isInterrupting={isInterrupting}
+                onInterrupt={handleInterrupt}
                 disabled={isViewingSubagent}
                 placeholder={
                   isViewingSubagent

--- a/web/src/app/craft/components/InputBar.stories.tsx
+++ b/web/src/app/craft/components/InputBar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { SWRConfig } from "swr";
 import { Button, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgArrowUp, SvgStop } from "@opal/icons";
+import { SvgArrowUp, SvgStop, SvgLoader } from "@opal/icons";
 import IconButton from "@/refresh-components/buttons/IconButton";
 import InputBar from "@/app/craft/components/InputBar";
 import {
@@ -226,19 +226,18 @@ export const Interrupt: Story = {
 };
 
 /**
- * Candidate treatments for the Stop control (shown next to the send button on
- * the input-bar surface). The shipped default is "Neutral solid + red icon".
+ * The shipped Stop control next to the send button, across its states:
+ * outlined + transparent with a neutral glyph (no red), a subtle neutral fill
+ * when "armed" by the first Esc, and a spinner once an interrupt is requested.
  */
-function StopButtonCandidate({
+function StopButtonState({
   label,
-  className,
-  iconClassName,
-  variant = "main-secondary",
+  armed = false,
+  stopping = false,
 }: {
   label: string;
-  className?: string;
-  iconClassName?: string;
-  variant?: "main-secondary" | "danger-primary";
+  armed?: boolean;
+  stopping?: boolean;
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -247,13 +246,15 @@ function StopButtonCandidate({
       </Text>
       <div className="flex flex-row items-center gap-1 rounded-16 bg-background-neutral-00 shadow-01 p-1 w-fit">
         <IconButton
-          main={variant === "main-secondary"}
-          danger={variant === "danger-primary"}
-          secondary={variant === "main-secondary"}
-          primary={variant === "danger-primary"}
-          icon={SvgStop}
-          className={className}
-          iconClassName={iconClassName}
+          main
+          tertiary
+          icon={stopping ? SvgLoader : SvgStop}
+          iconClassName={stopping ? "animate-spin" : undefined}
+          className={cn(
+            "border-[1.5px] border-border-02",
+            armed && "bg-background-tint-02!"
+          )}
+          disabled={stopping}
           tooltip="Stop · esc esc"
           aria-label="Stop generating"
         />
@@ -266,24 +267,9 @@ function StopButtonCandidate({
 export const StopButtonStyles: Story = {
   render: () => (
     <div className="flex flex-wrap gap-6">
-      <StopButtonCandidate
-        label="Soft-red surface + red icon (default)"
-        className="bg-action-danger-01! hover:bg-action-danger-02!"
-        iconClassName="stroke-action-danger-05!"
-      />
-      <StopButtonCandidate
-        label="Neutral solid + red icon"
-        className="bg-background-neutral-03! hover:bg-background-neutral-04!"
-        iconClassName="stroke-action-danger-05!"
-      />
-      <StopButtonCandidate
-        label="Neutral solid + neutral icon"
-        className="bg-background-neutral-03! hover:bg-background-neutral-04!"
-      />
-      <StopButtonCandidate
-        label="Solid red (danger primary)"
-        variant="danger-primary"
-      />
+      <StopButtonState label="Resting" />
+      <StopButtonState label="Armed (first Esc)" armed />
+      <StopButtonState label="Stopping" stopping />
     </div>
   ),
 };

--- a/web/src/app/craft/components/InputBar.stories.tsx
+++ b/web/src/app/craft/components/InputBar.stories.tsx
@@ -1,7 +1,10 @@
 import { useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { SWRConfig } from "swr";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
+import { cn } from "@opal/utils";
+import { SvgArrowUp, SvgStop } from "@opal/icons";
+import IconButton from "@/refresh-components/buttons/IconButton";
 import InputBar from "@/app/craft/components/InputBar";
 import {
   UploadFilesProvider,
@@ -53,10 +56,32 @@ type Story = StoryObj<typeof InputBar>;
 /** Idle input — typing + Enter (or the send button) submits immediately. */
 export const Default: Story = {};
 
-/** While a response streams, the send button is disabled and nothing submits. */
+/**
+ * While a response streams (empty input): a red Stop control appears to the
+ * left of the fixed send button, and the `esc esc to stop` hint sits next to
+ * the paperclip. The send button is disabled until you type. Press Esc twice
+ * (the first lights the first keycap) to interrupt.
+ */
 export const Running: Story = {
   args: {
     isRunning: true,
+    onInterrupt: () => console.log("interrupt"),
+    queuedMessages: [],
+    onQueueMessage: (text: string) => console.log("queue", text),
+    onRemoveQueuedMessage: (index: number) => console.log("remove", index),
+  },
+};
+
+/**
+ * The bridge state after an interrupt is requested: the Stop control shows a
+ * spinner, the hint reads `Stopping…`, and the send button is disabled so a
+ * queued send can't race the turn terminator.
+ */
+export const Interrupting: Story = {
+  args: {
+    isRunning: true,
+    isInterrupting: true,
+    onInterrupt: () => console.log("interrupt"),
   },
 };
 
@@ -137,6 +162,7 @@ function QueuedMessagesDemo() {
           console.log("onSubmit", { message, files })
         }
         isRunning={isRunning}
+        onInterrupt={() => setIsRunning(false)}
         placeholder="Continue the conversation..."
         queuedMessages={queued}
         onQueueMessage={enqueue}
@@ -148,4 +174,116 @@ function QueuedMessagesDemo() {
 
 export const QueuedMessages: Story = {
   render: () => <QueuedMessagesDemo />,
+};
+
+/**
+ * Interactive interrupt flow. While "streaming", type to see the send button
+ * turn into a Queue affordance alongside the red Stop control. Click Stop (or
+ * press Esc twice — the first Esc lights the first keycap) to request an
+ * interrupt: the control shows a brief `Stopping…` spinner, then the turn ends.
+ * "Restart stream" begins a new turn.
+ */
+function InterruptDemo() {
+  const [isRunning, setIsRunning] = useState(true);
+  const [isInterrupting, setIsInterrupting] = useState(false);
+
+  function handleInterrupt() {
+    setIsInterrupting(true);
+    // Simulate the backend turn-terminator arriving.
+    setTimeout(() => {
+      setIsInterrupting(false);
+      setIsRunning(false);
+    }, 900);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Button
+        prominence="secondary"
+        disabled={isRunning}
+        onClick={() => setIsRunning(true)}
+      >
+        Restart stream
+      </Button>
+      <InputBar
+        onSubmit={(message, files) =>
+          console.log("onSubmit", { message, files })
+        }
+        isRunning={isRunning}
+        isInterrupting={isInterrupting}
+        onInterrupt={handleInterrupt}
+        placeholder="Continue the conversation..."
+        queuedMessages={[]}
+        onQueueMessage={(text) => console.log("queue", text)}
+        onRemoveQueuedMessage={(index) => console.log("remove", index)}
+      />
+    </div>
+  );
+}
+
+export const Interrupt: Story = {
+  render: () => <InterruptDemo />,
+};
+
+/**
+ * Candidate treatments for the Stop control (shown next to the send button on
+ * the input-bar surface). The shipped default is "Neutral solid + red icon".
+ */
+function StopButtonCandidate({
+  label,
+  className,
+  iconClassName,
+  variant = "main-secondary",
+}: {
+  label: string;
+  className?: string;
+  iconClassName?: string;
+  variant?: "main-secondary" | "danger-primary";
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Text font="secondary-body" color="text-03">
+        {label}
+      </Text>
+      <div className="flex flex-row items-center gap-1 rounded-16 bg-background-neutral-00 shadow-01 p-1 w-fit">
+        <IconButton
+          main={variant === "main-secondary"}
+          danger={variant === "danger-primary"}
+          secondary={variant === "main-secondary"}
+          primary={variant === "danger-primary"}
+          icon={SvgStop}
+          className={className}
+          iconClassName={iconClassName}
+          tooltip="Stop · esc esc"
+          aria-label="Stop generating"
+        />
+        <IconButton icon={SvgArrowUp} tooltip="Send" aria-label="Send" />
+      </div>
+    </div>
+  );
+}
+
+export const StopButtonStyles: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-6">
+      <StopButtonCandidate
+        label="Soft-red surface + red icon (default)"
+        className="bg-action-danger-01! hover:bg-action-danger-02!"
+        iconClassName="stroke-action-danger-05!"
+      />
+      <StopButtonCandidate
+        label="Neutral solid + red icon"
+        className="bg-background-neutral-03! hover:bg-background-neutral-04!"
+        iconClassName="stroke-action-danger-05!"
+      />
+      <StopButtonCandidate
+        label="Neutral solid + neutral icon"
+        className="bg-background-neutral-03! hover:bg-background-neutral-04!"
+      />
+      <StopButtonCandidate
+        label="Solid red (danger primary)"
+        variant="danger-primary"
+      />
+    </div>
+  ),
 };

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -32,10 +32,13 @@ import {
   SvgFileText,
   SvgImage,
   SvgLoader,
+  SvgStop,
   SvgX,
   SvgPaperclip,
   SvgAlertCircle,
 } from "@opal/icons";
+import InterruptHint from "@/app/craft/components/InterruptHint";
+import { useDoubleEscapeInterrupt } from "@/hooks/useDoubleEscapeInterrupt";
 import { useContentEditable } from "@/hooks/useContentEditable";
 import { useUser } from "@/providers/UserProvider";
 import useUserSkills from "@/hooks/useUserSkills";
@@ -66,6 +69,10 @@ export interface InputBarProps {
   queuedMessages?: readonly QueuedMessage[];
   onQueueMessage?: (text: string) => void;
   onRemoveQueuedMessage?: (index: number) => void;
+  /** Interrupt the in-flight turn; when wired, shows the Stop control + Esc hint. */
+  onInterrupt?: () => void;
+  /** Interrupt requested, awaiting the turn to terminate. */
+  isInterrupting?: boolean;
 }
 
 /**
@@ -165,6 +172,8 @@ const InputBar = memo(
         queuedMessages,
         onQueueMessage,
         onRemoveQueuedMessage,
+        onInterrupt,
+        isInterrupting = false,
       },
       ref
     ) => {
@@ -362,8 +371,16 @@ const InputBar = memo(
       );
 
       const handleSubmit = useCallback(() => {
-        // File uploads / sandbox init are hard blockers regardless of queueing.
-        if (disabled || hasUploadingFiles || sandboxInitializing) return;
+        // File uploads / sandbox init / a pending interrupt are hard blockers
+        // regardless of queueing — keep this in sync with `canSubmit` so the
+        // keyboard (Enter) path can't bypass what the button disables.
+        if (
+          disabled ||
+          hasUploadingFiles ||
+          sandboxInitializing ||
+          isInterrupting
+        )
+          return;
 
         const text = message.trim();
 
@@ -388,6 +405,7 @@ const InputBar = memo(
         message,
         disabled,
         isRunning,
+        isInterrupting,
         hasUploadingFiles,
         sandboxInitializing,
         onSubmit,
@@ -421,7 +439,20 @@ const InputBar = memo(
         !disabled &&
         !hasUploadingFiles &&
         !sandboxInitializing &&
+        !isInterrupting &&
         (!isRunning || (queueEnabled && queue.length < MAX_QUEUED_MESSAGES));
+
+      // The Stop control + double-Esc shortcut are live only while a turn is
+      // streaming and no popover is claiming Esc for itself.
+      const interruptible = !!onInterrupt && isRunning;
+      const handleInterrupt = useCallback(() => {
+        if (interruptible && !isInterrupting) onInterrupt?.();
+      }, [interruptible, isInterrupting, onInterrupt]);
+      const { armed } = useDoubleEscapeInterrupt({
+        enabled:
+          interruptible && !isInterrupting && !skillPicker.open && !tilePopover,
+        onInterrupt: handleInterrupt,
+      });
 
       return (
         <Disabled disabled={disabled}>
@@ -517,7 +548,7 @@ const InputBar = memo(
             {/* Bottom controls */}
             <div className="flex justify-between items-center w-full p-1 min-h-[40px]">
               {/* Bottom left controls */}
-              <div className="flex flex-row items-center gap-1">
+              <div className="flex flex-row items-center gap-2">
                 {/* (+) button for file upload */}
                 <Button
                   disabled={disabled}
@@ -526,19 +557,60 @@ const InputBar = memo(
                   prominence="tertiary"
                   onClick={() => fileInputRef.current?.click()}
                 />
+                {/* Streaming-only: teaches the double-Esc interrupt. */}
+                {interruptible && (
+                  <InterruptHint armed={armed} interrupting={isInterrupting} />
+                )}
               </div>
 
               {/* Bottom right controls */}
               <div className="flex flex-row items-center gap-1">
-                {/* Submit button */}
+                {/* Stop: inserts to the LEFT of the fixed send button while
+                    streaming, so the send target never shifts. The IconButton
+                    variant is structural only — the soft-red surface comes from
+                    the className tokens (no "danger secondary" hover-tint look). */}
+                <div
+                  className={cn(
+                    "overflow-hidden transition-[width,opacity] duration-150 ease-out motion-reduce:transition-none",
+                    interruptible
+                      ? "w-8 opacity-100"
+                      : "w-0 opacity-0 pointer-events-none"
+                  )}
+                >
+                  <IconButton
+                    main
+                    secondary
+                    icon={isInterrupting ? SvgLoader : SvgStop}
+                    iconClassName={cn(
+                      isInterrupting
+                        ? "animate-spin"
+                        : "stroke-action-danger-05!"
+                    )}
+                    className={cn(
+                      armed
+                        ? "bg-action-danger-03! hover:bg-action-danger-03!"
+                        : "bg-action-danger-01! hover:bg-action-danger-02!"
+                    )}
+                    disabled={!interruptible || isInterrupting}
+                    onClick={handleInterrupt}
+                    tooltip="Stop · esc esc"
+                    aria-label="Stop generating"
+                  />
+                </div>
+                {/* Submit button — fixed rightmost in every state. */}
                 {/* TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved */}
                 <IconButton
                   icon={sandboxInitializing ? SvgLoader : SvgArrowUp}
                   onClick={handleSubmit}
                   disabled={!canSubmit}
                   tooltip={
-                    sandboxInitializing ? "Initializing sandbox..." : "Send"
+                    sandboxInitializing
+                      ? "Initializing sandbox..."
+                      : isRunning
+                        ? "Queue message"
+                        : "Send"
                   }
+                  aria-label={isRunning ? "Queue message" : "Send"}
                   iconClassName={
                     sandboxInitializing ? "animate-spin" : undefined
                   }

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -566,30 +566,25 @@ const InputBar = memo(
               {/* Bottom right controls */}
               <div className="flex flex-row items-center gap-1">
                 {/* Stop: inserts to the LEFT of the fixed send button while
-                    streaming, so the send target never shifts. The IconButton
-                    variant is structural only — the soft-red surface comes from
-                    the className tokens (no "danger secondary" hover-tint look). */}
+                    streaming, so the send target never shifts. Outlined +
+                    transparent with a neutral glyph (no red); the first Esc
+                    "arms" it with a subtle neutral fill. */}
                 <div
                   className={cn(
                     "overflow-hidden transition-[width,opacity] duration-150 ease-out motion-reduce:transition-none",
                     interruptible
-                      ? "w-8 opacity-100"
+                      ? "w-9 opacity-100"
                       : "w-0 opacity-0 pointer-events-none"
                   )}
                 >
                   <IconButton
                     main
-                    secondary
+                    tertiary
                     icon={isInterrupting ? SvgLoader : SvgStop}
-                    iconClassName={cn(
-                      isInterrupting
-                        ? "animate-spin"
-                        : "stroke-action-danger-05!"
-                    )}
+                    iconClassName={isInterrupting ? "animate-spin" : undefined}
                     className={cn(
-                      armed
-                        ? "bg-action-danger-03! hover:bg-action-danger-03!"
-                        : "bg-action-danger-01! hover:bg-action-danger-02!"
+                      "border-[1.5px] border-border-02",
+                      armed && "bg-background-tint-02!"
                     )}
                     disabled={!interruptible || isInterrupting}
                     onClick={handleInterrupt}

--- a/web/src/app/craft/components/InterruptHint.stories.tsx
+++ b/web/src/app/craft/components/InterruptHint.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import InterruptHint from "@/app/craft/components/InterruptHint";
+
+const meta: Meta<typeof InterruptHint> = {
+  title: "Apps/Craft/Interrupt Hint",
+  component: InterruptHint,
+  tags: ["autodocs"],
+  args: {
+    armed: false,
+    interrupting: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof InterruptHint>;
+
+/** At rest while streaming — teaches the double-Esc interrupt. */
+export const Default: Story = {};
+
+/** After the first Esc — the first keycap lights; a second Esc interrupts. */
+export const Armed: Story = {
+  args: {
+    armed: true,
+  },
+};
+
+/** Interrupt requested, awaiting the turn to terminate. */
+export const Interrupting: Story = {
+  args: {
+    interrupting: true,
+  },
+};

--- a/web/src/app/craft/components/InterruptHint.tsx
+++ b/web/src/app/craft/components/InterruptHint.tsx
@@ -1,0 +1,37 @@
+import { Text } from "@opal/components";
+import Keycap from "@/refresh-components/Keycap";
+
+interface InterruptHintProps {
+  /** First Esc pressed — the next Esc within the window interrupts. */
+  armed: boolean;
+  /** Interrupt requested, awaiting the turn to terminate. */
+  interrupting: boolean;
+}
+
+/**
+ * The streaming-only hint that teaches the double-Esc interrupt. At rest it
+ * reads `esc esc to stop`; the first Esc lights the first keycap; once an
+ * interrupt is requested it becomes `Stopping…`.
+ */
+export default function InterruptHint({
+  armed,
+  interrupting,
+}: InterruptHintProps) {
+  if (interrupting) {
+    return (
+      <Text font="secondary-body" color="text-02">
+        Stopping…
+      </Text>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 select-none">
+      <Keycap filled={armed}>esc</Keycap>
+      <Keycap>esc</Keycap>
+      <Text font="secondary-body" color="text-02">
+        to stop
+      </Text>
+    </div>
+  );
+}

--- a/web/src/app/craft/components/InterruptHint.tsx
+++ b/web/src/app/craft/components/InterruptHint.tsx
@@ -10,7 +10,7 @@ interface InterruptHintProps {
 
 /**
  * The streaming-only hint that teaches the double-Esc interrupt. At rest it
- * reads `esc esc to stop`; the first Esc lights the first keycap; once an
+ * reads `esc ×2 to interrupt`; the first Esc lights the keycap; once an
  * interrupt is requested it becomes `Stopping…`.
  */
 export default function InterruptHint({
@@ -28,9 +28,8 @@ export default function InterruptHint({
   return (
     <div className="flex items-center gap-1 select-none">
       <Keycap filled={armed}>esc</Keycap>
-      <Keycap>esc</Keycap>
       <Text font="secondary-body" color="text-02">
-        to stop
+        ×2 to interrupt
       </Text>
     </div>
   );

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -471,6 +471,12 @@ export interface BuildSessionData {
    * current run finishes (see the auto-send effect in BuildChatPanel).
    */
   queuedMessages: QueuedMessage[];
+  /**
+   * True between an interrupt request and the turn actually terminating. Drives
+   * the "stopping…" affordance; cleared by each terminal stream handler (and on
+   * a fresh turn / aborted fetch).
+   */
+  isInterrupting: boolean;
   error: string | null;
   webappUrl: string | null;
   /** Sandbox info from backend */
@@ -715,6 +721,7 @@ const createInitialSessionData = (
   toolCalls: [],
   streamItems: [],
   queuedMessages: [],
+  isInterrupting: false,
   error: null,
   webappUrl: null,
   sandbox: null,
@@ -2499,6 +2506,13 @@ export const useIsRunning = () =>
     if (!currentSessionId) return false;
     const session = sessions.get(currentSessionId);
     return session?.status === "running" || session?.status === "creating";
+  });
+
+export const useIsInterrupting = () =>
+  useBuildSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    if (!currentSessionId) return false;
+    return sessions.get(currentSessionId)?.isInterrupting ?? false;
   });
 
 export const useMessages = () =>

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -11,6 +11,7 @@ import {
 
 import {
   sendMessageStream,
+  interruptMessageStream,
   processSSEStream,
   fetchSession,
   RateLimitError,
@@ -143,7 +144,10 @@ export function useBuildStreaming() {
       setAbortController(sessionId, controller);
 
       // Set status to running and clear previous stream items
-      updateSessionData(sessionId, { status: "running" });
+      updateSessionData(sessionId, {
+        status: "running",
+        isInterrupting: false,
+      });
       clearStreamItems(sessionId);
 
       // Track accumulated content for streaming text/thinking
@@ -443,6 +447,7 @@ export function useBuildStreaming() {
               updateSessionData(sessionId, {
                 status: "active",
                 streamItems: [],
+                isInterrupting: false,
               });
               break;
             }
@@ -458,6 +463,7 @@ export function useBuildStreaming() {
               updateSessionData(sessionId, {
                 status: "failed",
                 error: parsed.message,
+                isInterrupting: false,
               });
               break;
             }
@@ -468,18 +474,22 @@ export function useBuildStreaming() {
         });
       } catch (err) {
         if ((err as Error).name === "AbortError") {
-          // User cancelled - no error handling needed
+          // Fetch aborted (session switch, unmount, or a superseding turn).
+          // Clear the flag so it can't wedge the controls "Stopping…".
+          updateSessionData(sessionId, { isInterrupting: false });
         } else if (err instanceof RateLimitError) {
           console.warn("[Streaming] Rate limit exceeded");
           updateSessionData(sessionId, {
             status: "active",
             error: SessionErrorCode.RATE_LIMIT_EXCEEDED,
+            isInterrupting: false,
           });
         } else {
           console.error("[Streaming] Stream error:", err);
           updateSessionData(sessionId, {
             status: "failed",
             error: (err as Error).message,
+            isInterrupting: false,
           });
         }
       } finally {
@@ -505,11 +515,39 @@ export function useBuildStreaming() {
     ]
   );
 
+  /**
+   * Interrupt the in-flight turn for a session. Asks the backend to interrupt
+   * the sandbox turn; the open SSE stream then terminates through its normal
+   * `prompt_response` path, which commits the partial output, flips the status
+   * to "active", and lets the queued-message auto-send drain naturally. We keep
+   * the stream open (rather than aborting the fetch) so that terminator can
+   * arrive — `isInterrupting` bridges the gap for immediate UI feedback.
+   */
+  const interruptStreaming = useCallback(
+    async (sessionId: string): Promise<void> => {
+      const session = useBuildSessionStore.getState().sessions.get(sessionId);
+      if (!session || session.status !== "running" || session.isInterrupting) {
+        return;
+      }
+
+      updateSessionData(sessionId, { isInterrupting: true });
+      try {
+        await interruptMessageStream(sessionId);
+      } catch (err) {
+        // Re-arm so the user can retry; the turn is still streaming.
+        console.error("[Streaming] Failed to interrupt:", err);
+        updateSessionData(sessionId, { isInterrupting: false });
+      }
+    },
+    [updateSessionData]
+  );
+
   return useMemo(
     () => ({
       streamMessage,
+      interruptStreaming,
       abortStream: abortCurrentSession,
     }),
-    [streamMessage, abortCurrentSession]
+    [streamMessage, interruptStreaming, abortCurrentSession]
   );
 }

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -346,6 +346,20 @@ export async function sendMessageStream(
   return res;
 }
 
+/**
+ * Interrupt the in-flight agent turn for a session. The backend interrupts the
+ * sandbox turn; the open /send-message stream then terminates normally.
+ */
+export async function interruptMessageStream(sessionId: string): Promise<void> {
+  const res = await fetch(`${BUILD_API_BASE}/sessions/${sessionId}/interrupt`, {
+    method: "POST",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to interrupt message: ${res.status}`);
+  }
+}
+
 // =============================================================================
 // Artifacts API
 // =============================================================================

--- a/web/src/hooks/useDoubleEscapeInterrupt.ts
+++ b/web/src/hooks/useDoubleEscapeInterrupt.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseDoubleEscapeInterruptArgs {
+  /** Only listen + arm while true (e.g. a response is streaming). */
+  enabled: boolean;
+  /** Fired on the second Esc within the window. */
+  onInterrupt: () => void;
+  /** Milliseconds the first Esc stays "armed" before disarming. */
+  windowMs?: number;
+}
+
+/**
+ * Double-Esc interrupt: the first Esc "arms" (returns `armed: true`) for a
+ * short window; a second Esc within it fires `onInterrupt`. If the window
+ * lapses, it disarms — no penalty. A single window-level listener handles
+ * Esc whether or not the input has focus; gate it via `enabled` so popovers
+ * (which consume Esc to close themselves) take precedence.
+ */
+export function useDoubleEscapeInterrupt({
+  enabled,
+  onInterrupt,
+  windowMs = 1500,
+}: UseDoubleEscapeInterruptArgs): { armed: boolean } {
+  const [armed, setArmed] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Held in a ref so the listener doesn't tear down on onInterrupt identity churn.
+  const onInterruptRef = useRef(onInterrupt);
+  onInterruptRef.current = onInterrupt;
+
+  const disarm = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setArmed(false);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      disarm();
+      return;
+    }
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      // Ignore auto-repeat: holding Esc must not count as the second press.
+      if (event.repeat) return;
+      // A popover already handled Esc (e.g. closed a menu) — leave it alone.
+      if (event.defaultPrevented || event.isComposing) return;
+
+      event.preventDefault();
+      if (timerRef.current !== null) {
+        disarm();
+        onInterruptRef.current();
+      } else {
+        setArmed(true);
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          setArmed(false);
+        }, windowMs);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      disarm();
+    };
+  }, [enabled, windowMs, disarm]);
+
+  return { armed };
+}

--- a/web/src/refresh-components/Keycap.stories.tsx
+++ b/web/src/refresh-components/Keycap.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Keycap from "@/refresh-components/Keycap";
+
+const meta: Meta<typeof Keycap> = {
+  title: "refresh-components/Keycap",
+  component: Keycap,
+  tags: ["autodocs"],
+  args: {
+    children: "esc",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Keycap>;
+
+/** Resting keycap used in inline keyboard hints. */
+export const Default: Story = {};
+
+/** "Armed" state — a hot danger fill (e.g. the first Esc of the double-Esc interrupt). */
+export const Filled: Story = {
+  args: {
+    filled: true,
+  },
+};
+
+export const Glyphs: Story = {
+  render: () => (
+    <div className="flex items-center gap-1">
+      <Keycap>↵</Keycap>
+      <Keycap>⌫</Keycap>
+      <Keycap>esc</Keycap>
+    </div>
+  ),
+};

--- a/web/src/refresh-components/Keycap.tsx
+++ b/web/src/refresh-components/Keycap.tsx
@@ -3,13 +3,14 @@ import { cn } from "@opal/utils";
 
 interface KeycapProps {
   children: string;
-  /** "Armed" state — renders as a hot danger-filled cap. */
+  /** "Armed" state — renders as a stronger neutral-filled cap. */
   filled?: boolean;
 }
 
 /**
  * A small boxed keyboard-key glyph (e.g. `esc`, `↵`, `⌫`) for inline shortcut
- * hints. The `filled` state renders a hot danger cap (e.g. an armed shortcut).
+ * hints. The `filled` state renders a stronger neutral cap (e.g. an armed
+ * shortcut).
  */
 export default function Keycap({ children, filled = false }: KeycapProps) {
   return (
@@ -17,14 +18,11 @@ export default function Keycap({ children, filled = false }: KeycapProps) {
       className={cn(
         "inline-flex items-center rounded-08 border px-1 leading-none transition-colors duration-150",
         filled
-          ? "border-action-danger-05 bg-action-danger-05"
+          ? "border-border-03 bg-background-tint-03"
           : "border-border-02 bg-background-tint-02"
       )}
     >
-      <Text
-        font="secondary-body"
-        color={filled ? "text-inverted-05" : "text-02"}
-      >
+      <Text font="secondary-body" color={filled ? "text-04" : "text-02"}>
         {children}
       </Text>
     </span>

--- a/web/src/refresh-components/Keycap.tsx
+++ b/web/src/refresh-components/Keycap.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@opal/components";
+import { cn } from "@opal/utils";
+
+interface KeycapProps {
+  children: string;
+  /** "Armed" state — renders as a hot danger-filled cap. */
+  filled?: boolean;
+}
+
+/**
+ * A small boxed keyboard-key glyph (e.g. `esc`, `↵`, `⌫`) for inline shortcut
+ * hints. The `filled` state renders a hot danger cap (e.g. an armed shortcut).
+ */
+export default function Keycap({ children, filled = false }: KeycapProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-08 border px-1 leading-none transition-colors duration-150",
+        filled
+          ? "border-action-danger-05 bg-action-danger-05"
+          : "border-border-02 bg-background-tint-02"
+      )}
+    >
+      <Text
+        font="secondary-body"
+        color={filled ? "text-inverted-05" : "text-02"}
+      >
+        {children}
+      </Text>
+    </span>
+  );
+}


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/ccdc0eb4-9647-4d5b-b837-77db6f8857d3


Lets you stop an in-flight Craft agent turn — via a **Stop** button next to Send or a **double-Esc** shortcut. The partial response is kept and any queued messages keep flowing.

Stop is wired all the way to the sandbox: `POST /build/sessions/{id}/interrupt` sets a cross-replica **interrupt fence**; the live `/send-message` stream polls it (before start + ~1×/s), aborts `opencode-serve`, and emits its own terminating `PromptResponse`. Self-terminating instead of waiting for opencode's `session.idle` means it works on the first-turn race and never leaves the turn (or its prompt-slot) hung.

## How Has This Been Tested?

- Manually in local Craft: stop mid-stream, stop during first-turn sandbox spin-up, rapid interrupt + queue-drain, and the double-Esc shortcut.
- Storybook stories for the Stop / queue states (`Running`, `Interrupting`, `Interrupt`, `StopButtonStyles`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Stop control and double‑Esc shortcut to interrupt an in‑flight Craft agent turn. Interrupts propagate via a tenant‑scoped fence; the running `/send-message` stream polls it (pre‑start and ~1/s), aborts `opencode-serve`, cleanly self‑terminates, preserves partial output, and queued messages keep flowing.

- New Features
  - Backend: `POST /build/sessions/{id}/interrupt` returns `MessageInterruptResponse` (sets a cross‑replica interrupt fence; `interrupted` is false when nothing is directly abortable). The stream resolves the opencode id up front, polls the fence, aborts `opencode-serve`, and emits a terminating `PromptResponse`; the fence is cleared when consumed and at turn end, guarded so slot release never blocks.
  - Frontend: Stop button next to Send and a double‑Esc shortcut via `useDoubleEscapeInterrupt`. A “Stopping…” bridge state (`isInterrupting`) gives instant feedback while SSE closes; `interruptStreaming` calls the new API and keeps the stream open so partial output persists. New `InterruptHint` and `Keycap` components with Storybook demos.

- Bug Fixes
  - Serialize turns and avoid dropped/phantom messages with a per‑session prompt lock that waits up to 10s behind an interrupted turn.
  - Honor first‑turn interrupts by resolving the opencode session id before driving the agent and checking the fence; fail open on transient cache errors. Clear the fence before releasing the slot so it never leaks or wedges the next turn.
  - Ensure `isInterrupting` resets on all terminal, error, and aborted‑fetch paths.

<sup>Written for commit e010ab84809fcf36ac61f3e2efdde1b5971ac0a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


