### PR TITLE
feat(auth): scope Personal Access Tokens via Permission intersection

### DIFF
--- a/backend/alembic/versions/b8a5e7068be5_add_scopes_to_personal_access_token.py
+++ b/backend/alembic/versions/b8a5e7068be5_add_scopes_to_personal_access_token.py
@@ -1,0 +1,31 @@
+"""add scopes to personal_access_token
+
+Revision ID: b8a5e7068be5
+Revises: 3a9b8d7c6e5f
+Create Date: 2026-06-02 10:52:55.752962
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "b8a5e7068be5"
+down_revision = "3a9b8d7c6e5f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Nullable: existing tokens get NULL = no restriction, so they keep full
+    # user access — no behavior change on upgrade.
+    op.add_column(
+        "personal_access_token",
+        sa.Column("scopes", postgresql.JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("personal_access_token", "scopes")

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -11,15 +11,14 @@ from collections.abc import Coroutine
 from typing import Any
 
 from fastapi import Depends
+from fastapi import Request
 
 from onyx.auth.users import current_user
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.permissions import parse_permission_values
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.utils.logger import setup_logger
-
-logger = setup_logger()
 
 ALL_PERMISSIONS: frozenset[str] = frozenset(p.value for p in Permission)
 
@@ -91,12 +90,7 @@ def resolve_effective_permissions(granted: set[str]) -> set[str]:
 
 def get_effective_permissions(user: User) -> set[Permission]:
     """Read granted permissions from the column and expand implied permissions."""
-    granted: set[Permission] = set()
-    for p in user.effective_permissions:
-        try:
-            granted.add(Permission(p))
-        except ValueError:
-            logger.warning("Skipping unknown permission '%s' for user %s", p, user.id)
+    granted = set(parse_permission_values(user.effective_permissions))
     if Permission.FULL_ADMIN_PANEL_ACCESS in granted:
         return set(Permission)
     expanded = resolve_effective_permissions({p.value for p in granted})
@@ -108,19 +102,29 @@ def require_permission(
 ) -> Callable[..., Coroutine[Any, Any, User]]:
     """FastAPI dependency factory for permission-based access control.
 
+    Effective authority is the user's permissions intersected with the
+    authenticating token's scopes. A restricted PAT carries its scopes on
+    ``request.state.token_scopes``; an unrestricted PAT, session, and API-key
+    auth leave it None, meaning no token-side restriction.
+
     Usage:
         @router.get("/endpoint")
         def endpoint(user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS))):
             ...
     """
 
-    async def dependency(user: User = Depends(current_user)) -> User:
-        effective = get_effective_permissions(user)
+    async def dependency(request: Request, user: User = Depends(current_user)) -> User:
+        effective_user_permissions = get_effective_permissions(user)
+        permitted_by_user = required in effective_user_permissions
 
-        if Permission.FULL_ADMIN_PANEL_ACCESS in effective:
-            return user
+        token_scopes: list[Permission] | None = getattr(
+            request.state, "token_scopes", None
+        )
+        permitted_by_token = token_scopes is None or required.value in (
+            resolve_effective_permissions({s.value for s in token_scopes})
+        )
 
-        if required not in effective:
+        if not (permitted_by_user and permitted_by_token):
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "You do not have the required permissions for this action.",

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -35,6 +35,7 @@ from fastapi import status
 from fastapi import WebSocket
 from fastapi.responses import JSONResponse
 from fastapi.responses import RedirectResponse
+from fastapi.routing import APIRoute
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager
 from fastapi_users import exceptions
@@ -70,6 +71,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
+from starlette.routing import BaseRoute
 
 from onyx.auth.api_key import get_hashed_api_key_from_request
 from onyx.auth.disposable_email_validator import is_disposable_email
@@ -123,11 +125,12 @@ from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import AccountType
+from onyx.db.enums import Permission
 from onyx.db.models import AccessToken
 from onyx.db.models import OAuthAccount
 from onyx.db.models import Persona
 from onyx.db.models import User
-from onyx.db.pat import fetch_user_for_pat
+from onyx.db.pat import resolve_pat
 from onyx.db.users import assign_user_to_default_groups__no_commit
 from onyx.db.users import get_user_by_email
 from onyx.db.users import is_limited_user
@@ -1794,6 +1797,32 @@ async def _maybe_refresh_oauth_tokens(
         )
 
 
+def _scoped_pat_permitted_on_route(
+    token_scopes: list[Permission] | None, route: BaseRoute | None
+) -> bool:
+    """Fail-closed coverage check for scoped PATs.
+
+    Unrestricted PAT / session / API-key auth (token_scopes is None) is
+    unaffected. A scoped PAT may only reach routes that declare a
+    require_permission dependency; require_permission then adjudicates whether
+    the scopes actually cover it. A route with no require_permission is denied,
+    so a narrowly-scoped token can't reach arbitrary endpoints that merely lack
+    a permission guard.
+    """
+    # No scopes (None) == unrestricted: session / unrestricted PAT / API-key
+    # auth carry no token cap, so every route is allowed.
+    if token_scopes is None:
+        return True
+    # Only an APIRoute carries a dependant; anything else (no match, a mounted
+    # or websocket route) declares no permission, so deny the scoped PAT.
+    if not isinstance(route, APIRoute):
+        return False
+    return any(
+        getattr(dependency.cache_key[0], "_is_require_permission", False)
+        for dependency in route.dependant.dependencies
+    )
+
+
 async def optional_user(
     request: Request,
     async_db_session: AsyncSession = Depends(get_async_session),
@@ -1807,12 +1836,28 @@ async def optional_user(
 
     try:
         if hashed_pat := get_hashed_pat_from_request(request):
-            user = await fetch_user_for_pat(hashed_pat, async_db_session)
+            pat = await resolve_pat(hashed_pat, async_db_session)
+            if pat is not None:
+                user = pat.user
+                # Expose the token's scopes so require_permission can cap the
+                # request to them.
+                request.state.token_scopes = pat.scopes
         elif hashed_api_key := get_hashed_api_key_from_request(request):
             user = await fetch_user_for_api_key(hashed_api_key, async_db_session)
     except ValueError:
         logger.warning("Issue with validating authentication token")
         return None
+
+    # Fail-closed: a scoped PAT may only reach routes guarded by a
+    # require_permission its scopes can satisfy (see require_permission).
+    if not _scoped_pat_permitted_on_route(
+        getattr(request.state, "token_scopes", None),
+        request.scope.get("route"),
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "This token's scopes do not permit this endpoint.",
+        )
 
     if user is not None:
         await _maybe_refresh_oauth_tokens(user, async_db_session, user_manager)

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -475,8 +475,8 @@ class HookFailStrategy(str, PyEnum):
 class Permission(str, PyEnum):
     """
     Permission tokens for group-based authorization and PAT scoping.
