### PR TITLE
feat(auth): add coarse API-surface permission scopes for PAT scoping

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -45,27 +45,34 @@ IMPLIED_PERMISSIONS: dict[str, set[str]] = {
         Permission.READ_AGENTS.value,
         Permission.READ_USERS.value,
     },
+    # basic grants the search/chat surfaces; admin grants read:admin (and the
+    # rest) via the FULL_ADMIN_PANEL_ACCESS short-circuit in
+    # resolve_effective_permissions.
+    Permission.BASIC_ACCESS.value: {
+        Permission.READ_SEARCH.value,
+        Permission.READ_CHAT.value,
+        Permission.WRITE_CHAT.value,
+    },
+    Permission.WRITE_CHAT.value: {Permission.READ_CHAT.value},
 }
 
 # Permissions that cannot be toggled via the group-permission API.
 # BASIC_ACCESS is always granted, FULL_ADMIN_PANEL_ACCESS is too broad,
-# and READ_* permissions are implied (never stored directly).
+# and implied permissions (READ_* and the API-surface scopes) are never
+# stored directly.
 NON_TOGGLEABLE_PERMISSIONS: frozenset[Permission] = frozenset(
     {
         Permission.BASIC_ACCESS,
         Permission.FULL_ADMIN_PANEL_ACCESS,
-        Permission.READ_CONNECTORS,
-        Permission.READ_DOCUMENT_SETS,
-        Permission.READ_AGENTS,
-        Permission.READ_USERS,
     }
+    | Permission.IMPLIED
 )
 
 
 def resolve_effective_permissions(granted: set[str]) -> set[str]:
     """Expand granted permissions with their implied permissions.
 
-    If "admin" is present, returns all 19 permissions.
+    If "admin" is present, returns all permissions.
     """
     if Permission.FULL_ADMIN_PANEL_ACCESS.value in granted:
         return set(ALL_PERMISSIONS)

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -469,9 +469,15 @@ class HookFailStrategy(str, PyEnum):
 
 class Permission(str, PyEnum):
     """
-    Permission tokens for group-based authorization.
-    19 tokens total. full_admin_panel_access is an override —
+    Permission tokens for group-based authorization and PAT scoping.
+    23 tokens total. full_admin_panel_access is an override —
     if present, any permission check passes.
+
+    The read:*/write:* "API-surface scopes" are coarser than the capability
+    tokens: they name request surfaces (search, chat, admin-read) rather than
+    admin capabilities. They are implied by basic / admin (so they're never
+    granted directly to a group) and exist primarily to scope Personal Access
+    Tokens.
     """
 
     # Basic (auto-granted to every new group)
@@ -482,6 +488,12 @@ class Permission(str, PyEnum):
     READ_DOCUMENT_SETS = "read:document_sets"
     READ_AGENTS = "read:agents"
     READ_USERS = "read:users"
+
+    # API-surface scopes — coarse, implied by basic/admin, used to scope PATs.
+    READ_SEARCH = "read:search"
+    READ_CHAT = "read:chat"
+    WRITE_CHAT = "write:chat"
+    READ_ADMIN = "read:admin"
 
     # Add / Manage pairs
     ADD_AGENTS = "add:agents"
@@ -514,5 +526,9 @@ Permission.IMPLIED = frozenset(
         Permission.READ_DOCUMENT_SETS,
         Permission.READ_AGENTS,
         Permission.READ_USERS,
+        Permission.READ_SEARCH,
+        Permission.READ_CHAT,
+        Permission.WRITE_CHAT,
+        Permission.READ_ADMIN,
     }
 )

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -8,6 +8,8 @@ import pytest
 
 from onyx.auth.permissions import ALL_PERMISSIONS
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import IMPLIED_PERMISSIONS
+from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import require_permission
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
@@ -23,9 +25,25 @@ class TestResolveEffectivePermissions:
     def test_empty_set(self) -> None:
         assert resolve_effective_permissions(set()) == set()
 
-    def test_basic_no_implications(self) -> None:
+    def test_basic_implies_api_surface_scopes(self) -> None:
         result = resolve_effective_permissions({"basic"})
