### PR TITLE
fix(craft): don't cache DockerSandboxManager singleton until init succeeds

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -408,8 +408,13 @@ class DockerSandboxManager(SandboxManager):
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialize()
+                    # Publish to the cache only after _initialize() succeeds, so a
+                    # transient init failure (e.g. the Docker socket briefly
+                    # unavailable) can't leave a half-built singleton that every
+                    # later caller reuses; the next call retries instead.
+                    instance = super().__new__(cls)
+                    instance._initialize()
+                    cls._instance = instance
         return cls._instance
 
     def _initialize(self) -> None:

--- a/backend/tests/unit/build/test_docker_sandbox_manager_singleton.py
+++ b/backend/tests/unit/build/test_docker_sandbox_manager_singleton.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+import pytest
+
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    DockerSandboxManager,
+)
+
+
+def test_failed_initialize_does_not_poison_singleton() -> None:
+    """A failed ``_initialize()`` must not cache a half-built singleton: ``__new__``
+    publishes to the class cache only after init succeeds, and a later construction
+    retries once the transient condition clears."""
+    DockerSandboxManager._instance = None
+    try:
+        attempts = {"count": 0}
+
+        def flaky_initialize(_self: DockerSandboxManager) -> None:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("transient docker socket failure")
+            # second attempt succeeds (no-op)
+
+        with patch.object(DockerSandboxManager, "_initialize", flaky_initialize):
+            with pytest.raises(RuntimeError, match="transient docker socket failure"):
+                DockerSandboxManager()
+
+            # failed init left nothing cached
+            assert DockerSandboxManager._instance is None
+
+            # next construction retries and becomes the cached instance
+            manager = DockerSandboxManager()
+            assert manager is DockerSandboxManager._instance
+            assert attempts["count"] == 2
+    finally:
+        DockerSandboxManager._instance = None


### PR DESCRIPTION
## Description

`DockerSandboxManager.__new__` (a process-wide singleton) assigns `cls._instance` **before** running `_initialize()`:

```python
cls._instance = super().__new__(cls)
cls._instance._initialize()
```

`_initialize()`'s first action is `self._docker = DockerClient(base_url=f"unix://{SANDBOX_DOCKER_SOCKET}")`, which connects eagerly (server-version negotiation). If the Docker socket is momentarily unavailable, that raises — but `cls._instance` already points at a half-built instance that never got `_docker`. Since the singleton is now non-`None`, every later `get_sandbox_manager()` returns that poisoned instance and raises:

```
AttributeError: 'DockerSandboxManager' object has no attribute '_docker'
```

with no recovery short of restarting the process. This takes down both sandbox creation and the `cleanup_idle_sandboxes` task — and because the cleanup task is what releases each session's `nextjs_port`, the allocations leak and the sandbox port pool (`SANDBOX_NEXTJS_PORT_START..END`) can fill up, after which new sessions fail with "No available ports in range".

The fix builds the instance in a local and only assigns `cls._instance` once `_initialize()` returns, so a transient initialization failure leaves the singleton unset and the next call retries.

## How Has This Been Tested?

Added `backend/tests/unit/build/test_docker_sandbox_manager_singleton.py`: it patches `_initialize` to raise on the first call and succeed on the second, then asserts that after the first failure `DockerSandboxManager._instance` is still `None` (no poisoned cache) and that a subsequent construction retries initialization and is cached. The test fails on the old ordering and passes with this change. `ruff check`, `ruff format`, and `ty` are clean on both changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the `DockerSandboxManager` singleton to cache only after `_initialize()` succeeds, so transient Docker socket failures don’t leave a half-built instance. This prevents sandbox creation/cleanup crashes and avoids Next.js port leaks.

- **Bug Fixes**
  - Build the instance locally and assign to the singleton only after `_initialize()` returns; failed init leaves the cache unset to allow retry.
  - Added a unit test to ensure a failed init does not poison the singleton and that the next construction is cached.

<sup>Written for commit 96db6740124a5975b0966abd5d85c6bc3d996f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

