### PR TITLE
feat(craft): External app per action default policy

### DIFF
--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -7,6 +7,8 @@ from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import InstanceOf
 
+from onyx.db.enums import EndpointPolicy
+
 
 class ExternalAppAction(str, Enum):
     """Marker base for every built-in provider's action-id enum.
@@ -85,3 +87,6 @@ class EndpointSpec(BaseModel):
     normalised_name: str
     description: str
     matches: tuple[MatchRule, ...]
+    # The policy a freshly-created built-in app starts this action at, unless the
+    # admin overrides it.
+    default_policy: EndpointPolicy = EndpointPolicy.ASK

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -1,3 +1,4 @@
+from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.actions import ExternalAppAction
@@ -31,18 +32,21 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="GET", path=_MESSAGES),
             RestRoute(method="GET", path=_MESSAGE_ITEM),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GmailAction.LABELS_READ,
         normalised_name="List labels",
         description="List the labels in the mailbox.",
         matches=(RestRoute(method="GET", path=f"{_USER}/labels"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GmailAction.PROFILE_READ,
         normalised_name="Read profile",
         description="Read the connected account's Gmail profile.",
         matches=(RestRoute(method="GET", path=f"{_USER}/profile"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GmailAction.MESSAGES_SEND,

--- a/backend/onyx/external_apps/providers/google_calendar.py
+++ b/backend/onyx/external_apps/providers/google_calendar.py
@@ -1,3 +1,4 @@
+from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.actions import ExternalAppAction
@@ -29,6 +30,7 @@ _ENDPOINTS: list[EndpointSpec] = [
         matches=(
             RestRoute(method="GET", path="/calendar/v3/users/{userId}/calendarList"),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GoogleCalendarAction.EVENTS_READ,
@@ -38,12 +40,14 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="GET", path=_EVENTS_COLLECTION),
             RestRoute(method="GET", path=_EVENT_ITEM),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GoogleCalendarAction.FREEBUSY_READ,
         normalised_name="Query free/busy",
         description="Query busy intervals across calendars.",
         matches=(RestRoute(method="POST", path="/calendar/v3/freeBusy"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=GoogleCalendarAction.EVENTS_CREATE,

--- a/backend/onyx/external_apps/providers/linear.py
+++ b/backend/onyx/external_apps/providers/linear.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -32,12 +33,14 @@ _ENDPOINTS: list[EndpointSpec] = [
         normalised_name="Read the connected user",
         description="Read the authenticated user's profile (viewer).",
         matches=(GraphQLOp(operation_type="query", field="viewer"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=LinearAction.TEAMS_READ,
         normalised_name="Read teams",
         description="List the workspace's teams.",
         matches=(GraphQLOp(operation_type="query", field="teams"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=LinearAction.ISSUES_READ,
@@ -48,12 +51,14 @@ _ENDPOINTS: list[EndpointSpec] = [
             GraphQLOp(operation_type="query", field="issue"),
             GraphQLOp(operation_type="query", field="issueSearch"),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=LinearAction.PROJECTS_READ,
         normalised_name="Read projects",
         description="List projects.",
         matches=(GraphQLOp(operation_type="query", field="projects"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=LinearAction.ISSUES_CREATE,

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -80,6 +80,7 @@ def _descriptor_for(
                 action_id=e.id,
                 normalised_name=e.normalised_name,
                 description=e.description,
+                default_policy=e.default_policy,
             )
             for e in spec.endpoint_catalog
         ],
@@ -118,15 +119,15 @@ def build_action_policies(
     catalog action, so the stored rows are the full source of truth.
 
     Each action resolves to the admin's validated override if supplied, else the
-    value already stored, else the ``ASK`` default. Unmentioned actions keep
-    their stored choice — a partial update (or an enable toggle that omits the
-    map) never clobbers existing policies. Raises if ``requested`` names an
-    action id outside the catalog.
+    value already stored, else the action's ``default_policy`` (``ASK`` unless the
+    provider declared otherwise). Unmentioned actions keep their stored choice — a
+    partial update (or an enable toggle that omits the map) never clobbers existing
+    policies. Raises if ``requested`` names an action id outside the catalog.
     """
     validated = validate_action_policies(app_type, requested or {})
     return {
         endpoint.id: validated.get(
-            endpoint.id, existing.get(endpoint.id, EndpointPolicy.ASK)
+            endpoint.id, existing.get(endpoint.id, endpoint.default_policy)
         )
         for endpoint in get_endpoint_catalog(app_type)
     }
