### PR TITLE
fix(teams connector): retry transient Microsoft Graph 5xx errors

### DIFF
--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -32,6 +32,7 @@ from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.connectors.teams.models import Message
+from onyx.connectors.teams.utils import execute_query_with_retry
 from onyx.connectors.teams.utils import fetch_expert_infos
 from onyx.connectors.teams.utils import fetch_external_access
 from onyx.connectors.teams.utils import fetch_messages
@@ -585,7 +586,9 @@ def _collect_all_teams(
                     lambda req: _update_request_url(request=req, next_url=url)
                 )
 
-            team_collection = query.execute_query()
+            team_collection = execute_query_with_retry(
+                query, method_name="_collect_all_teams"
+            )
         except (ClientRequestException, ValueError) as e:
             # If OData filter fails, fall back to client-side filtering
             if not use_client_side_filtering and odata_filter:
@@ -742,9 +745,8 @@ def _get_team_by_id(
     graph_client: GraphClient,
     team_id: str,
 ) -> Team:
-    team_collection = (
-        graph_client.teams.get().filter(f"id eq '{team_id}'").top(1).execute_query()
-    )
+    query = graph_client.teams.get().filter(f"id eq '{team_id}'").top(1)
+    team_collection = execute_query_with_retry(query, method_name="_get_team_by_id")
 
     if not team_collection:
         raise ValueError(f"No team with {team_id=} was found")
@@ -775,7 +777,9 @@ def _collect_all_channels_from_team(
                 lambda req: _update_request_url(request=req, next_url=url)
             )
 
-        channel_collection = query.execute_query()
+        channel_collection = execute_query_with_retry(
+            query, method_name="_collect_all_channels_from_team"
+        )
         channels.extend(channel for channel in channel_collection if channel.id)
 
         if not channel_collection.has_next:

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -131,6 +131,10 @@ def _retry(
                 retry_after=response.headers.get("Retry-After"),
             )
             retry_number += 1
