### PR TITLE
feat(craft): External app action non-availability mentioned in skill file

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -136,16 +136,10 @@ def get_external_app_by_skill_id(
     db_session: Session,
     skill_id: UUID,
 ) -> ExternalApp | None:
-    """The external-app gateway backing ``skill_id``, with its policies eager
-    loaded, or None if the skill isn't an external app."""
-    stmt = (
-        select(ExternalApp)
-        .options(
-            selectinload(ExternalApp.skill),
-            selectinload(ExternalApp.policies),
-        )
-        .where(ExternalApp.skill_id == skill_id)
-    )
+    """The external-app gateway backing ``skill_id``, or None if the skill isn't
+    an external app. Returns just the row — callers that need its policies fetch
+    them via ``get_policies``."""
+    stmt = select(ExternalApp).where(ExternalApp.skill_id == skill_id)
     return db_session.scalar(stmt)
 
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -132,6 +132,23 @@ def get_external_app_by_id(
     return db_session.scalar(stmt)
 
 
+def get_external_app_by_skill_id(
+    db_session: Session,
+    skill_id: UUID,
+) -> ExternalApp | None:
+    """The external-app gateway backing ``skill_id``, with its policies eager
+    loaded, or None if the skill isn't an external app."""
+    stmt = (
+        select(ExternalApp)
+        .options(
+            selectinload(ExternalApp.skill),
+            selectinload(ExternalApp.policies),
+        )
+        .where(ExternalApp.skill_id == skill_id)
+    )
+    return db_session.scalar(stmt)
+
+
 def get_external_apps(
     db_session: Session,
 ) -> list[ExternalApp]:

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
@@ -7,8 +7,6 @@ description: Read, search, and send email from the connected user's Gmail via a 
 
 Call the Gmail API as the connected user via the bundled helper.
 
-## Available actions
-
 {{ACTION_AVAILABILITY_SECTION}}
 
 ## Usage

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
@@ -7,6 +7,10 @@ description: Read, search, and send email from the connected user's Gmail via a 
 
 Call the Gmail API as the connected user via the bundled helper.
 
+## Available actions
+
+{{ACTION_AVAILABILITY_SECTION}}
+
 ## Usage
 
     python .opencode/skills/gmail/gmail_api.py <command> [args]

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md.template
@@ -7,8 +7,6 @@ description: Read and manage the connected user's Google Calendar via a light Ca
 
 Call the Google Calendar API as the connected user via the bundled helper.
 
-## Available actions
-
 {{ACTION_AVAILABILITY_SECTION}}
 
 ## Usage

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/SKILL.md.template
@@ -7,6 +7,10 @@ description: Read and manage the connected user's Google Calendar via a light Ca
 
 Call the Google Calendar API as the connected user via the bundled helper.
 
+## Available actions
+
+{{ACTION_AVAILABILITY_SECTION}}
+
 ## Usage
 
     python .opencode/skills/google-calendar/gcal_api.py <command> [args]

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md.template
@@ -7,8 +7,6 @@ description: Query and mutate Linear (issues, projects, teams) on the connected 
 
 Call Linear as the connected user via the bundled helper.
 
-## Available actions
-
 {{ACTION_AVAILABILITY_SECTION}}
 
 ## Usage

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/SKILL.md.template
@@ -7,6 +7,10 @@ description: Query and mutate Linear (issues, projects, teams) on the connected 
 
 Call Linear as the connected user via the bundled helper.
 
+## Available actions
+
+{{ACTION_AVAILABILITY_SECTION}}
+
 ## Usage
 
     python .opencode/skills/linear/linear_api.py <command> [args]

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md.template
@@ -7,8 +7,6 @@ description: Read, search, and post Slack messages on the connected user's behal
 
 Call the Slack Web API as the connected user via the bundled helper.
 
-## Available actions
-
 {{ACTION_AVAILABILITY_SECTION}}
 
 ## Usage

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/SKILL.md.template
@@ -7,6 +7,10 @@ description: Read, search, and post Slack messages on the connected user's behal
 
 Call the Slack Web API as the connected user via the bundled helper.
 
+## Available actions
+
+{{ACTION_AVAILABILITY_SECTION}}
+
 ## Usage
 
     python .opencode/skills/slack/slack_api.py <command> [args]

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -183,6 +183,12 @@ BUILT_IN_SKILLS: Final[dict[str, BuiltInSkillDefinition]] = (
 EXTERNAL_APP_BUILT_IN_SKILL_IDS: Final[dict[ExternalAppType, str]] = (
     _REGISTRY.external_app_skill_ids
 )
+# Inverse of the above: ``built_in_skill_id -> app_type``. Lets the skill push
+# path go from a ``Skill`` row's ``built_in_skill_id`` back to the provider
+# catalog without touching the DB. Skill ids are unique, so the inverse is too.
+EXTERNAL_APP_SKILL_ID_TO_APP_TYPE: Final[dict[str, ExternalAppType]] = {
+    skill_id: app_type for app_type, skill_id in EXTERNAL_APP_BUILT_IN_SKILL_IDS.items()
+}
 
 # Named handles so callers avoid bare slug literals.
 COMPANY_SEARCH: Final[BuiltInSkillDefinition] = BUILT_IN_SKILLS["company-search"]

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
+from onyx.db.external_app import get_external_app_by_skill_id
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
@@ -24,7 +25,9 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
 from onyx.skills.built_in import BUILT_IN_SKILLS
 from onyx.skills.built_in import BuiltInSkillDefinition
 from onyx.skills.built_in import COMPANY_SEARCH
+from onyx.skills.built_in import EXTERNAL_APP_SKILL_ID_TO_APP_TYPE
 from onyx.skills.rendering import render_company_search_skill
+from onyx.skills.rendering import render_external_app_skill
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -63,15 +66,29 @@ def _render_template(
     db_session: Session,
     user: User,
 ) -> None:
-    """Overwrite ``{slug}/SKILL.md`` with a per-user rendering. Only
-    company-search has a renderer today; other templated built-ins log
-    a warning and ship the static siblings as-is."""
+    """Overwrite ``{slug}/SKILL.md`` with a per-user rendering. company-search
+    and external-app built-ins have renderers; any other templated built-in logs
+    a warning and ships the static siblings as-is."""
     if definition.built_in_skill_id == COMPANY_SEARCH.built_in_skill_id:
         rendered = render_company_search_skill(
             db_session, user, definition.source_dir.parent
         )
         files[f"{skill.slug}/SKILL.md"] = rendered.encode("utf-8")
         return
+
+    app_type = EXTERNAL_APP_SKILL_ID_TO_APP_TYPE.get(definition.built_in_skill_id)
+    if app_type is not None:
+        external_app = get_external_app_by_skill_id(db_session, skill.id)
+        rendered = render_external_app_skill(
+            db_session,
+            skill.slug,
+            app_type,
+            external_app,
+            definition.source_dir.parent,
+        )
+        files[f"{skill.slug}/SKILL.md"] = rendered.encode("utf-8")
+        return
+
     logger.warning(
         "Built-in %s has_template=True but no renderer", definition.built_in_skill_id
     )

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -81,10 +81,9 @@ def _render_template(
         external_app = get_external_app_by_skill_id(db_session, skill.id)
         rendered = render_external_app_skill(
             db_session,
-            skill.slug,
             app_type,
             external_app,
-            definition.source_dir.parent,
+            definition.source_dir,
         )
         files[f"{skill.slug}/SKILL.md"] = rendered.encode("utf-8")
         return

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -88,9 +88,8 @@ def build_action_availability_section(
 ) -> str:
     """Render the enabled/disabled action lists from the app's effective policy.
 
-    ``DENY`` actions are disabled; everything else is available, with ``ASK``
-    actions annotated as requiring approval. Falls back to the catalog defaults
-    when no app row (and thus no stored override) exists.
+    ``DENY`` actions are disabled; everything else is available. Falls back to the
+    catalog defaults when no app row (and thus no stored override) exists.
     """
     stored = get_policies(db_session, external_app.id) if external_app else {}
     views = action_policy_views(app_type, stored)
@@ -100,22 +99,10 @@ def build_action_availability_section(
     available: list[str] = []
     disabled: list[str] = []
     for view in views:
-        if view.state == EndpointPolicy.DENY:
-            disabled.append(f"- **{view.normalised_name}** — {view.description}")
-            continue
-        suffix = " _(requires approval)_" if view.state == EndpointPolicy.ASK else ""
-        available.append(f"- **{view.normalised_name}** — {view.description}{suffix}")
+        bucket = disabled if view.state == EndpointPolicy.DENY else available
+        bucket.append(f"- **{view.normalised_name}** — {view.description}")
 
-    lines: list[str] = []
-    lines.append(
-        "These actions are enabled for you"
-        + (
-            "; actions marked _(requires approval)_ prompt the user before running."
-            if any("_(requires approval)_" in line for line in available)
-            else "."
-        )
-    )
-    lines.append("")
+    lines: list[str] = ["These actions are enabled for you:", ""]
     lines.extend(available or ["- (none)"])
     lines.append("")
     lines.append(

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -85,29 +85,23 @@ def build_action_availability_section(
     app_type: ExternalAppType,
     stored: dict[str, EndpointPolicy],
 ) -> str:
-    """Render the enabled/disabled action lists from the app's effective policy.
+    """Render the warning listing the app's ``DENY`` (unavailable) actions, or an
+    empty string when nothing is disabled. Available actions are intentionally
+    omitted — the skill body already documents what the agent can do; this only
+    fences off what it must not attempt.
 
-    ``DENY`` actions are disabled; everything else is available. ``stored`` is the
-    app's per-action overrides; an empty map falls back to the catalog defaults.
+    ``stored`` is the app's per-action overrides; an empty map falls back to the
+    catalog defaults.
     """
-    views = action_policy_views(app_type, stored)
-    if not views:
-        return "No actions are configured for this app."
-
-    available: list[str] = []
-    disabled: list[str] = []
-    for view in views:
-        bucket = disabled if view.state == EndpointPolicy.DENY else available
-        bucket.append(f"- **{view.normalised_name}** — {view.description}")
-
-    lines: list[str] = ["These actions are enabled for you:", ""]
-    lines.extend(available or ["- (none)"])
-    if disabled:
-        lines.append("")
-        lines.append("The following actions are disabled — do not attempt them:")
-        lines.append("")
-        lines.extend(disabled)
-    return "\n".join(lines)
+    disabled = [
+        f"- {view.normalised_name}"
+        for view in action_policy_views(app_type, stored)
+        if view.state == EndpointPolicy.DENY
+    ]
+    if not disabled:
+        return ""
+    header = "These actions are unavailable and should not be attempted:"
+    return "\n".join([header, "", *disabled])
 
 
 def render_external_app_skill(
@@ -123,4 +117,8 @@ def render_external_app_skill(
     template = (skill_dir / "SKILL.md.template").read_text()
     stored = get_policies(db_session, external_app.id) if external_app else {}
     section = build_action_availability_section(app_type, stored)
-    return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)
+    if section:
+        return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)
+    # Nothing disabled: drop the placeholder and its trailing blank line so the
+    # surrounding sections stay flush.
+    return template.replace(f"{ACTION_AVAILABILITY_PLACEHOLDER}\n\n", "")

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -8,10 +8,17 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import DocumentSourceDescription
 from onyx.db.connector import _INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import get_connector_credential_pairs_for_user
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.db.external_app import get_policies
+from onyx.db.models import ExternalApp
 from onyx.db.models import User
+from onyx.external_apps.providers.registry import action_policy_views
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+ACTION_AVAILABILITY_PLACEHOLDER = "{{ACTION_AVAILABILITY_SECTION}}"
 
 
 def build_available_sources_section(
@@ -72,3 +79,68 @@ def render_company_search_skill(
     template = template_path.read_text()
     sources_section = build_available_sources_section(db_session, user)
     return template.replace("{{AVAILABLE_SOURCES_SECTION}}", sources_section)
+
+
+def build_action_availability_section(
+    db_session: Session,
+    app_type: ExternalAppType,
+    external_app: ExternalApp | None,
+) -> str:
+    """Render the enabled/disabled action lists from the app's effective policy.
+
+    ``DENY`` actions are disabled; everything else is available, with ``ASK``
+    actions annotated as requiring approval. Falls back to the catalog defaults
+    when no app row (and thus no stored override) exists.
+    """
+    stored = get_policies(db_session, external_app.id) if external_app else {}
+    views = action_policy_views(app_type, stored)
+    if not views:
+        return "No actions are configured for this app."
+
+    available: list[str] = []
+    disabled: list[str] = []
+    for view in views:
+        if view.state == EndpointPolicy.DENY:
+            disabled.append(f"- **{view.normalised_name}** — {view.description}")
+            continue
+        suffix = " _(requires approval)_" if view.state == EndpointPolicy.ASK else ""
+        available.append(f"- **{view.normalised_name}** — {view.description}{suffix}")
+
+    lines: list[str] = []
+    lines.append(
+        "These actions are enabled for you"
+        + (
+            "; actions marked _(requires approval)_ prompt the user before running."
+            if any("_(requires approval)_" in line for line in available)
+            else "."
+        )
+    )
+    lines.append("")
+    lines.extend(available or ["- (none)"])
+    lines.append("")
+    lines.append(
+        "The following actions are disabled — do not attempt them:"
+        if disabled
+        else "No actions are disabled."
+    )
+    if disabled:
+        lines.append("")
+        lines.extend(disabled)
+    return "\n".join(lines)
+
+
+def render_external_app_skill(
+    db_session: Session,
+    slug: str,
+    app_type: ExternalAppType,
+    external_app: ExternalApp | None,
+    skills_dir: Path,
+) -> str:
+    """Render an external-app SKILL.md with its per-user action availability.
+
+    ``skills_dir`` is the parent directory of ``{slug}/``.
+    """
+    template_path = skills_dir / slug / "SKILL.md.template"
+    template = template_path.read_text()
+    section = build_action_availability_section(db_session, app_type, external_app)
+    return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -82,16 +82,14 @@ def render_company_search_skill(
 
 
 def build_action_availability_section(
-    db_session: Session,
     app_type: ExternalAppType,
-    external_app: ExternalApp | None,
+    stored: dict[str, EndpointPolicy],
 ) -> str:
     """Render the enabled/disabled action lists from the app's effective policy.
 
-    ``DENY`` actions are disabled; everything else is available. Falls back to the
-    catalog defaults when no app row (and thus no stored override) exists.
+    ``DENY`` actions are disabled; everything else is available. ``stored`` is the
+    app's per-action overrides; an empty map falls back to the catalog defaults.
     """
-    stored = get_policies(db_session, external_app.id) if external_app else {}
     views = action_policy_views(app_type, stored)
     if not views:
         return "No actions are configured for this app."
@@ -114,16 +112,15 @@ def build_action_availability_section(
 
 def render_external_app_skill(
     db_session: Session,
-    slug: str,
     app_type: ExternalAppType,
     external_app: ExternalApp | None,
-    skills_dir: Path,
+    skill_dir: Path,
 ) -> str:
     """Render an external-app SKILL.md with its per-user action availability.
 
-    ``skills_dir`` is the parent directory of ``{slug}/``.
+    ``skill_dir`` is the skill's on-disk directory (holds ``SKILL.md.template``).
     """
-    template_path = skills_dir / slug / "SKILL.md.template"
-    template = template_path.read_text()
-    section = build_action_availability_section(db_session, app_type, external_app)
+    template = (skill_dir / "SKILL.md.template").read_text()
+    stored = get_policies(db_session, external_app.id) if external_app else {}
+    section = build_action_availability_section(app_type, stored)
     return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -104,13 +104,9 @@ def build_action_availability_section(
 
     lines: list[str] = ["These actions are enabled for you:", ""]
     lines.extend(available or ["- (none)"])
-    lines.append("")
-    lines.append(
-        "The following actions are disabled — do not attempt them:"
-        if disabled
-        else "No actions are disabled."
-    )
     if disabled:
+        lines.append("")
+        lines.append("The following actions are disabled — do not attempt them:")
         lines.append("")
         lines.extend(disabled)
     return "\n".join(lines)

--- a/backend/tests/external_dependency_unit/craft/_test_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/_test_helpers.py
@@ -37,6 +37,7 @@ from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import ExternalApp
+from onyx.db.models import ExternalAppPolicy
 from onyx.db.models import ExternalAppUserCredential
 from onyx.db.models import Sandbox
 from onyx.db.models import Skill
@@ -218,8 +219,10 @@ def make_external_app(
     organization_credentials: dict[str, Any] | None = None,
     app_type: ExternalAppType = ExternalAppType.CUSTOM,
     upstream_url_patterns: list[str] | None = None,
+    action_policies: dict[str, EndpointPolicy] | None = None,
 ) -> ExternalApp:
-    """Insert an ``ExternalApp`` row backing ``skill``."""
+    """Insert an ``ExternalApp`` row backing ``skill``, plus any per-action
+    policy overrides in ``action_policies`` (``{action_id: policy}``)."""
     app = ExternalApp(
         skill_id=skill.id,
         app_type=app_type,
@@ -228,6 +231,15 @@ def make_external_app(
         organization_credentials=organization_credentials or {},
     )
     db_session.add(app)
+    db_session.flush()
+    for action_id, policy in (action_policies or {}).items():
+        db_session.add(
+            ExternalAppPolicy(
+                external_app_id=app.id,
+                action_id=action_id,
+                policy=policy,
+            )
+        )
     db_session.flush()
     return app
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -93,12 +93,12 @@ def test_unauthenticated_provider_delivers_nothing(
     assert not _has_slack_content(files)
 
 
-def test_denied_action_rendered_as_disabled(
+def test_denied_action_listed_as_unavailable(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    """A ``DENY`` policy override surfaces the action under the disabled list,
-    while the rest stay available; the raw template is never shipped."""
+    """A ``DENY`` policy override surfaces the action in the unavailable warning;
+    available actions are not listed, and the raw template is never shipped."""
     user = make_user(db_session)
     skill = _slack_skill(db_session)
     app = make_external_app(
@@ -115,20 +115,21 @@ def test_denied_action_rendered_as_disabled(
 
     assert f"{_SLACK_ID}/SKILL.md.template" not in files
     rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
-    disabled_section = rendered.split("disabled — do not attempt them:", 1)[1]
-    # The denied write lands in the disabled list as a bullet; a default-ALWAYS
-    # read does not (its "### List channels" usage header lives elsewhere).
-    assert "- **Post a message**" in disabled_section
-    assert "- **List channels**" not in disabled_section
+    warning = rendered.split(
+        "These actions are unavailable and should not be attempted:", 1
+    )[1]
+    # The denied write is listed; an available read is not (its "### List
+    # channels" usage header lives elsewhere, never as a "- List channels" item).
+    assert "- Post a message" in warning
+    assert "- List channels" not in warning
 
 
-def test_ask_default_action_rendered_as_available(
+def test_no_disabled_actions_omits_section(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    """With no overrides, the write action falls back to its ``ASK`` default,
-    which counts as available (not disabled) — ASK and ALWAYS aren't
-    distinguished in the skill file."""
+    """With no ``DENY`` overrides nothing is unavailable, so the warning section
+    is omitted entirely — available actions are never enumerated."""
     user = make_user(db_session)
     skill = _slack_skill(db_session)
     app = make_external_app(
@@ -143,10 +144,8 @@ def test_ask_default_action_rendered_as_available(
     files = build_skills_fileset_for_user(user, db_session)
 
     rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
-    # Slack's write action defaults to ASK -> available, not disabled.
-    assert "- **Post a message**" in rendered
-    # No DENY policies -> the disabled section is omitted entirely.
-    assert "disabled" not in rendered
+    # No DENY policies -> the unavailable-actions warning is omitted entirely.
+    assert "unavailable and should not be attempted" not in rendered
 
 
 def test_disabled_provider_delivers_nothing_even_when_authenticated(

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import Skill
 from onyx.db.models import User
+from onyx.external_apps.providers.slack import SlackAction
 from onyx.skills.built_in import SLACK
 from onyx.skills.push import build_skills_fileset_for_user
 from tests.external_dependency_unit.craft._test_helpers import make_external_app
@@ -89,6 +91,62 @@ def test_unauthenticated_provider_delivers_nothing(
     files = build_skills_fileset_for_user(user, db_session)
 
     assert not _has_slack_content(files)
+
+
+def test_denied_action_rendered_as_disabled(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """A ``DENY`` policy override surfaces the action under the disabled list,
+    while the rest stay available; the raw template is never shipped."""
+    user = make_user(db_session)
+    skill = _slack_skill(db_session)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+        action_policies={SlackAction.MESSAGES_WRITE.value: EndpointPolicy.DENY},
+    )
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+    db_session.commit()
+
+    files = build_skills_fileset_for_user(user, db_session)
+
+    assert f"{_SLACK_ID}/SKILL.md.template" not in files
+    rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
+    disabled_section = rendered.split("disabled — do not attempt them:", 1)[1]
+    # The denied write lands in the disabled list as a bullet; a default-ALWAYS
+    # read does not (its "### List channels" usage header lives elsewhere).
+    assert "- **Post a message**" in disabled_section
+    assert "- **List channels**" not in disabled_section
+
+
+def test_ask_default_action_rendered_as_available(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    """With no overrides, the write action falls back to its ``ASK`` default and
+    is rendered as available-with-approval rather than disabled."""
+    user = make_user(db_session)
+    skill = _slack_skill(db_session)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template=_AUTH_TEMPLATE,
+    )
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+    db_session.commit()
+
+    files = build_skills_fileset_for_user(user, db_session)
+
+    rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
+    available, _, disabled = rendered.partition("No actions are disabled.")
+    # Slack's write action defaults to ASK -> available, annotated, not disabled.
+    assert "Post a message" in available
+    assert "_(requires approval)_" in available
+    assert "No actions are disabled." in rendered
 
 
 def test_disabled_provider_delivers_nothing_even_when_authenticated(

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -126,8 +126,9 @@ def test_ask_default_action_rendered_as_available(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
-    """With no overrides, the write action falls back to its ``ASK`` default and
-    is rendered as available-with-approval rather than disabled."""
+    """With no overrides, the write action falls back to its ``ASK`` default,
+    which counts as available (not disabled) — ASK and ALWAYS aren't
+    distinguished in the skill file."""
     user = make_user(db_session)
     skill = _slack_skill(db_session)
     app = make_external_app(
@@ -142,10 +143,9 @@ def test_ask_default_action_rendered_as_available(
     files = build_skills_fileset_for_user(user, db_session)
 
     rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
-    available, _, disabled = rendered.partition("No actions are disabled.")
-    # Slack's write action defaults to ASK -> available, annotated, not disabled.
-    assert "Post a message" in available
-    assert "_(requires approval)_" in available
+    available, _, _ = rendered.partition("No actions are disabled.")
+    # Slack's write action defaults to ASK -> available, not disabled.
+    assert "- **Post a message**" in available
     assert "No actions are disabled." in rendered
 
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -143,10 +143,10 @@ def test_ask_default_action_rendered_as_available(
     files = build_skills_fileset_for_user(user, db_session)
 
     rendered = files[f"{_SLACK_ID}/SKILL.md"].decode("utf-8")
-    available, _, _ = rendered.partition("No actions are disabled.")
     # Slack's write action defaults to ASK -> available, not disabled.
-    assert "- **Post a message**" in available
-    assert "No actions are disabled." in rendered
+    assert "- **Post a message**" in rendered
+    # No DENY policies -> the disabled section is omitted entirely.
+    assert "disabled" not in rendered
 
 
 def test_disabled_provider_delivers_nothing_even_when_authenticated(

--- a/docs/external-app-skill-action-availability.md
+++ b/docs/external-app-skill-action-availability.md
@@ -41,10 +41,11 @@ Search messages are enabled; Post a message is disabled."
   the stored overrides. There is no getter by `skill_id` yet — add one.
 
 - **Availability semantics:** `DENY` = disabled; `ALWAYS`/`ASK` = available
-  (an `ASK` action *can* be used, it just prompts for approval). We render two
-  groups — Available and Disabled — and annotate `ASK` actions as
-  "requires approval" so the agent can prefer auto-approved paths. This matches
-  the gate's actual behavior and the user's "enabled / disabled" framing.
+  (an `ASK` action *can* be used, it just prompts for approval at egress). We
+  render two groups — Available and Disabled — and do **not** distinguish
+  `ASK` from `ALWAYS` in the skill file: the approval prompt is handled by the
+  gate at call time, so the agent only needs the binary enabled/disabled signal.
+  This matches the user's "enabled / disabled" framing.
 
 - **The skill file is a hint, not the enforcement boundary.** The proxy gate
   remains the source of truth. If policy changes after a sandbox is hydrated the

--- a/docs/external-app-skill-action-availability.md
+++ b/docs/external-app-skill-action-availability.md
@@ -1,0 +1,108 @@
+# Inject per-action availability into external-app skill files
+
+## Issues to Address
+
+External-app skills (Slack, Linear, Gmail, Google Calendar) ship a static
+`SKILL.md` that describes every action the helper script can perform. The agent
+running in the sandbox has no idea which of those actions the admin has actually
+enabled — that knowledge lives only in the `ExternalAppPolicy` table and is
+enforced lazily at egress by the sandbox proxy gate. The result: the agent
+happily attempts actions that are policy-`DENY`d, only to be blocked at call
+time (wasted turns, confusing failures).
+
+We want the skill file to state, per provider, which actions are available and
+which are disabled — rendered per-user from the effective policy at push time.
+Example: the Slack SKILL.md should say "List channels, Read channel messages,
+Search messages are enabled; Post a message is disabled."
+
+## Important Notes
+
+- **The rendering mechanism already exists.** `company-search` is a templated
+  built-in: its on-disk file is `SKILL.md.template`, and `skills/push.py`
+  →`_render_template()` substitutes a `{{AVAILABLE_SOURCES_SECTION}}` placeholder
+  per user via `skills/rendering.py:render_company_search_skill()`. We follow the
+  same pattern for external-app skills. `has_template` is derived from the
+  presence of `SKILL.md.template` on disk (`built_in.py`), and `_is_excluded`
+  already skips raw `.template` files from the static copy — so converting a
+  provider's `SKILL.md` → `SKILL.md.template` automatically routes it through
+  `_render_template`.
+
+- **Effective policy is already computed.** `external_apps/providers/registry.py`
+  →`action_policy_views(app_type, stored)` merges the code catalog with the
+  admin's sparse stored overrides and returns one `ActionPolicyView` per catalog
+  action with the effective `state` (`ALWAYS` / `ASK` / `DENY`). We reuse this
+  verbatim — no new policy-resolution logic.
+
+- **Mapping skill → app_type → policies.** An external-app built-in `Skill` row
+  has `built_in_skill_id` (e.g. `"slack"`). `EXTERNAL_APP_BUILT_IN_SKILL_IDS`
+  (`built_in.py`) maps `app_type → skill_id`; we add the inverse so the renderer
+  can go `built_in_skill_id → app_type`. The `ExternalApp` row links to the skill
+  via `ExternalApp.skill_id`; `db/external_app.py:get_policies(app_id)` returns
+  the stored overrides. There is no getter by `skill_id` yet — add one.
+
+- **Availability semantics:** `DENY` = disabled; `ALWAYS`/`ASK` = available
+  (an `ASK` action *can* be used, it just prompts for approval). We render two
+  groups — Available and Disabled — and annotate `ASK` actions as
+  "requires approval" so the agent can prefer auto-approved paths. This matches
+  the gate's actual behavior and the user's "enabled / disabled" framing.
+
+- **The skill file is a hint, not the enforcement boundary.** The proxy gate
+  remains the source of truth. If policy changes after a sandbox is hydrated the
+  file is stale until the next push;
+  `push_skill_to_affected_sandboxes` already re-pushes filesets on skill changes.
+  (Wiring policy-update → re-push is out of scope here; noted as a follow-up.)
+
+- **Atomicity:** converting a provider's `SKILL.md` to `.template` while
+  `_render_template` does not yet handle it would drop the file entirely (static
+  copy skips `.template`, renderer skips unknown skills). The template conversion
+  and the `_render_template` dispatch must land together.
+
+## Implementation Strategy
+
+1. **`db/external_app.py`** — add `get_external_app_by_skill_id(db_session,
+   skill_id) -> ExternalApp | None`, eager-loading `policies` (mirrors
+   `get_external_app_by_id`).
+
+2. **`skills/built_in.py`** — derive and export
+   `EXTERNAL_APP_SKILL_ID_TO_APP_TYPE` (inverse of
+   `EXTERNAL_APP_BUILT_IN_SKILL_IDS`).
+
+3. **`skills/rendering.py`** — add `render_external_app_skill(db_session,
+   slug, app_type, external_app, skills_dir) -> str`:
+   - read `{skills_dir}/{slug}/SKILL.md.template`
+   - `stored = get_policies(db_session, external_app.id)` (or `{}` if no app row)
+   - `views = action_policy_views(app_type, stored)`
+   - split into available (`state != DENY`) and disabled (`state == DENY`);
+     annotate `ASK` rows; build a markdown section
+   - substitute `{{ACTION_AVAILABILITY_SECTION}}` and return
+
+4. **`skills/push.py`** — extend `_render_template()`: if
+   `definition.built_in_skill_id` is in `EXTERNAL_APP_SKILL_ID_TO_APP_TYPE`,
+   look up the `ExternalApp` by `skill.id` and render via
+   `render_external_app_skill`; keep the company-search branch; keep the warning
+   fallback.
+
+5. **Templates** — for `slack`, `linear`, `gmail`, `google-calendar`: rename
+   `SKILL.md` → `SKILL.md.template` and insert an
+   `## Available actions\n\n{{ACTION_AVAILABILITY_SECTION}}` section near the top
+   (after the intro, before Usage). Content otherwise unchanged.
+
+## Tests
+
+External-dependency unit test (needs Postgres for the `ExternalApp` /
+`ExternalAppPolicy` / `Skill` rows), added alongside
+`tests/external_dependency_unit/craft/test_external_app_fileset.py`:
+
+- Slack app with a policy override setting `MESSAGES_WRITE` → `DENY`, others left
+  at their `ALWAYS` defaults; authenticated user. Assert the rendered
+  `slack/SKILL.md`:
+  - contains the available actions (e.g. "List channels") under the available
+    group,
+  - lists "Post a message" as disabled,
+  - does **not** ship `slack/SKILL.md.template` raw.
+- Slack app with no policy overrides: assert the write action falls back to its
+  `ASK` default and is rendered as available-with-approval (not disabled).
+
+Existing `test_external_app_fileset.py` (no overrides) must still pass — it only
+asserts presence of `slack/SKILL.md` and `slack/slack_api.py`, both still
+produced.

--- a/docs/external-app-skill-action-availability.md
+++ b/docs/external-app-skill-action-availability.md
@@ -10,10 +10,13 @@ enforced lazily at egress by the sandbox proxy gate. The result: the agent
 happily attempts actions that are policy-`DENY`d, only to be blocked at call
 time (wasted turns, confusing failures).
 
-We want the skill file to state, per provider, which actions are available and
-which are disabled — rendered per-user from the effective policy at push time.
-Example: the Slack SKILL.md should say "List channels, Read channel messages,
-Search messages are enabled; Post a message is disabled."
+We want the skill file to fence off, per provider, the actions the admin has
+disabled — rendered per-user from the effective policy at push time. Only the
+disabled (`DENY`) actions are listed; available actions are left to the skill
+body, which already documents them. Example: when an admin disables Slack
+posting, the Slack SKILL.md gains "These actions are unavailable and should not
+be attempted: - Post a message"; with nothing disabled, no such section is
+injected.
 
 ## Important Notes
 
@@ -40,12 +43,11 @@ Search messages are enabled; Post a message is disabled."
   via `ExternalApp.skill_id`; `db/external_app.py:get_policies(app_id)` returns
   the stored overrides. There is no getter by `skill_id` yet — add one.
 
-- **Availability semantics:** `DENY` = disabled; `ALWAYS`/`ASK` = available
-  (an `ASK` action *can* be used, it just prompts for approval at egress). We
-  render two groups — Available and Disabled — and do **not** distinguish
-  `ASK` from `ALWAYS` in the skill file: the approval prompt is handled by the
-  gate at call time, so the agent only needs the binary enabled/disabled signal.
-  This matches the user's "enabled / disabled" framing.
+- **Availability semantics:** only `DENY` is surfaced — those actions are listed
+  as unavailable. `ALWAYS` and `ASK` are both treated as available and are *not*
+  enumerated (the skill body documents them, and the `ASK` approval prompt is
+  handled by the gate at call time). When nothing is disabled the section is
+  omitted entirely, so the skill file is unchanged from its static form.
 
 - **The skill file is a hint, not the enforcement boundary.** The proxy gate
   remains the source of truth. If policy changes after a sandbox is hydrated the
@@ -68,25 +70,29 @@ Search messages are enabled; Post a message is disabled."
    `EXTERNAL_APP_SKILL_ID_TO_APP_TYPE` (inverse of
    `EXTERNAL_APP_BUILT_IN_SKILL_IDS`).
 
-3. **`skills/rendering.py`** — add `render_external_app_skill(db_session,
-   slug, app_type, external_app, skills_dir) -> str`:
-   - read `{skills_dir}/{slug}/SKILL.md.template`
-   - `stored = get_policies(db_session, external_app.id)` (or `{}` if no app row)
-   - `views = action_policy_views(app_type, stored)`
-   - split into available (`state != DENY`) and disabled (`state == DENY`);
-     annotate `ASK` rows; build a markdown section
-   - substitute `{{ACTION_AVAILABILITY_SECTION}}` and return
+3. **`skills/rendering.py`** — add:
+   - `build_action_availability_section(app_type, stored) -> str`:
+     `views = action_policy_views(app_type, stored)`, keep only `state == DENY`,
+     and return `"These actions are unavailable and should not be attempted:"`
+     followed by a `- {normalised_name}` list — or `""` when nothing is disabled.
+   - `render_external_app_skill(db_session, app_type, external_app, skill_dir)`:
+     read `{skill_dir}/SKILL.md.template`, resolve
+     `stored = get_policies(db_session, external_app.id)` (or `{}` if no app row),
+     and substitute `{{ACTION_AVAILABILITY_SECTION}}`. When the section is empty,
+     drop the placeholder *and* its trailing blank line so the surrounding
+     sections stay flush.
 
 4. **`skills/push.py`** — extend `_render_template()`: if
    `definition.built_in_skill_id` is in `EXTERNAL_APP_SKILL_ID_TO_APP_TYPE`,
    look up the `ExternalApp` by `skill.id` and render via
-   `render_external_app_skill`; keep the company-search branch; keep the warning
-   fallback.
+   `render_external_app_skill` (passing `definition.source_dir`); keep the
+   company-search branch; keep the warning fallback.
 
 5. **Templates** — for `slack`, `linear`, `gmail`, `google-calendar`: rename
-   `SKILL.md` → `SKILL.md.template` and insert an
-   `## Available actions\n\n{{ACTION_AVAILABILITY_SECTION}}` section near the top
-   (after the intro, before Usage). Content otherwise unchanged.
+   `SKILL.md` → `SKILL.md.template` and insert a bare `{{ACTION_AVAILABILITY_SECTION}}`
+   placeholder after the intro, before Usage (no surrounding heading — the
+   rendered block carries its own text and disappears when empty). Content
+   otherwise unchanged.
 
 ## Tests
 
@@ -95,14 +101,13 @@ External-dependency unit test (needs Postgres for the `ExternalApp` /
 `tests/external_dependency_unit/craft/test_external_app_fileset.py`:
 
 - Slack app with a policy override setting `MESSAGES_WRITE` → `DENY`, others left
-  at their `ALWAYS` defaults; authenticated user. Assert the rendered
-  `slack/SKILL.md`:
-  - contains the available actions (e.g. "List channels") under the available
-    group,
-  - lists "Post a message" as disabled,
+  at their defaults; authenticated user. Assert the rendered `slack/SKILL.md`:
+  - lists "Post a message" under the "unavailable ... should not be attempted"
+    warning,
+  - does **not** list an available read (e.g. "List channels") there,
   - does **not** ship `slack/SKILL.md.template` raw.
-- Slack app with no policy overrides: assert the write action falls back to its
-  `ASK` default and is rendered as available-with-approval (not disabled).
+- Slack app with no policy overrides: assert the unavailable-actions warning is
+  omitted entirely (available actions are never enumerated).
 
 Existing `test_external_app_fileset.py` (no overrides) must still pass — it only
 asserts presence of `slack/SKILL.md` and `slack/slack_api.py`, both still


### PR DESCRIPTION
## Description
Currently a skill file is static and mentions all the actions that are available even if some have been explicitly denied. This templates the external app skills files such that it can now tell which are approved and which are denied, disincentivizing the llm from running revoked actions.

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show per-user unavailable actions in external-app `SKILL.md` so the agent avoids blocked calls. Only denied actions are listed, and the section is omitted when nothing is disabled.

- **New Features**
  - Converted `slack`, `linear`, `gmail`, and `google-calendar` `SKILL.md` to `SKILL.md.template` with `{{ACTION_AVAILABILITY_SECTION}}`.
  - Render per-user on push using effective policies; `DENY` actions appear under “These actions are unavailable and should not be attempted:”. `ALWAYS`/`ASK` are treated as available and not enumerated; falls back to provider defaults, removes the placeholder when empty, and never ships templates raw.
  - Added `get_external_app_by_skill_id`, `EXTERNAL_APP_SKILL_ID_TO_APP_TYPE`, and `render_external_app_skill`; plus docs and tests verifying denied actions are listed and the section is omitted when none are disabled.

<sup>Written for commit ccf3817a912b30ec653923557c9cfed705823746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