-    23 tokens total. full_admin_panel_access is an override —
-    if present, any permission check passes.
+    full_admin_panel_access is an override — if present, any permission
+    check passes.
 
     The read:*/write:* "API-surface scopes" are coarser than the capability
     tokens: they name request surfaces (search, chat, admin-read) rather than

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -541,6 +541,14 @@ class PersonalAccessToken(Base):
         server_default=PatType.USER.value,
     )
 
+    # Permission values this token may exercise; NULL = no restriction (full
+    # user access). An empty list grants nothing (fail-closed).
+    scopes: Mapped[list[str] | None] = mapped_column(
+        postgresql.JSONB(),
+        nullable=True,
+        default=None,
+    )
+
     user: Mapped["User"] = relationship("User", foreign_keys=[user_id])
 
     # Indexes for performance

--- a/backend/onyx/db/pat.py
+++ b/backend/onyx/db/pat.py
@@ -3,11 +3,13 @@
 import asyncio
 from datetime import datetime
 from datetime import timezone
+from typing import NamedTuple
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import Session
 
 from onyx.auth.pat import build_displayable_pat
@@ -16,42 +18,62 @@ from onyx.auth.pat import generate_pat
 from onyx.auth.pat import hash_pat
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.enums import PatType
+from onyx.db.enums import Permission
 from onyx.db.models import PersonalAccessToken
 from onyx.db.models import User
+from onyx.db.permissions import parse_permission_values
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
 
