### PR TITLE
refactor(craft): extract sandbox state machine into sandbox_lifecycle.py [4/6]

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -50,7 +50,6 @@ from onyx.server.features.build.api.packets import ErrorPacket
 from onyx.server.features.build.api.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.configs import MAX_TOTAL_UPLOAD_SIZE_BYTES
 from onyx.server.features.build.configs import MAX_UPLOAD_FILES_PER_SESSION
-from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
 from onyx.server.features.build.db.build_session import allocate_nextjs_port
 from onyx.server.features.build.db.build_session import create_build_session__no_commit
 from onyx.server.features.build.db.build_session import create_message
@@ -64,9 +63,6 @@ from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import get_user_build_sessions
 from onyx.server.features.build.db.build_session import update_session_activity
 from onyx.server.features.build.db.build_session import upsert_agent_plan
-from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
-from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
-from onyx.server.features.build.db.sandbox import get_running_sandbox_count_by_tenant
 from onyx.server.features.build.db.sandbox import get_sandbox_by_session_id
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
@@ -87,6 +83,7 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.session import sandbox_lifecycle as _sandbox
 from onyx.server.features.build.session.errors import RateLimitError
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.errors import UploadLimitExceededError
@@ -375,30 +372,6 @@ class SessionManager:
                 "Failed to push user library to sandbox %s", sandbox_id, exc_info=True
             )
 
