### PR TITLE
feat(devcontainer): mount container-specific CLAUDE.md overlay

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -73,6 +73,18 @@ user has read/write access to the bind-mounted workspace:
   To override the auto-detection, set `DEVCONTAINER_REMOTE_USER` before running
   `ods dev up`.
 
+## Claude Code memory (devcontainer overlay)
+
+`.devcontainer/claude-code/CLAUDE.md` holds Claude Code instructions that apply **only inside
+the container** (e.g. service hostnames, "no Docker daemon in here"). It is bind-mounted
+read-only to `/etc/claude-code/CLAUDE.md` — Claude Code's managed-policy memory location — so it
+loads automatically alongside the project's root `CLAUDE.md`.
+
+Because it is a live bind mount, editing the file in the repo takes effect on the next Claude
+Code session — no image rebuild or container restart required. The directory (rather than the
+single file) is mounted so that atomic-save editors don't detach the mount, and so additional
+managed config (e.g. `managed-settings.json`) can be dropped in alongside it later.
+
 ## Firewall
 
 The container ships with an **opt-in** default-deny firewall (`init-firewall.sh`).

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -1,0 +1,22 @@
+# DEVCONTAINER OVERLAY
+
+Running **inside the Onyx dev container**. These notes are additive to the root
+`/workspace/CLAUDE.md`; on conflict with a host-oriented instruction there, prefer these.
+
+## No Docker daemon in here
+
+Don't use `docker` / `docker exec` / `docker compose`. Onyx services run as sibling
+containers on the `onyx_default` network, reachable directly by hostname — so the root
+guide's `docker exec -it onyx-relational_db-1 psql ...` won't work. Use
+`psql -h relational_db -U postgres -c "<SQL>"` instead.
+
+## Service hostnames (`onyx_default` network)
+
+Each is also exported as an env var:
+
+- Postgres: `relational_db` (`POSTGRES_HOST`)
+- Redis: `cache` (`REDIS_HOST`)
+- Vespa: `index` (`VESPA_HOST`)
+- Model server: `inference_model_server` (`MODEL_SERVER_HOST`)
+- OpenSearch: `opensearch` (`OPENSEARCH_HOST`)
+- MinIO / S3: `minio:9000` (`S3_ENDPOINT_URL=http://minio:9000`)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
   "mounts": [
     "source=${localEnv:HOME}/.claude,target=/home/dev/.claude,type=bind",
     "source=${localEnv:HOME}/.claude.json,target=/home/dev/.claude.json,type=bind",
+    "source=${localWorkspaceFolder}/.devcontainer/claude-code,target=/etc/claude-code,type=bind,readonly",
     "source=${localEnv:HOME}/.zshrc,target=/home/dev/.zshrc.host,type=bind,readonly",
     "source=${localEnv:HOME}/.gitconfig,target=/home/dev/.gitconfig,type=bind,readonly",
     "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",


### PR DESCRIPTION
## What

Adds a devcontainer-specific `CLAUDE.md` so Claude Code gets instructions that apply **only inside the dev container**, layered on top of the project's root `/workspace/CLAUDE.md`.

`.devcontainer/claude-code/` is bind-mounted read-only to `/etc/claude-code/` — Claude Code's managed-policy memory location — so the overlay loads automatically without touching the root `CLAUDE.md`.

## Why a live mount instead of baking it into the image

The image is pinned by digest, so baking the file in would mean a rebuild + republish + re-pin loop for every prompt tweak. A live bind mount means developers edit the repo file and start a new Claude session — changes take effect with no image rebuild or even container restart.

A **directory** (not single-file) mount is used so that atomic-save editors (VS Code, vim) don't detach the mount by replacing the file's inode, and so additional managed config (e.g. `managed-settings.json`) can be dropped in alongside it later.

## Overlay contents

Only what genuinely differs inside the container:
- **No Docker daemon in here** — the root guide's `docker exec -it onyx-relational_db-1 psql …` pattern won't work; use `psql -h relational_db -U postgres` instead (`psql` is installed).
- **`onyx_default` service hostnames** — `relational_db`, `cache`, `index`, `inference_model_server`, `opensearch`, `minio:9000` (sourced from `containerEnv`).
- **`ods` is host-only** — run `pytest` / `alembic` / `bun` directly rather than `ods dev exec`.

## Notes

- Kept the seed content conservative on purpose (no "all services are running" / hardcoded DB creds), so it stays accurate across container variants. Easy to expand with venv-activation and log-location notes if desired.
- The directory mount shadows anything baked into the image at `/etc/claude-code`. Nothing's there today; a future managed `managed-settings.json` would go in `.devcontainer/claude-code/` rather than the image.

## Testing

Config-only change. Verified `devcontainer.json` is valid JSON. Takes effect on next container create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts a devcontainer-specific `CLAUDE.md` overlay so Claude Code loads container-only guidance alongside the root `CLAUDE.md`. Uses a live, read-only bind mount so edits apply on the next Claude session without image rebuilds.

- **New Features**
  - Bind-mount `.devcontainer/claude-code` to `/etc/claude-code` (read-only) in `devcontainer.json`.
  - Add `.devcontainer/claude-code/CLAUDE.md` with container-only notes: no Docker daemon; `onyx_default` service hostnames with env vars inline; trimmed duplicates; removed the “ods is host-only” claim.
  - Document the overlay in `.devcontainer/README.md` (what it is, why a directory, how live updates work).

- **Migration**
  - Recreate the dev container once to pick up the new mount; after that, edit the overlay and start a new Claude session to apply changes.

<sup>Written for commit d9a83c82ec0fe5ff8a7b8b32b6e9009debda746c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

