### PR TITLE
chore: [Running GitHub actions for #11611]

### DIFF
--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -54,7 +54,7 @@ class ClickupConnector(LoadConnector, PollConnector):
         headers = {"Authorization": self.api_token}
 
         response = requests.get(
-            f"{CLICKUP_API_BASE_URL}/{endpoint}",
+            f"{CLICKUP_API_BASE_URL}/{endpoint.lstrip('/')}",
             headers=headers,
             params=params,
             timeout=REQUEST_TIMEOUT_SECONDS,


### PR DESCRIPTION
This PR runs GitHub Actions CI for #11611.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ClickUp connector URL construction by stripping a leading slash from the endpoint before concatenation. Prevents double slashes and avoids malformed requests to the ClickUp API.

<sup>Written for commit 4f364d65a4f009f913e14c0418483d1e161915b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

