### PR TITLE
chore: [Running GitHub actions for #11610]

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1036,7 +1036,7 @@ CODE_INTERPRETER_MAX_OUTPUT_LENGTH = int(
 #####
 # Miscellaneous
 #####
-JOB_TIMEOUT = 60 * 60 * 6  # 6 hours default
+JOB_TIMEOUT = int(os.environ.get("JOB_TIMEOUT_SECONDS") or 60 * 60 * 6)  # default 6h
 # Logs Onyx only model interactions like prompts, responses, messages etc.
 LOG_ONYX_MODEL_INTERACTIONS = (
     os.environ.get("LOG_ONYX_MODEL_INTERACTIONS", "").lower() == "true"


### PR DESCRIPTION
This PR runs GitHub Actions CI for #11610.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make job timeout configurable via the `JOB_TIMEOUT_SECONDS` env var, while keeping the default at 6 hours. This helps long-running syncs complete on large connectors.

- New Features
  - `JOB_TIMEOUT` now reads from `JOB_TIMEOUT_SECONDS`; defaults to 6h if unset.

- Migration
  - Optionally set `JOB_TIMEOUT_SECONDS` to increase the timeout for large syncs.

<sup>Written for commit 70542a0942fb222b376a5002f08d6dca7b578a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

