### PR TITLE
feat(craft): useful instructive error messages from proxy

### DIFF
--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -1,9 +1,11 @@
 """Sandbox-facing 403 error codes and response builder.
 
-Every 403 the proxy returns to the sandbox carries a stable `error` code that
-the sandbox-side SDK / curl wrapper matches on. Keeping the codes and the
-response shape in one place keeps the gate and the credential dispatcher
-emitting the same contract.
+Every 403 the proxy returns to the sandbox carries a stable `error` code plus a
+human-readable `message`. The agent running in the sandbox reads the `message`
+to understand what happened and what to do next; tooling and dashboards match on
+the stable `error` code. Keeping the codes, their prose, and the response shape
+in one place keeps the gate and the credential dispatcher emitting the same
+contract.
 """
 
 from __future__ import annotations
@@ -26,10 +28,89 @@ class SandboxProxyError(str, Enum):
     POLICY_DENIED = "policy_denied"
     CREDENTIAL_ERROR = "credential_error"
 
+    @property
+    def message(self) -> str:
+        """Prose explaining what happened and the recommended next step.
+
+        Addressed to the agent in the sandbox that receives the 403.
+        """
+        return _SANDBOX_ERROR_MESSAGES[self]
+
+
+_SANDBOX_ERROR_MESSAGES: dict[SandboxProxyError, str] = {
+    SandboxProxyError.UNIDENTIFIED_SANDBOX: (
+        "The proxy could not identify which workspace this request came from, so "
+        "it was blocked before reaching the network. This is an internal setup "
+        "issue, not a problem with the request itself — changing the request "
+        "will not help. Retry once; if it keeps failing, report that outbound "
+        "requests are currently failing and stop attempting this call."
+    ),
+    SandboxProxyError.NO_ACTIVE_SESSION: (
+        "This request needs to be tied to an active Craft session for approval, "
+        "but no such session could be found, so it was blocked. This usually "
+        "means the session ended or the request was made outside of a Craft "
+        "session. Retrying the same request will not help — tell the user the "
+        "action could not be authorized and ask how they want to proceed."
+    ),
+    SandboxProxyError.BODY_TOO_LARGE: (
+        "The request body is larger than the 1 MiB limit the proxy allows, so it "
+        "was blocked. Shrink the payload and try again — for example, send fewer "
+        "items per request, paginate, or break the work into smaller calls. "
+        "Large file uploads should go through a dedicated upload flow rather "
+        "than an inline request body."
+    ),
+    SandboxProxyError.USER_REJECTED: (
+        "The user reviewed this action and chose to reject it, so it was not "
+        "performed. Do not retry the same request — the rejection is "
+        "intentional. Stop, tell the user the action was declined, and ask how "
+        "they would like to continue or whether to take a different approach."
+    ),
+    SandboxProxyError.NOT_AUTHORIZED: (
+        "This action required the user's approval, but no response came back in "
+        "time and the request expired, so it was not performed. The user may "
+        "have been away from the screen. You may retry once to prompt them "
+        "again; if it keeps expiring, pause and let the user know this action is "
+        "waiting on their approval."
+    ),
+    SandboxProxyError.INTERNAL_ERROR: (
+        "The proxy hit an unexpected error while handling this request and "
+        "blocked it as a precaution. This is not a problem with the request "
+        "itself. Retry once; if it keeps failing, report that the action could "
+        "not be completed due to an internal error and stop retrying."
+    ),
+    SandboxProxyError.POLICY_DENIED: (
+        "This request targets an integration that the workspace administrator "
+        "has set to always deny, so it was blocked by policy. Retrying will not "
+        "help and the policy cannot be overridden from here. Tell the user this "
+        "integration is disabled by policy and look for an approach that does "
+        "not depend on it."
+    ),
+    SandboxProxyError.CREDENTIAL_ERROR: (
+        "The proxy could not obtain the credentials needed to authenticate this "
+        "request, so it was blocked. The integration is likely not connected, or "
+        "its saved credentials have expired or been revoked. Ask the user to "
+        "connect or reconnect this integration in their Craft settings, then "
+        "retry."
+    ),
+}
+
+# Fail fast at import if a code ever ships without prose, so the agent never
+# receives a 403 with an empty message.
+_missing = [code for code in SandboxProxyError if code not in _SANDBOX_ERROR_MESSAGES]
+if _missing:
+    raise RuntimeError(
+        f"SandboxProxyError codes missing a message: {[c.value for c in _missing]}"
+    )
+
 
 def http_403(code: SandboxProxyError) -> http.Response:
-    """Build a sandbox-visible 403 whose JSON body is `{"error": <code>}`."""
-    body = json.dumps({"error": code.value}).encode()
+    """Build a sandbox-visible 403.
+
+    The JSON body is `{"error": <code>, "message": <prose>}`: the stable `error`
+    code for tooling to match on, and human-readable `message` prose the agent
+    can act on.
+    """
+    body = json.dumps({"error": code.value, "message": code.message}).encode()
     return http.Response.make(
         403,
         content=body,

--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -94,14 +94,6 @@ _SANDBOX_ERROR_MESSAGES: dict[SandboxProxyError, str] = {
     ),
 }
 