-        assert result == {"basic"}
+        assert result == {"basic", "read:search", "read:chat", "write:chat"}
+
+    def test_write_chat_implies_read_chat(self) -> None:
+        result = resolve_effective_permissions({"write:chat"})
+        assert result == {"write:chat", "read:chat"}
+
+    def test_read_search_no_implications(self) -> None:
+        result = resolve_effective_permissions({"read:search"})
+        assert result == {"read:search"}
+
+    def test_basic_does_not_imply_read_admin(self) -> None:
+        """read:admin is admin-only — basic principals must never gain it."""
+        assert "read:admin" not in resolve_effective_permissions({"basic"})
+
+    def test_write_chat_does_not_imply_search(self) -> None:
+        """The chat write surface must not leak into the search surface."""
+        assert "read:search" not in resolve_effective_permissions({"write:chat"})
 
     def test_single_implication(self) -> None:
         result = resolve_effective_permissions({"add:agents"})
@@ -72,6 +90,9 @@ class TestResolveEffectivePermissions:
         )
         assert result == {
             "basic",
+            "read:search",
+            "read:chat",
+            "write:chat",
             "add:agents",
             "read:agents",
             "manage:connectors",
@@ -86,6 +107,10 @@ class TestResolveEffectivePermissions:
     def test_all_permissions_for_admin(self) -> None:
         result = resolve_effective_permissions({"admin"})
         assert len(result) == len(ALL_PERMISSIONS)
+
+    def test_admin_includes_api_surface_scopes(self) -> None:
+        result = resolve_effective_permissions({"admin"})
+        assert {"read:search", "read:chat", "write:chat", "read:admin"} <= result
 
 
 # ---------------------------------------------------------------------------
@@ -107,11 +132,16 @@ class TestGetEffectivePermissions:
         result = get_effective_permissions(user)
         assert result == set(Permission)
 
-    def test_basic_stays_basic(self) -> None:
+    def test_basic_expands_to_api_surface_scopes(self) -> None:
         user = MagicMock()
         user.effective_permissions = ["basic"]
         result = get_effective_permissions(user)
-        assert result == {Permission.BASIC_ACCESS}
+        assert result == {
+            Permission.BASIC_ACCESS,
+            Permission.READ_SEARCH,
+            Permission.READ_CHAT,
+            Permission.WRITE_CHAT,
+        }
 
     def test_empty_column(self) -> None:
         user = MagicMock()
@@ -173,3 +203,40 @@ class TestRequirePermission:
         dep = require_permission(Permission.BASIC_ACCESS)
         with pytest.raises(OnyxError):
             await dep(user=user)
+
+
+# ---------------------------------------------------------------------------
+# API-surface scope registration (pins the spec, not the impl)
+# ---------------------------------------------------------------------------
+
+
+class TestApiSurfaceScopeRegistration:
+    # Hardcoded spec: the complete implied-only set (4 READ_* capability reads
+    # + 4 API-surface scopes). Equality, not subset, so an accidentally
+    # over-broad set (a real capability made un-grantable) is also caught.
+    EXPECTED_IMPLIED = {
+        "read:connectors",
+        "read:document_sets",
+        "read:agents",
+        "read:users",
+        "read:search",
+        "read:chat",
+        "write:chat",
+        "read:admin",
+    }
+
+    def test_implied_set_matches_spec(self) -> None:
+        assert {p.value for p in Permission.IMPLIED} == self.EXPECTED_IMPLIED
+
+    def test_non_toggleable_is_implied_plus_basic_and_admin(self) -> None:
+        assert {p.value for p in NON_TOGGLEABLE_PERMISSIONS} == (
+            self.EXPECTED_IMPLIED | {"basic", "admin"}
+        )
+
+    def test_implication_edges_match_spec(self) -> None:
+        assert IMPLIED_PERMISSIONS["basic"] == {
+            "read:search",
+            "read:chat",
+            "write:chat",
+        }
+        assert IMPLIED_PERMISSIONS["write:chat"] == {"read:chat"}

--- a/docs/craft/features/pat-scopes/pat-scopes.md
+++ b/docs/craft/features/pat-scopes/pat-scopes.md
@@ -1,0 +1,185 @@
+# PAT Scopes — Permissions System
+
+This is the "Permissions system" that the secrets-injection and search docs repeatedly defer to
+(`secrets-injection/01-framework.md:162`, `02-onyx-pat.md:109`, `search/search-design.md:409,528`,
+`search/4-craft-search-outstanding-questions.md:24`). Today a CRAFT PAT authenticates as the full
+user at their own role; this plan adds per-token scopes so the sandbox can be handed a token that
+can *search* but not drain chat history or touch the admin panel.
+
+## Issues to Address
+
+A Personal Access Token grants the full authority of the user it belongs to. `PersonalAccessToken`
+(`backend/onyx/db/models.py:508`) has no scope column, and `fetch_user_for_pat`
+(`backend/onyx/db/pat.py:27`) returns the real `User` verbatim and discards the matched token row.
+The only attenuation is the optional expiry.
+
+We want PATs to carry a scope — a subset of the user's authority that the token exposes — built on
+the existing `Permission` enum (`backend/onyx/db/enums.py:469`) and the `require_permission`
+dependency (`backend/onyx/auth/permissions.py:99`) rather than a parallel authorization system. The
+first consumer is the Craft sandbox PAT minted by `ensure_sandbox_pat`
+(`backend/onyx/server/features/build/db/sandbox.py:28`); the mechanism is general-purpose and
+applies to user-created PATs too.
+
+Five new token scopes, at a coarser, API-surface granularity than the existing capability
+permissions:
+
+- `READ_SEARCH` — search/query endpoints
+- `READ_CHAT` — view chat sessions/messages
+- `WRITE_CHAT` — create sessions, send messages
+- `READ_ADMIN` — read-only admin panel (view settings, users, analytics; distinct from
+  `FULL_ADMIN_PANEL_ACCESS`)
+- `WILDCARD` (`*`) — passes all checks; the backward-compat default for existing PATs
+
+## Important Notes
+
+**The authority model is an intersection.** Effective authority for a request is
+`expand(user.effective_permissions) ∩ expand(token.scopes)`. The user-side check is unchanged — a
+token can never exceed its user. The token side is a new, second gate: `require_permission(P)`
+passes iff `P ∈ expand(user_perms)` **and** `P ∈ expand(token_scopes)`.
+
+**A closure already exists; we extend it.** `permissions.py` already implements implication: the
+`IMPLIED_PERMISSIONS` adjacency map (`backend/onyx/auth/permissions.py:27`) and
+`resolve_effective_permissions` (`:65`) compute the transitive closure of a granted set, with
+`FULL_ADMIN_PANEL_ACCESS` short-circuiting to all permissions. `get_effective_permissions` (`:85`)
+wraps it for a `User`. The new scopes plug into this same machinery rather than a second closure.
+
+**The implication rules bridge two granularities.** The existing `Permission` values are capability
+grants that live on `User.effective_permissions` (a `Mapped[list[str]]` JSONB column,
+`backend/onyx/db/models.py:366`); the new scopes are API-surface verbs that live on a token. They
+share one enum, so the intersection is a single vocabulary, but they occupy two domains —
+`user.effective_permissions` should never literally contain `READ_SEARCH`, and a token's scopes are
+normally the fine verbs or `WILDCARD`. Add these edges to `IMPLIED_PERMISSIONS`:
+
+```
+WILDCARD                → <all permissions>   (token-side sentinel; short-circuit)
+BASIC_ACCESS            → READ_SEARCH, READ_CHAT, WRITE_CHAT
+FULL_ADMIN_PANEL_ACCESS → READ_ADMIN
+WRITE_CHAT              → READ_CHAT
+```
+
+`BASIC_ACCESS` currently implies nothing, so its row is new; `FULL_ADMIN_PANEL_ACCESS` already
+short-circuits to everything, so `READ_ADMIN` falls out for free on the user side and the explicit
+edge documents intent. `expand(S)` is the transitive closure applied at **check time** to both the
+user permissions and the token scopes. Store the minimal granted set on each side; never persist an
+expanded set, or a later rule change silently mismatches old rows. Closure over the 19-member enum
+is free. `expand({})` (empty scope list) is `{}` — a token with no scopes passes nothing, which is
+the correct fail-closed default.
+
+Worked example — user is `BASIC_ACCESS`, token scope is `{READ_SEARCH}`:
+`expand(user) = {BASIC_ACCESS, READ_SEARCH, READ_CHAT, WRITE_CHAT}`, `expand(token) = {READ_SEARCH}`.
+A `require_permission(READ_SEARCH)` route passes; a `require_permission(WRITE_CHAT)` route blocks.
+
+**Implication flows coarse→fine only, so route migration is mandatory.** A `READ_SEARCH` token does
+*not* satisfy a `require_permission(BASIC_ACCESS)` route, because `BASIC_ACCESS ∉
+expand({READ_SEARCH})`. A scoped token can only reach routes explicitly guarded with a permission in
+its scope set. This is the safe direction — scoped tokens fail closed — but it means re-guarding
+routes with the fine permissions is the work that makes scopes usable, not an optional follow-up.
+WILDCARD tokens and backfilled legacy PATs are unaffected, since `expand({WILDCARD})` is everything.
+
+**Unguarded routes are denied for scoped tokens (fail-closed, decided).** Most endpoints depend only
+on `current_user`/`current_limited_user` with no `require_permission`. A scoped token is still a
+valid active user, so without extra handling it would sail through every unguarded route — making
+scoping advisory rather than a boundary. Given Craft's threat model (the secrets-injection effort
+assumes the sandbox is hostile), that is too leaky. Therefore: when a request is authenticated via a
+**non-WILDCARD** PAT, any matched route that did not declare a permission covered by the token's
+`expand(scopes)` is denied. WILDCARD tokens and session/cookie auth bypass this gate entirely, so
+existing behavior is preserved for everything except deliberately-scoped tokens. The gate is keyed
+on auth type and scopes, not on `UserRole` — a PAT user keeps their real role, and `UserRole.LIMITED`
+today applies only to anonymous users, so it is orthogonal to scoping.
+
+**`WILDCARD` is a token-side sentinel only.** It is never a value in `User.effective_permissions`
+and never a valid argument to `require_permission(...)` — it is the token-side analog of the
+user-side `FULL_ADMIN_PANEL_ACCESS` override. Worth a guard (type-level or a startup assertion) so
+nobody writes `require_permission(WILDCARD)`.
+
+**`READ_ADMIN` is the heaviest migration.** Today read and write admin endpoints both sit behind
+`FULL_ADMIN_PANEL_ACCESS`. Enforcing read-only admin means auditing those routes and splitting
+read → `READ_ADMIN`, write → `FULL_ADMIN_PANEL_ACCESS`. A real audit, not a rename.
+
+**Division of labor.** The token owner (separate work) handles the `PersonalAccessToken` scope
+column + migration and the route re-guarding. This plan owns the enum/closure extension, the
+auth-context plumbing contract, the second gate in `require_permission`, the fail-closed gate, and
+the Craft-PAT scoping that is the acceptance test for the whole effort.
+
+## Implementation strategy
+
+1. **Extend the `Permission` enum** (`backend/onyx/db/enums.py:469`) with `READ_SEARCH`, `READ_CHAT`,
+   `WRITE_CHAT`, `READ_ADMIN`, and the `WILDCARD` sentinel. Document in-place that some members are
+   coarse capabilities (user-side) and some are fine API scopes (token-side), bridged by the closure.
+
+2. **Extend the closure** in `backend/onyx/auth/permissions.py`: add the new edges to
+   `IMPLIED_PERMISSIONS` (`:27`) and special-case `WILDCARD` in the resolver to short-circuit to the
+   full set (mirroring the existing `FULL_ADMIN_PANEL_ACCESS` branch in `resolve_effective_permissions`,
+   `:70`). Pure function, no I/O.
+
+3. **Persist token scopes** (owner-handled). Add a `scopes` JSONB column to `PersonalAccessToken`
+   (`backend/onyx/db/models.py:508`) holding `list[str]` of `Permission` values. Backfill existing
+   rows to `["*"]` (WILDCARD) so legacy PATs are unchanged. This plan specifies the column shape and
+   the WILDCARD-default contract.
+
+4. **Plumb scopes into request context.** `fetch_user_for_pat` (`backend/onyx/db/pat.py:27`)
+   currently returns only the `User` and drops the token row; it must also surface the matched
+   token's `scopes`. The PAT branch of `optional_user` (`backend/onyx/auth/users.py:1809`) then
+   stashes them on the request (e.g. `request.state.token_scopes`). Session/cookie auth, API-key
+   auth, and legacy tokens default to `{WILDCARD}`. This is the seam the next two steps hang on.
+
+5. **Second gate in `require_permission`** (`backend/onyx/auth/permissions.py:99`). After the
+   existing user-permission check (which already raises
+   `OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS)` on failure, `:117`), also require
+   `P ∈ expand(request.state.token_scopes)`, with WILDCARD short-circuiting. Same `OnyxError` on
+   failure. This is the coarse→fine intersection.
+
+6. **Fail-closed gate for unguarded routes.** For requests authenticated via a non-WILDCARD PAT,
+   deny any matched route whose declared permissions are not covered by `expand(token_scopes)` —
+   including routes that declared none. The route's `require_permission` declarations are already
+   discoverable via the `_is_require_permission` sentinel that `check_router_auth`
+   (`backend/onyx/server/auth_check.py:96`, wired in `backend/onyx/main.py:719`) uses to introspect
+   route dependencies; reuse that detection. Implement as middleware or a router-level dependency.
+   WILDCARD and non-PAT auth bypass. Denials raise `OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS)`.
+
+7. **Re-guard routes with fine permissions** (owner-handled): search → `READ_SEARCH`, chat-read →
+   `READ_CHAT`, chat-write → `WRITE_CHAT`, read-only admin → `READ_ADMIN`. This plan provides the
+   target mapping; the audit/migration is the token owner's.
+
+8. **Scope the Craft PAT — the acceptance test.** Change `ensure_sandbox_pat`
+   (`backend/onyx/server/features/build/db/sandbox.py:28`) to mint CRAFT PATs with
+   `scopes=[READ_SEARCH]` (plus the minimal build/search scopes onyx-cli actually calls) instead of
+   the implicit full-access WILDCARD. This retires the "CRAFT PAT grants full user access" caveat
+   carried across the secrets-injection and search docs.
+
+## Tests
+
+Prefer external-dependency-unit and integration tests; the closure is the only piece that warrants a
+pure unit test.
+
+- **Unit — closure.** Pin the spec: `WILDCARD` expands to the full set; `BASIC_ACCESS` expands to
+  include `READ_SEARCH/READ_CHAT/WRITE_CHAT`; `WRITE_CHAT` includes `READ_CHAT`;
+  `FULL_ADMIN_PANEL_ACCESS` includes `READ_ADMIN`; `expand({})` is `{}`; transitivity holds. Add a
+  completeness check that every `IMPLIED_PERMISSIONS` key and value is a real `Permission` member. Do
+  not derive the expected output from the map — hardcode the spec.
+
+- **External-dependency unit — auth context plumbing.** Mint a PAT with a real `scopes` value against
+  a real DB, run it through the PAT auth path, and assert `request.state.token_scopes` carries the
+  stored scopes; assert session auth and a WILDCARD-backfilled legacy PAT both resolve to
+  `{WILDCARD}`.
+
+- **Integration — intersection and fail-closed.** With real routes: a `READ_SEARCH` token reaches a
+  `READ_SEARCH`-guarded search endpoint, is denied a `WRITE_CHAT`-guarded endpoint, and is denied an
+  unguarded (`current_user`-only) endpoint. A `WILDCARD` token reaches all three. A `READ_ADMIN`
+  token reaches a read-only admin endpoint but is denied a `FULL_ADMIN_PANEL_ACCESS` write endpoint.
+  Confirm a token whose scope exceeds the user's permissions is still capped by the user (the
+  intersection is min, not max). Assert denials return `OnyxErrorCode.INSUFFICIENT_PERMISSIONS`.
+
+- **Integration — Craft PAT acceptance.** A live Craft session's PAT can call `company_search` /
+  onyx-cli search but is denied chat-history reads and admin endpoints — the end-to-end proof the
+  deferred caveat is closed.
+
+## Out of scope
+
+- Migrating `ApiKey` (the synthetic-service-account model, `backend/onyx/db/api_key.py`) onto the
+  same scope mechanism. API keys already encode a restricted role via their synthetic user; folding
+  them in is a later unification.
+- A UI for users to choose scopes when minting a PAT. V1 scopes are set programmatically (Craft) or
+  via API; the management UI is a follow-up.
+- Per-resource / row-level scoping (e.g. "this token may read chat session X only"). Scopes are
+  endpoint-surface grants, not object ACLs.

