### PR TITLE
feat(mcp): add known-provider oauth schema and contracts

### DIFF
--- a/backend/alembic/versions/3a9b8d7c6e5f_add_mcp_known_provider_fields.py
+++ b/backend/alembic/versions/3a9b8d7c6e5f_add_mcp_known_provider_fields.py
@@ -1,7 +1,7 @@
 """add mcp known-provider oauth fields
 
 Revision ID: 3a9b8d7c6e5f
-Revises: d0e1f2a3b4c5
+Revises: 4d545225fd82
 Create Date: 2026-05-31 13:40:00.000000
 
 """
@@ -14,7 +14,7 @@ from onyx.db.enums import MCPOAuthProviderMode
 
 # revision identifiers, used by Alembic.
 revision = "3a9b8d7c6e5f"
-down_revision = "d0e1f2a3b4c5"
+down_revision = "4d545225fd82"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/3a9b8d7c6e5f_add_mcp_known_provider_fields.py
+++ b/backend/alembic/versions/3a9b8d7c6e5f_add_mcp_known_provider_fields.py
@@ -1,0 +1,59 @@
+"""add mcp known-provider oauth fields
+
+Revision ID: 3a9b8d7c6e5f
+Revises: d0e1f2a3b4c5
+Create Date: 2026-05-31 13:40:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from onyx.db.enums import MCPOAuthProviderMode
+
+# revision identifiers, used by Alembic.
+revision = "3a9b8d7c6e5f"
+down_revision = "d0e1f2a3b4c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_server",
+        sa.Column(
+            "oauth_provider_mode",
+            sa.Enum(
+                MCPOAuthProviderMode,
+                name="mcp_oauth_provider_mode",
+                native_enum=False,
+            ),
+            nullable=False,
+            server_default=MCPOAuthProviderMode.AUTO_DISCOVERY.value,
+        ),
+    )
+    op.add_column(
+        "mcp_server",
+        sa.Column("oauth_authorization_endpoint", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "mcp_server",
+        sa.Column("oauth_token_endpoint", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "mcp_server",
+        sa.Column("oauth_scopes_override", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "mcp_server",
+        sa.Column("oauth_additional_auth_params", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_server", "oauth_additional_auth_params")
+    op.drop_column("mcp_server", "oauth_scopes_override")
+    op.drop_column("mcp_server", "oauth_token_endpoint")
+    op.drop_column("mcp_server", "oauth_authorization_endpoint")
+    op.drop_column("mcp_server", "oauth_provider_mode")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -131,6 +131,11 @@ class MCPAuthenticationType(str, PyEnum):
     PT_OAUTH = "PT_OAUTH"  # Pass-Through OAuth
 
 
+class MCPOAuthProviderMode(str, PyEnum):
+    AUTO_DISCOVERY = "AUTO_DISCOVERY"
+    KNOWN_PROVIDER = "KNOWN_PROVIDER"
+
+
 class MCPTransport(str, PyEnum):
     """MCP transport types"""
 

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -8,7 +8,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
+from onyx.db.constants import UNSET
+from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.db.models import MCPAuthenticationType
@@ -104,6 +107,11 @@ def create_mcp_server__no_commit(
     transport: MCPTransport | None,
     auth_performer: MCPAuthenticationPerformer | None,
     db_session: Session,
+    oauth_provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.AUTO_DISCOVERY,
+    oauth_authorization_endpoint: str | None = None,
+    oauth_token_endpoint: str | None = None,
+    oauth_scopes_override: list[str] | None = None,
+    oauth_additional_auth_params: dict[str, str] | None = None,
     admin_connection_config_id: int | None = None,
 ) -> MCPServer:
     """Create a new MCP server"""
@@ -115,6 +123,11 @@ def create_mcp_server__no_commit(
         transport=transport,
         auth_type=auth_type,
         auth_performer=auth_performer,
+        oauth_provider_mode=oauth_provider_mode,
+        oauth_authorization_endpoint=oauth_authorization_endpoint,
+        oauth_token_endpoint=oauth_token_endpoint,
+        oauth_scopes_override=oauth_scopes_override,
+        oauth_additional_auth_params=oauth_additional_auth_params,
         admin_connection_config_id=admin_connection_config_id,
     )
     db_session.add(new_server)
@@ -131,6 +144,11 @@ def update_mcp_server__no_commit(
     auth_type: MCPAuthenticationType | None = None,
     admin_connection_config_id: int | None = None,
     auth_performer: MCPAuthenticationPerformer | None = None,
+    oauth_provider_mode: MCPOAuthProviderMode | None = None,
+    oauth_authorization_endpoint: str | None | UnsetType = UNSET,
+    oauth_token_endpoint: str | None | UnsetType = UNSET,
+    oauth_scopes_override: list[str] | None | UnsetType = UNSET,
+    oauth_additional_auth_params: dict[str, str] | None | UnsetType = UNSET,
     transport: MCPTransport | None = None,
     status: MCPServerStatus | None = None,
     last_refreshed_at: datetime.datetime | None = None,
@@ -150,6 +168,16 @@ def update_mcp_server__no_commit(
         server.admin_connection_config_id = admin_connection_config_id
     if auth_performer is not None:
         server.auth_performer = auth_performer
+    if oauth_provider_mode is not None:
+        server.oauth_provider_mode = oauth_provider_mode
+    if not isinstance(oauth_authorization_endpoint, UnsetType):
+        server.oauth_authorization_endpoint = oauth_authorization_endpoint
+    if not isinstance(oauth_token_endpoint, UnsetType):
+        server.oauth_token_endpoint = oauth_token_endpoint
+    if not isinstance(oauth_scopes_override, UnsetType):
+        server.oauth_scopes_override = oauth_scopes_override
+    if not isinstance(oauth_additional_auth_params, UnsetType):
+        server.oauth_additional_auth_params = oauth_additional_auth_params
     if transport is not None:
         server.transport = transport
     if status is not None:

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -78,6 +78,7 @@ from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.db.enums import OpenSearchDocumentMigrationStatus
@@ -4868,6 +4869,21 @@ class MCPServer(Base):
     # Who performs authentication for this server (ADMIN or PER_USER)
     auth_performer: Mapped[MCPAuthenticationPerformer | None] = mapped_column(
         Enum(MCPAuthenticationPerformer, native_enum=False), nullable=True
+    )
+    oauth_provider_mode: Mapped[MCPOAuthProviderMode] = mapped_column(
+        Enum(MCPOAuthProviderMode, native_enum=False),
+        nullable=False,
+        server_default=MCPOAuthProviderMode.AUTO_DISCOVERY.value,
+    )
+    oauth_authorization_endpoint: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )
+    oauth_token_endpoint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    oauth_scopes_override: Mapped[list[str] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
+    oauth_additional_auth_params: Mapped[dict[str, str] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
     )
     # Status tracking for configuration flow
     status: Mapped[MCPServerStatus] = mapped_column(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1176,6 +1176,11 @@ def _db_mcp_server_to_api_mcp_server(
         transport=db_server.transport,
         auth_type=db_server.auth_type,
         auth_performer=auth_performer,
+        oauth_provider_mode=db_server.oauth_provider_mode,
+        oauth_authorization_endpoint=db_server.oauth_authorization_endpoint,
+        oauth_token_endpoint=db_server.oauth_token_endpoint,
+        oauth_scopes_override=db_server.oauth_scopes_override,
+        oauth_additional_auth_params=db_server.oauth_additional_auth_params,
         is_authenticated=is_authenticated,
         user_authenticated=user_authenticated,
         status=db_server.status,
@@ -1631,6 +1636,22 @@ def _upsert_mcp_server(
                 or request.auth_performer != mcp_server.auth_performer
             )
         )
+        # Known-provider OAuth settings (endpoints/mode/scopes/extra params)
+        # determine where and with what scope user tokens are minted. A change
+        # to any of them invalidates existing user tokens, so it must trigger
+        # the same re-handshake wipe as a client_id/secret change.
+        oauth_provider_config_changed = (
+            request.auth_type == MCPAuthenticationType.OAUTH
+            and (
+                request.oauth_provider_mode != mcp_server.oauth_provider_mode
+                or request.oauth_authorization_endpoint
+                != mcp_server.oauth_authorization_endpoint
+                or request.oauth_token_endpoint != mcp_server.oauth_token_endpoint
+                or request.oauth_scopes_override != mcp_server.oauth_scopes_override
+                or request.oauth_additional_auth_params
+                != mcp_server.oauth_additional_auth_params
+            )
+        )
 
         changing_connection_config = (
             not mcp_server.admin_connection_config
@@ -1640,6 +1661,7 @@ def _upsert_mcp_server(
                     client_info is None
                     or request.oauth_client_id != client_info.client_id
                     or request.oauth_client_secret != (client_info.client_secret or "")
+                    or oauth_provider_config_changed
                 )
             )
             or (
@@ -1680,6 +1702,11 @@ def _upsert_mcp_server(
             server_url=request.server_url,
             auth_type=request.auth_type,
             auth_performer=request.auth_performer,
+            oauth_provider_mode=request.oauth_provider_mode,
+            oauth_authorization_endpoint=request.oauth_authorization_endpoint,
+            oauth_token_endpoint=request.oauth_token_endpoint,
+            oauth_scopes_override=request.oauth_scopes_override,
+            oauth_additional_auth_params=request.oauth_additional_auth_params,
             transport=request.transport,
         )
 
@@ -1707,6 +1734,11 @@ def _upsert_mcp_server(
             server_url=request.server_url,
             auth_type=request.auth_type,
             auth_performer=request.auth_performer,
+            oauth_provider_mode=request.oauth_provider_mode,
+            oauth_authorization_endpoint=request.oauth_authorization_endpoint,
+            oauth_token_endpoint=request.oauth_token_endpoint,
+            oauth_scopes_override=request.oauth_scopes_override,
+            oauth_additional_auth_params=request.oauth_additional_auth_params,
             transport=request.transport or MCPTransport.STREAMABLE_HTTP,
             db_session=db_session,
         )
@@ -2041,6 +2073,11 @@ def upsert_mcp_server(
             auth_performer=(
                 request.auth_performer.value if request.auth_performer else None
             ),
+            oauth_provider_mode=mcp_server.oauth_provider_mode,
+            oauth_authorization_endpoint=mcp_server.oauth_authorization_endpoint,
+            oauth_token_endpoint=mcp_server.oauth_token_endpoint,
+            oauth_scopes_override=mcp_server.oauth_scopes_override,
+            oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
             is_authenticated=(
                 mcp_server.auth_type == MCPAuthenticationType.NONE.value
                 or request.auth_performer == MCPAuthenticationPerformer.ADMIN
@@ -2139,6 +2176,11 @@ def create_mcp_server_simple(
         transport=mcp_server.transport,
         auth_type=mcp_server.auth_type,
         auth_performer=mcp_server.auth_performer,
+        oauth_provider_mode=mcp_server.oauth_provider_mode,
+        oauth_authorization_endpoint=mcp_server.oauth_authorization_endpoint,
+        oauth_token_endpoint=mcp_server.oauth_token_endpoint,
+        oauth_scopes_override=mcp_server.oauth_scopes_override,
+        oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
         is_authenticated=False,  # Not authenticated yet
         status=mcp_server.status,
         tool_count=0,  # New server, no tools yet

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -14,6 +14,7 @@ from pydantic import model_validator
 
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 
@@ -128,6 +129,25 @@ class MCPToolCreateRequest(BaseModel):
     )
     oauth_client_id: Optional[str] = Field(None, description="OAuth client ID")
     oauth_client_secret: Optional[str] = Field(None, description="OAuth client secret")
+    oauth_provider_mode: MCPOAuthProviderMode = Field(
+        default=MCPOAuthProviderMode.AUTO_DISCOVERY,
+        description=(
+            "OAuth provider bootstrap mode. AUTO_DISCOVERY uses SDK challenge/"
+            "metadata discovery; KNOWN_PROVIDER uses admin-configured endpoints."
+        ),
+    )
+    oauth_authorization_endpoint: Optional[str] = Field(
+        None, description="Known-provider OAuth authorization endpoint URL"
+    )
+    oauth_token_endpoint: Optional[str] = Field(
+        None, description="Known-provider OAuth token endpoint URL"
+    )
+    oauth_scopes_override: Optional[list[str]] = Field(
+        None, description="Optional scope override for known-provider OAuth"
+    )
+    oauth_additional_auth_params: Optional[dict[str, str]] = Field(
+        None, description="Optional extra query parameters for the authorization URL"
+    )
     oauth_client_id_changed: bool = Field(
         default=False,
         description=(
@@ -205,6 +225,29 @@ class MCPToolCreateRequest(BaseModel):
         # OAuth client ID/secret are optional. If provided, they will seed the
         # OAuth client info; otherwise, the MCP client will attempt dynamic
         # client registration.
+        if self.auth_type != MCPAuthenticationType.OAUTH:
+            self.oauth_provider_mode = MCPOAuthProviderMode.AUTO_DISCOVERY
+            self.oauth_authorization_endpoint = None
+            self.oauth_token_endpoint = None
+            self.oauth_scopes_override = None
+            self.oauth_additional_auth_params = None
+            return self
+
+        if self.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER:
+            if not self.oauth_authorization_endpoint:
+                raise ValueError(
+                    "oauth_authorization_endpoint is required for known-provider OAuth mode"
+                )
+            if not self.oauth_token_endpoint:
+                raise ValueError(
+                    "oauth_token_endpoint is required for known-provider OAuth mode"
+                )
+        else:
+            # AUTO_DISCOVERY: clear fields that only apply to KNOWN_PROVIDER
+            self.oauth_authorization_endpoint = None
+            self.oauth_token_endpoint = None
+            self.oauth_scopes_override = None
+            self.oauth_additional_auth_params = None
 
         return self
 
@@ -386,6 +429,11 @@ class MCPServer(BaseModel):
     transport: Optional[MCPTransport] = None
     auth_type: Optional[MCPAuthenticationType] = None
     auth_performer: Optional[MCPAuthenticationPerformer] = None
+    oauth_provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.AUTO_DISCOVERY
+    oauth_authorization_endpoint: Optional[str] = None
+    oauth_token_endpoint: Optional[str] = None
+    oauth_scopes_override: Optional[list[str]] = None
+    oauth_additional_auth_params: Optional[dict[str, str]] = None
     is_authenticated: bool
     user_authenticated: Optional[bool] = None
     status: MCPServerStatus
@@ -418,6 +466,11 @@ class MCPServerCreateResponse(BaseModel):
     server_url: str
     auth_type: str
     auth_performer: Optional[str]
+    oauth_provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.AUTO_DISCOVERY
+    oauth_authorization_endpoint: Optional[str] = None
+    oauth_token_endpoint: Optional[str] = None
+    oauth_scopes_override: Optional[list[str]] = None
+    oauth_additional_auth_params: Optional[dict[str, str]] = None
     is_authenticated: bool
 
 

--- a/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_per_user_listing_invariants.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 from onyx.auth.schemas import UserRole
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.server.features.mcp.api import _db_mcp_server_to_api_mcp_server
@@ -54,6 +55,11 @@ def _make_db_server(
     server.admin_connection_config_id = 42 if admin_config is not None else None
     server.status = MCPServerStatus.CONNECTED
     server.last_refreshed_at = None
+    server.oauth_provider_mode = MCPOAuthProviderMode.AUTO_DISCOVERY
+    server.oauth_authorization_endpoint = None
+    server.oauth_token_endpoint = None
+    server.oauth_scopes_override = None
+    server.oauth_additional_auth_params = None
     server.current_actions = []
     return server
 

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -26,6 +26,11 @@ export interface MCPServer {
   transport?: MCPTransportType;
   auth_type?: MCPAuthenticationType;
   auth_performer?: MCPAuthenticationPerformer;
+  oauth_provider_mode?: MCPOAuthProviderMode;
+  oauth_authorization_endpoint?: string;
+  oauth_token_endpoint?: string;
+  oauth_scopes_override?: string[];
+  oauth_additional_auth_params?: Record<string, string>;
   is_authenticated: boolean;
   user_authenticated?: boolean;
   auth_template?: any;
@@ -119,6 +124,11 @@ export enum MCPAuthenticationType {
 export enum MCPAuthenticationPerformer {
   ADMIN = "ADMIN",
   PER_USER = "PER_USER",
+}
+
+export enum MCPOAuthProviderMode {
+  AUTO_DISCOVERY = "AUTO_DISCOVERY",
+  KNOWN_PROVIDER = "KNOWN_PROVIDER",
 }
 
 export interface ApiResponse<T> {

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -11,6 +11,7 @@ import {
   ToolSnapshot,
   MCPAuthenticationType,
   MCPAuthenticationPerformer,
+  MCPOAuthProviderMode,
 } from "@/lib/tools/interfaces";
 export interface ToolStatusUpdateRequest {
   tool_ids: number[];
@@ -170,6 +171,11 @@ interface UpsertMCPServerResponse {
   server_url: string;
   auth_type: string;
   auth_performer: string;
+  oauth_provider_mode?: MCPOAuthProviderMode;
+  oauth_authorization_endpoint?: string;
+  oauth_token_endpoint?: string;
+  oauth_scopes_override?: string[];
+  oauth_additional_auth_params?: Record<string, string>;
   is_authenticated: boolean;
 }
 
@@ -183,6 +189,11 @@ export async function upsertMCPServer(serverData: {
   api_token?: string;
   oauth_client_id?: string;
   oauth_client_secret?: string;
+  oauth_provider_mode?: MCPOAuthProviderMode;
+  oauth_authorization_endpoint?: string;
+  oauth_token_endpoint?: string;
+  oauth_scopes_override?: string[];
+  oauth_additional_auth_params?: Record<string, string>;
   // Mirrors the LLM-provider `api_key_changed` pattern: explicitly signal
   // whether the OAuth credential fields were edited so the backend doesn't
   // overwrite stored values with masked placeholders on resubmit.


### PR DESCRIPTION
## Description

implement mcp oauth override schema changes. There are some MCP servers that don't use the standard 401 challenge to handle their OAuth but rather require you to go through their own separate OAuth process to get a token and then pass that token along (google logging MCP is one example, I believe other google MCPs work similarly). This starts a chain of PRs that accounts for these servers by letting admins work around their nonstandard Auth pattern.

## How Has This Been Tested?

final pr tested e2e

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds known-provider OAuth config for MCP servers via new schema fields and API contracts across backend and web. Also treats provider config changes as a token reset to prepare for future connect/callback flows.

- **New Features**
  - Added `MCPOAuthProviderMode` enum with `AUTO_DISCOVERY` (default) and `KNOWN_PROVIDER`.
  - New fields: `oauth_authorization_endpoint`, `oauth_token_endpoint`, `oauth_scopes_override`, `oauth_additional_auth_params`; passed through backend models, API requests/responses, and web interfaces/service.
  - Validation: if `auth_type=OAUTH` and mode is `KNOWN_PROVIDER`, authorization and token endpoints are required; otherwise these fields are cleared and `AUTO_DISCOVERY` is used.
  - Changing mode/endpoints/scopes/extra params now invalidates existing user tokens (same as client_id/secret changes).

- **Migration**
  - Run Alembic migration `3a9b8d7c6e5f`.
  - Existing servers default to `AUTO_DISCOVERY`; no action needed unless using a known provider.

<sup>Written for commit 0ebd50eff781831e6c1fe218dd157e8bb0737394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

