### PR TITLE
feat(mcp): make per-call MCP tool timeout env-configurable

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1032,6 +1032,12 @@ CODE_INTERPRETER_MAX_OUTPUT_LENGTH = int(
     os.environ.get("CODE_INTERPRETER_MAX_OUTPUT_LENGTH") or 50_000
 )
 
+# Per-call MCP read timeout; configurable since some tools (e.g. data-agent
+# servers) run longer than the default.
+MCP_TOOL_CALL_TIMEOUT_SECONDS = int(
+    os.environ.get("MCP_TOOL_CALL_TIMEOUT_SECONDS") or 300
+)
+
 
 #####
 # Miscellaneous

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_client.py
@@ -23,6 +23,7 @@ from mcp.types import TextResourceContents
 from mcp.types import Tool as MCPLibTool
 from pydantic import BaseModel
 
+from onyx.configs.app_configs import MCP_TOOL_CALL_TIMEOUT_SECONDS
 from onyx.db.enums import MCPTransport
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
@@ -156,7 +157,9 @@ def _create_mcp_client_function_runner(
             from datetime import timedelta
 
             async with ClientSession(
-                read, write, read_timeout_seconds=timedelta(seconds=300)
+                read,
+                write,
+                read_timeout_seconds=timedelta(seconds=MCP_TOOL_CALL_TIMEOUT_SECONDS),
             ) as session:
                 return await function(session, **kwargs)
 


### PR DESCRIPTION
## Description

The MCP client hardcodes a 300s read timeout per tool call (`backend/onyx/tools/tool_implementations/mcp/mcp_client.py`), so MCP tools that legitimately take longer than 5 minutes — e.g. data-agent / long-running query servers — get cut off mid-call.

This makes the timeout configurable via a new `MCP_TOOL_CALL_TIMEOUT_SECONDS` env var, **defaulting to the existing `300`** so behavior is unchanged unless explicitly overridden. Follows the existing env-config pattern (`MAX_LLM_CYCLES`, `REQUEST_TIMEOUT_SECONDS`, `CODE_INTERPRETER_DEFAULT_TIMEOUT_MS`).

## How Has This Been Tested?

- `uv run ruff check --fix`, `uv run ruff format`, and `uv run ty check` all pass on the changed files.
- Confirmed the default (300s) is preserved when the env var is unset, and that setting `MCP_TOOL_CALL_TIMEOUT_SECONDS` flows through to the `ClientSession` read timeout.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the per-call MCP tool read timeout configurable via `MCP_TOOL_CALL_TIMEOUT_SECONDS` (default 300s). This prevents long-running MCP tools (e.g., data-agent or query servers) from being cut off mid-call.

<sup>Written for commit 2beaa02cd168697cde8535c4839c50bbc797fe6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