--- a/docs/craft/features/secrets-injection/01-framework.md
+++ b/docs/craft/features/secrets-injection/01-framework.md
@@ -24,7 +24,6 @@ This plan generalises that single call site into a dispatcher with a uniform con
 class InjectionContext:
     sandbox: ResolvedSandbox
     match: RequestMatch | None     # None on off-catalog flows
-    db_session_factory: DBSessionFactory
 
 
 class CredentialUnavailableError(Exception):
@@ -74,8 +73,8 @@ proxy overwrites only the named header. The real secret never leaves the proxy.
 ## Resolvers
 
 - **`ExternalAppResolver`** — claims iff `match is not None`. The matcher has already done URL→app
-  resolution; the resolver opens a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)` and
-  delegates to `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
+  resolution; the resolver opens a session via `get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id)`
+  and delegates to `resolve_injection_headers(db, ctx.match.external_app_id, ctx.sandbox.user_id)`.
   Behaviour identical to the current `_inject_credentials`.
 - **`OnyxPatResolver`** — claims the `SANDBOX_API_SERVER_URL` host; reads `Sandbox.encrypted_pat`.
   See [Plan 2](./02-onyx-pat.md).
@@ -84,18 +83,20 @@ proxy overwrites only the named header. The real secret never leaves the proxy.
 
 In-proxy decryption works because the proxy Deployment already has `ENCRYPTION_KEY_SECRET` wired.
 