-    def _provision_sandbox(
-        self,
-        sandbox: Sandbox,
-        user: User,
-        user_id: UUID,
-        tenant_id: str,
-        all_llm_configs: list[LLMProviderConfig],
-    ) -> None:
-        """Ensure PAT, then provision the pod with every configured provider
-        pre-loaded so per-prompt model overrides can cross providers without a
-        pod restart. ``all_llm_configs[0]`` is the default model."""
-        onyx_pat = ensure_sandbox_pat(self._db_session, sandbox, user)
-        sandbox_info = self._sandbox_manager.provision(
-            sandbox_id=sandbox.id,
-            user_id=user_id,
-            tenant_id=tenant_id,
-            llm_config=all_llm_configs[0],
-            onyx_pat=onyx_pat,
-            all_llm_configs=all_llm_configs,
-        )
-        update_sandbox_status__no_commit(
-            self._db_session, sandbox.id, sandbox_info.status
-        )
-
     def ensure_sandbox_running(
         self,
         user_id: UUID,
@@ -436,113 +409,19 @@ class SessionManager:
             ValueError: Max concurrent sandboxes reached, or user missing.
             RuntimeError: Sandbox manager failed to provision the pod.
         """
-        sandbox = get_sandbox_by_user_id(self._db_session, user_id)
-
-        # If a concurrent caller is mid-provision, wait for them rather
-        # than race. We re-enter the state machine below with whatever
-        # status the row ends up in.
-        if sandbox is not None and sandbox.status == SandboxStatus.PROVISIONING:
-            sandbox = self._wait_for_provisioning_to_complete(
-                sandbox, provisioning_wait_seconds
-            )
-
-        # RUNNING + healthy is the hot path — return immediately.
-        if sandbox is not None and sandbox.status == SandboxStatus.RUNNING:
-            if self._sandbox_manager.health_check(sandbox.id, timeout=5.0):
-                return sandbox
-            # DB says RUNNING but the pod is gone; fall through to
-            # terminate + re-provision below.
-            logger.warning(
-                "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
-                sandbox.id,
-            )
-            self._sandbox_manager.terminate(sandbox.id)
-            update_sandbox_status__no_commit(
-                self._db_session, sandbox.id, SandboxStatus.TERMINATED
-            )
-
-        # All remaining branches will (re-)provision a pod, so honor
-        # per-tenant concurrency limits up front. We skip this check for
-        # the RUNNING+healthy path above because it doesn't add to the
-        # running count.
-        tenant_id = get_current_tenant_id()
-        if MULTI_TENANT:
-            running_count = get_running_sandbox_count_by_tenant(
-                self._db_session, tenant_id
-            )
-            if running_count >= SANDBOX_MAX_CONCURRENT_PER_ORG:
-                raise ValueError(
-                    f"Maximum concurrent sandboxes ({SANDBOX_MAX_CONCURRENT_PER_ORG}) reached"
-                )
-
         user = fetch_user_by_id(self._db_session, user_id)
         if user is None:
             raise ValueError(f"User {user_id} not found")
-
         _, all_llm_configs = self.build_llm_configs(user)
-
-        if sandbox is None:
-            sandbox = create_sandbox__no_commit(
-                db_session=self._db_session,
-                user_id=user_id,
-            )
-            logger.info(
-                "Created sandbox %s for user %s (headless provisioning)",
-                sandbox.id,
-                user_id,
-            )
-        else:
-            logger.info(
-                "Waking sandbox %s (status=%s) for user %s",
-                sandbox.id,
-                sandbox.status.value,
-                user_id,
-            )
-
-        self._provision_sandbox(sandbox, user, user_id, tenant_id, all_llm_configs)
-        return sandbox
-
-    def _wait_for_provisioning_to_complete(
-        self,
-        sandbox: Sandbox,
-        wait_seconds: float,
-        *,
-        poll_interval_seconds: float = 1.0,
-    ) -> Sandbox:
-        """Poll a PROVISIONING sandbox until it transitions or we time out.
-
-        Returns the same ``Sandbox`` object with refreshed attributes once
-        ``status`` is no longer ``PROVISIONING``. We rely on Postgres'
-        default READ COMMITTED isolation: ``session.refresh()`` issues a
-        fresh SELECT each iteration, so commits from the concurrent
-        provisioner become visible.
-
-        Raises:
-            SandboxProvisioningError: Status was still ``PROVISIONING``
-                when the deadline elapsed.
-        """
-        deadline = time.monotonic() + wait_seconds
-        started = time.monotonic()
-        logger.info(
-            "Waiting up to %.1fs for sandbox %s to finish provisioning",
-            wait_seconds,
-            sandbox.id,
+        return _sandbox.ensure_sandbox_ready(
+            self._db_session,
+            self._sandbox_manager,
+            user_id,
+            all_llm_configs,
+            policy=_sandbox.ProvisioningPolicy.POLL,
+            provisioning_wait_seconds=provisioning_wait_seconds,
+            user=user,
         )
-        while True:
-            self._db_session.refresh(sandbox)
-            if sandbox.status != SandboxStatus.PROVISIONING:
-                logger.info(
-                    "Sandbox %s left PROVISIONING after %.1fs (now=%s)",
-                    sandbox.id,
-                    time.monotonic() - started,
-                    sandbox.status.value,
-                )
-                return sandbox
-            if time.monotonic() >= deadline:
-                raise SandboxProvisioningError(
-                    f"Sandbox {sandbox.id} still PROVISIONING after {wait_seconds}s"
-                )
-            time.sleep(poll_interval_seconds)
 
     def create_session__no_commit(
         self,
@@ -576,18 +455,6 @@ class SessionManager:
             ValueError: If max concurrent sandboxes reached or no LLM provider
             RuntimeError: If sandbox provisioning fails
         """
-        tenant_id = get_current_tenant_id()
-
-        # Check sandbox limits for multi-tenant deployments
-        if MULTI_TENANT:
-            running_count = get_running_sandbox_count_by_tenant(
-                self._db_session, tenant_id
-            )
-            if running_count >= SANDBOX_MAX_CONCURRENT_PER_ORG:
-                raise ValueError(
-                    f"Maximum concurrent sandboxes ({SANDBOX_MAX_CONCURRENT_PER_ORG}) reached"
-                )
-
         # Fetch user early — needed for provider access checks, PAT, AGENTS.md.
         user = fetch_user_by_id(self._db_session, user_id)
         if not user:
@@ -628,79 +495,18 @@ class SessionManager:
             nextjs_port,
         )
 
