### PR TITLE
refactor(craft): point all callers at canonical session modules [7/6]

### DIFF
--- a/backend/onyx/server/features/build/api/messages_api.py
+++ b/backend/onyx/server/features/build/api/messages_api.py
@@ -21,7 +21,7 @@ from onyx.server.features.build.api.models import MessageRequest
 from onyx.server.features.build.api.models import MessageResponse
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
-from onyx.server.features.build.session.manager import RateLimitError
+from onyx.server.features.build.session.errors import RateLimitError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -47,8 +47,8 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
+from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.manager import SessionManager
-from onyx.server.features.build.session.manager import UploadLimitExceededError
 from onyx.server.features.build.utils import sanitize_filename
 from onyx.server.features.build.utils import validate_file
 from onyx.skills.push import build_user_skills_payload

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -53,8 +53,8 @@ from onyx.db.scheduled_task import mark_run_status
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.sandbox.event_schema import RequestPermissionRequest
-from onyx.server.features.build.session.manager import BuildStreamingState
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.streaming import BuildStreamingState
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -60,7 +60,6 @@ from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session import sandbox_lifecycle as _sandbox
 from onyx.server.features.build.session import streaming as _streaming
 from onyx.server.features.build.session.errors import RateLimitError
-from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.interrupt_signal import request_interrupt
 from onyx.server.features.build.session.llm_config import get_all_build_mode_llm_configs
@@ -74,18 +73,6 @@ from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
-
-
-# Re-exports kept for backward compatibility — these used to live in this
-# module before the split into focused submodules.
-__all__ = [
-    "BuildStreamingState",
-    "RateLimitError",
-    "SandboxProvisioningError",
-    "SessionManager",
-    "UploadLimitExceededError",
-    "get_all_build_mode_llm_configs",
-]
 
 
 # Hidden directories/files to filter from listings

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -31,7 +31,7 @@ from onyx.server.features.build.db.sandbox import update_sandbox_status__no_comm
 from onyx.server.features.build.sandbox.base import get_sandbox_manager
 from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
-from onyx.server.features.build.session.manager import SandboxProvisioningError
+from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -37,8 +37,8 @@ from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
-from onyx.server.features.build.session.manager import BuildStreamingState
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.streaming import BuildStreamingState
 from tests.external_dependency_unit.craft.stubs import StubSandboxManager
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -24,7 +24,7 @@ from onyx.db.models import User
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
-from onyx.server.features.build.session.manager import get_all_build_mode_llm_configs
+from onyx.server.features.build.session.llm_config import get_all_build_mode_llm_configs
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.manage.llm.models import ModelConfigurationView

--- a/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
@@ -5,7 +5,7 @@ Tests for chunk accumulation and finalize semantics — no DB required.
 
 from __future__ import annotations
 
-from onyx.server.features.build.session.manager import BuildStreamingState
+from onyx.server.features.build.session.streaming import BuildStreamingState
 
 
 class TestBuildStreamingState:


### PR DESCRIPTION
## Description

Closing PR in the SessionManager refactor stack. Removes the backward-compat re-export surface from `manager.py` and points every caller at the canonical home module for each symbol.

`manager.py` previously kept an `__all__` block re-exporting `RateLimitError`, `UploadLimitExceededError`, `SandboxProvisioningError`, `BuildStreamingState`, and `get_all_build_mode_llm_configs` so older `from ...session.manager import X` call sites kept working through the split into focused submodules. This removes that shim:

- Deletes the `__all__` block and the now-unused `SandboxProvisioningError` import from `manager.py`. The other four symbols stay imported because `manager.py`'s own body uses them (`RateLimitError`/`UploadLimitExceededError` are raised, `BuildStreamingState` types the persistence shims, `get_all_build_mode_llm_configs` backs `build_llm_configs`).
- Repoints every external caller to the canonical module:
  - `RateLimitError`, `UploadLimitExceededError`, `SandboxProvisioningError` → `session.errors`
  - `BuildStreamingState` → `session.streaming`
  - `get_all_build_mode_llm_configs` → `session.llm_config`

`SessionManager` continues to be imported from `manager` — that's its home. After this PR, `manager` is no longer a re-export hub; a repo-wide grep confirms it's only imported for `SessionManager`.

## How Has This Been Tested?

- `backend/tests/unit/build` + `backend/tests/unit/onyx/server/features/build/session` (102 passing)
- `ruff check`, `ruff format`, `ty check` clean
- Repo-wide grep: zero remaining non-canonical imports from `session.manager`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
