### PR TITLE
fix(chat): recover raw answer when content/citation processing strips it empty

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -12,6 +12,7 @@ from onyx.chat.citation_processor import CitationMode
 from onyx.chat.citation_processor import DynamicCitationProcessor
 from onyx.chat.citation_utils import update_citation_processor_from_tool_response
 from onyx.chat.emitter import Emitter
+from onyx.chat.llm_step import _looks_like_xml_tool_call_payload
 from onyx.chat.llm_step import extract_tool_calls_from_response_text
 from onyx.chat.llm_step import run_llm_step
 from onyx.chat.models import ChatMessageSimple
@@ -131,18 +132,6 @@ def _build_empty_llm_response_error(
             "completed. No text or tool calls were received from the upstream "
             "provider."
         ),
-    )
-
-
-def _looks_like_xml_tool_call_payload(text: str | None) -> bool:
-    """Detect XML-style marshaled tool calls emitted as plain text."""
-    if not text:
-        return False
-    lowered = text.lower()
-    return (
-        "<function_calls" in lowered
-        and "<invoke" in lowered
-        and "<parameter" in lowered
     )
 
 

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1414,6 +1414,51 @@ def run_llm_step_pkt_generator(
     if citation_processor:
         yield from _emit_citation_results(citation_processor.process_token(None))
 
+    # ── Empty-answer recovery ───────────────────────────────────────────────
+    # The model may emit real text that is then entirely consumed by content/
+    # citation processing, leaving an empty displayed answer. The most common
+    # trigger is an answer dominated by bracketed-numeric text that matches the
+    # citation pattern but has no entry in the citation mapping (e.g. a long
+    # bracketed number like "[123456789012345]", an array, or a list of ids):
+    # DynamicCitationProcessor intentionally strips such unmapped markers, which
+    # can reduce the whole answer to nothing even though the provider clearly
+    # responded. Without this guard the empty answer propagates to run_llm_loop
+    # and raises EmptyLLMResponseError ("the provider returned no text or tool
+    # calls"), which is both misleading and silent in logs. Surface the raw
+    # model output instead. Restricted to non-REQUIRED tool choice so the
+    # deep-research / forced-tool flows (where pre-tool content is reasoning and
+    # an empty answer is expected) keep relying on fallback tool extraction.
+    if (
+        tool_choice != ToolChoiceOptions.REQUIRED
+        and not tool_calls
+        and not accumulated_answer.strip()
+        and accumulated_raw_answer.strip()
+    ):
+        logger.warning(
+            "Answer empty after content/citation processing; recovering raw "
+            "model output (%d chars). provider=%s, model=%s, finish_reasons=%s",
+            len(accumulated_raw_answer),
+            llm.config.model_provider,
+            llm.config.model_name,
+            sorted(finish_reasons),
+        )
+        if not answer_start:
+            yield Packet(
+                placement=_current_placement(),
+                obj=AgentResponseStart(
+                    final_documents=final_documents,
+                    pre_answer_processing_seconds=pre_answer_processing_time,
+                ),
+            )
+            answer_start = True
+        yield Packet(
+            placement=_current_placement(),
+            obj=AgentResponseDelta(content=accumulated_raw_answer),
+        )
+        accumulated_answer = accumulated_raw_answer
+        if state_container:
+            state_container.set_answer_tokens(accumulated_answer)
+
     # Note: Content (AgentResponseDelta) doesn't need an explicit end packet - OverallStop handles it
     # Tool calls are handled by tool execution code and emit their own packets (e.g., SectionEnd)
     if LOG_ONYX_MODEL_INTERACTIONS:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -173,6 +173,18 @@ def _find_function_calls_open_marker(text_lower: str) -> int:
         search_from = idx + 1
 
 
+def _looks_like_xml_tool_call_payload(text: str | None) -> bool:
+    """Detect XML-style marshaled tool calls emitted as plain text."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return (
+        "<function_calls" in lowered
+        and "<invoke" in lowered
+        and "<parameter" in lowered
+    )
+
+
 def _try_parse_json_string(value: Any) -> Any:
     """Attempt to parse a JSON string value into its Python equivalent.
 
@@ -1389,11 +1401,15 @@ def run_llm_step_pkt_generator(
         # raw output instead of returning an empty answer, which would raise a
         # misleading EmptyLLMResponseError downstream. Skipped for REQUIRED tool
         # choice, where empty pre-tool content is expected (fallback extraction).
+        # Also skipped when the raw output is XML tool-call markup: run_llm_loop's
+        # fallback extraction will parse it into a real tool call, so surfacing it
+        # as an answer would leak raw markup to the client and pollute context.
         if (
             tool_choice != ToolChoiceOptions.REQUIRED
             and not tool_calls
             and not accumulated_answer.strip()
             and accumulated_raw_answer.strip()
+            and not _looks_like_xml_tool_call_payload(accumulated_raw_answer)
         ):
             logger.warning(
                 "Answer empty after content/citation processing; recovering raw "

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -174,15 +174,18 @@ def _find_function_calls_open_marker(text_lower: str) -> int:
 
 
 def _looks_like_xml_tool_call_payload(text: str | None) -> bool:
-    """Detect XML-style marshaled tool calls emitted as plain text."""
+    """Detect XML-style marshaled tool calls emitted as plain text.
+
+    Intentionally does NOT require a <parameter> tag: zero-argument invocations
+    (e.g. <function_calls><invoke name="get_time"></invoke></function_calls>) are
+    valid tool calls that _extract_xml_tool_calls_from_response_text can parse, so
+    requiring <parameter> would both miss them in fallback extraction and let the
+    empty-answer recovery leak the raw markup as an answer.
+    """
     if not text:
         return False
     lowered = text.lower()
-    return (
-        "<function_calls" in lowered
-        and "<invoke" in lowered
-        and "<parameter" in lowered
-    )
+    return "<function_calls" in lowered and "<invoke" in lowered
 
 
 def _try_parse_json_string(value: Any) -> Any:

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1372,6 +1372,76 @@ def run_llm_step_pkt_generator(
             tab_index=tab_index if use_existing_tab_index else None,
             sub_turn_index=sub_turn_index,
         )
+        # Close reasoning, flush any held-back citation text, and run empty-answer
+        # recovery BEFORE recording span output below — all while the generation
+        # span is still open — so the trace reflects the answer the user actually
+        # received rather than an intermediate (possibly empty) state.
+        yield from _close_reasoning_if_active()
+
+        # Flush any remaining content from citation processor
+        # Reasoning is always first so this should use the post-incremented value of turn_index
+        # Note that this doesn't need to handle any sub-turns as those docs will not have citations
+        # as clickable items and will be stripped out instead.
+        if citation_processor:
+            yield from _emit_citation_results(citation_processor.process_token(None))
+
+        # ── Empty-answer recovery ───────────────────────────────────────────
+        # The model may emit real text that is then entirely consumed by content/
+        # citation processing, leaving an empty displayed answer. The most common
+        # trigger is an answer dominated by bracketed-numeric text that matches
+        # the citation pattern but has no entry in the citation mapping (e.g. a
+        # long bracketed number like "[123456789012345]", an array, or a list of
+        # ids): DynamicCitationProcessor intentionally strips such unmapped
+        # markers, which can reduce the whole answer to nothing even though the
+        # provider clearly responded. Without this guard the empty answer
+        # propagates to run_llm_loop and raises EmptyLLMResponseError ("the
+        # provider returned no text or tool calls"), which is both misleading and
+        # silent in logs. Surface the raw model output instead. Restricted to
+        # non-REQUIRED tool choice so the deep-research / forced-tool flows (where
+        # pre-tool content is reasoning and an empty answer is expected) keep
+        # relying on fallback tool extraction.
+        if (
+            tool_choice != ToolChoiceOptions.REQUIRED
+            and not tool_calls
+            and not accumulated_answer.strip()
+            and accumulated_raw_answer.strip()
+        ):
+            logger.warning(
+                "Answer empty after content/citation processing; recovering raw "
+                "model output (%d chars). provider=%s, model=%s, finish_reasons=%s",
+                len(accumulated_raw_answer),
+                llm.config.model_provider,
+                llm.config.model_name,
+                sorted(finish_reasons),
+            )
+            if not answer_start:
+                # Mirror _emit_content_chunk: persist pre-answer timing before the
+                # first AgentResponseStart so the metric is populated even when the
+                # only content reached us via this recovery path.
+                if state_container and pre_answer_processing_time is not None:
+                    state_container.set_pre_answer_processing_time(
+                        pre_answer_processing_time
+                    )
+                yield Packet(
+                    placement=_current_placement(),
+                    obj=AgentResponseStart(
+                        final_documents=final_documents,
+                        pre_answer_processing_seconds=pre_answer_processing_time,
+                    ),
+                )
+                answer_start = True
+            yield Packet(
+                placement=_current_placement(),
+                obj=AgentResponseDelta(content=accumulated_raw_answer),
+            )
+            accumulated_answer = accumulated_raw_answer
+            if state_container:
+                state_container.set_answer_tokens(accumulated_answer)
+
+        # Record the final assistant output for tracing. Done after the citation
+        # flush and empty-answer recovery so the span reflects the answer the user
+        # received (including a recovered raw answer) rather than an intermediate
+        # empty state.
         if tool_calls:
             tool_calls_list: list[ToolCall] = [
                 ToolCall(
@@ -1402,62 +1472,6 @@ def run_llm_step_pkt_generator(
         # Record reasoning content for tracing (extended thinking from reasoning models)
         if accumulated_reasoning:
             span_generation.span_data.reasoning = accumulated_reasoning
-
-    # This may happen if the custom token processor is used to modify other packets into reasoning
-    # Then there won't necessarily be anything else to come after the reasoning tokens
-    yield from _close_reasoning_if_active()
-
-    # Flush any remaining content from citation processor
-    # Reasoning is always first so this should use the post-incremented value of turn_index
-    # Note that this doesn't need to handle any sub-turns as those docs will not have citations
-    # as clickable items and will be stripped out instead.
-    if citation_processor:
-        yield from _emit_citation_results(citation_processor.process_token(None))
-
-    # ── Empty-answer recovery ───────────────────────────────────────────────
-    # The model may emit real text that is then entirely consumed by content/
-    # citation processing, leaving an empty displayed answer. The most common
-    # trigger is an answer dominated by bracketed-numeric text that matches the
-    # citation pattern but has no entry in the citation mapping (e.g. a long
-    # bracketed number like "[123456789012345]", an array, or a list of ids):
-    # DynamicCitationProcessor intentionally strips such unmapped markers, which
-    # can reduce the whole answer to nothing even though the provider clearly
-    # responded. Without this guard the empty answer propagates to run_llm_loop
-    # and raises EmptyLLMResponseError ("the provider returned no text or tool
-    # calls"), which is both misleading and silent in logs. Surface the raw
-    # model output instead. Restricted to non-REQUIRED tool choice so the
-    # deep-research / forced-tool flows (where pre-tool content is reasoning and
-    # an empty answer is expected) keep relying on fallback tool extraction.
-    if (
-        tool_choice != ToolChoiceOptions.REQUIRED
-        and not tool_calls
-        and not accumulated_answer.strip()
-        and accumulated_raw_answer.strip()
-    ):
-        logger.warning(
-            "Answer empty after content/citation processing; recovering raw "
-            "model output (%d chars). provider=%s, model=%s, finish_reasons=%s",
-            len(accumulated_raw_answer),
-            llm.config.model_provider,
-            llm.config.model_name,
-            sorted(finish_reasons),
-        )
-        if not answer_start:
-            yield Packet(
-                placement=_current_placement(),
-                obj=AgentResponseStart(
-                    final_documents=final_documents,
-                    pre_answer_processing_seconds=pre_answer_processing_time,
-                ),
-            )
-            answer_start = True
-        yield Packet(
-            placement=_current_placement(),
-            obj=AgentResponseDelta(content=accumulated_raw_answer),
-        )
-        accumulated_answer = accumulated_raw_answer
-        if state_container:
-            state_container.set_answer_tokens(accumulated_answer)
 
     # Note: Content (AgentResponseDelta) doesn't need an explicit end packet - OverallStop handles it
     # Tool calls are handled by tool execution code and emit their own packets (e.g., SectionEnd)

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1372,10 +1372,8 @@ def run_llm_step_pkt_generator(
             tab_index=tab_index if use_existing_tab_index else None,
             sub_turn_index=sub_turn_index,
         )
-        # Close reasoning, flush any held-back citation text, and run empty-answer
-        # recovery BEFORE recording span output below — all while the generation
-        # span is still open — so the trace reflects the answer the user actually
-        # received rather than an intermediate (possibly empty) state.
+        # Run the flush + recovery below while the span is still open, so the
+        # span output recorded afterward reflects the answer the user received.
         yield from _close_reasoning_if_active()
 
         # Flush any remaining content from citation processor
@@ -1385,21 +1383,12 @@ def run_llm_step_pkt_generator(
         if citation_processor:
             yield from _emit_citation_results(citation_processor.process_token(None))
 
-        # ── Empty-answer recovery ───────────────────────────────────────────
-        # The model may emit real text that is then entirely consumed by content/
-        # citation processing, leaving an empty displayed answer. The most common
-        # trigger is an answer dominated by bracketed-numeric text that matches
-        # the citation pattern but has no entry in the citation mapping (e.g. a
-        # long bracketed number like "[123456789012345]", an array, or a list of
-        # ids): DynamicCitationProcessor intentionally strips such unmapped
-        # markers, which can reduce the whole answer to nothing even though the
-        # provider clearly responded. Without this guard the empty answer
-        # propagates to run_llm_loop and raises EmptyLLMResponseError ("the
-        # provider returned no text or tool calls"), which is both misleading and
-        # silent in logs. Surface the raw model output instead. Restricted to
-        # non-REQUIRED tool choice so the deep-research / forced-tool flows (where
-        # pre-tool content is reasoning and an empty answer is expected) keep
-        # relying on fallback tool extraction.
+        # Empty-answer recovery: the model emitted text but content/citation
+        # processing consumed all of it (e.g. an unmapped bracketed-numeric answer
+        # like "[123456789012345]" that the citation processor strips). Surface the
+        # raw output instead of returning an empty answer, which would raise a
+        # misleading EmptyLLMResponseError downstream. Skipped for REQUIRED tool
+        # choice, where empty pre-tool content is expected (fallback extraction).
         if (
             tool_choice != ToolChoiceOptions.REQUIRED
             and not tool_calls
@@ -1416,8 +1405,7 @@ def run_llm_step_pkt_generator(
             )
             if not answer_start:
                 # Mirror _emit_content_chunk: persist pre-answer timing before the
-                # first AgentResponseStart so the metric is populated even when the
-                # only content reached us via this recovery path.
+                # first AgentResponseStart.
                 if state_container and pre_answer_processing_time is not None:
                     state_container.set_pre_answer_processing_time(
                         pre_answer_processing_time
@@ -1438,10 +1426,7 @@ def run_llm_step_pkt_generator(
             if state_container:
                 state_container.set_answer_tokens(accumulated_answer)
 
-        # Record the final assistant output for tracing. Done after the citation
-        # flush and empty-answer recovery so the span reflects the answer the user
-        # received (including a recovered raw answer) rather than an intermediate
-        # empty state.
+        # Record assistant output for tracing (after flush + recovery).
         if tool_calls:
             tool_calls_list: list[ToolCall] = [
                 ToolCall(

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -19,6 +19,7 @@ from onyx.configs.constants import MessageType
 from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMConfig
+from onyx.llm.interfaces import ToolChoiceOptions
 from onyx.llm.models import AssistantMessage
 from onyx.llm.models import TextContentPart
 from onyx.llm.models import ToolMessage
@@ -720,3 +721,147 @@ class TestImageCap:
         assert len(translated) == 1
         assert isinstance(translated[0], UserMessage)
         assert len(_attached_image_file_ids(translated[0])) == 5
+
+
+class TestEmptyAnswerRecovery:
+    """Tests for the empty-answer recovery in run_llm_step_pkt_generator.
+
+    When the model emits real text that is entirely consumed by content/citation
+    processing (e.g. an answer dominated by bracketed-numeric text that matches
+    the citation pattern but has no mapping), the raw model output is surfaced
+    instead of returning an empty answer (which would otherwise raise
+    EmptyLLMResponseError downstream).
+    """
+
+    @staticmethod
+    def _make_llm() -> Any:
+        from unittest.mock import MagicMock
+
+        from onyx.llm.interfaces import LLMConfig
+
+        llm = MagicMock()
+        llm.config = LLMConfig(
+            model_provider="litellm_proxy",
+            model_name="claude-4.6-opus",
+            temperature=0.0,
+            max_input_tokens=100_000,
+        )
+        return llm
+
+    @staticmethod
+    def _content_stream(chunks: list[str]) -> Any:
+        from onyx.llm.model_response import Delta
+        from onyx.llm.model_response import ModelResponseStream
+        from onyx.llm.model_response import StreamingChoice
+
+        def _gen(*_args: Any, **_kwargs: Any) -> Any:
+            for i, chunk in enumerate(chunks):
+                yield ModelResponseStream(
+                    id="chunk",
+                    created="0",
+                    choice=StreamingChoice(
+                        finish_reason="stop" if i == len(chunks) - 1 else None,
+                        delta=Delta(content=chunk),
+                    ),
+                )
+
+        return _gen
+
+    def _run(
+        self,
+        chunks: list[str],
+        *,
+        with_citation_processor: bool,
+        tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO,
+    ) -> tuple[Any, list[Any]]:
+        from onyx.chat.citation_processor import CitationMode
+        from onyx.chat.citation_processor import DynamicCitationProcessor
+        from onyx.chat.llm_step import run_llm_step_pkt_generator
+
+        llm = self._make_llm()
+        llm.stream = self._content_stream(chunks)
+
+        citation_processor = (
+            DynamicCitationProcessor(citation_mode=CitationMode.HYPERLINK)
+            if with_citation_processor
+            else None
+        )
+
+        gen = run_llm_step_pkt_generator(
+            history=[],
+            tool_definitions=[],
+            tool_choice=tool_choice,
+            llm=llm,
+            placement=Placement(turn_index=0),
+            state_container=None,
+            citation_processor=citation_processor,
+        )
+
+        packets: list[Any] = []
+        result: Any = None
+        while True:
+            try:
+                packets.append(next(gen))
+            except StopIteration as stop:
+                result = stop.value
+                break
+
+        llm_step_result, _ = result
+        return llm_step_result, packets
+
+    def test_recovers_raw_when_citations_strip_entire_answer(self) -> None:
+        """An answer that is entirely an unmapped bracketed number is stripped to
+        empty by the citation processor; recovery surfaces the raw text."""
+        from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+
+        raw = "[1234567890123456789]"
+        llm_step_result, packets = self._run([raw], with_citation_processor=True)
+
+        # Without recovery this would be None -> EmptyLLMResponseError downstream.
+        assert llm_step_result.answer == raw
+        assert llm_step_result.raw_answer == raw
+        assert llm_step_result.tool_calls is None
+
+        # The recovered text is actually streamed to the client.
+        emitted = "".join(
+            p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
+        )
+        assert emitted == raw
+
+    def test_recovers_raw_for_numeric_list_answer(self) -> None:
+        raw = "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]"
+        llm_step_result, _ = self._run([raw], with_citation_processor=True)
+        assert llm_step_result.answer == raw
+
+    def test_no_recovery_for_normal_answer(self) -> None:
+        """Normal prose is unaffected — answer is the processed text, not a
+        duplicated raw fallback."""
+        from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+
+        chunks = ["The answer ", "is 42."]
+        llm_step_result, packets = self._run(chunks, with_citation_processor=True)
+        assert llm_step_result.answer == "The answer is 42."
+        emitted = "".join(
+            p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
+        )
+        # Streamed exactly once (no duplicate recovery emission).
+        assert emitted == "The answer is 42."
+
+    def test_no_recovery_when_no_content_emitted(self) -> None:
+        """A genuinely empty stream stays empty (so EmptyLLMResponseError can
+        still fire for real provider failures)."""
+        llm_step_result, _ = self._run([""], with_citation_processor=True)
+        assert llm_step_result.answer is None
+        assert llm_step_result.raw_answer is None
+
+    def test_no_recovery_in_required_tool_choice(self) -> None:
+        """In REQUIRED mode pre-tool content is reasoning and an empty answer is
+        expected; recovery must not fire (fallback tool extraction owns it)."""
+        raw = "[1234567890123456789]"
+        llm_step_result, _ = self._run(
+            [raw],
+            with_citation_processor=True,
+            tool_choice=ToolChoiceOptions.REQUIRED,
+        )
+        assert llm_step_result.answer is None
+        assert llm_step_result.raw_answer == raw

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -773,7 +773,14 @@ class TestEmptyAnswerRecovery:
         *,
         with_citation_processor: bool,
         tool_choice: ToolChoiceOptions = ToolChoiceOptions.AUTO,
+        state_container: Any = None,
+        pre_answer_processing_time: float | None = None,
+        span_sink: list[Any] | None = None,
     ) -> tuple[Any, list[Any]]:
+        from contextlib import nullcontext
+        from unittest.mock import patch
+
+        from onyx.chat import llm_step as _llm_step_module
         from onyx.chat.citation_processor import CitationMode
         from onyx.chat.citation_processor import DynamicCitationProcessor
         from onyx.chat.llm_step import run_llm_step_pkt_generator
@@ -787,24 +794,41 @@ class TestEmptyAnswerRecovery:
             else None
         )
 
-        gen = run_llm_step_pkt_generator(
-            history=[],
-            tool_definitions=[],
-            tool_choice=tool_choice,
-            llm=llm,
-            placement=Placement(turn_index=0),
-            state_container=None,
-            citation_processor=citation_processor,
+        # Capture the generation span so tests can assert what the trace recorded.
+        real_generation_span = _llm_step_module.generation_span
+
+        def _capturing_span(*args: Any, **kwargs: Any) -> Any:
+            span = real_generation_span(*args, **kwargs)
+            if span_sink is not None:
+                span_sink.append(span)
+            return span
+
+        span_patch = (
+            patch.object(_llm_step_module, "generation_span", _capturing_span)
+            if span_sink is not None
+            else nullcontext()
         )
 
-        packets: list[Any] = []
-        result: Any = None
-        while True:
-            try:
-                packets.append(next(gen))
-            except StopIteration as stop:
-                result = stop.value
-                break
+        with span_patch:
+            gen = run_llm_step_pkt_generator(
+                history=[],
+                tool_definitions=[],
+                tool_choice=tool_choice,
+                llm=llm,
+                placement=Placement(turn_index=0),
+                state_container=state_container,
+                citation_processor=citation_processor,
+                pre_answer_processing_time=pre_answer_processing_time,
+            )
+
+            packets: list[Any] = []
+            result: Any = None
+            while True:
+                try:
+                    packets.append(next(gen))
+                except StopIteration as stop:
+                    result = stop.value
+                    break
 
         llm_step_result, _ = result
         return llm_step_result, packets
@@ -865,3 +889,55 @@ class TestEmptyAnswerRecovery:
         )
         assert llm_step_result.answer is None
         assert llm_step_result.raw_answer == raw
+
+    def test_recovered_answer_is_recorded_in_tracing_span(self) -> None:
+        """The generation span output must reflect the recovered answer, not the
+        empty intermediate state (otherwise the recovered turn is invisible in
+        traces)."""
+        raw = "[1234567890123456789]"
+        span_sink: list[Any] = []
+        llm_step_result, _ = self._run(
+            [raw], with_citation_processor=True, span_sink=span_sink
+        )
+        assert llm_step_result.answer == raw
+
+        assert len(span_sink) == 1
+        output = span_sink[0].span_data.output
+        assert output is not None
+        # output is [AssistantMessage.model_dump()]; the recovered text is recorded.
+        assert any(raw in str(entry.get("content")) for entry in output)
+
+    def test_normal_answer_recorded_in_tracing_span(self) -> None:
+        """Sanity check that the moved span-output assignment still records normal
+        answers."""
+        span_sink: list[Any] = []
+        llm_step_result, _ = self._run(
+            ["Hello ", "world."], with_citation_processor=True, span_sink=span_sink
+        )
+        assert llm_step_result.answer == "Hello world."
+        output = span_sink[0].span_data.output
+        assert output is not None
+        assert any("Hello world." in str(entry.get("content")) for entry in output)
+
+    def test_recovery_sets_pre_answer_time_when_no_prior_answer_start(self) -> None:
+        """When all content is swallowed before reaching _emit_content_chunk (e.g.
+        an XML tool-call block the filter strips), recovery fires the
+        AgentResponseStart branch and must persist pre-answer timing — mirroring
+        the normal path — so the metric is not lost."""
+        from unittest.mock import MagicMock
+
+        # A complete <function_calls> block is stripped by the XML content filter,
+        # so _emit_content_chunk never runs and answer_start stays False, while the
+        # raw answer retains the text.
+        raw = "<function_calls><invoke>x</invoke></function_calls>"
+        state_container = MagicMock()
+        llm_step_result, _ = self._run(
+            [raw],
+            with_citation_processor=True,
+            state_container=state_container,
+            pre_answer_processing_time=1.5,
+        )
+
+        assert llm_step_result.answer == raw
+        state_container.set_pre_answer_processing_time.assert_called_once_with(1.5)
+        state_container.set_answer_tokens.assert_called_with(raw)

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -928,7 +928,8 @@ class TestEmptyAnswerRecovery:
 
         # A complete <function_calls> block is stripped by the XML content filter,
         # so _emit_content_chunk never runs and answer_start stays False, while the
-        # raw answer retains the text.
+        # raw answer retains the text. No <parameter> tag, so it is NOT classified
+        # as a tool-call payload (see test below) and recovery still fires.
         raw = "<function_calls><invoke>x</invoke></function_calls>"
         state_container = MagicMock()
         llm_step_result, _ = self._run(
@@ -941,3 +942,25 @@ class TestEmptyAnswerRecovery:
         assert llm_step_result.answer == raw
         state_container.set_pre_answer_processing_time.assert_called_once_with(1.5)
         state_container.set_answer_tokens.assert_called_with(raw)
+
+    def test_no_recovery_for_xml_tool_call_payload(self) -> None:
+        """When the raw output is XML tool-call markup (emitted as plain text),
+        recovery must NOT fire — run_llm_loop's fallback extraction parses it into
+        a real tool call, and surfacing the raw markup would leak it to the client
+        and pollute context."""
+        from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+
+        raw = (
+            '<function_calls><invoke name="search">'
+            '<parameter name="query">hi</parameter></invoke></function_calls>'
+        )
+        llm_step_result, packets = self._run([raw], with_citation_processor=True)
+
+        # answer stays None so the loop's fallback tool extraction can handle it.
+        assert llm_step_result.answer is None
+        assert llm_step_result.raw_answer == raw
+        # Nothing leaked to the client.
+        emitted = "".join(
+            p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
+        )
+        assert emitted == ""

--- a/backend/tests/unit/onyx/chat/test_llm_step.py
+++ b/backend/tests/unit/onyx/chat/test_llm_step.py
@@ -928,9 +928,9 @@ class TestEmptyAnswerRecovery:
 
         # A complete <function_calls> block is stripped by the XML content filter,
         # so _emit_content_chunk never runs and answer_start stays False, while the
-        # raw answer retains the text. No <parameter> tag, so it is NOT classified
-        # as a tool-call payload (see test below) and recovery still fires.
-        raw = "<function_calls><invoke>x</invoke></function_calls>"
+        # raw answer retains the text. No <invoke>, so it is NOT classified as a
+        # tool-call payload (see tests below) and recovery still fires.
+        raw = "<function_calls>noop</function_calls>"
         state_container = MagicMock()
         llm_step_result, _ = self._run(
             [raw],
@@ -960,6 +960,22 @@ class TestEmptyAnswerRecovery:
         assert llm_step_result.answer is None
         assert llm_step_result.raw_answer == raw
         # Nothing leaked to the client.
+        emitted = "".join(
+            p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
+        )
+        assert emitted == ""
+
+    def test_no_recovery_for_zero_arg_xml_tool_call(self) -> None:
+        """A zero-argument <invoke> (no <parameter>) is still valid tool-call
+        markup. Recovery must NOT fire — otherwise the raw markup leaks and the
+        fallback extractor can't parse the call."""
+        from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+
+        raw = '<function_calls><invoke name="get_time"></invoke></function_calls>'
+        llm_step_result, packets = self._run([raw], with_citation_processor=True)
+
+        assert llm_step_result.answer is None
+        assert llm_step_result.raw_answer == raw
         emitted = "".join(
             p.obj.content for p in packets if isinstance(p.obj, AgentResponseDelta)
         )


### PR DESCRIPTION
## Description

A model's answer can be entirely consumed by content/citation processing, leaving an empty answer even though the provider responded. The common trigger is an answer dominated by bracketed-numeric text that matches the citation pattern but isn't in the citation mapping (e.g. `[123456789012345]`, an array, a list of ids) — `DynamicCitationProcessor` strips such unmapped markers (existing, intended behavior).

The empty answer then raises `EmptyLLMResponseError` ("provider returned no text or tool calls") — misleading (it did respond) and unlogged. This became user-visible after the citation-regex ReDoS fix (#11527): the same long bracketed-digit content that used to hang the pod now streams to completion, where the stripping empties the answer. Reproduces across providers; works via Claude CLI (no citation post-processing).

**Fix:** in `run_llm_step_pkt_generator`, if the model emitted text but the answer is empty after processing (and there are no tool calls), surface the raw output instead of erroring, and log a warning. Gated to non-`REQUIRED` tool choice so deep-research / forced-tool flows keep using fallback tool extraction. Does **not** change the intended unmapped-citation stripping.

## How Has This Been Tested?

`TestEmptyAnswerRecovery` in `test_llm_step.py` (real generator + real `DynamicCitationProcessor`): bracketed-number / numeric-list recovery, normal prose unaffected, genuinely-empty stream still empty, `REQUIRED` no-recovery, recovered answer recorded in the tracing span, and pre-answer timing persisted. 229 chat tests pass; pre-commit clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