-        # Check if user already has a sandbox (one sandbox per user model)
-        existing_sandbox = get_sandbox_by_user_id(self._db_session, user_id)
-
-        if existing_sandbox:
-            # User already has a sandbox - check if it needs re-provisioning
-            sandbox = existing_sandbox
-            sandbox_id = sandbox.id
-
-            if sandbox.status in (
-                SandboxStatus.TERMINATED,
-                SandboxStatus.SLEEPING,
-                SandboxStatus.FAILED,
-            ):
-                # Re-provision sandbox (pod doesn't exist or failed)
-                logger.info(
-                    "Re-provisioning %s sandbox %s for user %s",
-                    sandbox.status.value,
-                    sandbox_id,
-                    user_id,
-                )
-                self._provision_sandbox(
-                    sandbox, user, user_id, tenant_id, all_llm_configs
-                )
-            elif sandbox.status.is_active():
-                # Verify pod is healthy before reusing (use short timeout for quick check)
-                if not self._sandbox_manager.health_check(sandbox_id, timeout=5.0):
-                    logger.warning(
-                        "Sandbox %s marked as %s but pod is unhealthy/missing. Entering recovery mode.",
-                        sandbox_id,
-                        sandbox.status,
-                    )
-                    # Terminate to clean up any lingering K8s resources
-                    self._sandbox_manager.terminate(sandbox_id)
-
-                    # Mark as terminated and re-provision
-                    update_sandbox_status__no_commit(
-                        self._db_session, sandbox_id, SandboxStatus.TERMINATED
-                    )
-
-                    logger.info(
-                        "Re-provisioning sandbox %s for user %s", sandbox_id, user_id
-                    )
-                    self._provision_sandbox(
-                        sandbox, user, user_id, tenant_id, all_llm_configs
-                    )
-                else:
-                    logger.info(
-                        "Reusing existing sandbox %s (status: %s) for new session %s",
-                        sandbox_id,
-                        sandbox.status,
-                        session_id,
-                    )
-            else:
-                # PROVISIONING status - sandbox is being created by another request
-                # Just fail this request
-                msg = (
-                    f"Sandbox {sandbox_id} has status {sandbox.status.value} and is being "
-                    f"created by another request for new session {session_id}"
-                )
-                logger.error(msg)
-                raise RuntimeError(msg)
-        else:
-            # Create new Sandbox record for the user (uses flush, caller commits)
-            sandbox = create_sandbox__no_commit(
-                db_session=self._db_session,
-                user_id=user_id,
-            )
-            sandbox_id = sandbox.id
-            logger.info(
-                "Created sandbox record %s for session %s", sandbox_id, session_id
-            )
-
-            self._provision_sandbox(sandbox, user, user_id, tenant_id, all_llm_configs)
+        # Ensure the user's sandbox is RUNNING. Interactive callers can't
+        # afford to wait through a concurrent provisioner, so we use the
+        # FAIL policy (raise RuntimeError if another request is mid-
+        # provision).
+        sandbox = _sandbox.ensure_sandbox_ready(
+            self._db_session,
+            self._sandbox_manager,
+            user_id,
+            all_llm_configs,
+            policy=_sandbox.ProvisioningPolicy.FAIL,
+            user=user,
+        )
 
         # Set up session workspace within the sandbox
         logger.info(
@@ -722,7 +528,6 @@ class SessionManager:
         self._hydrate_skills(sandbox.id, user, files=skills_files)
         self._hydrate_user_library(sandbox.id, user_id)
 
-        sandbox_id = sandbox.id
         logger.info(
             "Successfully created session %s with workspace in sandbox %s",
             session_id,

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -1,0 +1,235 @@
+"""Sandbox readiness state machine + provisioning, shared between
+interactive (``create_session__no_commit``) and headless
+(``ensure_sandbox_running``) flows."""
+
+import time
+from enum import Enum
+from uuid import UUID
+
+from sqlalchemy.orm import Session as DBSession
+
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
+from onyx.db.models import User
+from onyx.db.users import fetch_user_by_id
+from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
+from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
+from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
+from onyx.server.features.build.db.sandbox import get_running_sandbox_count_by_tenant
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
+from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
+from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.session.errors import SandboxProvisioningError
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+
+_HEALTHCHECK_TIMEOUT_SECONDS = 5.0
+
+
+class ProvisioningPolicy(str, Enum):
+    """How to handle a sandbox already in ``PROVISIONING`` when we arrive.
+
+    - ``POLL``: wait for the concurrent provisioner to finish, then re-enter
+      the state machine on the resulting status. Used by headless callers
+      (scheduled tasks) that can afford to block.
+    - ``FAIL``: raise immediately. Used by interactive callers (web request
+      handlers) that hit a wall-clock deadline.
+    """
+
+    POLL = "poll"
+    FAIL = "fail"
+
+
+def provision_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+    user: User,
+    user_id: UUID,
+    tenant_id: str,
+    all_llm_configs: list[LLMProviderConfig],
+) -> None:
+    """Ensure a PAT exists, then provision the pod with every accessible
+    provider pre-loaded so per-prompt model overrides can cross providers
+    without a pod restart. ``all_llm_configs[0]`` is the default.
+
+    Updates the sandbox row's status to whatever the manager returns.
+    Caller is responsible for committing.
+    """
+    onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
+    sandbox_info = sandbox_manager.provision(
+        sandbox_id=sandbox.id,
+        user_id=user_id,
+        tenant_id=tenant_id,
+        llm_config=all_llm_configs[0],
+        onyx_pat=onyx_pat,
+        all_llm_configs=all_llm_configs,
+    )
+    update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
+
+
+def _wait_for_provisioning_to_complete(
+    db_session: DBSession,
+    sandbox: Sandbox,
+    wait_seconds: float,
+    *,
+    poll_interval_seconds: float = 1.0,
+) -> Sandbox:
+    """Poll a ``PROVISIONING`` sandbox until it transitions or we time out.
+
+    Relies on Postgres' READ COMMITTED isolation: ``session.refresh()``
+    issues a fresh SELECT each iteration, so commits from the concurrent
+    provisioner become visible.
+
+    Raises:
+        SandboxProvisioningError: deadline elapsed before the status
+            changed.
+    """
+    deadline = time.monotonic() + wait_seconds
+    started = time.monotonic()
+    logger.info(
+        "Waiting up to %.1fs for sandbox %s to finish provisioning",
+        wait_seconds,
+        sandbox.id,
+    )
+    while True:
+        db_session.refresh(sandbox)
+        if sandbox.status != SandboxStatus.PROVISIONING:
+            logger.info(
+                "Sandbox %s left PROVISIONING after %.1fs (now=%s)",
+                sandbox.id,
+                time.monotonic() - started,
+                sandbox.status.value,
+            )
+            return sandbox
+        if time.monotonic() >= deadline:
+            raise SandboxProvisioningError(
+                f"Sandbox {sandbox.id} still PROVISIONING after {wait_seconds}s"
+            )
+        time.sleep(poll_interval_seconds)
+
+
+def _enforce_tenant_concurrency_limit(db_session: DBSession, tenant_id: str) -> None:
+    """No-op on self-hosted. On multi-tenant: raise if creating/waking a
+    sandbox would exceed the per-tenant cap."""
+    if not MULTI_TENANT:
+        return
+    running_count = get_running_sandbox_count_by_tenant(db_session, tenant_id)
+    if running_count >= SANDBOX_MAX_CONCURRENT_PER_ORG:
+        raise ValueError(
+            f"Maximum concurrent sandboxes ({SANDBOX_MAX_CONCURRENT_PER_ORG}) reached"
+        )
+
+
+def ensure_sandbox_ready(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    user_id: UUID,
+    all_llm_configs: list[LLMProviderConfig],
+    *,
+    policy: ProvisioningPolicy,
+    provisioning_wait_seconds: float = 30.0,
+    user: User | None = None,
+) -> Sandbox:
+    """Return a ``RUNNING`` sandbox for ``user_id``, creating, waking, or
+    recovering as needed.
+
+    Branches by current sandbox status:
+    - No sandbox row: create + provision.
+    - ``RUNNING`` + pod healthy: return as-is (hot path; no extra writes).
+    - ``RUNNING`` + pod missing/unhealthy: terminate, mark TERMINATED,
+      re-provision.
+    - ``SLEEPING`` / ``TERMINATED`` / ``FAILED``: re-provision in place.
+    - ``PROVISIONING``: depends on ``policy`` —
+        - ``POLL``: wait up to ``provisioning_wait_seconds`` then re-enter
+          the state machine on the new status (raises
+          ``SandboxProvisioningError`` on timeout).
+        - ``FAIL``: raise ``RuntimeError`` immediately so the caller can
+          return a fast error to the user.
+
+    Honors ``SANDBOX_MAX_CONCURRENT_PER_ORG`` when ``MULTI_TENANT`` for any
+    path that newly counts toward the running limit (create + revive).
+    Caller is responsible for committing.
+
+    Raises:
+        SandboxProvisioningError: Sandbox still ``PROVISIONING`` after the
+            wait window (POLL only).
+        ValueError: Concurrency cap reached, or user not found.
+        RuntimeError: Pod provisioning failed, or sandbox is mid-provision
+            under FAIL policy.
+    """
+    sandbox = get_sandbox_by_user_id(db_session, user_id)
+
+    # Resolve PROVISIONING upfront so the rest of the state machine sees a
+    # stable status (or knows there isn't one).
+    if sandbox is not None and sandbox.status == SandboxStatus.PROVISIONING:
+        if policy == ProvisioningPolicy.FAIL:
+            raise RuntimeError(
+                f"Sandbox {sandbox.id} has status PROVISIONING and is being "
+                f"created by another request"
+            )
+        sandbox = _wait_for_provisioning_to_complete(
+            db_session, sandbox, provisioning_wait_seconds
+        )
+
+    # Hot path: pod is up; nothing else to do.
+    if sandbox is not None and sandbox.status == SandboxStatus.RUNNING:
+        if sandbox_manager.health_check(
+            sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+        ):
+            return sandbox
+        logger.warning(
+            "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
+            sandbox.id,
+        )
+        sandbox_manager.terminate(sandbox.id)
+        update_sandbox_status__no_commit(
+            db_session, sandbox.id, SandboxStatus.TERMINATED
+        )
+        # Fall through into the re-provision path below.
+
+    if sandbox is not None and sandbox.status not in {
+        SandboxStatus.SLEEPING,
+        SandboxStatus.TERMINATED,
+        SandboxStatus.FAILED,
+    }:
+        raise RuntimeError(
+            f"Sandbox {sandbox.id} in unexpected status "
+            f"{sandbox.status.value}; refusing to provision"
+        )
+
+    # Everything below provisions a pod, which adds to the per-tenant cap.
+    tenant_id = get_current_tenant_id()
+    _enforce_tenant_concurrency_limit(db_session, tenant_id)
+
+    if user is None:
+        user = fetch_user_by_id(db_session, user_id)
+        if user is None:
+            raise ValueError(f"User {user_id} not found")
+
+    if sandbox is None:
+        sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user_id)
+        logger.info("Created sandbox %s for user %s", sandbox.id, user_id)
+    else:
+        logger.info(
+            "Reviving sandbox %s (status=%s) for user %s",
+            sandbox.id,
+            sandbox.status.value,
+            user_id,
+        )
+
+    provision_sandbox(
+        db_session,
+        sandbox_manager,
+        sandbox,
+        user,
+        user_id,
+        tenant_id,
+        all_llm_configs,
+    )
+    return sandbox

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -34,6 +34,7 @@ from onyx.server.features.build.db.sandbox import get_idle_sandboxes
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.craft._test_helpers import default_llm_config
 from tests.external_dependency_unit.craft._test_helpers import make_sandbox
