### PR TITLE
chore: [Running GitHub actions for #11660]

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -675,7 +675,7 @@ class LitellmLLM(LLM):
             SEND_USER_METADATA_TO_LLM_PROVIDER
             and self._model_provider == LlmProviderNames.OPENROUTER
             and user_identity is not None
-            and user_identity.session_id is not None
+            and user_identity.session_id
         ):
             if passthrough_kwargs is self._model_kwargs:
                 passthrough_kwargs = copy.deepcopy(self._model_kwargs)

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import threading
 from collections.abc import Iterator
@@ -657,6 +658,26 @@ class LitellmLLM(LLM):
             model_kwargs=self._model_kwargs,
             user_identity=user_identity,
         )
+
+        # OpenRouter sticky routing: inject session_id into extra_body so that
+        # OpenRouter pins all turns of a conversation to the same upstream provider,
+        # enabling prompt cache hits across turns.
+        # Without this, OpenRouter may alternate between e.g. Anthropic and Google
+        # for the same model, causing cache misses on every other turn.
+        # See: https://openrouter.ai/docs/features/provider-routing#session-id
+        if (
+            self._model_provider == LlmProviderNames.OPENROUTER
+            and user_identity is not None
+            and user_identity.session_id is not None
+        ):
+            if passthrough_kwargs is self._model_kwargs:
+                passthrough_kwargs = copy.deepcopy(self._model_kwargs)
+            existing_extra_body = passthrough_kwargs.get("extra_body") or {}
+            if isinstance(existing_extra_body, dict):
+                passthrough_kwargs["extra_body"] = {
+                    **existing_extra_body,
+                    "session_id": user_identity.session_id,
+                }
 
         try:
             # NOTE: must pass in None instead of empty strings otherwise litellm

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from typing import Union
 
 from onyx.configs.app_configs import MOCK_LLM_RESPONSE
+from onyx.configs.app_configs import SEND_USER_METADATA_TO_LLM_PROVIDER
 from onyx.configs.chat_configs import LLM_SOCKET_READ_TIMEOUT
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.configs.model_configs import LITELLM_EXTRA_BODY
@@ -665,8 +666,14 @@ class LitellmLLM(LLM):
         # Without this, OpenRouter may alternate between e.g. Anthropic and Google
         # for the same model, causing cache misses on every other turn.
         # See: https://openrouter.ai/docs/features/provider-routing#session-id
+        #
+        # Gated on SEND_USER_METADATA_TO_LLM_PROVIDER for consistency with the
+        # user/session metadata handled in build_litellm_passthrough_kwargs: an
+        # operator who opted out of sending session identifiers to providers
+        # should not have the session_id forwarded to OpenRouter either.
         if (
-            self._model_provider == LlmProviderNames.OPENROUTER
+            SEND_USER_METADATA_TO_LLM_PROVIDER
+            and self._model_provider == LlmProviderNames.OPENROUTER
             and user_identity is not None
             and user_identity.session_id is not None
         ):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -678,6 +678,12 @@ class LitellmLLM(LLM):
                     **existing_extra_body,
                     "session_id": user_identity.session_id,
                 }
+            else:
+                logger.warning(
+                    "OpenRouter sticky routing: extra_body is not a dict (%s), "
+                    "skipping session_id injection",
+                    type(existing_extra_body).__name__,
+                )
 
         try:
             # NOTE: must pass in None instead of empty strings otherwise litellm

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -51,6 +51,12 @@ def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
                 "Prompt caching enabled for OpenRouter Google/Gemini model: %s",
                 model_name,
             )
