### PR TITLE
perf(web): disable React Compiler in the dev server

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,5 +1,6 @@
 // Always require withSentryConfig
 const { withSentryConfig } = require("@sentry/nextjs");
+const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 
 const cspHeader = `
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
@@ -24,7 +25,8 @@ const nextConfig = {
   allowedDevOrigins: ["cataract-brunette-icon.ngrok-free.dev"],
   transpilePackages: ["@onyx-ai/opal"],
   typedRoutes: true,
-  reactCompiler: true,
+  // NOTE: `reactCompiler` is set per-phase in module.exports below — enabled for
+  // builds, disabled for the dev server. See the comment there for the rationale.
   // Pin the workspace root to this directory so Turbopack resolves modules
   // against web/bun.lock. Without this, Next.js detects multiple lockfiles
   // (the repo-root bun.lock and web/bun.lock) and infers the wrong root.
@@ -190,5 +192,22 @@ const sentryWebpackPluginOptions = {
   }),
 };
 
-// Export the module with conditional Sentry configuration
-module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+// Export the module with conditional Sentry configuration.
+//
+// React Compiler is a production runtime optimization (automatic memoization). It
+// provides no runtime benefit during local development, but it is expensive in the
+// dev server: under Turbopack there is no native SWC path, so Next runs
+// `babel-plugin-react-compiler` through a JS babel-loader that Turbopack executes
+// in a pool of per-CPU-core worker subprocesses. On a many-core machine this roughly
+// doubles dev-server peak memory and adds ~35-50% to route compile times.
+//
+// So enable it for builds (`next build`) and disable it for the dev server
+// (`next dev`). Set ENABLE_REACT_COMPILER=1 to force it on locally when you want to
+// validate React Compiler behavior in dev.
+module.exports = (phase) => {
+  const isDevServer = phase === PHASE_DEVELOPMENT_SERVER;
+  nextConfig.reactCompiler =
+    !isDevServer || process.env.ENABLE_REACT_COMPILER === "1";
+
+  return withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+};

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -206,8 +206,11 @@ const sentryWebpackPluginOptions = {
 // validate React Compiler behavior in dev.
 module.exports = (phase) => {
   const isDevServer = phase === PHASE_DEVELOPMENT_SERVER;
-  nextConfig.reactCompiler =
-    !isDevServer || process.env.ENABLE_REACT_COMPILER === "1";
-
-  return withSentryConfig(nextConfig, sentryWebpackPluginOptions);
+  return withSentryConfig(
+    {
+      ...nextConfig,
+      reactCompiler: !isDevServer || process.env.ENABLE_REACT_COMPILER === "1",
+    },
+    sentryWebpackPluginOptions
+  );
 };


### PR DESCRIPTION
## What

React Compiler is a production runtime optimization (automatic memoization). It provides no runtime benefit during local development, but it is expensive in the dev server.

Under Turbopack there is no native SWC path for React Compiler, so Next runs `babel-plugin-react-compiler` through a JS babel-loader that Turbopack executes in a pool of per-CPU-core worker subprocesses. On a many-core machine this roughly doubles dev-server peak memory and adds significant time to route compiles.

This makes `next.config.js` phase-aware: React Compiler stays on for `next build`, and is disabled for `next dev`. Set `ENABLE_REACT_COMPILER=1` to force it on locally when you want to validate React Compiler behavior in dev.

## Measurements

Cold cache, 24-core box (React Compiler ON → OFF):

| metric | RC ON | RC OFF |
|---|---|---|
| peak dev-server RSS | ~4.9 GB | ~2.8 GB |
| `/app` first compile (next.js) | ~27 s | ~17 s |
| babel loader workers | up to ~25 | ~2 |

Production builds are unchanged — RC still runs for `next build`.

## Test plan

- [x] Config resolves `reactCompiler` → `false` for the dev-server phase, `true` for the production-build phase, and `true` in dev when `ENABLE_REACT_COMPILER=1`.
- [x] `next dev` boots and compiles routes with the new config; loader-worker count drops from ~25 to ~2.
- [ ] Confirm `next build` still applies React Compiler (CI build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable React Compiler in the dev server to cut memory and speed up route compiles, while keeping it on for production builds. On a 24‑core box this dropped dev-server RSS from ~4.9 GB to ~2.8 GB and first compile from ~27s to ~17s.

- **Refactors**
  - Made `next.config.js` phase-aware: `reactCompiler` is off in `next dev` and on in `next build`.
  - Avoided mutating shared `nextConfig` by spreading into a fresh object in the export, so per-phase `reactCompiler` stays local.
  - Added an escape hatch: set `ENABLE_REACT_COMPILER=1` to enable it in dev for validation.

- **Migration**
  - No action needed. To test React Compiler locally in dev, run with `ENABLE_REACT_COMPILER=1`.

<sup>Written for commit c5fe237fb91c46781447870f568a25490f0c2a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

