### PR TITLE
feat(mcp): add known-provider OAuth controls in auth modal

### DIFF
--- a/web/src/components/oauth/OAuthCallbackPage.tsx
+++ b/web/src/components/oauth/OAuthCallbackPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 import { SvgCheck, SvgAlertTriangle } from "@opal/icons";
@@ -51,6 +51,10 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
   );
   const [secondsLeft, setSecondsLeft] = useState<number | null>(null);
 
+  // State + auth code are single-use; block duplicate POSTs (StrictMode
+  // double-invoke or re-renders) that race the first request and 400.
+  const hasProcessedRef = useRef(false);
+
   // Extract query parameters
   const code = searchParams?.get("code");
   const state = searchParams?.get("state");
@@ -86,7 +90,8 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
   ]);
 
   useEffect(() => {
-    const controller = new AbortController();
+    if (hasProcessedRef.current) return;
+    hasProcessedRef.current = true;
 
     const handleOAuthCallback = async () => {
       // Handle OAuth error from provider
@@ -124,7 +129,6 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
             "Content-Type": "application/json",
           },
           credentials: "include",
-          signal: controller.signal,
         });
 
         if (!response.ok) {
@@ -191,7 +195,6 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
         setIsError(false);
         setIsLoading(false);
       } catch (error) {
-        if (controller.signal.aborted) return;
         console.error("OAuth callback error:", error);
         setStatusMessage(config.errorMessage || "Something Went Wrong");
         setStatusDetails(
@@ -205,8 +208,9 @@ export default function OAuthCallbackPage({ config }: OAuthCallbackPageProps) {
     };
 
     handleOAuthCallback();
-    return () => controller.abort();
-  }, [code, state, error, errorDescription, searchParams, config]);
+    // Run once; the single-use callback must not re-fire (see hasProcessedRef).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const getStatusIcon = () => {
     if (isLoading) {

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -180,11 +180,9 @@ export default function MCPAuthenticationModal({
       } else {
         setActiveAuthTab("per-user");
       }
-      if (
+      setAdvancedOpen(
         fullServer.oauth_provider_mode === MCPOAuthProviderMode.KNOWN_PROVIDER
-      ) {
-        setAdvancedOpen(true);
-      }
+      );
     }
   }, [fullServer]);
 