@@ -137,14 +138,15 @@ def action_policy_views(
     stored: dict[str, EndpointPolicy],
 ) -> list[ActionPolicyView]:
     """Merge the catalog with the admin's stored overrides: each action's
-    effective ``state`` is the override if present, else ``ASK``.
-    Orphan stored ids (no longer in the catalog) are silently dropped."""
+    effective ``state`` is the override if present, else the action's
+    ``default_policy``. Orphan stored ids (no longer in the catalog) are
+    silently dropped."""
     return [
         ActionPolicyView(
             action_id=endpoint.id,
             normalised_name=endpoint.normalised_name,
             description=endpoint.description,
-            state=stored.get(endpoint.id, EndpointPolicy.ASK),
+            state=stored.get(endpoint.id, endpoint.default_policy),
         )
         for endpoint in get_endpoint_catalog(app_type)
     ]

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -31,6 +32,7 @@ _ENDPOINTS: list[EndpointSpec] = [
         normalised_name="List channels",
         description="List the workspace's channels and conversations.",
         matches=(RestRoute(method="POST", path="/api/conversations.list"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=SlackAction.MESSAGES_READ,
@@ -40,6 +42,7 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="POST", path="/api/conversations.history"),
             RestRoute(method="POST", path="/api/conversations.replies"),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=SlackAction.USERS_READ,
@@ -49,12 +52,14 @@ _ENDPOINTS: list[EndpointSpec] = [
             RestRoute(method="POST", path="/api/users.list"),
             RestRoute(method="POST", path="/api/users.info"),
         ),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=SlackAction.SEARCH_READ,
         normalised_name="Search messages",
         description="Full-text search across messages the user can see.",
         matches=(RestRoute(method="POST", path="/api/search.messages"),),
+        default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=SlackAction.MESSAGES_WRITE,

--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -329,7 +329,7 @@ class UpsertExternalAppRequest(BaseModel):
 
 class ActionPolicyView(BaseModel):
     """One action of a built-in app, with its effective policy — the admin's
-    stored override if set, otherwise ``ASK``."""
+    stored override if set, otherwise the action's ``default_policy``."""
 
     action_id: str
     normalised_name: str
@@ -414,6 +414,9 @@ class EndpointDescriptor(BaseModel):
     action_id: str
     normalised_name: str
     description: str
+    # The policy a new app's instance of this action defaults to; the create
+    # form seeds each action's selector with it (the admin can still override).
+    default_policy: EndpointPolicy
 
 
 class BuiltInExternalAppDescriptor(BaseModel):

