### PR TITLE
feat(helm): allow disabling bundled redis-operator independently

### DIFF
--- a/deployment/helm/charts/onyx/Chart.lock
+++ b/deployment/helm/charts/onyx/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: code-interpreter
   repository: https://onyx-dot-app.github.io/python-sandbox/
   version: 0.4.3
-digest: sha256:374deb7be92d1545c6981e99461414b6e4a89a1faf162882a9f66b824ce4d8c1
-generated: "2026-06-02T10:30:32.542373-07:00"
+digest: sha256:e3a28faa3b9274e7d70cbcb2d7e45685b028db6bad1b24425d4959ece89d7ca8
+generated: "2026-06-02T15:43:42.285202-07:00"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.15
+version: 0.5.16
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,8 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: changed
-      description: Bump the `code-interpreter` subchart from 0.4.2 to 0.4.3.
+    - kind: added
+      description: Allow disabling the bundled `redis-operator` subchart
+        independently of the Redis instance via `redisOperator.enabled`. Leave it
+        unset to keep the existing behavior (operator follows `redis.enabled`);
+        set it to `false` to skip the bundled operator and have an existing
+        cluster-wide redis-operator reconcile the chart's Redis CR.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0
@@ -33,11 +37,13 @@ dependencies:
     repository: https://kubernetes.github.io/ingress-nginx
     condition: nginx.enabled
     alias: nginx
-  # Installs the Redis CRD that the 'redis' subchart's CR binds to.
+  # Helm uses the first condition path that exists: `redisOperator.enabled` is
+  # unset by default, so this falls through to `redis.enabled`. Set it false to
+  # skip the bundled operator and reuse an existing one (see values.yaml).
   - name: redis-operator
     version: 0.24.0
     repository: https://ot-container-kit.github.io/helm-charts
-    condition: redis.enabled
+    condition: redisOperator.enabled,redis.enabled
   - name: redis
     version: 0.16.6
     repository: https://ot-container-kit.github.io/helm-charts

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -993,6 +993,12 @@ celery_worker_docfetching:
 #
 ######################################################################
 
+# Uncomment to skip the bundled redis-operator and let an existing cluster-wide
+# operator reconcile the Redis CR below (keep redis.enabled: true). Your operator
+# must provide the redis.redis.opstreelabs.in/v1beta2 CRDs. Unset = follow redis.enabled.
+# redisOperator:
+#   enabled: false
+
 redis:
   enabled: true
   redisStandalone:


### PR DESCRIPTION
## Description

Decouples the bundled `redis-operator` subchart from the `redis.enabled` flag so the operator can be disabled independently of the Redis instance.

Previously both the `redis-operator` and `redis` subcharts were gated on the single `redis.enabled` condition. That bundled operator creates cluster-scoped RBAC (a `ClusterRole`/`ClusterRoleBinding` named `redis-operator`), which collides with any existing cluster-wide redis-operator already installed via a separate Helm release — Helm refuses to adopt a cluster-scoped resource owned by another release, so the upgrade fails.

This PR adds a dedicated `redisOperator.enabled` toggle. The `redis-operator` dependency condition becomes the comma list `redisOperator.enabled,redis.enabled`; Helm evaluates the first path that exists. `redisOperator.enabled` is left unset by default, so it falls through to `redis.enabled` and **existing installs are unchanged**.

Operators who already run a cluster-wide redis-operator can now set `redisOperator.enabled: false` (keeping `redis.enabled: true`): the bundled operator is skipped, but the chart still renders the `redis.redis.opstreelabs.in/v1beta2` Redis CR for their existing operator to reconcile — no RBAC collision and no lifecycle coupling of the operator to the Onyx release. They must provide the matching CRDs.

Chart bumped to `0.5.16`.

## How Has This Been Tested?

`helm template` rendered in three modes, plus `helm lint`:

| Mode | Bundled operator | Redis CR |
|---|---|---|
| Default (nothing set) | present | present |
| `redisOperator.enabled=false` | skipped | present |
| `redis.enabled=false` | skipped | skipped |

Confirms the default path is backward-compatible, the new toggle drops only the operator while keeping the Redis CR, and fully disabling Redis still removes both.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `redisOperator.enabled` to disable the bundled `redis-operator` without turning off `redis`. Prevents cluster-scoped RBAC conflicts with an existing cluster-wide operator; defaults unchanged, chart bumped to `0.5.16`, and `Chart.lock` synced.

- **Migration**
  - If you already run a cluster-wide `redis-operator`, set `redisOperator.enabled: false` and keep `redis.enabled: true`.
  - Ensure the `redis.redis.opstreelabs.in/v1beta2` CRDs are installed; the chart will still render the Redis CR for your operator.

<sup>Written for commit aeeb87c6cc241c84767faf0759242228337fd615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

