### PR TITLE
feat(mcp): add known-provider oauth connect and callback flow

### DIFF
--- a/backend/onyx/auth/oauth_token_manager.py
+++ b/backend/onyx/auth/oauth_token_manager.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 from uuid import UUID
 
 import requests
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.db.models import OAuthConfig
@@ -14,6 +15,86 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
 
 logger = setup_logger()
+
+OAUTH_RESPONSE_TYPE_CODE = "code"
+OAUTH_GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code"
+OAUTH_PKCE_CHALLENGE_METHOD_S256 = "S256"
+
+
+class OAuthFlowParams(BaseModel):
+    """Stateless inputs for the OAuth 2.0 authorization-code grant, decoupled
+    from any storage model so both `OAuthConfig`-backed tool OAuth and MCP
+    known-provider OAuth can share the wire primitives below."""
+
+    authorization_url: str
+    token_url: str
+    client_id: str
+    client_secret: str | None = None
+    scopes: list[str] | None = None
+    additional_params: dict[str, Any] | None = None
+
+
+def build_oauth_authorization_url(
+    params: OAuthFlowParams,
+    redirect_uri: str,
+    state: str,
+    *,
+    code_challenge: str | None = None,
+    resource: str | None = None,
+) -> str:
+    """Construct an authorization-code-grant authorize URL. `code_challenge`
+    adds PKCE (S256); `resource` adds the RFC 8707 resource indicator. Both are
+    off by default so non-PKCE callers get an unchanged URL."""
+    query: dict[str, Any] = {
+        "client_id": params.client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": OAUTH_RESPONSE_TYPE_CODE,
+        "state": state,
+    }
+    if params.scopes:
+        query["scope"] = " ".join(params.scopes)
+    if code_challenge:
+        query["code_challenge"] = code_challenge
+        query["code_challenge_method"] = OAUTH_PKCE_CHALLENGE_METHOD_S256
+    if resource:
+        query["resource"] = resource
+    if params.additional_params:
+        query.update(params.additional_params)
+
+    separator = "&" if "?" in params.authorization_url else "?"
+    return f"{params.authorization_url}{separator}{urlencode(query)}"
+
+
+def exchange_oauth_code_for_token(
+    params: OAuthFlowParams,
+    code: str,
+    redirect_uri: str,
+    *,
+    code_verifier: str | None = None,
+) -> dict[str, Any]:
+    """Exchange an authorization code for tokens at the token endpoint. Sends
+    `code_verifier` when provided (PKCE). Returns the raw provider payload with
+    a computed `expires_at`; raises `requests.HTTPError` on a non-2xx response."""
+    data: dict[str, str] = {
+        "grant_type": OAUTH_GRANT_TYPE_AUTHORIZATION_CODE,
+        "code": code,
+        "client_id": params.client_id,
+        "redirect_uri": redirect_uri,
+    }
+    if params.client_secret:
+        data["client_secret"] = params.client_secret
+    if code_verifier:
+        data["code_verifier"] = code_verifier
+
+    response = requests.post(
+        params.token_url, data=data, headers={"Accept": "application/json"}
+    )
+    response.raise_for_status()
+
+    token_data = response.json()
+    if "expires_in" in token_data:
+        token_data["expires_at"] = int(time.time()) + token_data["expires_in"]
+    return token_data
 
 
 class OAuthTokenManager:
@@ -133,29 +214,9 @@ class OAuthTokenManager:
                 "OAuth client_id and client_secret are required for code exchange"
             )
 