-**Kubernetes-only.** The egress proxy exists only in the K8s sandbox backend. The docker
-self-hosted manager has no `HTTPS_PROXY` / `NO_PROXY` / CA env vars and keeps injecting real
-credentials via env vars. Every pod-side placeholder swap below is scoped to the K8s manager.
+**Kubernetes-only, and mandatory there.** The egress proxy exists only in the K8s sandbox backend,
+where it is now unconditional: `provision()` requires `SANDBOX_PROXY_HOST` (and
+`SANDBOX_API_SERVER_URL`) and always wires the initContainer, proxy env vars, and CA bundle — the
+earlier `SANDBOX_PROXY_HOST`-empty skip for tests/dev is gone (#11604), so every secret-bearing
+request provably transits the proxy. The docker self-hosted manager has no `HTTPS_PROXY` /
+`NO_PROXY` / CA env vars and keeps injecting real credentials via env vars. Every pod-side
+placeholder swap below is scoped to the K8s manager.
 
 ## Implementation
 
 1. **Refactor the gate call site.** `_inject_credentials_or_block` delegates to the dispatcher:
 
    ```python
-   ctx = InjectionContext(
-       sandbox=sandbox, match=match, db_session_factory=self._db_session_factory
-   )
+   ctx = InjectionContext(sandbox=sandbox, match=match)
    if self._dispatcher.apply(flow, ctx) is InjectionOutcome.BLOCKED:
        flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
    ```
@@ -116,8 +117,11 @@ credentials via env vars. Every pod-side placeholder swap below is scoped to the
    - `ONYX_PAT` env in `kubernetes_sandbox_manager.py` → non-empty placeholder. `ensure_sandbox_pat`
      keeps minting and persisting the PAT on the `Sandbox` row.
    - LLM keys in `OPENCODE_CONFIG_CONTENT` (built by `opencode_config.py`) → non-empty placeholders
-     for each `options.apiKey`. While in `_build_provider_block`, fix the pre-existing
-     `block["api"]` → `provider.<provider_name>.options.baseURL` field-name bug.
+     for each `options.apiKey`.
+
+   Not yet landed: the pre-existing `block["api"]` → `provider.<provider_name>.options.baseURL`
+   field-name bug in `_build_provider_block` (`opencode_config.py` still writes
+   `block["api"] = provider_config.api_base`). Tracked separately; placeholder swaps shipped without it.
 
    The docker manager continues to inject real credentials in both cases.
 
@@ -153,7 +157,7 @@ Each step is an independently revertible PR (Craft is beta — no feature flags)
 2. **Route the Onyx API through the proxy.** Loopback-only `NO_PROXY`; also fixes a pre-existing
    `EPERM` on outbound Onyx API calls from the sandbox. _Shipped with the Onyx PAT resolver._
 3. **Onyx PAT resolver** ([Plan 2](./02-onyx-pat.md)). _Shipped._
-4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)). Remaining.
+4. **LLM provider-key resolver** ([Plan 3](./03-llm-key.md)). _Shipped._
 
 ## Out of scope
 

