### PR TITLE
fix(confluence): skip image attachments in slim-doc pass when allow_images is False

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -1158,8 +1158,13 @@ class ConfluenceConnector(
                 expand=restrictions_expand,
                 limit=_SLIM_DOC_BATCH_SIZE,
             ):
-                # If you skip images, you'll skip them in the permission sync
-                attachment["metadata"].get("mediaType", "")
+                # If you skip images in the main indexing pass (allow_images
+                # is False), skip them here too. Otherwise the slim path emits
+                # a SlimDocument for an attachment the main path never produces
+                # a Document for, leaving a permanent chunk_count IS NULL row.
+                media_type = attachment.get("metadata", {}).get("mediaType", "")
+                if not self.allow_images and media_type.startswith("image/"):
+                    continue
                 if not validate_attachment_filetype(
                     attachment,
                 ):

--- a/backend/tests/unit/onyx/connectors/confluence/test_slim_doc_image_skip.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_slim_doc_image_skip.py
@@ -1,0 +1,127 @@
+"""Regression test for slim-doc / main-doc admission drift on Confluence
+attachments.
+
+When image extraction is disabled (`allow_images=False`), the main indexing
+pass skips image attachments and never produces a `Document` for them. The
+slim-doc pass must apply the same filter; otherwise it emits a `SlimDocument`
+for an image the main pass dropped, leaving a permanent `chunk_count IS NULL`
+ghost row that the periodic metadata-sync task can never reconcile.
+"""
+
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.models import SlimDocument
+
+_PAGE_CQL = "PAGE_CQL"
+_ATTACHMENT_CQL = "ATTACHMENT_CQL"
+
+_PAGE = {
+    "id": "111",
+    "_links": {"webui": "/spaces/X/pages/111/Page"},
+    "restrictions": {},
+    "space": {"key": "X"},
+    "ancestors": [],
+}
+_IMAGE_ATTACHMENT = {
+    "title": "diagram.png",
+    "metadata": {"mediaType": "image/png"},
+    "_links": {
+        "webui": "/pages/viewpageattachments.action?pageId=111&preview=diagram.png"
+    },
+    "restrictions": {},
+    "space": {"key": "X"},
+}
+_PDF_ATTACHMENT = {
+    "title": "spec.pdf",
+    "metadata": {"mediaType": "application/pdf"},
+    "_links": {"webui": "/download/attachments/111/spec.pdf"},
+    "restrictions": {},
+    "space": {"key": "X"},
+}
+
+
+@pytest.fixture
+def confluence_connector() -> ConfluenceConnector:
+    return ConfluenceConnector(
+        wiki_base="https://fake-cloud.atlassian.net/wiki",
+        is_cloud=True,
+    )
+
+
+def _collect_slim_doc_ids(connector: ConfluenceConnector) -> list[str]:
+    """Drive the pruning slim-doc path (include_permissions=False) with a
+    fake client and return every emitted SlimDocument id."""
+
+    def fake_paginate(**kwargs: Any) -> Any:
+        cql = kwargs.get("cql")
+        if cql == _PAGE_CQL:
+            return iter([_PAGE])
+        if cql == _ATTACHMENT_CQL:
+            return iter([_IMAGE_ATTACHMENT, _PDF_ATTACHMENT])
+        return iter([])
+
+    fake_client = mock.Mock(spec=OnyxConfluence)
+    fake_client.cql_paginate_all_expansions.side_effect = fake_paginate
+
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=fake_client,
+        ),
+        mock.patch.object(
+            connector, "_yield_space_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_yield_ancestor_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_maybe_yield_page_hierarchy_node", return_value=None
+        ),
+        mock.patch.object(connector, "_get_parent_hierarchy_raw_id", return_value=None),
+        mock.patch.object(
+            connector, "_construct_page_cql_query", return_value=_PAGE_CQL
+        ),
+        mock.patch.object(
+            connector, "_construct_attachment_query", return_value=_ATTACHMENT_CQL
+        ),
+    ):
+        ids: list[str] = []
+        for batch in connector.retrieve_all_slim_docs():
+            for item in batch:
+                if isinstance(item, SlimDocument):
+                    ids.append(item.id)
+    return ids
+
+
+def test_slim_docs_skip_images_when_allow_images_false(
+    confluence_connector: ConfluenceConnector,
+) -> None:
+    """allow_images=False mirrors the main pass: no SlimDocument for the
+    image attachment, so no ghost row is created."""
+    confluence_connector.allow_images = False
+
+    ids = _collect_slim_doc_ids(confluence_connector)
+
+    assert not any("viewpageattachments" in doc_id for doc_id in ids)
+    # the supported (non-image) attachment is still emitted
+    assert any("spec.pdf" in doc_id for doc_id in ids)
+
+
+def test_slim_docs_include_images_when_allow_images_true(
+    confluence_connector: ConfluenceConnector,
+) -> None:
+    """allow_images=True keeps image attachments, matching the main pass
+    which produces Documents for them."""
+    confluence_connector.allow_images = True
+
+    ids = _collect_slim_doc_ids(confluence_connector)
+
+    assert any("viewpageattachments" in doc_id for doc_id in ids)
+    assert any("spec.pdf" in doc_id for doc_id in ids)


