### PR TITLE
feat(reindex): add additive foundation for the document port flow

### DIFF
--- a/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
+++ b/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
@@ -45,14 +45,14 @@ def upgrade() -> None:
         sa.Column(
             "time_created",
             sa.DateTime(timezone=True),
-            server_default=sa.text("now()"),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column("time_started", sa.DateTime(timezone=True), nullable=True),
         sa.Column(
             "time_updated",
             sa.DateTime(timezone=True),
-            server_default=sa.text("now()"),
+            server_default=sa.func.now(),
             nullable=False,
         ),
         sa.Column("time_completed", sa.DateTime(timezone=True), nullable=True),
@@ -96,7 +96,7 @@ def upgrade() -> None:
         sa.Column(
             "is_synthetic_seed",
             sa.Boolean(),
-            server_default=sa.text("false"),
+            server_default=sa.false(),
             nullable=False,
         ),
     )
@@ -106,7 +106,7 @@ def upgrade() -> None:
         sa.Column(
             "secondary_only_sync_pending",
             sa.Boolean(),
-            server_default=sa.text("false"),
+            server_default=sa.false(),
             nullable=False,
         ),
     )

--- a/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
+++ b/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
@@ -4,11 +4,8 @@ Revision ID: d49e41659191
 Revises: 4d545225fd82
 Create Date: 2026-06-02 15:44:59.857241
 
