### PR TITLE
feat(craft): Add github as a built-in external app

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -380,6 +380,7 @@ class ExternalAppType(str, PyEnum):
     GMAIL = "GMAIL"
     SLACK = "SLACK"
     LINEAR = "LINEAR"
+    GITHUB = "GITHUB"
     CUSTOM = "CUSTOM"
 
 

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -198,7 +198,12 @@ class OAuthExternalAppProvider(ExternalAppProvider, abstract=True):
         try:
             response = requests.post(
                 self.spec.oauth.token_url,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                # Ask for JSON so providers that default to form-encoded
+                # refresh responses (e.g. GitHub) still parse via response.json().
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
                 data=self.build_refresh_request(
                     refresh_token, client_id, client_secret
                 ),

--- a/backend/onyx/external_apps/providers/github.py
+++ b/backend/onyx/external_apps/providers/github.py
@@ -114,8 +114,8 @@ class GitHubProvider(OAuthExternalAppProvider):
         ),
         descriptor=AdminDescriptorSpec(
             description=(
-                "Read repositories, issues, and pull requests — and open issues "
-                "and comments — on GitHub as the connected user inside Onyx Craft."
+                "Read repositories, issues, and pull requests, open new issues, "
+                "and add comments in GitHub on the user's behalf."
             ),
             upstream_url_patterns=["https://api\\.github\\.com/.*"],
             auth_template={"Authorization": "Bearer {access_token}"},

--- a/backend/onyx/external_apps/providers/github.py
+++ b/backend/onyx/external_apps/providers/github.py
@@ -1,0 +1,186 @@
+from typing import Any
+
+import requests
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.providers.actions import EndpointSpec
+from onyx.external_apps.providers.actions import ExternalAppAction
+from onyx.external_apps.providers.actions import RestRoute
+from onyx.external_apps.providers.base import AdminDescriptorSpec
+from onyx.external_apps.providers.base import OAuthExternalAppProvider
+from onyx.external_apps.providers.base import OAuthFlowSpec
+from onyx.external_apps.providers.base import OAuthProviderSpec
+from onyx.external_apps.providers.base import OrgCredentialField
+from onyx.external_apps.providers.base import token_response_error
+
+
+class GitHubAction(ExternalAppAction):
+    """Strongly-typed catalog ids for the GitHub provider."""
+
+    USER_READ = "github.user.read"
+    REPOS_READ = "github.repos.read"
+    ISSUES_READ = "github.issues.read"
+    PULLS_READ = "github.pulls.read"
+    SEARCH_READ = "github.search.read"
+    ISSUES_CREATE = "github.issues.create"
+    COMMENTS_CREATE = "github.comments.create"
+
+
+# GitHub's REST API is a path-addressed JSON API rooted at
+# https://api.github.com; the action is the method + path template. A `{name}`
+# segment matches one path segment (owner / repo / issue number, etc.).
+_ENDPOINTS: list[EndpointSpec] = [
+    EndpointSpec(
+        id=GitHubAction.USER_READ,
+        normalised_name="Read the connected user",
+        description="Read the authenticated user's profile.",
+        matches=(RestRoute(method="GET", path="/user"),),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.REPOS_READ,
+        normalised_name="Read repositories",
+        description="List the user's repositories and fetch a single repo.",
+        matches=(
+            RestRoute(method="GET", path="/user/repos"),
+            RestRoute(method="GET", path="/repos/{owner}/{repo}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.ISSUES_READ,
+        normalised_name="Read issues",
+        description="List a repo's issues and fetch a single issue with its comments.",
+        matches=(
+            RestRoute(method="GET", path="/repos/{owner}/{repo}/issues"),
+            RestRoute(method="GET", path="/repos/{owner}/{repo}/issues/{number}"),
+            RestRoute(
+                method="GET", path="/repos/{owner}/{repo}/issues/{number}/comments"
+            ),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.PULLS_READ,
+        normalised_name="Read pull requests",
+        description="List a repo's pull requests and fetch a single pull request.",
+        matches=(
+            RestRoute(method="GET", path="/repos/{owner}/{repo}/pulls"),
+            RestRoute(method="GET", path="/repos/{owner}/{repo}/pulls/{number}"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.SEARCH_READ,
+        normalised_name="Search",
+        description="Search repositories, issues, and pull requests.",
+        matches=(
+            RestRoute(method="GET", path="/search/repositories"),
+            RestRoute(method="GET", path="/search/issues"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.ISSUES_CREATE,
+        normalised_name="Create an issue",
+        description="Open a new issue in a repository.",
+        matches=(RestRoute(method="POST", path="/repos/{owner}/{repo}/issues"),),
+    ),
+    EndpointSpec(
+        id=GitHubAction.COMMENTS_CREATE,
+        normalised_name="Comment on an issue",
+        description="Add a comment to an issue or pull request.",
+        matches=(
+            RestRoute(
+                method="POST", path="/repos/{owner}/{repo}/issues/{number}/comments"
+            ),
+        ),
+    ),
+]
+
+
+class GitHubProvider(OAuthExternalAppProvider):
+    spec = OAuthProviderSpec(
+        app_type=ExternalAppType.GITHUB,
+        app_name="GitHub",
+        oauth=OAuthFlowSpec(
+            authorize_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            scope=" ".join(["repo", "read:org", "read:user"]),
+            scope_param="scope",
+        ),
+        descriptor=AdminDescriptorSpec(
+            description=(
+                "Read repositories, issues, and pull requests — and open issues "
+                "and comments — on GitHub as the connected user inside Onyx Craft."
+            ),
+            upstream_url_patterns=["https://api\\.github\\.com/.*"],
+            auth_template={"Authorization": "Bearer {access_token}"},
+            required_org_credential_fields=[
+                OrgCredentialField(
+                    key="client_id",
+                    label="Client ID",
+                    description=(
+                        "Found on your GitHub OAuth app's settings page "
+                        "(Settings → Developer settings → OAuth Apps)."
+                    ),
+                ),
+                OrgCredentialField(
+                    key="client_secret",
+                    label="Client Secret",
+                    description=(
+                        "Generated on the same OAuth app settings page. "
+                        "Treat this like a password."
+                    ),
+                    secret=True,
+                ),
+            ],
+            setup_instructions=(
+                "In GitHub: Settings → Developer settings → OAuth Apps → New "
+                "OAuth App. Set the Authorization callback URL to this Onyx "
+                "instance's callback URL (/craft/v1/apps/oauth/callback). Save, "
+                "then generate a client secret. Paste the Client ID and Client "
+                "Secret below. The agent is granted the repo, read:org, and "
+                "read:user scopes."
+            ),
+        ),
+        endpoint_catalog=_ENDPOINTS,
+    )
+
+    # GitHub signals a dead refresh token with `bad_refresh_token` rather than
+    # RFC-6749's `invalid_grant`; treat it as terminal so the user reconnects.
+    terminal_refresh_errors = frozenset({"invalid_grant", "bad_refresh_token"})
+
+    def classify_token_response(
+        self, response: requests.Response, body: dict[str, Any]
+    ) -> str | None:
+        # GitHub returns HTTP 200 with an `{"error": "..."}` body on failure
+        # (e.g. `bad_verification_code`, `bad_refresh_token`), so the generic
+        # non-2xx check wouldn't catch it. Surface the machine-readable code so
+        # terminal-vs-transient classification can match it.
+        if isinstance(body, dict) and body.get("error"):
+            return str(body["error"])
+        return token_response_error(response, body)
+
+    def extract_credentials(self, response_data: dict[str, Any]) -> dict[str, Any]:
+        access_token = response_data.get("access_token")
+        if not access_token:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "GitHub OAuth response did not contain an access token.",
+            )
+        creds: dict[str, Any] = {
+            "access_token": access_token,
+            "scope": response_data.get("scope"),
+            "token_type": response_data.get("token_type"),
+        }
+        # Present only when the OAuth app has expiring user tokens enabled
+        # (GitHub Apps); classic OAuth app tokens don't expire and omit these.
+        if response_data.get("refresh_token"):
+            creds["refresh_token"] = response_data["refresh_token"]
+        if response_data.get("expires_in"):
+            creds["expires_in"] = response_data["expires_in"]
+        return creds

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -5,6 +5,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.base import ExternalAppProvider
+from onyx.external_apps.providers.github import GitHubProvider
 from onyx.external_apps.providers.gmail import GmailProvider
 from onyx.external_apps.providers.google_calendar import GoogleCalendarProvider
 from onyx.external_apps.providers.linear import LinearProvider
@@ -19,6 +20,7 @@ _PROVIDER_CLASSES: list[type[ExternalAppProvider]] = [
     GoogleCalendarProvider,
     GmailProvider,
     LinearProvider,
+    GitHubProvider,
 ]
 
 

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -174,7 +174,10 @@ def handle_external_app_oauth_callback(
     try:
         response = requests.post(
             oauth.token_url,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
             data={
                 "grant_type": "authorization_code",
                 "client_id": client_id,

--- a/backend/onyx/server/features/build/api/external_apps_oauth_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_oauth_api.py
@@ -21,7 +21,6 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.base import OAuthExternalAppProvider
-from onyx.external_apps.providers.base import token_response_error
 from onyx.external_apps.providers.registry import get_provider_or_raise
 from onyx.external_apps.token_utils import stamp_expires_at
 from onyx.redis.redis_pool import get_redis_client
@@ -213,7 +212,7 @@ def handle_external_app_oauth_callback(
             status_code_override=response.status_code,
         )
 
-    error = token_response_error(response, response_data)
+    error = provider.classify_token_response(response, response_data)
     if error:
         logger.warning(
             "%s OAuth token exchange failed for user %s, app %d: %s",

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: github
-description: Read repositories, issues, and pull requests — and open issues and comments — on GitHub as the connected user via a light REST wrapper.
+description: Read repositories, issues, and pull requests, open new issues, and add comments in GitHub on the user's behalf via a light REST wrapper.
 ---
 
 # GitHub

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/SKILL.md.template
@@ -1,0 +1,78 @@
+---
+name: github
+description: Read repositories, issues, and pull requests — and open issues and comments — on GitHub as the connected user via a light REST wrapper.
+---
+
+# GitHub
+
+Call the GitHub REST API as the connected user via the bundled helper.
+
+{{ACTION_AVAILABILITY_SECTION}}
+
+## Usage
+
+    python .opencode/skills/github/github_api.py <command> [args]
+
+Read commands auto-paginate and prune empty / `*_url` fields. `create-issue`
+and `comment` are the only writes. Use `--raw` to skip pruning;
+`python github_api.py <command> -h` shows its flags.
+
+### The connected user
+
+```
+python github_api.py me
+```
+
+### Repositories
+
+```
+python github_api.py repos [--limit N]
+python github_api.py repo OWNER REPO
+```
+
+### Issues
+
+```
+python github_api.py issues OWNER REPO [--state open|closed|all] [--limit N]
+python github_api.py issue OWNER REPO 123
+```
+
+### Pull requests
+
+```
+python github_api.py pulls OWNER REPO [--state open|closed|all] [--limit N]
+python github_api.py pull OWNER REPO 123
+```
+
+### Search
+
+```
+python github_api.py search-repos "language:python stars:>500" [--limit N]
+python github_api.py search-issues "repo:owner/repo is:open label:bug" [--limit N]
+```
+
+### Open an issue (write)
+
+```
+python github_api.py create-issue OWNER REPO "Title" [--body "Details"]
+```
+
+### Comment on an issue or PR (write)
+
+```
+python github_api.py comment OWNER REPO 123 "Looking into this"
+```
+
+## Output
+
+JSON on stdout. List commands return `{"ok": true, "<command>": [...], "count":
+N, "truncated": bool}` (`truncated` means more results existed past `--limit`).
+Failures return `{"ok": false, "status": <code>, "error": "<message>"}` and exit
+non-zero — surface the error rather than retrying blindly.
+
+## Notes
+
+- Repos are addressed as `OWNER REPO` (two args), not `owner/repo`.
+- Search uses GitHub's query syntax; pass the whole query as one quoted arg.
+- Scopes were chosen by the admin. You cannot widen them; a 403 / `Resource not
+  accessible` usually means the needed scope wasn't granted — tell the user.

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/github_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/github_api.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""GitHub REST API wrapper for the Onyx Craft sandbox.
+
+Common GitHub operations exposed as subcommands. The connected user's token is
+injected by the egress gateway, so this script sends no credentials itself.
+Output is JSON on stdout; GitHub signals failure with a non-2xx status and a
+``{"message": ...}`` body, surfaced here as ``{"ok": false, ...}``.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_BASE = "https://api.github.com"
+_PER_PAGE = 100
+_DEFAULT_LIMIT = 100
+# GitHub requires a User-Agent and recommends pinning the API version.
+_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "onyx-craft",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+# GitHub objects carry dozens of `*_url` fields that are pure noise for an LLM.
+_KEEP_URLS = frozenset({"html_url"})
+
+
+def _prune(value: Any) -> Any:
+    """Recursively drop None / "" / [] / {} and GitHub's noisy `*_url` keys
+    (keeping `html_url`) so LLM-facing output stays small. Booleans and 0 are
+    kept — they carry signal."""
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            if k not in _KEEP_URLS and (k == "url" or k.endswith("_url")):
+                continue
+            pv = _prune(v)
+            if pv not in (None, "", [], {}):
+                out[k] = pv
+        return out
+    if isinstance(value, list):
+        return [_prune(v) for v in value]
+    return value
+
+
+def _request(
+    method: str, path: str, body: dict[str, Any] | None = None
+) -> tuple[Any, dict[str, str]]:
+    """Issue a request to the GitHub REST API; return (parsed_json, headers).
+    Raises urllib errors on transport / non-2xx failure (handled by caller)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(  # noqa: S310 — fixed https base url
+        _BASE + path,
+        data=data,
+        method=method,
+        headers=dict(
+            _HEADERS, **({"Content-Type": "application/json"} if data else {})
+        ),
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+        parsed = json.loads(raw) if raw else None
+        return parsed, {k.lower(): v for k, v in resp.headers.items()}
+
+
+def _next_path(link_header: str | None) -> str | None:
+    """Pull the `rel="next"` path out of GitHub's Link header, or None."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        section = part.split(";")
+        if len(section) < 2 or 'rel="next"' not in section[1]:
+            continue
+        url = section[0].strip().strip("<>")
+        split = urllib.parse.urlsplit(url)
+        return f"{split.path}?{split.query}" if split.query else split.path
+    return None
+
+
+def _paginate(
+    path: str, params: dict[str, Any], list_key: str, limit: int
+) -> dict[str, Any]:
+    """Page through a GitHub list endpoint up to `limit`. `list_key` selects the
+    array out of search responses (`items`) vs. bare-array endpoints (whole body)."""
+    query = dict(params, per_page=min(_PER_PAGE, limit))
+    next_path: str | None = f"{path}?{urllib.parse.urlencode(query)}"
+    items: list[Any] = []
+    while next_path and len(items) < limit:
+        parsed, headers = _request("GET", next_path)
+        batch = parsed.get(list_key, []) if isinstance(parsed, dict) else (parsed or [])
+        items.extend(batch)
+        next_path = _next_path(headers.get("link"))
+    truncated = bool(next_path) or len(items) > limit
+    return {
+        "ok": True,
+        list_key: items[:limit],
+        "count": min(len(items), limit),
+        "truncated": truncated,
+    }
+
+
+def _one(path: str, key: str) -> dict[str, Any]:
+    parsed, _ = _request("GET", path)
+    return {"ok": True, key: parsed}
+
+
+def _emit(result: dict[str, Any], raw: bool) -> int:
+    print(json.dumps(result if raw else _prune(result)))
+    return 0 if result.get("ok") else 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="github_api.py", description="GitHub REST API.")
+    p.add_argument("--raw", action="store_true", help="don't prune empty / url fields")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def with_limit(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    sub.add_parser("me", help="the connected user")
+
+    with_limit(sub.add_parser("repos", help="the user's repositories"))
+
+    sp = sub.add_parser("repo", help="one repository")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+
+    sp = sub.add_parser("issues", help="a repo's issues")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("--state", default="open", choices=["open", "closed", "all"])
+    with_limit(sp)
+
+    sp = sub.add_parser("issue", help="one issue")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("number")
+
+    sp = sub.add_parser("pulls", help="a repo's pull requests")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("--state", default="open", choices=["open", "closed", "all"])
+    with_limit(sp)
+
+    sp = sub.add_parser("pull", help="one pull request")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("number")
+
+    sp = sub.add_parser("search-repos", help="search repositories")
+    sp.add_argument("query")
+    with_limit(sp)
+
+    sp = sub.add_parser("search-issues", help="search issues and pull requests")
+    sp.add_argument("query")
+    with_limit(sp)
+
+    sp = sub.add_parser("create-issue", help="open an issue (write)")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("title")
+    sp.add_argument("--body")
+
+    sp = sub.add_parser("comment", help="comment on an issue or PR (write)")
+    sp.add_argument("owner")
+    sp.add_argument("repo")
+    sp.add_argument("number")
+    sp.add_argument("body")
+    return p
+
+
+def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
+    if a.cmd == "me":
+        return _one("/user", "user")
+
+    if a.cmd == "repos":
+        return _paginate("/user/repos", {"sort": "updated"}, "__list__", a.limit)
+
+    if a.cmd == "repo":
+        return _one(f"/repos/{a.owner}/{a.repo}", "repo")
+
+    if a.cmd == "issues":
+        return _paginate(
+            f"/repos/{a.owner}/{a.repo}/issues", {"state": a.state}, "__list__", a.limit
+        )
+
+    if a.cmd == "issue":
+        return _one(f"/repos/{a.owner}/{a.repo}/issues/{a.number}", "issue")
+
+    if a.cmd == "pulls":
+        return _paginate(
+            f"/repos/{a.owner}/{a.repo}/pulls", {"state": a.state}, "__list__", a.limit
+        )
+
+    if a.cmd == "pull":
+        return _one(f"/repos/{a.owner}/{a.repo}/pulls/{a.number}", "pull")
+
+    if a.cmd == "search-repos":
+        return _paginate("/search/repositories", {"q": a.query}, "items", a.limit)
+
+    if a.cmd == "search-issues":
+        return _paginate("/search/issues", {"q": a.query}, "items", a.limit)
+
+    if a.cmd == "create-issue":
+        body: dict[str, Any] = {"title": a.title}
+        if a.body:
+            body["body"] = a.body
+        parsed, _ = _request("POST", f"/repos/{a.owner}/{a.repo}/issues", body)
+        return {"ok": True, "issue": parsed}
+
+    # comment
+    parsed, _ = _request(
+        "POST",
+        f"/repos/{a.owner}/{a.repo}/issues/{a.number}/comments",
+        {"body": a.body},
+    )
+    return {"ok": True, "comment": parsed}
+
+
+def main(argv: list[str]) -> int:
+    a = _build_parser().parse_args(argv[1:])
+    # The bare-array list endpoints return their items under a sentinel key;
+    # rename it to a friendly name before emitting.
+    try:
+        result = _dispatch(a)
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")
+        try:
+            message = json.loads(detail).get("message", detail)
+        except ValueError:
+            message = detail
+        print(json.dumps({"ok": False, "status": e.code, "error": message}))
+        return 1
+    except urllib.error.URLError as e:
+        print(f"network error calling GitHub: {e.reason}", file=sys.stderr)
+        return 1
+    if "__list__" in result:
+        result[a.cmd] = result.pop("__list__")
+    return _emit(result, a.raw)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -172,6 +172,7 @@ _REGISTRY: Final = BuiltInSkillRegistry(
             skill_id="google-calendar", app_type=ExternalAppType.GOOGLE_CALENDAR
         ),
         ExternalAppBuiltInProvider(skill_id="gmail", app_type=ExternalAppType.GMAIL),
+        ExternalAppBuiltInProvider(skill_id="github", app_type=ExternalAppType.GITHUB),
     )
 )
 

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -1,4 +1,4 @@
-import { SvgSlack, SvgLinear, SvgGmail } from "@opal/logos";
+import { SvgSlack, SvgLinear, SvgGmail, SvgGithub } from "@opal/logos";
 import { SvgCalendar, SvgPlug } from "@opal/icons";
 import { IconFunctionComponent } from "@opal/types";
 
@@ -8,6 +8,7 @@ export type ExternalAppType =
   | "GOOGLE_CALENDAR"
   | "GMAIL"
   | "LINEAR"
+  | "GITHUB"
   | "CUSTOM";
 
 const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
@@ -16,6 +17,7 @@ const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
     GOOGLE_CALENDAR: SvgCalendar,
     GMAIL: SvgGmail,
     LINEAR: SvgLinear,
+    GITHUB: SvgGithub,
   };
 
 /** Logo for a known `app_type`, with a generic fallback for CUSTOM /


### PR DESCRIPTION
## Description
Adds github as a built-in external app. Authentication done via their O-Auth flow

<img width="924" height="873" alt="Screenshot 2026-06-01 at 8 42 32 PM" src="https://github.com/user-attachments/assets/7d7ad198-2bf8-4d75-963b-bc14465a023d" />


## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub as a built-in external app with OAuth, endpoint policies, and a sandbox skill so Craft can read repos/issues/PRs and create issues/comments as the connected user. Also updates OAuth flows to request JSON and surface body errors for GitHub compatibility.

- **New Features**
  - New `GITHUB` app type and `GitHubProvider` with OAuth (`authorize`/`token`) and scopes: `repo`, `read:org`, `read:user`.
  - Endpoint catalog for reads (user, repos, issues incl. comments, pulls, search) and writes (create issue, add comment); reads default to allow.
  - OAuth token exchange and refresh send `Accept: application/json` and classify body errors (e.g., `bad_verification_code`); treats GitHub’s `bad_refresh_token` as terminal.
  - Built-in skill wiring and UI logo; adds sandbox `github_api.py` with auto-pagination, pruned JSON, and commands for reads/search plus issue/comment writes.

- **Migration**
  - In GitHub: Settings → Developer settings → OAuth Apps → New OAuth App. Set the callback URL to your Onyx host at `/craft/v1/apps/oauth/callback`.
  - Copy the Client ID and Client Secret into the app’s org credentials in Craft.
  - Users can connect GitHub from Craft; tokens may be non‑expiring unless expiring user tokens are enabled in GitHub. Reconnect if refresh is rejected.

<sup>Written for commit 5d39c708ade2d53e82b26b5a40cb29f18a4b3d91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

