### PR TITLE
feat(craft): External app default timeout 3min

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/github_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/github/github_api.py
@@ -18,6 +18,7 @@ from typing import Any
 _BASE = "https://api.github.com"
 _PER_PAGE = 100
 _DEFAULT_LIMIT = 100
+_HTTP_TIMEOUT_SECONDS = 180
 # GitHub requires a User-Agent and recommends pinning the API version.
 _HEADERS = {
     "Accept": "application/vnd.github+json",
@@ -60,7 +61,7 @@ def _request(
             _HEADERS, **({"Content-Type": "application/json"} if data else {})
         ),
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         raw = resp.read().decode("utf-8")
         parsed = json.loads(raw) if raw else None
         return parsed, {k.lower(): v for k, v in resp.headers.items()}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
@@ -20,6 +20,7 @@ from typing import Any
 _BASE = "https://gmail.googleapis.com/gmail/v1/users/me/"
 _PAGE_SIZE = 100
 _DEFAULT_LIMIT = 25
+_HTTP_TIMEOUT_SECONDS = 180
 # Each listed message needs its own metadata GET (Gmail's list returns only
 # id/threadId), so fan them out concurrently rather than N sequential calls.
 _MAX_FETCH_WORKERS = 8
@@ -62,7 +63,7 @@ def _req(
     req = urllib.request.Request(  # noqa: S310 — fixed https base url
         url, data=data, method=method, headers=headers
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         raw = resp.read().decode("utf-8")
     return json.loads(raw) if raw.strip() else {}
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/gcal_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/google-calendar/gcal_api.py
@@ -16,6 +16,7 @@ _BASE = "https://www.googleapis.com/calendar/v3/"
 _PAGE_SIZE = 250
 _DEFAULT_LIMIT = 250
 _METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE")
+_HTTP_TIMEOUT_SECONDS = 180
 
 
 def _prune(value: Any) -> Any:
@@ -51,7 +52,7 @@ def _req(
     req = urllib.request.Request(  # noqa: S310 — fixed https base url
         url, data=data, method=method, headers=headers
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         raw = resp.read().decode("utf-8")
     return json.loads(raw) if raw.strip() else {}
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/linear_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/linear/linear_api.py
@@ -18,6 +18,7 @@ _ENDPOINT = "https://api.linear.app/graphql"
 _PAGE_SIZE = 100
 _DEFAULT_LIMIT = 100
 _IDENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
+_HTTP_TIMEOUT_SECONDS = 180
 
 _ISSUE_FIELDS = """
   id identifier title url priority
@@ -48,7 +49,7 @@ def _gql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
         method="POST",
         headers={"Content-Type": "application/json; charset=utf-8"},
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         return json.loads(resp.read().decode("utf-8"))
 
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/slack_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/slack/slack_api.py
@@ -17,6 +17,7 @@ _BASE = "https://slack.com/api/"
 _METHOD_RE = re.compile(r"^[a-z][a-zA-Z0-9._]*$")
 _PAGE_SIZE = 200
 _DEFAULT_LIMIT = 200
+_HTTP_TIMEOUT_SECONDS = 180
 
 
 def _prune(value: Any) -> Any:
@@ -39,7 +40,7 @@ def _call(method: str, body: dict[str, Any]) -> dict[str, Any]:
         method="POST",
         headers={"Content-Type": "application/json; charset=utf-8"},
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+    with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         return json.loads(resp.read().decode("utf-8"))
 
 


### PR DESCRIPTION
## Description
Not the nicest way to do it, but seems to be the best way in the current setup.

A more 'single source of truth' approach might involve something like templating python files or piping env-vars into the environment which imo is not worth looking into rn

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase external app HTTP timeout to 3 minutes to reduce premature failures on slow API calls. Applies to GitHub, Gmail, Google Calendar, Linear, and Slack skills.

- **Refactors**
  - Set `_HTTP_TIMEOUT_SECONDS = 180`.
  - Use it for all `urlopen` calls in GitHub, Gmail, Google Calendar, Linear, and Slack skill APIs.

<sup>Written for commit 45f71fa3f02e9647125c81d285b02fdeaae00524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