-# Fail fast at import if a code ever ships without prose, so the agent never
-# receives a 403 with an empty message.
-_missing = [code for code in SandboxProxyError if code not in _SANDBOX_ERROR_MESSAGES]
-if _missing:
-    raise RuntimeError(
-        f"SandboxProxyError codes missing a message: {[c.value for c in _missing]}"
-    )
-
 
 def http_403(code: SandboxProxyError) -> http.Response:
     """Build a sandbox-visible 403.

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -141,7 +141,9 @@ def test_apply_or_block_writes_403_on_blocked() -> None:
     assert flow.response.status_code == 403
     content = flow.response.content
     assert content is not None
-    assert json.loads(content) == {"error": SandboxProxyError.CREDENTIAL_ERROR.value}
+    body = json.loads(content)
+    assert body["error"] == SandboxProxyError.CREDENTIAL_ERROR.value
+    assert body["message"]
 
 
 def test_apply_or_block_leaves_response_unset_on_inject_or_pass_through() -> None:

--- a/backend/tests/unit/sandbox_proxy/test_errors.py
+++ b/backend/tests/unit/sandbox_proxy/test_errors.py
@@ -1,0 +1,39 @@
+"""Contract tests for the sandbox-facing 403 builder.
+
+Pins the response shape every code must satisfy without asserting the exact
+prose (which is free to be reworded). The completeness check guarantees a new
+code can't ship without a message.
+"""
+
+import json
+
+import pytest
+
+from onyx.sandbox_proxy.errors import http_403
+from onyx.sandbox_proxy.errors import SandboxProxyError
+
+
+@pytest.mark.parametrize("code", list(SandboxProxyError))
+def test_http_403_carries_code_and_prose(code: SandboxProxyError) -> None:
+    response = http_403(code)
+
+    assert response.status_code == 403
+    assert response.headers["content-type"] == "application/json"
+
+    assert response.content is not None
+    body = json.loads(response.content)
+
+    # Stable code for tooling, prose for the agent.
+    assert body["error"] == code.value
+    message = body["message"]
+    assert isinstance(message, str)
+    # Prose, not a restated code: non-trivial length and not the bare slug.
+    assert len(message) > 40
+    assert message != code.value
+
+
+def test_every_code_has_a_message() -> None:
+    # Mirrors the import-time guard so the contract is asserted in CI even if the
+    # module is already imported (and thus its guard already passed).
+    for code in SandboxProxyError:
+        assert code.message

--- a/backend/tests/unit/sandbox_proxy/test_errors.py
+++ b/backend/tests/unit/sandbox_proxy/test_errors.py
@@ -23,17 +23,15 @@ def test_http_403_carries_code_and_prose(code: SandboxProxyError) -> None:
     assert response.content is not None
     body = json.loads(response.content)
 
-    # Stable code for tooling, prose for the agent.
     assert body["error"] == code.value
     message = body["message"]
     assert isinstance(message, str)
-    # Prose, not a restated code: non-trivial length and not the bare slug.
+    # Prose, not the bare slug restated.
     assert len(message) > 40
     assert message != code.value
 
 
 def test_every_code_has_a_message() -> None:
-    # Mirrors the import-time guard so the contract is asserted in CI even if the
-    # module is already imported (and thus its guard already passed).
+    # A new code without prose makes `.message` raise KeyError here.
     for code in SandboxProxyError:
         assert code.message

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -126,7 +126,9 @@ def _assert_403(flow: http.HTTPFlow, expected_code: SandboxProxyError) -> None:
     content = flow.response.content
     assert content is not None
     body = json.loads(content)
-    assert body == {"error": expected_code.value}
+    assert body["error"] == expected_code.value
+    # The agent acts on `message`; it must always be present and non-empty.
+    assert body["message"]
 
 
 _MATCH = make_request_match(payload={"text": "hi"})

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -127,7 +127,6 @@ def _assert_403(flow: http.HTTPFlow, expected_code: SandboxProxyError) -> None:
     assert content is not None
     body = json.loads(content)
     assert body["error"] == expected_code.value
-    # The agent acts on `message`; it must always be present and non-empty.
     assert body["message"]
 
 

--- a/docs/craft/features/approvals/approvals-plan.md
+++ b/docs/craft/features/approvals/approvals-plan.md
@@ -282,7 +282,9 @@ deliberate split posture between fail-closed and fail-open:
   `OnyxError`):
   `unidentified_sandbox | body_too_large | user_rejected | not_authorized | internal_error`.
   `policy_denied` is reserved for Phase 4. The body is
-  `json.dumps({"error": code})` with `content-type: application/json`.
+  `json.dumps({"error": code, "message": prose})` with
+  `content-type: application/json` — `error` is the stable code tooling matches
+  on, `message` is human-readable prose the sandbox agent acts on.
 
 ### SIGTERM drain
 

--- a/docs/craft/features/approvals/phase-2-service-and-gating.md
+++ b/docs/craft/features/approvals/phase-2-service-and-gating.md
@@ -785,7 +785,9 @@ def _write_response_for_decision(
 protocol from `OnyxError`. Locked enum:
 `unidentified_sandbox | no_active_session | body_too_large | user_rejected | not_authorized | internal_error`.
 `policy_denied` is reserved for Phase 4. The body is
-`json.dumps({"error": code})` with `content-type: application/json`.
+`json.dumps({"error": code, "message": prose})` with
+`content-type: application/json` — `error` is the stable code, `message` is
+human-readable prose the sandbox agent acts on.
 Matcher exceptions do not produce 403s — they fail open per T2.6.
 
 **SIGTERM drain (`drain_inflight`).** Two phases, each best-effort:


### PR DESCRIPTION
## Description

So the agent knows what to do next.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add clear, instructive messages to all 403 responses from the Craft sandbox proxy so agents know what happened and what to do. Tooling still matches on the stable `error` code.

- **New Features**
  - 403 JSON now includes `{"error": <code>, "message": <prose>}` for every response.
  - Added `SandboxProxyError.message` that returns per-code prose.
  - New contract tests verify response shape and ensure every code has prose; gate/credential tests updated to assert `message`.
  - Docs updated to reflect the new response shape in approvals plan and phase-2.
  - Non-breaking: consumers can keep matching on `error` as before.

<sup>Written for commit 4b4a95fffe5d4cd8a06f4cf749441e27065770c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