+            # On the final permitted attempt there's nothing left to retry, so
+            # don't sleep just to raise — surface the failure immediately.
+            if retry_number >= MAX_RETRIES:
+                break
             logger.warning(
                 "Retryable Graph error %s on %s (attempt %s/%s); "
                 "sleeping %.1fs before retry.",

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -1,10 +1,13 @@
+import random
 import time
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timezone
-from http import HTTPStatus
+from typing import Any
 
 from office365.graph_client import GraphClient
+from office365.runtime.client_request_exception import ClientRequestException
+from office365.runtime.queries.client_query import ClientQuery
 from office365.teams.channels.channel import Channel
 from office365.teams.channels.channel import ConversationMember
 
@@ -18,6 +21,73 @@ logger = setup_logger()
 
 
 _PUBLIC_MEMBERSHIP_TYPE = "standard"  # public teams channel
+
+
+# Transient Microsoft Graph statuses worth retrying: rate limits (429) plus
+# gateway/server-side hiccups (500/502/503/504). Shared by both the raw
+# `execute_request_direct` path (`_retry`) and the SDK `execute_query` path
+# (`execute_query_with_retry`) so the two can't drift. Mirrors the SharePoint
+# connector's `GRAPH_API_RETRYABLE_STATUSES`.
+GRAPH_API_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+
+def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
+    """Honor a numeric ``Retry-After`` header when the server provides one,
+    otherwise capped exponential backoff (5s, 10s, 20s, capped at 30s) with
+    equal jitter so many concurrent failures don't all retry on the same tick.
+
+    ``attempt`` is 0-indexed (0 for the first retry).
+    """
+    if retry_after:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    base = min(30, (2**attempt) * 5)
+    return base / 2 + random.uniform(0, base / 2)
+
+
+def execute_query_with_retry(
+    query: ClientQuery,
+    method_name: str,
+    max_retries: int = 5,
+) -> Any:
+    """Execute an ``office365`` SDK query, retrying transient Graph errors
+    (rate limits + 5xx gateway/server hiccups) with capped backoff.
+
+    Mirrors the SharePoint connector's ``sleep_and_retry`` so the two Microsoft
+    Graph connectors behave consistently. Non-retryable statuses (e.g. 401/403/
+    404, or a malformed OData filter 400) and exhausted retries are re-raised
+    for the caller to handle.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            return query.execute_query()
+        except ClientRequestException as e:
+            status = e.response.status_code if e.response is not None else None
+            if status not in GRAPH_API_RETRYABLE_STATUSES or attempt >= max_retries:
+                raise
+
+            retry_after = (
+                e.response.headers.get("Retry-After")
+                if e.response is not None
+                else None
+            )
+            cooldown = _backoff_seconds(attempt=attempt, retry_after=retry_after)
+            logger.warning(
+                "Retryable Graph error on %s (status=%s, attempt %s/%s); "
+                "sleeping %.1fs before retry.",
+                method_name,
+                status,
+                attempt + 1,
+                max_retries + 1,
+                cooldown,
+            )
+            time.sleep(cooldown)
+
+    # The loop returns on success and raises on non-retryable / exhausted
+    # errors, so this is unreachable; it satisfies the type checker.
+    raise RuntimeError(f"execute_query_with_retry exhausted retries for {method_name}")
 
 
 def _sanitize_message_user_display_name(value: dict) -> dict:
@@ -53,10 +123,23 @@ def _retry(
 
             return json
 
-        if response.status_code == int(HTTPStatus.TOO_MANY_REQUESTS):
+        # Transient Graph errors (rate limits + 5xx gateway/server hiccups) are
+        # retried with backoff; any other status is surfaced immediately.
+        if response.status_code in GRAPH_API_RETRYABLE_STATUSES:
+            cooldown = _backoff_seconds(
+                attempt=retry_number,
+                retry_after=response.headers.get("Retry-After"),
+            )
             retry_number += 1
-
-            cooldown = int(response.headers.get("Retry-After", 10))
+            logger.warning(
+                "Retryable Graph error %s on %s (attempt %s/%s); "
+                "sleeping %.1fs before retry.",
+                response.status_code,
+                request_url,
+                retry_number,
+                MAX_RETRIES,
+                cooldown,
+            )
             time.sleep(cooldown)
 
             continue

--- a/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
@@ -1,0 +1,127 @@
+"""Tests for the Microsoft Graph SDK retry helper used by the Teams connector.
+
+These exercise `execute_query_with_retry`, which wraps `office365` SDK
+`execute_query()` calls and retries transient Graph errors (rate limits + 5xx
+gateway/server hiccups). A live daily-connector test cannot reliably induce a
+502, so the retry behaviour is verified here in isolation.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from office365.runtime.client_request_exception import ClientRequestException
+
+from onyx.connectors.teams.utils import _backoff_seconds
+from onyx.connectors.teams.utils import execute_query_with_retry
+from onyx.connectors.teams.utils import GRAPH_API_RETRYABLE_STATUSES
+
+
+def _client_request_exception(
+    status_code: int,
+    headers: dict[str, str] | None = None,
+) -> ClientRequestException:
+    """Build a ClientRequestException carrying a response with the given status.
+
+    `ClientRequestException.__init__` reads `response.headers` and
+    `response.content`, so those must be present and well-formed.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.content = b""
+    return ClientRequestException("error", response=response)
+
+
+def _query_returning(*side_effects: Any) -> MagicMock:
+    query = MagicMock()
+    query.execute_query = MagicMock(side_effect=list(side_effects))
+    return query
+
+
+def test_returns_result_without_retry_on_success() -> None:
+    sentinel = object()
+    query = _query_returning(sentinel)
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        result = execute_query_with_retry(query, method_name="test")
+
+    assert result is sentinel
+    assert query.execute_query.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("status", sorted(GRAPH_API_RETRYABLE_STATUSES))
+def test_retries_transient_status_then_succeeds(status: int) -> None:
+    sentinel = object()
+    query = _query_returning(_client_request_exception(status), sentinel)
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        result = execute_query_with_retry(query, method_name="test")
+
+    assert result is sentinel
+    assert query.execute_query.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404])
+def test_does_not_retry_non_retryable_status(status: int) -> None:
+    query = _query_returning(_client_request_exception(status))
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        with pytest.raises(ClientRequestException):
+            execute_query_with_retry(query, method_name="test")
+
+    assert query.execute_query.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_reraises_after_exhausting_retries() -> None:
+    # Always fails with a retryable status.
+    query = MagicMock()
+    query.execute_query = MagicMock(
+        side_effect=_client_request_exception(502),
+    )
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        with pytest.raises(ClientRequestException):
+            execute_query_with_retry(query, method_name="test", max_retries=2)
+
+    # max_retries=2 => 3 total attempts, sleeping between each of the first two.
+    assert query.execute_query.call_count == 3
+    assert mock_sleep.call_count == 2
+
+
+def test_does_not_retry_when_response_is_missing() -> None:
+    # A ClientRequestException with no response (status=None) is not retryable.
+    # (The office365 ctor dereferences response.headers, so build it normally
+    # then null the response to exercise the helper's `response is None` branch.)
+    exc = _client_request_exception(502)
+    exc.response = None
+    query = _query_returning(exc)
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        with pytest.raises(ClientRequestException):
+            execute_query_with_retry(query, method_name="test")
+
+    assert query.execute_query.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_backoff_honors_numeric_retry_after() -> None:
+    # An explicit Retry-After is used verbatim, not jittered.
+    assert _backoff_seconds(attempt=0, retry_after="7") == 7.0
+
+
+def test_backoff_falls_back_to_capped_jittered_exponential() -> None:
+    # Without a Retry-After, sleep stays within [base/2, base] for base=min(30, 5*2^n).
+    for attempt, base in [(0, 5), (1, 10), (2, 20), (3, 30), (10, 30)]:
+        delay = _backoff_seconds(attempt=attempt, retry_after=None)
+        assert base / 2 <= delay <= base
+
+
+def test_backoff_ignores_non_numeric_retry_after() -> None:
+    # HTTP-date Retry-After values fall through to jittered exponential backoff.
+    delay = _backoff_seconds(attempt=0, retry_after="Wed, 21 Oct 2026 07:28:00 GMT")
+    assert 2.5 <= delay <= 5

--- a/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
@@ -1,0 +1,107 @@
+"""Tests for `_retry`, the raw Microsoft Graph request path in the Teams
+connector (`execute_request_direct`), used by `fetch_messages`/`fetch_replies`.
+
+`_retry` retries transient Graph errors (rate limits + 5xx gateway/server
+hiccups) with backoff and surfaces everything else immediately. A live
+daily-connector test cannot reliably induce a 5xx, so the behaviour is verified
+here in isolation.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from requests.exceptions import HTTPError
+
+from onyx.connectors.teams.utils import _retry
+from onyx.connectors.teams.utils import GRAPH_API_RETRYABLE_STATUSES
+
+
+def _response(
+    ok: bool,
+    status_code: int = 200,
+    json_value: Any = None,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.ok = ok
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.json = MagicMock(return_value={} if json_value is None else json_value)
+    if not ok:
+        response.raise_for_status = MagicMock(
+            side_effect=HTTPError(f"{status_code} error")
+        )
+    return response
+
+
+def _graph_client(*responses: MagicMock) -> MagicMock:
+    graph_client = MagicMock()
+    graph_client.execute_request_direct = MagicMock(side_effect=list(responses))
+    return graph_client
+
+
+def test_returns_json_without_retry_on_success() -> None:
+    payload = {"value": [1, 2, 3]}
+    graph_client = _graph_client(_response(ok=True, json_value=payload))
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        result = _retry(graph_client=graph_client, request_url="teams")
+
+    assert result == payload
+    assert graph_client.execute_request_direct.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+@pytest.mark.parametrize("status", sorted(GRAPH_API_RETRYABLE_STATUSES))
+def test_retries_transient_status_then_succeeds(status: int) -> None:
+    payload = {"ok": True}
+    graph_client = _graph_client(
+        _response(ok=False, status_code=status),
+        _response(ok=True, json_value=payload),
+    )
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        result = _retry(graph_client=graph_client, request_url="teams")
+
+    assert result == payload
+    assert graph_client.execute_request_direct.call_count == 2
+    mock_sleep.assert_called_once()
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404])
+def test_does_not_retry_non_retryable_status(status: int) -> None:
+    graph_client = _graph_client(_response(ok=False, status_code=status))
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        with pytest.raises(HTTPError):
+            _retry(graph_client=graph_client, request_url="teams")
+
+    assert graph_client.execute_request_direct.call_count == 1
+    mock_sleep.assert_not_called()
+
+
+def test_raises_when_json_is_not_an_object() -> None:
+    # A 200 whose body is a JSON array (not an object) is a contract violation.
+    graph_client = _graph_client(_response(ok=True, json_value=[1, 2, 3]))
+
+    with patch("onyx.connectors.teams.utils.time.sleep"):
+        with pytest.raises(RuntimeError):
+            _retry(graph_client=graph_client, request_url="teams")
+
+
+def test_raises_runtime_error_after_exhausting_retries() -> None:
+    # Always returns a retryable status; _retry caps at MAX_RETRIES (10) attempts
+    # and then raises rather than looping forever.
+    graph_client = MagicMock()
+    graph_client.execute_request_direct = MagicMock(
+        return_value=_response(ok=False, status_code=503),
+    )
+
+    with patch("onyx.connectors.teams.utils.time.sleep") as mock_sleep:
+        with pytest.raises(RuntimeError, match="Max number of retries"):
+            _retry(graph_client=graph_client, request_url="teams")
+
+    assert graph_client.execute_request_direct.call_count == 10
+    assert mock_sleep.call_count == 10

