### PR TITLE
fix(perm-sync): stop creating skeleton document rows for unindexed docs

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -51,7 +51,6 @@ from onyx.db.connector import mark_cc_pair_as_permissions_synced
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.document import get_document_ids_for_connector_credential_pair
 from onyx.db.document import get_documents_for_connector_credential_pair_limited_columns
-from onyx.db.document import upsert_document_by_connector_credential_pair
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import AccessType
@@ -699,22 +698,15 @@ def element_update_permissions(
             )
 
             if isinstance(permissions, DocExternalAccess):
-                # Document permission update
-                created_new_doc = upsert_document_external_perms(
+                # Document permission update. This is a no-op for documents
+                # that have not been indexed yet -- the indexing pipeline
+                # populates the external access fields itself on insert.
+                upsert_document_external_perms(
                     db_session=db_session,
                     doc_id=permissions.doc_id,
                     external_access=external_access,
                     source_type=DocumentSource(source_type_str),
                 )
-
-                if created_new_doc:
-                    # If a new document was created, we associate it with the cc_pair
-                    upsert_document_by_connector_credential_pair(
-                        db_session=db_session,
-                        connector_id=connector_id,
-                        credential_id=credential_id,
-                        document_ids=[permissions.doc_id],
-                    )
             else:
                 # Hierarchy node permission update
                 db_update_hierarchy_node_permissions(

--- a/backend/ee/onyx/db/document.py
+++ b/backend/ee/onyx/db/document.py
@@ -8,46 +8,9 @@ from onyx.access.models import ExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
 from onyx.db.models import Document as DbDocument
+from onyx.utils.logger import setup_logger
 
-
-def upsert_document_external_perms__no_commit(
-    db_session: Session,
-    doc_id: str,
-    external_access: ExternalAccess,
-    source_type: DocumentSource,
-) -> None:
-    """
-    This sets the permissions for a document in postgres.
-    NOTE: this will replace any existing external access, it will not do a union
-    """
-    document = db_session.scalars(
-        select(DbDocument).where(DbDocument.id == doc_id)
-    ).first()
-
-    prefixed_external_groups = [
-        build_ext_group_name_for_onyx(
-            ext_group_name=group_id,
-            source=source_type,
-        )
-        for group_id in external_access.external_user_group_ids
-    ]
-
-    if not document:
-        # If the document does not exist, still store the external access
-        # So that if the document is added later, the external access is already stored
-        document = DbDocument(
-            id=doc_id,
-            semantic_id="",
-            external_user_emails=external_access.external_user_emails,
-            external_user_group_ids=prefixed_external_groups,
-            is_public=external_access.is_public,
-        )
-        db_session.add(document)
-        return
-
-    document.external_user_emails = list(external_access.external_user_emails)
-    document.external_user_group_ids = prefixed_external_groups
-    document.is_public = external_access.is_public
+logger = setup_logger()
 
 
 def upsert_document_external_perms(
@@ -55,10 +18,10 @@ def upsert_document_external_perms(
     doc_id: str,
     external_access: ExternalAccess,
     source_type: DocumentSource,
-) -> bool:
+) -> None:
     """
-    This sets the permissions for a document in postgres. Returns True if the
-    a new document was created, False otherwise.
+    This sets the permissions for an existing document in postgres. If the
+    document has not been indexed yet, this is a no-op.
     NOTE: this will replace any existing external access, it will not do a union
     """
     document = db_session.scalars(
@@ -74,19 +37,21 @@ def upsert_document_external_perms(
     }
 
     if not document:
-        # If the document does not exist, still store the external access
-        # So that if the document is added later, the external access is already stored
-        # The upsert function in the indexing pipeline does not overwrite the permissions fields
-        document = DbDocument(
-            id=doc_id,
-            semantic_id="",
-            external_user_emails=external_access.external_user_emails,
-            external_user_group_ids=prefixed_external_groups,
-            is_public=external_access.is_public,
+        # Do NOT pre-create a skeleton row here. The old behavior inserted
+        # DbDocument(id=doc_id, semantic_id="") to "stage" permissions for a
+        # doc that indexing would later populate. That row has no chunk_count,
+        # which is an invalid state for the OpenSearch backend and floods
+        # document_index_metadata_sync_task with ChunkCountNotFoundError. The
+        # indexing pipeline's upsert is already permission-aware (it populates
+        # the external access fields from Document.external_access on insert),
+        # so permissions land the moment the doc itself does. Worst case, the
+        # doc is picked up by the next permission sync run after indexing.
+        logger.info(
+            f"Skipping permission upsert for doc_id={doc_id} since it has not "
+            "been indexed yet. Permissions will be set when the document is "
+            "indexed or on the next permission sync run."
         )
-        db_session.add(document)
-        db_session.commit()
-        return True
+        return
 
     # If the document exists, we need to check if the external access has changed
     if (
@@ -99,5 +64,3 @@ def upsert_document_external_perms(
         document.is_public = external_access.is_public
         document.last_modified = datetime.now(timezone.utc)
         db_session.commit()
-
-    return False

--- a/backend/ee/onyx/db/document.py
+++ b/backend/ee/onyx/db/document.py
@@ -28,14 +28,6 @@ def upsert_document_external_perms(
         select(DbDocument).where(DbDocument.id == doc_id)
     ).first()
 
-    prefixed_external_groups: set[str] = {
-        build_ext_group_name_for_onyx(
-            ext_group_name=group_id,
-            source=source_type,
-        )
-        for group_id in external_access.external_user_group_ids
-    }
-
     if not document:
         # Do NOT pre-create a skeleton row here. The old behavior inserted
         # DbDocument(id=doc_id, semantic_id="") to "stage" permissions for a
@@ -46,12 +38,22 @@ def upsert_document_external_perms(
         # the external access fields from Document.external_access on insert),
         # so permissions land the moment the doc itself does. Worst case, the
         # doc is picked up by the next permission sync run after indexing.
-        logger.info(
+        # debug level since this can fire for every not-yet-indexed doc a
+        # perm sync run enumerates, which can be a very large number
+        logger.debug(
             f"Skipping permission upsert for doc_id={doc_id} since it has not "
             "been indexed yet. Permissions will be set when the document is "
             "indexed or on the next permission sync run."
         )
         return
+
+    prefixed_external_groups: set[str] = {
+        build_ext_group_name_for_onyx(
+            ext_group_name=group_id,
+            source=source_type,
+        )
+        for group_id in external_access.external_user_group_ids
+    }
 
     # If the document exists, we need to check if the external access has changed
     if (

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -489,6 +489,25 @@ def document_index_metadata_sync_task(
                     f"doc={document_id} action=no_operation elapsed={elapsed:.2f}"
                 )
                 completion_status = OnyxCeleryTaskCompletionStatus.SKIPPED
+            elif doc.chunk_count is None and not doc.semantic_id:
+                # Skeleton row created by an older version's permission sync
+                # for a doc that was never indexed (empty semantic_id, no
+                # chunk_count). There is nothing in the document index to
+                # update, and attempting to do so raises
+                # ChunkCountNotFoundError on the OpenSearch backend. Mark it
+                # synced so it stops being re-enqueued every sync cycle. This
+                # is safe: if the doc is ever actually indexed, its chunks are
+                # written with fresh metadata from Postgres at index time, and
+                # any later metadata change (perm sync, doc set update, boost/
+                # hide) bumps last_modified and re-marks the doc as dirty.
+                mark_document_as_synced(document_id, db_session)
+
+                elapsed = time.monotonic() - start
+                task_logger.info(
+                    f"doc={document_id} action=skip_unindexed_skeleton_row "
+                    f"elapsed={elapsed:.2f}"
+                )
+                completion_status = OnyxCeleryTaskCompletionStatus.SKIPPED
             else:
                 # document set sync
                 doc_sets = fetch_document_sets_for_document(document_id, db_session)

--- a/backend/tests/external_dependency_unit/ee/onyx/db/test_document_external_perms.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/db/test_document_external_perms.py
@@ -1,0 +1,93 @@
+"""
+Tests for upsert_document_external_perms.
+
+Permission sync can enumerate documents that have not been indexed yet (e.g.
+docs visible in the source but not yet picked up by an indexing run). Older
+versions pre-created skeleton Document rows (empty semantic_id, no chunk_count)
+to "stage" permissions for such docs. Those rows are an invalid state for the
+OpenSearch backend and flooded document_index_metadata_sync_task with
+ChunkCountNotFoundError. These tests lock in the new behavior: permission sync
+must never create Document rows, only update existing ones.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.document import upsert_document_external_perms
+from onyx.access.models import ExternalAccess
+from onyx.access.utils import build_ext_group_name_for_onyx
+from onyx.configs.constants import DocumentSource
+from onyx.db.models import Document as DbDocument
+
+
+def _get_document(db_session: Session, doc_id: str) -> DbDocument | None:
+    return db_session.scalars(select(DbDocument).where(DbDocument.id == doc_id)).first()
+
+
+def test_upsert_external_perms_does_not_create_missing_document(
+    db_session: Session,
+) -> None:
+    doc_id = f"test-ghost-doc-{uuid4().hex}"
+    external_access = ExternalAccess(
+        external_user_emails={"user1@example.com"},
+        external_user_group_ids={"group1"},
+        is_public=False,
+    )
+
+    upsert_document_external_perms(
+        db_session=db_session,
+        doc_id=doc_id,
+        external_access=external_access,
+        source_type=DocumentSource.CONFLUENCE,
+    )
+
+    # The critical assertion: no skeleton row was created
+    assert _get_document(db_session, doc_id) is None
+
+
+def test_upsert_external_perms_updates_existing_document(
+    db_session: Session,
+) -> None:
+    doc_id = f"test-existing-doc-{uuid4().hex}"
+    document = DbDocument(
+        id=doc_id,
+        semantic_id="Test Document",
+        external_user_emails=["old@example.com"],
+        external_user_group_ids=[],
+        is_public=True,
+    )
+    db_session.add(document)
+    db_session.commit()
+
+    try:
+        external_access = ExternalAccess(
+            external_user_emails={"new@example.com"},
+            external_user_group_ids={"Group1"},
+            is_public=False,
+        )
+
+        upsert_document_external_perms(
+            db_session=db_session,
+            doc_id=doc_id,
+            external_access=external_access,
+            source_type=DocumentSource.CONFLUENCE,
+        )
+
+        updated_doc = _get_document(db_session, doc_id)
+        assert updated_doc is not None
+        assert updated_doc.external_user_emails == ["new@example.com"]
+        assert updated_doc.external_user_group_ids == [
+            build_ext_group_name_for_onyx(
+                ext_group_name="Group1",
+                source=DocumentSource.CONFLUENCE,
+            )
+        ]
+        assert updated_doc.is_public is False
+        # Permission changes must bump last_modified so the document gets
+        # picked up by the document index metadata sync
+        assert updated_doc.last_modified is not None
+    finally:
+        db_session.delete(document)
+        db_session.commit()


### PR DESCRIPTION
## Description

Fixes a flood of `ChunkCountNotFoundError` from `document_index_metadata_sync_task` on the light worker for deployments running EE permission sync on the OpenSearch backend (reported by a self-hosted deployment on v4.0.x, where steady-state reached ~120k `document` rows with `chunk_count IS NULL` and hundreds of errors per minute).

**Root cause:** when permission sync enumerated a doc that had not been indexed yet, `upsert_document_external_perms` pre-created a skeleton `Document` row (`semantic_id=""`, no `chunk_count`) to "stage" the permissions. A document with no `chunk_count` is an invalid state for the OpenSearch backend, so the metadata sync task raised on every such row, every sync cycle. For sources where a purge empties the doc set (e.g. Slack), the next perm sync run re-staged the entire historical doc universe.

**Fix:**
- `upsert_document_external_perms` no longer creates skeleton rows — it's a no-op (with an info log) for docs that don't exist yet. This is safe and fail-closed: the indexing pipeline's `upsert_documents` already populates the external access fields from `Document.external_access` on insert (and `COALESCE`s on conflict), and connectors that don't fetch permissions inline are covered by the next perm sync run after indexing. The narrow pre-staging window only ever delayed access, never widened it.
- `document_index_metadata_sync_task` now detects skeleton rows left behind by older versions (`chunk_count IS NULL AND semantic_id = ''` — a combination only the old pre-staging path produced) and marks them synced instead of raising, so existing deployments converge without manual cleanup. Legacy docs with NULL `chunk_count` but a real `semantic_id` are untouched.
- Removed `upsert_document_external_perms__no_commit` (dead code, no callers) and the now-dead `created_new_doc` branch in `element_update_permissions`.

## How Has This Been Tested?

- New external dependency unit tests (`backend/tests/external_dependency_unit/ee/onyx/db/test_document_external_perms.py`):
  - perm sync upsert for a non-existent doc creates **no** `document` row
  - perm sync upsert for an existing doc replaces perms, prefixes group IDs, and bumps `last_modified`
- Existing `backend/tests/external_dependency_unit/permission_sync/` suite passes (35 passed)
- The fix (same approach) was built into a patched v4.0.4 image and deployed on the affected cluster: new ghost-row creation went from ~2,800/connector-run to 0, and `ChunkCountNotFoundError` dropped from hundreds/minute to zero within 30 minutes

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop creating skeleton document rows during permission sync for unindexed docs to eliminate `ChunkCountNotFoundError` spikes on OpenSearch. Permission updates now only apply to existing documents, and legacy skeleton rows are skipped and marked synced for clean convergence.

- **Bug Fixes**
  - Make `upsert_document_external_perms` a no-op (with debug log) when the doc is missing; no skeleton row pre-creation.
  - In `document_index_metadata_sync_task`, detect skeleton rows (`chunk_count IS NULL` and empty `semantic_id`), mark them synced, and skip processing.
  - Defer group-prefix computation until after confirming the document exists.
  - Remove dead code: `upsert_document_external_perms__no_commit` and the `created_new_doc` branch in `element_update_permissions`.
  - Add tests to ensure no row is created for missing docs and that updates replace perms and bump `last_modified` for existing docs.

<sup>Written for commit 26058261c76719731d5523014234ea622bfdc289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

