### PR TITLE
feat(craft): scope sandbox PAT to read:search + exempt /me from scope gate

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1797,28 +1797,24 @@ async def _maybe_refresh_oauth_tokens(
         )
 
 
+def scope_exempt() -> None:
+    """Marker dependency: tags a route reachable by any scoped PAT."""
+
+
+scope_exempt._is_scope_exempt = True  # ty: ignore[unresolved-attribute]
+
+
 def _scoped_pat_permitted_on_route(
     token_scopes: list[Permission] | None, route: BaseRoute | None
 ) -> bool:
-    """Fail-closed coverage check for scoped PATs.
-
-    Unrestricted PAT / session / API-key auth (token_scopes is None) is
-    unaffected. A scoped PAT may only reach routes that declare a
-    require_permission dependency; require_permission then adjudicates whether
-    the scopes actually cover it. A route with no require_permission is denied,
-    so a narrowly-scoped token can't reach arbitrary endpoints that merely lack
-    a permission guard.
-    """
-    # No scopes (None) == unrestricted: session / unrestricted PAT / API-key
-    # auth carry no token cap, so every route is allowed.
+    """Whether a scoped PAT may proceed on this route (fail-closed)."""
     if token_scopes is None:
         return True
-    # Only an APIRoute carries a dependant; anything else (no match, a mounted
-    # or websocket route) declares no permission, so deny the scoped PAT.
     if not isinstance(route, APIRoute):
         return False
     return any(
-        getattr(dependency.cache_key[0], "_is_require_permission", False)
+        getattr(dependency.call, "_is_require_permission", False)
+        or getattr(dependency.call, "_is_scope_exempt", False)
         for dependency in route.dependant.dependencies
     )
 

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -129,7 +129,7 @@ def check_router_auth(
         )
         if route_dependant_obj:
             for dependency in route_dependant_obj.dependencies:
-                depends_fn = dependency.cache_key[0]
+                depends_fn = dependency.call
                 if (
                     depends_fn == current_limited_user
                     or depends_fn == current_user

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.pat import hash_pat
 from onyx.db.enums import PatType
+from onyx.db.enums import Permission
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import PersonalAccessToken
 from onyx.db.models import Sandbox
@@ -55,6 +56,7 @@ def ensure_sandbox_pat(db_session: Session, sandbox: Sandbox, user: User) -> str
         name=f"craft-{user.id}",
         expiration_days=_PAT_EXPIRATION_DAYS,
         pat_type=PatType.CRAFT,
+        scopes=[Permission.READ_SEARCH],
     )
 
     sandbox.encrypted_pat = raw_token  # ty: ignore[invalid-assignment]

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -58,7 +58,7 @@ router = APIRouter(prefix="/search")
 @router.post("", dependencies=[Depends(require_vector_db)])
 def search(
     request: SearchRequest,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.READ_SEARCH)),
     db_session: Session = Depends(get_session),
 ) -> SearchResponse:
     # 1. Load persona

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -34,6 +34,7 @@ from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.auth.users import enforce_seat_limit_locked
 from onyx.auth.users import optional_user
