### PR TITLE
test(web): de-flake E2E tests (global-state isolation + afterEach race)

### DIFF
--- a/web/tests/e2e/admin/default-agent.spec.ts
+++ b/web/tests/e2e/admin/default-agent.spec.ts
@@ -38,7 +38,12 @@ async function clickAndWaitForPatch(
   await patchPromise;
 }
 
-test.describe("Chat Preferences Admin Page", () => {
+// @exclusive: every test here mutates the global (tenant-wide) default-assistant
+// `tool_ids` and creates/deletes the singleton default image-generation config in
+// beforeEach/afterEach. Running in the parallel `admin` project races against other
+// files that touch the same global state (e.g. chat/default_agent.spec.ts,
+// chat/actions_popover.spec.ts), causing flaky toggle-persistence failures.
+test.describe("Chat Preferences Admin Page @exclusive", () => {
   let testCcPairId: number | null = null;
   let webSearchProviderId: number | null = null;
   let imageGenConfigId: string | null = null;

--- a/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
+++ b/web/tests/e2e/admin/theme/appearance_theme_settings.spec.ts
@@ -104,15 +104,21 @@ test.describe("Appearance Theme Settings @exclusive", () => {
       }
     }
 
-    // Save reset
+    // Save reset. Arm the PUT waiter *before* clicking — a post-click
+    // waitForResponse can miss a fast response and then hang until the test
+    // timeout (the whole point of saveAndWaitForPut in AppearanceThemePage).
+    // This is best-effort cleanup, so bound it and swallow a missed/absent PUT
+    // rather than letting afterEach blow the 100s test budget.
     const saveButton = page.getByRole("button", { name: "Apply Changes" });
     if (await saveButton.isEnabled()) {
-      await saveButton.click();
-      await page.waitForResponse(
+      const putPromise = page.waitForResponse(
         (r) =>
           r.url().includes("/api/admin/enterprise-settings") &&
-          r.request().method() === "PUT"
+          r.request().method() === "PUT",
+        { timeout: 10_000 }
       );
+      await saveButton.click();
+      await putPromise.catch(() => {});
     }
 
     // Clear localStorage

--- a/web/tests/e2e/chat/default_agent.spec.ts
+++ b/web/tests/e2e/chat/default_agent.spec.ts
@@ -473,7 +473,9 @@ test.describe("Default Agent Tests", () => {
 
         // Toggle back to the original state
         await imageGenerationToggle.click();
-        await expect(imageGenerationToggle).toBeChecked({ checked: wasChecked });
+        await expect(imageGenerationToggle).toBeChecked({
+          checked: wasChecked,
+        });
       } else {
         // If no toggle found, just click the option itself
         await imageGenerationToolOption.click();

--- a/web/tests/e2e/chat/default_agent.spec.ts
+++ b/web/tests/e2e/chat/default_agent.spec.ts
@@ -449,33 +449,34 @@ test.describe("Default Agent Tests", () => {
         timeout: 5000,
       });
 
-      // Find a checkbox/toggle within the image-generation tool option
-      const imageGenerationToolOption = await page.$(
+      // Find the image-generation tool option
+      const imageGenerationToolOption = page.locator(
         TOOL_IDS.imageGenerationOption
       );
-      expect(imageGenerationToolOption).toBeTruthy();
+      await expect(imageGenerationToolOption).toBeVisible();
 
       // Look for a checkbox or switch within the tool option
-      const imageGenerationToggle = await imageGenerationToolOption?.$(
+      const imageGenerationToggle = imageGenerationToolOption.locator(
         TOOL_IDS.toggleInput
       );
 
-      if (imageGenerationToggle) {
-        const initialState = await imageGenerationToggle.isChecked();
-        await imageGenerationToggle.click();
+      if ((await imageGenerationToggle.count()) > 0) {
+        const wasChecked = await imageGenerationToggle.isChecked();
 
-        // Verify state changed
-        const newState = await imageGenerationToggle.isChecked();
-        expect(newState).toBe(!initialState);
-
-        // Toggle it back
+        // Toggle, then assert with auto-retrying matchers — the React toggle
+        // updates its checked state asynchronously after the click, so a
+        // one-shot isChecked() read can race ahead of the DOM change.
         await imageGenerationToggle.click();
-        const finalState = await imageGenerationToggle.isChecked();
-        expect(finalState).toBe(initialState);
+        await expect(imageGenerationToggle).toBeChecked({
+          checked: !wasChecked,
+        });
+
+        // Toggle back to the original state
+        await imageGenerationToggle.click();
+        await expect(imageGenerationToggle).toBeChecked({ checked: wasChecked });
       } else {
         // If no toggle found, just click the option itself
-        await imageGenerationToolOption?.click();
-        // Check if the option has some visual state change
+        await imageGenerationToolOption.click();
         // This is a fallback behavior if toggles work differently
       }
     });

--- a/web/tests/e2e/chat/default_agent.spec.ts
+++ b/web/tests/e2e/chat/default_agent.spec.ts
@@ -294,7 +294,13 @@ test.describe("Default Agent Tests", () => {
     });
   });
 
-  test.describe("Action Management Toggle", () => {
+  // @exclusive: these tests depend on the singleton default image-generation config
+  // being available and PATCH the global default-assistant `tool_ids`. In the parallel
+  // `admin` project, a concurrent file deleting/recreating the default image-gen config
+  // makes the Image Generation tool intermittently unavailable (disabled in the popover),
+  // and competing default-assistant PATCHes clobber toggle state. Serializing via the
+  // isolated `exclusive` project removes the race.
+  test.describe("Action Management Toggle @exclusive", () => {
     let imageGenConfigId: string | null = null;
 
     test.beforeAll(async ({ browser }) => {


### PR DESCRIPTION
De-flakes Playwright E2E tests surfaced by CI on this branch. Two independent root causes.

## 1. Global-state races in the parallel `admin` project

Two tests flaked because they race on **global, tenant-wide singleton state** while running in the parallel 4-worker `admin` project:

- `admin/default-agent.spec.ts` › *should toggle Image Generation tool on and off* — after toggle + reload the switch stayed `aria-checked=false`.
- `chat/default_agent.spec.ts` › *tool toggle state should persist across page refresh* — `click()` on the Image Generation option hung to timeout ("element is not enabled").

The shared state:
- **The default image-generation config** (`is_default=true`). `ImageGenerationTool.is_available()` checks this single row, and `GET /api/tool` drops the tool when unavailable. `createImageGenerationConfig` defaults to `is_default: true`, so multiple files churn the same singleton — `admin/default-agent.spec.ts` creates+deletes it on *every* `beforeEach`/`afterEach`.
- **The default-assistant `tool_ids`** — toggles do a read-modify-write `PATCH /api/admin/default-assistant` sending the full tool list, so concurrent PATCHes clobber each other.

**Fix:** tag both describe blocks `@exclusive` — the codebase's existing convention for global-state mutators (`onboarding_flow`, `llm_provider_setup`, `disable_default_agent`, …). CI runs `exclusive` as a separate matrix job on an isolated backend with `workers: 1` (serial), so they no longer race.

## 2. Post-click `waitForResponse` race in appearance-theme cleanup

- `admin/theme/appearance_theme_settings.spec.ts` › *custom help link uses the URL as the title when the label is empty* — timed out inside the `afterEach` reset hook.

The cleanup hook clicked "Apply Changes" and *then* called `page.waitForResponse` (no timeout) for the enterprise-settings PUT. When the PUT returns before the listener registers, the wait never resolves and eats the whole 100s test budget. `AppearanceThemePage.saveAndWaitForPut` already documents the correct pattern ("both promises MUST be armed before the click") — the cleanup hook just never adopted it.

**Fix:** arm the PUT waiter before the click, bound it to 10s, and swallow a missed/absent PUT so best-effort cleanup can't hang.

## Notes

Three other admin-project files create the same `is_default` image-gen config / PATCH the default-assistant in parallel (`chat/actions_popover.spec.ts`, `chat/llm_ordering.spec.ts`, `admin/image-generation/image-generation-content.spec.ts`). They weren't in the failing runs, and removing the two heaviest churners *reduces* their collision risk — left untagged to avoid bloating the serial `exclusive` suite, but they remain a latent flake source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)