### PR TITLE
fix(web): silence Node DEP0205 module.register() deprecation from Sentry

### DIFF
--- a/web/sentry.server.config.ts
+++ b/web/sentry.server.config.ts
@@ -15,5 +15,12 @@ if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
     // Disable performance monitoring and only capture errors
     tracesSampleRate: 0,
     profilesSampleRate: 0,
+
+    // We don't use tracing (tracesSampleRate: 0), so the ESM loader hooks that
+    // Sentry registers to auto-instrument libraries provide no value here. Skip
+    // registering them to avoid the Node DEP0205 deprecation warning emitted by
+    // @sentry/node-core's `module.register('import-in-the-middle/hook.mjs', ...)`
+    // call (`module.register()` is deprecated in favor of `module.registerHooks()`).
+    registerEsmLoaderHooks: false,
   });
 }


### PR DESCRIPTION
## Description

Node 26 emits `[DEP0205] DeprecationWarning: 'module.register()' is deprecated. Use 'module.registerHooks()' instead.` on web server startup.

The warning is **not** from our code — it comes from Sentry's server SDK (`@sentry/node-core`, pulled in via `@sentry/nextjs`), which registers [`import-in-the-middle`](https://github.com/nodejs/import-in-the-middle) ESM loader hooks via the now-deprecated `module.register()` API. The SDK gates that exact call:

```js
// @sentry/node-core/.../sdk/index.js
if (options.registerEsmLoaderHooks !== false) {
  initializeEsmLoader();   // the only module.register() call this app makes
}
```

Those hooks exist solely to auto-instrument libraries for **performance tracing**, which this app already disables (`tracesSampleRate: 0`, `profilesSampleRate: 0`). This PR passes `registerEsmLoaderHooks: false` in `web/sentry.server.config.ts` so the SDK skips the `module.register()` call entirely. Error capture is unaffected.

**Why not just upgrade Sentry?** It doesn't help. The latest 10.x still makes the same call — the bug is open against an SDK version newer than ours ([getsentry/sentry-javascript#20810](https://github.com/getsentry/sentry-javascript/issues/20810)) — and the underlying migration to `module.registerHooks()` is blocked on `import-in-the-middle` upstream ([nodejs/node#56241](https://github.com/nodejs/node/issues/56241)), since `registerHooks()` is synchronous/same-thread and not a drop-in replacement for the async, off-thread `register()` that IITM needs. This change is also version-independent.

Scope is the server (Node runtime) config only; the edge config doesn't use `@sentry/node` and never makes the call.

## How Has This Been Tested?

- `tsc --noEmit` on `web/` → 0 errors (`registerEsmLoaderHooks` is part of `NodeOptions`, accepted by the nextjs server `init`).
- Prettier → clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the Node [DEP0205] module.register() deprecation on web server startup by disabling Sentry’s ESM loader hooks. Error reporting is unchanged; we only stop unused tracing hooks.

- **Bug Fixes**
  - Set `registerEsmLoaderHooks: false` in `web/sentry.server.config.ts` so `@sentry/node-core` skips the `module.register()` call via `import-in-the-middle`.
  - Tracing stays off (`tracesSampleRate: 0`, `profilesSampleRate: 0`). Affects only the Node/server runtime; edge config is unchanged.

<sup>Written for commit e2568d72618669c12574e60c2094cfe5589b40f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

