### PR TITLE
fix(mcp): clarify auth error message for non-interactive bot requests (#11494)

### DIFF
--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -182,12 +182,23 @@ class MCPTool(Tool[None]):
 
             if requires_auth and not has_auth_config:
                 # Authentication required but not configured
-                auth_error_msg = (
-                    f"The {self._name} tool from {self.mcp_server.name} requires authentication "
-                    f"but no credentials have been provided. Tell the user to use the MCP dropdown in the "
-                    f"chat bar to authenticate with the {self.mcp_server.name} server before "
-                    f"using this tool."
-                )
+                if not self.user_email:
+                    auth_error_msg = (
+                        f"The {self._name} tool from {self.mcp_server.name} requires authentication, "
+                        f"but no credentials were found for this bot request. Slack/Discord bots and API "
+                        f"integrations do not support individual per-user or OAuth authentication. "
+                        f"Please ask your administrator to configure 'Shared Key' authentication for "
+                        f"this MCP server."
+                    )
+                else:
+                    auth_error_msg = (
+                        f"The {self._name} tool from {self.mcp_server.name} requires authentication "
+                        f"but no credentials have been provided. Tell the user to use the MCP dropdown in the "
+                        f"chat bar to authenticate with the {self.mcp_server.name} server before "
+                        f"using this tool."
+                    )
+
+                # EVERYTHING BELOW HERE REMAINS UNTOUCHED:
                 logger.warning(
                     "Authentication required for MCP tool '%s' but no credentials found",
                     self._name,


### PR DESCRIPTION
Closes #11494

## Description
This PR updates the MCP authentication fallback error message to dynamically handle background/non-interactive contexts (like Slack bots, Discord bots, or API-driven requests). 

Previously, when a bot request failed authentication due to a lack of individual user credentials, the backend returned a generic error instructing the user to use the "MCP dropdown in the chat bar." However, this dropdown only exists in the web UI. 

By checking if `self.user_email` is missing, the code now accurately identifies bot contexts and explicitly informs the user/administrator that they need to configure **"Shared Key"** authentication for the MCP server.

## How Has This Been Tested?
- Inspected the conditional logic block inside `backend/onyx/tools/tool_implementations/mcp/mcp_tool.py` to ensure it targets the empty string fallback (`not self.user_email`) discovered in the issue investigation.
- Verified that the fallback path safely preserves existing streaming/packet emitting behavior (`CustomToolDelta`, `ToolResponse`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies MCP auth errors for non-interactive bot/API requests by detecting missing user identity and guiding admins to configure "Shared Key" auth. This avoids web-only instructions in Slack/Discord while keeping current guidance for interactive users.

- **Bug Fixes**
  - If auth is required and no credentials are present, show bot-specific guidance when `user_email` is missing; otherwise keep the existing “use the MCP dropdown” message.
  - No changes to streaming or packet emission behavior.

<sup>Written for commit db79ea5eca165f6c73ff76b1726a949686cd527d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

