### PR TITLE
fix(ClickUp): connector API URL construction

### DIFF
--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -54,7 +54,7 @@ class ClickupConnector(LoadConnector, PollConnector):
         headers = {"Authorization": self.api_token}
 
         response = requests.get(
-            f"{CLICKUP_API_BASE_URL}/{endpoint}",
+            f"{CLICKUP_API_BASE_URL}/{endpoint.lstrip('/')}",
             headers=headers,
             params=params,
             timeout=REQUEST_TIMEOUT_SECONDS,


### PR DESCRIPTION
## Summary
- Normalize ClickUp API endpoints before joining them with the base API URL.
- Prevent URLs like `https://api.clickup.com/api/v2//team/.../task` during ClickUp indexing and comment retrieval.

## Root Cause
The connector passed endpoint paths that already started with `/`, while `_make_request()` also inserted a `/` between the base URL and endpoint.

## Validation
- Not run per request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed ClickUp connector request URL construction by stripping leading slashes from endpoint paths before joining with the base API. Prevents double-slash URLs (e.g., https://api.clickup.com/api/v2//team/.../task) and ensures valid endpoints during indexing and comment retrieval.

<sup>Written for commit 4f364d65a4f009f913e14c0418483d1e161915b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