--- a/backend/tests/integration/tests/external_apps/test_external_app_action_policies.py
+++ b/backend/tests/integration/tests/external_apps/test_external_app_action_policies.py
@@ -5,7 +5,8 @@ external apps, exercised end-to-end through the ``/admin/apps`` API via
 Contract under test (observed through the admin response's ``actions`` view):
 
 - a created built-in app returns its full action catalog — supplied policies
-  honoured, everything else ``ASK``;
+  honoured, everything else falling back to each action's declared
+  ``default_policy`` (Slack reads default to ``ALWAYS``, the write to ``ASK``);
 - a supplied map merges over the stored set: named actions update, unmentioned
   ones keep their value, and the full action set is unchanged;
 - an omitted map (``None`` — e.g. an enable toggle / rename) preserves choices;
@@ -82,16 +83,17 @@ def test_create_returns_full_catalog_with_overrides(
     )
 
     states = _states(created)
-    # Overrides honoured; unset catalog actions come back as ASK.
+    # Overrides honoured; unset catalog actions fall back to their declared
+    # default (Slack reads default to ALWAYS).
     assert states[SlackAction.MESSAGES_READ.value] == EndpointPolicy.ALWAYS
     assert states[SlackAction.MESSAGES_WRITE.value] == EndpointPolicy.DENY
-    assert states[SlackAction.CHANNELS_READ.value] == EndpointPolicy.ASK
-    assert states[SlackAction.USERS_READ.value] == EndpointPolicy.ASK
+    assert states[SlackAction.CHANNELS_READ.value] == EndpointPolicy.ALWAYS
+    assert states[SlackAction.USERS_READ.value] == EndpointPolicy.ALWAYS
     # The same set persists across a fresh read.
     assert _fetch_states(admin_user, created.id) == states
 
 
-def test_create_without_policies_yields_all_ask(
+def test_create_without_policies_yields_action_defaults(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
 ) -> None:
@@ -99,7 +101,13 @@ def test_create_without_policies_yields_all_ask(
 
     states = _states(created)
     assert states  # the catalog is non-empty
-    assert all(state == EndpointPolicy.ASK for state in states.values())
+    # No supplied policies → each action falls back to its declared default:
+    # reads auto-approve (ALWAYS), the write requires approval (ASK).
+    assert states[SlackAction.CHANNELS_READ.value] == EndpointPolicy.ALWAYS
+    assert states[SlackAction.MESSAGES_READ.value] == EndpointPolicy.ALWAYS
+    assert states[SlackAction.USERS_READ.value] == EndpointPolicy.ALWAYS
+    assert states[SlackAction.SEARCH_READ.value] == EndpointPolicy.ALWAYS
+    assert states[SlackAction.MESSAGES_WRITE.value] == EndpointPolicy.ASK
     assert _fetch_states(admin_user, created.id) == states
 
 

--- a/backend/tests/unit/external_apps/test_action_policy_defaults.py
+++ b/backend/tests/unit/external_apps/test_action_policy_defaults.py
@@ -1,0 +1,97 @@
+"""Per-action ``default_policy`` on ``EndpointSpec`` and how the registry seeds it.
+
+A provider can declare the out-of-the-box policy for each catalog action; the
+create flow (and the policy views) seed from it, defaulting to ``ASK``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers import registry
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.actions import ExternalAppAction
+from onyx.external_apps.providers.actions import RestRoute
+
+
+class _TestAction(ExternalAppAction):
+    READ = "test.read"
+    WRITE = "test.write"
+
+
+def _spec(
+    action: _TestAction, default_policy: EndpointPolicy | None = None
+) -> EndpointSpec:
+    kwargs = {} if default_policy is None else {"default_policy": default_policy}
+    return EndpointSpec(
+        id=action,
+        normalised_name=action.value,
+        description="d",
+        matches=(RestRoute(method="GET", path="/x"),),
+        **kwargs,
+    )
+
+
+def test_endpoint_spec_defaults_to_ask() -> None:
+    assert _spec(_TestAction.READ).default_policy == EndpointPolicy.ASK
+
+
+def test_endpoint_spec_accepts_override() -> None:
+    spec = _spec(_TestAction.WRITE, EndpointPolicy.ALWAYS)
+    assert spec.default_policy == EndpointPolicy.ALWAYS
+
+
+def test_build_action_policies_seeds_from_each_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No requested/stored values → each action falls back to its own
+    ``default_policy``, not a blanket ASK."""
+    catalog = [
+        _spec(_TestAction.READ, EndpointPolicy.ALWAYS),
+        _spec(_TestAction.WRITE),  # omitted → ASK
+    ]
+    monkeypatch.setattr(registry, "get_endpoint_catalog", lambda _app_type: catalog)
+
+    built = registry.build_action_policies(
+        ExternalAppType.SLACK, requested=None, existing={}
+    )
+    assert built[_TestAction.READ] == EndpointPolicy.ALWAYS
+    assert built[_TestAction.WRITE] == EndpointPolicy.ASK
+
+
+def test_build_action_policies_override_and_existing_win_over_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = [
+        _spec(_TestAction.READ, EndpointPolicy.ALWAYS),
+        _spec(_TestAction.WRITE, EndpointPolicy.ALWAYS),
+    ]
+    monkeypatch.setattr(registry, "get_endpoint_catalog", lambda _app_type: catalog)
+
+    built = registry.build_action_policies(
+        ExternalAppType.SLACK,
+        requested={"test.read": EndpointPolicy.DENY},
+        existing={"test.write": EndpointPolicy.ASK},
+    )
+    # admin override wins; else stored value wins; default only fills the gaps.
+    assert built[_TestAction.READ] == EndpointPolicy.DENY
+    assert built[_TestAction.WRITE] == EndpointPolicy.ASK
+
+
+def test_action_policy_views_seed_from_each_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    catalog = [
+        _spec(_TestAction.READ, EndpointPolicy.ALWAYS),
+        _spec(_TestAction.WRITE),  # omitted → ASK
+    ]
+    monkeypatch.setattr(registry, "get_endpoint_catalog", lambda _app_type: catalog)
+
+    states = {
+        v.action_id: v.state
+        for v in registry.action_policy_views(ExternalAppType.SLACK, stored={})
+    }
+    assert states[_TestAction.READ] == EndpointPolicy.ALWAYS
+    assert states[_TestAction.WRITE] == EndpointPolicy.ASK

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -264,7 +264,10 @@ export default function ConfigureProviderModal({
                             </Text>
                           </div>
                           <PolicyToggle
-                            value={policies[action.action_id] ?? "ASK"}
+                            value={
+                              policies[action.action_id] ??
+                              action.default_policy
+                            }
                             onChange={(value) =>
                               setPolicies((prev) => ({
                                 ...prev,

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -53,7 +53,9 @@ function bulkPolicyOf(
   actions: EndpointDescriptor[],
   policies: Record<string, EndpointPolicy>
 ): BulkPolicy {
-  const values = actions.map((action) => policies[action.action_id] ?? "ASK");
+  const values = actions.map(
+    (action) => policies[action.action_id] ?? action.default_policy
+  );
   if (values.length === 0) return "ASK";
   if (values.every((value) => value === "ALWAYS")) return "ALWAYS";
   if (values.every((value) => value === "ASK")) return "ASK";
@@ -97,15 +99,17 @@ export default function ConfigureProviderModal({
     }
     setCredentialValues(initial);
 
-    // Seed each action from the admin's stored choice (edit) or "Ask" by
-    // default (create) — every action starts in ask-approval mode.
+    // Seed each action from the admin's stored choice (edit) or the action's
+    // backend-declared default (create) — usually "Ask", but a provider can
+    // declare a different out-of-the-box stance per action.
     const storedState: Record<string, EndpointPolicy> = {};
     for (const action of existingApp?.actions ?? []) {
       storedState[action.action_id] = action.state;
     }
     const seededPolicies: Record<string, EndpointPolicy> = {};
     for (const action of descriptor.actions) {
-      seededPolicies[action.action_id] = storedState[action.action_id] ?? "ASK";
+      seededPolicies[action.action_id] =
+        storedState[action.action_id] ?? action.default_policy;
     }
     setPolicies(seededPolicies);
     // Open "Advanced" up front only when the stored choices can't be shown as a

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -44,6 +44,9 @@ export interface EndpointDescriptor {
   action_id: string;
   normalised_name: string;
   description: string;
+  // Policy a newly-created app seeds this action's selector with (admin can
+  // override). Mirrors `EndpointSpec.default_policy` on the backend.
+  default_policy: EndpointPolicy;
 }
 
 export interface ActionPolicyView {


### PR DESCRIPTION
## Description
We want to be able to set the default policy on a per action basis. For example, reads should always default to always while writes should default to ask.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-action default policies for external app actions so reads can default to Always while writes stay Ask. The create flow and admin UI now seed each action from backend-declared defaults.

- **New Features**
  - Added `default_policy` to backend `EndpointSpec` (ASK by default) and exposed on `EndpointDescriptor` (and web `EndpointDescriptor` type).
  - Set read actions to `ALWAYS` for `gmail`, `google_calendar`, `linear`, and `slack`.
  - Registry now builds policy maps and views using each action’s `default_policy`; stored choices and admin overrides still take precedence.
  - Updated `ConfigureProviderModal` to seed per-action policy from stored state or `default_policy`; bulk state and toggles use `default_policy` when unset.
  - Tests: added unit coverage for defaulting/precedence and tightened integration tests to explicitly assert read (`ALWAYS`) vs write (`ASK`) defaults on create.

<sup>Written for commit 01095f29f4182c7c82cf6b9df5d40d517a2a340a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