### PR DESCRIPTION
## Description

The Confluence slim-doc attachment loop read `mediaType` but discarded the value without acting on it — an unfinished skip-images check. As a result, the slim-doc / permission-sync pass used *looser* admission criteria than the main indexing pass:

- **Main pass** (`connector.py` ~L612): when `allow_images` is `False` (i.e. workspace `image_extraction_and_analysis_enabled = False`), image attachments are skipped and no `Document` is produced.
- **Slim pass** (`connector.py` ~L1161, before this change): emitted a `SlimDocument` for those same image attachments.

A `SlimDocument` with no sections never runs through chunking, so each one lands in Postgres as a `document` row with `chunk_count IS NULL` that the main pass never reconciles. The periodic `document_index_metadata_sync_task` then substitutes `-1` for the missing count and raises `ChunkCountNotFoundError` on every retry cycle, flooding `celery.app.trace` ERROR logs and consuming worker capacity indefinitely. The rows are invisible to users (no chunks → no search hits) but accumulate on every connector run and are never cleaned up.

This change mirrors the main pass guard in the slim loop: skip attachments whose media type is `image/*` when `allow_images` is `False`. `self.allow_images` already exists on the connector and is set from the workspace setting via the connector factory.

Note: this is the concrete single-connector fix. The broader smell — slim-doc emission criteria drifting out of sync with the main indexing pass (the Slack slim path has the same shape, and the metadata-sync task retries these rows forever rather than evicting them) — is worth a follow-up, filed separately.

## How Has This Been Tested?

New unit test `backend/tests/unit/onyx/connectors/confluence/test_slim_doc_image_skip.py` drives the slim-doc path with a fake Confluence client returning one image and one non-image attachment, asserting:

- `allow_images=False` → image attachment is not emitted (no ghost row), non-image attachment still emitted.
- `allow_images=True` → image attachment is emitted (matches the main pass).

Also verified that the test fails on the pre-fix code (the image ghost id is emitted) and passes with the fix, and that `pre-commit` (ty, ruff, ruff format, ripsecrets) passes on both changed files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip image attachments in the Confluence slim-doc pass when allow_images is False. This matches the main indexing behavior and stops creating ghost rows that trigger repeated metadata-sync errors.

- **Bug Fixes**
  - Mirror main pass guard: skip attachments with mediaType starting with image/ when allow_images is False.
  - Added a unit test covering both allow_images states; non-image attachments still emit slim docs.
  - Prevents ChunkCountNotFoundError log spam and unnecessary worker retries.

<sup>Written for commit 6e7faca1831df496c14c467a1972e4b0d5b7fbcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