-async def fetch_user_for_pat(
+class PatAuthResult(NamedTuple):
+    """A PAT resolved to its user and scopes (scopes None = unrestricted)."""
+
+    user: User
+    scopes: list[Permission] | None
+
+
+async def resolve_pat(
     hashed_token: str, async_db_session: AsyncSession
-) -> User | None:
-    """Fetch user associated with PAT. Returns None if invalid, expired, or inactive user.
+) -> PatAuthResult | None:
+    """Resolve a PAT to its user and scopes. Returns None if invalid, expired, or inactive user.
 
     NOTE: This is async since it's used during auth (which is necessarily async due to FastAPI Users).
     NOTE: Expired includes both naturally expired and user-revoked tokens (revocation sets expires_at=NOW()).
 
-    Uses select(User) as primary entity so that joined-eager relationships (e.g. oauth_accounts)
-    are loaded correctly — matching the pattern in fetch_user_for_api_key.
+    Loads the PAT with its user eagerly via contains_eager so the user's own
+    joined-eager relationships (e.g. oauth_accounts) populate, and .unique()
+    collapses the duplicate rows that joined collection produces.
     """
     now = datetime.now(timezone.utc)
 
-    user = await async_db_session.scalar(
-        select(User)
-        .join(PersonalAccessToken, PersonalAccessToken.user_id == User.id)
-        .where(PersonalAccessToken.hashed_token == hashed_token)
-        .where(User.is_active)  # ty: ignore[invalid-argument-type]
-        .where(
-            (PersonalAccessToken.expires_at.is_(None))
-            | (PersonalAccessToken.expires_at > now)
+    pat = (
+        (
+            await async_db_session.execute(
+                select(PersonalAccessToken)
+                .join(PersonalAccessToken.user)
+                .options(contains_eager(PersonalAccessToken.user))
+                .where(PersonalAccessToken.hashed_token == hashed_token)
+                .where(User.is_active)  # ty: ignore[invalid-argument-type]
+                .where(
+                    (PersonalAccessToken.expires_at.is_(None))
+                    | (PersonalAccessToken.expires_at > now)
+                )
+            )
         )
+        .scalars()
+        .unique()
+        .one_or_none()
     )
-    if not user:
+    if pat is None:
         return None
 
     _schedule_pat_last_used_update(hashed_token, now)
-    return user
+    # None (no scopes) = unrestricted; a stored list is parsed to Permissions.
+    scopes = parse_permission_values(pat.scopes) if pat.scopes is not None else None
+    return PatAuthResult(user=pat.user, scopes=scopes)
 
 
 def _schedule_pat_last_used_update(hashed_token: str, now: datetime) -> None:
@@ -91,8 +113,12 @@ def create_pat(
     name: str,
     expiration_days: int | None,
     pat_type: PatType = PatType.USER,
+    scopes: list[Permission] | None = None,
 ) -> tuple[PersonalAccessToken, str]:
     """Create new PAT. Returns (db_record, raw_token).
+
+    scopes defaults to None (no restriction — full user access); pass a list to
+    scope the token to specific permissions.
 
     Raises ValueError if user is inactive or not found.
     """
@@ -112,6 +138,7 @@ def create_pat(
         user_id=user_id,
         expires_at=calculate_expiration(expiration_days),
         pat_type=pat_type,
+        scopes=[s.value for s in scopes] if scopes is not None else None,
     )
     db_session.add(pat)
     db_session.flush()

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -8,15 +8,36 @@ other onyx/db/ modules such as users.py.
 """
 
 from collections import defaultdict
+from collections.abc import Iterable
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import Permission
 from onyx.db.models import PermissionGrant
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def parse_permission_values(values: Iterable[str]) -> list[Permission]:
+    """Parse stored permission strings into Permissions, dropping unknown values.
+
+    Stored values are validated on write, so an unknown one means stale/corrupt
+    data; we drop it (logged) rather than fail the read — dropping only ever
+    narrows access, so it fails safe.
+    """
+    parsed: list[Permission] = []
+    for value in values:
+        try:
+            parsed.append(Permission(value))
+        except ValueError:
+            logger.warning("Ignoring unknown permission value %r", value)
+    return parsed
 
 
 def recompute_user_permissions__no_commit(

--- a/backend/tests/integration/tests/permissions/test_pat_scopes.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scopes.py
@@ -1,0 +1,122 @@
+"""Integration tests for PAT scope enforcement.
+
+A PAT's scopes cap the request on top of the owner's permissions. Using the
+real auth plumbing (PAT header -> request.state.token_scopes -> require_permission):
+
+  - an unrestricted PAT (the default — no scopes) reaches BASIC_ACCESS
+    endpoints, and
+  - a PAT scoped to read:search is denied those same endpoints, because
+    read:search does not cover BASIC_ACCESS.
+
+This exercises the token-scope gate end-to-end against existing BASIC_ACCESS
+routes (no fine-grained route guards required).
+"""
+
+from uuid import UUID
+
+import pytest
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import Permission
+from onyx.db.pat import create_pat
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+# A representative BASIC_ACCESS-guarded endpoint.
+BASIC_ACCESS_ENDPOINT = ("GET", "/user/pats")
+
+
+def _pat_headers(user: DATestUser, scopes: list[Permission] | None) -> dict[str, str]:
+    with get_session_with_current_tenant() as db_session:
+        _, raw_token = create_pat(
+            db_session=db_session,
+            user_id=UUID(user.id),
+            name="scope_test_pat",
+            expiration_days=None,
+            scopes=scopes,
+        )
+        db_session.commit()
+    return {"Authorization": f"Bearer {raw_token}"}
+
+
+@pytest.fixture(scope="module")
+def basic_user_unrestricted_pat_headers(
+    permission_basic_user: DATestUser,
+) -> dict[str, str]:
+    return _pat_headers(permission_basic_user, scopes=None)
+
+
+@pytest.fixture(scope="module")
+def basic_user_search_scoped_pat_headers(
+    permission_basic_user: DATestUser,
+) -> dict[str, str]:
+    return _pat_headers(permission_basic_user, scopes=[Permission.READ_SEARCH])
+
+
+def test_unrestricted_pat_reaches_basic_access_endpoint(
+    basic_user_unrestricted_pat_headers: dict[str, str],
+) -> None:
+    method, path = BASIC_ACCESS_ENDPOINT
+    resp = client.request(
+        method,
+        f"{API_SERVER_URL}{path}",
+        headers=basic_user_unrestricted_pat_headers,
+        timeout=30,
+    )
+    assert resp.status_code < 400, (
+        f"Unrestricted PAT should reach {method} {path}, got {resp.status_code}"
+    )
+
+
+def test_search_scoped_pat_denied_on_basic_access_endpoint(
+    basic_user_search_scoped_pat_headers: dict[str, str],
+) -> None:
+    method, path = BASIC_ACCESS_ENDPOINT
+    resp = client.request(
+        method,
+        f"{API_SERVER_URL}{path}",
+        headers=basic_user_search_scoped_pat_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 403, (
+        f"read:search-scoped PAT should be denied on {method} {path} "
+        f"(read:search does not cover basic), got {resp.status_code}"
+    )
+
+
+# /me uses optional_user with no require_permission — an "unguarded" route. The
+# fail-closed gate denies a scoped PAT there while leaving an unrestricted PAT
+# (and sessions / API keys) untouched.
+UNGUARDED_ENDPOINT = ("GET", "/me")
+
+
+def test_unrestricted_pat_reaches_unguarded_endpoint(
+    basic_user_unrestricted_pat_headers: dict[str, str],
+) -> None:
+    method, path = UNGUARDED_ENDPOINT
+    resp = client.request(
+        method,
+        f"{API_SERVER_URL}{path}",
+        headers=basic_user_unrestricted_pat_headers,
+        timeout=30,
+    )
+    assert resp.status_code < 400, (
+        f"Unrestricted PAT should reach {method} {path}, got {resp.status_code}"
+    )
+
+
+def test_scoped_pat_denied_on_unguarded_endpoint(
+    basic_user_search_scoped_pat_headers: dict[str, str],
+) -> None:
+    method, path = UNGUARDED_ENDPOINT
+    resp = client.request(
+        method,
+        f"{API_SERVER_URL}{path}",
+        headers=basic_user_search_scoped_pat_headers,
+        timeout=30,
+    )
+    assert resp.status_code == 403, (
+        f"A scoped PAT must be denied on the unguarded route {method} {path} "
+        f"(fail-closed), got {resp.status_code}"
+    )

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -2,9 +2,12 @@
 Unit tests for onyx.auth.permissions — pure logic and FastAPI dependency.
 """
 
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import Request
 
 from onyx.auth.permissions import ALL_PERMISSIONS
 from onyx.auth.permissions import get_effective_permissions
@@ -15,6 +18,19 @@ from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+
+
+def _request(token_scopes: list[Permission] | None = None) -> Request:
+    """Fake request whose state carries (or omits) token scopes.
+
+    Omitted token_scopes mimics session / API-key auth — getattr returns None,
+    i.e. no token-side restriction.
+    """
+    state = SimpleNamespace()
+    if token_scopes is not None:
+        state.token_scopes = token_scopes
+    return cast(Request, SimpleNamespace(state=state))
+
 
 # ---------------------------------------------------------------------------
 # resolve_effective_permissions
@@ -163,7 +179,7 @@ class TestRequirePermission:
         user.effective_permissions = ["admin"]
 
         dep = require_permission(Permission.MANAGE_CONNECTORS)
-        result = await dep(user=user)
+        result = await dep(request=_request(), user=user)
         assert result is user
 
     @pytest.mark.asyncio
@@ -172,7 +188,7 @@ class TestRequirePermission:
         user.effective_permissions = ["manage:connectors"]
 
         dep = require_permission(Permission.MANAGE_CONNECTORS)
-        result = await dep(user=user)
+        result = await dep(request=_request(), user=user)
         assert result is user
 
     @pytest.mark.asyncio
@@ -182,7 +198,7 @@ class TestRequirePermission:
         user.effective_permissions = ["manage:connectors"]
 
         dep = require_permission(Permission.READ_CONNECTORS)
-        result = await dep(user=user)
+        result = await dep(request=_request(), user=user)
         assert result is user
 
     @pytest.mark.asyncio
@@ -192,7 +208,7 @@ class TestRequirePermission:
 
         dep = require_permission(Permission.MANAGE_CONNECTORS)
         with pytest.raises(OnyxError) as exc_info:
-            await dep(user=user)
+            await dep(request=_request(), user=user)
         assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
 
     @pytest.mark.asyncio
@@ -202,7 +218,68 @@ class TestRequirePermission:
 
         dep = require_permission(Permission.BASIC_ACCESS)
         with pytest.raises(OnyxError):
-            await dep(user=user)
+            await dep(request=_request(), user=user)
+
+    @pytest.mark.asyncio
+    async def test_pat_scope_within_user_permissions_passes(self) -> None:
+        """A scoped PAT may exercise a permission the user holds and the scope covers."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(Permission.READ_SEARCH)
+        result = await dep(request=_request([Permission.READ_SEARCH]), user=user)
+        assert result is user
+
+    @pytest.mark.asyncio
+    async def test_pat_scope_blocks_out_of_scope_permission(self) -> None:
+        """A search-scoped PAT is denied a chat-write endpoint even though the user holds it."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(Permission.WRITE_CHAT)
+        with pytest.raises(OnyxError) as exc_info:
+            await dep(request=_request([Permission.READ_SEARCH]), user=user)
+        assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+
+    @pytest.mark.asyncio
+    async def test_pat_scope_caps_admin(self) -> None:
+        """Token scopes cap even a full admin — a read:admin PAT can't write-admin."""
+        user = MagicMock()
+        user.effective_permissions = ["admin"]
+
+        dep = require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
+        with pytest.raises(OnyxError):
+            await dep(request=_request([Permission.READ_ADMIN]), user=user)
+
+    @pytest.mark.asyncio
+    async def test_unrestricted_pat_cannot_exceed_user(self) -> None:
+        """Even an unrestricted token can't grant a permission the user lacks (intersection is min)."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(Permission.MANAGE_CONNECTORS)
+        with pytest.raises(OnyxError):
+            await dep(request=_request(None), user=user)
+
+    @pytest.mark.asyncio
+    async def test_pat_scope_closure_applies(self) -> None:
+        """A write:chat-scoped token reaches a read:chat route (write:chat implies read:chat)."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(Permission.READ_CHAT)
+        result = await dep(request=_request([Permission.WRITE_CHAT]), user=user)
+        assert result is user
+
+    @pytest.mark.asyncio
+    async def test_empty_pat_scopes_deny_all(self) -> None:
+        """An explicit empty scope set grants nothing — fail-closed."""
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+
+        dep = require_permission(Permission.READ_SEARCH)
+        with pytest.raises(OnyxError):
+            await dep(request=_request([]), user=user)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/auth/test_scoped_pat_route_gate.py
+++ b/backend/tests/unit/onyx/auth/test_scoped_pat_route_gate.py
@@ -1,0 +1,53 @@
+"""Unit tests for the fail-closed scoped-PAT route gate.
+
+`_scoped_pat_permitted_on_route` decides whether a PAT-authenticated request may
+proceed past `optional_user`: an unrestricted token (None scopes) always may; a
+scoped token may only reach routes that declare a `require_permission` (which
+then adjudicates coverage). Routes with no such guard are denied outright.
+
+Uses real APIRoutes + real require_permission so the dependant introspection is
+exercised exactly as it is at runtime.
+"""
+
+from fastapi import Depends
+from fastapi.routing import APIRoute
+
+from onyx.auth.permissions import require_permission
+from onyx.auth.users import _scoped_pat_permitted_on_route
+from onyx.db.enums import Permission
+
+
+async def _endpoint() -> None: ...
+
+
+def _guarded_route() -> APIRoute:
+    return APIRoute(
+        "/x",
+        _endpoint,
+        dependencies=[Depends(require_permission(Permission.READ_SEARCH))],
+    )
+
+
+def _unguarded_route() -> APIRoute:
+    return APIRoute("/x", _endpoint)
+
+
+class TestScopedPatPermittedOnRoute:
+    def test_unrestricted_token_always_permitted(self) -> None:
+        # None scopes == session / unrestricted PAT / API key — gate is a no-op,
+        # even on an unguarded route.
+        assert _scoped_pat_permitted_on_route(None, _unguarded_route())
+
+    def test_scoped_token_allowed_on_require_permission_route(self) -> None:
+        # The gate only checks a guard exists; require_permission adjudicates coverage.
+        assert _scoped_pat_permitted_on_route(
+            [Permission.READ_SEARCH], _guarded_route()
+        )
+
+    def test_scoped_token_denied_on_unguarded_route(self) -> None:
+        assert not _scoped_pat_permitted_on_route(
+            [Permission.READ_SEARCH], _unguarded_route()
+        )
+
+    def test_scoped_token_denied_when_route_missing(self) -> None:
+        assert not _scoped_pat_permitted_on_route([Permission.READ_SEARCH], None)

--- a/docs/craft/features/pat-scopes/pat-scopes.md
+++ b/docs/craft/features/pat-scopes/pat-scopes.md
@@ -1,185 +1,106 @@
-# PAT Scopes — Permissions System
+# PAT Scopes
 
-This is the "Permissions system" that the secrets-injection and search docs repeatedly defer to
-(`secrets-injection/01-framework.md:162`, `02-onyx-pat.md:109`, `search/search-design.md:409,528`,
-`search/4-craft-search-outstanding-questions.md:24`). Today a CRAFT PAT authenticates as the full
-user at their own role; this plan adds per-token scopes so the sandbox can be handed a token that
-can *search* but not drain chat history or touch the admin panel.
+The "Permissions system" the secrets-injection and search docs defer to. A Personal Access Token
+historically authenticates as its owner with the owner's full authority; this adds per-token scopes
+so a token can be handed out that can *search* but not drain chat history or touch the admin panel.
+The first consumer is the Craft sandbox PAT.
 
 ## Issues to Address
 
-A Personal Access Token grants the full authority of the user it belongs to. `PersonalAccessToken`
-(`backend/onyx/db/models.py:508`) has no scope column, and `fetch_user_for_pat`
-(`backend/onyx/db/pat.py:27`) returns the real `User` verbatim and discards the matched token row.
-The only attenuation is the optional expiry.
+A PAT carries no scope — `fetch_user_for_pat` resolves the token to its `User` and the request runs
+with the user's full permissions. The only attenuation is the optional expiry.
 
-We want PATs to carry a scope — a subset of the user's authority that the token exposes — built on
-the existing `Permission` enum (`backend/onyx/db/enums.py:469`) and the `require_permission`
-dependency (`backend/onyx/auth/permissions.py:99`) rather than a parallel authorization system. The
-first consumer is the Craft sandbox PAT minted by `ensure_sandbox_pat`
-(`backend/onyx/server/features/build/db/sandbox.py:28`); the mechanism is general-purpose and
-applies to user-created PATs too.
+We want PATs to carry a scope: a subset of the owner's authority that the token exposes, built on the
+existing `Permission` enum and `require_permission` dependency rather than a parallel authorization
+system. Four token scopes, coarser than the existing capability permissions — they name request
+surfaces, not admin capabilities:
 
-Five new token scopes, at a coarser, API-surface granularity than the existing capability
-permissions:
-
-- `READ_SEARCH` — search/query endpoints
-- `READ_CHAT` — view chat sessions/messages
+- `READ_SEARCH` — search / query endpoints
+- `READ_CHAT` — view chat sessions and messages
 - `WRITE_CHAT` — create sessions, send messages
-- `READ_ADMIN` — read-only admin panel (view settings, users, analytics; distinct from
-  `FULL_ADMIN_PANEL_ACCESS`)
-- `WILDCARD` (`*`) — passes all checks; the backward-compat default for existing PATs
+- `READ_ADMIN` — read-only admin panel, distinct from `FULL_ADMIN_PANEL_ACCESS`
 
-## Important Notes
+A token with no scopes (`NULL`) is unrestricted — full user access. This is the backward-compatible
+default for existing and unscoped tokens.
 
-**The authority model is an intersection.** Effective authority for a request is
-`expand(user.effective_permissions) ∩ expand(token.scopes)`. The user-side check is unchanged — a
-token can never exceed its user. The token side is a new, second gate: `require_permission(P)`
-passes iff `P ∈ expand(user_perms)` **and** `P ∈ expand(token_scopes)`.
+## How it works
 
-**A closure already exists; we extend it.** `permissions.py` already implements implication: the
-`IMPLIED_PERMISSIONS` adjacency map (`backend/onyx/auth/permissions.py:27`) and
-`resolve_effective_permissions` (`:65`) compute the transitive closure of a granted set, with
-`FULL_ADMIN_PANEL_ACCESS` short-circuiting to all permissions. `get_effective_permissions` (`:85`)
-wraps it for a `User`. The new scopes plug into this same machinery rather than a second closure.
+**Authority is an intersection.** Effective authority for a request is
+`expand(user permissions) ∩ expand(token scopes)`. The user-side check is unchanged — a token can
+never exceed its owner. The token side is a second gate: `require_permission(P)` passes only if `P`
+is in both expanded sets. An unrestricted PAT, session/cookie, and API-key auth carry no token
+scopes (`None`), so there is no token-side restriction and their behavior is unchanged.
 
-**The implication rules bridge two granularities.** The existing `Permission` values are capability
-grants that live on `User.effective_permissions` (a `Mapped[list[str]]` JSONB column,
-`backend/onyx/db/models.py:366`); the new scopes are API-surface verbs that live on a token. They
-share one enum, so the intersection is a single vocabulary, but they occupy two domains —
-`user.effective_permissions` should never literally contain `READ_SEARCH`, and a token's scopes are
-normally the fine verbs or `WILDCARD`. Add these edges to `IMPLIED_PERMISSIONS`:
+**One closure bridges two granularities.** `permissions.py` already computes the transitive closure
+of a permission set under an implication map, with admin short-circuiting to everything. The new
+scopes plug into that same map rather than a second system. The existing `Permission` values are
+capability grants stored on the user; the new scopes are API-surface verbs stored on a token. They
+share one enum — so the intersection is a single vocabulary — but occupy two domains: a user never
+holds `READ_SEARCH` directly, it is implied. The implication edges:
 
 ```
-WILDCARD                → <all permissions>   (token-side sentinel; short-circuit)
 BASIC_ACCESS            → READ_SEARCH, READ_CHAT, WRITE_CHAT
-FULL_ADMIN_PANEL_ACCESS → READ_ADMIN
 WRITE_CHAT              → READ_CHAT
+FULL_ADMIN_PANEL_ACCESS → READ_ADMIN         (already covered by the admin short-circuit; explicit for intent)
 ```
 
-`BASIC_ACCESS` currently implies nothing, so its row is new; `FULL_ADMIN_PANEL_ACCESS` already
-short-circuits to everything, so `READ_ADMIN` falls out for free on the user side and the explicit
-edge documents intent. `expand(S)` is the transitive closure applied at **check time** to both the
-user permissions and the token scopes. Store the minimal granted set on each side; never persist an
-expanded set, or a later rule change silently mismatches old rows. Closure over the 19-member enum
-is free. `expand({})` (empty scope list) is `{}` — a token with no scopes passes nothing, which is
-the correct fail-closed default.
+The closure runs at check time on both sides; only the minimal granted set is persisted, so changing
+a rule never leaves stale expanded data. "Unrestricted" is represented as the *absence* of scopes
+(`NULL` in the column, `None` on the request) rather than a wildcard value — so it needs no entry in
+the enum or the closure. An empty scope list (`[]`), by contrast, expands to nothing — a token with
+an explicit empty scope set passes nothing, the correct fail-closed default.
 
-Worked example — user is `BASIC_ACCESS`, token scope is `{READ_SEARCH}`:
-`expand(user) = {BASIC_ACCESS, READ_SEARCH, READ_CHAT, WRITE_CHAT}`, `expand(token) = {READ_SEARCH}`.
-A `require_permission(READ_SEARCH)` route passes; a `require_permission(WRITE_CHAT)` route blocks.
+Example — owner has `BASIC_ACCESS`, token scope is `READ_SEARCH`: a `READ_SEARCH` route passes; a
+`WRITE_CHAT` route is denied even though the owner could otherwise write chat.
 
-**Implication flows coarse→fine only, so route migration is mandatory.** A `READ_SEARCH` token does
-*not* satisfy a `require_permission(BASIC_ACCESS)` route, because `BASIC_ACCESS ∉
-expand({READ_SEARCH})`. A scoped token can only reach routes explicitly guarded with a permission in
-its scope set. This is the safe direction — scoped tokens fail closed — but it means re-guarding
-routes with the fine permissions is the work that makes scopes usable, not an optional follow-up.
-WILDCARD tokens and backfilled legacy PATs are unaffected, since `expand({WILDCARD})` is everything.
+**Implication flows coarse→fine, so route guards must use the fine permissions.** A `READ_SEARCH`
+token does not satisfy a route guarded by `BASIC_ACCESS` — a scoped token only reaches routes guarded
+with a permission in its scope set. This is the safe direction (scoped tokens fail closed), but it
+means re-guarding the relevant routes with the fine permissions is what makes scopes usable.
+Unrestricted and legacy (`NULL`-scope) tokens are unaffected.
 
-**Unguarded routes are denied for scoped tokens (fail-closed, decided).** Most endpoints depend only
-on `current_user`/`current_limited_user` with no `require_permission`. A scoped token is still a
-valid active user, so without extra handling it would sail through every unguarded route — making
-scoping advisory rather than a boundary. Given Craft's threat model (the secrets-injection effort
-assumes the sandbox is hostile), that is too leaky. Therefore: when a request is authenticated via a
-**non-WILDCARD** PAT, any matched route that did not declare a permission covered by the token's
-`expand(scopes)` is denied. WILDCARD tokens and session/cookie auth bypass this gate entirely, so
-existing behavior is preserved for everything except deliberately-scoped tokens. The gate is keyed
-on auth type and scopes, not on `UserRole` — a PAT user keeps their real role, and `UserRole.LIMITED`
-today applies only to anonymous users, so it is orthogonal to scoping.
+**Unguarded routes (fail-closed).** Most endpoints depend only on `current_user` with no
+`require_permission`, so the intersection gate alone wouldn't constrain them — a scoped token would
+pass. To close that, `optional_user` (the single HTTP auth funnel) denies a scoped PAT on any route
+whose matched `request.scope["route"]` declares no `require_permission` dependency — reusing the same
+`_is_require_permission` sentinel `check_router_auth` introspects. A scoped PAT therefore reaches only
+routes guarded by a permission, and `require_permission` then adjudicates coverage. Unrestricted PATs,
+sessions, and API-key auth (token scopes `None`) are untouched; websocket auth has its own path and is
+unaffected.
 
-**`WILDCARD` is a token-side sentinel only.** It is never a value in `User.effective_permissions`
-and never a valid argument to `require_permission(...)` — it is the token-side analog of the
-user-side `FULL_ADMIN_PANEL_ACCESS` override. Worth a guard (type-level or a startup assertion) so
-nobody writes `require_permission(WILDCARD)`.
+## Delivery
 
-**`READ_ADMIN` is the heaviest migration.** Today read and write admin endpoints both sit behind
-`FULL_ADMIN_PANEL_ACCESS`. Enforcing read-only admin means auditing those routes and splitting
-read → `READ_ADMIN`, write → `FULL_ADMIN_PANEL_ACCESS`. A real audit, not a rename.
+Sequenced so enforcement is complete before any scoped token exists:
 
-**Division of labor.** The token owner (separate work) handles the `PersonalAccessToken` scope
-column + migration and the route re-guarding. This plan owns the enum/closure extension, the
-auth-context plumbing contract, the second gate in `require_permission`, the fail-closed gate, and
-the Craft-PAT scoping that is the acceptance test for the whole effort.
+1. **Permission vocabulary + closure** — the four API-surface scopes and their implication edges.
+   *Shipped.*
+2. **Token scopes + intersection** — a nullable `scopes` column (existing rows stay `NULL` =
+   unrestricted), plumbed onto the request at PAT auth and intersected in `require_permission`.
+   *Shipped.* Enforces on `require_permission` routes only.
+3. **Fail-closed gate** — `optional_user` denies a scoped PAT on routes that declare no
+   `require_permission`, so enforcement covers non-guarded routes too. *Shipped.*
+4. **Re-guard routes** with the fine permissions (search / chat read+write / admin read vs. write).
+   The `READ_ADMIN` split is a real audit, not a rename.
+5. **Scope the Craft PAT** — `ensure_sandbox_pat` mints `[READ_SEARCH]` (plus whatever onyx-cli needs)
+   instead of unrestricted, retiring the "CRAFT PAT grants full user access" caveat. This is the
+   acceptance test for the effort.
 
-## Implementation strategy
-
-1. **Extend the `Permission` enum** (`backend/onyx/db/enums.py:469`) with `READ_SEARCH`, `READ_CHAT`,
-   `WRITE_CHAT`, `READ_ADMIN`, and the `WILDCARD` sentinel. Document in-place that some members are
-   coarse capabilities (user-side) and some are fine API scopes (token-side), bridged by the closure.
-
-2. **Extend the closure** in `backend/onyx/auth/permissions.py`: add the new edges to
-   `IMPLIED_PERMISSIONS` (`:27`) and special-case `WILDCARD` in the resolver to short-circuit to the
-   full set (mirroring the existing `FULL_ADMIN_PANEL_ACCESS` branch in `resolve_effective_permissions`,
-   `:70`). Pure function, no I/O.
-
-3. **Persist token scopes** (owner-handled). Add a `scopes` JSONB column to `PersonalAccessToken`
-   (`backend/onyx/db/models.py:508`) holding `list[str]` of `Permission` values. Backfill existing
-   rows to `["*"]` (WILDCARD) so legacy PATs are unchanged. This plan specifies the column shape and
-   the WILDCARD-default contract.
-
-4. **Plumb scopes into request context.** `fetch_user_for_pat` (`backend/onyx/db/pat.py:27`)
-   currently returns only the `User` and drops the token row; it must also surface the matched
-   token's `scopes`. The PAT branch of `optional_user` (`backend/onyx/auth/users.py:1809`) then
-   stashes them on the request (e.g. `request.state.token_scopes`). Session/cookie auth, API-key
-   auth, and legacy tokens default to `{WILDCARD}`. This is the seam the next two steps hang on.
-
-5. **Second gate in `require_permission`** (`backend/onyx/auth/permissions.py:99`). After the
-   existing user-permission check (which already raises
-   `OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS)` on failure, `:117`), also require
-   `P ∈ expand(request.state.token_scopes)`, with WILDCARD short-circuiting. Same `OnyxError` on
-   failure. This is the coarse→fine intersection.
-
-6. **Fail-closed gate for unguarded routes.** For requests authenticated via a non-WILDCARD PAT,
-   deny any matched route whose declared permissions are not covered by `expand(token_scopes)` —
-   including routes that declared none. The route's `require_permission` declarations are already
-   discoverable via the `_is_require_permission` sentinel that `check_router_auth`
-   (`backend/onyx/server/auth_check.py:96`, wired in `backend/onyx/main.py:719`) uses to introspect
-   route dependencies; reuse that detection. Implement as middleware or a router-level dependency.
-   WILDCARD and non-PAT auth bypass. Denials raise `OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS)`.
-
-7. **Re-guard routes with fine permissions** (owner-handled): search → `READ_SEARCH`, chat-read →
-   `READ_CHAT`, chat-write → `WRITE_CHAT`, read-only admin → `READ_ADMIN`. This plan provides the
-   target mapping; the audit/migration is the token owner's.
-
-8. **Scope the Craft PAT — the acceptance test.** Change `ensure_sandbox_pat`
-   (`backend/onyx/server/features/build/db/sandbox.py:28`) to mint CRAFT PATs with
-   `scopes=[READ_SEARCH]` (plus the minimal build/search scopes onyx-cli actually calls) instead of
-   the implicit full-access WILDCARD. This retires the "CRAFT PAT grants full user access" caveat
-   carried across the secrets-injection and search docs.
+Setting scopes when minting a PAT is currently internal (a `create_pat` argument); a user-facing
+API/UI and surfacing scopes on token listings are follow-ups.
 
 ## Tests
 
-Prefer external-dependency-unit and integration tests; the closure is the only piece that warrants a
-pure unit test.
-
-- **Unit — closure.** Pin the spec: `WILDCARD` expands to the full set; `BASIC_ACCESS` expands to
-  include `READ_SEARCH/READ_CHAT/WRITE_CHAT`; `WRITE_CHAT` includes `READ_CHAT`;
-  `FULL_ADMIN_PANEL_ACCESS` includes `READ_ADMIN`; `expand({})` is `{}`; transitivity holds. Add a
-  completeness check that every `IMPLIED_PERMISSIONS` key and value is a real `Permission` member. Do
-  not derive the expected output from the map — hardcode the spec.
-
-- **External-dependency unit — auth context plumbing.** Mint a PAT with a real `scopes` value against
-  a real DB, run it through the PAT auth path, and assert `request.state.token_scopes` carries the
-  stored scopes; assert session auth and a WILDCARD-backfilled legacy PAT both resolve to
-  `{WILDCARD}`.
-
-- **Integration — intersection and fail-closed.** With real routes: a `READ_SEARCH` token reaches a
-  `READ_SEARCH`-guarded search endpoint, is denied a `WRITE_CHAT`-guarded endpoint, and is denied an
-  unguarded (`current_user`-only) endpoint. A `WILDCARD` token reaches all three. A `READ_ADMIN`
-  token reaches a read-only admin endpoint but is denied a `FULL_ADMIN_PANEL_ACCESS` write endpoint.
-  Confirm a token whose scope exceeds the user's permissions is still capped by the user (the
-  intersection is min, not max). Assert denials return `OnyxErrorCode.INSUFFICIENT_PERMISSIONS`.
-
-- **Integration — Craft PAT acceptance.** A live Craft session's PAT can call `company_search` /
-  onyx-cli search but is denied chat-history reads and admin endpoints — the end-to-end proof the
-  deferred caveat is closed.
+- **Unit (closure + gate).** Pin the implication spec with hardcoded expected sets plus a completeness
+  check; cover the intersection truth table — an unrestricted token imposes no cap, scope-within-user
+  passes, out-of-scope denied, a scoped token caps even an admin, and a token can't exceed its user.
+- **External-dependency.** A scoped PAT's scopes round-trip through the real column; unscoped defaults
+  to `NULL` (unrestricted).
+- **Integration.** With real auth plumbing, a scoped PAT is denied on a route its scopes don't cover
+  while an unrestricted PAT passes. Craft acceptance: a search-scoped session PAT can search but not
+  read chat history or reach admin.
 
 ## Out of scope
 
-- Migrating `ApiKey` (the synthetic-service-account model, `backend/onyx/db/api_key.py`) onto the
-  same scope mechanism. API keys already encode a restricted role via their synthetic user; folding
-  them in is a later unification.
-- A UI for users to choose scopes when minting a PAT. V1 scopes are set programmatically (Craft) or
-  via API; the management UI is a follow-up.
-- Per-resource / row-level scoping (e.g. "this token may read chat session X only"). Scopes are
-  endpoint-surface grants, not object ACLs.
+- Folding `ApiKey` (the synthetic-service-account model) onto the same mechanism — API keys already
+  encode a restricted role via their synthetic user.
+- Per-resource / row-level scoping — scopes are endpoint-surface grants, not object ACLs.


### PR DESCRIPTION
## Description

Adds per-PAT scopes (PR 2 of the [PAT scopes plan](docs/craft/features/pat-scopes/pat-scopes.md)). Effective authority becomes `user permissions ∩ token scopes`, reusing the existing `Permission` enum and implication closure — no parallel system.

- Nullable `scopes` column on `PersonalAccessToken` (`NULL` = unrestricted, so existing tokens are unchanged; migration just adds the column).
- PAT auth surfaces the token's scopes on `request.state.token_scopes`; `require_permission` denies if the required permission isn't in both the user's permissions and the token's scopes.
- **Fail-closed for unguarded routes:** `optional_user` denies a scoped PAT on any route that declares no `require_permission` (reusing the `_is_require_permission` sentinel `check_router_auth` introspects). So a scoped token reaches only routes guarded by a permission it covers; unrestricted PATs / sessions / API keys / websocket auth are untouched.
- `create_pat(scopes=...)` to mint scoped tokens (internal for now); unscoped auth stays unrestricted.

Scope enforcement is now complete (guarded + unguarded routes). Re-guarding routes with finer permissions and scoping the Craft PAT are follow-up PRs. No behavior change until a token is explicitly scoped (none are yet).

## How Has This Been Tested?

Unit tests for the closure + the intersection gate (within-user passes, out-of-scope denied, scoped token caps an admin, token can't exceed user, empty scopes fail-closed) and the fail-closed route gate (scoped token denied on a guard-less route). Integration tests assert a scoped PAT is denied on a `require_permission` route it doesn't cover and on an unguarded route (`/me`), while an unrestricted PAT passes both.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