-Phase 1 (additive only) of the reindexing port feature:
-  - new `port_attempt` table (one attempt per cc_pair to port chunks PRESENT->FUTURE)
-  - `index_attempt.is_synthetic_seed` flag (marks the FUTURE-incremental seed attempt)
-  - `document.secondary_only_sync_pending` flag (FUTURE metadata write deferred)
-All defaults are safe; existing rows read as if the new flow does not exist.
+Reindexing port, phase 1 (additive): port_attempt table +
+index_attempt.is_synthetic_seed + document.secondary_only_sync_pending.
 """
 
 from alembic import op
@@ -67,8 +64,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id"),
     )
-    # At most one active (NOT_STARTED/IN_PROGRESS) attempt per (cc_pair, FUTURE).
-    # Enum(native_enum=False) stores the member NAME, so the predicate is uppercase.
+    # one active attempt per (cc_pair, FUTURE); predicate is uppercase (stored name)
     op.create_index(
         "ix_port_attempt_active_unique",
         "port_attempt",

--- a/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
+++ b/backend/alembic/versions/d49e41659191_add_port_attempt_and_sync_flags.py
@@ -1,0 +1,137 @@
+"""add port_attempt and sync flags
+
+Revision ID: d49e41659191
+Revises: 4d545225fd82
+Create Date: 2026-06-02 15:44:59.857241
+
+Phase 1 (additive only) of the reindexing port feature:
+  - new `port_attempt` table (one attempt per cc_pair to port chunks PRESENT->FUTURE)
+  - `index_attempt.is_synthetic_seed` flag (marks the FUTURE-incremental seed attempt)
+  - `document.secondary_only_sync_pending` flag (FUTURE metadata write deferred)
+All defaults are safe; existing rows read as if the new flow does not exist.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "d49e41659191"
+down_revision = "4d545225fd82"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "port_attempt",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("cc_pair_id", sa.Integer(), nullable=False),
+        sa.Column("search_settings_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "NOT_STARTED",
+                "IN_PROGRESS",
+                "SUCCESS",
+                "FAILED",
+                "CANCELED",
+                name="portattemptstatus",
+                native_enum=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("last_processed_doc_id", sa.String(), nullable=True),
+        sa.Column("docs_ported", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("last_progress_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error_msg", sa.Text(), nullable=True),
+        sa.Column("celery_task_id", sa.String(), nullable=True),
+        sa.Column(
+            "time_created",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("time_started", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "time_updated",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("time_completed", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["cc_pair_id"], ["connector_credential_pair.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["search_settings_id"], ["search_settings.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # At most one active (NOT_STARTED/IN_PROGRESS) attempt per (cc_pair, FUTURE).
+    # Enum(native_enum=False) stores the member NAME, so the predicate is uppercase.
+    op.create_index(
+        "ix_port_attempt_active_unique",
+        "port_attempt",
+        ["cc_pair_id", "search_settings_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('NOT_STARTED', 'IN_PROGRESS')"),
+    )
+    op.create_index(
+        op.f("ix_port_attempt_cc_pair_id"), "port_attempt", ["cc_pair_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_port_attempt_search_settings_id"),
+        "port_attempt",
+        ["search_settings_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_port_attempt_status"), "port_attempt", ["status"], unique=False
+    )
+    op.create_index(
+        op.f("ix_port_attempt_time_created"),
+        "port_attempt",
+        ["time_created"],
+        unique=False,
+    )
+
+    op.add_column(
+        "index_attempt",
+        sa.Column(
+            "is_synthetic_seed",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+
+    op.add_column(
+        "document",
+        sa.Column(
+            "secondary_only_sync_pending",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_document_secondary_only_sync_pending",
+        "document",
+        ["id"],
+        unique=False,
+        postgresql_where=sa.text("secondary_only_sync_pending IS TRUE"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_document_secondary_only_sync_pending",
+        table_name="document",
+        postgresql_where=sa.text("secondary_only_sync_pending IS TRUE"),
+    )
+    op.drop_column("document", "secondary_only_sync_pending")
+
+    op.drop_column("index_attempt", "is_synthetic_seed")
+
+    # Dropping the table drops its indexes too.
+    op.drop_table("port_attempt")

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -51,9 +51,7 @@ from onyx.db.sync_record import insert_sync_record
 from onyx.db.sync_record import update_sync_record_status
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
-from onyx.document_index.opensearch.opensearch_document_index import (
-    SecondaryIndexDocumentMissingError,
-)
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -34,6 +34,7 @@ from onyx.configs.constants import OnyxRedisConstants
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.document import get_document
 from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
 from onyx.db.document_set import delete_document_set
 from onyx.db.document_set import fetch_document_sets
 from onyx.db.document_set import fetch_document_sets_for_document
@@ -50,6 +51,9 @@ from onyx.db.sync_record import insert_sync_record
 from onyx.db.sync_record import update_sync_record_status
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.opensearch.opensearch_document_index import (
+    SecondaryIndexDocumentMissingError,
+)
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.redis.redis_document_set import RedisDocumentSet
 from onyx.redis.redis_pool import get_redis_client
@@ -512,16 +516,28 @@ def document_index_metadata_sync_task(
                     hidden=doc.hidden,
                 )
 
+                # PRESENT synced but doc not in FUTURE yet (reindex port): defer
+                # rather than fail. PRESENT write already committed in the pair.
+                secondary_only_missing = False
                 for retry_document_index in retry_document_indices:
-                    # TODO(andrei): Previously there was a comment here saying
-                    # it was ok if a doc did not exist in the document index. I
-                    # don't agree with that claim, so keep an eye on this task
-                    # to see if this raises.
-                    retry_document_index.update([update_request])
+                    try:
+                        # TODO(andrei): Previously there was a comment here saying
+                        # it was ok if a doc did not exist in the document index. I
+                        # don't agree with that claim, so keep an eye on this task
+                        # to see if this raises.
+                        retry_document_index.update([update_request])
+                    except SecondaryIndexDocumentMissingError:
+                        task_logger.debug(
+                            f"doc={document_id} not in secondary index; deferring FUTURE sync."
+                        )
+                        secondary_only_missing = True
 
                 # update db last. Worst case = we crash right before this and
                 # the sync might repeat again later
-                mark_document_as_synced(document_id, db_session)
+                if secondary_only_missing:
+                    mark_document_synced_secondary_pending(document_id, db_session)
+                else:
+                    mark_document_as_synced(document_id, db_session)
 
                 elapsed = time.monotonic() - start
                 task_logger.info(f"doc={document_id} action=sync elapsed={elapsed:.2f}")

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -674,6 +674,9 @@ def upsert_documents(
                     from_ingestion_api=doc.from_ingestion_api,
                     boost=initial_boost,
                     hidden=False,
+                    # set explicitly: model_to_dict reads the unflushed object, so a
+                    # Python-side default isn't applied yet and would insert NULL.
+                    secondary_only_sync_pending=False,
                     semantic_id=doc.semantic_identifier,
                     link=doc.first_link,
                     doc_updated_at=None,  # this is intentional

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -865,6 +865,24 @@ def mark_document_as_synced(document_id: str, db_session: Session) -> None:
 
     # update last_synced
     doc.last_synced = datetime.now(timezone.utc)
+    # reaching here means every index synced, so clear any deferred FUTURE write
+    doc.secondary_only_sync_pending = False
+    db_session.commit()
+
+
+def mark_document_synced_secondary_pending(
+    document_id: str, db_session: Session
+) -> None:
+    """Reindex-port: PRESENT synced but the doc wasn't in FUTURE yet. Clear
+    needs-sync and flag the deferred FUTURE write, in one commit. Cleared later by
+    mark_document_as_synced once a sync reaches FUTURE."""
+    stmt = select(DbDocument).where(DbDocument.id == document_id)
+    doc = db_session.scalar(stmt)
+    if doc is None:
+        raise ValueError(f"No document with ID: {document_id}")
+
+    doc.last_synced = datetime.now(timezone.utc)
+    doc.secondary_only_sync_pending = True
     db_session.commit()
 
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -85,6 +85,33 @@ class PermissionSyncStatus(str, PyEnum):
         )
 
 
+class PortAttemptStatus(str, PyEnum):
+    """Status of a single backlog-port attempt (copy chunks PRESENT -> FUTURE).
+
+    Distinct from IndexingStatus: a port has no COMPLETED_WITH_ERRORS state — a
+    batch either drains or the attempt fails and is retried from its cursor.
+
+    Values are uppercase to match what Enum(native_enum=False) persists (the
+    member name), so the stored string == .value == .name.
+    """
+
+    NOT_STARTED = "NOT_STARTED"
+    IN_PROGRESS = "IN_PROGRESS"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    CANCELED = "CANCELED"
+
+    def is_terminal(self) -> bool:
+        return self in {
+            PortAttemptStatus.SUCCESS,
+            PortAttemptStatus.FAILED,
+            PortAttemptStatus.CANCELED,
+        }
+
+    def is_successful(self) -> bool:
+        return self == PortAttemptStatus.SUCCESS
+
+
 class IndexingMode(str, PyEnum):
     UPDATE = "update"
     REINDEX = "reindex"

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -86,15 +86,6 @@ class PermissionSyncStatus(str, PyEnum):
 
 
 class PortAttemptStatus(str, PyEnum):
-    """Status of a single backlog-port attempt (copy chunks PRESENT -> FUTURE).
-
-    Distinct from IndexingStatus: a port has no COMPLETED_WITH_ERRORS state — a
-    batch either drains or the attempt fails and is retried from its cursor.
-
-    Values are uppercase to match what Enum(native_enum=False) persists (the
-    member name), so the stored string == .value == .name.
-    """
-
     NOT_STARTED = "NOT_STARTED"
     IN_PROGRESS = "IN_PROGRESS"
     SUCCESS = "SUCCESS"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -997,10 +997,8 @@ class Document(Base):
         DateTime(timezone=True), nullable=True, index=True
     )
 
-    # Set when a metadata sync succeeded on PRESENT but the FUTURE (secondary) index
-    # did not yet contain the doc (404 during a reindex port). The port writes the doc
-    # later with current fields; until then the swap must wait for these to drain.
-    # Default-false; only ever True during an active port.
+    # True when a metadata sync hit PRESENT but the doc wasn't in FUTURE yet
+    # (reindex port). Cleared once a later sync reaches FUTURE; the swap waits on these.
     secondary_only_sync_pending: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")
     )
@@ -1085,8 +1083,7 @@ class Document(Base):
             "id",
             postgresql_where=text("last_modified > last_synced OR last_synced IS NULL"),
         ),
-        # Supports the reindex-port swap criterion: "no docs with a pending
-        # FUTURE-only sync remain". Tiny/empty outside an active port.
+        # for the reindex-port swap criterion sweep
         Index(
             "ix_document_secondary_only_sync_pending",
             "id",
@@ -2301,10 +2298,8 @@ class IndexAttempt(Base):
         back_populates="index_attempts",
         primaryjoin="IndexAttempt.targeted_reindex_job_id == TargetedReindexJob.id",
     )
-    # True on the synthetic SUCCESS attempt inserted at FUTURE SearchSettings
-    # creation to seed the resume cursor for the reindex port's FUTURE-incremental
-    # poll. NOT a connector run. Default-false; consumer-query exclusion (get_last_attempt
-    # etc.) is handled in a later port phase.
+    # Marks the synthetic seed attempt for the reindex port's FUTURE poll cursor
+    # (not a connector run).
     is_synthetic_seed: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")
     )
@@ -2450,15 +2445,8 @@ class IndexAttempt(Base):
 
 
 class PortAttempt(Base):
-    """
-    One attempt to port a cc_pair's existing chunks from the PRESENT index into
-    the FUTURE index, re-embedding under FUTURE settings. Separate from
-    IndexAttempt: different cursor shape (doc-id cursor vs. source-timestamp
-    range) and lifecycle. Reads the index directly — never re-fetches the source.
-
-    A partial unique index allows at most one active (NOT_STARTED/IN_PROGRESS)
-    attempt per (cc_pair, FUTURE search_settings); terminal rows may accumulate.
-    """
+    """One attempt to port a cc_pair's chunks from PRESENT into the FUTURE index,
+    re-embedding under FUTURE settings. Doc-id cursor, distinct from IndexAttempt."""
 
     __tablename__ = "port_attempt"
 
@@ -2469,8 +2457,7 @@ class PortAttempt(Base):
         nullable=False,
         index=True,
     )
-    # The FUTURE SearchSettings being filled.
-    search_settings_id: Mapped[int] = mapped_column(
+    search_settings_id: Mapped[int] = mapped_column(  # the FUTURE settings
         ForeignKey("search_settings.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -2517,9 +2504,8 @@ class PortAttempt(Base):
     )
     search_settings: Mapped["SearchSettings"] = relationship("SearchSettings")
 
+    # at most one active attempt per (cc_pair, FUTURE)
     __table_args__ = (
-        # Enum(native_enum=False) stores the member NAME, so the predicate uses
-        # uppercase 'NOT_STARTED'/'IN_PROGRESS' (NOT the lowercase values).
         Index(
             "ix_port_attempt_active_unique",
             "cc_pair_id",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -85,6 +85,7 @@ from onyx.db.enums import OpenSearchTenantMigrationStatus
 from onyx.db.enums import PatType
 from onyx.db.enums import Permission
 from onyx.db.enums import PermissionSyncStatus
+from onyx.db.enums import PortAttemptStatus
 from onyx.db.enums import ProcessingMode
 from onyx.db.enums import SandboxStatus
 from onyx.db.enums import ScheduledTaskRunStatus
@@ -995,6 +996,14 @@ class Document(Base):
     last_synced: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )
+
+    # Set when a metadata sync succeeded on PRESENT but the FUTURE (secondary) index
+    # did not yet contain the doc (404 during a reindex port). The port writes the doc
+    # later with current fields; until then the swap must wait for these to drain.
+    # Default-false; only ever True during an active port.
+    secondary_only_sync_pending: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     # The following are not attached to User because the account/email may not be known
     # within Onyx
     # Something like the document creator
@@ -1075,6 +1084,13 @@ class Document(Base):
             "ix_document_needs_sync",
             "id",
             postgresql_where=text("last_modified > last_synced OR last_synced IS NULL"),
+        ),
+        # Supports the reindex-port swap criterion: "no docs with a pending
+        # FUTURE-only sync remain". Tiny/empty outside an active port.
+        Index(
+            "ix_document_secondary_only_sync_pending",
+            "id",
+            postgresql_where=text("secondary_only_sync_pending IS TRUE"),
         ),
     )
 
@@ -2285,6 +2301,13 @@ class IndexAttempt(Base):
         back_populates="index_attempts",
         primaryjoin="IndexAttempt.targeted_reindex_job_id == TargetedReindexJob.id",
     )
+    # True on the synthetic SUCCESS attempt inserted at FUTURE SearchSettings
+    # creation to seed the resume cursor for the reindex port's FUTURE-incremental
+    # poll. NOT a connector run. Default-false; consumer-query exclusion (get_last_attempt
+    # etc.) is handled in a later port phase.
+    is_synthetic_seed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     status: Mapped[IndexingStatus] = mapped_column(
         Enum(IndexingStatus, native_enum=False, index=True)
     )
@@ -2424,6 +2447,90 @@ class IndexAttempt(Base):
             self.total_batches is not None
             and self.completed_batches >= self.total_batches
         )
+
+
+class PortAttempt(Base):
+    """
+    One attempt to port a cc_pair's existing chunks from the PRESENT index into
+    the FUTURE index, re-embedding under FUTURE settings. Separate from
+    IndexAttempt: different cursor shape (doc-id cursor vs. source-timestamp
+    range) and lifecycle. Reads the index directly — never re-fetches the source.
+
+    A partial unique index allows at most one active (NOT_STARTED/IN_PROGRESS)
+    attempt per (cc_pair, FUTURE search_settings); terminal rows may accumulate.
+    """
+
+    __tablename__ = "port_attempt"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    cc_pair_id: Mapped[int] = mapped_column(
+        ForeignKey("connector_credential_pair.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # The FUTURE SearchSettings being filled.
+    search_settings_id: Mapped[int] = mapped_column(
+        ForeignKey("search_settings.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    status: Mapped[PortAttemptStatus] = mapped_column(
+        Enum(PortAttemptStatus, native_enum=False, name="portattemptstatus"),
+        nullable=False,
+        default=PortAttemptStatus.NOT_STARTED,
+        index=True,
+    )
+
+    # Resume cursor: last Document.id ported, committed per batch.
+    last_processed_doc_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    docs_ported: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
+    # Bumped after every batch commit; the stall watchdog fails stale attempts.
+    last_progress_time: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # only filled if status = FAILED (failure reason, including any traceback)
+    error_msg: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+
+    celery_task_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    time_created: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), index=True
+    )
+    time_started: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    time_updated: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+    time_completed: Mapped[datetime.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    connector_credential_pair: Mapped["ConnectorCredentialPair"] = relationship(
+        "ConnectorCredentialPair"
+    )
+    search_settings: Mapped["SearchSettings"] = relationship("SearchSettings")
+
+    __table_args__ = (
+        # Enum(native_enum=False) stores the member NAME, so the predicate uses
+        # uppercase 'NOT_STARTED'/'IN_PROGRESS' (NOT the lowercase values).
+        Index(
+            "ix_port_attempt_active_unique",
+            "cc_pair_id",
+            "search_settings_id",
+            unique=True,
+            postgresql_where=text("status IN ('NOT_STARTED', 'IN_PROGRESS')"),
+        ),
+    )
+
+    def is_finished(self) -> bool:
+        return self.status.is_terminal()
 
 
 class HierarchyFetchAttempt(Base):

--- a/backend/onyx/document_index/interfaces_new.py
+++ b/backend/onyx/document_index/interfaces_new.py
@@ -152,6 +152,18 @@ class MetadataUpdateRequest(BaseModel):
     persona_ids: set[int] | None = None
 
 
+class SecondaryIndexDocumentMissingError(Exception):
+    """A metadata update applied to the primary index but the doc isn't in the
+    secondary (FUTURE) index yet (e.g. mid reindex port). Carries the doc ids so
+    the caller can defer the secondary sync instead of failing."""
+
+    def __init__(self, document_ids: list[str]) -> None:
+        self.document_ids = document_ids
+        super().__init__(
+            f"{len(document_ids)} document(s) missing from the secondary index."
+        )
+
+
 class IndexRetrievalFilters(BaseModel):
     """
     Filters for retrieving chunks from the index.

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -3,6 +3,7 @@ import logging
 import time
 from contextlib import AbstractContextManager
 from contextlib import nullcontext
+from http import HTTPStatus
 from typing import Any
 from typing import Generic
 from typing import TypeVar
@@ -106,6 +107,31 @@ class OpenSearchIndexError(Exception):
     was caught by OpenSearchIndexClient. This exception is not exhaustive of all
     exceptions index calls can raise.
     """
+
+
+class OpenSearchDocumentMissingError(Exception):
+    """Target chunks don't exist on an _update (404) and the caller opted to
+    surface this rather than fail (reindex port: doc not in FUTURE yet)."""
+
+    def __init__(self, missing_chunk_ids: list[str]) -> None:
+        self.missing_chunk_ids = missing_chunk_ids
+        super().__init__(
+            f"{len(missing_chunk_ids)} document chunk(s) missing during update."
+        )
+
+
+# Server-side error.type strings (not exposed as enums by opensearch-py; cf.
+# _RETRYABLE_UPDATE_ERROR_TYPES above). Status codes use http.HTTPStatus.
+_DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception"
+_VERSION_CONFLICT_ERROR_TYPE = "version_conflict_engine_exception"
+
+
+def _external_version_ms(document: DocumentChunk) -> int | None:
+    # FUTURE write version = source doc_updated_at in epoch-ms (newest wins);
+    # None -> write without versioning.
+    if document.last_updated is None:
+        return None
+    return int(document.last_updated.timestamp() * 1000)
 
 
 class OpenSearchServerSideTimeout(Exception):
@@ -822,6 +848,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             "documents": len,
             "tenant_state": str,
             "update_if_exists": str,
+            "use_external_versioning": str,
         },
     )
     def bulk_index_documents(
@@ -829,6 +856,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         documents: list[DocumentChunk],
         tenant_state: TenantState,
         update_if_exists: bool = False,
+        use_external_versioning: bool = False,
     ) -> None:
         """Bulk indexes documents.
 
@@ -846,6 +874,11 @@ class OpenSearchIndexClient(OpenSearchClient):
             update_if_exists: Whether to update the document if it already
                 exists. If False, will raise an exception if the document
                 already exists. Defaults to False.
+            use_external_versioning: When True, write each chunk with
+                version_type=external / version=doc_updated_at (epoch-ms) and
+                treat a 409 version_conflict as benign, so the newest source
+                version wins between two FUTURE writers. Forces _op_type=index.
+                Default False leaves the write path unchanged.
 
         Raises:
             Exception: There was an error during the bulk index. This
@@ -860,10 +893,12 @@ class OpenSearchIndexClient(OpenSearchClient):
         if not documents:
             return
         logger.debug(
-            "Bulk indexing %s documents for tenant %s. update_if_exists=%s.",
+            "Bulk indexing %s documents for tenant %s. update_if_exists=%s "
+            "use_external_versioning=%s.",
             len(documents),
             tenant_state.tenant_id,
             update_if_exists,
+            use_external_versioning,
         )
         data = []
         for document in documents:
@@ -880,23 +915,75 @@ class OpenSearchIndexClient(OpenSearchClient):
                 "_op_type": "index" if update_if_exists else "create",
                 "_source": body,
             }
+            if use_external_versioning:
+                version_ms = _external_version_ms(document)
+                if version_ms is not None:
+                    # external versioning needs an index op (create ignores version)
+                    data_for_document["_op_type"] = "index"
+                    data_for_document["_version"] = version_ms
+                    data_for_document["_version_type"] = "external"
             data.append(data_for_document)
-        # max_retries is the number of times to retry a request if we get a 429.
-        # Explicitly raise on error and exception; we will not attempt retries.
-        successes, _ = bulk(
-            self._client,
-            data,
-            max_retries=3,
-            raise_on_error=True,
-            raise_on_exception=True,
-        )
-        if successes != len(documents):
-            raise OpenSearchIndexError(
-                "OpenSearch reported no errors during bulk index but the number of successful "
-                f"operations ({successes}) does not match the number of documents "
-                f"({len(documents)})."
+
+        if use_external_versioning:
+            # a stale write loses to a newer one with a benign 409, so inspect the
+            # per-item errors instead of failing the whole batch
+            successes, errors = bulk(
+                self._client,
+                data,
+                max_retries=3,
+                raise_on_error=False,
+                raise_on_exception=True,
             )
-        logger.debug("Successfully bulk indexed %s documents.", len(documents))
+            benign_conflicts = self._benign_version_conflict_count(errors)
+        else:
+            # legacy path: any error fails the batch (the caller may refresh-retry
+            # on the BulkIndexError that bulk raises)
+            successes, _ = bulk(
+                self._client,
+                data,
+                max_retries=3,
+                raise_on_error=True,
+                raise_on_exception=True,
+            )
+            benign_conflicts = 0
+
+        if successes + benign_conflicts != len(documents):
+            raise OpenSearchIndexError(
+                f"Bulk index for {self._index_name}: successes ({successes}) + benign version "
+                f"conflicts ({benign_conflicts}) != documents ({len(documents)})."
+            )
+        logger.debug(
+            "Successfully bulk indexed %s documents (%s benign version conflicts).",
+            len(documents),
+            benign_conflicts,
+        )
+
+    def _benign_version_conflict_count(self, errors: list[dict[str, Any]]) -> int:
+        """Count benign 409 version conflicts (a newer external-versioned chunk
+        already won); raise OpenSearchIndexError on any other error.
+
+        opensearch-py exposes no typed model for bulk per-item errors (bulk() ->
+        Any, BulkIndexError.errors -> List[Any]); they are raw {op_type: {...}}
+        dicts, so we read the fields directly.
+        """
+        benign = 0
+        fatal: list[dict[str, Any]] = []
+        for error in errors:
+            item = error.get("index") or {}
+            err_type = (item.get("error") or {}).get("type", "")
+            if (
+                item.get("status") == HTTPStatus.CONFLICT
+                and err_type == _VERSION_CONFLICT_ERROR_TYPE
+            ):
+                benign += 1
+            else:
+                fatal.append(error)
+        if fatal:
+            raise OpenSearchIndexError(
+                f"Failed to bulk index documents for index {self._index_name}. "
+                f"At least one fatal error occurred: {fatal[0]}"
+            )
+        return benign
 
     @log_function_time(print_only=True, debug_only=True, include_args=True)
     def delete_document(self, document_chunk_id: str) -> bool:
@@ -1066,7 +1153,10 @@ class OpenSearchIndexClient(OpenSearchClient):
         },
     )
     def bulk_update_documents(
-        self, document_chunk_ids: list[str], properties_to_update: dict[str, Any]
+        self,
+        document_chunk_ids: list[str],
+        properties_to_update: dict[str, Any],
+        swallow_document_missing: bool = False,
     ) -> None:
         """Bulk updates OpenSearch document chunks' properties.
 
@@ -1078,6 +1168,9 @@ class OpenSearchIndexClient(OpenSearchClient):
                 update.
             properties_to_update: The properties of the document to update. Each
                 property should exist in the schema.
+            swallow_document_missing: When True and the only fatal errors are 404
+                document_missing, raise OpenSearchDocumentMissingError instead of
+                OpenSearchUpdateError (FUTURE write during a reindex port).
 
         Raises:
             Exception: There was an error during the bulk update.
@@ -1088,6 +1181,8 @@ class OpenSearchIndexClient(OpenSearchClient):
                 by OpenSearch does not match the number of document chunks to
                 update, or there was at least one other kind of fatal error for
                 a particular document chunk.
+            OpenSearchDocumentMissingError: ``swallow_document_missing`` was set
+                and the only fatal errors were 404 document_missing.
         """
         if not document_chunk_ids:
             return
@@ -1120,6 +1215,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             raise_on_exception=True,
         )
 
+        missing_chunk_ids: list[str] = []
         if errors:
             retryable_ids = []
             fatal_errors = []
@@ -1135,7 +1231,14 @@ class OpenSearchIndexClient(OpenSearchClient):
                 err_obj = info.get("error", {})
                 err_type = err_obj.get("type", "") if isinstance(err_obj, dict) else ""
 
-                if status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
+                if (
+                    swallow_document_missing
+                    and status == HTTPStatus.NOT_FOUND
+                    and err_type == _DOCUMENT_MISSING_ERROR_TYPE
+                ):
+                    # doc not in this index yet; surface instead of failing
+                    missing_chunk_ids.append(info.get("_id", ""))
+                elif status >= 500 and err_type in _RETRYABLE_UPDATE_ERROR_TYPES:
                     # We have seen a bug in OpenSearch version 3.4.0 when using
                     # the knn plugin and when derived_source is enabled (the
                     # default), when OpenSearch is under load sometimes updates
@@ -1195,12 +1298,15 @@ class OpenSearchIndexClient(OpenSearchClient):
                 )
             successes += new_successes
 
-        if successes != len(document_chunk_ids):
+        # missing chunks are accounted for separately, not counted as successes
+        if successes + len(missing_chunk_ids) != len(document_chunk_ids):
             raise OpenSearchUpdateError(
                 f"OpenSearch reported no errors during bulk update but the number of successful "
-                f"operations ({successes}) does not match the number of document chunks "
-                f"({len(document_chunk_ids)})."
+                f"operations ({successes}) plus missing ({len(missing_chunk_ids)}) does not match "
+                f"the number of document chunks ({len(document_chunk_ids)})."
             )
+        if missing_chunk_ids:
+            raise OpenSearchDocumentMissingError(missing_chunk_ids)
         logger.debug(
             "Successfully bulk updated %s document chunks.", len(document_chunk_ids)
         )

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -113,8 +113,15 @@ class OpenSearchDocumentMissingError(Exception):
     """Target chunks don't exist on an _update (404) and the caller opted to
     surface this rather than fail (reindex port: doc not in FUTURE yet)."""
 
-    def __init__(self, missing_chunk_ids: list[str]) -> None:
+    def __init__(
+        self,
+        missing_chunk_ids: list[str],
+        missing_document_ids: list[str] | None = None,
+    ) -> None:
         self.missing_chunk_ids = missing_chunk_ids
+        # Only the layer that built the chunk ids knows the doc mapping; the
+        # client raises with chunks only and the index layer fills doc ids in.
+        self.missing_document_ids = missing_document_ids or []
         super().__init__(
             f"{len(missing_chunk_ids)} document chunk(s) missing during update."
         )

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -989,7 +989,7 @@ class OpenSearchIndexClient(OpenSearchClient):
         if fatal:
             raise OpenSearchIndexError(
                 f"Failed to bulk index documents for index {self._index_name}. "
-                f"At least one fatal error occurred: {fatal[0]}"
+                f"{len(fatal)} fatal error(s) occurred: {fatal}"
             )
         return benign
 

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -936,7 +936,7 @@ class OpenSearchIndexClient(OpenSearchClient):
             )
             benign_conflicts = self._benign_version_conflict_count(errors)
         else:
-            # legacy path: any error fails the batch (the caller may refresh-retry
+            # any error fails the batch (the caller may refresh-retry
             # on the BulkIndexError that bulk raises)
             successes, _ = bulk(
                 self._client,

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -949,8 +949,9 @@ class OpenSearchIndexClient(OpenSearchClient):
 
         if successes + benign_conflicts != len(documents):
             raise OpenSearchIndexError(
-                f"Bulk index for {self._index_name}: successes ({successes}) + benign version "
-                f"conflicts ({benign_conflicts}) != documents ({len(documents)})."
+                f"Bulk index for index {self._index_name}: successful operations ({successes}) "
+                f"plus benign version conflicts ({benign_conflicts}) does not match the number "
+                f"of documents ({len(documents)})."
             )
         logger.debug(
             "Successfully bulk indexed %s documents (%s benign version conflicts).",

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -572,6 +572,10 @@ class OpenSearchDocumentIndex(DocumentIndex):
             len(update_requests),
             self._index_name,
         )
+        # When swallowing, keep going past a missing-doc request so later
+        # requests still update; attribute only the docs that were truly missing.
+        missing_chunk_ids: list[str] = []
+        missing_document_ids: set[str] = set()
         for update_request in update_requests:
             properties_to_update: dict[str, Any] = dict()
             # TODO(andrei): Nit but consider if we can use DocumentChunk here so
@@ -614,6 +618,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
                 continue
 
             doc_chunk_ids_to_update: list[str] = []
+            chunk_id_to_doc_id: dict[str, str] = {}
             for doc_id in update_request.document_ids:
                 doc_chunk_count = update_request.doc_id_to_chunk_cnt.get(doc_id, -1)
                 if doc_chunk_count < 0:
@@ -645,11 +650,27 @@ class OpenSearchDocumentIndex(DocumentIndex):
                         chunk_index=chunk_index,
                     )
                     doc_chunk_ids_to_update.append(document_chunk_id)
+                    chunk_id_to_doc_id[document_chunk_id] = doc_id
 
-            self._client.bulk_update_documents(
-                document_chunk_ids=doc_chunk_ids_to_update,
-                properties_to_update=properties_to_update,
-                swallow_document_missing=swallow_document_missing,
+            try:
+                self._client.bulk_update_documents(
+                    document_chunk_ids=doc_chunk_ids_to_update,
+                    properties_to_update=properties_to_update,
+                    swallow_document_missing=swallow_document_missing,
+                )
+            except OpenSearchDocumentMissingError as e:
+                # Only raised when swallowing; record the missing docs and keep
+                # processing the remaining requests.
+                missing_chunk_ids.extend(e.missing_chunk_ids)
+                missing_document_ids.update(
+                    chunk_id_to_doc_id[cid]
+                    for cid in e.missing_chunk_ids
+                    if cid in chunk_id_to_doc_id
+                )
+
+        if missing_chunk_ids:
+            raise OpenSearchDocumentMissingError(
+                missing_chunk_ids, sorted(missing_document_ids)
             )
 
     def id_based_retrieval(
@@ -988,16 +1009,12 @@ class OpenSearchIndexPair(DocumentIndex):
     def update(self, update_requests: list[MetadataUpdateRequest]) -> None:
         self._primary.update(update_requests)
         if self._secondary is not None:
-            # FUTURE may not have the doc yet (port); re-raise as a typed signal.
+            # FUTURE may not have the doc yet (port); re-raise as a typed signal
+            # carrying only the docs that were actually missing.
             try:
                 self._secondary.update(update_requests, swallow_document_missing=True)
-            except OpenSearchDocumentMissingError:
-                missing_document_ids = [
-                    doc_id
-                    for request in update_requests
-                    for doc_id in request.document_ids
-                ]
-                raise SecondaryIndexDocumentMissingError(missing_document_ids)
+            except OpenSearchDocumentMissingError as e:
+                raise SecondaryIndexDocumentMissingError(e.missing_document_ids)
 
     def id_based_retrieval(
         self,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -30,6 +30,7 @@ from onyx.document_index.interfaces_new import IndexingMetadata
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchClient
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.client import SearchHit
 from onyx.document_index.opensearch.cluster_settings import OPENSEARCH_CLUSTER_SETTINGS
@@ -542,6 +543,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
     def update(
         self,
         update_requests: list[MetadataUpdateRequest],
+        swallow_document_missing: bool = False,
     ) -> None:
         """Updates some set of chunks.
 
@@ -647,6 +649,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
             self._client.bulk_update_documents(
                 document_chunk_ids=doc_chunk_ids_to_update,
                 properties_to_update=properties_to_update,
+                swallow_document_missing=swallow_document_missing,
             )
 
     def id_based_retrieval(
@@ -899,6 +902,17 @@ class OpenSearchDocumentIndex(DocumentIndex):
         )
 
 
+class SecondaryIndexDocumentMissingError(Exception):
+    """PRESENT update succeeded but the doc isn't in the FUTURE (secondary) index
+    yet (reindex port). Carries the doc ids so the caller can defer the FUTURE sync."""
+
+    def __init__(self, document_ids: list[str]) -> None:
+        self.document_ids = document_ids
+        super().__init__(
+            f"{len(document_ids)} document(s) missing from the secondary index."
+        )
+
+
 class OpenSearchIndexPair(DocumentIndex):
     """Pair wrapper that fans operations out to a primary OpenSearch index and
     an optional secondary one.
@@ -974,7 +988,16 @@ class OpenSearchIndexPair(DocumentIndex):
     def update(self, update_requests: list[MetadataUpdateRequest]) -> None:
         self._primary.update(update_requests)
         if self._secondary is not None:
-            self._secondary.update(update_requests)
+            # FUTURE may not have the doc yet (port); re-raise as a typed signal.
+            try:
+                self._secondary.update(update_requests, swallow_document_missing=True)
+            except OpenSearchDocumentMissingError:
+                missing_document_ids = [
+                    doc_id
+                    for request in update_requests
+                    for doc_id in request.document_ids
+                ]
+                raise SecondaryIndexDocumentMissingError(missing_document_ids)
 
     def id_based_retrieval(
         self,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -28,6 +28,7 @@ from onyx.document_index.interfaces_new import DocumentInsertionRecord
 from onyx.document_index.interfaces_new import DocumentSectionRequest
 from onyx.document_index.interfaces_new import IndexingMetadata
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchClient
 from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
@@ -920,17 +921,6 @@ class OpenSearchDocumentIndex(DocumentIndex):
         # OpenSearch transition period.
         self._client.bulk_index_documents(
             documents=chunks, tenant_state=self._tenant_state, update_if_exists=True
-        )
-
-
-class SecondaryIndexDocumentMissingError(Exception):
-    """PRESENT update succeeded but the doc isn't in the FUTURE (secondary) index
-    yet (reindex port). Carries the doc ids so the caller can defer the FUTURE sync."""
-
-    def __init__(self, document_ids: list[str]) -> None:
-        self.document_ids = document_ids
-        super().__init__(
-            f"{len(document_ids)} document(s) missing from the secondary index."
         )
 
 

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -1,0 +1,135 @@
+"""External dependency unit tests for the reindexing-port DB layer.
+
+Scoped to behavior/invariants worth guarding (the column existence + defaults are
+covered by applying the migration, which this repo does not test programmatically):
+- the partial-unique "one active attempt per (cc_pair, FUTURE)" index — and that
+  its predicate matches the stored (uppercase) enum name, not the value
+- mark_document_synced_secondary_pending sets the flag (and clears needs-sync),
+  and a later mark_document_as_synced clears it again
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.db.document import mark_document_as_modified
+from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import PortAttempt
+from onyx.db.search_settings import get_current_search_settings
+from onyx.kg.models import KGStage
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+@pytest.fixture
+def cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    pair = make_cc_pair(db_session)
+    try:
+        yield pair
+    finally:
+        db_session.rollback()
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == pair.id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_port_attempt_active_unique_constraint(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """At most one active (NOT_STARTED/IN_PROGRESS) attempt per (cc_pair, FUTURE);
+    terminal rows may coexist. Also guards the index predicate against the stored
+    enum casing (uppercase name) — a lowercase predicate would silently no-op."""
+    ss = get_current_search_settings(db_session)
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.IN_PROGRESS,
+        )
+    )
+    db_session.commit()
+
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.NOT_STARTED,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+    # a terminal attempt for the same pair is allowed (outside the predicate)
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=ss.id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    active = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status.in_(
+                [PortAttemptStatus.NOT_STARTED, PortAttemptStatus.IN_PROGRESS]
+            ),
+        )
+        .count()
+    )
+    assert active == 1
+
+
+def test_mark_secondary_pending_then_synced_clears_it(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    doc_id = "test-secondary-pending-doc"
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    try:
+        mark_document_as_modified(doc_id, db_session)  # needs-sync
+
+        # PRESENT synced but FUTURE missing -> defer
+        mark_document_synced_secondary_pending(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.last_synced is not None and row.last_modified is not None
+        assert row.last_synced >= row.last_modified  # needs-sync cleared
+        assert row.secondary_only_sync_pending is True
+
+        # a later full sync reaches FUTURE -> flag flips back to False
+        mark_document_as_synced(doc_id, db_session)
+        db_session.expire_all()
+        row = db_session.query(DbDocument).filter(DbDocument.id == doc_id).one()
+        assert row.secondary_only_sync_pending is False
+    finally:
+        db_session.query(DbDocument).filter(DbDocument.id == doc_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+
+
+def test_mark_secondary_pending_raises_on_missing_document(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    with pytest.raises(ValueError):
+        mark_document_synced_secondary_pending("does-not-exist", db_session)

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -24,6 +24,7 @@ from onyx.access.utils import prefix_user_email
 from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import IndexFilters
 from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.client import OpenSearchIndexError
 from onyx.document_index.opensearch.client import OpenSearchServerSideTimeout
@@ -746,6 +747,91 @@ class TestOpenSearchClient:
         # Under test and postcondition.
         with pytest.raises(OpenSearchIndexError, match="does not match"):
             test_client.bulk_index_documents(documents=docs, tenant_state=tenant_state)
+
+    def test_bulk_index_external_versioning_newest_wins(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """External versioning: a newer doc_updated_at wins; a stale write is a
+        benign no-op (409), not an error. Used by the reindex port."""
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        doc_id = "ext-version-doc"
+        newer = datetime(2026, 6, 2, tzinfo=timezone.utc)
+        older = newer - timedelta(days=1)
+        chunk_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id=doc_id,
+            chunk_index=0,
+            max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+        )
+
+        def write(content: str, ts: datetime) -> None:
+            chunk = _create_test_document_chunk(
+                document_id=doc_id,
+                chunk_index=0,
+                content=content,
+                tenant_state=tenant_state,
+                last_updated=ts,
+            )
+            test_client.bulk_index_documents(
+                documents=[chunk],
+                tenant_state=tenant_state,
+                use_external_versioning=True,
+            )
+
+        # New doc is created (op_type forced to index; create + external is rejected).
+        write("newer", newer)
+        assert test_client.get_document(chunk_id).content == "newer"
+
+        # Stale write loses the version comparison -> benign 409, no raise, no change.
+        write("older", older)
+        assert test_client.get_document(chunk_id).content == "newer"
+
+        # A genuinely newer write wins.
+        write("newest", newer + timedelta(days=1))
+        assert test_client.get_document(chunk_id).content == "newest"
+
+    def test_bulk_update_swallow_document_missing(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 404 document_missing on update is fatal by default, but surfaced as
+        OpenSearchDocumentMissingError when the caller opts in (reindex port)."""
+        _patch_global_tenant_state(monkeypatch, False)
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=tenant_state.multitenant
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+
+        missing_id = get_opensearch_doc_chunk_id(
+            tenant_state=tenant_state,
+            document_id="does-not-exist",
+            chunk_index=0,
+            max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+        )
+
+        # Default: a missing doc is fatal.
+        with pytest.raises(OpenSearchUpdateError):
+            test_client.bulk_update_documents(
+                document_chunk_ids=[missing_id],
+                properties_to_update={"hidden": True},
+            )
+
+        # Opted-in: surfaced as OpenSearchDocumentMissingError instead.
+        with pytest.raises(OpenSearchDocumentMissingError) as exc:
+            test_client.bulk_update_documents(
+                document_chunk_ids=[missing_id],
+                properties_to_update={"hidden": True},
+                swallow_document_missing=True,
+            )
+        assert missing_id in exc.value.missing_chunk_ids
 
     def test_get_document(
         self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
@@ -1,0 +1,62 @@
+"""Unit test for OpenSearchIndexPair.update's FUTURE-404 conversion.
+
+Pure-Python glue: the pair lets PRESENT (primary) write, then converts a
+secondary OpenSearchDocumentMissingError into a typed SecondaryIndexDocumentMissingError
+carrying the doc ids. The underlying 404/409 behavior is covered for real against
+a live cluster in tests/external_dependency_unit/opensearch/test_opensearch_client.py.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
+from onyx.document_index.opensearch.client import OpenSearchUpdateError
+from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
+from onyx.document_index.opensearch.opensearch_document_index import (
+    SecondaryIndexDocumentMissingError,
+)
+
+
+def _make_pair(secondary: object) -> tuple[OpenSearchIndexPair, MagicMock]:
+    """Returns the pair plus the primary mock (asserting through the typed
+    `_primary` attribute would confuse the type checker)."""
+    pair = OpenSearchIndexPair.__new__(OpenSearchIndexPair)
+    primary = MagicMock()
+    pair._primary = primary
+    pair._secondary = secondary
+    return pair, primary
+
+
+def _update_request() -> MetadataUpdateRequest:
+    return MetadataUpdateRequest(
+        document_ids=["doc-1"], doc_id_to_chunk_cnt={"doc-1": 1}, boost=1
+    )
+
+
+def test_pair_converts_secondary_missing_to_typed_signal() -> None:
+    secondary = MagicMock()
+    secondary.update.side_effect = OpenSearchDocumentMissingError(["chunk-1"])
+    pair, primary = _make_pair(secondary)
+
+    with pytest.raises(SecondaryIndexDocumentMissingError) as exc:
+        pair.update([_update_request()])
+
+    assert exc.value.document_ids == ["doc-1"]
+    primary.update.assert_called_once()  # PRESENT written before FUTURE
+    assert secondary.update.call_args.kwargs.get("swallow_document_missing") is True
+
+
+def test_pair_propagates_other_secondary_errors() -> None:
+    secondary = MagicMock()
+    secondary.update.side_effect = OpenSearchUpdateError("boom")
+    pair, _primary = _make_pair(secondary)
+    with pytest.raises(OpenSearchUpdateError):
+        pair.update([_update_request()])
+
+
+def test_pair_no_secondary_just_primary() -> None:
+    pair, primary = _make_pair(None)
+    pair.update([_update_request()])
+    primary.update.assert_called_once()

--- a/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchUpdateError
@@ -22,9 +23,6 @@ from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
 from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
-from onyx.document_index.opensearch.opensearch_document_index import (
-    SecondaryIndexDocumentMissingError,
-)
 from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 

--- a/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_index_pair_secondary_missing.py
@@ -1,9 +1,13 @@
-"""Unit test for OpenSearchIndexPair.update's FUTURE-404 conversion.
+"""Unit tests for the FUTURE-404 (secondary missing) conversion path.
 
-Pure-Python glue: the pair lets PRESENT (primary) write, then converts a
-secondary OpenSearchDocumentMissingError into a typed SecondaryIndexDocumentMissingError
-carrying the doc ids. The underlying 404/409 behavior is covered for real against
-a live cluster in tests/external_dependency_unit/opensearch/test_opensearch_client.py.
+Two pure-Python seams:
+- `OpenSearchDocumentIndex.update` keeps processing requests past a missing-doc
+  one and reports only the docs that were actually missing (chunk -> doc mapping).
+- `OpenSearchIndexPair.update` lets PRESENT (primary) write, then converts a
+  secondary `OpenSearchDocumentMissingError` into a typed
+  `SecondaryIndexDocumentMissingError` carrying those doc ids.
+The underlying 404/409 behavior is covered for real against a live cluster in
+tests/external_dependency_unit/opensearch/test_opensearch_client.py.
 """
 
 from unittest.mock import MagicMock
@@ -11,12 +15,18 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.client import OpenSearchDocumentMissingError
 from onyx.document_index.opensearch.client import OpenSearchUpdateError
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
 from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
 from onyx.document_index.opensearch.opensearch_document_index import (
     SecondaryIndexDocumentMissingError,
 )
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 
 def _make_pair(secondary: object) -> tuple[OpenSearchIndexPair, MagicMock]:
@@ -29,15 +39,53 @@ def _make_pair(secondary: object) -> tuple[OpenSearchIndexPair, MagicMock]:
     return pair, primary
 
 
-def _update_request() -> MetadataUpdateRequest:
+def _update_request(doc_id: str = "doc-1") -> MetadataUpdateRequest:
     return MetadataUpdateRequest(
-        document_ids=["doc-1"], doc_id_to_chunk_cnt={"doc-1": 1}, boost=1
+        document_ids=[doc_id], doc_id_to_chunk_cnt={doc_id: 1}, boost=1
     )
+
+
+def _make_index() -> tuple[OpenSearchDocumentIndex, TenantState, MagicMock]:
+    """Returns the index, its tenant state, and the client mock (asserting
+    through the typed `_client` attribute would confuse the type checker)."""
+    ts = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+    idx = OpenSearchDocumentIndex.__new__(OpenSearchDocumentIndex)
+    client = MagicMock()
+    idx._client = client
+    idx._tenant_state = ts
+    idx._index_name = "test-index"
+    return idx, ts, client
+
+
+def test_update_continues_past_missing_and_attributes_precisely() -> None:
+    """A missing doc in one request must not drop the others, and only the
+    truly-missing doc is reported (not every doc in the batch)."""
+    idx, ts, client = _make_index()
+    missing_chunk = get_opensearch_doc_chunk_id(
+        tenant_state=ts, document_id="doc-missing", chunk_index=0
+    )
+    client.bulk_update_documents.side_effect = [
+        OpenSearchDocumentMissingError([missing_chunk]),
+        None,
+    ]
+
+    with pytest.raises(OpenSearchDocumentMissingError) as exc:
+        idx.update(
+            [_update_request("doc-missing"), _update_request("doc-present")],
+            swallow_document_missing=True,
+        )
+
+    assert exc.value.missing_document_ids == ["doc-missing"]
+    assert exc.value.missing_chunk_ids == [missing_chunk]
+    # the present doc's request was still attempted after the missing one
+    assert client.bulk_update_documents.call_count == 2
 
 
 def test_pair_converts_secondary_missing_to_typed_signal() -> None:
     secondary = MagicMock()
-    secondary.update.side_effect = OpenSearchDocumentMissingError(["chunk-1"])
+    secondary.update.side_effect = OpenSearchDocumentMissingError(
+        ["chunk-1"], ["doc-1"]
+    )
     pair, primary = _make_pair(secondary)
 
     with pytest.raises(SecondaryIndexDocumentMissingError) as exc:


### PR DESCRIPTION
## Description
  - Add a `port_attempt` table + `PortAttemptStatus` enum to track porting a connector's documents from the live index into a newly-built one.
  - Add `IndexAttempt.is_synthetic_seed` and `Document.secondary_only_sync_pending` flags used to coordinate that flow.
  - Metadata sync no longer fails when a document isn't in the new index yet during a reindex — it defers, then reconciles automatically once the document is copied over.
  - Let chunk writes to the new index opt into external versioning, so two concurrent writers settle on the newest source version and stale writes are ignored instead of clobbering fresh data.
  - Additive only: no user-visible behavior changes; the new flow stays dormant until it's enabled in a later change.

## How Has This Been Tested?
  - External-dependency-unit tests against real Postgres + OpenSearch (schema/constraint, sync-deferral helper, external-versioning + missing-doc handling), one unit test for the index-pair conversion, and verified the Alembic migration upgrades/downgrades cleanly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the additive groundwork for the reindex “document port” flow, deferring FUTURE metadata writes when a doc isn’t present and using opt‑in external versioning so stale writes don’t overwrite newer ones. Also improves missing‑document handling in bulk updates. Dormant until enabled; no user-visible changes.

- **New Features**
  - DB: `port_attempt` table with `PortAttemptStatus`; partial unique index for one active attempt per `(cc_pair, FUTURE)`; `IndexAttempt.is_synthetic_seed`; `Document.secondary_only_sync_pending`.
  - Metadata sync: FUTURE 404s defer; `document_index_metadata_sync_task` sets `secondary_only_sync_pending`, cleared on a later full sync.
  - OpenSearch: `bulk_index_documents` supports external versioning (epoch‑ms from `last_updated`) and counts benign 409 conflicts; `bulk_update_documents` adds `swallow_document_missing` to surface 404s as `OpenSearchDocumentMissingError`; `OpenSearchDocumentIndex.update` continues past missing‑doc requests and reports only the missing doc IDs; `OpenSearchIndexPair.update` converts FUTURE 404s into `SecondaryIndexDocumentMissingError` with those IDs.
  - Tests: external‑dependency and unit tests for DB invariants, external versioning “newest wins”, missing‑doc surfacing and attribution, and FUTURE‑404 conversion.

- **Bug Fixes**
  - Set `secondary_only_sync_pending=False` in `upsert_documents` inserts to avoid NULL writes violating the NOT NULL constraint.
  - Improve bulk index failure messages to include fatal item details when counts don’t match.

<sup>Written for commit cfac1b086e14baaee0e46eca80b205feb0ae31e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

