### PR TITLE
refactor(input): centralize input-bar keydown precedence + tiles storybook

### DIFF
--- a/web/src/app/craft/components/InputBar.stories.tsx
+++ b/web/src/app/craft/components/InputBar.stories.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { SWRConfig } from "swr";
 import { Button, Text } from "@opal/components";
@@ -12,6 +12,11 @@ import {
 } from "@/app/craft/contexts/UploadFilesContext";
 import { UserProvider } from "@/providers/UserProvider";
 import { QueuedMessage } from "@/app/app/interfaces";
+import {
+  createRichInputTileNode,
+  getPasteTilePreview,
+  getPasteTileMeta,
+} from "@/lib/richInputTile";
 
 // InputBar mounts UserProvider/UploadFilesContext and calls useUserSkills,
 // which fetch /api/me, /api/auth/type and /api/skills. There's no backend in
@@ -26,7 +31,7 @@ const SWR_NO_FETCH = {
 };
 
 const meta: Meta<typeof InputBar> = {
-  title: "Apps/Craft/Input Bar",
+  title: "Apps/Craft/Input Bar/Input Bar",
   component: InputBar,
   tags: ["autodocs"],
   decorators: [
@@ -272,4 +277,70 @@ export const StopButtonStyles: Story = {
       <StopButtonState label="Stopping" stopping />
     </div>
   ),
+};
+
+const TILE_PASTE_TEXT = `def fibonacci(n: int) -> int:
+    if n < 2:
+        return n
+    a, b = 0, 1
+    for _ in range(n - 1):
+        a, b = b, a + b
+    return b`;
+
+/**
+ * Shows the inline rich tiles inside the input: a blue skill tile (from the
+ * slash-skill picker) and a paste tile (from collapsing a large paste). The
+ * tiles are real DOM nodes built by `createRichInputTileNode` — the same path
+ * the live input uses — injected into the contentEditable and synced via an
+ * `input` event so the placeholder clears and the message serializes correctly.
+ */
+function TilesDemo() {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const editable =
+      wrapperRef.current?.querySelector<HTMLDivElement>('[role="textbox"]');
+    if (!editable || editable.childNodes.length > 0) return;
+
+    editable.appendChild(document.createTextNode("Refactor "));
+    editable.appendChild(
+      createRichInputTileNode({
+        type: "skill",
+        text: "/deep-research ",
+        preview: "Skill: deep-research",
+        meta: "",
+        skillSlug: "deep-research",
+      })
+    );
+    editable.appendChild(document.createTextNode(" using this snippet "));
+    editable.appendChild(
+      createRichInputTileNode({
+        type: "paste",
+        text: TILE_PASTE_TEXT,
+        preview: getPasteTilePreview(TILE_PASTE_TEXT),
+        meta: getPasteTileMeta(TILE_PASTE_TEXT),
+      })
+    );
+    editable.appendChild(document.createTextNode(" "));
+
+    // Mirror the live paths: fire an input event so the hook syncs state from
+    // the DOM (clears the placeholder, serializes tile text into the message).
+    editable.dispatchEvent(new InputEvent("input", { bubbles: true }));
+  }, []);
+
+  return (
+    <div ref={wrapperRef}>
+      <InputBar
+        onSubmit={(message, files) =>
+          console.log("onSubmit", { message, files })
+        }
+        isRunning={false}
+        placeholder="Continue the conversation..."
+      />
+    </div>
+  );
+}
+
+export const Tiles: Story = {
+  render: () => <TilesDemo />,
 };

--- a/web/src/app/craft/components/InputBar.tsx
+++ b/web/src/app/craft/components/InputBar.tsx
@@ -55,6 +55,7 @@ import {
 import { getTextContent } from "@/lib/contentEditable";
 import { isSkillTile } from "@/lib/richInputTile";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
+import { handleInputNavKeys } from "@/sections/input/inputBarKeys";
 import { useQueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
 import {
   QueuedMessage,
@@ -486,17 +487,14 @@ const InputBar = memo(
               return;
             }
           }
-          // Queue nav owns keys while a message is highlighted, so it must run
-          // before tile handling (whose Backspace guard would otherwise win).
-          if (queueEnabled && queueNav.handleKeyDown(event)) return;
-          if (handleTileKeyDown(event)) return;
+          if (handleInputNavKeys(event, queueNav, handleTileKeyDown)) return;
 
           if (isSubmitEnter) {
             event.preventDefault();
             handleSubmit();
           }
         },
-        [handleSubmit, handleTileKeyDown, queueEnabled, queueNav, openSkillInfo]
+        [handleSubmit, handleTileKeyDown, queueNav, openSkillInfo]
       );
 
       const canSubmit =

