### PR TITLE
refactor(craft): make sandbox egress proxy unconditional

### DIFF
--- a/.vscode/.env.k8s.template
+++ b/.vscode/.env.k8s.template
@@ -135,11 +135,7 @@ SANDBOX_API_SERVER_URL=http://host.docker.internal:3000
 
 SANDBOX_NAMESPACE=onyx-sandboxes
 
-# In-cluster Service hosting the egress proxy. The api_server reads this when
-# building sandbox pod specs (HTTPS_PROXY env, hostAliases, CA-bundle mounts);
-# leaving it unset disables proxy wiring entirely, which means Craft sandboxes
-# can hit external APIs without going through the approval gate. Required for
-# any approval / gate testing.
+# In-cluster Service hosting the egress proxy. Required.
 SANDBOX_PROXY_HOST=onyx-sandbox-proxy.onyx.svc.cluster.local
 
 # Ed25519 private key signing pushes to the sandbox push daemon. Must match

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -96,8 +96,7 @@ SANDBOX_POD_MEMORY_LIMIT = os.environ.get("SANDBOX_POD_MEMORY_LIMIT", "10Gi")
 # Sandbox egress proxy
 # ============================================================================
 
-# Empty host disables proxy wiring for tests/dev (the initContainer is skipped
-# and HTTPS_PROXY isn't set on the sandbox).
+# Required when SANDBOX_BACKEND=kubernetes.
 SANDBOX_PROXY_HOST = os.environ.get("SANDBOX_PROXY_HOST", "")
 SANDBOX_PROXY_PORT = int(os.environ.get("SANDBOX_PROXY_PORT", "8080"))
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -157,8 +157,6 @@ _PROXY_DNS_RETRY_BACKOFF_S = 0.5
 
 
 def _resolve_proxy_ip() -> str:
-    if not SANDBOX_PROXY_HOST:
-        raise RuntimeError("_resolve_proxy_ip called without SANDBOX_PROXY_HOST")
     last_err: OSError | None = None
     for attempt in range(_PROXY_DNS_RETRY_ATTEMPTS):
         try:
