### PR TITLE
feat(craft): update default LLM models per provider

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -67,9 +67,9 @@ ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 # test_build_mode_provider_types_sync.py.
 BUILD_MODE_ALLOWED_PROVIDER_TYPES = ["anthropic", "openai", "openrouter"]
 BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE = {
-    "anthropic": "claude-opus-4-7",
+    "anthropic": "claude-opus-4-8",
     "openai": "gpt-5.5",
-    "openrouter": "moonshotai/kimi-k2.6",
+    "openrouter": "minimax/minimax-m3",
 }
 
 # Dev/debug-only: exposes an SSE endpoint that tails the sandbox pod's

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -12,7 +12,7 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 
 # 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
 _ADAPTIVE_THINKING_MODELS = frozenset(
-    {"claude-opus-4-6", "claude-opus-4-7", "claude-sonnet-4-6"}
+    {"claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6"}
 )
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -80,14 +80,14 @@ class TestGetAllBuildModeLlmConfigs:
                 _provider(
                     name="Anthropic",
                     provider="anthropic",
-                    models=[_model("claude-opus-4-7")],
+                    models=[_model("claude-opus-4-8")],
                     api_key="k-anthropic",
                 )
             ]
         )
         assert [(c.provider, c.model_name) for c in configs] == [
             ("openai", "gpt-4o"),
-            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-opus-4-8"),
         ]
         assert configs[1].api_key == "k-anthropic"
 
@@ -124,13 +124,13 @@ class TestGetAllBuildModeLlmConfigs:
                     provider="anthropic",
                     models=[
                         _model("claude-opus-4-6"),
-                        _model("claude-opus-4-7"),
+                        _model("claude-opus-4-8"),
                         _model("claude-sonnet-4-6"),
                     ],
                 )
             ]
         )
-        assert configs[1].model_name == "claude-opus-4-7"
+        assert configs[1].model_name == "claude-opus-4-8"
 
     def test_uses_first_visible_for_type_without_recommended(self) -> None:
         # A provider type with no recommended-model entry falls back to first visible.
@@ -146,19 +146,21 @@ class TestGetAllBuildModeLlmConfigs:
         assert configs[1].model_name == "gemini-2.5-pro"
 
     def test_skips_hidden_models_when_picking_first(self) -> None:
+        # A provider type without a recommended-model entry falls back to the
+        # first *visible* model, skipping hidden ones.
         configs = _run(
             [
                 _provider(
-                    name="Anthropic",
-                    provider="anthropic",
+                    name="Google",
+                    provider="google",
                     models=[
-                        _model("claude-hidden-1", is_visible=False),
-                        _model("claude-opus-4-7"),
+                        _model("gemini-hidden", is_visible=False),
+                        _model("gemini-2.5-pro"),
                     ],
                 )
             ]
         )
