### PR TITLE
refactor(craft): extract session exception classes to errors.py [1/6]

### DIFF
--- a/backend/onyx/server/features/build/session/errors.py
+++ b/backend/onyx/server/features/build/session/errors.py
@@ -1,0 +1,32 @@
+"""Exception types raised by the build session layer.
+
+Kept in a tiny module so callers can import them without pulling in the
+full SessionManager dependency tree.
+"""
+
+
+class RateLimitError(Exception):
+    """Raised by ``SessionManager.check_rate_limit`` when the user has
+    exhausted their build-mode message budget."""
+
+    def __init__(
+        self,
+        message: str,
+        messages_used: int,
+        limit: int,
+        reset_timestamp: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.messages_used = messages_used
+        self.limit = limit
+        self.reset_timestamp = reset_timestamp
+
+
+class UploadLimitExceededError(ValueError):
+    """Raised when an upload would exceed the per-session file count or
+    total size limit."""
+
+
+class SandboxProvisioningError(RuntimeError):
+    """Raised when a sandbox is mid-provision and the caller cannot wait
+    it out."""

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,9 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.session.errors import RateLimitError
+from onyx.server.features.build.session.errors import SandboxProvisioningError
+from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.interrupt_signal import clear_interrupt
 from onyx.server.features.build.session.interrupt_signal import is_interrupt_requested
 from onyx.server.features.build.session.interrupt_signal import request_interrupt
@@ -155,14 +158,6 @@ def get_all_build_mode_llm_configs(
             )
         )
     return configs
-
-
-class UploadLimitExceededError(ValueError):
-    """Raised when file upload limits are exceeded."""
-
-
-class SandboxProvisioningError(RuntimeError):
-    """Raised when a sandbox is mid-provision and the caller cannot wait it out."""
 
 
 class BuildStreamingState:
@@ -305,22 +300,6 @@ HIDDEN_PATTERNS = {
     ".env",
     ".gitignore",
 }
-
-
-class RateLimitError(Exception):
-    """Exception raised when rate limit is exceeded."""
-
-    def __init__(
-        self,
-        message: str,
-        messages_used: int,
-        limit: int,
-        reset_timestamp: str | None = None,
-    ):
-        super().__init__(message)
-        self.messages_used = messages_used
-        self.limit = limit
-        self.reset_timestamp = reset_timestamp
 
 
 class SessionManager:


### PR DESCRIPTION
## Description

PR 1 of 6 in the SessionManager refactor stack. Moves `RateLimitError`, `UploadLimitExceededError`, and `SandboxProvisioningError` from `session/manager.py` into a new `session/errors.py`. `manager.py` re-imports them so `from ...session.manager import RateLimitError` still works.

Pure move — no behavior change.

## How Has This Been Tested?

- `ruff check` + `ty check` clean
- `pytest backend/tests/unit/onyx/server/features/build/session/` — 67/67 pass

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check