@@ -196,8 +194,6 @@ def _placeholder_llm_configs(
 
 
 def _proxy_main_container_env_vars() -> list[client.V1EnvVar]:
-    if not SANDBOX_PROXY_HOST:
-        return []
     proxy_url = f"http://{_PROXY_ALIAS}:{SANDBOX_PROXY_PORT}"
     no_proxy = _NO_PROXY
     return [
@@ -635,16 +631,10 @@ class KubernetesSandboxManager(SandboxManager):
                 client.V1VolumeMount(
                     name="managed", mount_path="/workspace/managed", read_only=True
                 ),
-                *(
-                    [
-                        client.V1VolumeMount(
-                            name=_PROXY_CA_BUNDLE_VOLUME,
-                            mount_path=_PROXY_CA_BUNDLE_DIR,
-                            read_only=True,
-                        )
-                    ]
-                    if SANDBOX_PROXY_HOST
-                    else []
+                client.V1VolumeMount(
+                    name=_PROXY_CA_BUNDLE_VOLUME,
+                    mount_path=_PROXY_CA_BUNDLE_DIR,
+                    read_only=True,
                 ),
             ],
             resources=client.V1ResourceRequirements(
@@ -720,16 +710,10 @@ class KubernetesSandboxManager(SandboxManager):
                     name="workspace", mount_path="/workspace/sessions"
                 ),
                 client.V1VolumeMount(name="managed", mount_path="/workspace/managed"),
-                *(
-                    [
-                        client.V1VolumeMount(
-                            name=_PROXY_CA_BUNDLE_VOLUME,
-                            mount_path=_PROXY_CA_BUNDLE_DIR,
-                            read_only=True,
-                        )
-                    ]
-                    if SANDBOX_PROXY_HOST
-                    else []
+                client.V1VolumeMount(
+                    name=_PROXY_CA_BUNDLE_VOLUME,
+                    mount_path=_PROXY_CA_BUNDLE_DIR,
+                    read_only=True,
                 ),
             ],
             resources=client.V1ResourceRequirements(
@@ -766,34 +750,30 @@ class KubernetesSandboxManager(SandboxManager):
             ),
         ]
 
-        init_containers: list[client.V1Container] = []
-        host_aliases: list[client.V1HostAlias] | None = None
-        if SANDBOX_PROXY_HOST:
-            init_containers.append(_proxy_init_container())
-            volumes.extend(
-                [
-                    client.V1Volume(
-                        name=_PROXY_CA_SOURCE_VOLUME,
-                        config_map=client.V1ConfigMapVolumeSource(
-                            name=SANDBOX_PROXY_CA_CONFIGMAP,
-                            optional=False,
-                        ),
+        volumes.extend(
+            [
+                client.V1Volume(
+                    name=_PROXY_CA_SOURCE_VOLUME,
+                    config_map=client.V1ConfigMapVolumeSource(
+                        name=SANDBOX_PROXY_CA_CONFIGMAP,
+                        optional=False,
                     ),
-                    client.V1Volume(
-                        name=_PROXY_CA_BUNDLE_VOLUME,
-                        empty_dir=client.V1EmptyDirVolumeSource(),
-                    ),
-                ]
-            )
-            # kubelet injects hostAliases into every container's /etc/hosts;
-            # initContainer mutations don't propagate, so we set it here.
-            host_aliases = [
-                client.V1HostAlias(ip=_resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
+                ),
+                client.V1Volume(
+                    name=_PROXY_CA_BUNDLE_VOLUME,
+                    empty_dir=client.V1EmptyDirVolumeSource(),
+                ),
             ]
+        )
+        # kubelet injects hostAliases into every container's /etc/hosts;
+        # initContainer mutations don't propagate, so we set it here.
+        host_aliases = [
+            client.V1HostAlias(ip=_resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
+        ]
 
         pod_spec = client.V1PodSpec(
             service_account_name=self._service_account,
-            init_containers=init_containers or None,
+            init_containers=[_proxy_init_container()],
             containers=[sandbox_container, sidecar_container],
             host_aliases=host_aliases,
             share_process_namespace=False,
@@ -1258,6 +1238,17 @@ class KubernetesSandboxManager(SandboxManager):
 
         pod_name = self._get_pod_name(str(sandbox_id))
 
+        if not onyx_pat:
+            raise ValueError("onyx_pat is required for Kubernetes sandbox provisioning")
+        if not SANDBOX_API_SERVER_URL:
+            raise ValueError(
+                "SANDBOX_API_SERVER_URL must be set for Kubernetes sandbox provisioning"
+            )
+        if not SANDBOX_PROXY_HOST:
+            raise ValueError(
+                "SANDBOX_PROXY_HOST must be set for Kubernetes sandbox provisioning"
+            )
+
         # Check if pod already exists and is healthy (idempotency check)
         if self._pod_exists_and_healthy(pod_name):
             logger.info(
@@ -1288,13 +1279,6 @@ class KubernetesSandboxManager(SandboxManager):
                 last_heartbeat=None,
             )
 
-        if not onyx_pat:
-            raise ValueError("onyx_pat is required for Kubernetes sandbox provisioning")
-        if not SANDBOX_API_SERVER_URL:
-            raise ValueError(
-                "SANDBOX_API_SERVER_URL must be set for Kubernetes sandbox provisioning"
-            )
-
         try:
             # Re-provision: clear tombstone + cached info so subscribes
             # build a fresh bus with the new Secret's password.
@@ -1306,18 +1290,13 @@ class KubernetesSandboxManager(SandboxManager):
             # provider for cross-provider model overrides; keys are swapped for
             # the proxy placeholder so the pod never holds them.
             providers = _placeholder_llm_configs(all_llm_configs or [llm_config])
-            # Only register the egress-tagging plugin when the proxy is
-            # deployed; otherwise it would no-op (no HTTP(S)_PROXY to re-tag).
-            session_tag_plugins = (
-                [_OPENCODE_SESSION_TAG_PLUGIN_PATH] if SANDBOX_PROXY_HOST else None
-            )
             opencode_config_json = json.dumps(
                 build_multi_provider_opencode_config(
                     providers=providers,
                     default_provider=llm_config.provider,
                     default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
-                    plugins=session_tag_plugins,
+                    plugins=[_OPENCODE_SESSION_TAG_PLUGIN_PATH],
                 )
             )
             self._provision_opencode_secret(str(sandbox_id), opencode_config_json)

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -34,7 +34,6 @@ from kubernetes.client.rest import ApiException
 from onyx.db.enums import SandboxStatus
 from onyx.server.features.build.configs import SANDBOX_BACKEND
 from onyx.server.features.build.configs import SANDBOX_NAMESPACE
-from onyx.server.features.build.configs import SANDBOX_PROXY_HOST
 from onyx.server.features.build.configs import SandboxBackend
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
@@ -502,13 +501,6 @@ def test_managed_directory_is_read_only_from_sandbox_container(
 # ---------------------------------------------------------------------------
 
 
-_proxy_required = pytest.mark.skipif(
-    not SANDBOX_PROXY_HOST,
-    reason="SANDBOX_PROXY_HOST not set; proxy not deployed in this env",
-)
-
-
-@_proxy_required
 def test_sandbox_etc_hosts_resolves_proxy_alias(
     k8s_client: client.CoreV1Api,
     pool_session: tuple[UUID, UUID, str],
@@ -531,7 +523,6 @@ def test_sandbox_etc_hosts_resolves_proxy_alias(
     )
 
 
-@_proxy_required
 def test_sandbox_egress_only_flows_via_proxy(
     provisioned_sandbox: tuple[UUID, str],
     k8s_client: client.CoreV1Api,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -41,11 +41,16 @@ def _gen_key_b64() -> str:
     return base64.b64encode(seed).decode()
 
 
+_TEST_PROXY_IP = "10.255.255.254"
+
+
 @pytest.fixture(autouse=True)
 def _push_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("ONYX_SANDBOX_PUSH_PRIVATE_KEY", _gen_key_b64())
     monkeypatch.setattr(ksm, "_push_private_key", None, raising=False)
     monkeypatch.setattr(ksm, "_push_public_key_b64", None, raising=False)
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "sandbox-proxy.onyx.svc")
+    monkeypatch.setattr(ksm, "_resolve_proxy_ip", lambda: _TEST_PROXY_IP)
 
 
 def _build_pod() -> client.V1Pod:
@@ -148,7 +153,12 @@ def test_workspace_volume_is_shared_for_session_io(pod: client.V1Pod) -> None:
     work, the sidecar to tar/untar snapshots.
     """
     volume_names = {v.name for v in pod.spec.volumes}
-    assert volume_names == {"workspace", "managed"}
+    assert volume_names == {
+        "workspace",
+        "managed",
+        "sandbox-ca-source",
+        "sandbox-ca-bundle",
+    }
     for name in ("sandbox", "sidecar"):
         mount = _mount(_container(pod, name), "workspace")
         assert mount.mount_path == "/workspace/sessions"
@@ -177,30 +187,60 @@ def test_onyx_pat_env_is_placeholder_not_real(pod: client.V1Pod) -> None:
     assert env["ONYX_PAT"] == ksm._PROXY_INJECTED_PLACEHOLDER
 
 
-def test_no_proxy_is_loopback_only(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_no_proxy_is_loopback_only() -> None:
     """Only loopback may bypass the proxy; the Onyx API host must route through
     it so the PAT can be injected on the wire."""
-    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "sandbox-proxy")
     env = {e.name: e.value for e in ksm._proxy_main_container_env_vars()}
     assert set(env["NO_PROXY"].split(",")) == {"127.0.0.1", "localhost"}
     assert env["no_proxy"] == env["NO_PROXY"]
 
 
-def test_no_proxy_env_on_sandbox_container_when_proxy_unconfigured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """With no proxy host, the built pod's sandbox container must carry no proxy
-    env at all — pinning the actual spec, not just the helper, so a hardcoded or
-    misplaced proxy var can't create a silent direct-egress (un-injected) path."""
-    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "")
-    env = {e.name for e in _container(_build_pod(), "sandbox").env}
-    assert env.isdisjoint(
-        {
-            "HTTP_PROXY",
-            "HTTPS_PROXY",
-            "NO_PROXY",
-            "http_proxy",
-            "https_proxy",
-            "no_proxy",
-        }
-    )
+# ---------------------------------------------------------------------------
+# Egress proxy wiring on the built pod (mandatory — no direct-egress path)
+# ---------------------------------------------------------------------------
+
+
+_PROXY_ENV_NAMES = {
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+}
+
+
+def test_proxy_env_is_set_on_sandbox_and_sidecar(pod: client.V1Pod) -> None:
+    """Both containers' outbound traffic must be routed through the proxy —
+    sandbox for the agent, sidecar for `aws s3` (the pod-wide iptables
+    lockdown blocks direct egress for either)."""
+    for name in ("sandbox", "sidecar"):
+        env = {e.name for e in _container(pod, name).env}
+        assert _PROXY_ENV_NAMES.issubset(env), (
+            f"{name} container missing proxy env: {_PROXY_ENV_NAMES - env}"
+        )
+
+
+def test_proxy_init_container_present(pod: client.V1Pod) -> None:
+    """The iptables-lockdown initContainer must run before any user code —
+    it's what blocks direct egress that the HTTPS_PROXY env doesn't catch."""
+    init_names = [c.name for c in (pod.spec.init_containers or [])]
+    assert init_names == ["sandbox-init"]
+
+
+def test_host_aliases_pin_proxy(pod: client.V1Pod) -> None:
+    """The iptables rules block DNS, so the proxy hostname must be resolved
+    via pod hostAliases."""
+    assert pod.spec.host_aliases is not None
+    aliases = {ha.ip: ha.hostnames for ha in pod.spec.host_aliases}
+    assert aliases == {_TEST_PROXY_IP: ["sandbox-proxy"]}
+
+
+def test_ca_bundle_mounted_read_only_on_both_containers(pod: client.V1Pod) -> None:
+    """The proxy terminates TLS with its own CA, so every container that
+    makes HTTPS calls must mount the CA bundle. Read-only — the bundle is
+    populated by the initContainer and must not be writable by the agent."""
+    for name in ("sandbox", "sidecar"):
+        mount = _mount(_container(pod, name), "sandbox-ca-bundle")
+        assert mount.read_only is True
+        assert mount.mount_path == "/etc/ssl/sandbox"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.13
+version: 0.5.14
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,11 +17,10 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump the `code-interpreter` subchart from 0.3.3 to 0.4.2,
-        which makes the executor egress lockdown configurable
-        (`kubernetesExecutor.netAdminLockdown`) and adds an always-applied
-        deny-all egress NetworkPolicy for executor/session pods running
-        untrusted code.
+      description: Sandbox egress proxy is now unconditional when
+        `ENABLE_CRAFT=true`. The `sandboxProxy.enabled` value and the
+        `onyx.sandboxProxyEnabled` template helper have been removed; every
+        Craft sandbox routes outbound traffic through the proxy.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -186,3 +186,10 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- $engine := default "hpa" .Values.autoscaling.engine -}}
 {{- $engine | lower -}}
 {{- end }}
+
+{{/*
+"true" when ENABLE_CRAFT is set in configMap, empty otherwise.
+*/}}
+{{- define "onyx.craftEnabled" -}}
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" -}}true{{- end -}}
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -186,10 +186,3 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- $engine := default "hpa" .Values.autoscaling.engine -}}
 {{- $engine | lower -}}
 {{- end }}
-
-{{/*
-True when the sandbox proxy stack should render (Craft enabled + proxy enabled).
-*/}}
-{{- define "onyx.sandboxProxyEnabled" -}}
-{{- and (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") (.Values.sandboxProxy | default dict).enabled -}}
-{{- end }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
   {{- if .Values.codeInterpreter.enabled }}
   CODE_INTERPRETER_BASE_URL: "http://{{ .Release.Name }}-code-interpreter:{{ .Values.codeInterpreter.service.port }}"
   {{- end }}
-  {{- if eq (include "onyx.sandboxProxyEnabled" .) "true" }}
+  {{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
   SANDBOX_PROXY_HOST: "{{ include "onyx.fullname" . }}-sandbox-proxy.{{ .Release.Namespace }}.svc.cluster.local"
   SANDBOX_PROXY_PORT: "{{ (((.Values.sandboxProxy | default dict).service | default dict).proxyPort | default 8080) }}"
   {{- end }}

--- a/deployment/helm/charts/onyx/templates/configmap.yaml
+++ b/deployment/helm/charts/onyx/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
   {{- if .Values.codeInterpreter.enabled }}
   CODE_INTERPRETER_BASE_URL: "http://{{ .Release.Name }}-code-interpreter:{{ .Values.codeInterpreter.service.port }}"
   {{- end }}
-  {{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+  {{- if eq (include "onyx.craftEnabled" .) "true" }}
   SANDBOX_PROXY_HOST: "{{ include "onyx.fullname" . }}-sandbox-proxy.{{ .Release.Namespace }}.svc.cluster.local"
   SANDBOX_PROXY_PORT: "{{ (((.Values.sandboxProxy | default dict).service | default dict).proxyPort | default 8080) }}"
   {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "onyx.sandboxProxyEnabled" .) "true" }}
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "onyx.sandboxProxyEnabled" .) "true" }}
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 # Ingress restricted to the sandbox namespace. The proxy has no
 # authentication on its port; this is the K8s-level control that keeps

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 # Ingress restricted to the sandbox namespace. The proxy has no
 # authentication on its port; this is the K8s-level control that keeps

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") (gt (int ((.Values.sandboxProxy | default dict).replicaCount | default 1)) 1) }}
+{{- if and (eq (include "onyx.craftEnabled" .) "true") (gt (int ((.Values.sandboxProxy | default dict).replicaCount | default 1)) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (include "onyx.sandboxProxyEnabled" .) "true") (gt (int ((.Values.sandboxProxy | default dict).replicaCount | default 1)) 1) }}
+{{- if and (eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true") (gt (int ((.Values.sandboxProxy | default dict).replicaCount | default 1)) 1) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "onyx.sandboxProxyEnabled" .) "true" }}
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 apiVersion: v1
 kind: ServiceAccount

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 apiVersion: v1
 kind: ServiceAccount

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "onyx.sandboxProxyEnabled" .) "true" }}
+{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-proxy/service.yaml
@@ -1,4 +1,4 @@
-{{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" }}
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/deployment/helm/charts/onyx/values-localdev.yaml
+++ b/deployment/helm/charts/onyx/values-localdev.yaml
@@ -82,8 +82,6 @@ configMap:
   SANDBOX_API_SERVER_URL: "http://host.docker.internal:3000"
   ENABLE_PAID_ENTERPRISE_EDITION_FEATURES: "true"
 
-# Can't be disabled when ENABLE_CRAFT=true: sandbox pods won't start
-# without the CA ConfigMap the proxy projects.
 sandboxProxy:
   replicaCount: 1
   resources:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1460,9 +1460,8 @@ configMap:
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
 
-# -- Sandbox egress proxy. Only deployed when ENABLE_CRAFT=true.
+# -- Sandbox egress proxy.
 sandboxProxy:
-  enabled: true
   replicaCount: 2
   containerPorts:
     proxy: 8080


### PR DESCRIPTION
## Description

Make the Craft sandbox egress proxy unconditional. The proxy was previously gated two ways: `if SANDBOX_PROXY_HOST:` branches in the K8s sandbox manager, and a `sandboxProxy.enabled` field plus `onyx.sandboxProxyEnabled` helm helper. When either was off, the sandbox pod was built without the iptables-lockdown initContainer, without `HTTPS_PROXY` env, and without the CA-bundle mount — silently allowing direct egress with the placeholder credentials baked into the pod. The proxy is part of Craft's security model; making it optional was a footgun. Every Craft deployment now wires the proxy.

Changes:
- `kubernetes_sandbox_manager.py`: removed every `if SANDBOX_PROXY_HOST` branch (5 sites). Init container, env vars, volume mounts, host_aliases, and the session-tag plugin are now always wired. Added a `SANDBOX_PROXY_HOST` precondition alongside the existing `SANDBOX_API_SERVER_URL` check, hoisted above the `_pod_exists_and_healthy` reuse shortcut.
- Helm chart: deleted the `onyx.sandboxProxyEnabled` helper and the `sandboxProxy.enabled` field. All sandbox-proxy resources (deployment, service, rbac, pdb, networkpolicy) and the configmap entries now render under the same `ENABLE_CRAFT=true` gate already used by `sandbox-namespace.yaml`.
- Tests: deleted `test_no_proxy_env_on_sandbox_container_when_proxy_unconfigured` (scenario is now impossible). Added four positive assertions in `test_pod_spec.py` — `test_proxy_env_is_set_on_sandbox_and_sidecar`, `test_proxy_init_container_present`, `test_host_aliases_pin_proxy`, `test_ca_bundle_mounted_read_only_on_both_containers`. Restored strict equality on `test_workspace_volume_is_shared_for_session_io` (now includes the two proxy volumes). Autouse fixture monkeypatches `_resolve_proxy_ip` to a sentinel `10.255.255.254` so tests don't hit DNS. Removed `_proxy_required = pytest.mark.skipif(not SANDBOX_PROXY_HOST, ...)` from the external-dependency suite.

Docker-compose proxy work is in flight separately; this PR intentionally leaves `deployment/docker_compose/` alone.

## How Has This Been Tested?

- [x] `pytest tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py` — 13/13 pass (9 existing + 4 new).
- [x] `helm template -f values-localdev.yaml --set auth.opensearch.values.opensearch_admin_password=test deployment/helm/charts/onyx` — all 5 sandbox-proxy resources render + `SANDBOX_PROXY_HOST`/`PORT` populate in the configmap when `ENABLE_CRAFT=true`; zero proxy resources render when unset.
- [ ] CI K8s lane (\`pr-craft-k8s-tests.yml\`) — needs to confirm the un-gated \`test_sandbox_etc_hosts_resolves_proxy_alias\` and \`test_sandbox_egress_only_flows_via_proxy\` still run green in-cluster.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Craft sandbox egress proxy always-on in Kubernetes to force all sandbox traffic through the proxy and remove direct egress paths. This hardens security and simplifies configuration by removing proxy toggles.

- **Refactors**
  - Kubernetes: proxy wiring is unconditional (iptables init container, HTTPS/NO_PROXY env, CA bundle mounts, hostAliases, session-tag plugin). Provision now requires `SANDBOX_PROXY_HOST`.
  - Helm: replaced `onyx.sandboxProxyEnabled` with `onyx.craftEnabled`; removed `.Values.sandboxProxy.enabled`. Proxy resources render when `ENABLE_CRAFT=true`; ConfigMap sets `SANDBOX_PROXY_HOST/PORT` under that gate. Bumped chart to `0.5.14`.
  - Tests: deleted proxy-optional case; added assertions for proxy env, init container, hostAliases, and CA bundle; stubbed proxy DNS; removed proxy-based skips.

- **Migration**
  - Set `SANDBOX_PROXY_HOST` (and `PORT`) when `SANDBOX_BACKEND=kubernetes`; provisioning fails if unset.
  - Remove any usage of `.Values.sandboxProxy.enabled`; rely on `ENABLE_CRAFT=true` to deploy the proxy.
  - Docker Compose is unchanged.

<sup>Written for commit 0e47d9dd5cd339291e6a1e020417df106c5af092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