--- a/web/src/app/craft/components/InterruptHint.stories.tsx
+++ b/web/src/app/craft/components/InterruptHint.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import InterruptHint from "@/app/craft/components/InterruptHint";
 
 const meta: Meta<typeof InterruptHint> = {
-  title: "Apps/Craft/Interrupt Hint",
+  title: "Apps/Craft/Input Bar/Interrupt Hint",
   component: InterruptHint,
   tags: ["autodocs"],
   args: {

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -69,6 +69,7 @@ import {
   useChatSessionStore,
 } from "@/app/app/stores/useChatSessionStore";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
+import { handleInputNavKeys } from "@/sections/input/inputBarKeys";
 
 export interface AppInputBarHandle {
   reset: () => void;
@@ -866,11 +867,10 @@ const AppInputBar = React.memo(
                       }
                       data-empty={!message ? "" : undefined}
                       onKeyDown={(event) => {
-                        // Queue nav owns keys while a message is highlighted, so
-                        // it must run before tile handling (whose Backspace guard
-                        // would otherwise win).
-                        if (queueNav.handleKeyDown(event)) return;
-                        if (handleTileKeyDown(event)) return;
+                        if (
+                          handleInputNavKeys(event, queueNav, handleTileKeyDown)
+                        )
+                          return;
 
                         // Enter to submit or queue (Shift+Enter falls through to browser default: inserts <br>)
                         if (

--- a/web/src/sections/input/__tests__/inputBarKeys.test.ts
+++ b/web/src/sections/input/__tests__/inputBarKeys.test.ts
@@ -1,0 +1,28 @@
+import type { KeyboardEvent } from "react";
+import { handleInputNavKeys } from "@/sections/input/inputBarKeys";
+
+const event = {} as KeyboardEvent<HTMLDivElement>;
+
+describe("handleInputNavKeys", () => {
+  it("lets queue navigation consume the event first, skipping tile handling", () => {
+    const queueNav = { handleKeyDown: jest.fn(() => true) };
+    const tile = jest.fn(() => false);
+    expect(handleInputNavKeys(event, queueNav, tile)).toBe(true);
+    expect(queueNav.handleKeyDown).toHaveBeenCalledTimes(1);
+    expect(tile).not.toHaveBeenCalled();
+  });
+
+  it("falls through to tile handling when queue navigation declines", () => {
+    const queueNav = { handleKeyDown: jest.fn(() => false) };
+    const tile = jest.fn(() => true);
+    expect(handleInputNavKeys(event, queueNav, tile)).toBe(true);
+    expect(queueNav.handleKeyDown).toHaveBeenCalledTimes(1);
+    expect(tile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false when neither handler consumes the event", () => {
+    expect(
+      handleInputNavKeys(event, { handleKeyDown: () => false }, () => false)
+    ).toBe(false);
+  });
+});

--- a/web/src/sections/input/inputBarKeys.ts
+++ b/web/src/sections/input/inputBarKeys.ts
@@ -1,0 +1,19 @@
+import type { KeyboardEvent } from "react";
+import type { QueuedMessageNavigation } from "@/hooks/useQueuedMessageNavigation";
+
+/**
+ * Consults an input bar's navigation handlers in priority order, returning
+ * whether one consumed the event (the caller should then stop processing it).
+ *
+ * Queue navigation runs first: while a queued message is highlighted it owns
+ * keys like Backspace and Enter, and the rich-tile handler's leading-tile
+ * Backspace guard would otherwise swallow the queue's delete key. Each handler
+ * is a no-op outside its active state, so neither interferes with the other.
+ */
+export function handleInputNavKeys(
+  event: KeyboardEvent<HTMLDivElement>,
+  queueNav: Pick<QueuedMessageNavigation, "handleKeyDown">,
+  handleTileKeyDown: (event: KeyboardEvent<HTMLDivElement>) => boolean
+): boolean {
+  return queueNav.handleKeyDown(event) || handleTileKeyDown(event);
+}


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

Both input bars (Craft `InputBar` and chat `AppInputBar`) hand-wired the same keydown ordering, and it had drifted — causing a regression where the leading-tile Backspace guard swallowed the key that deletes a highlighted queued message.

This extracts that ordering into one tested helper, `handleInputNavKeys(event, queueNav, handleTileKeyDown)`: queue nav runs first (a no-op unless a message is highlighted), then tile handling. Both bars call it, dropping the duplicated logic and Craft's redundant `queueEnabled` guard. Also adds a Storybook `TilesDemo` for the input-bar tiles.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

- New unit test `inputBarKeys.test.ts` pins the precedence (queue first, tile fallback, neither → `false`).
- `tsc` / `oxlint` / jest pass; verified manually in the browser.
- Covered by e2e `queued_messages.spec.ts > "deletes highlighted message with Backspace"`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)