### PR TITLE
fix(web): pin Turbopack workspace root to web/

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -25,6 +25,12 @@ const nextConfig = {
   transpilePackages: ["@onyx-ai/opal"],
   typedRoutes: true,
   reactCompiler: true,
+  // Pin the workspace root to this directory so Turbopack resolves modules
+  // against web/bun.lock. Without this, Next.js detects multiple lockfiles
+  // (the repo-root bun.lock and web/bun.lock) and infers the wrong root.
+  turbopack: {
+    root: __dirname,
+  },
   images: {
     // Used to fetch favicons
     remotePatterns: [


### PR DESCRIPTION
## Problem

Running the Next.js dev server emitted a workspace-root warning:

> ⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
> We detected multiple lockfiles and selected the directory of `.../bun.lock` as the root directory.

Next.js 16 (Turbopack) walks up the tree looking for a lockfile to determine the workspace root. Because there's a `bun.lock` at the repo root **and** at `web/bun.lock`, it could pick the wrong one, which affects module resolution.

## Fix

Explicitly pin `turbopack.root` to the `web/` directory in `next.config.js` using `__dirname`. Since the config file lives in `web/`, `__dirname` resolves to the web directory at runtime regardless of where the repo/worktree is checked out — so resolution always uses `web/bun.lock` and the warning is silenced.

```js
turbopack: {
  root: __dirname,
},
```

In Next.js 16, Turbopack is stable, so `turbopack` is a top-level config key (no longer under `experimental`).

## Testing

- Config loads cleanly and `turbopack.root` resolves to the `web/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the Turbopack workspace root to the `web/` folder so Next.js resolves modules against `web/bun.lock` and the workspace-root warning is removed. Implemented by setting `turbopack.root = __dirname` in `web/next.config.js` (Turbopack is a top‑level key in Next.js 16).

<sup>Written for commit ef4b954cf847846614e0adca81d3642f61fe2f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

