### PR TITLE
feat(auth): scope chat APIs with read:chat / write:chat

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import Depends
 from fastapi import Request
 
+from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import current_user
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -99,40 +100,29 @@ def get_effective_permissions(user: User) -> set[Permission]:
 
 def require_permission(
     required: Permission,
+    *,
+    allow_anonymous: bool = False,
 ) -> Callable[..., Coroutine[Any, Any, User]]:
-    """FastAPI dependency factory for permission-based access control.
+    """FastAPI dependency factory: require ``required`` of the caller, capped by the
+    authenticating token's scopes (unrestricted PAT / session / API key = no cap).
+    allow_anonymous admits the anonymous user where the tenant permits it (the
+    anonymous-capable chat surface)."""
+    base_user = current_chat_accessible_user if allow_anonymous else current_user
 
-    Effective authority is the user's permissions intersected with the
-    authenticating token's scopes. A restricted PAT carries its scopes on
-    ``request.state.token_scopes``; an unrestricted PAT, session, and API-key
-    auth leave it None, meaning no token-side restriction.
-
-    Usage:
-        @router.get("/endpoint")
-        def endpoint(user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS))):
-            ...
-    """
-
-    async def dependency(request: Request, user: User = Depends(current_user)) -> User:
-        effective_user_permissions = get_effective_permissions(user)
-        permitted_by_user = required in effective_user_permissions
-
+    async def dependency(request: Request, user: User = Depends(base_user)) -> User:
         token_scopes: list[Permission] | None = getattr(
             request.state, "token_scopes", None
         )
+        permitted_by_user = required in get_effective_permissions(user)
         permitted_by_token = token_scopes is None or required.value in (
             resolve_effective_permissions({s.value for s in token_scopes})
         )
-
         if not (permitted_by_user and permitted_by_token):
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "You do not have the required permissions for this action.",
             )
-
         return user
 
-    dependency._is_require_permission = (  # ty: ignore[unresolved-attribute]
-        True  # sentinel for auth_check detection
-    )
+    dependency._is_require_permission = True  # ty: ignore[unresolved-attribute]
     return dependency

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1871,6 +1871,7 @@ def get_anonymous_user() -> User:
         is_superuser=False,
         role=UserRole.LIMITED,
         account_type=AccountType.ANONYMOUS,
+        effective_permissions=[Permission.BASIC_ACCESS.value],
         use_memories=False,
         enable_memory_tool=False,
     )

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -151,7 +151,7 @@ def _get_available_tokens_for_persona(
 
 @router.get("/get-user-chat-sessions", tags=PUBLIC_API_TAGS)
 def get_user_chat_sessions(
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.READ_CHAT)),
     db_session: Session = Depends(get_session),
     project_id: int | None = None,
     only_non_project_chats: bool = True,
