### PR TITLE
refactor(craft): up arrow queued message hint in input bar

### DIFF
--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -38,6 +38,7 @@ import {
   SvgAlertCircle,
 } from "@opal/icons";
 import InterruptHint from "@/app/craft/components/InterruptHint";
+import Keycap from "@/refresh-components/Keycap";
 import { useDoubleEscapeInterrupt } from "@/hooks/useDoubleEscapeInterrupt";
 import { useContentEditable } from "@/hooks/useContentEditable";
 import { useUser } from "@/providers/UserProvider";
@@ -532,11 +533,7 @@ const InputBar = memo(
                 aria-multiline={true}
                 aria-disabled={disabled}
                 aria-placeholder={placeholder}
-                data-placeholder={
-                  !message && queueEnabled && queue.length > 0
-                    ? "Press up to edit queued messages"
-                    : placeholder
-                }
+                data-placeholder={placeholder}
                 data-empty={!message ? "" : undefined}
                 onCopy={handleCopy}
                 onCut={handleCut}
@@ -561,14 +558,28 @@ const InputBar = memo(
                 {interruptible && (
                   <InterruptHint armed={armed} interrupting={isInterrupting} />
                 )}
+                {/* Queued messages-only: teaches the Up arrow to edit queued message.*/}
+                {!message && queueEnabled && queue.length > 0 && (
+                  <>
+                    {interruptible && (
+                      <Text font="secondary-body" color="text-02">
+                        ·
+                      </Text>
+                    )}
+                    <div className="flex items-center gap-1 select-none">
+                      <Keycap>↑</Keycap>
+                      <Text font="secondary-body" color="text-02">
+                        to edit queued messages
+                      </Text>
+                    </div>
+                  </>
+                )}
               </div>
 
               {/* Bottom right controls */}
               <div className="flex flex-row items-center gap-1">
                 {/* Stop: inserts to the LEFT of the fixed send button while
-                    streaming, so the send target never shifts. Outlined +
-                    transparent with a neutral glyph (no red); the first Esc
-                    "arms" it with a subtle neutral fill. */}
+                    streaming. The first Esc "arms" it with a subtle neutral fill. */}
                 <div
                   className={cn(
                     "overflow-hidden transition-[width,opacity] duration-150 ease-out motion-reduce:transition-none",


### PR DESCRIPTION
## Description

Craft input bar: replace the "Press up to edit queued messages" placeholder with an inline `↑ to edit queued messages` hint next to the `esc ×2 to interrupt` hint. Craft-only; the main chat input bar is untouched.

Before:
<img width="669" height="188" alt="image" src="https://github.com/user-attachments/assets/60495c26-4bc4-4823-a8c5-31e1ec3566ef" />


After:
<img width="669" height="188" alt="image" src="https://github.com/user-attachments/assets/5b411313-2d54-4a1b-8f0b-3f14a188c631" />


## How Has This Been Tested?

Manual: queued a message mid-stream and confirmed the hint renders and `↑` edits the queued message.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
