### PR TITLE
ci: tolerate merge-queue branch deletion in paths-filter steps

### DIFF
--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the step's
+        # outputs go empty and the `|| 'true'` fallback above runs everything.
+        continue-on-error: true
         with:
           filters: |
             db:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -64,6 +64,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the step's
+        # outputs go empty and the `|| 'true'` fallback above runs everything.
+        continue-on-error: true
         with:
           filters: |
             integration:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -91,6 +91,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the step's
+        # outputs go empty and the `|| 'true'` fallback above runs everything.
+        continue-on-error: true
         with:
           filters: |
             playwright:

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the step's
+        # outputs go empty and the `|| 'true'` fallback above runs everything.
+        continue-on-error: true
         with:
           filters: |
             python:

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -124,6 +124,14 @@ jobs:
       - name: Detect Connector changes
         id: changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the outputs go
+        # empty, so the base connector suite below still runs and only the
+        # optional HubSpot/Salesforce/GitHub steps are skipped (they're
+        # non-blocking on presubmit and the daily cron covers them anyway).
+        continue-on-error: true
         with:
           filters: |
             hubspot:

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -31,6 +31,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # ratchet:dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        # In the merge queue, GitHub can delete the ephemeral
+        # `gh-readonly-queue/*` branch mid-run (e.g. when an entry ahead in the
+        # queue fails and the queue is rebuilt), after which paths-filter fails
+        # fetching that now-missing ref. Tolerate it: on failure the step's
+        # outputs go empty and the `|| 'true'` fallback above runs everything.
+        continue-on-error: true
         with:
           filters: |
             python:


### PR DESCRIPTION
## What

Mark every `dorny/paths-filter` step across the PR test workflows `continue-on-error: true` so a transient merge-queue race can't fail the job.

## Why

Example failure: [run 26854563629](https://github.com/onyx-dot-app/onyx/actions/runs/26854563629/job/79194711466)

```
git fetch --no-tags --depth=100 origin main gh-readonly-queue/main/pr-11356-...
fatal: couldn't find remote ref gh-readonly-queue/main/pr-11356-...
```

These workflows run on `merge_group`. GitHub's merge queue tests each entry on an **ephemeral** `gh-readonly-queue/*` branch. When an entry *ahead* in the queue fails (or the queue is reordered/dequeued), GitHub deletes and recreates the queue branches with new SHAs. If that happens mid-run, `paths-filter` — which does its own `git fetch` of the head ref *by name* to compute the diff — fails because the ref no longer exists, and the whole job goes red for a reason unrelated to the change under test.

Note this can't be fixed by passing `merge_group.head_ref`: that's the *same* ephemeral branch, and even the head SHA can become unfetchable once the branch is torn down. The robust move is to make the race **benign** rather than try to avoid it.

## How

`continue-on-error: true` lets the step fail softly; each workflow's existing fallback then takes over:

- **5 filter-gated suites** (`pr-python-tests`, `pr-python-checks`, `pr-database-tests`, `pr-integration-tests`, `pr-playwright-tests`) read `${{ steps.filter.outputs.X || 'true' }}`. Empty outputs → `'true'` → the full suite runs (safe direction).
- **`pr-python-connector-tests`** runs its base connector suite unconditionally and only gates the optional HubSpot/Salesforce/GitHub steps on the filter outputs. Empty outputs → base suite still runs; the optional steps skip (they're non-blocking on presubmit and the daily cron covers them).

In the normal case (branch still exists) nothing changes — filtering works and still saves CI.

## Test plan

- [x] YAML structure / indentation verified across all 6 files
- [ ] Confirm green through the merge queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened PR test workflows against merge-queue races by marking all `dorny/paths-filter` steps `continue-on-error: true`. This avoids job failures when `gh-readonly-queue/*` refs disappear mid-run and safely falls back to running full suites.

- **Bug Fixes**
  - Applied to: `pr-python-tests`, `pr-python-checks`, `pr-database-tests`, `pr-integration-tests`, `pr-playwright-tests`, `pr-python-connector-tests`.
  - On filter failure: five suites run everything via their `|| 'true'` default; connector tests run the base suite while optional HubSpot/Salesforce/GitHub steps skip.
  - Normal case unchanged: filtering still works and saves CI time.

<sup>Written for commit bad2c4a04c020ad60fb1e9b8e3506d31ae7c0b73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

