### PR TITLE
perf(ci): split MCP playwright tests into their own shard

### DIFF
--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -305,10 +305,23 @@ jobs:
       - "extras=ecr-cache"
       - volume=50gb
     timeout-minutes: 45
+    # Poor-man's sharding: each matrix entry is a Playwright `--project` running on
+    # its own runner. The MCP shard is the only one that needs the extra MCP
+    # server containers, so only it loads the mcp-* compose files. `compose-files`
+    # is consumed via the COMPOSE_FILE env var (colon-separated) at the job level
+    # so every `docker compose` invocation in the job (up + logs) uses it.
+    env:
+      COMPOSE_FILE: ${{ matrix.compose-files }}
     strategy:
       fail-fast: false
       matrix:
-        project: [admin, exclusive]
+        include:
+          - project: admin
+            compose-files: docker-compose.yml:docker-compose.dev.yml
+          - project: exclusive
+            compose-files: docker-compose.yml:docker-compose.dev.yml
+          - project: mcp
+            compose-files: docker-compose.yml:docker-compose.dev.yml:docker-compose.mcp-oauth-test.yml:docker-compose.mcp-api-key-test.yml:docker-compose.mcp-per-user-key-test.yml
     steps:
       - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
 
@@ -375,9 +388,11 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Start Docker containers
+        # Compose file set comes from COMPOSE_FILE (matrix.compose-files); the
+        # mcp shard additionally brings up the mcp-* server containers.
         run: |
           cd deployment/docker_compose
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mcp-oauth-test.yml -f docker-compose.mcp-api-key-test.yml -f docker-compose.mcp-per-user-key-test.yml up -d --wait --wait-timeout 300
+          docker compose up -d --wait --wait-timeout 300
         id: start_docker
 
       - name: Seed dev license
@@ -409,22 +424,24 @@ jobs:
           retention-days: 30
 
       # --- Visual Regression Diff ---
+      # The mcp shard captures no screenshots, so it skips the visual-regression
+      # steps entirely (no needless AWS/uv setup, no empty row in the PR comment).
       - name: Configure AWS credentials
-        if: always()
+        if: always() && matrix.project != 'mcp'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
 
       - name: Install the latest version of uv
-        if: always()
+        if: always() && matrix.project != 'mcp'
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # ratchet:astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: false
           version: "0.9.9"
 
       - name: Determine baseline revision
-        if: always()
+        if: always() && matrix.project != 'mcp'
         id: baseline-rev
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -448,7 +465,7 @@ jobs:
           fi
 
       - name: Generate screenshot diff report
-        if: always()
+        if: always() && matrix.project != 'mcp'
         env:
           PROJECT: ${{ matrix.project }}
           PLAYWRIGHT_S3_BUCKET: ${{ env.PLAYWRIGHT_S3_BUCKET }}
@@ -459,7 +476,7 @@ jobs:
             --rev "${BASELINE_REV}"
 
       - name: Upload visual diff report to S3