@@ -50,10 +51,9 @@ class TestProvisionTransitions:
         db_session: Session,
         test_user: User,
         stub_sandbox_manager: StubSandboxManager,
-        session_manager_with_stub: SessionManager,
     ) -> None:
         # Create a sandbox row in PROVISIONING (the state set by
-        # create_sandbox__no_commit before _provision_sandbox is called).
+        # create_sandbox__no_commit before provision_sandbox is called).
         sandbox = create_sandbox__no_commit(db_session, test_user.id)
         db_session.commit()
         assert sandbox.status == SandboxStatus.PROVISIONING
@@ -66,7 +66,9 @@ class TestProvisionTransitions:
             last_heartbeat=None,
         )
 
-        session_manager_with_stub._provision_sandbox(
+        provision_sandbox(
+            db_session=db_session,
+            sandbox_manager=stub_sandbox_manager,
             sandbox=sandbox,
             user=test_user,
             user_id=test_user.id,
@@ -88,17 +90,19 @@ class TestProvisionFailureRollback:
         self,
         db_session: Session,
         test_user: User,
-        session_manager_with_stub: SessionManager,
+        stub_sandbox_manager: StubSandboxManager,
     ) -> None:
         # Mirror the endpoint pattern: create_sandbox__no_commit (flush only),
-        # then call _provision_sandbox; if it raises, the caller rolls back so
+        # then call provision_sandbox; if it raises, the caller rolls back so
         # no Sandbox row persists.
         sandbox = create_sandbox__no_commit(db_session, test_user.id)
         sandbox_id = sandbox.id
         # No provision_returns => stub raises NotImplementedError on provision().
 
         with pytest.raises(NotImplementedError):
-            session_manager_with_stub._provision_sandbox(
+            provision_sandbox(
+                db_session=db_session,
+                sandbox_manager=stub_sandbox_manager,
                 sandbox=sandbox,
                 user=test_user,
                 user_id=test_user.id,

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -339,14 +339,18 @@ class TestGetLlmConfigFallback:
         )
 
 
-class TestSessionManagerProvisionForwardsAllLlmConfigs:
-    """``SessionManager._provision_sandbox`` must forward the full
+class TestProvisionSandboxForwardsAllLlmConfigs:
+    """``sandbox_lifecycle.provision_sandbox`` must forward the full
     multi-provider list to ``sandbox_manager.provision()`` — passing only
     the default collapses ``opencode.json`` and per-prompt model
     overrides start failing with "Model not found" until pod restart.
     """
 
     def test_provision_passes_all_llm_configs(self) -> None:
+        from onyx.server.features.build.session.sandbox_lifecycle import (
+            provision_sandbox,
+        )
+
         sandbox_id = uuid4()
         user_id = uuid4()
         tenant_id = "tenant-x"
@@ -363,10 +367,6 @@ class TestSessionManagerProvisionForwardsAllLlmConfigs:
             last_heartbeat=datetime.now(),
         )
 
-        manager = SessionManager.__new__(SessionManager)
-        manager._db_session = cast(Session, MagicMock())  # type: ignore[attr-defined]
-        manager._sandbox_manager = sandbox_manager  # type: ignore[attr-defined]
-
         all_configs = [
             _OPENAI_DEFAULT,
             LLMProviderConfig(
@@ -379,14 +379,18 @@ class TestSessionManagerProvisionForwardsAllLlmConfigs:
 
         with (
             patch(
-                "onyx.server.features.build.session.manager.ensure_sandbox_pat",
+                "onyx.server.features.build.session.sandbox_lifecycle."
+                "ensure_sandbox_pat",
                 return_value="pat-token",
             ),
             patch(
-                "onyx.server.features.build.session.manager.update_sandbox_status__no_commit"
+                "onyx.server.features.build.session.sandbox_lifecycle."
+                "update_sandbox_status__no_commit"
             ),
         ):
-            manager._provision_sandbox(
+            provision_sandbox(
+                db_session=cast(Session, MagicMock()),
+                sandbox_manager=sandbox_manager,
                 sandbox=sandbox,
                 user=user,
                 user_id=user_id,


### PR DESCRIPTION
## Description

PR 4 of 6 in the SessionManager refactor stack. Extracts the sandbox state machine into `session/sandbox_lifecycle.py` and unifies the two near-duplicate implementations behind one `ensure_sandbox_ready(..., *, policy)` helper: `POLL` for headless callers (`ensure_sandbox_running`), `FAIL` for interactive (`create_session__no_commit`). Also moves `provision_sandbox`, `terminate_user_sandbox`, and the skill/library hydration helpers.

**Behavior change to flag:** the `SANDBOX_MAX_CONCURRENT_PER_ORG` cap is now checked only when the request actually provisions a pod. Before, `create_session__no_commit` checked upfront — a user with a healthy sandbox would still fail when the tenant was at cap. Aligns with the existing behavior of `ensure_sandbox_running`.

Stacked on #11650.

## How Has This Been Tested?

- `ruff check` + `ty check` clean
- `pytest backend/tests/unit/onyx/server/features/build/session/` — 67/67 pass (incl. the renamed provision-forwards test)
- Needs CI for the external-dependency-unit tests in `backend/tests/external_dependency_unit/craft/` (sandbox/session lifecycle, `ensure_sandbox_running`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check