--- a/docs/craft/features/secrets-injection/02-onyx-pat.md
+++ b/docs/craft/features/secrets-injection/02-onyx-pat.md
@@ -8,8 +8,8 @@ CRAFT PAT lives only in the proxy.
 
 ## How it works
 
-**What gets injected.** The resolver claims by host (the Onyx API is never an external app, so
-`match` is ignored) and renders two headers:
+**What gets injected.** The resolver claims by host and port (the Onyx API is never an external app,
+so `match` is ignored) and renders two headers:
 
 | Header | Value |
 |---|---|
@@ -51,8 +51,9 @@ standard env vars in `_proxy_main_container_env_vars()` — `REQUESTS_CA_BUNDLE`
 installs the CA into the system trust store via `update-ca-certificates`.
 
 **Pod-side placeholder is non-empty.** onyx-cli treats an empty token as unconfigured, so the
-pod's `ONYX_PAT` env ships a non-empty placeholder (`_ONYX_PAT_PLACEHOLDER`, a private constant in
-`kubernetes_sandbox_manager.py`) and the proxy overwrites both auth headers per the Plan 1
+pod's `ONYX_PAT` env ships a non-empty placeholder (`_PROXY_INJECTED_PLACEHOLDER =
+"replaced_by_egress_proxy"`, a private constant in `kubernetes_sandbox_manager.py` shared with the
+LLM apiKey placeholders) and the proxy overwrites both auth headers per the Plan 1
 placeholder/overwrite contract.
 
 **Failure mode.** A missing row, a `None` `encrypted_pat`, or a decrypt failure raises
@@ -67,14 +68,15 @@ proxy and continues to inject the real PAT directly as the `ONYX_PAT` env var.
 
 1. **`OnyxPatResolver`** (`onyx/sandbox_proxy/resolvers/onyx_pat.py`) implementing the Plan 1
    `CredentialResolver` protocol.
-   - `claims(request, ctx)`: True iff `request.host` is the host of `SANDBOX_API_SERVER_URL`
-     (case-insensitive); False when the var is unset.
-   - `resolve(request, ctx)`: open a session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`,
+   - `claims(request, ctx)`: True iff `request.host` (case-insensitive) and `request.port` match the
+     host and port of `SANDBOX_API_SERVER_URL` (port defaults to 443/80 by scheme); False when the
+     var is unset.
+   - `resolve(request, ctx)`: open a session via `get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id)`,
      load `Sandbox` by `ctx.sandbox.sandbox_id`, decrypt `encrypted_pat`, return the two headers.
      Raise `CredentialUnavailableError` on missing row, `None` PAT, or decrypt failure.
 
 2. **Pod-side placeholder swap** in `kubernetes_sandbox_manager.py`: the pod's `ONYX_PAT` env is