@@ -267,7 +267,9 @@ def get_chat_session(
     session_id: UUID,
     is_shared: bool = False,
     include_deleted: bool = False,
-    user: User = Depends(current_chat_accessible_user),
+    user: User = Depends(
+        require_permission(Permission.READ_CHAT, allow_anonymous=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> ChatSessionDetailResponse:
     user_id = user.id
@@ -379,7 +381,9 @@ def get_chat_session(
 @router.post("/create-chat-session", tags=PUBLIC_API_TAGS)
 def create_new_chat_session(
     chat_session_creation_request: ChatSessionCreationRequest,
-    user: User = Depends(current_chat_accessible_user),
+    user: User = Depends(
+        require_permission(Permission.WRITE_CHAT, allow_anonymous=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> CreateChatSessionID:
     try:
@@ -550,7 +554,9 @@ def delete_chat_session_by_id(
 def handle_send_chat_message(
     chat_message_req: SendMessageRequest,
     request: Request,
-    user: User = Depends(current_chat_accessible_user),
+    user: User = Depends(
+        require_permission(Permission.WRITE_CHAT, allow_anonymous=True)
+    ),
     _rate_limit_check: None = Depends(check_token_rate_limits),
     _api_key_usage_check: None = Depends(check_api_key_usage),
 ) -> StreamingResponse | ChatFullResponse:
@@ -914,7 +920,7 @@ async def search_chats(
     query: str | None = Query(None),
     page: int = Query(1),
     page_size: int = Query(10),
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.READ_CHAT)),
     db_session: Session = Depends(get_session),
 ) -> ChatSearchResponse:
     """
@@ -992,7 +998,7 @@ async def search_chats(
 @router.post("/stop-chat-session/{chat_session_id}", tags=PUBLIC_API_TAGS)
 def stop_chat_session(
     chat_session_id: UUID,
-    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.WRITE_CHAT)),
     db_session: Session = Depends(get_session),
 ) -> dict[str, str]:
     """

--- a/backend/tests/integration/common_utils/http_client.py
+++ b/backend/tests/integration/common_utils/http_client.py
@@ -17,6 +17,8 @@ from typing import Any
 
 from fastapi.testclient import TestClient
 
+from tests.integration.common_utils.constants import API_SERVER_URL
+
 _test_client: TestClient | None = None
 
 
@@ -42,3 +44,11 @@ class _TestClientProxy:
 
 
 client = _TestClientProxy()
+
+
+def request_status(headers: dict[str, str], route: tuple[str, str]) -> int:
+    """Issue ``route`` (method, path) with ``headers`` and return the status code."""
+    method, path = route
+    return client.request(
+        method, f"{API_SERVER_URL}{path}", headers=headers, timeout=30
+    ).status_code

--- a/backend/tests/integration/common_utils/managers/pat.py
+++ b/backend/tests/integration/common_utils/managers/pat.py
@@ -62,6 +62,22 @@ class PATManager:
         return raw_token
 
     @staticmethod
+    def scoped_auth_headers(
+        name: str,
+        expiration_days: int | None,
+        user_performing_action: DATestUser,
+        scopes: list[Permission] | None,
+    ) -> dict[str, str]:
+        """Mint a scoped PAT and return its bearer auth headers."""
+        raw_token = PATManager.create_scoped(
+            name=name,
+            expiration_days=expiration_days,
+            user_performing_action=user_performing_action,
+            scopes=scopes,
+        )
+        return PATManager.get_auth_headers(raw_token)
+
+    @staticmethod
     def list(user_performing_action: DATestUser) -> list[DATestPAT]:
         """List all PATs for a user.
 

--- a/backend/tests/integration/tests/permissions/test_chat_scopes.py
+++ b/backend/tests/integration/tests/permissions/test_chat_scopes.py
@@ -1,0 +1,73 @@
+"""Integration tests for READ_CHAT / WRITE_CHAT scope enforcement on chat routes."""
+
+import pytest
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.http_client import request_status
+from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.test_models import DATestUser
+
+_SESSION_ID = "00000000-0000-0000-0000-000000000000"
+
+READ_CHAT_ROUTE = ("GET", "/chat/get-user-chat-sessions")
+WRITE_CHAT_ROUTE = ("POST", f"/chat/stop-chat-session/{_SESSION_ID}")
+BASIC_ONLY_ROUTE = ("DELETE", f"/chat/delete-chat-session/{_SESSION_ID}")
+# read:chat route on the allow_anonymous path.
+CHAT_DEP_ROUTE = ("GET", f"/chat/get-chat-session/{_SESSION_ID}")
+
+
+@pytest.fixture(scope="module")
+def read_chat_headers(permission_basic_user: DATestUser) -> dict[str, str]:
+    return PATManager.scoped_auth_headers(
+        "chat_scope_test_pat", None, permission_basic_user, [Permission.READ_CHAT]
+    )
+
+
+@pytest.fixture(scope="module")
+def write_chat_headers(permission_basic_user: DATestUser) -> dict[str, str]:
+    return PATManager.scoped_auth_headers(
+        "chat_scope_test_pat", None, permission_basic_user, [Permission.WRITE_CHAT]
+    )
+
+
+@pytest.fixture(scope="module")
+def read_search_headers(permission_basic_user: DATestUser) -> dict[str, str]:
+    return PATManager.scoped_auth_headers(
+        "chat_scope_test_pat", None, permission_basic_user, [Permission.READ_SEARCH]
+    )
+
+
+def test_read_chat_reaches_read_route(read_chat_headers: dict[str, str]) -> None:
+    assert request_status(read_chat_headers, READ_CHAT_ROUTE) < 400
+
+
+def test_read_chat_denied_on_write_route(read_chat_headers: dict[str, str]) -> None:
+    assert request_status(read_chat_headers, WRITE_CHAT_ROUTE) == 403
+
+
+def test_read_chat_denied_on_basic_route(read_chat_headers: dict[str, str]) -> None:
+    assert request_status(read_chat_headers, BASIC_ONLY_ROUTE) == 403
+
+
+def test_write_chat_reaches_read_route(write_chat_headers: dict[str, str]) -> None:
+    assert request_status(write_chat_headers, READ_CHAT_ROUTE) < 400
+
+
+def test_write_chat_reaches_write_route(write_chat_headers: dict[str, str]) -> None:
+    # bogus id -> 4xx, never 403
+    assert request_status(write_chat_headers, WRITE_CHAT_ROUTE) != 403
+
+
+def test_write_chat_denied_on_delete(write_chat_headers: dict[str, str]) -> None:
+    assert request_status(write_chat_headers, BASIC_ONLY_ROUTE) == 403
+
+
+def test_read_chat_reaches_chat_dep_route(read_chat_headers: dict[str, str]) -> None:
+    # bogus id -> 4xx, never 403
+    assert request_status(read_chat_headers, CHAT_DEP_ROUTE) != 403
+
+
+def test_non_chat_scope_denied_on_chat_dep_route(
+    read_search_headers: dict[str, str],
+) -> None:
+    assert request_status(read_search_headers, CHAT_DEP_ROUTE) == 403

--- a/backend/tests/integration/tests/permissions/test_pat_scopes.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scopes.py
@@ -3,8 +3,7 @@
 import pytest
 
 from onyx.db.enums import Permission
-from tests.integration.common_utils.constants import API_SERVER_URL
-from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.http_client import request_status
 from tests.integration.common_utils.managers.pat import PATManager
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -12,41 +11,28 @@ BASIC_ACCESS_ENDPOINT = ("GET", "/user/pats")
 IDENTITY_ENDPOINT = ("GET", "/me")
 
 
-def _pat_headers(user: DATestUser, scopes: list[Permission] | None) -> dict[str, str]:
-    raw_token = PATManager.create_scoped(
-        name="scope_test_pat",
-        expiration_days=None,
-        user_performing_action=user,
-        scopes=scopes,
-    )
-    return PATManager.get_auth_headers(raw_token)
-
-
 @pytest.fixture(scope="module")
 def unrestricted_pat_headers(
     permission_basic_user: DATestUser,
 ) -> dict[str, str]:
-    return _pat_headers(permission_basic_user, scopes=None)
+    return PATManager.scoped_auth_headers(
+        "scope_test_pat", None, permission_basic_user, None
+    )
 
 
 @pytest.fixture(scope="module")
 def search_scoped_pat_headers(
     permission_basic_user: DATestUser,
 ) -> dict[str, str]:
-    return _pat_headers(permission_basic_user, scopes=[Permission.READ_SEARCH])
-
-
-def _request(headers: dict[str, str], endpoint: tuple[str, str]) -> int:
-    method, path = endpoint
-    return client.request(
-        method, f"{API_SERVER_URL}{path}", headers=headers, timeout=30
-    ).status_code
+    return PATManager.scoped_auth_headers(
+        "scope_test_pat", None, permission_basic_user, [Permission.READ_SEARCH]
+    )
 
 
 def test_unrestricted_pat_reaches_basic_access_endpoint(
     unrestricted_pat_headers: dict[str, str],
 ) -> None:
-    status = _request(unrestricted_pat_headers, BASIC_ACCESS_ENDPOINT)
+    status = request_status(unrestricted_pat_headers, BASIC_ACCESS_ENDPOINT)
     assert status < 400, (
         f"Unrestricted PAT should reach BASIC_ACCESS route, got {status}"
     )
@@ -55,7 +41,7 @@ def test_unrestricted_pat_reaches_basic_access_endpoint(
 def test_search_scoped_pat_denied_on_basic_access_endpoint(
     search_scoped_pat_headers: dict[str, str],
 ) -> None:
-    status = _request(search_scoped_pat_headers, BASIC_ACCESS_ENDPOINT)
+    status = request_status(search_scoped_pat_headers, BASIC_ACCESS_ENDPOINT)
     assert status == 403, (
         f"read:search PAT should be denied on BASIC_ACCESS route, got {status}"
     )
@@ -64,12 +50,12 @@ def test_search_scoped_pat_denied_on_basic_access_endpoint(
 def test_search_scoped_pat_reaches_identity_endpoint(
     search_scoped_pat_headers: dict[str, str],
 ) -> None:
-    status = _request(search_scoped_pat_headers, IDENTITY_ENDPOINT)
+    status = request_status(search_scoped_pat_headers, IDENTITY_ENDPOINT)
     assert status < 400, f"scoped PAT should reach the scope-exempt /me, got {status}"
 
 
 def test_unrestricted_pat_reaches_identity_endpoint(
     unrestricted_pat_headers: dict[str, str],
 ) -> None:
-    status = _request(unrestricted_pat_headers, IDENTITY_ENDPOINT)
+    status = request_status(unrestricted_pat_headers, IDENTITY_ENDPOINT)
     assert status < 400, f"Unrestricted PAT should reach /me, got {status}"

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -15,6 +15,7 @@ from onyx.auth.permissions import IMPLIED_PERMISSIONS
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import require_permission
 from onyx.auth.permissions import resolve_effective_permissions
+from onyx.auth.users import get_anonymous_user
 from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -280,6 +281,31 @@ class TestRequirePermission:
         dep = require_permission(Permission.READ_SEARCH)
         with pytest.raises(OnyxError):
             await dep(request=_request([]), user=user)
+
+
+class TestAnonymousUserPermissions:
+    def test_anonymous_user_resolves_to_basic_scopes(self) -> None:
+        assert get_effective_permissions(get_anonymous_user()) == {
+            Permission.BASIC_ACCESS,
+            Permission.READ_SEARCH,
+            Permission.READ_CHAT,
+            Permission.WRITE_CHAT,
+        }
+
+    @pytest.mark.asyncio
+    async def test_allow_anonymous_admits_anonymous_user(self) -> None:
+        anon = get_anonymous_user()
+        dep = require_permission(Permission.WRITE_CHAT, allow_anonymous=True)
+        assert await dep(request=_request(None), user=anon) is anon
+
+    @pytest.mark.asyncio
+    async def test_allow_anonymous_still_caps_scoped_token(self) -> None:
+        user = MagicMock()
+        user.effective_permissions = ["basic"]
+        dep = require_permission(Permission.WRITE_CHAT, allow_anonymous=True)
+        with pytest.raises(OnyxError) as exc_info:
+            await dep(request=_request([Permission.READ_SEARCH]), user=user)
+        assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
 
 
 # ---------------------------------------------------------------------------

--- a/docs/craft/features/pat-scopes/pat-scopes.md
+++ b/docs/craft/features/pat-scopes/pat-scopes.md
@@ -74,6 +74,12 @@ with a `scope_exempt` dependency (a sibling `_is_scope_exempt` sentinel the gate
 `_is_require_permission`), and `/me` carries it. Without it the fail-closed gate would deny a scoped
 PAT on `/me`, which a token has no business being locked out of.
 
+**Anonymous-capable routes (chat).** The core chat endpoints (send-message, create-session,
+view-session) admit anonymous users, so they are guarded with `require_permission(perm,
+allow_anonymous=True)`, which resolves the anonymous user (when the tenant allows it) instead of
+rejecting it, while still capping scoped PATs to `perm`. Anonymous, session, and unrestricted callers
+are unaffected; a scoped token is held to `read:chat` / `write:chat`.
+
 ## Delivery
 
 Sequenced so enforcement is complete before any scoped token exists:
@@ -86,11 +92,12 @@ Sequenced so enforcement is complete before any scoped token exists:
 3. **Fail-closed gate** — `optional_user` denies a scoped PAT on routes that declare no
    `require_permission`, so enforcement covers non-guarded routes too. *Shipped.*
 4. **Re-guard routes** with the fine permissions (search / chat read+write / admin read vs. write).
-   `POST /search` — the endpoint the Craft sandbox actually hits (its agent's `company-search` skill
-   runs `onyx-cli search`, which calls `POST /search` and nothing else) — now carries `READ_SEARCH`.
-   *Shipped (the one route the sandbox needs).* The rest of the search surface (web-search, the
-   read-only `/manage` metadata used by the separate MCP server) plus the chat read/write and
-   `READ_ADMIN` splits remain.
+   `POST /search` carries `READ_SEARCH` (the route the Craft sandbox's `onyx-cli search` hits).
+   *Shipped.* On the chat surface, `read:chat` guards listing/viewing one's own sessions and
+   chat-history search; `write:chat` guards create-session, send-message, and stop (it excludes delete
+   and session-config). The remaining chat endpoints (delete, rename, share, config toggles, feedback,
+   file download, token-count helpers) keep their existing guards and are not fine-scoped. *Shipped.*
+   The web-search / `/manage` search surface and the `READ_ADMIN` admin split remain.
 5. **Scope the Craft PAT** — `ensure_sandbox_pat` mints `[READ_SEARCH]` instead of unrestricted,
    retiring the "CRAFT PAT grants full user access" caveat. *Shipped.* This is the acceptance test for
    the effort: the search-scoped sandbox PAT reaches `POST /search` (via `onyx-cli search`) and `/me`,


### PR DESCRIPTION
## Description

Adds fine-grained chat scopes to Personal Access Tokens, the next step in putting meaningful scopes on the APIs (after `read:search`).

- `read:chat` guards listing/viewing one's own sessions and chat-history search; `write:chat` guards create-session, send-message, and stop — it excludes delete and session-config.
- The anonymous-capable chat endpoints (view/create/send) use a new `require_chat_permission`, which preserves anonymous access and additionally caps scoped PATs (sharing `require_permission`'s authority check + fail-closed-gate sentinel). The other chat endpoints keep their existing guards.
- Fixes a latent bug: `get_anonymous_user()` now grants `[basic]` (was unset → would `TypeError` in `get_effective_permissions`).

Builds on the merged PAT-scopes infra (user-perms ∩ token-scopes intersection + fail-closed gate). Exposing scope selection in the PAT-creation UI is a follow-up.

## How Has This Been Tested?

- **Unit** (`test_permissions.py`): the shared authority cap + closure, and the anonymous `[basic]` grant resolving through `get_effective_permissions`.
- **Integration** (`test_chat_scopes.py`): `read:chat` reaches read routes and is denied on write/delete; `write:chat` reaches read+write and is denied on delete (pins `write:chat` ≠ delete); a `require_chat_permission` route is both admitted (scoped) and capped (wrong scope → 403).
- `ty` / `ruff` / format clean; unit tests pass. Reviewed across two adversarially-verified multi-agent passes (only nits).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds read:chat and write:chat scopes to chat APIs and enforces them on key routes. Anonymous access still works on view/create/send, while scoped PATs are limited to their declared chat scope.

- **New Features**
  - Enforce read:chat on GET /chat/get-user-chat-sessions, GET /chat/get-chat-session/{id} (allows anonymous), and GET /chat/search; enforce write:chat on POST /chat/create-chat-session, POST /chat/send-chat-message, and POST /chat/stop-chat-session/{id}. Delete and session-config remain out of scope.
  - Extend `require_permission` with `allow_anonymous=True` for anonymous-capable chat routes; uses `current_chat_accessible_user` and preserves the token-scope cap and fail-closed sentinel.

- **Bug Fixes**
  - get_anonymous_user() now grants BASIC_ACCESS so implied scopes resolve correctly.

<sup>Written for commit 637bc499379d13efedec44a7c80841ee2f665493. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