+from onyx.auth.users import scope_exempt
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import AuthBackend
@@ -873,7 +874,7 @@ def get_current_user_permissions(
     return sorted(p.value for p in get_effective_permissions(user))
 
 
-@router.get("/me", tags=PUBLIC_API_TAGS)
+@router.get("/me", tags=PUBLIC_API_TAGS, dependencies=[Depends(scope_exempt)])
 def verify_user_logged_in(
     request: Request,
     user: User | None = Depends(optional_user),

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_pat.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.pat import hash_pat
 from onyx.db.enums import PatType
+from onyx.db.enums import Permission
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import PersonalAccessToken
 from onyx.db.models import Sandbox
@@ -59,6 +60,7 @@ class TestEnsureSandboxPat:
         pat = db_session.query(PersonalAccessToken).filter_by(hashed_token=hashed).one()
         assert pat.pat_type == PatType.CRAFT
         assert pat.user_id == test_user.id
+        assert pat.scopes == [Permission.READ_SEARCH.value]
 
     def test_second_call_reuses_token(
         self,

--- a/backend/tests/integration/common_utils/managers/pat.py
+++ b/backend/tests/integration/common_utils/managers/pat.py
@@ -1,7 +1,12 @@
 """Helper for managing Personal Access Tokens in integration tests."""
 
+from uuid import UUID
+
 import httpx
 
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import Permission
+from onyx.db.pat import create_pat
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestPAT
@@ -36,6 +41,25 @@ class PATManager:
         )
         response.raise_for_status()
         return DATestPAT(**response.json())
+
+    @staticmethod
+    def create_scoped(
+        name: str,
+        expiration_days: int | None,
+        user_performing_action: DATestUser,
+        scopes: list[Permission] | None,
+    ) -> str:
+        """Mint a PAT with explicit scopes and return the raw token."""
+        with get_session_with_current_tenant() as db_session:
+            _, raw_token = create_pat(
+                db_session=db_session,
+                user_id=UUID(user_performing_action.id),
+                name=name,
+                expiration_days=expiration_days,
+                scopes=scopes,
+            )
+            db_session.commit()
+        return raw_token
 
     @staticmethod
     def list(user_performing_action: DATestUser) -> list[DATestPAT]:

--- a/backend/tests/integration/tests/permissions/test_pat_scopes.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scopes.py
@@ -1,122 +1,75 @@
-"""Integration tests for PAT scope enforcement.
-
-A PAT's scopes cap the request on top of the owner's permissions. Using the
-real auth plumbing (PAT header -> request.state.token_scopes -> require_permission):
-
-  - an unrestricted PAT (the default — no scopes) reaches BASIC_ACCESS
-    endpoints, and
-  - a PAT scoped to read:search is denied those same endpoints, because
-    read:search does not cover BASIC_ACCESS.
-
-This exercises the token-scope gate end-to-end against existing BASIC_ACCESS
-routes (no fine-grained route guards required).
-"""
-
-from uuid import UUID
+"""Integration tests for PAT scope enforcement through the real auth plumbing."""
 
 import pytest
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import Permission
-from onyx.db.pat import create_pat
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.test_models import DATestUser
 
-# A representative BASIC_ACCESS-guarded endpoint.
 BASIC_ACCESS_ENDPOINT = ("GET", "/user/pats")
+IDENTITY_ENDPOINT = ("GET", "/me")
 
 
 def _pat_headers(user: DATestUser, scopes: list[Permission] | None) -> dict[str, str]:
-    with get_session_with_current_tenant() as db_session:
-        _, raw_token = create_pat(
-            db_session=db_session,
-            user_id=UUID(user.id),
-            name="scope_test_pat",
-            expiration_days=None,
-            scopes=scopes,
-        )
-        db_session.commit()
-    return {"Authorization": f"Bearer {raw_token}"}
+    raw_token = PATManager.create_scoped(
+        name="scope_test_pat",
+        expiration_days=None,
+        user_performing_action=user,
+        scopes=scopes,
+    )
+    return PATManager.get_auth_headers(raw_token)
 
 
 @pytest.fixture(scope="module")
-def basic_user_unrestricted_pat_headers(
+def unrestricted_pat_headers(
     permission_basic_user: DATestUser,
 ) -> dict[str, str]:
     return _pat_headers(permission_basic_user, scopes=None)
 
 
 @pytest.fixture(scope="module")
-def basic_user_search_scoped_pat_headers(
+def search_scoped_pat_headers(
     permission_basic_user: DATestUser,
 ) -> dict[str, str]:
     return _pat_headers(permission_basic_user, scopes=[Permission.READ_SEARCH])
 
 
+def _request(headers: dict[str, str], endpoint: tuple[str, str]) -> int:
+    method, path = endpoint
+    return client.request(
+        method, f"{API_SERVER_URL}{path}", headers=headers, timeout=30
+    ).status_code
+
+
 def test_unrestricted_pat_reaches_basic_access_endpoint(
-    basic_user_unrestricted_pat_headers: dict[str, str],
+    unrestricted_pat_headers: dict[str, str],
 ) -> None:
-    method, path = BASIC_ACCESS_ENDPOINT
-    resp = client.request(
-        method,
-        f"{API_SERVER_URL}{path}",
-        headers=basic_user_unrestricted_pat_headers,
-        timeout=30,
-    )
-    assert resp.status_code < 400, (
-        f"Unrestricted PAT should reach {method} {path}, got {resp.status_code}"
+    status = _request(unrestricted_pat_headers, BASIC_ACCESS_ENDPOINT)
+    assert status < 400, (
+        f"Unrestricted PAT should reach BASIC_ACCESS route, got {status}"
     )
 
 
 def test_search_scoped_pat_denied_on_basic_access_endpoint(
-    basic_user_search_scoped_pat_headers: dict[str, str],
+    search_scoped_pat_headers: dict[str, str],
 ) -> None:
-    method, path = BASIC_ACCESS_ENDPOINT
-    resp = client.request(
-        method,
-        f"{API_SERVER_URL}{path}",
-        headers=basic_user_search_scoped_pat_headers,
-        timeout=30,
-    )
-    assert resp.status_code == 403, (
-        f"read:search-scoped PAT should be denied on {method} {path} "
-        f"(read:search does not cover basic), got {resp.status_code}"
+    status = _request(search_scoped_pat_headers, BASIC_ACCESS_ENDPOINT)
+    assert status == 403, (
+        f"read:search PAT should be denied on BASIC_ACCESS route, got {status}"
     )
 
 
-# /me uses optional_user with no require_permission — an "unguarded" route. The
-# fail-closed gate denies a scoped PAT there while leaving an unrestricted PAT
-# (and sessions / API keys) untouched.
-UNGUARDED_ENDPOINT = ("GET", "/me")
-
-
-def test_unrestricted_pat_reaches_unguarded_endpoint(
-    basic_user_unrestricted_pat_headers: dict[str, str],
+def test_search_scoped_pat_reaches_identity_endpoint(
+    search_scoped_pat_headers: dict[str, str],
 ) -> None:
-    method, path = UNGUARDED_ENDPOINT
-    resp = client.request(
-        method,
-        f"{API_SERVER_URL}{path}",
-        headers=basic_user_unrestricted_pat_headers,
-        timeout=30,
-    )
-    assert resp.status_code < 400, (
-        f"Unrestricted PAT should reach {method} {path}, got {resp.status_code}"
-    )
+    status = _request(search_scoped_pat_headers, IDENTITY_ENDPOINT)
+    assert status < 400, f"scoped PAT should reach the scope-exempt /me, got {status}"
 
 
-def test_scoped_pat_denied_on_unguarded_endpoint(
-    basic_user_search_scoped_pat_headers: dict[str, str],
+def test_unrestricted_pat_reaches_identity_endpoint(
+    unrestricted_pat_headers: dict[str, str],
 ) -> None:
-    method, path = UNGUARDED_ENDPOINT
-    resp = client.request(
-        method,
-        f"{API_SERVER_URL}{path}",
-        headers=basic_user_search_scoped_pat_headers,
-        timeout=30,
-    )
-    assert resp.status_code == 403, (
-        f"A scoped PAT must be denied on the unguarded route {method} {path} "
-        f"(fail-closed), got {resp.status_code}"
-    )
+    status = _request(unrestricted_pat_headers, IDENTITY_ENDPOINT)
+    assert status < 400, f"Unrestricted PAT should reach /me, got {status}"

--- a/backend/tests/integration/tests/search/test_search_api.py
+++ b/backend/tests/integration/tests/search/test_search_api.py
@@ -8,11 +8,13 @@ import httpx
 import pytest
 
 from onyx.db.enums import AccessType
+from onyx.db.enums import Permission
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.cc_pair import CCPairManager
 from tests.integration.common_utils.managers.document import DocumentManager
 from tests.integration.common_utils.managers.document_set import DocumentSetManager
+from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.managers.persona import PersonaManager
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager
@@ -188,3 +190,29 @@ def test_unauthenticated_returns_401() -> None:
         json={"query": "test"},
     )
     assert resp.status_code == 403
+
+
+def test_read_search_scoped_pat_can_search(
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    api_key: DATestAPIKey,
+) -> None:
+    cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
+    doc_content = "scoped pat search api unique document"
+    DocumentManager.seed_doc_with_content(cc_pair, doc_content, api_key)
+
+    raw_token = PATManager.create_scoped(
+        name="search-scoped-pat",
+        expiration_days=7,
+        user_performing_action=admin_user,
+        scopes=[Permission.READ_SEARCH],
+    )
+    resp = client.post(
+        SEARCH_URL,
+        json={"query": doc_content},
+        headers=PATManager.get_auth_headers(raw_token),
+    )
+    assert resp.status_code == 200
+
+    matches = [r for r in resp.json()["results"] if doc_content in r["content"]]
+    assert len(matches) == 1

--- a/backend/tests/unit/onyx/auth/test_scoped_pat_route_gate.py
+++ b/backend/tests/unit/onyx/auth/test_scoped_pat_route_gate.py
@@ -3,10 +3,11 @@
 `_scoped_pat_permitted_on_route` decides whether a PAT-authenticated request may
 proceed past `optional_user`: an unrestricted token (None scopes) always may; a
 scoped token may only reach routes that declare a `require_permission` (which
-then adjudicates coverage). Routes with no such guard are denied outright.
+then adjudicates coverage) or are marked `scope_exempt` (identity endpoints).
+Routes with neither are denied outright.
 
-Uses real APIRoutes + real require_permission so the dependant introspection is
-exercised exactly as it is at runtime.
+Uses real APIRoutes + real require_permission / scope_exempt so the dependant
+introspection is exercised exactly as it is at runtime.
 """
 
 from fastapi import Depends
@@ -14,6 +15,7 @@ from fastapi.routing import APIRoute
 
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import _scoped_pat_permitted_on_route
+from onyx.auth.users import scope_exempt
 from onyx.db.enums import Permission
 
 
@@ -26,6 +28,10 @@ def _guarded_route() -> APIRoute:
         _endpoint,
         dependencies=[Depends(require_permission(Permission.READ_SEARCH))],
     )
+
+
+def _scope_exempt_route() -> APIRoute:
+    return APIRoute("/x", _endpoint, dependencies=[Depends(scope_exempt)])
 
 
 def _unguarded_route() -> APIRoute:
@@ -42,6 +48,11 @@ class TestScopedPatPermittedOnRoute:
         # The gate only checks a guard exists; require_permission adjudicates coverage.
         assert _scoped_pat_permitted_on_route(
             [Permission.READ_SEARCH], _guarded_route()
+        )
+
+    def test_scoped_token_allowed_on_scope_exempt_route(self) -> None:
+        assert _scoped_pat_permitted_on_route(
+            [Permission.READ_SEARCH], _scope_exempt_route()
         )
 
     def test_scoped_token_denied_on_unguarded_route(self) -> None:

--- a/docs/craft/features/pat-scopes/pat-scopes.md
+++ b/docs/craft/features/pat-scopes/pat-scopes.md
@@ -68,6 +68,12 @@ routes guarded by a permission, and `require_permission` then adjudicates covera
 sessions, and API-key auth (token scopes `None`) are untouched; websocket auth has its own path and is
 unaffected.
 
+**Identity endpoints are scope-exempt.** "Who am I" endpoints must be reachable by any valid token
+regardless of authority — the industry-standard treatment of OAuth `/userinfo`. A route marks itself
+with a `scope_exempt` dependency (a sibling `_is_scope_exempt` sentinel the gate honors alongside
+`_is_require_permission`), and `/me` carries it. Without it the fail-closed gate would deny a scoped
+PAT on `/me`, which a token has no business being locked out of.
+
 ## Delivery
 
 Sequenced so enforcement is complete before any scoped token exists:
@@ -80,10 +86,15 @@ Sequenced so enforcement is complete before any scoped token exists:
 3. **Fail-closed gate** — `optional_user` denies a scoped PAT on routes that declare no
    `require_permission`, so enforcement covers non-guarded routes too. *Shipped.*
 4. **Re-guard routes** with the fine permissions (search / chat read+write / admin read vs. write).
-   The `READ_ADMIN` split is a real audit, not a rename.
-5. **Scope the Craft PAT** — `ensure_sandbox_pat` mints `[READ_SEARCH]` (plus whatever onyx-cli needs)
-   instead of unrestricted, retiring the "CRAFT PAT grants full user access" caveat. This is the
-   acceptance test for the effort.
+   `POST /search` — the endpoint the Craft sandbox actually hits (its agent's `company-search` skill
+   runs `onyx-cli search`, which calls `POST /search` and nothing else) — now carries `READ_SEARCH`.
+   *Shipped (the one route the sandbox needs).* The rest of the search surface (web-search, the
+   read-only `/manage` metadata used by the separate MCP server) plus the chat read/write and
+   `READ_ADMIN` splits remain.
+5. **Scope the Craft PAT** — `ensure_sandbox_pat` mints `[READ_SEARCH]` instead of unrestricted,
+   retiring the "CRAFT PAT grants full user access" caveat. *Shipped.* This is the acceptance test for
+   the effort: the search-scoped sandbox PAT reaches `POST /search` (via `onyx-cli search`) and `/me`,
+   and nothing else.
 
 Setting scopes when minting a PAT is currently internal (a `create_pat` argument); a user-facing
 API/UI and surfacing scopes on token listings are follow-ups.

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -738,7 +738,9 @@ export function useLlmManager(
         currentChatSession.current_temperature_override,
         isAnthropicModel ? 1.0 : 2.0
       );
-    } else if (liveAgent?.tools.some((tool) => tool.name === SEARCH_TOOL_ID)) {
+    } else if (
+      liveAgent?.tools.some((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID)
+    ) {
       return 0;
     }
     return 0.5;
@@ -783,7 +785,9 @@ export function useLlmManager(
 
     if (currentChatSession?.current_temperature_override) {
       setTemperature(currentChatSession.current_temperature_override);
-    } else if (liveAgent?.tools.some((tool) => tool.name === SEARCH_TOOL_ID)) {
+    } else if (
+      liveAgent?.tools.some((tool) => tool.in_code_tool_id === SEARCH_TOOL_ID)
+    ) {
       setTemperature(0);
     } else {
       setTemperature(0.5);


### PR DESCRIPTION
## Description

Scopes the Craft sandbox PAT to **search-only**, so the token handed to the sandbox can't exercise the owner's full account.

The sandbox's only use of the token is its `company-search` skill running `onyx-cli search` → `POST /search`. So:

- `POST /search` now requires `READ_SEARCH` (was `BASIC_ACCESS`). No human/session impact — `BASIC_ACCESS` already implies `READ_SEARCH`.
- `ensure_sandbox_pat` mints `[READ_SEARCH]` instead of unrestricted.
- `/me` is marked `scope_exempt` so a scoped token can still reach its own identity (OAuth `/userinfo` convention); the fail-closed gate now admits routes declaring `require_permission` **or** `scope_exempt`.

Builds on the prior PAT-scopes work (token `scopes`, the user∩token intersection, the fail-closed gate). Broader search-surface and chat/admin route splits are deferred.

## How Has This Been Tested?

- Unit: gate admits scoped PATs on `require_permission`/`scope_exempt` routes, denies unguarded.
- Integration: scoped PAT denied on a `BASIC_ACCESS` route, reaches `/me`; a `READ_SEARCH` PAT reaches `POST /search` and returns results (the real `onyx-cli` path).
- External-dep: minted Craft PAT scopes == `[read:search]`.
- `ty` / `ruff` / format clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