-   set to `_ONYX_PAT_PLACEHOLDER`, and `_create_sandbox_pod` no longer takes an `onyx_pat`
+   set to `_PROXY_INJECTED_PLACEHOLDER`, and `_create_sandbox_pod` no longer takes an `onyx_pat`
    argument. `provision()` still takes and validates `onyx_pat` — it guarantees the PAT was minted
    and persisted to `Sandbox.encrypted_pat` before the pod starts, even though the pod only ships
    the placeholder. `ensure_sandbox_pat` is unchanged. The docker manager keeps injecting the real
@@ -84,15 +86,15 @@ proxy and continues to inject the real PAT directly as the `ONYX_PAT` env var.
    `_compute_no_proxy_list()`), so the Onyx API host transits the proxy.
 
 4. **Register in `build_resolvers()`** (`server.py`):
-   `[OnyxPatResolver(), ExternalAppResolver()]`. Hosts are disjoint.
+   `[OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]`. Hosts are disjoint.
 
 ## Tests
 
 - **Unit** (`backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py`): with a fake `Sandbox`
-  row and a mock `db_session_factory`, the resolver returns both auth headers as `Bearer <pat>`.
-  Negative cases — missing row, `encrypted_pat is None`, decrypt raises — each raise
-  `CredentialUnavailableError`. `claims` is True for the API host (case-insensitive), False for
-  others, and False when `SANDBOX_API_SERVER_URL` is unset.
+  row and a patched `get_session_with_tenant`, the resolver returns both auth headers as
+  `Bearer <pat>`. Negative cases — missing row, `encrypted_pat is None`, decrypt raises — each raise
+  `CredentialUnavailableError`. `claims` is True for the API host and port (case-insensitive), False
+  for others, and False when `SANDBOX_API_SERVER_URL` is unset.
 
 - **External-dependency unit**
   (`backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py`): against a
