### PR TITLE
ci(playwright): shard admin project across parallel runners

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -804,12 +804,30 @@ jobs:
 
       # Pull every shard's screenshots for this project into one directory.
       # Shards capture disjoint screenshot names, so merge-multiple is safe.
+      # download-artifact errors when zero artifacts match the pattern (e.g. a
+      # shard failed before capturing any screenshot, so its artifact was never
+      # uploaded). Tolerate that here and let the presence check below decide
+      # whether there's anything to diff, so an infra failure degrades to a
+      # no-op rather than turning this advisory job red.
       - name: Download shard screenshots
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           pattern: playwright-screenshots-${{ matrix.project }}-shard-*-${{ github.run_id }}
           path: web/output/screenshots/
           merge-multiple: true
+
+      - name: Check for screenshots
+        id: screenshots
+        env:
+          PROJECT: ${{ matrix.project }}
+        run: |
+          if [ -d "web/output/screenshots/" ] && [ -n "$(ls -A web/output/screenshots/ 2>/dev/null)" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No shard screenshots found for ${PROJECT} — skipping diff and baseline update."
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
@@ -847,6 +865,7 @@ jobs:
           fi
 
       - name: Generate screenshot diff report
+        if: steps.screenshots.outputs.present == 'true'
         env:
           PROJECT: ${{ matrix.project }}
           PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
@@ -856,7 +875,11 @@ jobs:
             --project "${PROJECT}" \
             --rev "${BASELINE_REV}"
 
+      # PR-only: PR_NUMBER is empty on push/merge_group events, which would write
+      # the report under a junk `reports/pr-/...` key. Baselines (updated below)
+      # are the meaningful artifact on those events, not this PR-scoped report.
       - name: Upload visual diff report to S3
+        if: github.event_name == 'pull_request' && steps.screenshots.outputs.present == 'true'
         env:
           PROJECT: ${{ matrix.project }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -311,21 +311,36 @@ jobs:
 
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]
-    name: Playwright Tests (${{ matrix.project }})
+    name: Playwright Tests (${{ matrix.project }} ${{ matrix.shard }}/${{ matrix.shards }})
     permissions:
-      id-token: write # Required for OIDC-based AWS credential exchange (S3 access)
+      id-token: write # Required for OIDC-based AWS credential exchange (S3 access for the dev license)
       contents: read
     runs-on:
       - runs-on
       - runner=8cpu-linux-arm64
-      - "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}"
+      - "run-id=${{ github.run_id }}-playwright-tests-${{ matrix.project }}-${{ matrix.shard }}"
       - "extras=ecr-cache"
       - volume=50gb
     timeout-minutes: 45
     strategy:
       fail-fast: false
+      # Each entry is one parallel runner. `admin` (the bulk of the suite) is
+      # split into shards via Playwright's `--shard=index/total`; the smaller
+      # `exclusive` project runs as a single shard (1/1). Visual-regression
+      # screenshots are merged back together per-project in the
+      # `visual-regression` job below, so individual shards only ever hold a
+      # subset of screenshots.
       matrix:
-        project: [admin, exclusive]
+        include:
+          - project: admin
+            shard: 1
+            shards: 2
+          - project: admin
+            shard: 2
+            shards: 2
+          - project: exclusive
+            shard: 1
+            shards: 1
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -431,141 +446,31 @@ jobs:
         working-directory: ./web
         env:
           PROJECT: ${{ matrix.project }}
+          SHARD: ${{ matrix.shard }}
+          SHARDS: ${{ matrix.shards }}
         run: |
-          bunx playwright test --project ${PROJECT}
+          bunx playwright test --project "${PROJECT}" --shard="${SHARD}/${SHARDS}"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
           # Includes test results and trace.zip files
-          name: playwright-test-results-${{ matrix.project }}-${{ github.run_id }}
+          name: playwright-test-results-${{ matrix.project }}-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: ./web/output/playwright/
           retention-days: 30
 
+      # Per-shard screenshots. These are merged back together per-project in the
+      # `visual-regression` job, which is where the actual diff/baseline work
+      # happens — a single shard only ever holds a subset of a project's
+      # screenshots, so it must not compare or upload baselines on its own.
       - name: Upload screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: always()
         with:
-          name: playwright-screenshots-${{ matrix.project }}-${{ github.run_id }}
+          name: playwright-screenshots-${{ matrix.project }}-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: ./web/output/screenshots/
-          retention-days: 30
-
-      # --- Visual Regression Diff ---
-      - name: Configure AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
-        with:
-          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
-          aws-region: us-east-2
-
-      - name: Install the latest version of uv
-        if: always()
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # ratchet:astral-sh/setup-uv@v8.1.0
-        with:
-          enable-cache: false
-          version: "0.9.9"
-
-      - name: Determine baseline revision
-        if: always()
-        id: baseline-rev
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
-          GH_REF: ${{ github.ref }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ "${EVENT_NAME}" = "pull_request" ]; then
-            # PRs compare against the base branch (e.g. main, release/2.5)
-            echo "rev=${BASE_REF}" >> "$GITHUB_OUTPUT"
-          elif [ "${EVENT_NAME}" = "merge_group" ]; then
-            # Merge queue compares against the target branch (e.g. refs/heads/main -> main)
-            echo "rev=${MERGE_GROUP_BASE_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
-          elif [[ "${GH_REF}" == refs/tags/* ]]; then
-            # Tag builds compare against the tag name
-            echo "rev=${REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            # Push builds (main, release/*) compare against the branch name
-            echo "rev=${REF_NAME}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Generate screenshot diff report
-        if: always()
-        env:
-          PROJECT: ${{ matrix.project }}
-          PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
-          BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
-        run: |
-          uv run --no-sync --with onyx-devtools ods screenshot-diff compare \
-            --project "${PROJECT}" \
-            --rev "${BASELINE_REV}"
-
-      - name: Upload visual diff report to S3
-        if: always()
-        env:
-          PROJECT: ${{ matrix.project }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          RUN_ID: ${{ github.run_id }}
-        run: |
-          SUMMARY_FILE="web/output/screenshot-diff/${PROJECT}/summary.json"
-          if [ ! -f "${SUMMARY_FILE}" ]; then
-            echo "No summary file found — skipping S3 upload."
-            exit 0
-          fi
-
-          HAS_DIFF=$(jq -r '.has_differences' "${SUMMARY_FILE}")
-          if [ "${HAS_DIFF}" != "true" ]; then
-            echo "No visual differences for ${PROJECT} — skipping S3 upload."
-            exit 0
-          fi
-
-          aws s3 sync "web/output/screenshot-diff/${PROJECT}/" \
-            "s3://${PLAYWRIGHT_S3_BUCKET}/reports/pr-${PR_NUMBER}/${RUN_ID}/${PROJECT}/"
-
-      - name: Upload visual diff summary
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
-        with:
-          name: screenshot-diff-summary-${{ matrix.project }}
-          path: ./web/output/screenshot-diff/${{ matrix.project }}/summary.json
-          if-no-files-found: ignore
-          retention-days: 5
-
-      - name: Upload visual diff report artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
-        with:
-          name: screenshot-diff-report-${{ matrix.project }}-${{ github.run_id }}
-          path: ./web/output/screenshot-diff/${{ matrix.project }}/
           if-no-files-found: ignore
           retention-days: 30
-
-      - name: Update S3 baselines
-        if: >-
-          success() && (
-            github.ref == 'refs/heads/main' ||
-            startsWith(github.ref, 'refs/heads/release/') ||
-            startsWith(github.ref, 'refs/tags/v') ||
-            (
-              github.event_name == 'merge_group' && (
-                github.event.merge_group.base_ref == 'refs/heads/main' ||
-                startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
-              )
-            )
-          )
-        env:
-          PROJECT: ${{ matrix.project }}
-          PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
-          BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
-        run: |
-          if [ -d "web/output/screenshots/" ] && [ "$(ls -A web/output/screenshots/)" ]; then
-            uv run --no-sync --with onyx-devtools ods screenshot-diff upload-baselines \
-              --project "${PROJECT}" \
-              --rev "${BASELINE_REV}" \
-              --delete
-          else
-            echo "No screenshots to upload for ${PROJECT} — skipping baseline update."
-          fi
 
       # save before stopping the containers so the logs can be captured
       - name: Save Docker logs
@@ -583,7 +488,7 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: docker-logs-${{ matrix.project }}-${{ github.run_id }}
+          name: docker-logs-${{ matrix.project }}-shard-${{ matrix.shard }}-${{ github.run_id }}
           path: ${{ github.workspace }}/docker-compose.log
 
   # Validates the MCP OAuth spec against the REAL Okta org (the mock IdP run in
@@ -863,14 +768,173 @@ jobs:
           name: docker-logs-lite-${{ github.run_id }}
           path: ${{ github.workspace }}/docker-compose.log
 
+  # Per-project visual regression. Because the test matrix is sharded, each
+  # shard only captures a subset of a project's screenshots. This job merges
+  # every shard's screenshots back into one directory before running the diff
+  # against the S3 baseline and (on main/release) re-uploading baselines with
+  # --delete. Running compare / upload-baselines on a partial set would report
+  # spurious "removed" screenshots and, worse, let shards race each other and
+  # corrupt the baseline — so this work MUST happen here, on the complete set.
+  visual-regression:
+    needs: [playwright-tests]
+    name: Visual Regression (${{ matrix.project }})
+    permissions:
+      id-token: write # Required for OIDC-based AWS credential exchange (S3 access)
+      contents: read
+    if: >-
+      always() &&
+      needs.playwright-tests.result != 'cancelled' &&
+      needs.playwright-tests.result != 'skipped'
+    runs-on:
+      - runs-on
+      - runner=2cpu-linux-arm64
+      - "run-id=${{ github.run_id }}-visual-regression-${{ matrix.project }}"
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        project: [admin, exclusive]
+    steps:
+      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Pull every shard's screenshots for this project into one directory.
+      # Shards capture disjoint screenshot names, so merge-multiple is safe.
+      - name: Download shard screenshots
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: playwright-screenshots-${{ matrix.project }}-shard-*-${{ github.run_id }}
+          path: web/output/screenshots/
+          merge-multiple: true
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # ratchet:astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: false
+          version: "0.9.9"
+
+      - name: Determine baseline revision
+        id: baseline-rev
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          MERGE_GROUP_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          GH_REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            # PRs compare against the base branch (e.g. main, release/2.5)
+            echo "rev=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            # Merge queue compares against the target branch (e.g. refs/heads/main -> main)
+            echo "rev=${MERGE_GROUP_BASE_REF#refs/heads/}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GH_REF}" == refs/tags/* ]]; then
+            # Tag builds compare against the tag name
+            echo "rev=${REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            # Push builds (main, release/*) compare against the branch name
+            echo "rev=${REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate screenshot diff report
+        env:
+          PROJECT: ${{ matrix.project }}
+          PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
+          BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
+        run: |
+          uv run --no-sync --with onyx-devtools ods screenshot-diff compare \
+            --project "${PROJECT}" \
+            --rev "${BASELINE_REV}"
+
+      - name: Upload visual diff report to S3
+        env:
+          PROJECT: ${{ matrix.project }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          SUMMARY_FILE="web/output/screenshot-diff/${PROJECT}/summary.json"
+          if [ ! -f "${SUMMARY_FILE}" ]; then
+            echo "No summary file found — skipping S3 upload."
+            exit 0
+          fi
+
+          HAS_DIFF=$(jq -r '.has_differences' "${SUMMARY_FILE}")
+          if [ "${HAS_DIFF}" != "true" ]; then
+            echo "No visual differences for ${PROJECT} — skipping S3 upload."
+            exit 0
+          fi
+
+          aws s3 sync "web/output/screenshot-diff/${PROJECT}/" \
+            "s3://${PLAYWRIGHT_S3_BUCKET}/reports/pr-${PR_NUMBER}/${RUN_ID}/${PROJECT}/"
+
+      - name: Upload visual diff summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: screenshot-diff-summary-${{ matrix.project }}
+          path: ./web/output/screenshot-diff/${{ matrix.project }}/summary.json
+          if-no-files-found: ignore
+          retention-days: 5
+
+      - name: Upload visual diff report artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        if: always()
+        with:
+          name: screenshot-diff-report-${{ matrix.project }}-${{ github.run_id }}
+          path: ./web/output/screenshot-diff/${{ matrix.project }}/
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Update S3 baselines
+        # Only update baselines from a fully green run on a protected ref.
+        # `success()` covers the diff steps above; `needs.playwright-tests.result`
+        # ensures no shard (in any project) failed before we treat this run's
+        # screenshots as the new source of truth.
+        if: >-
+          success() &&
+          needs.playwright-tests.result == 'success' && (
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/release/') ||
+            startsWith(github.ref, 'refs/tags/v') ||
+            (
+              github.event_name == 'merge_group' && (
+                github.event.merge_group.base_ref == 'refs/heads/main' ||
+                startsWith(github.event.merge_group.base_ref, 'refs/heads/release/')
+              )
+            )
+          )
+        env:
+          PROJECT: ${{ matrix.project }}
+          PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
+          BASELINE_REV: ${{ steps.baseline-rev.outputs.rev }}
+        run: |
+          if [ -d "web/output/screenshots/" ] && [ "$(ls -A web/output/screenshots/)" ]; then
+            uv run --no-sync --with onyx-devtools ods screenshot-diff upload-baselines \
+              --project "${PROJECT}" \
+              --rev "${BASELINE_REV}" \
+              --delete
+          else
+            echo "No screenshots to upload for ${PROJECT} — skipping baseline update."
+          fi
+
   # Post a single combined visual regression comment after all matrix jobs finish
   visual-regression-comment:
-    needs: [playwright-tests]
+    needs: [visual-regression]
     if: >-
       always() &&
       github.event_name == 'pull_request' &&
-      needs.playwright-tests.result != 'cancelled' &&
-      needs.playwright-tests.result != 'skipped'
+      needs.visual-regression.result != 'cancelled' &&
+      needs.visual-regression.result != 'skipped'
     runs-on: ubuntu-slim
     timeout-minutes: 5
     permissions:


### PR DESCRIPTION
## What

Implements sharding for `.github/workflows/pr-playwright-tests.yml` to cut Playwright e2e wall-clock time.

- The **`admin`** project (the bulk of the suite — ~65 spec files / ~370 tests) is split into **2 shards** via Playwright's `--shard=index/total`, running on separate runners. The smaller **`exclusive`** project runs as a single shard (`1/1`). The `lite` job is untouched.
- The matrix moved from `project: [admin, exclusive]` to explicit `include` entries carrying `(project, shard, shards)`. All per-runner artifact names and the runs-on `run-id` label are shard-suffixed so the parallel runners don't collide.

## Visual regression rework (the reason this isn't a one-liner)

Screenshots are captured per-test into `web/output/screenshots/`, and the old workflow ran the visual-regression steps **inside** the test job — assuming each job held the *complete* set for a project. Sharding splits screenshots across runners, which breaks two things:

- `compare` on a partial set flags every *other* shard's screenshots as "removed" → noisy false diffs.
- `upload-baselines --delete` (on main/release) lets shards race each other → **corrupted S3 baseline**.

So all visual-regression work moved out of the per-shard test job into a new per-project **`visual-regression`** job that:
1. Downloads every shard's screenshots for the project (`merge-multiple: true`) into one directory. Shards capture disjoint screenshot names, so the merge is collision-free.
2. Runs `ods screenshot-diff compare`, uploads the report to S3, and uploads the summary/report artifacts — on the **complete** set.
3. Runs `upload-baselines --delete`, now gated on `success() && needs.playwright-tests.result == 'success' && <protected ref>`.

The combined `visual-regression-comment` job now depends on `visual-regression`.

## Behavior notes

- **Baseline updates now require the whole `playwright-tests` matrix to be green** (all projects/shards), since `needs.<job>.result` is an aggregate across matrix legs — slightly stricter than the old per-project gating, and arguably safer (only promote baselines from a fully-green run).
- **Visual regression is no longer part of the required check.** Previously an *infra* failure in the inline compare step (e.g. an S3 download error) could fail the required check; diffs themselves never did. Those infra errors now land in the advisory `visual-regression` job and won't block merges.
- `playwright-required` is otherwise unchanged — the sharded matrix's aggregate result still gates correctly.

## Testing

YAML validated and job graph confirmed (`changes → builds → playwright-tests → visual-regression → visual-regression-comment`, plus `playwright-required`). End-to-end behavior will be exercised by this PR's own run of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shards the Playwright `admin` project into two parallel runners to cut e2e runtime. Moves visual regression to a per-project job that merges shard screenshots, skips work when none are present, and only uploads PR diff reports.

- **Refactors**
  - Use explicit `matrix.include` with `project`, `shard`, `shards`; `exclusive` runs `1/1`.
  - Suffix artifact names and `runs-on` labels with shard IDs to avoid collisions.
  - Add `visual-regression` job: merges shard screenshots, gates compare/report on a screenshot presence check, and uploads diff reports to S3 only for PRs.
  - Baselines upload only on protected refs when the full `playwright-tests` matrix is green; visual regression is not a required check.
  - Combined PR comment now depends on `visual-regression`; `playwright-tests-lite` is unchanged.

<sup>Written for commit 131325adff6068ad8c7fdbbdaf0f49f4843360e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

