### PR TITLE
feat(config): make JOB_TIMEOUT configurable via JOB_TIMEOUT_SECONDS

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1036,7 +1036,7 @@ CODE_INTERPRETER_MAX_OUTPUT_LENGTH = int(
 #####
 # Miscellaneous
 #####
-JOB_TIMEOUT = 60 * 60 * 6  # 6 hours default
+JOB_TIMEOUT = int(os.environ.get("JOB_TIMEOUT_SECONDS") or 60 * 60 * 6)  # default 6h
 # Logs Onyx only model interactions like prompts, responses, messages etc.
 LOG_ONYX_MODEL_INTERACTIONS = (
     os.environ.get("LOG_ONYX_MODEL_INTERACTIONS", "").lower() == "true"


### PR DESCRIPTION
## Description

`JOB_TIMEOUT` is the shared `soft_time_limit` / internal stop-timeout used by many background Celery jobs — connector deletion, pruning, Vespa sync, doc permission sync, external group sync, cleanup, and the TTL/usage-reporting tasks. It is currently hardcoded to 6 hours.

On very large connectors, a full document-permission-sync (or external-group-sync / pruning) sweep can legitimately take longer than 6 hours. Because `PermissionSyncCallback.should_stop()` enforces this limit internally — Celery's `soft_time_limit` doesn't fire under thread pools, as the callback's own comment notes — the sweep is aborted at the 6h mark and never records a completed full sync. It then simply restarts on the next schedule and aborts again, so `last_full_permission_sync` never advances.

This makes the timeout configurable via the `JOB_TIMEOUT_SECONDS` environment variable, defaulting to the existing `60 * 60 * 6` so behavior is unchanged unless an operator opts in. Matches the existing `int(os.environ.get(...) or <default>)` pattern used elsewhere in this module.

## How Has This Been Tested?

- `uv run ruff check`, `uv run ruff format --check`, and `uv run ty check` pass on the changed file.
- `JOB_TIMEOUT_SECONDS` unset → `JOB_TIMEOUT == 60 * 60 * 6` (unchanged default).
- `JOB_TIMEOUT_SECONDS=86400` → `JOB_TIMEOUT == 86400`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `JOB_TIMEOUT` configurable via `JOB_TIMEOUT_SECONDS`, keeping the default at 6 hours. This allows long-running background jobs (like full permission or group syncs) to finish without being cut off.

<sup>Written for commit 70542a0942fb222b376a5002f08d6dca7b578a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

