### PR TITLE
fix(craft): center the welcome screen content

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -472,8 +472,7 @@ export default function BuildChatPanel({
           ref={scrollContainerRef}
           onScroll={handleScroll}
           // min-h-0 lets this flex child scroll internally instead of growing
-          // the column past the page bounds.
-          className="flex-1 min-h-0 overflow-auto"
+          className="flex flex-col flex-1 min-h-0 overflow-auto"
         >
           <AnimatePresence mode="wait" initial={false}>
             <motion.div
@@ -482,6 +481,7 @@ export default function BuildChatPanel({
               animate={{ opacity: 1, y: 0 }}
               exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+              className="flex flex-col flex-1"
             >
               {isViewingSubagent && viewedSubagentSessionId ? (
                 <SubagentView subagentSessionId={viewedSubagentSessionId} />

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -471,7 +471,6 @@ export default function BuildChatPanel({
         <div
           ref={scrollContainerRef}
           onScroll={handleScroll}
-          // min-h-0 lets this flex child scroll internally instead of growing
           className="flex flex-col flex-1 min-h-0 overflow-auto"
         >
           <AnimatePresence mode="wait" initial={false}>


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centered the Craft welcome screen by switching the chat panel scroll container and animated wrapper to a flex column layout while keeping internal scrolling intact across screen sizes. Also removed an obsolete inline comment.

<sup>Written for commit 12247465e2ba2815edcd302ff5a5dd20bfc547b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

