### PR TITLE
feat(admin): add HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL env var

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -108,6 +108,12 @@ ONYX_QUERY_HISTORY_TYPE = QueryHistoryType(
     (os.environ.get("ONYX_QUERY_HISTORY_TYPE") or QueryHistoryType.NORMAL.value).lower()
 )
 
+# Visibility-only: hides the Query History page from the admin sidebar; the
+# history APIs + recording stay on (unlike ONYX_QUERY_HISTORY_TYPE=disabled).
+HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL = (
+    os.environ.get("HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL", "").lower() == "true"
+)
+
 #####
 # Web Configs
 #####

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -89,6 +89,9 @@ class Settings(BaseModel):
     auto_scroll: bool | None = False
     query_history_type: QueryHistoryType | None = None
 
+    # Visibility-only: hides the sidebar page; query-history APIs + recording stay on.
+    hide_query_history_from_admin_panel: bool = False
+
     # Image processing settings
     image_extraction_and_analysis_enabled: bool | None = True
     image_analysis_max_size_mb: int | None = 20

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -3,6 +3,7 @@ from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
+from onyx.configs.app_configs import HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
@@ -60,6 +61,7 @@ def load_settings() -> Settings:
 
     settings.show_extra_connectors = SHOW_EXTRA_CONNECTORS
     settings.opensearch_indexing_enabled = ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
+    settings.hide_query_history_from_admin_panel = HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL
 
     # Resolve context-aware defaults for token threshold.
     # None = admin hasn't set a value yet → use context-aware default.

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -289,6 +289,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 
 ## Miscellaneous
 # ONYX_QUERY_HISTORY_TYPE=
+# Hide the Query History page from the admin sidebar (visibility-only; the history
+# APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).
+# HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL=true
 # CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS=
 # VESPA_LANGUAGE_OVERRIDE=
 

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -34,6 +34,9 @@ export interface Settings {
   temperature_override_enabled: boolean;
   query_history_type: QueryHistoryType;
 
+  // Visibility-only: hides the sidebar page; query-history APIs + recording stay on.
+  hide_query_history_from_admin_panel?: boolean;
+
   deep_research_enabled?: boolean;
   multi_model_chat_enabled?: boolean;
   search_ui_enabled?: boolean;

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -148,7 +148,10 @@ function buildItems(
   // 7. Usage (admin only)
   if (!isCurator) {
     addGated(SECTIONS.USAGE, ADMIN_ROUTES.USAGE, Tier.BUSINESS);
-    if (settings?.settings.query_history_type !== "disabled") {
+    if (
+      settings?.settings.query_history_type !== "disabled" &&
+      !settings?.settings.hide_query_history_from_admin_panel
+    ) {
       addGated(SECTIONS.USAGE, ADMIN_ROUTES.QUERY_HISTORY, Tier.BUSINESS);
     }
   }


### PR DESCRIPTION
## Description

Adds a `HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL` environment variable that hides the **Query History** page from the admin sidebar, without disabling query history itself.

Today the only way to remove the Query History page is to set `query_history_type` (env: `ONYX_QUERY_HISTORY_TYPE`) to `disabled`. That has two side effects which make it unsuitable when you only want to hide the page:

- it also disables the query history APIs and stops recording, and
- it's an admin-editable setting in Chat Preferences, so any admin can switch it back to "Show with User Info" and the page returns.

Some deployments want to keep recording query history (and keep the APIs available for exports/automation) while ensuring in-app admins can't browse it from the UI — and can't toggle that visibility back on. This flag is a visibility-only, deploy-time control: when `HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL=true` the sidebar item is removed, while the query history APIs and recording are left completely untouched.

Implementation mirrors the existing surfaced flags (e.g. `show_extra_connectors`):

- read once in `app_configs.py`,
- applied to `Settings` in `load_settings()` and exposed via `/settings`,
- read in `AdminSidebar` alongside the existing `query_history_type !== "disabled"` check.

Defaults to `false`, so behavior is unchanged unless the var is set.

## How Has This Been Tested?

- Backend lint/format/types on the changed files: `ruff check`, `ruff format`/`black`, and `ty` all pass.
- Frontend format/lint on the changed files: `oxfmt --check` and `oxlint` both pass.
- Traced the data flow end to end: the new field is set in `load_settings()`, serialized into the `/settings` response via `UserSettings`, typed in the web `Settings` interface, and consumed by `AdminSidebar`, where it gates the same `addGated(... QUERY_HISTORY ...)` call that `query_history_type` already guards. With the var unset (default `false`), the sidebar is identical to before.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL` to hide the Query History page from the admin sidebar without disabling recording or APIs. Defaults to false; set to true for a visibility-only, deploy-time control that admins can’t re-enable in the UI.

- New Features
  - Backend: reads the env in `app_configs.py`, wires it in the settings model/store, and exposes `hide_query_history_from_admin_panel` via `/settings`.
  - Frontend: adds the field to the `Settings` interface and updates `AdminSidebar` to hide Query History even when `query_history_type` isn’t `disabled`.
  - Docs: documented in `deployment/docker_compose/env.template`.

<sup>Written for commit e936ff14904196a757bb70f6ccc0d214a72dcd32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