-        assert configs[1].model_name == "claude-opus-4-7"
+        assert configs[1].model_name == "gemini-2.5-pro"
 
     def test_dedupes_when_default_provider_also_in_build_mode_rows(self) -> None:
         """If the default's provider type is also tagged as build-mode, we
@@ -183,7 +185,7 @@ class TestGetAllBuildModeLlmConfigs:
                 _provider(
                     name="Anthropic",
                     provider="anthropic",
-                    models=[_model("claude-opus-4-7")],
+                    models=[_model("claude-opus-4-8")],
                 ),
                 _provider(
                     name="Google",
@@ -194,7 +196,7 @@ class TestGetAllBuildModeLlmConfigs:
         )
         assert [(c.provider, c.model_name) for c in configs] == [
             ("openai", "gpt-4o"),
-            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-opus-4-8"),
             ("google", "gemini-2.5-pro"),
         ]
 
@@ -242,14 +244,14 @@ class TestGetLlmConfigFallback:
         provider = _provider(
             name="Anthropic",
             provider="anthropic",
-            models=[_model("claude-opus-4-7")],
+            models=[_model("claude-opus-4-8")],
             api_key="k-anthropic",
         )
         with self._patch_providers([provider]):
             config = self._manager().build_llm_configs(self._user(), None, None)[0]
         assert (config.provider, config.model_name) == (
             "anthropic",
-            "claude-opus-4-7",
+            "claude-opus-4-8",
         )
         assert config.api_key == "k-anthropic"
 
@@ -326,7 +328,7 @@ class TestGetLlmConfigFallback:
         with self._patch_providers(
             [
                 _provider(
-                    name="a", provider="anthropic", models=[_model("claude-opus-4-7")]
+                    name="a", provider="anthropic", models=[_model("claude-opus-4-8")]
                 )
             ]
         ):
@@ -335,7 +337,7 @@ class TestGetLlmConfigFallback:
             )[0]
         assert (config.provider, config.model_name) == (
             "anthropic",
-            "claude-opus-4-7",
+            "claude-opus-4-8",
         )
 
 

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -37,8 +37,8 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     providerName: "anthropic",
     recommended: true,
     models: [
-      { name: "claude-opus-4-7", label: "Claude Opus 4.7", recommended: true },
-      { name: "claude-opus-4-6", label: "Claude Opus 4.6" },
+      { name: "claude-opus-4-8", label: "Claude Opus 4.8", recommended: true },
+      { name: "claude-opus-4-7", label: "Claude Opus 4.7" },
       { name: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
     ],
     apiKeyPlaceholder: "sk-ant-...",
@@ -64,9 +64,13 @@ export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
     providerName: "openrouter",
     models: [
       {
+        name: "minimax/minimax-m3",
+        label: "MiniMax M3",
+        recommended: true,
+      },
+      {
         name: "moonshotai/kimi-k2.6",
         label: "Kimi K2.6",
-        recommended: true,
       },
     ],
     apiKeyPlaceholder: "sk-or-...",


### PR DESCRIPTION
## Description

Updates Onyx Craft's default LLM models per provider.

| Provider | Recommended default |
|----------|---------------------|
| anthropic | `claude-opus-4-8` (was `claude-opus-4-7`) |
| openai | `gpt-5.5` (unchanged) |
| openrouter | `minimax/minimax-m3` (was `moonshotai/kimi-k2.6`) |

- `configs.py` — `BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE` updated for anthropic and openrouter.
- `constants.ts` — `BUILD_MODE_PROVIDERS`: Anthropic list is now Opus 4.8 (recommended), Opus 4.7, Sonnet 4.6; OpenRouter adds MiniMax M3 (recommended) and keeps Kimi K2.6. Kept in sync with the backend (enforced by `test_build_mode_provider_types_sync.py`).
- `opencode_config.py` — added `claude-opus-4-8` to the adaptive-thinking set (and dropped `claude-opus-4-6`, no longer offered in Craft) so the new default uses adaptive thinking instead of the fixed-budget fallback.
- Updated affected fixtures in `test_get_all_build_mode_llm_configs.py`.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/server/features/build/` — passes (368 passed; the only failures are pre-existing `test_send_message_with_bus.py` env/network errors present on `main`).
- `test_build_mode_provider_types_sync.py` — passes (backend/frontend defaults aligned).
- TypeScript type check + oxfmt/oxlint via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Craft’s default LLMs: Anthropic now defaults to `claude-opus-4-8` and OpenRouter to `minimax/minimax-m3`; OpenAI stays `gpt-5.5`. Adds `claude-opus-4-8` to adaptive thinking so the new default uses it.

- **New Features**
  - Backend: updates `BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE` (Anthropic → `claude-opus-4-8`, OpenRouter → `minimax/minimax-m3`).
  - Frontend: updates `BUILD_MODE_PROVIDERS`; Anthropic list is Opus 4.8 (recommended), Opus 4.7, Sonnet 4.6; OpenRouter adds MiniMax M3 (recommended) and keeps Kimi K2.6.
  - Adaptive thinking: adds `claude-opus-4-8`, removes `claude-opus-4-6`.
  - Tests: updates fixtures; backend/frontend defaults remain in sync.

<sup>Written for commit 6329147e234b56388b49a1b2ef8ebec88f4ebff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

