### PR TITLE
chore(devcontainer): re-install `node`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,13 +58,16 @@ RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 # still runs under bun; Node is here only as the runtime for the test runner.
 # The chromium browser binary is installed at test time (web global-setup), not
 # baked here, so its version tracks web/package.json's floating @playwright/test.
-ARG NODE_VERSION=24.16.0
-RUN NODE_ARCH=$(case $(dpkg --print-architecture) in amd64) echo x64 ;; arm64) echo arm64 ;; esac) \
-  && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" \
-     | tar -xz -C /opt \
-  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/node" /usr/local/bin/node \
-  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/npm" /usr/local/bin/npm \
-  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/npx" /usr/local/bin/npx \
+#
+# Copied from the official node image (digest-pinned like bun above) instead of
+# fetched from nodejs.org, so a compromised mirror or MITM can't swap the binary
+# and buildkit resolves the right arch from the manifest list. Keep both COPY
+# refs in sync when bumping the version. npm/npx are scripts under
+# node_modules/npm; recreate their PATH symlinks since we copy the bare binary.
+COPY --from=node:24.16.0-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:24.16.0-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+  && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
   && node --version
 
 # Install the apt packages Playwright needs to run headless Chromium for
@@ -112,8 +115,8 @@ WORKDIR /workspace
 ARG CLAUDE_CODE_VERSION=latest
 RUN BUN_INSTALL=/usr/local bun install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 
-# Install opencode CLI for Craft agent functionality. Bun runs it directly,
-# so we don't need a separate Node.js install.
+# Install opencode CLI for Craft agent functionality. Like Claude Code, it
+# runs under bun (the Node.js install above exists only for Playwright's runner).
 ARG OPENCODE_VERSION=latest
 RUN BUN_INSTALL=/usr/local bun install -g opencode-ai@${OPENCODE_VERSION}
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,6 +52,21 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY --from=oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
+# Install Node.js. Bun is the JS package manager, but Playwright's e2e test
+# runner (web/tests/e2e) forks worker processes that require Node — running it
+# under bun alone hangs the runner. Daily JS tooling (Claude Code, opencode)
+# still runs under bun; Node is here only as the runtime for the test runner.
+# The chromium browser binary is installed at test time (web global-setup), not
+# baked here, so its version tracks web/package.json's floating @playwright/test.
+ARG NODE_VERSION=24.16.0
+RUN NODE_ARCH=$(case $(dpkg --print-architecture) in amd64) echo x64 ;; arm64) echo arm64 ;; esac) \
+  && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.gz" \
+     | tar -xz -C /opt \
+  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/node" /usr/local/bin/node \
+  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/npm" /usr/local/bin/npm \
+  && ln -sf "/opt/node-v${NODE_VERSION}-linux-${NODE_ARCH}/bin/npx" /usr/local/bin/npx \
+  && node --version
+
 # Install the apt packages Playwright needs to run headless Chromium for
 # the web-search open_url tool. The browser binary itself is downloaded
 # from the integration test conftest's _install_playwright fixture so

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:0cc5c815b430c0463cff047b8ecbc66eb7ed54abfaf19295f4cafa80a1367905",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:616f411af60ef8e868d3b486c00484d539096e7012bb4ac173ace15979f6950e",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",


### PR DESCRIPTION
## Description

This is needed by playwright and probably running the dev server in the devcontainer

## How Has This Been Tested?

```
ods dev up
ods dev exec ods web playwright
```

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-installed `node` in the devcontainer so `@playwright/test` can fork worker processes reliably for e2e runs. `bun` remains the JS package manager; `node` is only used as the test runner runtime.

- **Dependencies**
  - Install Node.js v24.16.0 by copying from the digest-pinned `node:24.16.0-trixie-slim` image, recreate `npm`/`npx` symlinks, and bump the devcontainer image to `onyxdotapp/onyx-devcontainer@sha256:616f411af60ef8e868d3b486c00484d539096e7012bb4ac173ace15979f6950e`; Playwright browser binaries are still fetched at test time.

<sup>Written for commit 9ef350c69efad93278e9dd327dbbc294a6613aa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

