### PR TITLE
fix(web): stage embedding model when connecting registry-less cloud providers (LiteLLM/Azure)

### DIFF
--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -53,6 +53,7 @@ import {
   SwitchoverType,
   type ConfiguredEmbeddingProvider,
   type EmbeddingModel,
+  type EmbeddingModelRequest,
   type EmbeddingModelState,
   type EmbeddingProvider,
 } from "@/lib/indexing/interfaces";
@@ -314,7 +315,17 @@ interface ProviderGroupProps {
    * `LiteLLMProviderModal` can preload its model-spec fields on edit.
    */
   existingModel?: EmbeddingModel;
-  onSelectModel: (modelName: string) => void;
+  /**
+   * Stage a model into the parent form. `customModel` is populated only when
+   * the provider has no pre-registered models and the user defined the spec in
+   * the connect modal (LiteLLM / Azure) — the parent uses it to set both
+   * `model_name` and `custom_model`, and to remember this cloud provider as the
+   * staged model's owner so submit doesn't misresolve it as self-hosted.
+   */
+  onSelectModel: (
+    modelName: string,
+    customModel?: EmbeddingModelRequest
+  ) => void;
   onDeselectModel: () => void;
 }
 
@@ -423,10 +434,10 @@ function ProviderGroup({
           <connectModal.Provider>
             <ProviderCredentialsModal
               provider={provider}
-              onSubmit={async () => {
+              onSubmit={async (customModel) => {
                 await mutate(SWR_KEYS.embeddingProviders);
                 if (pendingConnectModel) {
-                  onSelectModel(pendingConnectModel.modelName);
+                  onSelectModel(pendingConnectModel.modelName, customModel);
                   setPendingConnectModel(null);
                 }
                 connectModal.toggle(false);
@@ -451,8 +462,15 @@ function ProviderGroup({
       <providerCreationModal.Provider>
         <ProviderCredentialsModal
           provider={provider}
-          onSubmit={async () => {
+          onSubmit={async (customModel) => {
             await mutate(SWR_KEYS.embeddingProviders);
+            // Providers with no pre-registered models (LiteLLM / Azure) define
+            // their model spec right here — stage it so the user can apply it.
+            // Without this the provider row is saved but the model is dropped,
+            // so no search-settings row is ever created.
+            if (customModel?.modelName) {
+              onSelectModel(customModel.modelName, customModel);
+            }
             providerCreationModal.toggle(false);
           }}
         />
@@ -673,6 +691,16 @@ interface IndexSettingsFormValues {
    * model.
    */
   custom_model: EmbeddingModel | null;
+  /**
+   * The cloud provider that owns a staged `custom_model` (LiteLLM / Azure).
+   * Those providers have no pre-registered models, so `resolveProviderName`
+   * can't recover their identity from the model name alone and would fall
+   * through to `CUSTOM` (self-hosted) — sending `provider_type=null` to the
+   * backend and bypassing the cloud credentials. Carrying it explicitly keeps
+   * the staged model bound to its provider. `null` for registered or
+   * self-hosted models, where name-based resolution is sufficient.
+   */
+  custom_model_provider: EmbeddingProviderName | null;
   enable_contextual_rag: boolean;
   contextual_rag_model_configuration_id: number | null;
 }
@@ -840,6 +868,7 @@ export default function IndexSettingsPage() {
     () => ({
       model_name: currentEmbeddingModel?.model_name ?? "",
       custom_model: null,
+      custom_model_provider: null,
       enable_contextual_rag: searchSettings?.enable_contextual_rag ?? false,
       contextual_rag_model_configuration_id:
         searchSettings?.contextual_rag_model_configuration_id ?? null,
@@ -937,7 +966,13 @@ export default function IndexSettingsPage() {
                 toast.error("Could not find the selected model");
                 return;
               }
-              const providerName = resolveProviderName(values.model_name, null);
+              // A staged custom model from a no-registry cloud provider
+              // (LiteLLM / Azure) carries its owning provider explicitly;
+              // otherwise fall back to resolving the provider from the model
+              // name against the static registry.
+              const providerName =
+                values.custom_model_provider ??
+                resolveProviderName(values.model_name, null);
 
               const response = await setNewSearchSettings({
                 model: stagedModel,
@@ -986,6 +1021,9 @@ export default function IndexSettingsPage() {
                             customModel.modelName
                           );
                           void setFieldValue("custom_model", customModel);
+                          // Self-hosted custom models resolve to CUSTOM by
+                          // name — no cloud provider to bind.
+                          void setFieldValue("custom_model_provider", null);
                         }
                         customModelModal.toggle(false);
                       }}
@@ -1168,14 +1206,26 @@ export default function IndexSettingsPage() {
                                                     undefined)
                                                   : undefined
                                               }
-                                              onSelectModel={(name) => {
+                                              onSelectModel={(
+                                                name,
+                                                customModel
+                                              ) => {
                                                 void setFieldValue(
                                                   "model_name",
                                                   name
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
-                                                  null
+                                                  customModel ?? null
+                                                );
+                                                // Bind a just-defined LiteLLM /
+                                                // Azure model to its provider so
+                                                // submit doesn't misresolve it.
+                                                void setFieldValue(
+                                                  "custom_model_provider",
+                                                  customModel
+                                                    ? provider.providerName
+                                                    : null
                                                 );
                                               }}
                                               onDeselectModel={() => {
@@ -1185,6 +1235,10 @@ export default function IndexSettingsPage() {
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
+                                                  null
+                                                );
+                                                void setFieldValue(
+                                                  "custom_model_provider",
                                                   null
                                                 );
                                               }}
@@ -1227,6 +1281,10 @@ export default function IndexSettingsPage() {
                                                   "custom_model",
                                                   null
                                                 );
+                                                void setFieldValue(
+                                                  "custom_model_provider",
+                                                  null
+                                                );
                                               }}
                                               onDeselectModel={() => {
                                                 void setFieldValue(
@@ -1235,6 +1293,10 @@ export default function IndexSettingsPage() {
                                                 );
                                                 void setFieldValue(
                                                   "custom_model",
+                                                  null
+                                                );
+                                                void setFieldValue(
+                                                  "custom_model_provider",
                                                   null
                                                 );
                                               }}
@@ -1321,12 +1383,20 @@ export default function IndexSettingsPage() {
                                           icon={SvgRevert}
                                           prominence="internal"
                                           tooltip="Revert embedding model selection"
-                                          onClick={() =>
+                                          onClick={() => {
                                             void setFieldValue(
                                               "model_name",
                                               initialFormValues.model_name
-                                            )
-                                          }
+                                            );
+                                            void setFieldValue(
+                                              "custom_model",
+                                              null
+                                            );
+                                            void setFieldValue(
+                                              "custom_model_provider",
+                                              null
+                                            );
+                                          }}
                                         />
                                       )}
                                       <Button

--- a/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
@@ -264,10 +264,16 @@ interface AzureFormValues {
   apiKey: string;
   apiVersion: string;
   deploymentName: string;
+  modelName: string;
+  modelDim: number;
+  queryPrefix: string;
+  passagePrefix: string;
+  normalize: boolean;
 }
 function AzureProviderModal({
   provider,
   existingCredentials,
+  existingModel,
   onSubmit,
 }: ProviderModalProps) {
   const isEditing = !!existingCredentials;
@@ -283,6 +289,7 @@ function AzureProviderModal({
       : Yup.string().trim().required("API key is required"),
     apiVersion: Yup.string().trim().required("API version is required"),
     deploymentName: Yup.string().trim().required("Deployment name is required"),
+    ...modelSpecSchemaShape,
   });
 
   const initialValues: AzureFormValues = {
@@ -290,6 +297,11 @@ function AzureProviderModal({
     apiKey: maskedApiKey,
     apiVersion: existingCredentials?.api_version ?? "",
     deploymentName: existingCredentials?.deployment_name ?? "",
+    modelName: existingModel?.modelName ?? "",
+    modelDim: existingModel?.modelDim ?? 0,
+    queryPrefix: existingModel?.queryPrefix ?? "",
+    passagePrefix: existingModel?.passagePrefix ?? "",
+    normalize: existingModel?.normalize ?? false,
   };
 
   return (
@@ -309,7 +321,13 @@ function AzureProviderModal({
             deploymentName: values.deploymentName,
           })
         ) {
-          onSubmit();
+          onSubmit({
+            modelName: values.modelName.trim(),
+            modelDim: values.modelDim,
+            normalize: values.normalize,
+            queryPrefix: values.queryPrefix || null,
+            passagePrefix: values.passagePrefix || null,
+          });
         }
       }}
     >
@@ -331,6 +349,8 @@ function AzureProviderModal({
           placeholder="my-embedding-deployment"
           subDescription="The deployment name you configured for this embedding model in Azure."
         />
+
+        <ModelSpecFields modelNameSubDescription="A label for this model in Onyx. Azure routes requests by deployment name, so this only needs to be a unique identifier." />
       </ModalShell>
     </Formik>
   );

--- a/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
+++ b/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
@@ -91,14 +91,17 @@ export class IndexSettingsPage {
     this.currentSetupModal = modal;
   }
 
+  // Fields are targeted by input id (which equals the Formik field name) rather
+  // than by label: Opal's InputVertical folds each field's subDescription into
+  // its accessible name, so a label match like "Deployment Name" also matches
+  // the Model Name field whose description mentions "deployment name".
+
   async fillLiteLLMCredentials(creds: {
     apiBaseUrl: string;
     apiKey: string;
   }): Promise<void> {
-    await this.activeSetupModal
-      .getByLabel("API Base URL")
-      .fill(creds.apiBaseUrl);
-    await this.activeSetupModal.getByLabel(/api key/i).fill(creds.apiKey);
+    await this.activeSetupModal.locator("#apiUrl").fill(creds.apiBaseUrl);
+    await this.activeSetupModal.locator("#apiKey").fill(creds.apiKey);
   }
 
   async fillAzureCredentials(creds: {
@@ -107,13 +110,11 @@ export class IndexSettingsPage {
     apiVersion: string;
     deploymentName: string;
   }): Promise<void> {
-    await this.activeSetupModal.getByLabel("Target URL").fill(creds.targetUrl);
-    await this.activeSetupModal.getByLabel(/api key/i).fill(creds.apiKey);
+    await this.activeSetupModal.locator("#apiUrl").fill(creds.targetUrl);
+    await this.activeSetupModal.locator("#apiKey").fill(creds.apiKey);
+    await this.activeSetupModal.locator("#apiVersion").fill(creds.apiVersion);
     await this.activeSetupModal
-      .getByLabel("API Version")
-      .fill(creds.apiVersion);
-    await this.activeSetupModal
-      .getByLabel("Deployment Name")
+      .locator("#deploymentName")
       .fill(creds.deploymentName);
   }
 
@@ -121,9 +122,9 @@ export class IndexSettingsPage {
     modelName: string;
     modelDim: number;
   }): Promise<void> {
-    await this.activeSetupModal.getByLabel("Model Name").fill(spec.modelName);
+    await this.activeSetupModal.locator("#modelName").fill(spec.modelName);
     await this.activeSetupModal
-      .getByLabel("Model Dimension")
+      .locator("#modelDim")
       .fill(String(spec.modelDim));
   }
 

--- a/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
+++ b/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
@@ -1,0 +1,157 @@
+/**
+ * Page Object Model for the Admin Index Settings page
+ * (/admin/configuration/index-settings).
+ *
+ * Encapsulates all locators and interactions for the embedding-model picker
+ * and the cloud-provider setup modals so specs stay declarative.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+
+const INDEX_SETTINGS_URL = "/admin/configuration/index-settings";
+
+export class IndexSettingsPage {
+  readonly page: Page;
+
+  readonly pageTitle: Locator;
+  readonly viewAllModelsButton: Locator;
+  readonly cloudTab: Locator;
+  readonly selfHostedTab: Locator;
+  readonly applyReindexButton: Locator;
+
+  // The provider setup modal opened via `openProviderSetup`. Held so the
+  // credential / model-spec fill methods scope their fields to the right
+  // dialog without the spec passing the provider name around.
+  private currentSetupModal: Locator | null = null;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.pageTitle = page.getByLabel("admin-page-title");
+    this.viewAllModelsButton = page.getByRole("button", {
+      name: /view all models/i,
+    });
+    this.cloudTab = page.getByRole("tab", { name: /cloud.based/i });
+    this.selfHostedTab = page.getByRole("tab", { name: /self.hosted/i });
+    this.applyReindexButton = page.getByRole("button", {
+      name: "Apply & Re-index",
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  async goto(): Promise<void> {
+    await this.page.goto(INDEX_SETTINGS_URL);
+    await this.page.waitForLoadState("networkidle");
+    await expect(this.pageTitle).toHaveText(/index settings/i);
+  }
+
+  async expandModelPicker(): Promise<void> {
+    await expect(this.viewAllModelsButton).toBeVisible({ timeout: 10000 });
+    await this.viewAllModelsButton.click();
+  }
+
+  async switchToCloudTab(): Promise<void> {
+    await expect(this.cloudTab).toBeVisible({ timeout: 10000 });
+    await this.cloudTab.click();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cloud-provider setup modal (LiteLLM / Azure — providers with no
+  // pre-registered models render an "Add Configuration" card)
+  // ---------------------------------------------------------------------------
+
+  private setupModalFor(displayName: string): Locator {
+    return this.page.getByRole("dialog", {
+      name: new RegExp(`set up ${displayName}`, "i"),
+    });
+  }
+
+  private get activeSetupModal(): Locator {
+    if (!this.currentSetupModal) {
+      throw new Error(
+        "No provider setup modal is open — call openProviderSetup() first."
+      );
+    }
+    return this.currentSetupModal;
+  }
+
+  async openProviderSetup(displayName: string): Promise<void> {
+    await this.page
+      .getByText(
+        new RegExp(
+          `add configs for your ${displayName} embedding providers`,
+          "i"
+        )
+      )
+      .click();
+    const modal = this.setupModalFor(displayName);
+    await expect(modal).toBeVisible({ timeout: 10000 });
+    this.currentSetupModal = modal;
+  }
+
+  async fillLiteLLMCredentials(creds: {
+    apiBaseUrl: string;
+    apiKey: string;
+  }): Promise<void> {
+    await this.activeSetupModal
+      .getByLabel("API Base URL")
+      .fill(creds.apiBaseUrl);
+    await this.activeSetupModal
+      .getByLabel("API Key", { exact: true })
+      .fill(creds.apiKey);
+  }
+
+  async fillAzureCredentials(creds: {
+    targetUrl: string;
+    apiKey: string;
+    apiVersion: string;
+    deploymentName: string;
+  }): Promise<void> {
+    await this.activeSetupModal.getByLabel("Target URL").fill(creds.targetUrl);
+    await this.activeSetupModal
+      .getByLabel("API Key", { exact: true })
+      .fill(creds.apiKey);
+    await this.activeSetupModal
+      .getByLabel("API Version")
+      .fill(creds.apiVersion);
+    await this.activeSetupModal
+      .getByLabel("Deployment Name")
+      .fill(creds.deploymentName);
+  }
+
+  async fillModelSpec(spec: {
+    modelName: string;
+    modelDim: number;
+  }): Promise<void> {
+    await this.activeSetupModal.getByLabel("Model Name").fill(spec.modelName);
+    await this.activeSetupModal
+      .getByLabel("Model Dimension")
+      .fill(String(spec.modelDim));
+  }
+
+  /** Submit the open setup modal ("Connect") and wait for it to close. */
+  async submitProviderSetup(): Promise<void> {
+    const connectButton = this.activeSetupModal.getByRole("button", {
+      name: /connect/i,
+    });
+    await expect(connectButton).toBeEnabled({ timeout: 5000 });
+    await connectButton.click();
+    await expect(this.activeSetupModal).not.toBeVisible({ timeout: 15000 });
+    this.currentSetupModal = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Staging / apply
+  // ---------------------------------------------------------------------------
+
+  /** Assert a model has been staged into the form (Apply & Re-index appears). */
+  async expectModelStaged(): Promise<void> {
+    await expect(this.applyReindexButton).toBeVisible({ timeout: 10000 });
+  }
+
+  async applyReindex(): Promise<void> {
+    await this.applyReindexButton.click();
+  }
+}

--- a/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
+++ b/web/tests/e2e/admin/index-settings/IndexSettingsPage.ts
@@ -98,9 +98,7 @@ export class IndexSettingsPage {
     await this.activeSetupModal
       .getByLabel("API Base URL")
       .fill(creds.apiBaseUrl);
-    await this.activeSetupModal
-      .getByLabel("API Key", { exact: true })
-      .fill(creds.apiKey);
+    await this.activeSetupModal.getByLabel(/api key/i).fill(creds.apiKey);
   }
 
   async fillAzureCredentials(creds: {
@@ -110,9 +108,7 @@ export class IndexSettingsPage {
     deploymentName: string;
   }): Promise<void> {
     await this.activeSetupModal.getByLabel("Target URL").fill(creds.targetUrl);
-    await this.activeSetupModal
-      .getByLabel("API Key", { exact: true })
-      .fill(creds.apiKey);
+    await this.activeSetupModal.getByLabel(/api key/i).fill(creds.apiKey);
     await this.activeSetupModal
       .getByLabel("API Version")
       .fill(creds.apiVersion);

--- a/web/tests/e2e/admin/index-settings/index_settings.spec.ts
+++ b/web/tests/e2e/admin/index-settings/index_settings.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { loginAs } from "@tests/e2e/utils/auth";
+import { IndexSettingsPage } from "./IndexSettingsPage";
 
 const INDEX_SETTINGS_URL = "/admin/configuration/index-settings";
 const EMBEDDING_PROVIDER_API = "**/api/admin/embedding/embedding-provider**";
@@ -366,34 +367,34 @@ test.describe("Index Settings — switchover strategies @exclusive", () => {
 // set-new-search-settings with the typed model AND the correct provider_type.
 // ---------------------------------------------------------------------------
 
-interface EmptyRegistryProvider {
+interface EmptyRegistryProviderCase {
   providerType: string;
   displayName: string;
-  // Fills the credential fields unique to this provider (the model-spec
-  // fields are shared and filled by the test body).
-  fillCredentials: (modal: Locator) => Promise<void>;
+  // Fills the credential fields unique to this provider via the page object
+  // (the shared model-spec fields are filled by the test body).
+  fillCredentials: (indexSettings: IndexSettingsPage) => Promise<void>;
 }
 
-const EMPTY_REGISTRY_PROVIDERS: EmptyRegistryProvider[] = [
+const EMPTY_REGISTRY_PROVIDERS: EmptyRegistryProviderCase[] = [
   {
     providerType: "litellm",
     displayName: "LiteLLM",
-    fillCredentials: async (modal) => {
-      await modal.getByLabel("API Base URL").fill("https://proxy.example.com");
-      await modal.getByLabel("API Key", { exact: true }).fill("sk-test-key");
-    },
+    fillCredentials: (indexSettings) =>
+      indexSettings.fillLiteLLMCredentials({
+        apiBaseUrl: "https://proxy.example.com",
+        apiKey: "sk-test-key",
+      }),
   },
   {
     providerType: "azure",
     displayName: "Azure",
-    fillCredentials: async (modal) => {
-      await modal
-        .getByLabel("Target URL")
-        .fill("https://res.openai.azure.com/openai/v1/embeddings");
-      await modal.getByLabel("API Key", { exact: true }).fill("az-test-key");
-      await modal.getByLabel("API Version").fill("2023-05-15");
-      await modal.getByLabel("Deployment Name").fill("my-deployment");
-    },
+    fillCredentials: (indexSettings) =>
+      indexSettings.fillAzureCredentials({
+        targetUrl: "https://res.openai.azure.com/openai/v1/embeddings",
+        apiKey: "az-test-key",
+        apiVersion: "2023-05-15",
+        deploymentName: "my-deployment",
+      }),
   },
 ];
 
@@ -442,40 +443,24 @@ test.describe("Index Settings — empty-registry providers @exclusive", () => {
         });
       });
 
-      await navigateToIndexSettings(page);
-      await expandModelPicker(page);
-      await switchToCloudTab(page);
+      const indexSettings = new IndexSettingsPage(page);
+      await indexSettings.goto();
+      await indexSettings.expandModelPicker();
+      await indexSettings.switchToCloudTab();
 
       // Empty-registry providers render an "Add Configuration" card instead of
-      // model cards. Open it and confirm the right provider modal appeared.
-      await page
-        .getByText(
-          new RegExp(
-            `add configs for your ${displayName} embedding providers`,
-            "i"
-          )
-        )
-        .click();
-      const modal = page.getByRole("dialog", {
-        name: new RegExp(`set up ${displayName}`, "i"),
+      // model cards. Open it, fill the credentials + model spec, and connect.
+      await indexSettings.openProviderSetup(displayName);
+      await fillCredentials(indexSettings);
+      await indexSettings.fillModelSpec({
+        modelName: "my-embed-model",
+        modelDim: 1024,
       });
-      await expect(modal).toBeVisible({ timeout: 10000 });
-
-      await fillCredentials(modal);
-      await modal.getByLabel("Model Name").fill("my-embed-model");
-      await modal.getByLabel("Model Dimension").fill("1024");
-
-      const connectButton = modal.getByRole("button", { name: /connect/i });
-      await expect(connectButton).toBeEnabled({ timeout: 5000 });
-      await connectButton.click();
-      await expect(modal).not.toBeVisible({ timeout: 15000 });
+      await indexSettings.submitProviderSetup();
 
       // The just-defined model must be staged — Apply & Re-index appears.
-      const applyButton = page.getByRole("button", {
-        name: "Apply & Re-index",
-      });
-      await expect(applyButton).toBeVisible({ timeout: 10000 });
-      await applyButton.click();
+      await indexSettings.expectModelStaged();
+      await indexSettings.applyReindex();
 
       const body = await bodyPromise;
       expect(body.model_name).toBe("my-embed-model");

--- a/web/tests/e2e/admin/index-settings/index_settings.spec.ts
+++ b/web/tests/e2e/admin/index-settings/index_settings.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 import { loginAs } from "@tests/e2e/utils/auth";
 
 const INDEX_SETTINGS_URL = "/admin/configuration/index-settings";
@@ -352,4 +352,138 @@ test.describe("Index Settings — switchover strategies @exclusive", () => {
 
     await expect.poll(() => setNewSettingsCalled, { timeout: 5000 }).toBe(true);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Empty-registry cloud providers (LiteLLM / Azure)
+//
+// These providers ship no pre-registered models, so their connect modal
+// collects the model spec (name + dimension) itself. Regression coverage for
+// the bug where that spec was dropped after the provider row was saved: the
+// model was never staged (so no search-settings row was ever created), and
+// even when staged it was misresolved as self-hosted (provider_type=null),
+// bypassing the saved cloud credentials. Both must reach
+// set-new-search-settings with the typed model AND the correct provider_type.
+// ---------------------------------------------------------------------------
+
+interface EmptyRegistryProvider {
+  providerType: string;
+  displayName: string;
+  // Fills the credential fields unique to this provider (the model-spec
+  // fields are shared and filled by the test body).
+  fillCredentials: (modal: Locator) => Promise<void>;
+}
+
+const EMPTY_REGISTRY_PROVIDERS: EmptyRegistryProvider[] = [
+  {
+    providerType: "litellm",
+    displayName: "LiteLLM",
+    fillCredentials: async (modal) => {
+      await modal.getByLabel("API Base URL").fill("https://proxy.example.com");
+      await modal.getByLabel("API Key", { exact: true }).fill("sk-test-key");
+    },
+  },
+  {
+    providerType: "azure",
+    displayName: "Azure",
+    fillCredentials: async (modal) => {
+      await modal
+        .getByLabel("Target URL")
+        .fill("https://res.openai.azure.com/openai/v1/embeddings");
+      await modal.getByLabel("API Key", { exact: true }).fill("az-test-key");
+      await modal.getByLabel("API Version").fill("2023-05-15");
+      await modal.getByLabel("Deployment Name").fill("my-deployment");
+    },
+  },
+];
+
+test.describe("Index Settings — empty-registry providers @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  for (const {
+    providerType,
+    displayName,
+    fillCredentials,
+  } of EMPTY_REGISTRY_PROVIDERS) {
+    test(`connecting ${displayName} stages its model and applies with provider_type="${providerType}"`, async ({
+      page,
+    }) => {
+      // Stub the credential test + save so no real endpoint/key is needed.
+      await page.route(TEST_EMBEDDING_API, async (route) => {
+        await route.fulfill({ status: 200, body: JSON.stringify({}) });
+      });
+      await page.route(EMBEDDING_PROVIDER_API, async (route) => {
+        const method = route.request().method();
+        if (method === "PUT") {
+          await route.fulfill({
+            status: 200,
+            body: JSON.stringify({ provider_type: providerType }),
+          });
+        } else if (method === "GET") {
+          await route.fulfill({ status: 200, body: JSON.stringify([]) });
+        } else {
+          await route.continue();
+        }
+      });
+
+      // Capture the search-settings request body — this is what the bug broke.
+      const bodyPromise = new Promise<Record<string, unknown>>((resolve) => {
+        void page.route(SET_NEW_SETTINGS_API, async (route) => {
+          resolve(
+            JSON.parse(route.request().postData() ?? "{}") as Record<
+              string,
+              unknown
+            >
+          );
+          await route.fulfill({ status: 200, body: JSON.stringify({}) });
+        });
+      });
+
+      await navigateToIndexSettings(page);
+      await expandModelPicker(page);
+      await switchToCloudTab(page);
+
+      // Empty-registry providers render an "Add Configuration" card instead of
+      // model cards. Open it and confirm the right provider modal appeared.
+      await page
+        .getByText(
+          new RegExp(
+            `add configs for your ${displayName} embedding providers`,
+            "i"
+          )
+        )
+        .click();
+      const modal = page.getByRole("dialog", {
+        name: new RegExp(`set up ${displayName}`, "i"),
+      });
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      await fillCredentials(modal);
+      await modal.getByLabel("Model Name").fill("my-embed-model");
+      await modal.getByLabel("Model Dimension").fill("1024");
+
+      const connectButton = modal.getByRole("button", { name: /connect/i });
+      await expect(connectButton).toBeEnabled({ timeout: 5000 });
+      await connectButton.click();
+      await expect(modal).not.toBeVisible({ timeout: 15000 });
+
+      // The just-defined model must be staged — Apply & Re-index appears.
+      const applyButton = page.getByRole("button", {
+        name: "Apply & Re-index",
+      });
+      await expect(applyButton).toBeVisible({ timeout: 10000 });
+      await applyButton.click();
+
+      const body = await bodyPromise;
+      expect(body.model_name).toBe("my-embed-model");
+      expect(Number(body.model_dim)).toBe(1024);
+      // The core regression: the model is bound to its cloud provider, NOT
+      // sent as provider_type=null (which the backend treats as self-hosted
+      // and would ignore the credentials we just saved).
+      expect(body.provider_type).toBe(providerType);
+    });
+  }
 });


### PR DESCRIPTION
## Description

On a clean install, adding a **LiteLLM** (or **Azure**) embedding provider saved the provider row (`PUT /api/admin/embedding/embedding-provider` → 200) but the model never appeared and no `search_settings` row was created — "nothing happens after Connect."

Unlike OpenAI/Cohere/Voyage/Google, LiteLLM and Azure ship **no pre-registered models**, so their connect modal collects the model spec (name + dimension) itself. Two stacked bugs dropped that spec:

1. **Spec discarded on connect.** The `providerCreationModal` / `connectModal` `onSubmit` handlers in `ProviderGroup` ignored the model spec the modal returned, so it was never staged into the form and the **Apply & Re-index** action never appeared.
2. **Provider misresolved on submit.** Even once staged, submit called `resolveProviderName(model_name, null)`, which for an empty-registry provider falls through to `CUSTOM` and sends `provider_type=null`. The backend treats null as **self-hosted** and would ignore the cloud credentials just saved.

Azure was additionally worse off: its modal collected only credentials and never gathered the (non-nullable) `model_name` / `model_dim` at all.

### Fixes
- Forward the model spec returned by the connect modals into the form (`model_name` + `custom_model`).
- Track the owning cloud provider in a new `custom_model_provider` form field so submit binds the staged model to its provider instead of misresolving it as self-hosted.
- Add the shared `ModelSpecFields` to the Azure modal so it collects `model_name` / `model_dim` (Azure still routes by `deployment_name`; the model name is a label).
- Clear the new field on deselect / revert so a reverted custom model isn't re-applied.

## How Has This Been Tested?

- Added a parameterized e2e regression test (`web/tests/e2e/admin/index-settings/index_settings.spec.ts`) covering **both LiteLLM and Azure** that connects the provider, asserts the model stages (Apply & Re-index appears), and asserts `set-new-search-settings` carries the correct `model_name`, `model_dim`, and `provider_type` (i.e. **not** `null`).
- `tsc`, `oxlint`, and `oxfmt --check` pass on the changed files.

> Note: the full e2e run could not be executed in my local environment (its Playwright global-setup provisions basic-auth test users via `/api/auth/register`, which is disabled on the SSO-configured dev instance). The test runs against the standard CI test users.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing embedding model staging when connecting registry-less cloud providers (LiteLLM, Azure). The model now stages on connect and saves with the correct provider, so Apply & Re-index works and credentials are used.

- **Bug Fixes**
  - Stage model spec from connect modals (`model_name`, `custom_model`).
  - Bind staged models to their provider via `custom_model_provider` to avoid resolving as `CUSTOM` (`provider_type` not `null`).
  - Collect the model spec in the Azure modal; Azure still routes by `deployment_name`.
  - Clear `custom_model_provider` on deselect/revert to avoid re-applying a reverted model.
  - Add a parameterized e2e test for LiteLLM/Azure to assert staging and correct `set-new-search-settings` payload.
  - Fix e2e page object: use `/api key/i` for the API Key label to match accessible name and prevent CI timeouts.
  - Target setup-modal fields by input id in e2e to avoid label ambiguity and keep the Azure test stable.

- **Refactors**
  - Introduce an `IndexSettingsPage` Playwright page object and refactor the new tests to use it.

<sup>Written for commit dd81d18a0c1c3f9e61b002300bc84c705787e5c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

