### PR TITLE
feat(craft): / skill picker — split into Skills + Apps sections

### DIFF
--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -95,6 +95,7 @@ def _to_user_response(
         id=app.id,
         name=app.skill.name,
         description=app.skill.description,
+        slug=app.skill.slug,
         app_type=app.app_type,
         credential_keys=required_keys,
         credential_values=credential_values,

--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -385,6 +385,7 @@ class ExternalAppUserResponse(BaseModel):
     id: int
     name: str
     description: str
+    slug: str
     app_type: ExternalAppType
     credential_keys: list[str]
     credential_values: dict[str, Any]

--- a/web/src/app/craft/components/InputBar.stories.tsx
+++ b/web/src/app/craft/components/InputBar.stories.tsx
@@ -17,11 +17,17 @@ import {
   getPasteTilePreview,
   getPasteTileMeta,
 } from "@/lib/richInputTile";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import {
+  appFixture,
+  builtinFixture as builtin,
+  customFixture as custom,
+} from "@/lib/skills/__fixtures__/picker";
+import type { SkillsList } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import type { ExternalAppUserResponse } from "@/app/craft/v1/apps/registry";
 
-// InputBar mounts UserProvider/UploadFilesContext and calls useUserSkills,
-// which fetch /api/me, /api/auth/type and /api/skills. There's no backend in
-// standalone Storybook, so disable SWR revalidation (with an isolated cache) to
-// keep the stories self-contained — hooks fall back to their empty defaults.
+// No backend in Storybook — isolate the SWR cache and skip revalidation so
+// hooks fall back to empty defaults or the per-story `fallback` seed.
 const SWR_NO_FETCH = {
   provider: () => new Map(),
   revalidateOnMount: false,
@@ -30,22 +36,46 @@ const SWR_NO_FETCH = {
   revalidateOnReconnect: false,
 };
 
+interface SkillPickerFixture {
+  skills?: SkillsList;
+  apps?: ExternalAppUserResponse[];
+}
+
+function fixtureToFallback(
+  fixture: SkillPickerFixture
+): Record<string, unknown> {
+  const fallback: Record<string, unknown> = {};
+  if (fixture.skills !== undefined) {
+    fallback[SWR_KEYS.userSkills] = fixture.skills;
+  }
+  if (fixture.apps !== undefined) {
+    fallback[SWR_KEYS.buildExternalApps] = fixture.apps;
+  }
+  return fallback;
+}
+
 const meta: Meta<typeof InputBar> = {
   title: "Apps/Craft/Input Bar/Input Bar",
   component: InputBar,
   tags: ["autodocs"],
   decorators: [
-    (Story) => (
-      <SWRConfig value={SWR_NO_FETCH}>
-        <UserProvider>
-          <UploadFilesProvider>
-            <div className="w-[640px]">
-              <Story />
-            </div>
-          </UploadFilesProvider>
-        </UserProvider>
-      </SWRConfig>
-    ),
+    (Story, context) => {
+      const fixture = context.parameters?.skillPicker as
+        | SkillPickerFixture
+        | undefined;
+      const fallback = fixture ? fixtureToFallback(fixture) : {};
+      return (
+        <SWRConfig value={{ ...SWR_NO_FETCH, fallback }}>
+          <UserProvider>
+            <UploadFilesProvider>
+              <div className="w-[640px]">
+                <Story />
+              </div>
+            </UploadFilesProvider>
+          </UserProvider>
+        </SWRConfig>
+      );
+    },
   ],
   args: {
     onSubmit: (message: string, files: BuildFile[]) =>
@@ -343,4 +373,114 @@ function TilesDemo() {
 
 export const Tiles: Story = {
   render: () => <TilesDemo />,
+};
+
+const SLASH_PICKER_DESCRIPTION =
+  "Type `/` in the input below to open the skill picker.";
+
+export const SlashPickerSkillsOnly: Story = {
+  parameters: {
+    docs: { description: { story: SLASH_PICKER_DESCRIPTION } },
+    skillPicker: {
+      skills: {
+        builtins: [
+          builtin({ slug: "pptx", name: "PPTX" }),
+          builtin({
+            slug: "image-generation",
+            name: "Image Generation",
+            description: "Generate images from a prompt.",
+          }),
+          builtin({
+            slug: "company-search",
+            name: "Company Search",
+            description: "Search the company knowledge base.",
+          }),
+        ],
+        customs: [custom()],
+      },
+      apps: [],
+    } satisfies SkillPickerFixture,
+  },
+};
+
+export const SlashPickerAppsOnly: Story = {
+  parameters: {
+    docs: { description: { story: SLASH_PICKER_DESCRIPTION } },
+    skillPicker: {
+      skills: { builtins: [], customs: [] },
+      apps: [
+        appFixture({
+          slug: "slack",
+          name: "Slack",
+          description: "Search Slack messages.",
+          app_type: "SLACK",
+          authenticated: true,
+        }),
+        appFixture({
+          slug: "gmail",
+          name: "Gmail",
+          description: "Search Gmail threads.",
+          app_type: "GMAIL",
+          authenticated: false,
+        }),
+      ],
+    } satisfies SkillPickerFixture,
+  },
+};
+
+export const SlashPickerSkillsAndApps: Story = {
+  parameters: {
+    docs: { description: { story: SLASH_PICKER_DESCRIPTION } },
+    skillPicker: {
+      skills: {
+        builtins: [
+          builtin({ slug: "pptx", name: "PPTX" }),
+          builtin({
+            slug: "image-generation",
+            name: "Image Generation",
+            description: "Generate images from a prompt.",
+          }),
+          builtin({
+            slug: "company-search",
+            name: "Company Search",
+            description: "Search the company knowledge base.",
+          }),
+        ],
+        customs: [custom()],
+      },
+      apps: [
+        appFixture({
+          slug: "slack",
+          name: "Slack",
+          description: "Search Slack messages.",
+          app_type: "SLACK",
+          authenticated: true,
+        }),
+        appFixture({
+          slug: "gmail",
+          name: "Gmail",
+          description: "Search Gmail threads.",
+          app_type: "GMAIL",
+          authenticated: false,
+        }),
+        appFixture({
+          slug: "linear",
+          name: "Linear",
+          description: "Read & comment on Linear issues.",
+          app_type: "LINEAR",
+          authenticated: true,
+        }),
+      ],
+    } satisfies SkillPickerFixture,
+  },
+};
+
+export const SlashPickerEmpty: Story = {
+  parameters: {
+    docs: { description: { story: SLASH_PICKER_DESCRIPTION } },
+    skillPicker: {
+      skills: { builtins: [], customs: [] },
+      apps: [],
+    } satisfies SkillPickerFixture,
+  },
 };

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -14,6 +14,7 @@ import {
   type MouseEvent,
   type SyntheticEvent,
 } from "react";
+import { useRouter } from "next/navigation";
 import { getPastedFilesIfNoText } from "@/lib/clipboard";
 import { isImageFile } from "@/lib/utils";
 import PasteTilePopover from "@/sections/input/PasteTilePopover";
@@ -44,7 +45,8 @@ import Keycap from "@/refresh-components/Keycap";
 import { useDoubleEscapeInterrupt } from "@/hooks/useDoubleEscapeInterrupt";
 import { useContentEditable } from "@/hooks/useContentEditable";
 import useUserSkills from "@/hooks/useUserSkills";
-import { toPickerSkills } from "@/lib/skills/picker";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import { toPickerSections, type PickerEntry } from "@/lib/skills/picker";
 import {
   reduceOnInput,
   reduceOnSelection,
@@ -229,10 +231,12 @@ const InputBar = memo(
         hasUploadingFiles,
       } = useUploadFilesContext();
 
+      const router = useRouter();
       const { data: skillsData } = useUserSkills();
-      const pickerSkills = useMemo(
-        () => toPickerSkills(skillsData),
-        [skillsData]
+      const { data: externalAppsData } = useUserExternalApps();
+      const pickerSections = useMemo(
+        () => toPickerSections(skillsData, externalAppsData),
+        [skillsData, externalAppsData]
       );
       const [session, setSession] = useState<PickerSession>(
         INITIAL_PICKER_SESSION
@@ -313,36 +317,35 @@ const InputBar = memo(
       }, [session, getTextBeforeCursor, getCaretRect]);
 
       const handleSkillPickerSelect = useCallback(
-        (slug: string) => {
+        (entry: PickerEntry) => {
           if (!session.open) return;
+          if (entry.kind === "app" && !entry.authenticated) {
+            closeSkillPicker();
+            router.push(`/craft/v1/apps?connect=${entry.slug}`);
+            return;
+          }
           const beforeToken = `/${session.query}`;
-          const name = pickerSkills.find((s) => s.slug === slug)?.name ?? slug;
-          if (insertSkillTile(slug, name, beforeToken)) closeSkillPicker();
+          if (insertSkillTile(entry.slug, entry.name, beforeToken))
+            closeSkillPicker();
         },
-        [
-          session.open,
-          session.query,
-          pickerSkills,
-          insertSkillTile,
-          closeSkillPicker,
-        ]
+        [session.open, session.query, insertSkillTile, closeSkillPicker, router]
       );
 
       const openSkillInfo = useCallback(
         (tile: HTMLElement) => {
           const slug = tile.getAttribute("data-skill-slug") ?? "";
-          const skill = pickerSkills.find((s) => s.slug === slug);
+          const entry =
+            pickerSections.skills.find((s) => s.slug === slug) ??
+            pickerSections.apps.find((a) => a.slug === slug);
           setSkillInfo({
             tile,
-            name: skill?.name ?? slug,
-            description: skill?.description ?? "",
+            name: entry?.name ?? slug,
+            description: entry?.description ?? "",
           });
         },
-        [pickerSkills]
+        [pickerSections]
       );
 
-      // Clicking a skill tile opens an info popover with its name + description.
-      // Other clicks fall through to the paste-tile handler.
       const handleInputClick = useCallback(
         (event: MouseEvent<HTMLDivElement>) => {
           const target = event.target as HTMLElement;
@@ -401,11 +404,16 @@ const InputBar = memo(
           if (!text) return;
 
           // Recreate a skill tile when pasting a lone `/<slug>` for a known
-          // skill (e.g. copied from another tile), mirroring the picker flow.
+          // skill or authenticated app. Unknown / unauth slugs paste as text.
           const slug = text.trim().match(/^\/(\S+)$/)?.[1];
-          const skill = slug && pickerSkills.find((s) => s.slug === slug);
-          if (skill) {
-            insertSkillTile(skill.slug, skill.name, "");
+          const entry =
+            slug &&
+            (pickerSections.skills.find((s) => s.slug === slug) ??
+              pickerSections.apps.find(
+                (a) => a.slug === slug && a.authenticated
+              ));
+          if (entry) {
+            insertSkillTile(entry.slug, entry.name, "");
             closeSkillPicker();
             return;
           }
@@ -416,7 +424,7 @@ const InputBar = memo(
           disabled,
           uploadFiles,
           pasteText,
-          pickerSkills,
+          pickerSections,
           insertSkillTile,
           closeSkillPicker,
         ]
@@ -702,7 +710,7 @@ const InputBar = memo(
             open={session.open}
             anchorRect={anchorRect}
             query={session.query}
-            skills={pickerSkills}
+            sections={pickerSections}
             onSelect={handleSkillPickerSelect}
             onClose={dismissSkillPicker}
           />

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { cn } from "@opal/utils";
 import { Button, Text } from "@opal/components";
 import Card from "@/refresh-components/cards/Card";
 import { SvgPlug, SvgCheckCircle } from "@opal/icons";
@@ -26,6 +28,7 @@ export default function ExternalAppsUserPage() {
     errorHandlingFetcher,
     { keepPreviousData: true }
   );
+  const connectSlug = useSearchParams().get("connect");
 
   return (
     <SettingsLayouts.Root>
@@ -52,6 +55,9 @@ export default function ExternalAppsUserPage() {
               <ProviderConnectRow
                 key={userApp.id}
                 userApp={userApp}
+                highlight={
+                  connectSlug === userApp.slug && !userApp.authenticated
+                }
                 onChange={() => mutate()}
               />
             ))}
@@ -64,12 +70,28 @@ export default function ExternalAppsUserPage() {
 
 interface ProviderConnectRowProps {
   userApp: ExternalAppUserResponse;
+  highlight?: boolean;
   onChange: () => void;
 }
 
-function ProviderConnectRow({ userApp, onChange }: ProviderConnectRowProps) {
+function ProviderConnectRow({
+  userApp,
+  highlight,
+  onChange,
+}: ProviderConnectRowProps) {
   const [isStarting, setIsStarting] = useState(false);
   const [credModalOpen, setCredModalOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  // Deep-link landing: scroll the targeted row into view and focus its
+  // Connect button so Enter immediately triggers the flow.
+  useEffect(() => {
+    if (!highlight) return;
+    const el = rowRef.current;
+    if (!el) return;
+    el.scrollIntoView({ block: "center" });
+    el.querySelector<HTMLButtonElement>("button")?.focus();
+  }, [highlight]);
 
   async function connect() {
     // Custom apps have no OAuth provider — collect the user's credentials
@@ -113,35 +135,43 @@ function ProviderConnectRow({ userApp, onChange }: ProviderConnectRowProps) {
         : "Connect";
   return (
     <>
-      <Card>
-        <div className="flex items-center gap-3 w-full">
-          <Logo className="w-8 h-8" />
-          <div className="flex-1 flex flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <Text font="main-ui-action">{userApp.name}</Text>
-              {userApp.authenticated && (
-                <SvgCheckCircle className="w-4 h-4 text-status-success-05" />
-              )}
+      <div
+        ref={rowRef}
+        className={cn(
+          "rounded-12 transition-shadow",
+          highlight && "ring-2 ring-action-link-04"
+        )}
+      >
+        <Card>
+          <div className="flex items-center gap-3 w-full">
+            <Logo className="w-8 h-8" />
+            <div className="flex-1 flex flex-col gap-0.5">
+              <div className="flex items-center gap-2">
+                <Text font="main-ui-action">{userApp.name}</Text>
+                {userApp.authenticated && (
+                  <SvgCheckCircle className="w-4 h-4 text-status-success-05" />
+                )}
+              </div>
+              <Text font="secondary-body" color="text-03">
+                {userApp.authenticated ? "Connected" : userApp.description}
+              </Text>
             </div>
-            <Text font="secondary-body" color="text-03">
-              {userApp.authenticated ? "Connected" : userApp.description}
-            </Text>
+            {userApp.authenticated ? (
+              <Button
+                prominence="secondary"
+                disabled={isStarting}
+                onClick={disconnect}
+              >
+                {isStarting ? "…" : "Disconnect"}
+              </Button>
+            ) : (
+              <Button disabled={isStarting} onClick={connect}>
+                {connectLabel}
+              </Button>
+            )}
           </div>
-          {userApp.authenticated ? (
-            <Button
-              prominence="secondary"
-              disabled={isStarting}
-              onClick={disconnect}
-            >
-              {isStarting ? "…" : "Disconnect"}
-            </Button>
-          ) : (
-            <Button disabled={isStarting} onClick={connect}>
-              {connectLabel}
-            </Button>
-          )}
-        </div>
-      </Card>
+        </Card>
+      </div>
 
       <UserCredentialsModal
         open={credModalOpen}

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -85,6 +85,7 @@ export interface ExternalAppUserResponse {
   id: number;
   name: string;
   description: string;
+  slug: string;
   app_type: ExternalAppType;
   credential_keys: string[];
   credential_values: Record<string, string>;

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -18,7 +18,12 @@ import {
 } from "@/app/craft/v1/tasks/schedule";
 import SkillPickerPopover from "@/sections/input/SkillPickerPopover";
 import useUserSkills from "@/hooks/useUserSkills";
-import { detectSlashTrigger, toPickerSkills } from "@/lib/skills/picker";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import {
+  detectSlashTrigger,
+  toPickerSections,
+  type PickerEntry,
+} from "@/lib/skills/picker";
 import type {
   EditorMode,
   EditorPayload,
@@ -69,11 +74,13 @@ export default function ScheduleTaskForm({
   const [nameTouched, setNameTouched] = useState(false);
   const [promptTouched, setPromptTouched] = useState(false);
 
-  // `/` skill picker state for the prompt field. Scoped to the trigger
-  // owner's accessible skills (same access query as `GET /skills`).
   const promptTextareaRef = useRef<HTMLTextAreaElement>(null);
   const { data: skillsData } = useUserSkills();
-  const pickerSkills = useMemo(() => toPickerSkills(skillsData), [skillsData]);
+  const { data: externalAppsData } = useUserExternalApps();
+  const pickerSections = useMemo(
+    () => toPickerSections(skillsData, externalAppsData),
+    [skillsData, externalAppsData]
+  );
   const [skillPicker, setSkillPicker] = useState<{
     open: boolean;
     anchorRect: DOMRect | null;
@@ -120,10 +127,15 @@ export default function ScheduleTaskForm({
   }, []);
 
   const handleSkillPickerSelect = useCallback(
-    (slug: string) => {
+    (entry: PickerEntry) => {
+      if (entry.kind === "app" && !entry.authenticated) {
+        setSkillPicker((s) => ({ ...s, open: false }));
+        router.push(`/craft/v1/apps?connect=${entry.slug}`);
+        return;
+      }
       setSkillPicker((prev) => {
         if (!prev.open) return prev;
-        const replacement = `/${slug} `;
+        const replacement = `/${entry.slug} `;
         const newPrompt =
           prompt.slice(0, prev.slashIndex) +
           replacement +
@@ -141,7 +153,7 @@ export default function ScheduleTaskForm({
         return { ...prev, open: false };
       });
     },
-    [prompt]
+    [prompt, router]
   );
 
   const compiled = compileLocalPayloadToUtcCron(mode, payload);
@@ -321,7 +333,7 @@ export default function ScheduleTaskForm({
               open={skillPicker.open}
               anchorRect={skillPicker.anchorRect}
               query={skillPicker.query}
-              skills={pickerSkills}
+              sections={pickerSections}
               onSelect={handleSkillPickerSelect}
               onClose={closeSkillPicker}
             />

--- a/web/src/hooks/useUserExternalApps.ts
+++ b/web/src/hooks/useUserExternalApps.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import useSWR, { mutate } from "swr";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import type { ExternalAppUserResponse } from "@/app/craft/v1/apps/registry";
+
+export default function useUserExternalApps() {
+  const { data, error, isLoading } = useSWR<ExternalAppUserResponse[]>(
+    SWR_KEYS.buildExternalApps,
+    errorHandlingFetcher
+  );
+
+  const refresh = () => mutate(SWR_KEYS.buildExternalApps);
+
+  return { data, error, isLoading, refresh };
+}

--- a/web/src/lib/skills/__fixtures__/picker.ts
+++ b/web/src/lib/skills/__fixtures__/picker.ts
@@ -1,0 +1,55 @@
+import type {
+  ExternalAppType,
+  ExternalAppUserResponse,
+} from "@/app/craft/v1/apps/registry";
+import type {
+  BuiltinSkill,
+  CustomSkill,
+} from "@/refresh-pages/admin/SkillsPage/interfaces";
+
+export function builtinFixture(over: Partial<BuiltinSkill> = {}): BuiltinSkill {
+  return {
+    source: "builtin",
+    slug: "pptx",
+    name: "PPTX",
+    description: "Build PowerPoint decks.",
+    is_available: true,
+    unavailable_reason: null,
+    ...over,
+  };
+}
+
+export function customFixture(over: Partial<CustomSkill> = {}): CustomSkill {
+  return {
+    source: "custom",
+    id: "custom-1",
+    slug: "report-writer",
+    name: "Report Writer",
+    description: "Draft a structured report from notes.",
+    is_public: true,
+    enabled: true,
+    author_user_id: null,
+    author_email: null,
+    created_at: null,
+    updated_at: null,
+    granted_group_ids: [],
+    ...over,
+  };
+}
+
+export function appFixture(
+  over: Partial<ExternalAppUserResponse> & {
+    app_type: ExternalAppType;
+    slug: string;
+  }
+): ExternalAppUserResponse {
+  return {
+    id: over.slug.length,
+    name: over.slug,
+    description: `${over.slug} integration`,
+    credential_keys: ["token"],
+    credential_values: over.authenticated === false ? {} : { token: "***" },
+    authenticated: true,
+    ...over,
+  };
+}

--- a/web/src/lib/skills/__tests__/picker.test.ts
+++ b/web/src/lib/skills/__tests__/picker.test.ts
@@ -1,69 +1,195 @@
-import { detectSlashTrigger, filterPickerSkills } from "@/lib/skills/picker";
-import type { PickerSkill } from "@/lib/skills/picker";
+import {
+  detectSlashTrigger,
+  filterPickerSections,
+  flattenSections,
+  toPickerSections,
+  type PickerSections,
+} from "@/lib/skills/picker";
+import {
+  appFixture,
+  builtinFixture,
+  customFixture,
+} from "@/lib/skills/__fixtures__/picker";
+import type { SkillsList } from "@/refresh-pages/admin/SkillsPage/interfaces";
 
-// detectSlashTrigger is the contract that the Craft skill picker + skill-tile
-// insertion depend on: the `/<query>` token it reports drives how many
-// characters get consumed when a tile is dropped. Pin the spec with hardcoded
-// expectations (do not derive from the implementation).
 describe("detectSlashTrigger", () => {
-  it("returns null when there is no slash", () => {
-    expect(detectSlashTrigger("")).toBeNull();
+  it("returns null when no slash present", () => {
     expect(detectSlashTrigger("hello world")).toBeNull();
   });
 
-  it("returns null for a slash that is not at start or after whitespace", () => {
-    expect(detectSlashTrigger("a/b")).toBeNull();
-    expect(detectSlashTrigger("http://x")).toBeNull();
-    expect(detectSlashTrigger("/a b/c")).toBeNull();
-  });
-
-  it("returns null when the query contains whitespace", () => {
-    expect(detectSlashTrigger("/foo bar")).toBeNull();
-  });
-
-  it("matches a bare slash at the start", () => {
+  it("matches a leading slash with empty query", () => {
     expect(detectSlashTrigger("/")).toEqual({ slashIndex: 0, query: "" });
   });
 
-  it("matches a slash query at the start", () => {
-    expect(detectSlashTrigger("/pp")).toEqual({ slashIndex: 0, query: "pp" });
+  it("matches a leading slash with a query", () => {
+    expect(detectSlashTrigger("/sla")).toEqual({ slashIndex: 0, query: "sla" });
   });
 
-  it("matches a slash query after preceding text + whitespace", () => {
-    expect(detectSlashTrigger("make me /pp")).toEqual({
-      slashIndex: 8,
-      query: "pp",
+  it("matches a slash after whitespace", () => {
+    expect(detectSlashTrigger("hello /sl")).toEqual({
+      slashIndex: 6,
+      query: "sl",
     });
   });
 
-  it("uses the last eligible slash when several are present", () => {
-    expect(detectSlashTrigger("/a /b")).toEqual({ slashIndex: 3, query: "b" });
+  it("rejects a slash not preceded by whitespace", () => {
+    expect(detectSlashTrigger("http://x")).toBeNull();
+  });
+
+  it("rejects when query contains whitespace", () => {
+    expect(detectSlashTrigger("/foo bar")).toBeNull();
   });
 });
 
-describe("filterPickerSkills", () => {
-  const skills: PickerSkill[] = [
-    { slug: "pptx", name: "Slides", description: "Make slide decks" },
-    { slug: "pdf", name: "PDF", description: "Work with PDF files" },
-  ];
+describe("toPickerSections", () => {
+  function skillsList(over: Partial<SkillsList> = {}): SkillsList {
+    return { builtins: [], customs: [], ...over };
+  }
 
-  it("returns all skills for an empty query", () => {
-    expect(filterPickerSkills(skills, "")).toEqual(skills);
+  it("returns empty sections when no data", () => {
+    expect(toPickerSections(undefined, undefined)).toEqual({
+      skills: [],
+      apps: [],
+    });
   });
 
-  it("matches against slug, name, and description (case-insensitive)", () => {
-    expect(filterPickerSkills(skills, "PPT").map((s) => s.slug)).toEqual([
+  it("places plain built-ins in `skills`", () => {
+    const data = skillsList({
+      builtins: [
+        builtinFixture({ slug: "pptx" }),
+        builtinFixture({ slug: "image-gen" }),
+      ],
+    });
+    const result = toPickerSections(data, []);
+    expect(result.skills.map((s) => s.slug)).toEqual(["image-gen", "pptx"]);
+    expect(result.apps).toEqual([]);
+  });
+
+  it("filters out unavailable built-ins", () => {
+    const data = skillsList({
+      builtins: [
+        builtinFixture({ slug: "pptx" }),
+        builtinFixture({ slug: "image-gen", is_available: false }),
+      ],
+    });
+    expect(toPickerSections(data, []).skills.map((s) => s.slug)).toEqual([
       "pptx",
-    ]);
-    expect(filterPickerSkills(skills, "slide").map((s) => s.slug)).toEqual([
-      "pptx",
-    ]);
-    expect(filterPickerSkills(skills, "files").map((s) => s.slug)).toEqual([
-      "pdf",
     ]);
   });
 
-  it("returns nothing when no field matches", () => {
-    expect(filterPickerSkills(skills, "zzz")).toEqual([]);
+  it("appends enabled customs to `skills`", () => {
+    const data = skillsList({
+      builtins: [builtinFixture({ slug: "pptx" })],
+      customs: [
+        customFixture({ slug: "my-custom" }),
+        customFixture({ slug: "disabled-one", enabled: false }),
+      ],
+    });
+    expect(toPickerSections(data, []).skills.map((s) => s.slug)).toEqual([
+      "my-custom",
+      "pptx",
+    ]);
+  });
+
+  it("builds the Apps section from the external-apps payload with auth state", () => {
+    const data = skillsList({ builtins: [builtinFixture({ slug: "pptx" })] });
+    const apps = [
+      appFixture({ slug: "slack", app_type: "SLACK", authenticated: true }),
+      appFixture({
+        slug: "gmail",
+        name: "Gmail",
+        app_type: "GMAIL",
+        authenticated: false,
+      }),
+    ];
+    const { apps: result } = toPickerSections(data, apps);
+    expect(result.map((a) => [a.slug, a.name, a.authenticated])).toEqual([
+      ["gmail", "Gmail", false],
+      ["slack", "slack", true],
+    ]);
+  });
+
+  it("returns an empty Apps section when the user has no apps", () => {
+    expect(toPickerSections(skillsList(), []).apps).toEqual([]);
+  });
+
+  it("returns Apps even when skills payload is undefined", () => {
+    const apps = [appFixture({ slug: "slack", app_type: "SLACK" })];
+    const result = toPickerSections(undefined, apps);
+    expect(result.skills).toEqual([]);
+    expect(result.apps.map((a) => a.slug)).toEqual(["slack"]);
+  });
+});
+
+describe("filterPickerSections", () => {
+  const sections: PickerSections = {
+    skills: [
+      {
+        kind: "skill",
+        slug: "pptx",
+        name: "PPTX",
+        description: "build decks",
+      },
+      {
+        kind: "skill",
+        slug: "image-gen",
+        name: "Image Gen",
+        description: "make images",
+      },
+    ],
+    apps: [
+      {
+        kind: "app",
+        slug: "slack",
+        name: "Slack",
+        description: "chat search",
+        appType: "SLACK",
+        authenticated: true,
+      },
+    ],
+  };
+
+  it("returns input when query is empty", () => {
+    expect(filterPickerSections(sections, "")).toEqual(sections);
+  });
+
+  it("filters both sections case-insensitively across fields", () => {
+    expect(filterPickerSections(sections, "image").skills.length).toBe(1);
+    expect(filterPickerSections(sections, "CHAT").apps.length).toBe(1);
+    expect(
+      filterPickerSections(sections, "deck").skills.map((s) => s.slug)
+    ).toEqual(["pptx"]);
+  });
+
+  it("returns empty sections when nothing matches", () => {
+    const empty = filterPickerSections(sections, "zzz");
+    expect(empty.skills).toEqual([]);
+    expect(empty.apps).toEqual([]);
+  });
+});
+
+describe("flattenSections", () => {
+  it("returns skills before apps in render order", () => {
+    const sections: PickerSections = {
+      skills: [
+        { kind: "skill", slug: "a", name: "A", description: "" },
+        { kind: "skill", slug: "b", name: "B", description: "" },
+      ],
+      apps: [
+        {
+          kind: "app",
+          slug: "c",
+          name: "C",
+          description: "",
+          appType: "SLACK",
+          authenticated: true,
+        },
+      ],
+    };
+    expect(flattenSections(sections).map((e) => e.slug)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
   });
 });

--- a/web/src/lib/skills/picker.ts
+++ b/web/src/lib/skills/picker.ts
@@ -1,60 +1,89 @@
-/**
- * Shared types + utilities for the `/` skill picker.
- *
- * Used by the Craft chat input (`InputBar`) and the scheduled trigger prompt
- * (`ScheduleTaskForm`). Both surfaces read the same `GET /skills` payload via
- * `useUserSkills` and feed it through `toPickerSkills` to get the picker's
- * `{ slug, name, description }` shape.
- */
-
+import type {
+  ExternalAppType,
+  ExternalAppUserResponse,
+} from "@/app/craft/v1/apps/registry";
 import type { SkillsList } from "@/refresh-pages/admin/SkillsPage/interfaces";
 
 export interface PickerSkill {
+  kind: "skill";
   slug: string;
   name: string;
   description: string;
 }
 
-/**
- * Normalize the user-facing skills payload to picker rows. The server already
- * filters to the user's accessible set; we defensively drop unavailable
- * builtins and disabled customs here too. Sorted by slug for stable ordering.
- */
-export function toPickerSkills(data: SkillsList | undefined): PickerSkill[] {
-  if (!data) return [];
-  const builtins = data.builtins
-    .filter((b) => b.is_available)
-    .map((b) => ({
+export interface PickerApp {
+  kind: "app";
+  slug: string;
+  name: string;
+  description: string;
+  appType: ExternalAppType;
+  authenticated: boolean;
+}
+
+export type PickerEntry = PickerSkill | PickerApp;
+
+export interface PickerSections {
+  skills: PickerSkill[];
+  apps: PickerApp[];
+}
+
+const EMPTY_SECTIONS: PickerSections = { skills: [], apps: [] };
+
+// `/api/skills` omits external-app-backed skills; the Apps section is built
+// from `/api/build/apps` instead.
+export function toPickerSections(
+  skillsData: SkillsList | undefined,
+  externalApps: ExternalAppUserResponse[] | undefined
+): PickerSections {
+  if (!skillsData && !externalApps) return EMPTY_SECTIONS;
+
+  const skills: PickerSkill[] = [];
+  const apps: PickerApp[] = [];
+
+  for (const b of skillsData?.builtins ?? []) {
+    if (!b.is_available) continue;
+    skills.push({
+      kind: "skill",
       slug: b.slug,
       name: b.name,
       description: b.description,
-    }));
-  const customs = data.customs
-    .filter((c) => c.enabled)
-    .map((c) => ({
+    });
+  }
+
+  for (const c of skillsData?.customs ?? []) {
+    if (!c.enabled) continue;
+    skills.push({
+      kind: "skill",
       slug: c.slug,
       name: c.name,
       description: c.description,
-    }));
-  return [...builtins, ...customs].sort((a, b) => a.slug.localeCompare(b.slug));
+    });
+  }
+
+  for (const app of externalApps ?? []) {
+    apps.push({
+      kind: "app",
+      slug: app.slug,
+      name: app.name,
+      description: app.description,
+      appType: app.app_type,
+      authenticated: app.authenticated,
+    });
+  }
+
+  skills.sort((a, b) => a.slug.localeCompare(b.slug));
+  apps.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  return { skills, apps };
 }
 
 export interface SlashTrigger {
-  /** Index of the active "/" character in the full text. */
   slashIndex: number;
-  /** Text typed between "/" and the cursor (exclusive of "/"). */
   query: string;
 }
 
-/**
- * Detect whether the cursor is currently inside a "/" trigger scope.
- *
- * Rules:
- * - The "/" must be at the start of the text or preceded by whitespace.
- * - Between the "/" and the cursor there must be no whitespace.
- * - The cursor must be at or after the "/" position (always true since the
- *   slash is found by lastIndexOf in `textBeforeCursor`).
- */
+// Trigger rules: "/" must be at start-of-text or after whitespace; the query
+// (chars between "/" and the cursor) must not contain whitespace.
 export function detectSlashTrigger(
   textBeforeCursor: string
 ): SlashTrigger | null {
@@ -72,19 +101,27 @@ export function detectSlashTrigger(
   return { slashIndex, query };
 }
 
-/**
- * Filter picker rows by a query string. Matches against slug, name, and
- * description (case-insensitive substring).
- */
-export function filterPickerSkills(
-  skills: PickerSkill[],
-  query: string
-): PickerSkill[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return skills;
-  return skills.filter((s) =>
-    [s.slug, s.name, s.description].some((field) =>
-      field.toLowerCase().includes(q)
-    )
+function matchesQuery(entry: PickerEntry, query: string): boolean {
+  if (!query) return true;
+  return [entry.slug, entry.name, entry.description].some((field) =>
+    field.toLowerCase().includes(query)
   );
+}
+
+export function filterPickerSections(
+  sections: PickerSections,
+  query: string
+): PickerSections {
+  const q = query.trim().toLowerCase();
+  if (!q) return sections;
+  return {
+    skills: sections.skills.filter((s) => matchesQuery(s, q)),
+    apps: sections.apps.filter((a) => matchesQuery(a, q)),
+  };
+}
+
+// Skills first, then apps — must match the popover's visual render order so
+// keyboard nav indices line up.
+export function flattenSections(sections: PickerSections): PickerEntry[] {
+  return [...sections.skills, ...sections.apps];
 }

--- a/web/src/sections/input/SkillPickerPopover.tsx
+++ b/web/src/sections/input/SkillPickerPopover.tsx
@@ -1,31 +1,40 @@
 "use client";
 
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import { Popover, Text } from "@opal/components";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import { filterPickerSkills, type PickerSkill } from "@/lib/skills/picker";
+import {
+  filterPickerSections,
+  flattenSections,
+  type PickerApp,
+  type PickerEntry,
+  type PickerSections,
+} from "@/lib/skills/picker";
+import { getAppTypeLogo } from "@/app/craft/v1/apps/registry";
+import { cn } from "@opal/utils";
 
 interface SkillPickerPopoverProps {
   open: boolean;
   anchorRect: DOMRect | null;
   query: string;
-  skills: PickerSkill[];
-  onSelect: (slug: string) => void;
+  sections: PickerSections;
+  onSelect: (entry: PickerEntry) => void;
   onClose: () => void;
 }
 
-// Floating popover for the `/` skill picker. Visually mirrors the
-// Prompt Shortcuts dropdown by reusing Opal's `Popover` + `Popover.Menu` +
-// `LineItem`. Positioning is driven by a hidden zero-width anchor element
-// placed at the caret (for contentEditable inputs) or at the textarea rect
-// (for the schedule-task form), since Radix Popover positions relative to a
-// DOM anchor rather than a virtual rect. A global keydown listener handles
-// arrow / Enter / Tab / Escape so the host input keeps focus.
 function SkillPickerPopover({
   open,
   anchorRect,
   query,
-  skills,
+  sections,
   onSelect,
   onClose,
 }: SkillPickerPopoverProps) {
@@ -33,13 +42,22 @@ function SkillPickerPopover({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   const filtered = useMemo(
-    () => filterPickerSkills(skills, query),
-    [skills, query]
+    () => filterPickerSections(sections, query),
+    [sections, query]
   );
+  const flatEntries = useMemo(() => flattenSections(filtered), [filtered]);
 
   useEffect(() => {
     setSelectedIndex(0);
   }, [open, query]);
+
+  // SWR may revalidate while open and shrink the row count; clamp so Enter
+  // doesn't silently fall back to a different row than the one highlighted.
+  useEffect(() => {
+    setSelectedIndex((i) =>
+      flatEntries.length === 0 ? 0 : Math.min(i, flatEntries.length - 1)
+    );
+  }, [flatEntries.length]);
 
   useEffect(() => {
     if (!open) return;
@@ -58,22 +76,24 @@ function SkillPickerPopover({
       if (e.key === "ArrowDown") {
         e.preventDefault();
         e.stopPropagation();
-        if (filtered.length === 0) return;
-        setSelectedIndex((i) => (i + 1) % filtered.length);
+        if (flatEntries.length === 0) return;
+        setSelectedIndex((i) => (i + 1) % flatEntries.length);
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         e.stopPropagation();
-        if (filtered.length === 0) return;
-        setSelectedIndex((i) => (i - 1 + filtered.length) % filtered.length);
+        if (flatEntries.length === 0) return;
+        setSelectedIndex(
+          (i) => (i - 1 + flatEntries.length) % flatEntries.length
+        );
       } else if (e.key === "Enter" || e.key === "Tab") {
         e.preventDefault();
         e.stopPropagation();
-        if (filtered.length === 0) {
+        if (flatEntries.length === 0) {
           onClose();
           return;
         }
-        const skill = filtered[selectedIndex] ?? filtered[0];
-        if (skill) onSelect(skill.slug);
+        const entry = flatEntries[selectedIndex] ?? flatEntries[0];
+        if (entry) onSelect(entry);
       } else if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
@@ -83,11 +103,16 @@ function SkillPickerPopover({
 
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [open, filtered, selectedIndex, onSelect, onClose]);
+  }, [open, flatEntries, selectedIndex, onSelect, onClose]);
 
   if (!anchorRect) return null;
 
-  return (
+  // `position: fixed` is containing-block-relative under a transformed
+  // ancestor (Storybook docs view, some app shells), so portal to body to
+  // keep the anchor's coords viewport-relative.
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
     <Popover
       open={open}
       onOpenChange={(next) => {
@@ -115,45 +140,178 @@ function SkillPickerPopover({
         data-testid="skill-picker-popover"
         aria-label="Skill picker"
       >
-        <div className="px-2 pt-1.5 pb-1">
-          <Text font="secondary-action" color="text-04">
-            Skills
-          </Text>
-        </div>
         <Popover.Menu scrollContainerRef={scrollContainerRef}>
-          {filtered.length === 0
-            ? [
-                <div key="empty" className="p-2">
-                  <Text font="secondary-body" color="text-03">
-                    No matching skills
-                  </Text>
-                </div>,
-              ]
-            : filtered.map((skill, idx) => {
-                const isSelected = idx === selectedIndex;
-                const description = skill.description;
-                return (
-                  <LineItem
-                    key={skill.slug}
-                    interactive={false}
-                    selected={isSelected}
-                    emphasized={isSelected}
-                    description={description}
-                    onMouseEnter={() => setSelectedIndex(idx)}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      onSelect(skill.slug);
-                    }}
-                    data-row-index={idx}
-                    data-testid={`skill-picker-row-${skill.slug}`}
-                  >
-                    {`/${skill.slug}`}
-                  </LineItem>
-                );
-              })}
+          {buildMenuChildren({
+            filtered,
+            flatEntries,
+            selectedIndex,
+            onSelect,
+            onHover: setSelectedIndex,
+          })}
         </Popover.Menu>
       </Popover.Content>
-    </Popover>
+    </Popover>,
+    document.body
+  );
+}
+
+interface BuildMenuChildrenArgs {
+  filtered: PickerSections;
+  flatEntries: PickerEntry[];
+  selectedIndex: number;
+  onSelect: (entry: PickerEntry) => void;
+  onHover: (idx: number) => void;
+}
+
+// `Popover.Menu` renders a literal `null` between children as a divider.
+function buildMenuChildren({
+  filtered,
+  flatEntries,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: BuildMenuChildrenArgs): ReactNode[] {
+  if (flatEntries.length === 0) {
+    return [
+      <div key="empty" className="p-2">
+        <Text font="secondary-body" color="text-03">
+          No matching skills
+        </Text>
+      </div>,
+    ];
+  }
+
+  const skillsCount = filtered.skills.length;
+  const children: ReactNode[] = [];
+
+  flatEntries.forEach((entry, idx) => {
+    if (idx === 0 && skillsCount > 0) {
+      children.push(<SectionHeader key="skills-header" label="Skills" />);
+    }
+    if (idx === skillsCount && filtered.apps.length > 0) {
+      if (skillsCount > 0) children.push(null);
+      children.push(<SectionHeader key="apps-header" label="Apps" />);
+    }
+    const selected = idx === selectedIndex;
+    children.push(
+      entry.kind === "app" ? (
+        <AppRow
+          key={`app-${entry.slug}`}
+          app={entry}
+          selected={selected}
+          onHover={() => onHover(idx)}
+          onPick={() => onSelect(entry)}
+          rowIndex={idx}
+        />
+      ) : (
+        <SkillRow
+          key={`skill-${entry.slug}`}
+          slug={entry.slug}
+          description={entry.description}
+          selected={selected}
+          onHover={() => onHover(idx)}
+          onPick={() => onSelect(entry)}
+          rowIndex={idx}
+        />
+      )
+    );
+  });
+
+  return children;
+}
+
+function SectionHeader({ label }: { label: string }) {
+  return (
+    <div className="px-2 pt-1 pb-0.5">
+      <Text font="secondary-action" color="text-03">
+        {label}
+      </Text>
+    </div>
+  );
+}
+
+interface SkillRowProps {
+  slug: string;
+  description: string;
+  selected: boolean;
+  onHover: () => void;
+  onPick: () => void;
+  rowIndex: number;
+}
+
+function SkillRow({
+  slug,
+  description,
+  selected,
+  onHover,
+  onPick,
+  rowIndex,
+}: SkillRowProps) {
+  return (
+    <div className="cursor-pointer">
+      <LineItem
+        interactive={false}
+        selected={selected}
+        emphasized={selected}
+        description={description}
+        onMouseEnter={onHover}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onPick();
+        }}
+        data-row-index={rowIndex}
+        data-testid={`skill-picker-row-${slug}`}
+      >
+        {`/${slug}`}
+      </LineItem>
+    </div>
+  );
+}
+
+interface AppRowProps {
+  app: PickerApp;
+  selected: boolean;
+  onHover: () => void;
+  onPick: () => void;
+  rowIndex: number;
+}
+
+function AppRow({ app, selected, onHover, onPick, rowIndex }: AppRowProps) {
+  const Logo = getAppTypeLogo(app.appType);
+  const unauth = !app.authenticated;
+  return (
+    <div className="cursor-pointer">
+      <LineItem
+        interactive={false}
+        selected={selected}
+        emphasized={selected}
+        description={app.description}
+        onMouseEnter={onHover}
+        onMouseDown={(e) => {
+          e.preventDefault();
+          onPick();
+        }}
+        rightChildren={
+          unauth ? (
+            <Text font="secondary-action" color="text-03" nowrap>
+              Connect
+            </Text>
+          ) : undefined
+        }
+        data-row-index={rowIndex}
+        data-testid={`skill-picker-row-${app.slug}`}
+      >
+        <span
+          className={cn(
+            "inline-flex items-center gap-2",
+            unauth && "opacity-50"
+          )}
+        >
+          <Logo className="h-4 w-4 shrink-0" />
+          <span>{`/${app.slug}`}</span>
+        </span>
+      </LineItem>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description
<img width="932" height="451" alt="image" src="https://github.com/user-attachments/assets/6751cb82-136a-4b79-87be-1b05497b567d" />

Split the Craft `/` skill picker into two sections: **Skills** (plain built-ins + customs) and **Apps** (external app integrations like Slack, Gmail). App rows show the provider logo and are auth-aware — unauthenticated rows render with a `Connect` hint and route to `/craft/v1/apps?connect=<slug>` on select instead of inserting an unusable slug. The apps page reads the param, scrolls the matching row into view, and focuses its Connect button.

The Apps section is sourced from `/api/build/apps` (which now exposes `slug`), since `/api/skills` excludes external-app rows by design. Same picker is used in the chat input and the scheduled-task prompt.

## How Has This Been Tested?

- `jest src/lib/skills/__tests__/picker.test.ts` — 17/17 pass.
- InputBar Storybook stories for each picker state (skills only, apps only with mixed auth, both, empty).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
