### PR TITLE
test(playwright): isolate /admin/indexing/status visual regression

### DIFF
--- a/web/tests/e2e/admin/admin_pages.spec.ts
+++ b/web/tests/e2e/admin/admin_pages.spec.ts
@@ -28,6 +28,22 @@ async function discoverAdminPages(page: Page): Promise<string[]> {
   });
 }
 
+/**
+ * Admin routes excluded from the parallel visual-regression sweep because other
+ * specs mutate their rendered content while this test is running.
+ *
+ * `/admin/indexing/status` renders the list of existing connectors. Several
+ * specs create file connectors mid-run via `apiClient.createFileConnector(...)`
+ * (agents, chat, permission-sync, inline file management), and since this
+ * `describe` block runs in parallel, a connector row appearing or disappearing
+ * during the screenshot yields non-deterministic baseline diffs. Excluding the
+ * page here keeps the sweep stable; a shared visual baseline isn't a good fit
+ * for a list whose contents depend on concurrent test state.
+ */
+const VISUAL_REGRESSION_EXCLUDED_PATHS = new Set<string>([
+  "/admin/indexing/status",
+]);
+
 for (const theme of THEMES) {
   test(`Admin pages – ${theme} mode`, async ({ page }) => {
     await setThemeBeforeNavigation(page, theme);
@@ -39,6 +55,9 @@ for (const theme of THEMES) {
     ).toBeGreaterThan(0);
 
     for (const href of adminHrefs) {
+      // Skip pages whose content is mutated by other specs running in parallel.
+      if (VISUAL_REGRESSION_EXCLUDED_PATHS.has(href)) continue;
+
       const slug = href.replace(/^\/admin\//, "").replace(/\//g, "--");
 
       await test.step(

--- a/web/tests/e2e/admin/connector/IndexingStatusPage.ts
+++ b/web/tests/e2e/admin/connector/IndexingStatusPage.ts
@@ -1,0 +1,59 @@
+/**
+ * Page Object Model for the connector status page (`/admin/indexing/status`).
+ *
+ * Encapsulates the locators and interactions used by the visual-regression
+ * spec so it stays declarative (see `web/tests/e2e/README.md` §1).
+ */
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+export class IndexingStatusPage {
+  readonly page: Page;
+  readonly pageTitle: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageTitle = page.locator('[aria-label="admin-page-title"]');
+  }
+
+  /**
+   * The collapsed summary row for a connector source group, located by its
+   * display name (e.g. "File" for the `file` source). Connectors are grouped
+   * by source and shown collapsed by default, so the source display name is
+   * the stable signal that the table has rendered with data.
+   */
+  sourceGroup(displayName: string): Locator {
+    return this.page.getByText(displayName, { exact: true }).first();
+  }
+
+  async goto() {
+    await this.page.goto("/admin/indexing/status");
+    await expect(this.pageTitle).toBeVisible({ timeout: 10_000 });
+  }
+
+  /**
+   * Wait for a source group to render so we don't snapshot the loading
+   * skeleton, then settle the network before any screenshot.
+   */
+  async waitForSourceGroup(displayName: string) {
+    await expect(this.sourceGroup(displayName)).toBeVisible({
+      timeout: 15_000,
+    });
+    await this.page.waitForLoadState("networkidle");
+  }
+
+  /**
+   * Capture a full-page visual snapshot. Masks the same dynamic columns the
+   * admin-pages sweep masked so the relocated baseline stays comparable.
+   */
+  async expectScreenshot(name: string) {
+    await expectScreenshot(this.page, {
+      name,
+      mask: [
+        '[data-testid="admin-date-range-selector-button"]',
+        '[data-column-id="updated_at"]',
+      ],
+    });
+  }
+}

--- a/web/tests/e2e/admin/connector/indexing_status_visual.spec.ts
+++ b/web/tests/e2e/admin/connector/indexing_status_visual.spec.ts
@@ -1,8 +1,7 @@
-import { test, expect } from "@playwright/test";
-import { loginAs } from "@tests/e2e/utils/auth";
+import { test } from "@playwright/test";
 import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
 import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
-import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+import { IndexingStatusPage } from "@tests/e2e/admin/connector/IndexingStatusPage";
 
 /**
  * Visual-regression coverage for the connector status page
@@ -19,16 +18,17 @@ import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
  * remove connectors while we snapshot. We seed exactly one paused file connector
  * via the API, screenshot the page in each theme, and tear the connector down
  * afterwards — keeping the rendered state deterministic.
+ *
+ * Auth comes from the `exclusive` project's `storageState`; each test gets a
+ * fresh context, so no explicit login is needed.
  */
 const CONNECTOR_NAME = "Visual Regression File Connector";
+const FILE_SOURCE_GROUP = "File";
 
 test.describe("Connector status page — visual @exclusive", () => {
   let ccPairId: number | null = null;
 
   test.beforeEach(async ({ page }) => {
-    await page.context().clearCookies();
-    await loginAs(page, "admin");
-
     const apiClient = new OnyxApiClient(page.request);
     ccPairId = await apiClient.createFileConnector(CONNECTOR_NAME);
   });
@@ -37,41 +37,23 @@ test.describe("Connector status page — visual @exclusive", () => {
     if (ccPairId === null) return;
 
     const apiClient = new OnyxApiClient(page.request);
-    try {
-      await apiClient.deleteCCPair(ccPairId);
-    } catch (error) {
-      console.warn(`Failed to delete test connector ${ccPairId}: ${error}`);
-    } finally {
-      ccPairId = null;
-    }
+    const idToDelete = ccPairId;
+    ccPairId = null;
+
+    // Let cleanup failures surface: a leaked connector would add a second
+    // "File" row to the next theme test's screenshot, reintroducing exactly
+    // the non-determinism this spec exists to remove.
+    await apiClient.deleteCCPair(idToDelete);
   });
 
   for (const theme of THEMES) {
     test(`indexing status page – ${theme} mode`, async ({ page }) => {
       await setThemeBeforeNavigation(page, theme);
 
-      await page.goto("/admin/indexing/status");
-
-      await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible(
-        { timeout: 10000 }
-      );
-
-      // Wait for the seeded connector's source group ("File", the display name
-      // for the `file` source) to render so we don't snapshot the loading
-      // skeleton. The group row is shown collapsed by default.
-      await expect(page.getByText("File", { exact: true }).first()).toBeVisible(
-        { timeout: 15000 }
-      );
-
-      await page.waitForLoadState("networkidle");
-
-      await expectScreenshot(page, {
-        name: `admin-${theme}-indexing--status`,
-        mask: [
-          '[data-testid="admin-date-range-selector-button"]',
-          '[data-column-id="updated_at"]',
-        ],
-      });
+      const statusPage = new IndexingStatusPage(page);
+      await statusPage.goto();
+      await statusPage.waitForSourceGroup(FILE_SOURCE_GROUP);
+      await statusPage.expectScreenshot(`admin-${theme}-indexing--status`);
     });
   }
 });

--- a/web/tests/e2e/admin/connector/indexing_status_visual.spec.ts
+++ b/web/tests/e2e/admin/connector/indexing_status_visual.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "@tests/e2e/utils/auth";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+/**
+ * Visual-regression coverage for the connector status page
+ * (`/admin/indexing/status`).
+ *
+ * This page is deliberately excluded from the parallel admin-pages sweep (see
+ * `VISUAL_REGRESSION_EXCLUDED_PATHS` in `admin_pages.spec.ts`): it renders the
+ * list of existing connectors, and specs in the parallel `admin` project create
+ * file connectors mid-run via `apiClient.createFileConnector(...)`, mutating the
+ * table while the sweep screenshots it and producing flaky baseline diffs.
+ *
+ * The `@exclusive` tag moves this test into the serial `exclusive` project
+ * (`workers: 1`, run as its own CI matrix job), so no other spec can add or
+ * remove connectors while we snapshot. We seed exactly one paused file connector
+ * via the API, screenshot the page in each theme, and tear the connector down
+ * afterwards — keeping the rendered state deterministic.
+ */
+const CONNECTOR_NAME = "Visual Regression File Connector";
+
+test.describe("Connector status page — visual @exclusive", () => {
+  let ccPairId: number | null = null;
+
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+
+    const apiClient = new OnyxApiClient(page.request);
+    ccPairId = await apiClient.createFileConnector(CONNECTOR_NAME);
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (ccPairId === null) return;
+
+    const apiClient = new OnyxApiClient(page.request);
+    try {
+      await apiClient.deleteCCPair(ccPairId);
+    } catch (error) {
+      console.warn(`Failed to delete test connector ${ccPairId}: ${error}`);
+    } finally {
+      ccPairId = null;
+    }
+  });
+
+  for (const theme of THEMES) {
+    test(`indexing status page – ${theme} mode`, async ({ page }) => {
+      await setThemeBeforeNavigation(page, theme);
+
+      await page.goto("/admin/indexing/status");
+
+      await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible(
+        { timeout: 10000 }
+      );
+
+      // Wait for the seeded connector's source group ("File", the display name
+      // for the `file` source) to render so we don't snapshot the loading
+      // skeleton. The group row is shown collapsed by default.
+      await expect(page.getByText("File", { exact: true }).first()).toBeVisible(
+        { timeout: 15000 }
+      );
+
+      await page.waitForLoadState("networkidle");
+
+      await expectScreenshot(page, {
+        name: `admin-${theme}-indexing--status`,
+        mask: [
+          '[data-testid="admin-date-range-selector-button"]',
+          '[data-column-id="updated_at"]',
+        ],
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Problem

`admin_pages.spec.ts` runs in `mode: "parallel"` and screenshots every admin route discovered from the sidebar. `/admin/indexing/status` renders the **list of existing connectors**, and several specs in the parallel `admin` project create file connectors mid-run via `apiClient.createFileConnector(...)`:

- `agents/create_and_edit_agent.spec.ts`
- `chat/actions_popover.spec.ts`, `chat/default_app_mode.spec.ts`
- `admin/default-agent.spec.ts`
- `admin/connector/permission-sync-tabs.spec.ts`, `connectors/inlineFileManagement.spec.ts`

A connector row appearing/disappearing while the sweep screenshots the page produced **non-deterministic baseline diffs** (the `admin-light-indexing--status` / `admin-dark-indexing--status` screenshots).

## Fix

1. **Exclude `/admin/indexing/status` from the parallel sweep** via a documented `VISUAL_REGRESSION_EXCLUDED_PATHS` allow-list in `admin_pages.spec.ts` (both themes — the mutation isn't theme-specific).
2. **Add a dedicated `@exclusive` spec** (`admin/connector/indexing_status_visual.spec.ts`) so we don't lose coverage. It seeds exactly one paused file connector through the API, screenshots the page in light + dark using the same screenshot name and masks as the old sweep, then tears the connector down.

The `exclusive` project runs serially (`workers: 1`) **as its own CI matrix job** (`matrix.project: [admin, exclusive]`, each with its own Docker stack), so the connector-creating specs in the `admin` project can't run concurrently with this screenshot — the rendered state is deterministic.

## Testing

- `oxfmt`, `oxlint` (0 warnings/0 errors), and `tsgo` type-check all pass on both files.
- The e2e suite was **not run locally** (no Onyx services running in my environment); the `exclusive` CI matrix job will exercise the new spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated `/admin/indexing/status` visual regression to a serial `@exclusive` spec to stop flaky diffs from parallel connector creation. Keeps light/dark screenshots stable, with a cleaner spec structure.

- **Bug Fixes**
  - Excluded `/admin/indexing/status` from the parallel admin sweep via `VISUAL_REGRESSION_EXCLUDED_PATHS`.
  - Added `admin/connector/indexing_status_visual.spec.ts` (`@exclusive`): seeds one paused file connector, snapshots both themes, then deletes it.
  - Runs in the `exclusive` project (workers: 1, separate CI job) to prevent concurrent connector mutations.

- **Refactors**
  - Added `admin/connector/IndexingStatusPage.ts` Page Object and drove the spec through it.
  - Let `deleteCCPair` errors propagate; removed manual login/cookie clears (project `storageState` provides auth).

<sup>Written for commit dbca1d78ca5b17dbe4e5b1fd113631919f9d62eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