--- a/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
@@ -103,5 +103,7 @@ def test_raises_runtime_error_after_exhausting_retries() -> None:
         with pytest.raises(RuntimeError, match="Max number of retries"):
             _retry(graph_client=graph_client, request_url="teams")
 
+    # 10 attempts are made, but the final (exhausted) attempt raises immediately
+    # instead of sleeping, so there are only 9 backoff sleeps.
     assert graph_client.execute_request_direct.call_count == 10
-    assert mock_sleep.call_count == 10
+    assert mock_sleep.call_count == 9


### PR DESCRIPTION
## Description

The Teams **daily connector test** (`test_loading_all_docs_from_teams_connector`) was failing on a sporadic upstream **502 Bad Gateway** from `graph.microsoft.com`:

```
ClientRequestException: ('UnknownError', 'Bad Gateway',
'502 Server Error: Bad Gateway for url:
https://graph.microsoft.com/v1.0/teams/.../channels')
```

The 502 surfaced out of `_collect_all_channels_from_team`, which called the `office365` SDK `execute_query()` with **no retry logic**. That exact code path also runs in production via the docfetching worker, so the right fix is to make the *connector* resilient to transient Graph errors — not to tolerate/skip the 502 in the test (which would hide regressions and leave prod exposed). With the connector retrying, the daily test passes for free while a *sustained* Graph outage still fails it correctly.

