### PR TITLE
feat(embeddings): add OpenRouter as an embedding provider

### DIFF
--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -564,6 +564,24 @@ class CloudEmbedding:
         result = response.json()
         return [embedding["embedding"] for embedding in result["data"]]
 
+    async def _embed_openrouter(
+        self, texts: list[str], model_name: str | None
+    ) -> list[Embedding]:
+        if not model_name:
+            raise ValueError("Model name is required for OpenRouter embedding.")
+
+        if not self.api_key:
+            raise ValueError("API key is required for OpenRouter embedding.")
+
+        response = await self.http_client.post(
+            "https://openrouter.ai/api/v1/embeddings",
+            json={"model": model_name, "input": texts},
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+        response.raise_for_status()
+        result = response.json()
+        return [embedding["embedding"] for embedding in result["data"]]
+
     @retry(
         retry=retry_if_exception_type(RuntimeError),
         stop=stop_after_attempt(_RETRY_TRIES),
@@ -588,6 +606,8 @@ class CloudEmbedding:
                 return await self._embed_azure(texts, f"azure/{deployment_name}")
             elif self.provider == EmbeddingProvider.LITELLM:
                 return await self._embed_litellm_proxy(texts, model_name)
+            elif self.provider == EmbeddingProvider.OPENROUTER:
+                return await self._embed_openrouter(texts, model_name)
 
             embedding_type = EmbeddingModelTextType.get_type(self.provider, text_type)
             if self.provider == EmbeddingProvider.COHERE:

--- a/backend/shared_configs/enums.py
+++ b/backend/shared_configs/enums.py
@@ -8,6 +8,7 @@ class EmbeddingProvider(str, Enum):
     GOOGLE = "google"
     LITELLM = "litellm"
     AZURE = "azure"
+    OPENROUTER = "openrouter"
 
 
 class RerankerProvider(str, Enum):

--- a/web/src/lib/indexing/index.ts
+++ b/web/src/lib/indexing/index.ts
@@ -7,6 +7,7 @@ import {
   SvgMicrosoft,
   SvgNomic,
   SvgOpenai,
+  SvgOpenrouter,
   SvgVoyage,
 } from "@opal/logos";
 import {
@@ -155,6 +156,15 @@ export const CLOUD_BASED_PROVIDERS: EmbeddingProvider[] = [
     displayName: "LiteLLM",
     icon: SvgLitellm,
     apiLink: "https://docs.litellm.ai/docs/proxy/quick_start",
+    embeddingModels: [],
+  },
+  {
+    providerName: EmbeddingProviderName.OPENROUTER,
+    displayName: "OpenRouter",
+    icon: SvgOpenrouter,
+    docsLink: "https://openrouter.ai/docs/embeddings",
+    apiLink: "https://openrouter.ai/settings/keys",
+    costslink: "https://openrouter.ai/models?category=embedding",
     embeddingModels: [],
   },
   {

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -12,6 +12,7 @@ export enum EmbeddingProviderName {
   GOOGLE = "google",
   LITELLM = "litellm",
   AZURE = "azure",
+  OPENROUTER = "openrouter",
 
   // Self-hosted
   NOMIC = "nomic",

--- a/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx
@@ -423,6 +423,78 @@ function LiteLLMProviderModal({
 }
 
 // ---------------------------------------------------------------------------
+// OpenRouter
+// ---------------------------------------------------------------------------
+
+interface OpenRouterFormValues {
+  apiKey: string;
+  modelName: string;
+  modelDim: number;
+  queryPrefix: string;
+  passagePrefix: string;
+  normalize: boolean;
+}
+function OpenRouterProviderModal({
+  provider,
+  existingCredentials,
+  existingModel,
+  onSubmit,
+}: ProviderModalProps) {
+  const isEditing = !!existingCredentials;
+  const maskedApiKey = existingCredentials?.api_key ?? "";
+
+  const schema = Yup.object({
+    apiKey: isEditing
+      ? Yup.string().trim()
+      : Yup.string().trim().required("API key is required"),
+    ...modelSpecSchemaShape,
+  });
+
+  const initialValues: OpenRouterFormValues = {
+    apiKey: maskedApiKey,
+    modelName: existingModel?.modelName ?? "",
+    modelDim: existingModel?.modelDim ?? 0,
+    queryPrefix: existingModel?.queryPrefix ?? "",
+    passagePrefix: existingModel?.passagePrefix ?? "",
+    normalize: existingModel?.normalize ?? false,
+  };
+
+  return (
+    <Formik<OpenRouterFormValues>
+      initialValues={initialValues}
+      validationSchema={schema}
+      validateOnMount
+      onSubmit={async (values) => {
+        const apiKey =
+          values.apiKey === maskedApiKey ? null : values.apiKey || null;
+        if (
+          await testAndSaveProviderCredentials({
+            provider,
+            apiKey,
+            modelName: values.modelName.trim(),
+          })
+        ) {
+          onSubmit({
+            modelName: values.modelName.trim(),
+            modelDim: values.modelDim,
+            normalize: values.normalize,
+            queryPrefix: values.queryPrefix || null,
+            passagePrefix: values.passagePrefix || null,
+          });
+        }
+      }}
+    >
+      <ModalShell provider={provider} isEditing={isEditing}>
+        <ApiKeyField provider={provider} />
+        <ModelSpecFields
+          modelNameSubDescription="Onyx will connect to this model via the OpenRouter API."
+        />
+      </ModalShell>
+    </Formik>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Custom Self-Hosted
 // ---------------------------------------------------------------------------
 
@@ -476,6 +548,8 @@ export function ProviderCredentialsModal(props: ProviderModalProps) {
       return <AzureProviderModal {...props} />;
     case EmbeddingProviderName.LITELLM:
       return <LiteLLMProviderModal {...props} />;
+    case EmbeddingProviderName.OPENROUTER:
+      return <OpenRouterProviderModal {...props} />;
     case EmbeddingProviderName.CUSTOM:
       return <CustomSelfHostedModal {...props} />;
     default:


### PR DESCRIPTION
## Summary

- Adds **OpenRouter** as a new cloud embedding provider alongside OpenAI, Cohere, Voyage, Google, Azure, and LiteLLM.
- The API endpoint URL (`https://openrouter.ai/api/v1/embeddings`) is hard-coded since it never changes — only an **API key** and a **model name** are required from the user.
- Reuses the OpenAI-compatible wire format (POST with `model` + `input` fields) already implemented for the LiteLLM proxy path, but as a dedicated provider so it appears as its own entry in the admin UI.

## Changes

### Backend
- `backend/shared_configs/enums.py` — adds `OPENROUTER = "openrouter"` to `EmbeddingProvider`.
- `backend/onyx/natural_language_processing/search_nlp_models.py` — adds `_embed_openrouter()` to `CloudEmbedding` and routes `EmbeddingProvider.OPENROUTER` through it in `embed()`.

### Frontend
- `web/src/lib/indexing/interfaces.ts` — adds `OPENROUTER = "openrouter"` to `EmbeddingProviderName`.
- `web/src/lib/indexing/index.ts` — registers the OpenRouter provider in `CLOUD_BASED_PROVIDERS` with the existing `SvgOpenrouter` logo and links to the OpenRouter docs / key management / pricing pages.
- `web/src/refresh-pages/admin/IndexSettingsPage/modals.tsx` — adds `OpenRouterProviderModal` (API key + model spec fields, URL is not user-configurable) and wires it into `ProviderCredentialsModal`.

## Test plan

- [ ] In the admin embedding settings page, verify "OpenRouter" appears as a new cloud provider option with its logo.
- [ ] Click "Connect" on OpenRouter, enter a valid API key and a model name (e.g. `openai/text-embedding-3-small`), confirm the test call succeeds and the provider is saved.
- [ ] Verify the API URL field is absent from the OpenRouter modal (hard-coded).
- [ ] Select an OpenRouter model as the active embedding model and reindex a document; confirm chunks embed correctly.
- [ ] Attempt to save with an invalid API key; confirm an error toast appears and nothing is persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenRouter as a cloud embedding provider using the OpenAI-compatible embeddings API. Users connect with an API key and model name; the URL is fixed and the provider shows up as its own option in the admin UI.

- **New Features**
  - Backend: added `OPENROUTER` provider and `_embed_openrouter` posting to https://openrouter.ai/api/v1/embeddings with `model` and `input`; routed in `embed()`.
  - Frontend: registered provider in `CLOUD_BASED_PROVIDERS` with `SvgOpenrouter` and links to docs/keys/pricing.
  - Admin UI: new modal with API key + model fields (no URL), wired into `ProviderCredentialsModal`.

- **Migration**
  - No changes for existing providers.
  - To enable: in Index Settings > Embeddings, connect OpenRouter, enter API key and a model (e.g., `openai/text-embedding-3-small`), then select it as the active model.

<sup>Written for commit 2f7f0d28cd536548e50b60ee0b4db78f9e531e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