-        if: always()
+        if: always() && matrix.project != 'mcp'
         env:
           PROJECT: ${{ matrix.project }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -482,7 +499,7 @@ jobs:
 
       - name: Upload visual diff summary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
+        if: always() && matrix.project != 'mcp'
         with:
           name: screenshot-diff-summary-${{ matrix.project }}
           path: ./web/output/screenshot-diff/${{ matrix.project }}/summary.json
@@ -491,7 +508,7 @@ jobs:
 
       - name: Upload visual diff report artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
+        if: always() && matrix.project != 'mcp'
         with:
           name: screenshot-diff-report-${{ matrix.project }}-${{ github.run_id }}
           path: ./web/output/screenshot-diff/${{ matrix.project }}/
@@ -500,7 +517,7 @@ jobs:
 
       - name: Update S3 baselines
         if: >-
-          success() && (
+          success() && matrix.project != 'mcp' && (
             github.ref == 'refs/heads/main' ||
             startsWith(github.ref, 'refs/heads/release/') ||
             startsWith(github.ref, 'refs/tags/v') ||

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
         storageState: "admin_auth.json",
       },
       grepInvert: [/@exclusive/, /@lite/],
+      // MCP tests run as their own shard (the `mcp` project below). They are
+      // heavier and need extra server containers, so we keep them out of the
+      // admin shard to roughly halve its runtime.
+      testIgnore: /\/tests\/e2e\/mcp\//,
     },
     {
       // this suite runs independently and serially + slower
@@ -54,6 +58,21 @@ export default defineConfig({
       },
       grep: /@exclusive/,
       workers: 1,
+    },
+    {
+      // Poor-man's sharding: MCP tests are split into their own shard. They are
+      // slow and require extra server containers (oauth / api-key / per-user-key),
+      // so isolating them keeps the admin shard lean and lets the two run in
+      // parallel. Selected by path so any spec added under tests/e2e/mcp/ is
+      // automatically picked up. Captures no screenshots, so it is excluded from
+      // visual regression in the workflow.
+      name: "mcp",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+        storageState: "admin_auth.json",
+      },
+      testMatch: /.*\/tests\/e2e\/mcp\/.*\.spec\.ts/,
     },
     {
       // runs against the Onyx Lite stack (DISABLE_VECTOR_DB=true, no Vespa/Redis)


### PR DESCRIPTION
## What

"Poor-man's sharding" for the Playwright suite: extract the `web/tests/e2e/mcp/` tests into a dedicated `mcp` Playwright project that runs on its own runner, instead of letting them sit inside the `admin` shard.

The MCP tests were ~half of the `admin` shard's wall-clock time and were the **only** tests that needed the extra `mcp-*` server containers, so isolating them is a cheap, big win without resorting to real `--shard` splitting (which would fragment the per-project screenshot/visual-regression reports across machines).

## Changes

**`web/playwright.config.ts`**
- New `mcp` project selected **by path** (`testMatch: /…\/tests\/e2e\/mcp\/.*\.spec\.ts/`) — any spec added under `tests/e2e/mcp/` is picked up automatically, no per-file tagging.
- `admin` project gains `testIgnore: /\/tests\/e2e\/mcp\//` so it no longer runs the MCP specs.

**`.github/workflows/pr-playwright-tests.yml`**
- `playwright-tests` matrix is now `admin`, `exclusive`, `mcp` (via `include`).
- Each matrix entry carries a `compose-files` list consumed through `COMPOSE_FILE` (job-level env, colon-separated). Only the `mcp` shard loads `docker-compose.mcp-oauth-test.yml` / `mcp-api-key-test.yml` / `mcp-per-user-key-test.yml`; `admin`/`exclusive` start a leaner stack.
- The MCP tests capture **no** screenshots, so the `mcp` shard is excluded from the visual-regression steps (`matrix.project != 'mcp'`), keeping the PR's visual-regression comment to `admin` + `exclusive` only and skipping needless AWS/uv setup on that shard.

## Why this is safe
- Nothing outside `tests/e2e/mcp/` references the MCP server containers, so `admin`/`exclusive` lose nothing by not starting them.
- No MCP test uses `toHaveScreenshot` / the visual-regression helper, so there are no baselines to migrate.
- The required check (`playwright-required`) aggregates the whole `playwright-tests` matrix, so the `mcp` shard is gating like the others.

## Validation
- Partition verified directly against the project regexes: exactly the 3 `mcp/` spec files map to `mcp`, the other 62 spec files stay in `admin`, zero leakage either direction.
- `prettier --check` clean on the config; `actionlint` clean on the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split MCP e2e Playwright tests into their own `mcp` project and CI shard to reduce `admin` runtime and only start MCP containers when needed. Visual regression stays on `admin` and `exclusive` only.

- **Refactors**
  - Added `mcp` Playwright project selected by path (`tests/e2e/mcp/`); `admin` now ignores that directory.
  - Updated workflow matrix to `admin`, `exclusive`, `mcp`; pass compose files via `COMPOSE_FILE`, with MCP-only stacks loaded on the `mcp` shard.
  - Skipped visual regression steps for `mcp` (no screenshots), keeping reports to `admin` and `exclusive`.

<sup>Written for commit 9d3789fa774debda5a350280b6a23721c3ef0765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

