### PR TITLE
fix(craft): scope CraftToolGroup error styling to individual cards

### DIFF
--- a/web/lib/opal/src/components/tag/colors.ts
+++ b/web/lib/opal/src/components/tag/colors.ts
@@ -2,12 +2,13 @@
 // surfaces (e.g. the raw-DOM skill tile in richInputTile.ts) can source the same
 // classes without pulling in the component/CSS barrel.
 
-export type TagColor = "green" | "purple" | "blue" | "gray" | "amber";
+export type TagColor = "green" | "purple" | "blue" | "gray" | "amber" | "red";
 
 export const TAG_COLORS: Record<TagColor, { bg: string; text: string }> = {
   green: { bg: "bg-theme-green-01", text: "text-theme-green-05" },
   blue: { bg: "bg-theme-blue-01", text: "text-theme-blue-05" },
   purple: { bg: "bg-theme-purple-01", text: "text-theme-purple-05" },
   amber: { bg: "bg-theme-amber-01", text: "text-theme-amber-05" },
+  red: { bg: "bg-status-error-01", text: "text-status-error-05" },
   gray: { bg: "bg-background-tint-02", text: "text-text-03" },
 };

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -230,10 +230,7 @@ export default function CraftToolCard({
           <CollapsibleTrigger asChild>
             <button className={triggerClass}>{headerRow}</button>
           </CollapsibleTrigger>
-          <CollapsibleContent>
-            {/* Flush, no horizontal padding so the body extends from the trigger. */}
-            <div className="pt-0 pb-2">{renderBody(toolCall)}</div>
-          </CollapsibleContent>
+          <CollapsibleContent>{renderBody(toolCall)}</CollapsibleContent>
         </Collapsible>
       ) : (
         <div className={triggerClass}>{headerRow}</div>

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
@@ -113,6 +113,7 @@ export const WithInProgress: Story = {
 
 export const WithFailure: Story = {
   args: {
+    defaultOpen: true,
     toolCalls: [
       EDIT_API_SERVICES,
       BASH_TYPECHECK_FAIL,

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Tag, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgAlertCircle, SvgCheckAll, SvgChevronDown } from "@opal/icons";
+import { SvgCheckAll, SvgChevronDown } from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
@@ -37,11 +37,6 @@ function renderStatusIcon(toolCalls: ToolCallState[]) {
       <SvgLoader
         className={cn(baseClass, "stroke-status-info-05 animate-spin")}
       />
-    );
-  }
-  if (aggregate === "failed") {
-    return (
-      <SvgAlertCircle className={cn(baseClass, "stroke-status-error-05")} />
     );
   }
   return <SvgCheckAll className={cn(baseClass, "stroke-text-03")} />;
@@ -83,11 +78,7 @@ export default function CraftToolGroup({
               </Text>
               <span className="ml-auto shrink-0 flex items-center gap-2">
                 {failedCount > 0 && (
-                  <Tag
-                    title={`${failedCount} failed`}
-                    size="sm"
-                    color="amber"
-                  />
+                  <Tag title={`${failedCount} failed`} size="sm" color="red" />
                 )}
                 <Tag
                   title={`${toolCalls.length} calls`}

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Tag, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgCheckAll, SvgChevronDown } from "@opal/icons";
+import { SvgAlertCircle, SvgCheckAll, SvgChevronDown } from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
@@ -32,11 +32,16 @@ function aggregateStatus(toolCalls: ToolCallState[]): ToolCallState["status"] {
 function renderStatusIcon(toolCalls: ToolCallState[]) {
   const baseClass = "size-4 shrink-0";
   const aggregate = aggregateStatus(toolCalls);
-  if (aggregate === "in_progress" || aggregate === "pending") {
+  if (aggregate === "in_progress") {
     return (
       <SvgLoader
         className={cn(baseClass, "stroke-status-info-05 animate-spin")}
       />
+    );
+  }
+  if (aggregate === "failed") {
+    return (
+      <SvgAlertCircle className={cn(baseClass, "stroke-status-error-05")} />
     );
   }
   return <SvgCheckAll className={cn(baseClass, "stroke-text-03")} />;

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -3,18 +3,14 @@
 import { useEffect, useRef, useState } from "react";
 import { Tag, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgChevronDown } from "@opal/icons";
+import { SvgCheckAll, SvgChevronDown } from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
 import CraftToolCard from "@/app/craft/components/tool-cards/CraftToolCard";
-import {
-  getStatusDisplay,
-  getToolIcon,
-  SvgLoader,
-} from "@/app/craft/components/tool-cards/helpers";
+import { SvgLoader } from "@/app/craft/components/tool-cards/helpers";
 import type { ToolCallState } from "@/app/craft/types/displayTypes";
 
 interface CraftToolGroupProps {
@@ -36,20 +32,14 @@ function aggregateStatus(toolCalls: ToolCallState[]): ToolCallState["status"] {
 function renderStatusIcon(toolCalls: ToolCallState[]) {
   const baseClass = "size-4 shrink-0";
   const aggregate = aggregateStatus(toolCalls);
-  const display = getStatusDisplay(aggregate);
-  if (display.showSpinner) {
+  if (aggregate === "in_progress" || aggregate === "pending") {
     return (
       <SvgLoader
         className={cn(baseClass, "stroke-status-info-05 animate-spin")}
       />
     );
   }
-  const StatusIcon = display.icon;
-  if (StatusIcon) {
-    return <StatusIcon className={cn(baseClass, display.iconClass)} />;
-  }
-  const ToolIcon = getToolIcon(toolCalls[0]!.kind);
-  return <ToolIcon className={cn(baseClass, "stroke-text-03")} />;
+  return <SvgCheckAll className={cn(baseClass, "stroke-text-03")} />;
 }
 
 export default function CraftToolGroup({
@@ -57,31 +47,22 @@ export default function CraftToolGroup({
   autoCollapse = false,
 }: CraftToolGroupProps) {
   const aggregate = aggregateStatus(toolCalls);
-  const hasFailure = aggregate === "failed";
-  // Open while the run is active (or on failure) so streaming calls stay
-  // visible and nothing collapses as new calls append; settled groups (e.g.
-  // re-rendered history) start collapsed.
-  const [isOpen, setIsOpen] = useState(
-    aggregate === "in_progress" || hasFailure
-  );
+  // Open while the run is active so streaming calls stay visible and nothing
+  // collapses as new calls append; settled groups start collapsed.
+  const [isOpen, setIsOpen] = useState(aggregate === "in_progress");
   const failedCount = toolCalls.filter((t) => t.status === "failed").length;
 
   // Fold closed once a message follows; fire once so a manual re-open sticks.
   const didAutoCollapse = useRef(false);
   useEffect(() => {
-    if (autoCollapse && !hasFailure && !didAutoCollapse.current) {
+    if (autoCollapse && !didAutoCollapse.current) {
       didAutoCollapse.current = true;
       setIsOpen(false);
     }
-  }, [autoCollapse, hasFailure]);
+  }, [autoCollapse]);
 
   return (
-    <div
-      className={cn(
-        "rounded-08 overflow-hidden",
-        hasFailure && "border border-status-error-03 bg-status-error-00"
-      )}
-    >
+    <div className="rounded-08 overflow-hidden">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <CollapsibleTrigger asChild>
           <button
@@ -96,7 +77,7 @@ export default function CraftToolGroup({
                 Working
               </Text>
               <span className="ml-auto shrink-0 flex items-center gap-2">
-                {hasFailure && failedCount > 0 && (
+                {failedCount > 0 && (
                   <Tag
                     title={`${failedCount} failed`}
                     size="sm"

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -17,6 +17,8 @@ interface CraftToolGroupProps {
   toolCalls: ToolCallState[];
   /** Once an assistant message follows, animate the block closed. */
   autoCollapse?: boolean;
+  /** Override the initial open/closed state (useful in Storybook). */
+  defaultOpen?: boolean;
 }
 
 function aggregateStatus(toolCalls: ToolCallState[]): ToolCallState["status"] {
@@ -45,11 +47,14 @@ function renderStatusIcon(toolCalls: ToolCallState[]) {
 export default function CraftToolGroup({
   toolCalls,
   autoCollapse = false,
+  defaultOpen,
 }: CraftToolGroupProps) {
   const aggregate = aggregateStatus(toolCalls);
   // Open while the run is active so streaming calls stay visible and nothing
   // collapses as new calls append; settled groups start collapsed.
-  const [isOpen, setIsOpen] = useState(aggregate === "in_progress");
+  const [isOpen, setIsOpen] = useState(
+    defaultOpen ?? aggregate === "in_progress"
+  );
   const failedCount = toolCalls.filter((t) => t.status === "failed").length;
 
   // Fold closed once a message follows; fire once so a manual re-open sticks.


### PR DESCRIPTION
## Description

Redesign `CraftToolGroup` header to reflect progress rather than outcome. Previously, a single failed tool call would paint the entire group container red (error border + background), even when other calls succeeded. Individual `CraftToolCard` rows already render their own error styling when nested, so the container-level failure state was redundant and misleading.

Changes:
- Remove the container-level red border/bg triggered by any failure in the group
- Replace the per-status icon (`SvgCheckSquare` / `SvgAlertCircle`) with a binary: spinner while any call is in-progress, `SvgCheckAll` (neutral `stroke-text-03`) once all calls are settled — regardless of individual outcomes
- Remove `hasFailure` from the initial open state and auto-collapse guard; settled groups now start collapsed unconditionally
- Keep the amber "N failed" badge on the header for at-a-glance discoverability without coloring the whole block

## How Has This Been Tested?

Manual inspection of component logic and visual review of the rendered output.

<img width="751" height="346" alt="Screenshot 2026-06-02 at 10 49 04" src="https://github.com/user-attachments/assets/bfbc23c6-4510-4703-ac45-2f41288741c7" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes error styling in `CraftToolGroup` to individual tool cards and makes the header status neutral. Adds a red failed-count badge and keeps collapse behavior consistent during runs.

- **Bug Fixes**
  - Scoped errors to `CraftToolCard`; removed group border/background.
  - Header: spinner while `in_progress`, neutral `SvgCheckAll` when settled; removed failure/tool icons and a dead pending branch.
  - Open behavior: opens only during `in_progress`; new `defaultOpen` prop can override; `autoCollapse` now closes even on failures.
  - Failed-count badge is red via new `red` `Tag` color.
  - Removed extra bottom padding in `CraftToolCard` body to prevent red-bg bleed on failed cards.

<sup>Written for commit 2e9ed1b55789f4aa40fa70382494c820e9b288a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