+            # NOTE: Reusing VertexAIPromptCacheProvider is safe today because it
+            # only does implicit caching (no message mutation). These requests go
+            # through OpenRouter, not the Vertex SDK.
+            # TODO: once Vertex explicit caching (context-cache block IDs) lands,
+            # split this out into a dedicated OpenRouter Google provider so the
+            # Vertex-specific behavior doesn't leak into OpenRouter requests.
             return VertexAIPromptCacheProvider()
         elif model_name.startswith(OPENROUTER_OPENAI_PREFIX):
             logger.debug(

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -42,18 +42,18 @@ def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
     elif llm_config.model_provider == LlmProviderNames.OPENROUTER:
         model_name = llm_config.model_name or ""
         if model_name.startswith(OPENROUTER_ANTHROPIC_PREFIX):
-            logger.info(
+            logger.debug(
                 "Prompt caching enabled for OpenRouter Anthropic model: %s", model_name
             )
             return AnthropicPromptCacheProvider()
         elif model_name.startswith(OPENROUTER_GOOGLE_PREFIX):
-            logger.info(
+            logger.debug(
                 "Prompt caching enabled for OpenRouter Google/Gemini model: %s",
                 model_name,
             )
             return VertexAIPromptCacheProvider()
         elif model_name.startswith(OPENROUTER_OPENAI_PREFIX):
-            logger.info(
+            logger.debug(
                 "Prompt caching enabled for OpenRouter OpenAI model: %s", model_name
             )
             return OpenAIPromptCacheProvider()

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -1,5 +1,7 @@
 """Factory for creating provider-specific prompt cache adapters."""
 
+import logging
+
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMConfig
 from onyx.llm.prompt_cache.providers.anthropic import AnthropicPromptCacheProvider
@@ -8,7 +10,15 @@ from onyx.llm.prompt_cache.providers.noop import NoOpPromptCacheProvider
 from onyx.llm.prompt_cache.providers.openai import OpenAIPromptCacheProvider
 from onyx.llm.prompt_cache.providers.vertex import VertexAIPromptCacheProvider
 
+logger = logging.getLogger(__name__)
+
 ANTHROPIC_BEDROCK_TAG = "anthropic."
+
+# OpenRouter model name prefixes — used to determine which upstream provider
+# is being called so the correct caching strategy can be applied.
+OPENROUTER_ANTHROPIC_PREFIX = "anthropic/"
+OPENROUTER_GOOGLE_PREFIX = "google/"
+OPENROUTER_OPENAI_PREFIX = "openai/"
 
 
 def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
@@ -29,6 +39,29 @@ def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
         return AnthropicPromptCacheProvider()
     elif llm_config.model_provider == LlmProviderNames.VERTEX_AI:
         return VertexAIPromptCacheProvider()
+    elif llm_config.model_provider == LlmProviderNames.OPENROUTER:
+        model_name = llm_config.model_name or ""
+        if model_name.startswith(OPENROUTER_ANTHROPIC_PREFIX):
+            logger.info(
+                "Prompt caching enabled for OpenRouter Anthropic model: %s", model_name
+            )
+            return AnthropicPromptCacheProvider()
+        elif model_name.startswith(OPENROUTER_GOOGLE_PREFIX):
+            logger.info(
+                "Prompt caching enabled for OpenRouter Google/Gemini model: %s",
+                model_name,
+            )
+            return VertexAIPromptCacheProvider()
+        elif model_name.startswith(OPENROUTER_OPENAI_PREFIX):
+            logger.info(
+                "Prompt caching enabled for OpenRouter OpenAI model: %s", model_name
+            )
+            return OpenAIPromptCacheProvider()
+        else:
+            logger.debug(
+                "Prompt caching not supported for OpenRouter model: %s", model_name
+            )
+            return NoOpPromptCacheProvider()
     else:
         # Default to no-op for providers without caching support
         return NoOpPromptCacheProvider()


### PR DESCRIPTION
This PR runs GitHub Actions CI for #11660.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable prompt caching and sticky routing for `OpenRouter` to improve cache hits and reduce costs. Maps `OpenRouter` model prefixes to provider-specific cache adapters and, when allowed, passes a `session_id` so conversations stay on one upstream.

- **Bug Fixes**
  - Prompt cache provider selection: add `OpenRouter` mapping — `anthropic/*` -> Anthropic, `google/*` -> Vertex AI, `openai/*` -> OpenAI; otherwise no-op. Add debug logs.
  - Sticky routing: for `OpenRouter`, if `SEND_USER_METADATA_TO_LLM_PROVIDER` is enabled and a truthy `session_id` is present, inject it into `extra_body` (deep-copy kwargs if needed). Warn if `extra_body` is not a dict.

<sup>Written for commit 793c84d0ada8df95e971f1bc77f7b3667fd8c4f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