-        data: dict[str, str] = {
-            "grant_type": "authorization_code",
-            "code": code,
-            "client_id": self._unwrap_sensitive_str(self.oauth_config.client_id),
-            "client_secret": self._unwrap_sensitive_str(
-                self.oauth_config.client_secret
-            ),
-            "redirect_uri": redirect_uri,
-        }
-        response = requests.post(
-            self.oauth_config.token_url,
-            data=data,
-            headers={"Accept": "application/json"},
+        return exchange_oauth_code_for_token(
+            self._flow_params(self.oauth_config), code, redirect_uri
         )
-        response.raise_for_status()
-
-        token_data = response.json()
-
-        # Calculate expires_at if expires_in is present
-        if "expires_in" in token_data:
-            token_data["expires_at"] = int(time.time()) + token_data["expires_in"]
-
-        return token_data
 
     @staticmethod
     def build_authorization_url(
@@ -164,28 +225,27 @@ class OAuthTokenManager:
         """Build OAuth authorization URL"""
         if oauth_config.client_id is None:
             raise ValueError("OAuth client_id is required to build authorization URL")
+        return build_oauth_authorization_url(
+            OAuthTokenManager._flow_params(oauth_config), redirect_uri, state
+        )
 
-        params: dict[str, Any] = {
-            "client_id": OAuthTokenManager._unwrap_sensitive_str(
-                oauth_config.client_id
-            ),
-            "redirect_uri": redirect_uri,
-            "response_type": "code",
-            "state": state,
-        }
-
-        # Add scopes if configured
-        if oauth_config.scopes:
-            params["scope"] = " ".join(oauth_config.scopes)
-
-        # Add any additional provider-specific parameters
-        if oauth_config.additional_params:
-            params.update(oauth_config.additional_params)
-
-        # Check if URL already has query parameters
-        separator = "&" if "?" in oauth_config.authorization_url else "?"
-
-        return f"{oauth_config.authorization_url}{separator}{urlencode(params)}"
+    @staticmethod
+    def _flow_params(oauth_config: OAuthConfig) -> OAuthFlowParams:
+        if oauth_config.client_id is None:
+            raise ValueError("OAuth client_id is required")
+        client_secret = (
+            OAuthTokenManager._unwrap_sensitive_str(oauth_config.client_secret)
+            if oauth_config.client_secret is not None
+            else None
+        )
+        return OAuthFlowParams(
+            authorization_url=oauth_config.authorization_url,
+            token_url=oauth_config.token_url,
+            client_id=OAuthTokenManager._unwrap_sensitive_str(oauth_config.client_id),
+            client_secret=client_secret,
+            scopes=oauth_config.scopes,
+            additional_params=oauth_config.additional_params,
+        )
 
     @staticmethod
     def _unwrap_sensitive_str(value: SensitiveValue[str] | str) -> str:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -5,10 +5,10 @@ import hashlib
 import json
 from enum import Enum
 from secrets import token_urlsafe
-from typing import cast
 from typing import Literal
 from urllib.parse import urlparse
 
+import requests
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
@@ -24,6 +24,9 @@ from pydantic import AnyUrl
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.auth.oauth_token_manager import build_oauth_authorization_url
+from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
+from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.auth.users import current_curator_or_admin_user
@@ -32,6 +35,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import MCPTransport
 from onyx.db.enums import Permission
@@ -57,6 +61,8 @@ from onyx.db.models import User
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_tools_by_mcp_server_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.mcp.models import apply_auto_substitutions
 from onyx.server.features.mcp.models import MCPApiKeyResponse
@@ -83,6 +89,7 @@ from onyx.tools.tool_implementations.mcp.mcp_client import log_exception_group
 from onyx.utils.encryption import mask_string
 from onyx.utils.encryption import reject_masked_credentials
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -507,11 +514,49 @@ def make_pkce_pair() -> tuple[str, str]:
     return verifier, challenge
 
 
+MCP_OAUTH_CALLBACK_PATH = "/mcp/oauth/callback"
+
+
+def _mcp_oauth_redirect_uri() -> str:
+    return f"{WEB_DOMAIN}{MCP_OAUTH_CALLBACK_PATH}"
+
+
+def _mcp_known_provider_flow_params(
+    mcp_server: DbMCPServer,
+    client_info: OAuthClientInformationFull,
+) -> OAuthFlowParams:
+    """Map a known-provider MCP server + its stored client credentials onto the
+    shared OAuth flow descriptor consumed by the OAuthTokenManager primitives."""
+    if (
+        not mcp_server.oauth_authorization_endpoint
+        or not mcp_server.oauth_token_endpoint
+    ):
+        raise OnyxError(
+            OnyxErrorCode.MISSING_REQUIRED_FIELD,
+            "Known-provider OAuth mode requires oauth_authorization_endpoint "
+            "and oauth_token_endpoint",
+        )
+    if not client_info.client_id:
+        raise OnyxError(
+            OnyxErrorCode.MISSING_REQUIRED_FIELD,
+            "Known-provider OAuth mode requires a non-empty client_id",
+        )
+    return OAuthFlowParams(
+        authorization_url=mcp_server.oauth_authorization_endpoint,
+        token_url=mcp_server.oauth_token_endpoint,
+        client_id=client_info.client_id,
+        client_secret=client_info.client_secret,
+        scopes=mcp_server.oauth_scopes_override,
+        additional_params=mcp_server.oauth_additional_auth_params,
+    )
+
+
 class MCPOauthState(BaseModel):
     server_id: int
     return_path: str
     is_admin: bool
     state: str
+    code_verifier: str | None = None
 
 
 @admin_router.post("/oauth/connect", response_model=MCPUserOAuthConnectResponse)
@@ -635,6 +680,60 @@ async def _connect_oauth(
     connection_config_dict = extract_connection_data(
         connection_config, apply_mask=False
     )
+
+    if mcp_server.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER:
+        client_info_raw = connection_config_dict.get(MCPOAuthKeys.CLIENT_INFO.value)
+        if not client_info_raw:
+            raise OnyxError(
+                OnyxErrorCode.MISSING_REQUIRED_FIELD,
+                "Known-provider OAuth mode requires a configured OAuth client_id. "
+                "Please set client credentials in the auth modal.",
+            )
+
+        client_info = OAuthClientInformationFull.model_validate(client_info_raw)
+        if not client_info.client_id:
+            raise OnyxError(
+                OnyxErrorCode.MISSING_REQUIRED_FIELD,
+                "Known-provider OAuth mode requires a non-empty client_id",
+            )
+
+        state = token_urlsafe(32)
+        code_verifier, code_challenge = make_pkce_pair()
+        state_obj = MCPOauthState(
+            server_id=mcp_server.id,
+            return_path=request.return_path,
+            is_admin=is_admin,
+            state=state,
+            code_verifier=code_verifier,
+        )
+        redis_client = get_redis_client()
+        state_key = key_state(str(user.id))
+        logger.info(
+            "Known-provider OAuth connect: stored state for server_id=%s user_id=%s tenant=%s",
+            mcp_server.id,
+            user.id,
+            get_current_tenant_id(),
+        )
+        redis_client.set(
+            state_key,
+            state_obj.model_dump_json(),
+            ex=STATE_TTL_SECONDS,
+        )
+
+        oauth_url = build_oauth_authorization_url(
+            _mcp_known_provider_flow_params(mcp_server, client_info),
+            _mcp_oauth_redirect_uri(),
+            state,
+            code_challenge=code_challenge,
+            resource=(
+                mcp_server.server_url if request.include_resource_param else None
+            ),
+        )
+        return MCPUserOAuthConnectResponse(
+            server_id=int(request.server_id),
+            oauth_url=oauth_url,
+        )
+
     is_connected = (
         MCPOAuthKeys.CLIENT_INFO.value in connection_config_dict
         and connection_config_dict.get("headers")
@@ -782,7 +881,15 @@ async def process_oauth_callback(
         raise HTTPException(status_code=400, detail="Missing state parameter")
     if not code:
         raise HTTPException(status_code=400, detail="Missing code parameter")
-    stored_data = cast(bytes, redis_client.get(key_state(user_id)))
+
+    state_key = key_state(user_id)
+    stored_data = redis_client.get(state_key)
+    logger.info(
+        "OAuth callback: state lookup for user_id=%s tenant=%s found=%s",
+        user_id,
+        get_current_tenant_id(),
+        stored_data is not None,
+    )
     if not stored_data:
         raise HTTPException(
             status_code=400, detail="Invalid or expired state parameter"
@@ -794,7 +901,70 @@ async def process_oauth_callback(
     except Exception:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    user_id = str(user.id)
+    if state != state_data.state:
+        logger.warning(
+            "OAuth callback: state mismatch for user_id=%s server_id=%s",
+            user_id,
+            server_id,
+        )
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid OAuth state")
+
+    if mcp_server.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER:
+        user_config = get_user_connection_config(mcp_server.id, user.email, db_session)
+        if not user_config:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "User connection config not found for known-provider callback",
+            )
+
+        user_config_data = extract_connection_data(user_config, apply_mask=False)
+        client_info_raw = user_config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+        if not client_info_raw:
+            raise OnyxError(
+                OnyxErrorCode.MISSING_REQUIRED_FIELD,
+                "Known-provider callback missing client info. "
+                "Reconfigure OAuth client credentials and retry.",
+            )
+
+        client_info = OAuthClientInformationFull.model_validate(client_info_raw)
+        try:
+            token_payload = exchange_oauth_code_for_token(
+                _mcp_known_provider_flow_params(mcp_server, client_info),
+                code,
+                _mcp_oauth_redirect_uri(),
+                code_verifier=state_data.code_verifier,
+            )
+        except requests.HTTPError as e:
+            detail = e.response.text if e.response is not None else str(e)
+            upstream_status = e.response.status_code if e.response is not None else None
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                f"Known-provider OAuth token exchange failed: {detail}",
+                status_code_override=upstream_status,
+            )
+        if not token_payload.get("access_token"):
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY, "Token response missing access_token"
+            )
+        oauth_token = OAuthToken.model_validate(token_payload)
+
+        user_config_data[MCPOAuthKeys.TOKENS.value] = oauth_token.model_dump(
+            mode="json"
+        )
+        user_config_data["headers"] = {
+            "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
+        }
+        update_connection_config(user_config.id, db_session, user_config_data)
+        redis_client.delete(key_state(user_id))
+
+        db_session.commit()
+        return MCPOAuthCallbackResponse(
+            success=True,
+            server_id=mcp_server.id,
+            server_name=mcp_server.name,
+            message=f"OAuth authorization completed successfully for {mcp_server.name}",
+            redirect_url=state_data.return_path,
+        )
 
     r = get_redis_client()
 

--- a/backend/tests/external_dependency_unit/tools/test_oauth_token_manager.py
+++ b/backend/tests/external_dependency_unit/tools/test_oauth_token_manager.py
@@ -9,6 +9,8 @@ All HTTP requests to external OAuth providers are mocked.
 import time
 from unittest.mock import Mock
 from unittest.mock import patch
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import pytest
@@ -16,6 +18,9 @@ from requests import HTTPError
 from requests import Response
 from sqlalchemy.orm import Session
 
+from onyx.auth.oauth_token_manager import build_oauth_authorization_url
+from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
+from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import OAuthTokenManager
 from onyx.db.models import OAuthConfig
 from onyx.db.oauth_config import create_oauth_config
@@ -514,3 +519,87 @@ class TestUnwrapSensitiveStr:
 
         # Plain str input
         assert OAuthTokenManager._unwrap_sensitive_str("plain_string") == "plain_string"
+
+
+def _known_flow_params() -> OAuthFlowParams:
+    return OAuthFlowParams(
+        authorization_url="https://provider.example.com/authorize",
+        token_url="https://provider.example.com/token",
+        client_id="known_client_id",
+        client_secret="known_client_secret",
+        scopes=["read", "write"],
+        additional_params={"prompt": "consent"},
+    )
+
+
+class TestSharedOAuthPrimitives:
+    """The storage-agnostic wire primitives shared by tool OAuth and MCP
+    known-provider OAuth. PKCE and the resource indicator are opt-in and must
+    not appear unless requested."""
+
+    def test_build_authorization_url_includes_pkce_and_resource(self) -> None:
+        url = build_oauth_authorization_url(
+            _known_flow_params(),
+            redirect_uri="https://onyx.example.com/mcp/oauth/callback",
+            state="state_abc",
+            code_challenge="challenge_xyz",
+            resource="https://mcp.example.com/server",
+        )
+        query = parse_qs(urlparse(url).query)
+        assert query["client_id"] == ["known_client_id"]
+        assert query["response_type"] == ["code"]
+        assert query["state"] == ["state_abc"]
+        assert query["code_challenge"] == ["challenge_xyz"]
+        assert query["code_challenge_method"] == ["S256"]
+        assert query["resource"] == ["https://mcp.example.com/server"]
+        assert query["scope"] == ["read write"]
+        assert query["prompt"] == ["consent"]
+
+    def test_build_authorization_url_omits_pkce_and_resource_by_default(self) -> None:
+        url = build_oauth_authorization_url(
+            _known_flow_params(),
+            redirect_uri="https://onyx.example.com/callback",
+            state="state_abc",
+        )
+        query = parse_qs(urlparse(url).query)
+        assert "code_challenge" not in query
+        assert "code_challenge_method" not in query
+        assert "resource" not in query
+
+    @patch("onyx.auth.oauth_token_manager.requests.post")
+    def test_exchange_code_sends_code_verifier(self, mock_post: Mock) -> None:
+        mock_response = Mock(spec=Response)
+        mock_response.json.return_value = {
+            "access_token": "tok",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        token_data = exchange_oauth_code_for_token(
+            _known_flow_params(),
+            code="auth_code",
+            redirect_uri="https://onyx.example.com/mcp/oauth/callback",
+            code_verifier="verifier_123",
+        )
+
+        assert token_data["access_token"] == "tok"
+        assert "expires_at" in token_data
+        sent = mock_post.call_args[1]["data"]
+        assert sent["grant_type"] == "authorization_code"
+        assert sent["code"] == "auth_code"
+        assert sent["code_verifier"] == "verifier_123"
+        assert sent["client_secret"] == "known_client_secret"
+
+    @patch("onyx.auth.oauth_token_manager.requests.post")
+    def test_exchange_code_raises_on_http_error(self, mock_post: Mock) -> None:
+        mock_response = Mock(spec=Response)
+        mock_response.raise_for_status.side_effect = HTTPError("bad code")
+        mock_post.return_value = mock_response
+        with pytest.raises(HTTPError):
+            exchange_oauth_code_for_token(
+                _known_flow_params(),
+                code="bad",
+                redirect_uri="https://onyx.example.com/callback",
+            )


### PR DESCRIPTION
## Description

the backend of the mcp oauth override (see #11599 for more details)

## How Has This Been Tested?

final pr tested e2e

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"mcp-known-provider-1-schema-api-contract","parentHead":"ac2ef6ba8392e1d0bd4a67b31ff94d2a4e5d4c01","parentPull":11599,"trunk":"main"}
```
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a direct known-provider OAuth flow for MCP servers that builds the authorize URL (PKCE and optional `resource`) and exchanges the code on callback, then saves tokens/headers. This lets users connect without waiting for an SDK 401 challenge.

- **New Features**
  - Connect: builds authorize URL via `build_oauth_authorization_url` using configured `oauth_authorization_endpoint`/`client_id`, PKCE S256, optional scopes/params, and optional `resource=<server_url>`; stores per-user `state` + `code_verifier` in Redis with TTL; redirect URI is `WEB_DOMAIN` + `/mcp/oauth/callback`; validates client_id presence.
  - Callback: validates `state`, exchanges code via `exchange_oauth_code_for_token` with PKCE, saves tokens and sets `Authorization` header, clears `state`, redirects; maps upstream token errors to BAD_GATEWAY with provider status/text.
  - Shared helpers: added `OAuthFlowParams`, `build_oauth_authorization_url`, and `exchange_oauth_code_for_token`; `OAuthTokenManager` now delegates to them; unit tests cover PKCE/resource and code exchange.

- **Migration**
  - Set `oauth_provider_mode` to `KNOWN_PROVIDER` for the MCP server.
  - Configure `oauth_authorization_endpoint`, `oauth_token_endpoint`, and OAuth client credentials (`client_id`, optional `client_secret`) in the auth modal.
  - Optionally set `oauth_scopes_override` and `oauth_additional_auth_params`; pass `include_resource_param` when the provider requires `resource=<server_url>`.

<sup>Written for commit 445339f1c9c4f50d292938913a854fa8975e9d4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