@@ -392,12 +390,16 @@ export default function MCPAuthenticationModal({
   };
 
   const handleSubmit = async (values: MCPAuthFormValues) => {
-    const serverData = constructServerData(values);
-    if (!serverData || !mcpServer) return;
+    if (!mcpServer) return;
 
     setIsSubmitting(true);
 
     try {
+      // constructServerData throws on invalid oauth_additional_auth_params JSON;
+      // keep it inside the try so the catch surfaces a toast.
+      const serverData = constructServerData(values);
+      if (!serverData) return;
+
       const authType = values.auth_type;
       // Step 1: Save the authentication configuration to the MCP server
       const { data: serverResult, error: serverError } =

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -5,6 +5,8 @@ import useSWR, { KeyedMutator } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import Modal from "@/refresh-components/Modal";
+import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
+import { Section } from "@/layouts/general-layouts";
 import { FormField } from "@/refresh-components/form/FormField";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import {
@@ -24,6 +26,7 @@ import { useModal } from "@/refresh-components/contexts/ModalContext";
 import {
   MCPAuthenticationPerformer,
   MCPAuthenticationType,
+  MCPOAuthProviderMode,
   MCPTransportType,
   MCPServerStatus,
   MCPServer,
@@ -57,7 +60,16 @@ export interface MCPAuthFormValues {
   user_credentials: Record<string, string>;
   oauth_client_id: string;
   oauth_client_secret: string;
+  oauth_provider_mode: MCPOAuthProviderMode;
+  oauth_authorization_endpoint: string;
+  oauth_token_endpoint: string;
+  oauth_scopes_override: string;
+  oauth_additional_auth_params: string;
 }
+
+const GOOGLE_AUTHORIZATION_ENDPOINT_HINT =
+  "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_ENDPOINT_HINT = "https://oauth2.googleapis.com/token";
 
 const validationSchema = Yup.object().shape({
   transport: Yup.string()
@@ -99,6 +111,30 @@ const validationSchema = Yup.object().shape({
     then: (schema) => schema.notRequired(),
     otherwise: (schema) => schema.notRequired(),
   }),
+  oauth_authorization_endpoint: Yup.string().when(
+    ["auth_type", "oauth_provider_mode"],
+    {
+      is: (authType: string, providerMode: string) =>
+        authType === MCPAuthenticationType.OAUTH &&
+        providerMode === MCPOAuthProviderMode.KNOWN_PROVIDER,
+      then: (schema) =>
+        schema.required(
+          "Authorization endpoint is required in known-provider mode"
+        ),
+      otherwise: (schema) => schema.notRequired(),
+    }
+  ),
+  oauth_token_endpoint: Yup.string().when(
+    ["auth_type", "oauth_provider_mode"],
+    {
+      is: (authType: string, providerMode: string) =>
+        authType === MCPAuthenticationType.OAUTH &&
+        providerMode === MCPOAuthProviderMode.KNOWN_PROVIDER,
+      then: (schema) =>
+        schema.required("Token endpoint is required in known-provider mode"),
+      otherwise: (schema) => schema.notRequired(),
+    }
+  ),
 });
 
 export default function MCPAuthenticationModal({
@@ -112,6 +148,8 @@ export default function MCPAuthenticationModal({
     "per-user"
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Open the Advanced (known-provider) section by default when configured.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Check if OAuth is enabled for the Onyx instance
   const authType = useAuthType();
@@ -141,6 +179,11 @@ export default function MCPAuthenticationModal({
         setActiveAuthTab("admin");
       } else {
         setActiveAuthTab("per-user");
+      }
+      if (
+        fullServer.oauth_provider_mode === MCPOAuthProviderMode.KNOWN_PROVIDER
+      ) {
+        setAdvancedOpen(true);
       }
     }
   }, [fullServer]);
@@ -173,6 +216,11 @@ export default function MCPAuthenticationModal({
         user_credentials: {},
         oauth_client_id: "",
         oauth_client_secret: "",
+        oauth_provider_mode: MCPOAuthProviderMode.AUTO_DISCOVERY,
+        oauth_authorization_endpoint: "",
+        oauth_token_endpoint: "",
+        oauth_scopes_override: "",
+        oauth_additional_auth_params: "",
       };
     }
 
@@ -192,6 +240,17 @@ export default function MCPAuthenticationModal({
       // OAuth Credentials
       oauth_client_id: fullServer.admin_credentials?.client_id || "",
       oauth_client_secret: fullServer.admin_credentials?.client_secret || "",
+      oauth_provider_mode:
+        fullServer.oauth_provider_mode || MCPOAuthProviderMode.AUTO_DISCOVERY,
+      oauth_authorization_endpoint:
+        fullServer.oauth_authorization_endpoint || "",
+      oauth_token_endpoint: fullServer.oauth_token_endpoint || "",
+      oauth_scopes_override: fullServer.oauth_scopes_override
+        ? fullServer.oauth_scopes_override.join(", ")
+        : "",
+      oauth_additional_auth_params: fullServer.oauth_additional_auth_params
+        ? JSON.stringify(fullServer.oauth_additional_auth_params)
+        : "",
       // Auth Template
       auth_template: (fullServer.auth_template as MCPAuthTemplate) || {
         headers: { Authorization: "Bearer {api_key}" },
@@ -250,6 +309,37 @@ export default function MCPAuthenticationModal({
     const isPerUserApiToken =
       values.auth_performer === MCPAuthenticationPerformer.PER_USER &&
       authType === MCPAuthenticationType.API_TOKEN;
+    const isKnownProviderOauth =
+      authType === MCPAuthenticationType.OAUTH &&
+      values.oauth_provider_mode === MCPOAuthProviderMode.KNOWN_PROVIDER;
+
+    const parsedScopes = values.oauth_scopes_override
+      .split(",")
+      .map((scope) => scope.trim())
+      .filter(Boolean);
+
+    let parsedAdditionalAuthParams: Record<string, string> | undefined;
+    if (
+      isKnownProviderOauth &&
+      values.oauth_additional_auth_params &&
+      values.oauth_additional_auth_params.trim()
+    ) {
+      try {
+        const parsed = JSON.parse(values.oauth_additional_auth_params);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("Additional auth params must be a JSON object");
+        }
+        parsedAdditionalAuthParams = Object.fromEntries(
+          Object.entries(parsed).map(([key, value]) => [key, String(value)])
+        );
+      } catch (error) {
+        throw new Error(
+          error instanceof Error
+            ? `Invalid additional auth params JSON: ${error.message}`
+            : "Invalid additional auth params JSON"
+        );
+      }
+    }
 
     return {
       name: mcpServer.name,
@@ -277,6 +367,24 @@ export default function MCPAuthenticationModal({
       oauth_client_secret:
         authType === MCPAuthenticationType.OAUTH
           ? values.oauth_client_secret
+          : undefined,
+      oauth_provider_mode:
+        authType === MCPAuthenticationType.OAUTH
+          ? values.oauth_provider_mode
+          : undefined,
+      oauth_authorization_endpoint: isKnownProviderOauth
+        ? values.oauth_authorization_endpoint
+        : undefined,
+      oauth_token_endpoint: isKnownProviderOauth
+        ? values.oauth_token_endpoint
+        : undefined,
+      oauth_scopes_override:
+        isKnownProviderOauth && parsedScopes.length > 0
+          ? parsedScopes
+          : undefined,
+      oauth_additional_auth_params:
+        isKnownProviderOauth && parsedAdditionalAuthParams
+          ? parsedAdditionalAuthParams
           : undefined,
       ...oauthChangedFlags,
       existing_server_id: mcpServer.id,
@@ -416,6 +524,12 @@ export default function MCPAuthenticationModal({
                           value={values.auth_type}
                           onValueChange={(value) => {
                             setFieldValue("auth_type", value);
+                            if (value !== MCPAuthenticationType.OAUTH) {
+                              setFieldValue(
+                                "oauth_provider_mode",
+                                MCPOAuthProviderMode.AUTO_DISCOVERY
+                              );
+                            }
                             // For OAuth + OAuth pass-through, we only support per-user auth
                             if (
                               value === MCPAuthenticationType.OAUTH ||
@@ -552,7 +666,6 @@ export default function MCPAuthenticationModal({
                           these credentials first. Make sure to grant Onyx
                           necessary scopes/permissions for your actions.
                         </Text>
-
                         {/* Redirect URI */}
                         <div className="flex items-center gap-1 w-full">
                           <Text
@@ -582,6 +695,167 @@ export default function MCPAuthenticationModal({
                           />
                         </div>
                       </div>
+
+                      <SimpleCollapsible
+                        open={advancedOpen}
+                        onOpenChange={setAdvancedOpen}
+                      >
+                        <SimpleCollapsible.Header
+                          title="Advanced"
+                          description="Configure a known OAuth provider with explicit authorization and token endpoints instead of automatic discovery."
+                        />
+                        <SimpleCollapsible.Content>
+                          <Section alignItems="stretch" height="auto">
+                            <FormField
+                              name="oauth_provider_mode"
+                              state={
+                                errors.oauth_provider_mode &&
+                                touched.oauth_provider_mode
+                                  ? "error"
+                                  : touched.oauth_provider_mode
+                                    ? "success"
+                                    : "idle"
+                              }
+                            >
+                              <FormField.Label>Provider Mode</FormField.Label>
+                              <FormField.Control asChild>
+                                <InputSelect
+                                  value={values.oauth_provider_mode}
+                                  onValueChange={(value) => {
+                                    setFieldValue("oauth_provider_mode", value);
+                                  }}
+                                >
+                                  <InputSelect.Trigger placeholder="Select mode" />
+                                  <InputSelect.Content>
+                                    <InputSelect.Item
+                                      value={
+                                        MCPOAuthProviderMode.AUTO_DISCOVERY
+                                      }
+                                      description="Use MCP SDK challenge/discovery flow (default)."
+                                    >
+                                      Auto Discovery
+                                    </InputSelect.Item>
+                                    <InputSelect.Item
+                                      value={
+                                        MCPOAuthProviderMode.KNOWN_PROVIDER
+                                      }
+                                      description="Use configured authorization/token endpoints."
+                                    >
+                                      Known Provider
+                                    </InputSelect.Item>
+                                  </InputSelect.Content>
+                                </InputSelect>
+                              </FormField.Control>
+                            </FormField>
+
+                            {values.oauth_provider_mode ===
+                              MCPOAuthProviderMode.KNOWN_PROVIDER && (
+                              <>
+                                <FormField
+                                  name="oauth_authorization_endpoint"
+                                  state={
+                                    errors.oauth_authorization_endpoint &&
+                                    touched.oauth_authorization_endpoint
+                                      ? "error"
+                                      : touched.oauth_authorization_endpoint
+                                        ? "success"
+                                        : "idle"
+                                  }
+                                >
+                                  <FormField.Label>
+                                    Authorization Endpoint
+                                  </FormField.Label>
+                                  <FormField.Control asChild>
+                                    <InputTypeIn
+                                      name="oauth_authorization_endpoint"
+                                      value={
+                                        values.oauth_authorization_endpoint
+                                      }
+                                      onChange={handleChange}
+                                      placeholder={
+                                        GOOGLE_AUTHORIZATION_ENDPOINT_HINT
+                                      }
+                                    />
+                                  </FormField.Control>
+                                  <FormField.Message
+                                    messages={{
+                                      error:
+                                        errors.oauth_authorization_endpoint,
+                                    }}
+                                  />
+                                </FormField>
+
+                                <FormField
+                                  name="oauth_token_endpoint"
+                                  state={
+                                    errors.oauth_token_endpoint &&
+                                    touched.oauth_token_endpoint
+                                      ? "error"
+                                      : touched.oauth_token_endpoint
+                                        ? "success"
+                                        : "idle"
+                                  }
+                                >
+                                  <FormField.Label>
+                                    Token Endpoint
+                                  </FormField.Label>
+                                  <FormField.Control asChild>
+                                    <InputTypeIn
+                                      name="oauth_token_endpoint"
+                                      value={values.oauth_token_endpoint}
+                                      onChange={handleChange}
+                                      placeholder={GOOGLE_TOKEN_ENDPOINT_HINT}
+                                    />
+                                  </FormField.Control>
+                                  <FormField.Message
+                                    messages={{
+                                      error: errors.oauth_token_endpoint,
+                                    }}
+                                  />
+                                </FormField>
+
+                                <FormField name="oauth_scopes_override">
+                                  <FormField.Label optional>
+                                    Scopes Override (comma-separated)
+                                  </FormField.Label>
+                                  <FormField.Control asChild>
+                                    <InputTypeIn
+                                      name="oauth_scopes_override"
+                                      value={values.oauth_scopes_override}
+                                      onChange={handleChange}
+                                      placeholder="https://www.googleapis.com/auth/logging.read"
+                                    />
+                                  </FormField.Control>
+                                </FormField>
+
+                                <FormField name="oauth_additional_auth_params">
+                                  <FormField.Label optional>
+                                    Additional Auth Params (JSON)
+                                  </FormField.Label>
+                                  <FormField.Control asChild>
+                                    <InputTypeIn
+                                      name="oauth_additional_auth_params"
+                                      value={
+                                        values.oauth_additional_auth_params
+                                      }
+                                      onChange={handleChange}
+                                      placeholder='{"access_type":"offline","prompt":"consent"}'
+                                    />
+                                  </FormField.Control>
+                                </FormField>
+
+                                <Text as="p" text03 secondaryBody>
+                                  Known-provider mode requires endpoint
+                                  configuration. Google reference endpoints:
+                                  authorization{" "}
+                                  {GOOGLE_AUTHORIZATION_ENDPOINT_HINT} and token{" "}
+                                  {GOOGLE_TOKEN_ENDPOINT_HINT}.
+                                </Text>
+                              </>
+                            )}
+                          </Section>
+                        </SimpleCollapsible.Content>
+                      </SimpleCollapsible>
                     </div>
                   )}
 


### PR DESCRIPTION
## Description

frontend for mcp oauth override (see #11599 for details)
<img width="474" height="679" alt="Screenshot 2026-06-02 at 1 47 21 PM" src="https://github.com/user-attachments/assets/0b60aa0d-fd62-4491-8ef8-03096c5c6f8e" />
<img width="478" height="899" alt="Screenshot 2026-06-02 at 1 47 25 PM" src="https://github.com/user-attachments/assets/18329009-2baa-4b7f-a9c0-f4bebc8951f8" />


## How Has This Been Tested?

tested e2e in next PR

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"mcp-known-provider-2-backend-connect-callback","parentHead":"0e921339b1c19093a702b85c1f7e28447e32292a","parentPull":11605,"trunk":"main"}
```
-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds known-provider OAuth controls to the MCP authentication modal so admins can set explicit endpoints, scopes, and auth params with validation and normalized payloads. Also hardens the OAuth callback to submit only once to prevent duplicate requests.

- **New Features**
  - Advanced section with Provider Mode select (Auto Discovery default, Known Provider) that auto-opens when configured; resets to Auto Discovery when switching away from OAuth.
  - In Known Provider mode: fields for Authorization Endpoint and Token Endpoint (required); optional Scopes (comma-separated → array) and Additional Auth Params (JSON → object with string values). Includes Google endpoint placeholders.

- **Bug Fixes**
  - OAuth callback now runs exactly once via a mount-only effect and ref guard, preventing duplicate POSTs and 400 errors.

<sup>Written for commit 95eb844b240ae02a9c704dbbfe871e76b1a47ca7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