@@ -101,8 +103,8 @@ proxy and continues to inject the real PAT directly as the `ONYX_PAT` env var.
   through real `EncryptedString`.
 
 - **Pod spec** (`backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py`): the
-  pod's `ONYX_PAT` env equals `_ONYX_PAT_PLACEHOLDER` (never the real token); `NO_PROXY` is loopback
-  only.
+  pod's `ONYX_PAT` env equals `_PROXY_INJECTED_PLACEHOLDER` (never the real token); `NO_PROXY` is
+  loopback only.
 
 ## Out of scope
 

--- a/docs/craft/features/secrets-injection/03-llm-key.md
+++ b/docs/craft/features/secrets-injection/03-llm-key.md
@@ -23,7 +23,7 @@ type:
 `claims()` matches `request.host` against this table; no DB session is opened.
 
 **Row resolution.** Tenancy is per-PostgreSQL-schema, so the resolver opens a
-session via `ctx.db_session_factory(ctx.sandbox.tenant_id)`, loads the sandbox
+session via `get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id)`, loads the sandbox
 owner (`fetch_user_by_id`), and calls `fetch_all_supported_build_llm_providers`
 — the same access-scoped fetch provisioning uses. It then takes the first
 provider of the claimed type, matching how provisioning picks the key


### PR DESCRIPTION
## Description

Foundation PR for **PAT scopes** (plan: `docs/craft/features/pat-scopes/pat-scopes.md`).

Adds four coarse "API-surface scope" tokens to the `Permission` enum so a PAT can later be scoped to a request surface: `READ_SEARCH`, `READ_CHAT`, `WRITE_CHAT`, `READ_ADMIN`. Wires them into the existing `IMPLIED_PERMISSIONS` closure (`BASIC_ACCESS → search/chat`, `WRITE_CHAT → READ_CHAT`; `READ_ADMIN` falls out of the `admin → all` short-circuit) and marks them implied-only / non-toggleable.

Additive and inert — nothing consumes the scopes yet; no route or token behavior changes. `WILDCARD`, the PAT `scopes` column, and the `require_permission` intersection land in follow-ups. No DB migration (perms are JSONB + `native_enum=False`).

Also refreshes the secrets-injection docs (stale `db_session_factory`, placeholder rename, LLM resolver, proxy framing).

## How Has This Been Tested?

`backend/tests/unit/onyx/auth/test_permissions.py` (29 passing): hardcoded implication spec, exact-equality completeness checks, and negative cases (`basic ≠> read:admin`, `write:chat ≠> read:search`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
