### PR TITLE
fix(search-settings): coerce null embedding prefixes to empty string

### DIFF
--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -42,8 +42,11 @@ def create_search_settings(
         model_name=search_settings.model_name,
         model_dim=search_settings.model_dim,
         normalize=search_settings.normalize,
-        query_prefix=search_settings.query_prefix,
-        passage_prefix=search_settings.passage_prefix,
+        # These DB columns are NOT NULL. Registry-less cloud providers (e.g.
+        # Bedrock/LiteLLM/Azure) can arrive without prefixes, so coerce None to
+        # the empty-string "no prefix" sentinel to avoid a NotNullViolation.
+        query_prefix=search_settings.query_prefix or "",
+        passage_prefix=search_settings.passage_prefix or "",
         status=status,
         index_name=search_settings.index_name,
         provider_type=search_settings.provider_type,

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -21,6 +21,11 @@ from shared_configs.enums import EmbeddingProvider
 
 logger = setup_logger()
 
+# search_settings columns that are NOT NULL but whose Pydantic source fields are
+# typed str | None. Registry-less cloud providers (e.g. Bedrock/LiteLLM/Azure)
+# can arrive without prefixes; coerce None -> "" to avoid a NotNullViolation.
+_NOT_NULL_STR_FIELDS = {"query_prefix", "passage_prefix"}
+
 
 class ActiveSearchSettings:
     primary: SearchSettings
@@ -42,9 +47,7 @@ def create_search_settings(
         model_name=search_settings.model_name,
         model_dim=search_settings.model_dim,
         normalize=search_settings.normalize,
-        # These DB columns are NOT NULL. Registry-less cloud providers (e.g.
-        # Bedrock/LiteLLM/Azure) can arrive without prefixes, so coerce None to
-        # the empty-string "no prefix" sentinel to avoid a NotNullViolation.
+        # See _NOT_NULL_STR_FIELDS: coerce None -> "" to avoid a NotNullViolation.
         query_prefix=search_settings.query_prefix or "",
         passage_prefix=search_settings.passage_prefix or "",
         status=status,
@@ -186,6 +189,10 @@ def update_search_settings(
     mapped_columns = {c.key for c in sa_inspect(SearchSettings).mapper.columns}
     for field, value in updated_settings.model_dump().items():
         if field not in preserved_fields and field in mapped_columns:
+            # A client that explicitly sends null for a NOT NULL prefix column
+            # must not write NULL (NotNullViolation). See _NOT_NULL_STR_FIELDS.
+            if value is None and field in _NOT_NULL_STR_FIELDS:
+                value = ""
             setattr(current_settings, field, value)
 
 

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -151,8 +151,8 @@ class EmbeddingModelDetail(BaseModel):
     id: int | None = None
     model_name: str
     normalize: bool
-    query_prefix: str | None
-    passage_prefix: str | None
+    query_prefix: str | None = ""
+    passage_prefix: str | None = ""
     api_url: str | None = None
     provider_type: EmbeddingProvider | None = None
     api_key: str | None = None

--- a/backend/tests/external_dependency_unit/search_settings/test_search_settings.py
+++ b/backend/tests/external_dependency_unit/search_settings/test_search_settings.py
@@ -15,6 +15,7 @@ from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import upsert_llm_provider
 from onyx.db.models import IndexModelStatus
 from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import update_search_settings
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.indexing.indexing_pipeline import IndexingPipelineResult
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
@@ -22,6 +23,7 @@ from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
 from onyx.server.manage.search_settings import set_new_search_settings
 from onyx.server.manage.search_settings import update_saved_search_settings
+from shared_configs.configs import PRESERVED_SEARCH_FIELDS
 
 TEST_PROVIDER_NAME = "test-contextual-provider"
 TEST_MODEL_NAME = "test-contextual-model"
@@ -322,6 +324,37 @@ def test_create_search_settings_coerces_none_prefixes(
 
     assert created.query_prefix == ""
     assert created.passage_prefix == ""
+
+
+def test_update_search_settings_coerces_none_prefixes(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    """The update path setattr's columns straight from model_dump(). Today's
+    callers always include the prefixes in PRESERVED_SEARCH_FIELDS, but if a
+    caller does NOT preserve them, an explicit null must still not write NULL to
+    the NOT NULL columns. Exercises the coercion with prefixes un-preserved
+    (while keeping 'id' preserved so the PK isn't nulled)."""
+    current = create_search_settings(
+        search_settings=_make_saved_search_settings(enable_contextual_rag=False),
+        db_session=db_session,
+        status=IndexModelStatus.PRESENT,
+    )
+
+    updated = _make_saved_search_settings(enable_contextual_rag=False)
+    updated.query_prefix = None
+    updated.passage_prefix = None
+
+    preserved = [
+        f
+        for f in PRESERVED_SEARCH_FIELDS
+        if f not in ("query_prefix", "passage_prefix")
+    ]
+    update_search_settings(current, updated, preserved_fields=preserved)
+    db_session.commit()
+
+    assert current.query_prefix == ""
+    assert current.passage_prefix == ""
 
 
 def test_creation_request_defaults_blank_prefixes() -> None:

--- a/backend/tests/external_dependency_unit/search_settings/test_search_settings.py
+++ b/backend/tests/external_dependency_unit/search_settings/test_search_settings.py
@@ -299,3 +299,46 @@ def test_indexing_pipeline_skips_llm_when_contextual_rag_disabled(
     _run_indexing_pipeline_with_mocks(mock_get_llm, mock_index_handler, db_session)
 
     mock_get_llm.assert_not_called()
+
+
+def test_create_search_settings_coerces_none_prefixes(
+    tenant_context: None,  # noqa: ARG001
+    db_session: Session,
+) -> None:
+    """Registry-less cloud providers (e.g. Bedrock/LiteLLM/Azure) can arrive
+    without query/passage prefixes. The search_settings DB columns are NOT
+    NULL, so create_search_settings must coerce None -> "" instead of raising
+    a NotNullViolation. Regression test for the v4.0.x embedding-switch bug."""
+    saved = _make_saved_search_settings(enable_contextual_rag=False)
+    # Explicitly force the None path the failing customer hit.
+    saved.query_prefix = None
+    saved.passage_prefix = None
+
+    created = create_search_settings(
+        search_settings=saved,
+        db_session=db_session,
+        status=IndexModelStatus.FUTURE,
+    )
+
+    assert created.query_prefix == ""
+    assert created.passage_prefix == ""
+
+
+def test_creation_request_defaults_blank_prefixes() -> None:
+    """When the client omits query/passage prefixes entirely, the Pydantic
+    request model should default them to "" rather than leaving them unset/None."""
+    request = SearchSettingsCreationRequest(
+        model_name="bedrock-titan-embed-text-2",
+        model_dim=1024,
+        normalize=False,
+        provider_type=None,
+        index_name=None,
+        multipass_indexing=False,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+        reduced_dimension=None,
+        enable_contextual_rag=False,
+        contextual_rag_model_configuration_id=None,
+    )
+
+    assert request.query_prefix == ""
+    assert request.passage_prefix == ""


### PR DESCRIPTION
## Description

Creating new search settings for a registry-less cloud embedding provider (e.g. Bedrock / LiteLLM / Azure) with the optional prefix fields left blank sent `query_prefix` / `passage_prefix` as `None`. The `search_settings` DB columns are `NOT NULL`, so the insert failed with:

```
psycopg2.errors.NotNullViolation: null value in column "query_prefix" of relation "search_settings" violates not-null constraint
```

The SQLAlchemy model declares these columns `nullable=True`, but no migration ever dropped the original `NOT NULL` constraint, so the DB still rejects NULLs. This latent bug surfaced once #11606 unblocked the UI flow for connecting these providers.

Fix is **pure code, no schema migration** (so it can be cherry-picked cleanly):
- Coerce `None -> ""` (the empty-string "no prefix" sentinel, matching the original embedding-models migration semantics) in `create_search_settings`.
- Default the Pydantic request fields (`EmbeddingModelDetail.query_prefix` / `passage_prefix`) to `""` so `None` never arrives when the client omits them.

The model's `nullable=True` annotation is left as-is to keep the hotfix surface minimal.

## How Has This Been Tested?

Added two external-dependency-unit regression tests in `test_search_settings.py`:
- `test_create_search_settings_coerces_none_prefixes` — drives the exact `None` path through the DB layer and asserts it persists `""` instead of raising `NotNullViolation`.
- `test_creation_request_defaults_blank_prefixes` — asserts the request model defaults blank prefixes to `""`.

Both pass. Pre-commit (ty type-check, ruff) passes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DB failures when creating or updating search settings with blank embedding prefixes by coercing null prefixes to empty strings and defaulting request fields to avoid NOT NULL errors.

- **Bug Fixes**
  - Coerce `None` to `""` for `query_prefix` and `passage_prefix` in both `create_search_settings` and `update_search_settings` to satisfy NOT NULL DB columns.
  - Default `EmbeddingModelDetail.query_prefix` and `EmbeddingModelDetail.passage_prefix` to `""` so omitted fields never send `None`.
  - Added regression tests for create/update paths and request defaults. No schema migration required.

<sup>Written for commit 8bbaaf4c6290d4b86e28d05d6355578d47a1e79c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

