### PR TITLE
ci(connectors): run connector tests post-merge instead of in the merge queue

### DIFF
--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -17,7 +17,18 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  merge_group:
+  # Connector tests are non-blocking (not a required status check) and exercise
+  # real external connector APIs, so they don't belong in the merge queue.
+  # Running on `merge_group` only exposed them to the ephemeral
+  # `gh-readonly-queue/*` branch-deletion race in paths-filter -- when an entry
+  # ahead in the queue fails and GitHub tears down/recreates the queue branches
+  # mid-run, paths-filter's fetch of the head ref by name fails and the whole job
+  # goes red for a reason unrelated to the change under test -- without gating any
+  # merge. Run on PRs for pre-merge signal and on push-to-main for post-merge
+  # detection of whatever actually landed; `main` is a permanent ref so the race
+  # can't happen. The daily schedule stays the full-coverage safety net. `paths`
+  # is not evaluated for tag pushes, so the `v*.*.*` release trigger below still
+  # fires regardless of changed files.
   pull_request:
     branches: [main]
     paths:
@@ -28,6 +39,15 @@ on:
       - ".github/actions/build-backend-image/**"
       - ".github/actions/login-ecr-pullthrough-cache/**"
   push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/pr-python-connector-tests.yml"
+      - ".github/actions/build-backend-image/**"
+      - ".github/actions/login-ecr-pullthrough-cache/**"
     tags:
       - "v*.*.*"
   schedule:


### PR DESCRIPTION
## What

Stop running the Connector Tests workflow on `merge_group`. Run it on `push` to `main` (post-merge) instead, alongside the existing PR presubmit and daily schedule.

## Why

Connector tests have been intermittently failing in the merge queue with:

```
git fetch --no-tags --depth=100 origin main gh-readonly-queue/main/pr-11356-...
fatal: couldn't find remote ref gh-readonly-queue/main/pr-11356-...
##[error]The process '/usr/bin/git' failed with exit code 128
```
([example run](https://github.com/onyx-dot-app/onyx/actions/runs/26854563629/job/79194711466))

The merge queue tests each entry on an **ephemeral `gh-readonly-queue/*` branch**. `dorny/paths-filter` computes its diff by fetching the head ref **by name** to find the merge-base. When an entry ahead in the queue fails (or the queue is reordered/dequeued), GitHub deletes and recreates the queue branches with new SHAs. If that happens mid-run, the by-name fetch hits a ref that no longer exists → exit 128 → the whole job goes red, unrelated to the change under test.

**Why only the connector workflow hits this:** its paths-filter step runs inside `connectors-check`, which `needs: build-backend-image` — so it executes ~3+ minutes after the event, a wide window for the queue branch to be torn down. The other workflows run paths-filter in a no-`needs:` `changes` job within seconds of the event, so they almost never race it.

**Why moving it off the queue is safe:** `connectors-check` is **not** a required status check (main's ruleset requires only `quality-checks`, `playwright-required`, `database-tests`, `backend-check`, `mypy-check`, `Jest Tests`, `required`). It's non-blocking and exercises real external connector APIs — exactly the kind of slow/flaky suite that doesn't belong in the merge queue. Running it on `merge_group` gated nothing and only added a race surface.

## How

- Remove the `merge_group:` trigger.
- Add `push: branches: [main]` so the suite runs post-merge against `main` (a **permanent** ref — the branch-deletion race cannot occur).
- Scope the push trigger with the same `paths:` as the PR trigger so unrelated (e.g. frontend-only) merges don't run it. `paths` is **not** evaluated for tag pushes, so the existing `v*.*.*` release trigger still fires regardless of changed files.
- PR presubmit (pre-merge signal) and the daily `schedule` (full-coverage safety net, with its Slack alert) are unchanged.

Post-merge is detection rather than prevention, but since these tests were already non-blocking, no gating is lost — and the daily cron's Slack alert remains the signal for "broken vs. flaky."

## Test plan

- [x] Workflow YAML parses; triggers are now `pull_request, push, schedule` with `push` = `{branches:[main], paths, tags}`
- [ ] Confirm a merge to `main` triggers the run and a frontend-only merge does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run connector tests on pushes to `main` (post-merge) instead of in the merge queue to eliminate flaky failures from ephemeral `gh-readonly-queue/*` branches. PR presubmit and the daily schedule remain; tag releases still trigger.

- **Refactors**
  - Removed `merge_group` trigger.
  - Added `push: branches: [main]` with `paths` filter to avoid unrelated runs.
  - Avoids `dorny/paths-filter` by-name fetch failures when queue branches are recycled.

<sup>Written for commit def2c99bbcd4293b8b08298409bf429d236b82ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

