### PR TITLE
chore(craft): bump sandbox image to v0.1.50

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -47,7 +47,7 @@ ATTACHMENTS_DIRECTORY = "attachments"
 SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.44"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.50"
 )
 
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -231,7 +231,7 @@ SANDBOX_SERVICE_ACCOUNT_NAME=sandbox-file-sync  # Has S3 access via IRSA for sna
 
 ```bash
 # Container image (defaults to a pinned tag in docker-compose.yml)
-SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.44
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.50
 
 # Public URL the sandbox agent uses to reach Onyx (HTTPS, externally resolvable —
 # compose hostnames like http://api_server:8080 will not resolve from inside the

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -10,7 +10,7 @@ services:
       # Public Onyx URL — internal compose hostnames don't resolve from
       # the sandbox bridge.
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.44}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.50}
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}
@@ -28,7 +28,7 @@ services:
       # same backend to snapshot + terminate sandboxes.
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.44}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.50}
       - SANDBOX_DOCKER_NETWORK=${SANDBOX_DOCKER_NETWORK:-onyx_craft_sandbox}
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}
       - SANDBOX_DOCKER_CPU_LIMIT=${SANDBOX_DOCKER_CPU_LIMIT:-1.0}

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -35,7 +35,7 @@ IMAGE_TAG=latest
 # SANDBOX_API_SERVER_URL=https://onyx.your-org.example
 #
 ## Sandbox container image. Pinned by default for reproducibility.
-# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.44
+# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.50
 #
 ## Sandbox bridge network. Created by install.sh (or manually:
 ##   docker network create onyx_craft_sandbox


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the default sandbox container image to `onyxdotapp/sandbox:v0.1.50` to pick up recent fixes and keep configs and docs in sync.

- **Dependencies**
  - Set default `SANDBOX_CONTAINER_IMAGE` to `onyxdotapp/sandbox:v0.1.50`.
  - Updated references in configs, `docker-compose`, env template, and README.

<sup>Written for commit 39a137b168b4c166a9cccafb1ff2cdc3406ce8e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

