### PR TITLE
Revert "fix(confluence): use Bearer auth for scoped tokens on Cloud"

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -486,8 +486,7 @@ class OnyxConfluence:
                 "Connecting to Confluence with Personal Access Token as user: %s",
                 credentials["confluence_username"],
             )
-            use_basic_auth: bool = self._is_cloud and not self.scoped_token
-            if use_basic_auth:
+            if self._is_cloud:
                 confluence = Confluence(
                     url=self._url,
                     username=credentials["confluence_username"],


### PR DESCRIPTION
Reverts onyx-dot-app/onyx#11363

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Confluence Cloud auth change that used Bearer tokens for scoped PATs. Cloud connections now always use basic auth (username + PAT), restoring the previous behavior and fixing failed logins with scoped tokens.

<sup>Written for commit c1fed95f8aff93defd8b26ac375081bb5b8ef65c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

