### PR TITLE
chore(helm): Bump to 0.5.15

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -19,6 +19,6 @@ dependencies:
   version: 5.4.0
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
-  version: 0.4.2
-digest: sha256:582be82967d30c1f095f51264d63eaae77b9dc6a6f380db881bda9476366a6b6
-generated: "2026-05-28T12:24:39.943866-07:00"
+  version: 0.4.3
+digest: sha256:374deb7be92d1545c6981e99461414b6e4a89a1faf162882a9f66b824ce4d8c1
+generated: "2026-06-02T10:30:32.542373-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.14
+version: 0.5.15
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,10 +17,7 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Sandbox egress proxy is now unconditional when
-        `ENABLE_CRAFT=true`. The `sandboxProxy.enabled` value and the
-        `onyx.sandboxProxyEnabled` template helper have been removed; every
-        Craft sandbox routes outbound traffic through the proxy.
+      description: Bump the `code-interpreter` subchart from 0.4.2 to 0.4.3.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0
@@ -50,6 +47,6 @@ dependencies:
     repository: https://charts.min.io/
     condition: minio.enabled
   - name: code-interpreter
-    version: 0.4.2
+    version: 0.4.3
     repository: https://onyx-dot-app.github.io/python-sandbox/
     condition: codeInterpreter.enabled


### PR DESCRIPTION
## Description
Bump the code interpreter version and correspondingly bump the helm version

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the Onyx Helm chart to 0.5.15 and updates the `code-interpreter` subchart from 0.4.2 to 0.4.3.

<sup>Written for commit faae7fc56409d83bd66a3362c26acf23dc578969. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

