### PR TITLE
fix(craft): bump default sandbox image to v0.1.49 (opencode-serve compatible)

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -47,7 +47,7 @@ ATTACHMENTS_DIRECTORY = "attachments"
 SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.44"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.49"
 )
 
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -231,7 +231,7 @@ SANDBOX_SERVICE_ACCOUNT_NAME=sandbox-file-sync  # Has S3 access via IRSA for sna
 
 ```bash
 # Container image (defaults to a pinned tag in docker-compose.yml)
-SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.44
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.49
 
 # Public URL the sandbox agent uses to reach Onyx (HTTPS, externally resolvable —
 # compose hostnames like http://api_server:8080 will not resolve from inside the

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -10,7 +10,7 @@ services:
       # Public Onyx URL — internal compose hostnames don't resolve from
       # the sandbox bridge.
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.44}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.49}
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}
@@ -28,7 +28,7 @@ services:
       # same backend to snapshot + terminate sandboxes.
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.44}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.49}
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -35,7 +35,7 @@ IMAGE_TAG=latest
 # SANDBOX_API_SERVER_URL=https://onyx.your-org.example
 #
 ## Sandbox container image. Pinned by default for reproducibility.
-# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.44
+# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.49
 #
 ## Sandbox bridge network. Created by install.sh (or manually:
 ##   docker network create onyx_craft_sandbox


### PR DESCRIPTION
## Description

The default `SANDBOX_CONTAINER_IMAGE` is `onyxdotapp/sandbox:v0.1.44`, which **predates the opencode-serve migration**. In `v0.1.44` the image's `/workspace/entrypoint.sh` is just `sleep infinity` — it never launches `opencode serve`.

The current Docker sandbox backend creates the container with `command=["/workspace/entrypoint.sh"]` and then waits for opencode-serve on port `4096` (`_wait_for_opencode_serve_ready`). With the stale default image, every provision fails with:

```
Session creation failed: opencode-serve never became ready in sandbox container sandbox-...
```

`onyxdotapp/sandbox:v0.1.49`'s `entrypoint.sh` runs `opencode serve --hostname 0.0.0.0 --port 4096` in a restart loop — exactly what the backend expects. This bumps the default to `v0.1.49` in:

- `backend/onyx/server/features/build/configs.py` (`SANDBOX_CONTAINER_IMAGE` default)
- `deployment/docker_compose/docker-compose.craft.yml` (api_server + background)
- `deployment/docker_compose/env.template`
- `backend/onyx/server/features/build/sandbox/README.md`

(Maintainers: please confirm `v0.1.49` is the intended pairing for current `main` — happy to adjust to whichever sandbox tag is canonical.)

## How Has This Been Tested?

Verified empirically against a Docker-backend deployment: with the `v0.1.44` default, provisioning reaches "Created sandbox record" then fails at `opencode-serve never became ready` (the container's PID 1 is `sleep infinity`, no opencode process). Pinning `v0.1.49` makes the same flow succeed — `opencode serve --port 4096` runs inside the sandbox and the session reaches ACTIVE. Docs/config-only change; `ruff check` + `ruff format` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump default sandbox image to `onyxdotapp/sandbox:v0.1.49` so the entrypoint starts `opencode serve` on port 4096, fixing Docker-backend provisioning failures with the old `v0.1.44` image.

- **Bug Fixes**
  - Set default image to `onyxdotapp/sandbox:v0.1.49` in configs, compose overlay, env template, and sandbox README.
  - Ensures the container entrypoint runs `opencode serve` (0.0.0.0:4096) as expected by the backend.
  - Prevents "opencode-serve never became ready" errors in fresh Craft deployments.

<sup>Written for commit 9c3b68fffc245aed55aa28808e784a0a4ac8b5e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

