### PR TITLE
feat(agents): add per-agent toggle to omit answer citations with default true

### DIFF
--- a/backend/alembic/versions/b3d9f1a2c4e7_add_include_citations_to_persona.py
+++ b/backend/alembic/versions/b3d9f1a2c4e7_add_include_citations_to_persona.py
@@ -1,0 +1,32 @@
+"""Add include_citations to persona
+
+Revision ID: b3d9f1a2c4e7
+Revises: 366c05b6f485
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b3d9f1a2c4e7"
+down_revision = "366c05b6f485"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "persona",
+        sa.Column(
+            "include_citations",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("persona", "include_citations")

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1252,7 +1252,16 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
                     chat_files=setup.chat_files_for_tools,
-                    include_citations=setup.new_msg_req.include_citations,
+                    # Citations are emitted only when both the request allows them
+                    # and the agent (persona) is configured to include them.
+                    include_citations=(
+                        setup.new_msg_req.include_citations
+                        and (
+                            setup.persona.include_citations
+                            if setup.persona
+                            else True
+                        )
+                    ),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                     inject_memories_in_prompt=user.use_memories,
                 )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1219,6 +1219,12 @@ def _run_models(
                     f"Forced tool {setup.forced_tool_id} not found in tools"
                 )
 
+            # Citations are emitted only when both the request allows them
+            # and the agent (persona) is configured to include them.
+            include_citations = setup.new_msg_req.include_citations and (
+                setup.persona.include_citations if setup.persona else True
+            )
+
             # Per-thread copy: run_llm_loop mutates simple_chat_history in-place.
             if n_models == 1 and setup.new_msg_req.deep_research:
                 if setup.chat_session.project_id:
@@ -1235,6 +1241,7 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
                     all_injected_file_metadata=setup.all_injected_file_metadata,
+                    include_citations=include_citations,
                 )
             else:
                 run_llm_loop(
@@ -1252,16 +1259,7 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
                     chat_files=setup.chat_files_for_tools,
-                    # Citations are emitted only when both the request allows them
-                    # and the agent (persona) is configured to include them.
-                    include_citations=(
-                        setup.new_msg_req.include_citations
-                        and (
-                            setup.persona.include_citations
-                            if setup.persona
-                            else True
-                        )
-                    ),
+                    include_citations=include_citations,
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                     inject_memories_in_prompt=user.use_memories,
                 )

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1221,7 +1221,7 @@ def _run_models(
 
             # Citations are emitted only when both the request allows them
             # and the agent (persona) is configured to include them.
-            include_citations = setup.new_msg_req.include_citations and (
+            include_citations: bool = setup.new_msg_req.include_citations and (
                 setup.persona.include_citations if setup.persona else True
             )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3684,6 +3684,11 @@ class Persona(Base):
         String(length=PROMPT_LENGTH), nullable=True
     )
     datetime_aware: Mapped[bool] = mapped_column(Boolean, default=True)
+    # Controls whether the agent's answers include inline citations ([[1]](...))
+    # and a sources list. Defaults to True (citations shown).
+    include_citations: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default="true", nullable=False
+    )
 
     uploaded_image_id: Mapped[str | None] = mapped_column(String, nullable=True)
     icon_name: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -316,6 +316,7 @@ def create_update_persona(
             search_start_date=create_persona_request.search_start_date,
             label_ids=create_persona_request.label_ids,
             is_featured=create_persona_request.is_featured,
+            include_citations=create_persona_request.include_citations,
             user_file_ids=converted_user_file_ids,
             commit=False,
             hierarchy_node_ids=create_persona_request.hierarchy_node_ids,
@@ -929,6 +930,7 @@ def upsert_persona(
     search_start_date: datetime | None = None,
     builtin_persona: bool = False,
     is_featured: bool | None = None,
+    include_citations: bool | None = None,
     label_ids: list[int] | None = None,
     user_file_ids: list[UUID] | None = None,
     hierarchy_node_ids: list[int] | None = None,
@@ -1058,6 +1060,11 @@ def upsert_persona(
         existing_persona.is_featured = (
             is_featured if is_featured is not None else existing_persona.is_featured
         )
+        existing_persona.include_citations = (
+            include_citations
+            if include_citations is not None
+            else existing_persona.include_citations
+        )
         # Update embedded prompt fields if provided
         if system_prompt is not None:
             existing_persona.system_prompt = system_prompt
@@ -1124,6 +1131,9 @@ def upsert_persona(
             is_listed=is_listed,
             search_start_date=search_start_date,
             is_featured=(is_featured if is_featured is not None else False),
+            include_citations=(
+                include_citations if include_citations is not None else True
+            ),
             user_files=user_files or [],
             labels=labels or [],
             hierarchy_nodes=hierarchy_nodes or [],

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -9,6 +9,7 @@ from typing import cast
 
 from onyx.chat.chat_state import ChatStateContainer
 from onyx.chat.citation_processor import CitationMapping
+from onyx.chat.citation_processor import CitationMode
 from onyx.chat.citation_processor import DynamicCitationProcessor
 from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import construct_message_history
@@ -111,6 +112,7 @@ def generate_final_report(
     saved_reasoning: str | None = None,
     pre_answer_processing_time: float | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    include_citations: bool = True,
 ) -> bool:
     """Generate the final research report.
 