This follows the precedent already set by the SharePoint connector (same SDK, same Graph API), which classifies `{429, 500, 502, 503, 504}` as retryable.

### Changes
- Add a shared `GRAPH_API_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}` and `_backoff_seconds` (honors a numeric `Retry-After`, else capped exponential backoff with equal jitter), mirroring SharePoint's helper.
- Add `execute_query_with_retry()` for SDK `execute_query()` calls and wire it into the three data-fetching call sites: `_collect_all_channels_from_team` (the one that 502'd), `_collect_all_teams`, and `_get_team_by_id`. Non-retryable statuses (401/403/404, malformed-OData 400) and exhausted retries re-raise.
- Extend the existing `_retry` (raw `execute_request_direct` path used by `fetch_messages`/`fetch_replies`) from **429-only** to the same transient set + shared backoff.
- Left `validate_connector_settings` fail-fast (it's intentionally inside a short `run_with_timeout`).

## How Has This Been Tested?

New unit tests for **both** retry paths (`backend/tests/unit/onyx/connectors/teams/`):
- `test_execute_query_with_retry.py` — SDK path: success, retry-then-succeed across every retryable status, no-retry on each non-retryable status, retry exhaustion, the `response is None` branch, and `_backoff_seconds` bounds.
- `test_retry_request.py` — raw path: same matrix plus the non-dict-JSON contract violation and the `MAX_RETRIES` cap.

Full teams unit suite: **30 passed** (3 existing + 27 new). `ruff` and `ty` clean on all changed files.

The live daily test against real Teams can't run locally (needs Teams secrets); it'll validate end-to-end in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Teams connector retry transient Microsoft Graph errors with capped backoff to stop flaky 5xx/429 failures. Skip the backoff sleep on the final retry attempt so exhausted retries fail fast.

- **Bug Fixes**
  - Add shared `GRAPH_API_RETRYABLE_STATUSES` = {429, 500, 502, 503, 504} and `_backoff_seconds` (honors numeric `Retry-After`; else jittered exponential capped at 30s).
  - Introduce `execute_query_with_retry()` for `office365` `execute_query()` calls; used in `_collect_all_teams`, `_get_team_by_id`, and `_collect_all_channels_from_team`. Non-retryable errors still bubble up.
  - Expand `_retry` (raw `execute_request_direct` path) to the same status set and backoff, and avoid sleeping on the last permitted attempt.
  - Align behavior with the SharePoint connector for consistency.

<sup>Written for commit 1d9a6ee9e4d5dcd8ae3bf68b22849a2a79f92165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