@@ -144,7 +146,14 @@ def generate_final_report(
             all_injected_file_metadata=all_injected_file_metadata,
         )
 
-        citation_processor = DynamicCitationProcessor()
+        # When include_citations is False (the persona has citations disabled),
+        # use REMOVE mode so the final report strips citation markers and emits no
+        # sources, mirroring run_llm_loop's behavior for the non-deep-research path.
+        citation_processor = DynamicCitationProcessor(
+            citation_mode=(
+                CitationMode.HYPERLINK if include_citations else CitationMode.REMOVE
+            )
+        )
         citation_processor.update_citation_mapping(citation_mapping)
 
         # Only passing in the cited documents as the whole list would be too long
@@ -205,6 +214,7 @@ def run_deep_research_llm_loop(
     user_identity: LLMUserIdentity | None = None,
     chat_session_id: str | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
+    include_citations: bool = True,
 ) -> None:
     with trace(
         "run_deep_research_llm_loop",
@@ -458,6 +468,7 @@ def run_deep_research_llm_loop(
                         user_identity=user_identity,
                         pre_answer_processing_time=elapsed_seconds,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -562,6 +573,7 @@ def run_deep_research_llm_loop(
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -584,6 +596,7 @@ def run_deep_research_llm_loop(
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
+                        include_citations=include_citations,
                     )
                     final_turn_index = report_turn_index + (1 if report_reasoned else 0)
                     break
@@ -657,6 +670,7 @@ def run_deep_research_llm_loop(
                             pre_answer_processing_time=time.monotonic()
                             - processing_start_time,
                             all_injected_file_metadata=all_injected_file_metadata,
+                            include_citations=include_citations,
                         )
                         final_turn_index = report_turn_index + (
                             1 if report_reasoned else 0

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -135,8 +135,9 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
-    # When False, the agent's answers omit inline citations and the sources list
-    include_citations: bool = True
+    # When False, the agent's answers omit inline citations and the sources list.
+    # None means "leave unchanged" on update; upsert_persona defaults it to True on create.
+    include_citations: bool | None = None
 
 
 class MinimalPersonaSnapshot(BaseModel):

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -135,6 +135,8 @@ class PersonaUpsertRequest(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str
     datetime_aware: bool
+    # When False, the agent's answers omit inline citations and the sources list
+    include_citations: bool = True
 
 
 class MinimalPersonaSnapshot(BaseModel):
@@ -265,6 +267,7 @@ class PersonaSnapshot(BaseModel):
     replace_base_system_prompt: bool = False
     task_prompt: str | None = None
     datetime_aware: bool = True
+    include_citations: bool = True
 
     @classmethod
     def from_model(cls, persona: Persona) -> "PersonaSnapshot":
@@ -314,6 +317,7 @@ class PersonaSnapshot(BaseModel):
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
             datetime_aware=persona.datetime_aware,
+            include_citations=persona.include_citations,
         )
 
 
@@ -380,6 +384,7 @@ class FullPersonaSnapshot(PersonaSnapshot):
             replace_base_system_prompt=persona.replace_base_system_prompt,
             task_prompt=persona.task_prompt,
             datetime_aware=persona.datetime_aware,
+            include_citations=persona.include_citations,
         )
 
 

--- a/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
+++ b/backend/tests/external_dependency_unit/answer/test_persona_include_citations.py
@@ -1,0 +1,139 @@
+"""External-dependency-unit tests for the persona-level `include_citations` flag.
+
+These verify that an agent (persona) configured with `include_citations=False`
+turns citations off for its answers, and that the persona flag combines with the
+per-request `SendMessageRequest.include_citations` flag via a logical AND.
+
+Why we assert on the value passed into `run_llm_loop` rather than only on the
+rendered answer: the citation processor only produces inline `[[n]]` links and
+`CitationInfo` packets for citation numbers that resolve to a *real* document in
+the citation mapping. Populating that mapping deterministically requires a
+multi-cycle search-tool flow (LLM emits a tool call -> search returns docs ->
+LLM emits an answer that cites them), which is brittle to drive without exact
+packet-sequence assertions. Instead we run a single-cycle answer and spy on the
+effective `include_citations` value handed to `run_llm_loop` (which selects the
+`DynamicCitationProcessor` mode). That value is the single decision point that
+governs whether any citation / sources output is emitted, so it is the precise
+thing this feature changes. For the disabled case we additionally confirm the
+`ChatFullResponse`-shape behavior the feature promises: no `CitationInfo` is
+emitted and the `[n]` marker is stripped from the rendered answer.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.chat import process_message
+from onyx.db.chat import create_chat_session
+from onyx.db.persona import upsert_persona
+from onyx.server.query_and_chat.models import SendMessageRequest
+from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
+from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.server.query_and_chat.streaming_models import Packet
+from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
+from tests.external_dependency_unit.answer.stream_test_utils import tokenise
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.mock_llm import LLMAnswerResponse
+from tests.external_dependency_unit.mock_llm import use_mock_llm
+
+
+@pytest.mark.parametrize(
+    "persona_include_citations, request_include_citations, expected_effective",
+    [
+        # Agent config disables citations -> off regardless of the request flag.
+        (False, True, False),
+        # Request disables citations -> off even when the agent allows them (AND).
+        (True, False, False),
+        # Both allow citations -> on.
+        (True, True, True),
+    ],
+)
+def test_persona_include_citations_controls_citation_generation(
+    db_session: Session,
+    full_deployment_setup: None,  # noqa: ARG001
+    mock_external_deps: None,  # noqa: ARG001
+    persona_include_citations: bool,
+    request_include_citations: bool,
+    expected_effective: bool,
+) -> None:
+    ensure_default_llm_provider(db_session)
+    test_user = create_test_user(db_session, email_prefix="test_include_citations")
+
+    persona = upsert_persona(
+        user=None,  # system persona
+        name=f"Citations Persona {uuid.uuid4()}",
+        description="Persona for include_citations behavior test",
+        starter_messages=None,
+        system_prompt=None,
+        task_prompt=None,
+        datetime_aware=None,
+        is_public=True,
+        db_session=db_session,
+        tool_ids=[],  # no tools -> single LLM answer cycle
+        document_set_ids=None,
+        is_listed=True,
+        default_model_configuration_id=None,
+        include_citations=persona_include_citations,
+    )
+
+    # Persist the configured flag exactly as requested.
+    assert persona.include_citations is persona_include_citations
+
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description="include_citations test",
+        user_id=test_user.id,
+        persona_id=persona.id,
+    )
+
+    # The answer contains a citation marker so we can confirm it is stripped when
+    # citations are disabled.
+    answer_tokens = tokenise("Onyx is great [1].")
+
+    with (
+        use_mock_llm() as mock_llm,
+        patch.object(
+            process_message,
+            "run_llm_loop",
+            wraps=process_message.run_llm_loop,
+        ) as spy_run_llm_loop,
+    ):
+        mock_llm.add_response(LLMAnswerResponse(answer_tokens=answer_tokens))
+
+        request = SendMessageRequest(
+            message="Tell me about Onyx",
+            chat_session_id=chat_session.id,
+            include_citations=request_include_citations,
+        )
+
+        answer_stream = process_message.handle_stream_message_objects(
+            new_msg_req=request,
+            user=test_user,
+        )
+
+        # The message-id packet is emitted before the LLM stream is consumed.
+        next(answer_stream)
+        mock_llm.forward_till_end()
+
+        answer_text = ""
+        citation_infos: list[CitationInfo] = []
+        for part in answer_stream:
+            obj = part.obj if isinstance(part, Packet) else part
+            if isinstance(obj, AgentResponseDelta) and obj.content:
+                answer_text += obj.content
+            elif isinstance(obj, CitationInfo):
+                citation_infos.append(obj)
+
+    # The persona and request flags must combine (logical AND) into the value
+    # passed to run_llm_loop, which selects the DynamicCitationProcessor mode.
+    assert spy_run_llm_loop.call_args is not None
+    assert spy_run_llm_loop.call_args.kwargs["include_citations"] is expected_effective
+
+    if not expected_effective:
+        # Citations disabled -> no CitationInfo packets and the [n] marker is
+        # stripped from the rendered answer (no inline citation, no sources).
+        assert citation_infos == []
+        assert "[1]" not in answer_text
+        assert "[[" not in answer_text

--- a/backend/tests/unit/onyx/deep_research/test_dr_citations.py
+++ b/backend/tests/unit/onyx/deep_research/test_dr_citations.py
@@ -1,0 +1,77 @@
+"""Unit tests for per-persona `include_citations` gating in the deep-research path.
+
+The deep-research loop only emits user-facing citations from the final report
+(`generate_final_report`). That step is the single decision point that selects
+the `DynamicCitationProcessor` mode, mirroring `run_llm_loop` for the regular
+path: HYPERLINK when citations are enabled, REMOVE when the persona disabled
+them. These tests spy on the `citation_processor` handed to `run_llm_step` to
+confirm the mode is chosen from `include_citations`, rather than driving the
+full multi-cycle loop (which is brittle to set up).
+"""
+
+from contextlib import contextmanager
+from typing import Any
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.chat.citation_processor import CitationMode
+from onyx.chat.citation_processor import DynamicCitationProcessor
+from onyx.chat.models import LlmStepResult
+from onyx.deep_research import dr_loop
+
+
+@contextmanager
+def _noop_span(*_args: Any, **_kwargs: Any) -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+@pytest.mark.parametrize(
+    "include_citations, expected_mode",
+    [
+        (True, CitationMode.HYPERLINK),
+        (False, CitationMode.REMOVE),
+    ],
+)
+def test_generate_final_report_citation_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    include_citations: bool,
+    expected_mode: CitationMode,
+) -> None:
+    captured: dict[str, DynamicCitationProcessor | None] = {"processor": None}
+
+    def fake_run_llm_step(*_args: Any, **kwargs: Any) -> tuple[LlmStepResult, bool]:
+        captured["processor"] = kwargs["citation_processor"]
+        result = LlmStepResult(
+            reasoning=None,
+            answer="Final report body.",
+            tool_calls=None,
+        )
+        return result, False
+
+    # Isolate the decision point: skip tracing, history construction, and the LLM call.
+    monkeypatch.setattr(dr_loop, "run_llm_step", fake_run_llm_step)
+    monkeypatch.setattr(dr_loop, "construct_message_history", lambda *a, **k: [])
+    monkeypatch.setattr(dr_loop, "function_span", _noop_span)
+
+    llm = MagicMock()
+    llm.config.max_input_tokens = 100_000
+
+    has_reasoned = dr_loop.generate_final_report(
+        history=[],
+        research_plan="plan",
+        llm=llm,
+        token_counter=len,
+        state_container=MagicMock(),
+        emitter=MagicMock(),
+        turn_index=1,
+        citation_mapping={},
+        user_identity=None,
+        include_citations=include_citations,
+    )
+
+    assert has_reasoned is False
+    processor = captured["processor"]
+    assert isinstance(processor, DynamicCitationProcessor)
+    assert processor.citation_mode is expected_mode

--- a/web/src/app/app/shared/[chatId]/page.tsx
+++ b/web/src/app/app/shared/[chatId]/page.tsx
@@ -27,6 +27,7 @@ export function constructMiniFiedPersona(name: string, id: number): Agent {
     task_prompt: null,
     datetime_aware: true,
     replace_base_system_prompt: false,
+    include_citations: true,
   };
 }
 

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -23,7 +23,7 @@ function buildAgentUpsertRequest(
     remove_image: params.remove_image,
     search_start_date: params.search_start_date,
     datetime_aware: params.datetime_aware,
-    include_citations: params.include_citations ?? true,
+    include_citations: params.include_citations,
     is_featured: params.is_featured ?? false,
     default_model_configuration_id:
       params.default_model_configuration_id ?? null,

--- a/web/src/lib/agents/svc.ts
+++ b/web/src/lib/agents/svc.ts
@@ -23,6 +23,7 @@ function buildAgentUpsertRequest(
     remove_image: params.remove_image,
     search_start_date: params.search_start_date,
     datetime_aware: params.datetime_aware,
+    include_citations: params.include_citations ?? true,
     is_featured: params.is_featured ?? false,
     default_model_configuration_id:
       params.default_model_configuration_id ?? null,

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -65,6 +65,7 @@ export interface Agent extends MinimalAgent {
   replace_base_system_prompt: boolean;
   task_prompt: string | null;
   datetime_aware: boolean;
+  include_citations: boolean;
 }
 
 export interface FullAgent extends Agent {
@@ -80,6 +81,7 @@ export interface AgentUpsertParameters {
   replace_base_system_prompt: boolean;
   task_prompt: string;
   datetime_aware: boolean;
+  include_citations: boolean;
   document_set_ids: number[];
   is_public: boolean;
   default_model_configuration_id?: number | null;
@@ -104,6 +106,7 @@ export interface AgentUpsertRequest {
   system_prompt: string;
   task_prompt: string;
   datetime_aware: boolean;
+  include_citations: boolean;
   document_set_ids: number[];
   is_public: boolean;
   default_model_configuration_id: number | null;

--- a/web/src/refresh-pages/AgentEditorPage.tsx
+++ b/web/src/refresh-pages/AgentEditorPage.tsx
@@ -642,6 +642,7 @@ export default function AgentEditorPage({
       : null,
     replace_base_system_prompt:
       existingAgent?.replace_base_system_prompt ?? false,
+    include_citations: existingAgent?.include_citations ?? true,
     reminders: existingAgent?.task_prompt ?? "",
     // For new agents, default to false for optional tools to avoid
     // "Tool not available" errors when the tool isn't configured.
@@ -761,6 +762,7 @@ export default function AgentEditorPage({
         (value) => !value || !isDateInFuture(value)
       ),
     replace_base_system_prompt: Yup.boolean(),
+    include_citations: Yup.boolean(),
     reminders: Yup.string().optional(),
 
     // MCP servers - dynamically add validation for each server with nested tool validation
@@ -882,6 +884,7 @@ export default function AgentEditorPage({
         replace_base_system_prompt: values.replace_base_system_prompt,
         task_prompt: values.reminders || "",
         datetime_aware: false,
+        include_citations: values.include_citations,
       };
 
       // Call API
@@ -1636,6 +1639,13 @@ export default function AgentEditorPage({
                                   description='Remove the base system prompt which includes useful instructions (e.g. "You can use Markdown tables"). This may affect response quality.'
                                 >
                                   <SwitchField name="replace_base_system_prompt" />
+                                </InputHorizontal>
+                                <InputHorizontal
+                                  withLabel="include_citations"
+                                  title="Include Citations"
+                                  description="Show inline citations and a sources list pointing to the documents used in the answer. Turn off to hide sources from responses."
+                                >
+                                  <SwitchField name="include_citations" />
                                 </InputHorizontal>
                               </GeneralLayouts.Section>
                             </Card>


### PR DESCRIPTION
## Description
Add an include_citations boolean to personas (default true). When an agent disables it, its answers omit inline citation markers and the sources list for every caller (web, API, Slack, Discord) by feeding the flag into the existing per-request citation path (CitationMode.REMOVE).

DB: new Persona.include_citations column + migration (server_default true)
API: PersonaUpsertRequest + Persona snapshots
Wiring: logical AND of request flag and persona flag in process_message
Frontend: agent editor toggle + types/service plumbing
Test: external_dependency_unit test for the effective-flag wiring

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?
Test: external_dependency_unit test for the effective-flag wiring
<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-agent include_citations toggle (default on) that controls whether answers show inline citation markers and the sources list. Applies across all surfaces and deep research using request.include_citations AND persona.include_citations.

- **New Features**
  - DB: Persona.include_citations column (default true).
  - API: PersonaUpsertRequest `include_citations` (nullable on update to preserve False) and Persona snapshots.
  - Backend: compute the effective flag once; pass to `run_llm_loop` and deep research via `run_deep_research_llm_loop` into `generate_final_report`.
  - Frontend: Agent Editor toggle plus types/service updates; shared-chat stub sets `include_citations`; removed redundant fallback in the editor.
  - Tests: coverage for AND wiring and deep-research citation mode.

- **Migration**
  - Run the DB migration to add Persona.include_citations (defaults to true; existing agents unchanged).

<sup>Written for commit 804e48d9520de1909fde06e3831920fad7f7f08f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

