### PR TITLE
feat(craft): scheduled task pre-approvals — gate short-circuit + grants

### DIFF
--- a/backend/alembic/versions/99ecd56cb2ce_scheduled_task_pre_approvals.py
+++ b/backend/alembic/versions/99ecd56cb2ce_scheduled_task_pre_approvals.py
@@ -2,9 +2,10 @@
 
 Per-app pre-approval grants on scheduled tasks: the egress gate skips
 the approval park for a RUNNING scheduled run whose task grants the
-matched app. ``decided_via`` distinguishes pre-approved audit rows from
-human clicks; ``external_app_id`` makes the run-history feedback loop
-resolvable (``app_name`` is not unique across app instances).
+matched app. Grants live in ``scheduled_task_pre_approved_app`` (one row
+per (task, app), FK to both). ``decided_via`` distinguishes pre-approved
+audit rows from human clicks; ``external_app_id`` makes the run-history
+feedback loop resolvable (``app_name`` is not unique across app instances).
 
 Revision ID: 99ecd56cb2ce
 Revises: b8a5e7068be5
@@ -24,13 +25,28 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        "scheduled_task",
+    op.create_table(
+        "scheduled_task_pre_approved_app",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("scheduled_task_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("external_app_id", sa.Integer(), nullable=False),
         sa.Column(
-            "pre_approved_app_ids",
-            postgresql.JSONB(),
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
             nullable=False,
-            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["scheduled_task_id"], ["scheduled_task.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["external_app_id"], ["external_app.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scheduled_task_id",
+            "external_app_id",
+            name="uq_scheduled_task_pre_approved_app",
         ),
     )
     op.add_column(
@@ -57,4 +73,4 @@ def downgrade() -> None:
     )
     op.drop_column("action_approval", "external_app_id")
     op.drop_column("action_approval", "decided_via")
-    op.drop_column("scheduled_task", "pre_approved_app_ids")
+    op.drop_table("scheduled_task_pre_approved_app")

--- a/backend/alembic/versions/99ecd56cb2ce_scheduled_task_pre_approvals.py
+++ b/backend/alembic/versions/99ecd56cb2ce_scheduled_task_pre_approvals.py
@@ -1,0 +1,60 @@
+"""scheduled task pre-approvals
+
+Per-app pre-approval grants on scheduled tasks: the egress gate skips
+the approval park for a RUNNING scheduled run whose task grants the
+matched app. ``decided_via`` distinguishes pre-approved audit rows from
+human clicks; ``external_app_id`` makes the run-history feedback loop
+resolvable (``app_name`` is not unique across app instances).
+
+Revision ID: 99ecd56cb2ce
+Revises: b8a5e7068be5
+Create Date: 2026-06-02 17:17:53.925335
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "99ecd56cb2ce"
+down_revision = "b8a5e7068be5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_task",
+        sa.Column(
+            "pre_approved_app_ids",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "action_approval",
+        sa.Column("decided_via", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "action_approval",
+        sa.Column("external_app_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_action_approval_external_app_id",
+        "action_approval",
+        "external_app",
+        ["external_app_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_action_approval_external_app_id", "action_approval", type_="foreignkey"
+    )
+    op.drop_column("action_approval", "external_app_id")
+    op.drop_column("action_approval", "decided_via")
+    op.drop_column("scheduled_task", "pre_approved_app_ids")

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -289,6 +289,7 @@ class NotificationType(str, Enum):
     LICENSE_EXPIRY_WARNING = "license_expiry_warning"
     SCHEDULED_TASK_FAILED = "scheduled_task_failed"
     SCHEDULED_TASK_AWAITING_APPROVAL = "scheduled_task_awaiting_approval"
+    SCHEDULED_TASK_PRE_APPROVED_ACTION = "scheduled_task_pre_approved_action"
     APPROVAL_REQUESTED = "approval_requested"
 
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -299,6 +299,12 @@ class ApprovalDecision(str, PyEnum):
     EXPIRED = "EXPIRED"
 
 
+class ApprovalDecidedVia(str, PyEnum):
+    # NULL on legacy rows and proxy-written EXPIRED claims.
+    USER = "USER"
+    PRE_APPROVAL = "PRE_APPROVAL"
+
+
 class ScheduledTaskStatus(str, PyEnum):
     ACTIVE = "ACTIVE"
     PAUSED = "PAUSED"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5519,15 +5519,6 @@ class ScheduledTask(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     prompt: Mapped[str] = mapped_column(Text, nullable=False)
 
-    # Apps whose ASK-gated actions skip the park for this task's runs.
-    # Reset to [] on prompt change — a grant is tied to a specific intent.
-    pre_approved_app_ids: Mapped[list[int]] = mapped_column(
-        PGJSONB,
-        nullable=False,
-        default=list,
-        server_default=text("'[]'::jsonb"),
-    )
-
     # Canonical 5-field cron expression. The three UI editor modes (interval,
     # daily/weekly, advanced) all compile to this string on save.
     cron_expression: Mapped[str] = mapped_column(String, nullable=False)
@@ -5567,6 +5558,20 @@ class ScheduledTask(Base):
         back_populates="task",
         cascade="all, delete-orphan",
     )
+    # Apps whose ASK-gated actions skip the park for this task's runs.
+    # Cleared on prompt change — a grant is tied to a specific intent.
+    pre_approved_apps: Mapped[list["ScheduledTaskPreApprovedApp"]] = relationship(
+        "ScheduledTaskPreApprovedApp",
+        back_populates="task",
+        cascade="all, delete-orphan",
+        order_by="ScheduledTaskPreApprovedApp.id",
+    )
+
+    @property
+    def pre_approved_app_ids(self) -> list[int]:
+        """Granted external-app ids in grant order. Set via
+        ``onyx.db.scheduled_task.set_pre_approved_apps``."""
+        return [grant.external_app_id for grant in self.pre_approved_apps]
 
     __table_args__ = (
         # Dispatcher hot path: WHERE status='active' AND deleted=false
@@ -5655,6 +5660,45 @@ class ScheduledTaskRun(Base):
         # Session-view banner lookup: get_scheduled_run_context filters by
         # session_id on every session open.
         Index("ix_scheduled_task_run_session", "session_id"),
+    )
+
+
+class ScheduledTaskPreApprovedApp(Base):
+    """One (task, app) pre-approval grant: the matched app's ASK-gated
+    actions skip the approval park for the task's RUNNING runs.
+
+    Deleting the task (CASCADE) or the app (CASCADE) drops the grant; a
+    stale grant on a removed app is meaningless. The unique constraint
+    keeps grants idempotent and its index serves the per-task lookup.
+    """
+
+    __tablename__ = "scheduled_task_pre_approved_app"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    scheduled_task_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("scheduled_task.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    external_app_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("external_app.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    task: Mapped[ScheduledTask] = relationship(
+        "ScheduledTask", back_populates="pre_approved_apps"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "scheduled_task_id",
+            "external_app_id",
+            name="uq_scheduled_task_pre_approved_app",
+        ),
     )
 
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -59,6 +59,7 @@ from onyx.configs.constants import TokenRateLimitScope
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
 from onyx.db.enums import AccountType
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import ArtifactType
 from onyx.db.enums import BuildSessionStatus
@@ -5483,6 +5484,17 @@ class ActionApproval(Base):
     decided_at: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    decided_via: Mapped[ApprovalDecidedVia | None] = mapped_column(
+        Enum(ApprovalDecidedVia, native_enum=False, name="approvaldecidedvia"),
+        nullable=True,
+    )
+    # Lookups key off this id, not ``app_name``: the latter isn't unique
+    # across instances (self-hosted GitLab/Jira share an app_type).
+    external_app_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("external_app.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
 
 class ScheduledTask(Base):
@@ -5506,6 +5518,15 @@ class ScheduledTask(Base):
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
     prompt: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Apps whose ASK-gated actions skip the park for this task's runs.
+    # Reset to [] on prompt change — a grant is tied to a specific intent.
+    pre_approved_app_ids: Mapped[list[int]] = mapped_column(
+        PGJSONB,
+        nullable=False,
+        default=list,
+        server_default=text("'[]'::jsonb"),
+    )
 
     # Canonical 5-field cron expression. The three UI editor modes (interval,
     # daily/weekly, advanced) all compile to this string on save.

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5558,8 +5558,6 @@ class ScheduledTask(Base):
         back_populates="task",
         cascade="all, delete-orphan",
     )
-    # Apps whose ASK-gated actions skip the park for this task's runs.
-    # Cleared on prompt change — a grant is tied to a specific intent.
     pre_approved_apps: Mapped[list["ScheduledTaskPreApprovedApp"]] = relationship(
         "ScheduledTaskPreApprovedApp",
         back_populates="task",

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -30,6 +30,7 @@ from onyx.db.enums import ScheduledTaskSkipReason
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.models import ScheduledTask
+from onyx.db.models import ScheduledTaskPreApprovedApp
 from onyx.db.models import ScheduledTaskRun
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -78,11 +79,21 @@ def create_scheduled_task(
         editor_mode=editor_mode,
         status=status,
         next_run_at=next_run_at,
-        pre_approved_app_ids=pre_approved_app_ids or [],
     )
+    set_pre_approved_apps(task, pre_approved_app_ids or [])
     db_session.add(task)
     db_session.flush()
     return task
+
+
+def set_pre_approved_apps(task: ScheduledTask, app_ids: list[int]) -> None:
+    """Replace a task's pre-approval grants with ``app_ids`` (order-preserving,
+    deduped). Removed grants are deleted via the ``delete-orphan`` cascade.
+    """
+    deduped = list(dict.fromkeys(app_ids))
+    task.pre_approved_apps = [
+        ScheduledTaskPreApprovedApp(external_app_id=app_id) for app_id in deduped
+    ]
 
 
 def get_scheduled_task(
@@ -164,9 +175,9 @@ def update_scheduled_task(
         task.name = name
     if prompt is not None and prompt != task.prompt:
         task.prompt = prompt
-        task.pre_approved_app_ids = []
+        set_pre_approved_apps(task, [])
     if pre_approved_app_ids is not None:
-        task.pre_approved_app_ids = pre_approved_app_ids
+        set_pre_approved_apps(task, pre_approved_app_ids)
     if editor_mode is not None:
         task.editor_mode = editor_mode
     if cron_expression is not None and cron_expression != task.cron_expression:
@@ -483,22 +494,27 @@ def get_live_scheduled_run_grants(
     """``(run_id, pre_approved_app_ids)`` when ``session_id`` is a currently
     RUNNING scheduled run; ``None`` otherwise.
 
-    The join to ``scheduled_task_run`` subsumes the session-origin check
+    The ``scheduled_task_run`` lookup subsumes the session-origin check
     (only SCHEDULED-origin sessions have run rows); the RUNNING filter means
     interactive follow-ups on a finished scheduled session park as usual.
     """
-    row = db_session.execute(
-        select(ScheduledTaskRun.id, ScheduledTask.pre_approved_app_ids)
-        .join(ScheduledTask, ScheduledTaskRun.task_id == ScheduledTask.id)
-        .where(
+    run = db_session.execute(
+        select(ScheduledTaskRun.id, ScheduledTaskRun.task_id).where(
             ScheduledTaskRun.session_id == session_id,
             ScheduledTaskRun.status == ScheduledTaskRunStatus.RUNNING,
         )
     ).first()
-    if row is None:
+    if run is None:
         return None
-    run_id, app_ids = row
-    return run_id, list(app_ids or [])
+    run_id, task_id = run
+    app_ids = list(
+        db_session.execute(
+            select(ScheduledTaskPreApprovedApp.external_app_id)
+            .where(ScheduledTaskPreApprovedApp.scheduled_task_id == task_id)
+            .order_by(ScheduledTaskPreApprovedApp.id)
+        ).scalars()
+    )
+    return run_id, app_ids
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -485,12 +485,15 @@ def find_stuck_runs(
 # Egress-gate pre-approval lookup
 # ---------------------------------------------------------------------------
 
+# (run_id, granted external-app ids) for a RUNNING scheduled run, else None.
+ScheduledRunGrants = tuple[UUID, list[int]] | None
+
 
 def get_live_scheduled_run_grants(
     *,
     db_session: Session,
     session_id: UUID,
-) -> tuple[UUID, list[int]] | None:
+) -> ScheduledRunGrants:
     """``(run_id, pre_approved_app_ids)`` when ``session_id`` is a currently
     RUNNING scheduled run; ``None`` otherwise.
 

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -87,12 +87,15 @@ def create_scheduled_task(
 
 
 def set_pre_approved_apps(task: ScheduledTask, app_ids: list[int]) -> None:
-    """Replace a task's pre-approval grants with ``app_ids`` (order-preserving,
-    deduped). Removed grants are deleted via the ``delete-orphan`` cascade.
+    """Replace a task's pre-approval grants with ``app_ids`` (deduped). Reuses
+    existing rows so re-submitting a granted app is a no-op — recreating it
+    would orphan+reinsert the same unique key in one flush, which Postgres
+    rejects. Removed grants drop via the ``delete-orphan`` cascade.
     """
-    deduped = list(dict.fromkeys(app_ids))
+    existing = {grant.external_app_id: grant for grant in task.pre_approved_apps}
     task.pre_approved_apps = [
-        ScheduledTaskPreApprovedApp(external_app_id=app_id) for app_id in deduped
+        existing.get(app_id) or ScheduledTaskPreApprovedApp(external_app_id=app_id)
+        for app_id in dict.fromkeys(app_ids)
     ]
 
 
@@ -175,7 +178,9 @@ def update_scheduled_task(
         task.name = name
     if prompt is not None and prompt != task.prompt:
         task.prompt = prompt
-        set_pre_approved_apps(task, [])
+        # Prompt change resets grants unless this same patch supplies new ones.
+        if pre_approved_app_ids is None:
+            pre_approved_app_ids = []
     if pre_approved_app_ids is not None:
         set_pre_approved_apps(task, pre_approved_app_ids)
     if editor_mode is not None:

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -54,6 +54,7 @@ def create_scheduled_task(
     cron_expression: str,
     editor_mode: EditorMode,
     status: ScheduledTaskStatus = ScheduledTaskStatus.ACTIVE,
+    pre_approved_app_ids: list[int] | None = None,
     now: datetime | None = None,
 ) -> ScheduledTask:
     """Insert a new ``ScheduledTask``.
@@ -77,6 +78,7 @@ def create_scheduled_task(
         editor_mode=editor_mode,
         status=status,
         next_run_at=next_run_at,
+        pre_approved_app_ids=pre_approved_app_ids or [],
     )
     db_session.add(task)
     db_session.flush()
@@ -135,6 +137,7 @@ def update_scheduled_task(
     cron_expression: str | None = None,
     editor_mode: EditorMode | None = None,
     status: ScheduledTaskStatus | None = None,
+    pre_approved_app_ids: list[int] | None = None,
     now: datetime | None = None,
 ) -> ScheduledTask:
     """Apply a partial update to a scheduled task.
@@ -144,6 +147,9 @@ def update_scheduled_task(
         ``next_run_at`` is recomputed from ``now``.
       - If ``status`` transitions to PAUSED, ``next_run_at`` is set to NULL.
       - If ``status`` transitions to ACTIVE, ``next_run_at`` is recomputed.
+      - If ``prompt`` changes value, ``pre_approved_app_ids`` resets to []
+        (a grant is tied to a specific intent). Grants in the same patch
+        still win.
 
     Raises:
         OnyxError(NOT_FOUND): the task does not exist or is not owned by
@@ -156,8 +162,11 @@ def update_scheduled_task(
     schedule_changed = False
     if name is not None:
         task.name = name
-    if prompt is not None:
+    if prompt is not None and prompt != task.prompt:
         task.prompt = prompt
+        task.pre_approved_app_ids = []
+    if pre_approved_app_ids is not None:
+        task.pre_approved_app_ids = pre_approved_app_ids
     if editor_mode is not None:
         task.editor_mode = editor_mode
     if cron_expression is not None and cron_expression != task.cron_expression:
@@ -459,6 +468,37 @@ def find_stuck_runs(
         )
     )
     return list(db_session.execute(stmt).scalars())
+
+
+# ---------------------------------------------------------------------------
+# Egress-gate pre-approval lookup
+# ---------------------------------------------------------------------------
+
+
+def get_live_scheduled_run_grants(
+    *,
+    db_session: Session,
+    session_id: UUID,
+) -> tuple[UUID, list[int]] | None:
+    """``(run_id, pre_approved_app_ids)`` when ``session_id`` is a currently
+    RUNNING scheduled run; ``None`` otherwise.
+
+    The join to ``scheduled_task_run`` subsumes the session-origin check
+    (only SCHEDULED-origin sessions have run rows); the RUNNING filter means
+    interactive follow-ups on a finished scheduled session park as usual.
+    """
+    row = db_session.execute(
+        select(ScheduledTaskRun.id, ScheduledTask.pre_approved_app_ids)
+        .join(ScheduledTask, ScheduledTaskRun.task_id == ScheduledTask.id)
+        .where(
+            ScheduledTaskRun.session_id == session_id,
+            ScheduledTaskRun.status == ScheduledTaskRunStatus.RUNNING,
+        )
+    ).first()
+    if row is None:
+        return None
+    run_id, app_ids = row
+    return run_id, list(app_ids or [])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -439,15 +439,10 @@ class GateAddon:
     def _resolve_auto_approval(
         self, db: Session, ctx: SessionContext, match: RequestMatch
     ) -> _AutoApproval | None:
-        """Grant sources, checked before the park; first hit wins, ``None``
-        parks. The single extension point for skipping the approval park.
-
-        Each source inspects ``match`` and may scope at any granularity — the
-        whole app (``match.external_app_id``) or a specific action
-        (``match.decisive.action_type``). Today: scheduled-task pre-approval.
-        Future session-scoped grants (auto-approve-all, per-app, per-action)
-        add a source here and reuse the mint/inject/notify path unchanged.
-        """
+        """Resolve a gated request to an auto-approval, or ``None`` to park."""
+        # Scheduled-task grants are the only auto-approval type today. As other
+        # types appear (session-scoped, per-action), each becomes a source
+        # resolved here — first hit wins.
         return self._scheduled_task_grant(db, ctx, match)
 
     def _scheduled_task_grant(

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -26,6 +26,7 @@ from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
 from onyx.db.scheduled_task import get_live_scheduled_run_grants
+from onyx.db.scheduled_task import ScheduledRunGrants
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.action_matcher import ActionMatcher
@@ -82,10 +83,6 @@ class _AutoApproval:
     notification_data: dict[str, str | int]
 
 
-# Result of the scheduled-run grant lookup: (run_id, granted_app_ids) for a
-# RUNNING scheduled run, or None.
-_GrantLookup = tuple[UUID, list[int]] | None
-
 # Grants for a RUNNING scheduled run are stable for the run's lifetime, so the
 # lookup is cached per session instead of hitting Postgres on every gated
 # request. The TTL bounds staleness from the RUNNING -> terminal transition
@@ -107,14 +104,16 @@ class _GrantCache:
     def __init__(
         self,
         ttl_s: float = _GRANT_CACHE_TTL_S,
+        max_entries: int = _GRANT_CACHE_MAX_ENTRIES,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self._ttl_s = ttl_s
+        self._max_entries = max_entries
         self._clock = clock
         self._lock = threading.Lock()
-        self._entries: dict[UUID, tuple[float, _GrantLookup]] = {}
+        self._entries: dict[UUID, tuple[float, ScheduledRunGrants]] = {}
 
-    def get(self, session_id: UUID) -> tuple[bool, _GrantLookup]:
+    def get(self, session_id: UUID) -> tuple[bool, ScheduledRunGrants]:
         """Return ``(hit, value)``. ``hit`` is False on miss/expiry — the
         value is meaningless then and the caller must do the DB lookup."""
         now = self._clock()
@@ -124,10 +123,10 @@ class _GrantCache:
                 return False, None
             return True, entry[1]
 
-    def put(self, session_id: UUID, value: _GrantLookup) -> None:
+    def put(self, session_id: UUID, value: ScheduledRunGrants) -> None:
         now = self._clock()
         with self._lock:
-            if len(self._entries) >= _GRANT_CACHE_MAX_ENTRIES:
+            if len(self._entries) >= self._max_entries:
                 self._entries = {
                     sid: e for sid, e in self._entries.items() if e[0] > now
                 }

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -7,13 +7,15 @@ Fail-open: `ActionMatcher` exceptions and non-matching action types.
 import asyncio
 import base64
 import binascii
+import operator
 import threading
-import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
+from cachetools import cachedmethod
+from cachetools import TTLCache
 from mitmproxy import http
 from sqlalchemy.orm import Session
 
@@ -88,41 +90,6 @@ _GRANT_CACHE_TTL_S = 60.0
 _GRANT_CACHE_MAX_ENTRIES = 4096
 
 
-class _GrantCache:
-    """Per-session TTL cache of the scheduled-run grant lookup; lock-guarded
-    because the lookup runs on the gate's worker threads."""
-
-    def __init__(
-        self,
-        ttl_s: float = _GRANT_CACHE_TTL_S,
-        max_entries: int = _GRANT_CACHE_MAX_ENTRIES,
-        clock: Callable[[], float] = time.monotonic,
-    ) -> None:
-        self._ttl_s = ttl_s
-        self._max_entries = max_entries
-        self._clock = clock
-        self._lock = threading.Lock()
-        self._entries: dict[UUID, tuple[float, ScheduledRunGrants]] = {}
-
-    def get(self, session_id: UUID) -> tuple[bool, ScheduledRunGrants]:
-        """``(hit, value)``; on miss ``hit`` is False and the caller hits the DB."""
-        now = self._clock()
-        with self._lock:
-            entry = self._entries.get(session_id)
-            if entry is None or entry[0] <= now:
-                return False, None
-            return True, entry[1]
-
-    def put(self, session_id: UUID, value: ScheduledRunGrants) -> None:
-        now = self._clock()
-        with self._lock:
-            if len(self._entries) >= self._max_entries:
-                self._entries = {
-                    sid: e for sid, e in self._entries.items() if e[0] > now
-                }
-            self._entries[session_id] = (now + self._ttl_s, value)
-
-
 class ParkedApprovals:
     """Approvals the proxy is currently parked on, grouped by tenant.
 
@@ -178,7 +145,12 @@ class GateAddon:
         # Tracks running `request()` coroutines so the drain can `asyncio.wait`
         # on real completion instead of sleeping. Self-cleaning.
         self._inflight_tasks: set[asyncio.Task[None]] = set()
-        self._grant_cache = _GrantCache()
+        # Per-session memoization of the scheduled-run grant lookup. Lock-guarded
+        # because `_live_grants` runs on the gate's worker threads.
+        self._grant_cache: TTLCache[UUID, ScheduledRunGrants] = TTLCache(
+            maxsize=_GRANT_CACHE_MAX_ENTRIES, ttl=_GRANT_CACHE_TTL_S
+        )
+        self._grant_cache_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # mitmproxy hooks
@@ -288,7 +260,6 @@ class GateAddon:
         # Auto-approval short-circuit: a grant source (today: a RUNNING
         # scheduled run pre-approving this app) skips the park. Off-thread to
         # keep sync DB work off the event loop; failure falls through to park.
-        auto_approved: bool
         try:
             auto_approved = await asyncio.to_thread(self._try_auto_approve, ctx, match)
         except Exception:
@@ -301,9 +272,8 @@ class GateAddon:
             )
             auto_approved = False
         if auto_approved:
-            # Same off-thread rationale as the ALWAYS / post-approval paths.
-            # Fail closed: an unguarded raise would let mitmproxy forward the
-            # original request, bypassing the gate after an APPROVED row exists.
+            # Fail closed: an unguarded raise here would let mitmproxy forward
+            # the original request, bypassing the gate after an APPROVED row exists.
             try:
                 await asyncio.to_thread(
                     self._dispatch_injection_or_block,
@@ -489,17 +459,20 @@ class GateAddon:
         # resolved here — first hit wins.
         return self._scheduled_task_grant(db, ctx, match)
 
+    @cachedmethod(
+        operator.attrgetter("_grant_cache"),
+        key=lambda _self, _db, session_id: session_id,
+        lock=operator.attrgetter("_grant_cache_lock"),
+    )
+    def _live_grants(self, db: Session, session_id: UUID) -> ScheduledRunGrants:
+        return get_live_scheduled_run_grants(db_session=db, session_id=session_id)
+
     def _scheduled_task_grant(
         self, db: Session, ctx: SessionContext, match: RequestMatch
     ) -> _AutoApproval | None:
         """Grant source: a RUNNING scheduled run whose task pre-approves the
         matched app."""
-        hit, grants = self._grant_cache.get(ctx.session_id)
-        if not hit:
-            grants = get_live_scheduled_run_grants(
-                db_session=db, session_id=ctx.session_id
-            )
-            self._grant_cache.put(ctx.session_id, grants)
+        grants = self._live_grants(db, ctx.session_id)
         if grants is None:
             return None
         run_id, granted_app_ids = grants

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -17,9 +17,11 @@ from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
+from onyx.db.scheduled_task import get_live_scheduled_run_grants
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.action_matcher import ActionMatcher
@@ -222,6 +224,30 @@ class GateAddon:
             return
         ctx, match = gate_target
 
+        # Pre-approval short-circuit: a RUNNING scheduled run granting this
+        # app skips the park. Off-thread to keep sync DB work off the event
+        # loop; failure falls through to the normal park flow.
+        try:
+            pre_approved = await asyncio.to_thread(self._try_pre_approve, ctx, match)
+        except Exception:
+            logger.exception(
+                "gate.pre_approval_check_error session_id=%s tenant_id=%s "
+                "action_type=%s",
+                ctx.session_id,
+                ctx.tenant_id,
+                match.decisive.action_type,
+            )
+            pre_approved = False
+        if pre_approved:
+            # Same off-thread rationale as the ALWAYS / post-approval paths.
+            await asyncio.to_thread(
+                self._dispatch_injection_or_block,
+                flow,
+                sandbox=ctx.without_session(),
+                match=match,
+            )
+            return
+
         # mitmproxy forwards the original request on unhandled addon
         # exceptions, silently bypassing the gate. Fail closed instead.
         approval_id: UUID | None = None
@@ -380,6 +406,55 @@ class GateAddon:
         )
         return ctx, match
 
+    def _try_pre_approve(self, ctx: SessionContext, match: RequestMatch) -> bool:
+        """Insert a pre-decided APPROVED row for a RUNNING scheduled run that
+        grants the matched app; False otherwise (falls through to the park).
+
+        Bypassing ``try_record_decision``'s arbiter is safe: nothing parks
+        on a pre-decided row.
+        """
+        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
+            grants = get_live_scheduled_run_grants(
+                db_session=db, session_id=ctx.session_id
+            )
+            if grants is None:
+                return False
+            run_id, granted_app_ids = grants
+            if match.external_app_id not in granted_app_ids:
+                return False
+            row = action_approval.insert_action_approval(
+                db,
+                session_id=ctx.session_id,
+                actions=[a.model_dump(mode="json") for a in match.actions],
+                app_name=match.app_name,
+                payload=match.payload,
+                external_app_id=match.external_app_id,
+                decision=ApprovalDecision.APPROVED,
+                decided_via=ApprovalDecidedVia.PRE_APPROVAL,
+            )
+            approval_id = row.approval_id
+            db.commit()
+
+        logger.info(
+            "gate.pre_approved approval_id=%s session_id=%s tenant_id=%s "
+            "run_id=%s external_app_id=%s action_type=%s",
+            approval_id,
+            ctx.session_id,
+            ctx.tenant_id,
+            run_id,
+            match.external_app_id,
+            match.decisive.action_type,
+        )
+        try:
+            self._notify_pre_approved(run_id, ctx, match)
+        except Exception as e:
+            logger.warning(
+                "gate.pre_approve_notify_failed approval_id=%s error=%s",
+                approval_id,
+                str(e),
+            )
+        return True
+
     def _persist_approval_row(self, ctx: SessionContext, match: RequestMatch) -> UUID:
         """Commit the row, register it for the drain, announce to the chat.
 
@@ -394,6 +469,7 @@ class GateAddon:
                 actions=actions_payload,
                 app_name=match.app_name,
                 payload=match.payload,
+                external_app_id=match.external_app_id,
             )
             approval_id = row.approval_id
             db.commit()
@@ -626,6 +702,28 @@ class GateAddon:
     # ------------------------------------------------------------------
     # Notification dispatch
     # ------------------------------------------------------------------
+
+    def _notify_pre_approved(
+        self, run_id: UUID, ctx: SessionContext, match: RequestMatch
+    ) -> None:
+        """Best-effort notification, one per (run, app).
+
+        ``create_notification`` dedups on (user, type, additional_data), so
+        the payload must stay exactly this pair — anything per-request would
+        defeat the dedup.
+        """
+        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
+            create_notification(
+                user_id=ctx.user_id,
+                notif_type=NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION,
+                db_session=db,
+                title=f"Scheduled task used {match.app_name} (pre-approved)",
+                additional_data={
+                    "run_id": str(run_id),
+                    "external_app_id": match.external_app_id,
+                },
+                autocommit=True,
+            )
 
     def _notify_approval_requested(
         self, approval_id: UUID, ctx: SessionContext, match: RequestMatch

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -7,6 +7,8 @@ Fail-open: `ActionMatcher` exceptions and non-matching action types.
 import asyncio
 import base64
 import binascii
+import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
@@ -80,6 +82,58 @@ class _AutoApproval:
     notification_data: dict[str, str | int]
 
 
+# Result of the scheduled-run grant lookup: (run_id, granted_app_ids) for a
+# RUNNING scheduled run, or None.
+_GrantLookup = tuple[UUID, list[int]] | None
+
+# Grants for a RUNNING scheduled run are stable for the run's lifetime, so the
+# lookup is cached per session instead of hitting Postgres on every gated
+# request. The TTL bounds staleness from the RUNNING -> terminal transition
+# (e.g. an interactive follow-up on a finished scheduled session must park
+# again once the entry expires).
+_GRANT_CACHE_TTL_S = 60.0
+# Soft cap; expired entries are pruned before a write once the map grows past
+# this, bounding memory under a churn of distinct sessions.
+_GRANT_CACHE_MAX_ENTRIES = 4096
+
+
+class _GrantCache:
+    """Per-session TTL cache of the scheduled-run grant lookup.
+
+    Read from the gate's worker threads (the lookup runs under
+    ``asyncio.to_thread``), so every access is lock-guarded.
+    """
+
+    def __init__(
+        self,
+        ttl_s: float = _GRANT_CACHE_TTL_S,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl_s = ttl_s
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._entries: dict[UUID, tuple[float, _GrantLookup]] = {}
+
+    def get(self, session_id: UUID) -> tuple[bool, _GrantLookup]:
+        """Return ``(hit, value)``. ``hit`` is False on miss/expiry — the
+        value is meaningless then and the caller must do the DB lookup."""
+        now = self._clock()
+        with self._lock:
+            entry = self._entries.get(session_id)
+            if entry is None or entry[0] <= now:
+                return False, None
+            return True, entry[1]
+
+    def put(self, session_id: UUID, value: _GrantLookup) -> None:
+        now = self._clock()
+        with self._lock:
+            if len(self._entries) >= _GRANT_CACHE_MAX_ENTRIES:
+                self._entries = {
+                    sid: e for sid, e in self._entries.items() if e[0] > now
+                }
+            self._entries[session_id] = (now + self._ttl_s, value)
+
+
 class ParkedApprovals:
     """Approvals the proxy is currently parked on, grouped by tenant.
 
@@ -135,6 +189,8 @@ class GateAddon:
         # Tracks running `request()` coroutines so the drain can `asyncio.wait`
         # on real completion instead of sleeping. Self-cleaning.
         self._inflight_tasks: set[asyncio.Task[None]] = set()
+        # Per-session cache of the scheduled-run grant lookup (hot path).
+        self._grant_cache = _GrantCache()
 
     # ------------------------------------------------------------------
     # mitmproxy hooks
@@ -450,7 +506,12 @@ class GateAddon:
     ) -> _AutoApproval | None:
         """Grant source: a RUNNING scheduled run whose task pre-approves the
         matched app. App-level granularity, per scheduled-task semantics."""
-        grants = get_live_scheduled_run_grants(db_session=db, session_id=ctx.session_id)
+        hit, grants = self._grant_cache.get(ctx.session_id)
+        if not hit:
+            grants = get_live_scheduled_run_grants(
+                db_session=db, session_id=ctx.session_id
+            )
+            self._grant_cache.put(ctx.session_id, grants)
         if grants is None:
             return None
         run_id, granted_app_ids = grants

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -83,23 +83,14 @@ class _AutoApproval:
     notification_data: dict[str, str | int]
 
 
-# Grants for a RUNNING scheduled run are stable for the run's lifetime, so the
-# lookup is cached per session instead of hitting Postgres on every gated
-# request. The TTL bounds staleness from the RUNNING -> terminal transition
-# (e.g. an interactive follow-up on a finished scheduled session must park
-# again once the entry expires).
+# TTL bounds staleness past a run's RUNNING -> terminal transition.
 _GRANT_CACHE_TTL_S = 60.0
-# Soft cap; expired entries are pruned before a write once the map grows past
-# this, bounding memory under a churn of distinct sessions.
 _GRANT_CACHE_MAX_ENTRIES = 4096
 
 
 class _GrantCache:
-    """Per-session TTL cache of the scheduled-run grant lookup.
-
-    Read from the gate's worker threads (the lookup runs under
-    ``asyncio.to_thread``), so every access is lock-guarded.
-    """
+    """Per-session TTL cache of the scheduled-run grant lookup; lock-guarded
+    because the lookup runs on the gate's worker threads."""
 
     def __init__(
         self,
@@ -114,8 +105,7 @@ class _GrantCache:
         self._entries: dict[UUID, tuple[float, ScheduledRunGrants]] = {}
 
     def get(self, session_id: UUID) -> tuple[bool, ScheduledRunGrants]:
-        """Return ``(hit, value)``. ``hit`` is False on miss/expiry — the
-        value is meaningless then and the caller must do the DB lookup."""
+        """``(hit, value)``; on miss ``hit`` is False and the caller hits the DB."""
         now = self._clock()
         with self._lock:
             entry = self._entries.get(session_id)
@@ -188,7 +178,6 @@ class GateAddon:
         # Tracks running `request()` coroutines so the drain can `asyncio.wait`
         # on real completion instead of sleeping. Self-cleaning.
         self._inflight_tasks: set[asyncio.Task[None]] = set()
-        # Per-session cache of the scheduled-run grant lookup (hot path).
         self._grant_cache = _GrantCache()
 
     # ------------------------------------------------------------------
@@ -504,7 +493,7 @@ class GateAddon:
         self, db: Session, ctx: SessionContext, match: RequestMatch
     ) -> _AutoApproval | None:
         """Grant source: a RUNNING scheduled run whose task pre-approves the
-        matched app. App-level granularity, per scheduled-task semantics."""
+        matched app."""
         hit, grants = self._grant_cache.get(ctx.session_id)
         if not hit:
             grants = get_live_scheduled_run_grants(

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -8,10 +8,12 @@ import asyncio
 import base64
 import binascii
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
 from mitmproxy import http
+from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
@@ -61,6 +63,21 @@ CacheFactory = Callable[[str], CacheBackend]
 # Relative deep link routed through the Next router by NotificationsPopover.tsx;
 # must mirror the frontend's CRAFT_PATH + sessionId search param.
 _CRAFT_SESSION_LINK_TEMPLATE = "/craft/v1?sessionId={session_id}"
+
+
+@dataclass(frozen=True)
+class _AutoApproval:
+    """A decision to approve a gated request without parking it.
+
+    Produced by a grant source in ``_resolve_auto_approval``; the
+    mint/inject/notify path that consumes it is source-agnostic. Carries how
+    to attribute the audit row (``decided_via``) and the bell entry to raise.
+    """
+
+    decided_via: ApprovalDecidedVia
+    notif_type: NotificationType
+    notification_title: str
+    notification_data: dict[str, str | int]
 
 
 class ParkedApprovals:
@@ -224,22 +241,22 @@ class GateAddon:
             return
         ctx, match = gate_target
 
-        # Pre-approval short-circuit: a RUNNING scheduled run granting this
-        # app skips the park. Off-thread to keep sync DB work off the event
-        # loop; failure falls through to the normal park flow.
-        pre_approved: bool
+        # Auto-approval short-circuit: a grant source (today: a RUNNING
+        # scheduled run pre-approving this app) skips the park. Off-thread to
+        # keep sync DB work off the event loop; failure falls through to park.
+        auto_approved: bool
         try:
-            pre_approved = await asyncio.to_thread(self._try_pre_approve, ctx, match)
+            auto_approved = await asyncio.to_thread(self._try_auto_approve, ctx, match)
         except Exception:
             logger.exception(
-                "gate.pre_approval_check_error session_id=%s tenant_id=%s "
+                "gate.auto_approval_check_error session_id=%s tenant_id=%s "
                 "action_type=%s",
                 ctx.session_id,
                 ctx.tenant_id,
                 match.decisive.action_type,
             )
-            pre_approved = False
-        if pre_approved:
+            auto_approved = False
+        if auto_approved:
             # Same off-thread rationale as the ALWAYS / post-approval paths.
             # Fail closed: an unguarded raise would let mitmproxy forward the
             # original request, bypassing the gate after an APPROVED row exists.
@@ -252,7 +269,7 @@ class GateAddon:
                 )
             except Exception:
                 logger.exception(
-                    "gate.pre_approved_dispatch_error session_id=%s tenant_id=%s "
+                    "gate.auto_approved_dispatch_error session_id=%s tenant_id=%s "
                     "action_type=%s",
                     ctx.session_id,
                     ctx.tenant_id,
@@ -419,21 +436,51 @@ class GateAddon:
         )
         return ctx, match
 
-    def _try_pre_approve(self, ctx: SessionContext, match: RequestMatch) -> bool:
-        """Insert a pre-decided APPROVED row for a RUNNING scheduled run that
-        grants the matched app; False otherwise (falls through to the park).
+    def _resolve_auto_approval(
+        self, db: Session, ctx: SessionContext, match: RequestMatch
+    ) -> _AutoApproval | None:
+        """Grant sources, checked before the park; first hit wins, ``None``
+        parks. The single extension point for skipping the approval park.
+
+        Each source inspects ``match`` and may scope at any granularity — the
+        whole app (``match.external_app_id``) or a specific action
+        (``match.decisive.action_type``). Today: scheduled-task pre-approval.
+        Future session-scoped grants (auto-approve-all, per-app, per-action)
+        add a source here and reuse the mint/inject/notify path unchanged.
+        """
+        return self._scheduled_task_grant(db, ctx, match)
+
+    def _scheduled_task_grant(
+        self, db: Session, ctx: SessionContext, match: RequestMatch
+    ) -> _AutoApproval | None:
+        """Grant source: a RUNNING scheduled run whose task pre-approves the
+        matched app. App-level granularity, per scheduled-task semantics."""
+        grants = get_live_scheduled_run_grants(db_session=db, session_id=ctx.session_id)
+        if grants is None:
+            return None
+        run_id, granted_app_ids = grants
+        if match.external_app_id not in granted_app_ids:
+            return None
+        return _AutoApproval(
+            decided_via=ApprovalDecidedVia.PRE_APPROVAL,
+            notif_type=NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION,
+            notification_title=f"Scheduled task used {match.app_name} (pre-approved)",
+            notification_data={
+                "run_id": str(run_id),
+                "external_app_id": match.external_app_id,
+            },
+        )
+
+    def _try_auto_approve(self, ctx: SessionContext, match: RequestMatch) -> bool:
+        """Mint a pre-decided APPROVED row if a grant source covers this
+        request; False otherwise (falls through to the park). Source-agnostic.
 
         Bypassing ``try_record_decision``'s arbiter is safe: nothing parks
         on a pre-decided row.
         """
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
-            grants = get_live_scheduled_run_grants(
-                db_session=db, session_id=ctx.session_id
-            )
-            if grants is None:
-                return False
-            run_id, granted_app_ids = grants
-            if match.external_app_id not in granted_app_ids:
+            approval = self._resolve_auto_approval(db, ctx, match)
+            if approval is None:
                 return False
             row = action_approval.insert_action_approval(
                 db,
@@ -443,26 +490,26 @@ class GateAddon:
                 payload=match.payload,
                 external_app_id=match.external_app_id,
                 decision=ApprovalDecision.APPROVED,
-                decided_via=ApprovalDecidedVia.PRE_APPROVAL,
+                decided_via=approval.decided_via,
             )
             approval_id = row.approval_id
             db.commit()
 
         logger.info(
-            "gate.pre_approved approval_id=%s session_id=%s tenant_id=%s "
-            "run_id=%s external_app_id=%s action_type=%s",
+            "gate.auto_approved approval_id=%s session_id=%s tenant_id=%s "
+            "decided_via=%s external_app_id=%s action_type=%s",
             approval_id,
             ctx.session_id,
             ctx.tenant_id,
-            run_id,
+            approval.decided_via,
             match.external_app_id,
             match.decisive.action_type,
         )
         try:
-            self._notify_pre_approved(run_id, ctx, match)
+            self._notify_auto_approved(ctx, approval)
         except Exception as e:
             logger.warning(
-                "gate.pre_approve_notify_failed approval_id=%s error=%s",
+                "gate.auto_approve_notify_failed approval_id=%s error=%s",
                 approval_id,
                 str(e),
             )
@@ -716,25 +763,22 @@ class GateAddon:
     # Notification dispatch
     # ------------------------------------------------------------------
 
-    def _notify_pre_approved(
-        self, run_id: UUID, ctx: SessionContext, match: RequestMatch
+    def _notify_auto_approved(
+        self, ctx: SessionContext, approval: _AutoApproval
     ) -> None:
-        """Best-effort notification, one per (run, app).
+        """Best-effort bell entry for an auto-approved action.
 
         ``create_notification`` dedups on (user, type, additional_data), so
-        the payload must stay exactly this pair — anything per-request would
-        defeat the dedup.
+        the grant source must keep ``notification_data`` a stable per-scope
+        key — anything per-request would defeat the dedup.
         """
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             create_notification(
                 user_id=ctx.user_id,
-                notif_type=NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION,
+                notif_type=approval.notif_type,
                 db_session=db,
-                title=f"Scheduled task used {match.app_name} (pre-approved)",
-                additional_data={
-                    "run_id": str(run_id),
-                    "external_app_id": match.external_app_id,
-                },
+                title=approval.notification_title,
+                additional_data=approval.notification_data,
                 autocommit=True,
             )
 

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -241,12 +241,24 @@ class GateAddon:
             pre_approved = False
         if pre_approved:
             # Same off-thread rationale as the ALWAYS / post-approval paths.
-            await asyncio.to_thread(
-                self._dispatch_injection_or_block,
-                flow,
-                sandbox=ctx.without_session(),
-                match=match,
-            )
+            # Fail closed: an unguarded raise would let mitmproxy forward the
+            # original request, bypassing the gate after an APPROVED row exists.
+            try:
+                await asyncio.to_thread(
+                    self._dispatch_injection_or_block,
+                    flow,
+                    sandbox=ctx.without_session(),
+                    match=match,
+                )
+            except Exception:
+                logger.exception(
+                    "gate.pre_approved_dispatch_error session_id=%s tenant_id=%s "
+                    "action_type=%s",
+                    ctx.session_id,
+                    ctx.tenant_id,
+                    match.decisive.action_type,
+                )
+                flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             return
 
         # mitmproxy forwards the original request on unhandled addon

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -227,6 +227,7 @@ class GateAddon:
         # Pre-approval short-circuit: a RUNNING scheduled run granting this
         # app skips the park. Off-thread to keep sync DB work off the event
         # loop; failure falls through to the normal park flow.
+        pre_approved: bool
         try:
             pre_approved = await asyncio.to_thread(self._try_pre_approve, ctx, match)
         except Exception:

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -24,6 +24,7 @@ from onyx.auth.permissions import require_permission
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -165,7 +166,10 @@ def submit_decision(
         )
 
     decided = action_approval.try_record_decision(
-        db_session, approval_id=approval_id, decision=body.decision
+        db_session,
+        approval_id=approval_id,
+        decision=body.decision,
+        decided_via=ApprovalDecidedVia.USER,
     )
     if decided is None:
         # Lost the race. Expire the cached row — SQLAlchemy's identity

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import POLICY_SEVERITY
@@ -29,10 +30,18 @@ def insert_action_approval(
     actions: list[dict[str, Any]],
     app_name: str,
     payload: dict[str, Any],
+    external_app_id: int | None = None,
+    decision: ApprovalDecision | None = None,
+    decided_via: ApprovalDecidedVia | None = None,
 ) -> ActionApproval:
-    """Commit a pending approval. ``actions`` is the JSONB list of
+    """Commit an approval row. ``actions`` is the JSONB list of
     ``ActionMatch``-shaped dicts; must be non-empty. Re-sorted
-    strictest-policy-first so every reader can rely on ``actions[0]``."""
+    strictest-policy-first so every reader can rely on ``actions[0]``.
+
+    Defaults to a pending row (``decision IS NULL``). Passing ``decision``
+    inserts it pre-decided — safe to bypass ``try_record_decision``'s
+    arbiter because nothing parks on a pre-decided row.
+    """
     if not actions:
         raise ValueError("actions must be non-empty")
     sorted_actions = sorted(
@@ -45,6 +54,10 @@ def insert_action_approval(
         actions=sorted_actions,
         app_name=app_name,
         payload=payload,
+        external_app_id=external_app_id,
+        decision=decision,
+        decided_at=datetime.now(timezone.utc) if decision is not None else None,
+        decided_via=decided_via,
     )
     db_session.add(row)
     db_session.flush()
@@ -56,6 +69,7 @@ def try_record_decision(
     *,
     approval_id: UUID,
     decision: ApprovalDecision,
+    decided_via: ApprovalDecidedVia | None = None,
 ) -> ActionApproval | None:
     """Conditional UPDATE that succeeds only while `decision IS NULL`.
 
@@ -65,7 +79,11 @@ def try_record_decision(
         update(ActionApproval)
         .where(ActionApproval.approval_id == approval_id)
         .where(ActionApproval.decision.is_(None))
-        .values(decision=decision, decided_at=datetime.now(timezone.utc))
+        .values(
+            decision=decision,
+            decided_at=datetime.now(timezone.utc),
+            decided_via=decided_via,
+        )
         .returning(ActionApproval)
         .execution_options(synchronize_session=False)
     )

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -38,6 +38,7 @@ from onyx.db.enums import Permission
 from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
+from onyx.db.external_app import get_external_apps
 from onyx.db.models import ScheduledTask
 from onyx.db.models import ScheduledTaskRun
 from onyx.db.models import User
@@ -130,6 +131,7 @@ class ScheduledTaskCreate(_Forbid):
     editor_payload: EditorPayload
     status: ScheduledTaskStatus = ScheduledTaskStatus.ACTIVE
     run_immediately: bool = False
+    pre_approved_app_ids: list[int] = Field(default_factory=list)
 
     _dispatch = model_validator(mode="before")(_dispatch_editor_payload)
 
@@ -146,6 +148,7 @@ class ScheduledTaskPatch(_Forbid):
     editor_mode: EditorMode | None = None
     editor_payload: EditorPayload | None = None
     status: ScheduledTaskStatus | None = None
+    pre_approved_app_ids: list[int] | None = None
 
     _dispatch = model_validator(mode="before")(_dispatch_editor_payload)
 
@@ -216,6 +219,7 @@ class ScheduledTaskDetail(BaseModel):
     next_run_at: datetime | None
     next_runs: list[datetime]
     last_run: RunSummary | None
+    pre_approved_app_ids: list[int]
     created_at: datetime
     updated_at: datetime
 
@@ -303,9 +307,29 @@ def _detail(
         next_run_at=task.next_run_at,
         next_runs=next_runs,
         last_run=RunSummary.from_model(last_run) if last_run is not None else None,
+        pre_approved_app_ids=task.pre_approved_app_ids,
         created_at=task.created_at,
         updated_at=task.updated_at,
     )
+
+
+def _validated_app_ids(db_session: Session, app_ids: list[int]) -> list[int]:
+    """Dedupe (order-preserving) and verify each id is a configured app.
+
+    Existence-only: a grant on an app that never produces an ASK match is
+    inert, so credential / has-ASK-action filtering stays editor-side.
+    """
+    deduped = list(dict.fromkeys(app_ids))
+    if not deduped:
+        return []
+    known_ids = {app.id for app in get_external_apps(db_session)}
+    unknown = [app_id for app_id in deduped if app_id not in known_ids]
+    if unknown:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Unknown external app id(s): {unknown}",
+        )
+    return deduped
 
 
 def _enqueue_executor(run_id: UUID) -> None:
@@ -389,6 +413,9 @@ def create_task(
         cron_expression=cron_expression,
         editor_mode=request.editor_mode,
         status=request.status,
+        pre_approved_app_ids=_validated_app_ids(
+            db_session, request.pre_approved_app_ids
+        ),
     )
 
     if request.run_immediately:
@@ -449,6 +476,11 @@ def patch_task(
         cron_expression=cron_expression,
         editor_mode=request.editor_mode,
         status=request.status,
+        pre_approved_app_ids=(
+            _validated_app_ids(db_session, request.pre_approved_app_ids)
+            if request.pre_approved_app_ids is not None
+            else None
+        ),
     )
     db_session.commit()
     db_session.refresh(task)

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -31,7 +31,16 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.db.action_approval import insert_action_approval
 from onyx.server.features.build.scheduled_tasks import api as scheduled_tasks_api
 from tests.external_dependency_unit.craft._test_helpers import default_action_entries
+from tests.external_dependency_unit.craft._test_helpers import make_external_app
+from tests.external_dependency_unit.craft._test_helpers import make_skill
 from tests.external_dependency_unit.craft._test_helpers import make_user
+
+
+def _make_app(db_session: Session) -> int:
+    """Create a real ``ExternalApp`` and return its id. Grants now FK to
+    ``external_app``, so tests can't use arbitrary ints."""
+    app = make_external_app(db_session, skill=make_skill(db_session), auth_template={})
+    return app.id
 
 
 def _seed_task(
@@ -68,7 +77,8 @@ def test_grants_returned_for_running_run(
 ) -> None:
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[7, 9])
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a, app_b])
     run = insert_run(
         db_session=db_session,
         task_id=task.id,
@@ -87,7 +97,7 @@ def test_grants_returned_for_running_run(
     assert grants is not None
     run_id, app_ids = grants
     assert run_id == run.id
-    assert app_ids == [7, 9]
+    assert app_ids == [app_a, app_b]
 
 
 @pytest.mark.parametrize(
@@ -108,7 +118,7 @@ def test_no_grants_for_non_running_run(
     usual — the RUNNING filter is the load-bearing scope guard."""
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+    task = _seed_task(db_session, user, pre_approved_app_ids=[_make_app(db_session)])
     run = insert_run(
         db_session=db_session,
         task_id=task.id,
@@ -206,7 +216,7 @@ def test_prompt_value_change_resets_grants(
     tenant_context: None,  # noqa: ARG001
 ) -> None:
     user = make_user(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+    task = _seed_task(db_session, user, pre_approved_app_ids=[_make_app(db_session)])
 
     updated = update_scheduled_task(
         db_session=db_session,
@@ -226,7 +236,8 @@ def test_identical_prompt_resubmit_keeps_grants(
     """The editor round-trips the prompt on every save; an unchanged value
     must not wipe grants."""
     user = make_user(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[7], prompt="same")
+    app = _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app], prompt="same")
 
     updated = update_scheduled_task(
         db_session=db_session,
@@ -237,7 +248,7 @@ def test_identical_prompt_resubmit_keeps_grants(
     )
     db_session.commit()
 
-    assert updated.pre_approved_app_ids == [7]
+    assert updated.pre_approved_app_ids == [app]
 
 
 def test_grants_in_same_patch_win_over_prompt_reset(
@@ -247,18 +258,19 @@ def test_grants_in_same_patch_win_over_prompt_reset(
     """The editor's re-enable-in-the-same-submit flow: a prompt change plus
     explicit grants in one patch keeps the supplied grants."""
     user = make_user(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
 
     updated = update_scheduled_task(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
         prompt="a different prompt",
-        pre_approved_app_ids=[9],
+        pre_approved_app_ids=[app_b],
     )
     db_session.commit()
 
-    assert updated.pre_approved_app_ids == [9]
+    assert updated.pre_approved_app_ids == [app_b]
 
 
 def test_create_persists_grants(
@@ -266,8 +278,10 @@ def test_create_persists_grants(
     tenant_context: None,  # noqa: ARG001
 ) -> None:
     user = make_user(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[3, 1])
-    assert task.pre_approved_app_ids == [3, 1]
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    # Insertion order is preserved (not sorted): pass the higher id first.
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_b, app_a])
+    assert task.pre_approved_app_ids == [app_b, app_a]
 
     bare = _seed_task(db_session, user)
     assert bare.pre_approved_app_ids == []

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -1,0 +1,305 @@
+"""Scheduled-task pre-approvals (ext-dep): real SQL for the grant lookup,
+the pre-decided insert, and the prompt-edit reset rule.
+
+The gate-side short-circuit behavior (skip park / fall through / DENY
+ordering) is covered with stubs in ``tests/unit/sandbox_proxy/test_gate.py``;
+this file pins the queries those stubs stand in for.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ApprovalDecidedVia
+from onyx.db.enums import ApprovalDecision
+from onyx.db.enums import ScheduledTaskRunStatus
+from onyx.db.enums import ScheduledTaskStatus
+from onyx.db.enums import ScheduledTaskTriggerSource
+from onyx.db.models import BuildSession
+from onyx.db.models import ScheduledTask
+from onyx.db.models import User
+from onyx.db.scheduled_task import create_scheduled_task
+from onyx.db.scheduled_task import get_live_scheduled_run_grants
+from onyx.db.scheduled_task import insert_run
+from onyx.db.scheduled_task import mark_run_status
+from onyx.db.scheduled_task import update_scheduled_task
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.db.action_approval import insert_action_approval
+from onyx.server.features.build.scheduled_tasks import api as scheduled_tasks_api
+from tests.external_dependency_unit.craft._test_helpers import default_action_entries
+from tests.external_dependency_unit.craft._test_helpers import make_user
+
+
+def _seed_task(
+    db_session: Session,
+    user: User,
+    *,
+    pre_approved_app_ids: list[int] | None = None,
+    prompt: str = "Summarise yesterday's events",
+) -> ScheduledTask:
+    task = create_scheduled_task(
+        db_session=db_session,
+        user_id=user.id,
+        name="nightly-report",
+        prompt=prompt,
+        cron_expression="0 9 * * *",
+        editor_mode="advanced",
+        status=ScheduledTaskStatus.ACTIVE,
+        pre_approved_app_ids=pre_approved_app_ids,
+    )
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+# ---------------------------------------------------------------------------
+# get_live_scheduled_run_grants
+# ---------------------------------------------------------------------------
+
+
+def test_grants_returned_for_running_run(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[7, 9])
+    run = insert_run(
+        db_session=db_session,
+        task_id=task.id,
+        trigger_source=ScheduledTaskTriggerSource.SCHEDULED,
+    )
+    mark_run_status(
+        db_session=db_session,
+        run_id=run.id,
+        status=ScheduledTaskRunStatus.RUNNING,
+        session_id=bs.id,
+    )
+    db_session.commit()
+
+    grants = get_live_scheduled_run_grants(db_session=db_session, session_id=bs.id)
+
+    assert grants is not None
+    run_id, app_ids = grants
+    assert run_id == run.id
+    assert app_ids == [7, 9]
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        ScheduledTaskRunStatus.SUCCEEDED,
+        ScheduledTaskRunStatus.FAILED,
+        ScheduledTaskRunStatus.AWAITING_APPROVAL,
+    ],
+)
+def test_no_grants_for_non_running_run(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+    status: ScheduledTaskRunStatus,
+) -> None:
+    """A finished scheduled session (interactive follow-up turns) parks as
+    usual — the RUNNING filter is the load-bearing scope guard."""
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+    run = insert_run(
+        db_session=db_session,
+        task_id=task.id,
+        trigger_source=ScheduledTaskTriggerSource.SCHEDULED,
+    )
+    mark_run_status(
+        db_session=db_session,
+        run_id=run.id,
+        status=status,
+        session_id=bs.id,
+    )
+    db_session.commit()
+
+    assert (
+        get_live_scheduled_run_grants(db_session=db_session, session_id=bs.id) is None
+    )
+
+
+def test_no_grants_for_interactive_session(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    """Sessions with no run row (interactive origin) never match."""
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+
+    assert (
+        get_live_scheduled_run_grants(db_session=db_session, session_id=bs.id) is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# insert_action_approval — pre-decided rows
+# ---------------------------------------------------------------------------
+
+
+def test_insert_pre_decided_row(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+
+    row = insert_action_approval(
+        db_session,
+        session_id=bs.id,
+        actions=default_action_entries(),
+        app_name="Slack",
+        payload={"text": "hi"},
+        decision=ApprovalDecision.APPROVED,
+        decided_via=ApprovalDecidedVia.PRE_APPROVAL,
+    )
+    db_session.commit()
+    db_session.refresh(row)
+
+    assert row.decision == ApprovalDecision.APPROVED
+    assert row.decided_via == ApprovalDecidedVia.PRE_APPROVAL
+    assert row.decided_at is not None
+    assert row.decided_at.tzinfo is not None
+
+
+def test_insert_default_row_stays_pending(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+
+    row = insert_action_approval(
+        db_session,
+        session_id=bs.id,
+        actions=default_action_entries(),
+        app_name="Slack",
+        payload={},
+    )
+    db_session.commit()
+    db_session.refresh(row)
+
+    assert row.decision is None
+    assert row.decided_at is None
+    assert row.decided_via is None
+    assert row.external_app_id is None
+
+
+# ---------------------------------------------------------------------------
+# update_scheduled_task — prompt-edit reset rule
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_value_change_resets_grants(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        prompt="exfiltrate everything",
+    )
+    db_session.commit()
+
+    assert updated.pre_approved_app_ids == []
+
+
+def test_identical_prompt_resubmit_keeps_grants(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The editor round-trips the prompt on every save; an unchanged value
+    must not wipe grants."""
+    user = make_user(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[7], prompt="same")
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        prompt="same",
+        name="renamed",
+    )
+    db_session.commit()
+
+    assert updated.pre_approved_app_ids == [7]
+
+
+def test_grants_in_same_patch_win_over_prompt_reset(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The editor's re-enable-in-the-same-submit flow: a prompt change plus
+    explicit grants in one patch keeps the supplied grants."""
+    user = make_user(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[7])
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        prompt="a different prompt",
+        pre_approved_app_ids=[9],
+    )
+    db_session.commit()
+
+    assert updated.pre_approved_app_ids == [9]
+
+
+def test_create_persists_grants(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[3, 1])
+    assert task.pre_approved_app_ids == [3, 1]
+
+    bare = _seed_task(db_session, user)
+    assert bare.pre_approved_app_ids == []
+
+
+# ---------------------------------------------------------------------------
+# API validation helper
+# ---------------------------------------------------------------------------
+
+
+def test_validated_app_ids_rejects_unknown_and_dedupes(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dedupe is order-preserving; any id outside the tenant's apps raises
+    INVALID_INPUT. Apps are stubbed — only the validation logic is under
+    test, not ``get_external_apps``'s SQL."""
+
+    class _App:
+        def __init__(self, app_id: int) -> None:
+            self.id = app_id
+
+    monkeypatch.setattr(
+        scheduled_tasks_api,
+        "get_external_apps",
+        lambda _db: [_App(7), _App(9)],
+    )
+
+    assert scheduled_tasks_api._validated_app_ids(db_session, []) == []
+    assert scheduled_tasks_api._validated_app_ids(db_session, [9, 7, 9]) == [9, 7]
+
+    with pytest.raises(OnyxError) as exc_info:
+        scheduled_tasks_api._validated_app_ids(db_session, [7, 123])
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -277,6 +277,51 @@ def test_grants_in_same_patch_win_over_prompt_reset(
     assert updated.pre_approved_app_ids == [app_b]
 
 
+def test_resubmitting_existing_grant_is_idempotent(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Re-submitting an already-granted app must not orphan+reinsert the same
+    (task, app) unique key in one flush (which Postgres rejects). The editor
+    re-sends current grants on every save, so this is the common path."""
+    user = make_user(db_session)
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        pre_approved_app_ids=[app_a, app_b],  # app_a already granted
+    )
+    db_session.commit()
+
+    assert set(updated.pre_approved_app_ids) == {app_a, app_b}
+
+
+def test_prompt_change_plus_reincluded_grant_is_idempotent(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Prompt change + re-including a granted app in one patch must not
+    orphan+reinsert the same (task, app) key. The reset-then-set must resolve
+    to a single grant write, not two."""
+    user = make_user(db_session)
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a], prompt="orig")
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        prompt="changed",
+        pre_approved_app_ids=[app_a, app_b],  # app_a re-included AND prompt changed
+    )
+    db_session.commit()
+
+    assert set(updated.pre_approved_app_ids) == {app_a, app_b}
+
+
 def test_create_persists_grants(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from typing import Callable
 
 import pytest
+from sqlalchemy import delete
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ApprovalDecidedVia
@@ -19,7 +21,9 @@ from onyx.db.enums import ScheduledTaskRunStatus
 from onyx.db.enums import ScheduledTaskStatus
 from onyx.db.enums import ScheduledTaskTriggerSource
 from onyx.db.models import BuildSession
+from onyx.db.models import ExternalApp
 from onyx.db.models import ScheduledTask
+from onyx.db.models import ScheduledTaskPreApprovedApp
 from onyx.db.models import User
 from onyx.db.scheduled_task import create_scheduled_task
 from onyx.db.scheduled_task import get_live_scheduled_run_grants
@@ -279,12 +283,74 @@ def test_create_persists_grants(
 ) -> None:
     user = make_user(db_session)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
+    assert app_a < app_b  # ids autoincrement, so the higher id is created last
     # Insertion order is preserved (not sorted): pass the higher id first.
     task = _seed_task(db_session, user, pre_approved_app_ids=[app_b, app_a])
     assert task.pre_approved_app_ids == [app_b, app_a]
 
     bare = _seed_task(db_session, user)
     assert bare.pre_approved_app_ids == []
+
+
+# ---------------------------------------------------------------------------
+# FK referential actions (deliberate, documented ondelete choices)
+# ---------------------------------------------------------------------------
+
+
+def test_deleting_app_drops_grants(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """``external_app_id`` is ``ON DELETE CASCADE``: removing an app drops its
+    grant rows — a grant on a removed app is meaningless."""
+    user = make_user(db_session)
+    app_id = _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_id])
+    assert task.pre_approved_app_ids == [app_id]
+
+    db_session.execute(delete(ExternalApp).where(ExternalApp.id == app_id))
+    db_session.commit()
+
+    remaining = (
+        db_session.execute(
+            select(ScheduledTaskPreApprovedApp).where(
+                ScheduledTaskPreApprovedApp.scheduled_task_id == task.id
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert remaining == []
+
+
+def test_deleting_app_nulls_action_approval_fk(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    """``action_approval.external_app_id`` is ``ON DELETE SET NULL``: an audit
+    row survives app deletion with the FK cleared, not cascaded away."""
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+    app_id = _make_app(db_session)
+    row = insert_action_approval(
+        db_session,
+        session_id=bs.id,
+        actions=default_action_entries(),
+        app_name="Slack",
+        payload={},
+        external_app_id=app_id,
+        decision=ApprovalDecision.APPROVED,
+        decided_via=ApprovalDecidedVia.PRE_APPROVAL,
+    )
+    db_session.commit()
+    assert row.external_app_id == app_id
+
+    db_session.execute(delete(ExternalApp).where(ExternalApp.id == app_id))
+    db_session.commit()
+    db_session.refresh(row)
+
+    assert row.external_app_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -557,6 +557,34 @@ async def test_pre_approved_scheduled_run_skips_park(
 
 
 @pytest.mark.asyncio
+async def test_pre_approval_dispatch_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dispatch raising after the APPROVED row is committed blocks (403) — it
+    must not let mitmproxy forward the original request."""
+    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
+    _spy_pipeline(addon, monkeypatch)
+    _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
+    _spy_pre_approve_insert(monkeypatch)
+    monkeypatch.setattr(
+        gate_mod,
+        "create_notification",
+        lambda **kw: None,  # noqa: ARG005
+    )
+
+    def _boom(*args: Any, **kwargs: Any) -> None:  # noqa: ARG001
+        raise RuntimeError("credential refresh failed")
+
+    monkeypatch.setattr(addon, "_dispatch_injection_or_block", _boom)
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    _assert_403(flow, SandboxProxyError.INTERNAL_ERROR)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "grants",
     [

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -580,6 +580,26 @@ async def test_grant_lookup_cached_across_requests(
     assert lookup_calls == [UUID(_TAG_UUID)]  # second request served from cache
 
 
+def test_grant_lookup_cache_keyed_on_session_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cache key is ``session_id`` alone (not the db handle): the same
+    session re-queried with a fresh db hits cache, a different session misses.
+    Guards the key lambda against leaking one session's grants to another."""
+    addon = _build(
+        resolver=_StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID)),
+        matcher=_StubMatcher(result=_MATCH),
+    )
+    lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
+    s1, s2 = uuid4(), uuid4()
+
+    addon._live_grants(MagicMock(), s1)
+    addon._live_grants(MagicMock(), s1)  # same session, different db -> cache hit
+    addon._live_grants(MagicMock(), s2)  # different session -> miss
+
+    assert lookup_calls == [s1, s2]
+
+
 @pytest.mark.asyncio
 async def test_pre_approval_dispatch_failure_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
@@ -655,67 +675,6 @@ async def test_deny_wins_over_pre_approval_grant(
     assert lookup_calls == []  # DENY fires before the short-circuit
     assert not spy.approval_ran
     assert spy.dispatched == []
-
-
-# ---------------------------------------------------------------------------
-# _GrantCache — TTL behavior
-# ---------------------------------------------------------------------------
-
-
-def test_grant_cache_hit_miss_and_expiry() -> None:
-    now = [100.0]
-    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: now[0])
-    session_id = uuid4()
-
-    assert cache.get(session_id) == (False, None)  # miss before any put
-
-    cache.put(session_id, (_RUN_ID, [7]))
-    assert cache.get(session_id) == (True, (_RUN_ID, [7]))
-
-    now[0] += 59.0  # still inside the TTL window
-    assert cache.get(session_id) == (True, (_RUN_ID, [7]))
-
-    now[0] += 2.0  # now past expiry
-    assert cache.get(session_id) == (False, None)
-
-
-def test_grant_cache_caches_none() -> None:
-    """A negative lookup is cached too, so interactive sessions don't re-hit
-    Postgres on every gated request."""
-    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: 0.0)
-    session_id = uuid4()
-
-    cache.put(session_id, None)
-    assert cache.get(session_id) == (True, None)
-
-
-def test_grant_cache_keyed_per_session() -> None:
-    """One session's grants are never served for another session."""
-    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: 0.0)
-    granted, other = uuid4(), uuid4()
-
-    cache.put(granted, (_RUN_ID, [7]))
-
-    assert cache.get(granted) == (True, (_RUN_ID, [7]))
-    assert cache.get(other) == (False, None)  # miss — not the granted session
-
-
-def test_grant_cache_prunes_expired_over_soft_cap() -> None:
-    """Once the map exceeds the cap, a write prunes expired entries so memory
-    stays bounded; still-live entries survive."""
-    now = [0.0]
-    cache = gate_mod._GrantCache(ttl_s=60.0, max_entries=2, clock=lambda: now[0])
-
-    expired_a, expired_b = uuid4(), uuid4()
-    cache.put(expired_a, None)
-    cache.put(expired_b, None)
-
-    now[0] = 61.0  # both above expire
-    live = uuid4()
-    cache.put(live, (_RUN_ID, [7]))  # at cap (2) -> prune runs before insert
-
-    assert cache.get(live) == (True, (_RUN_ID, [7]))
-    assert cache._entries.keys() == {live}  # the two expired entries were dropped
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -557,6 +557,30 @@ async def test_pre_approved_scheduled_run_skips_park(
 
 
 @pytest.mark.asyncio
+async def test_grant_lookup_cached_across_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-session grant cache is consulted before Postgres: two gated
+    requests on the same session hit the DB lookup only once."""
+    sandbox = _sandbox()
+    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
+    _spy_pipeline(addon, monkeypatch)
+    lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
+    _spy_pre_approve_insert(monkeypatch)
+    monkeypatch.setattr(
+        gate_mod,
+        "create_notification",
+        lambda **kw: None,  # noqa: ARG005
+    )
+
+    await addon.request(_flow(proxy_auth=_basic_auth(_TAG_UUID)))
+    await addon.request(_flow(proxy_auth=_basic_auth(_TAG_UUID)))
+
+    assert lookup_calls == [UUID(_TAG_UUID)]  # second request served from cache
+
+
+@pytest.mark.asyncio
 async def test_pre_approval_dispatch_failure_fails_closed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -631,6 +655,38 @@ async def test_deny_wins_over_pre_approval_grant(
     assert lookup_calls == []  # DENY fires before the short-circuit
     assert not spy.approval_ran
     assert spy.dispatched == []
+
+
+# ---------------------------------------------------------------------------
+# _GrantCache — TTL behavior
+# ---------------------------------------------------------------------------
+
+
+def test_grant_cache_hit_miss_and_expiry() -> None:
+    now = [100.0]
+    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: now[0])
+    session_id = uuid4()
+
+    assert cache.get(session_id) == (False, None)  # miss before any put
+
+    cache.put(session_id, (_RUN_ID, [7]))
+    assert cache.get(session_id) == (True, (_RUN_ID, [7]))
+
+    now[0] += 59.0  # still inside the TTL window
+    assert cache.get(session_id) == (True, (_RUN_ID, [7]))
+
+    now[0] += 2.0  # now past expiry
+    assert cache.get(session_id) == (False, None)
+
+
+def test_grant_cache_caches_none() -> None:
+    """A negative lookup is cached too, so interactive sessions don't re-hit
+    Postgres on every gated request."""
+    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: 0.0)
+    session_id = uuid4()
+
+    cache.put(session_id, None)
+    assert cache.get(session_id) == (True, None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -26,6 +26,7 @@ import pytest
 from mitmproxy import http
 from redis.exceptions import RedisError
 
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import RequestMatch
@@ -468,6 +469,139 @@ async def test_ask_denied_blocks(
 
     assert spy.approval_ran  # required approval before blocking
     _assert_403(flow, expected_code)
+    assert spy.dispatched == []
+
+
+# ---------------------------------------------------------------------------
+# request() — scheduled-task pre-approval short-circuit
+#
+# The grant lookup (`get_live_scheduled_run_grants`) is stubbed here; its
+# SQL is covered against real Postgres in
+# external_dependency_unit/craft/test_scheduled_task_pre_approvals.py.
+# ---------------------------------------------------------------------------
+
+
+_RUN_ID = UUID("55555555-5555-5555-5555-555555555555")
+# make_request_match defaults external_app_id=42.
+_GRANTED_APP_ID = 42
+
+
+def _stub_grants(
+    monkeypatch: pytest.MonkeyPatch,
+    result: tuple[UUID, list[int]] | None | Exception,
+) -> list[UUID]:
+    """Stub the gate's grant lookup; returns the recorded session_ids."""
+    calls: list[UUID] = []
+
+    def _lookup(*, db_session: Any, session_id: UUID) -> tuple[UUID, list[int]] | None:  # noqa: ARG001
+        calls.append(session_id)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(gate_mod, "get_live_scheduled_run_grants", _lookup)
+    return calls
+
+
+def _spy_pre_approve_insert(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Capture insert_action_approval kwargs (the DB session is a MagicMock)."""
+    inserted: list[dict[str, Any]] = []
+
+    def _fake_insert(db: Any, **kwargs: Any) -> Any:  # noqa: ARG001
+        inserted.append(kwargs)
+        row = MagicMock()
+        row.approval_id = uuid4()
+        return row
+
+    monkeypatch.setattr(
+        gate_mod.action_approval, "insert_action_approval", _fake_insert
+    )
+    return inserted
+
+
+@pytest.mark.asyncio
+async def test_pre_approved_scheduled_run_skips_park(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Granted app on a RUNNING scheduled run: forwarded immediately with a
+    pre-decided APPROVED row — the park pipeline never runs."""
+    user_id = uuid4()
+    sandbox = _sandbox(user_id=user_id)
+    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
+    spy = _spy_pipeline(addon, monkeypatch)
+    _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
+    inserted = _spy_pre_approve_insert(monkeypatch)
+    notified: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        gate_mod, "create_notification", lambda **kw: notified.append(kw)
+    )
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert flow.response is None  # forwarded
+    assert not spy.approval_ran  # park pipeline skipped
+    assert spy.awaited == []
+    assert spy.dispatched == [(_MATCH, user_id, sandbox.tenant_id)]
+    assert len(inserted) == 1
+    assert inserted[0]["decision"] == ApprovalDecision.APPROVED
+    assert inserted[0]["decided_via"] == ApprovalDecidedVia.PRE_APPROVAL
+    assert inserted[0]["external_app_id"] == _GRANTED_APP_ID
+    # Dedup contract: additional_data is exactly the stable (run, app) pair.
+    assert len(notified) == 1
+    assert notified[0]["additional_data"] == {
+        "run_id": str(_RUN_ID),
+        "external_app_id": _GRANTED_APP_ID,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "grants",
+    [
+        None,  # not a scheduled run (or run not RUNNING)
+        (_RUN_ID, []),  # scheduled run, app not granted
+        (_RUN_ID, [_GRANTED_APP_ID + 1]),  # different app granted
+        RuntimeError("db down"),  # lookup failure → fail-to-ask
+    ],
+    ids=["no_live_run", "no_grants", "other_app", "lookup_error"],
+)
+async def test_no_pre_approval_falls_through_to_park(
+    monkeypatch: pytest.MonkeyPatch,
+    grants: tuple[UUID, list[int]] | None | Exception,
+) -> None:
+    """Every non-granted shape (including a lookup crash) parks as usual."""
+    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
+    spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
+    _stub_grants(monkeypatch, grants)
+    inserted = _spy_pre_approve_insert(monkeypatch)
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert spy.approval_ran  # normal park pipeline
+    _assert_403(flow, SandboxProxyError.USER_REJECTED)
+    assert inserted == []  # no pre-decided row minted
+
+
+@pytest.mark.asyncio
+async def test_deny_wins_over_pre_approval_grant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admin DENY blocks before the grant lookup is ever consulted."""
+    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH_DENY))
+    spy = _spy_pipeline(addon, monkeypatch)
+    lookup_calls = _stub_grants(monkeypatch, (_RUN_ID, [_GRANTED_APP_ID]))
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    _assert_403(flow, SandboxProxyError.POLICY_DENIED)
+    assert lookup_calls == []  # DENY fires before the short-circuit
+    assert not spy.approval_ran
     assert spy.dispatched == []
 
 
@@ -1067,6 +1201,7 @@ def test_persist_approval_row_commits_announces_notifies(
         "actions": [a.model_dump(mode="json") for a in _MATCH.actions],
         "app_name": _MATCH.app_name,
         "payload": _MATCH.payload,
+        "external_app_id": _MATCH.external_app_id,
     }
 
     # insert -> commit -> rpush: announce must not precede the commit,

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -689,6 +689,35 @@ def test_grant_cache_caches_none() -> None:
     assert cache.get(session_id) == (True, None)
 
 
+def test_grant_cache_keyed_per_session() -> None:
+    """One session's grants are never served for another session."""
+    cache = gate_mod._GrantCache(ttl_s=60.0, clock=lambda: 0.0)
+    granted, other = uuid4(), uuid4()
+
+    cache.put(granted, (_RUN_ID, [7]))
+
+    assert cache.get(granted) == (True, (_RUN_ID, [7]))
+    assert cache.get(other) == (False, None)  # miss — not the granted session
+
+
+def test_grant_cache_prunes_expired_over_soft_cap() -> None:
+    """Once the map exceeds the cap, a write prunes expired entries so memory
+    stays bounded; still-live entries survive."""
+    now = [0.0]
+    cache = gate_mod._GrantCache(ttl_s=60.0, max_entries=2, clock=lambda: now[0])
+
+    expired_a, expired_b = uuid4(), uuid4()
+    cache.put(expired_a, None)
+    cache.put(expired_b, None)
+
+    now[0] = 61.0  # both above expire
+    live = uuid4()
+    cache.put(live, (_RUN_ID, [7]))  # at cap (2) -> prune runs before insert
+
+    assert cache.get(live) == (True, (_RUN_ID, [7]))
+    assert cache._entries.keys() == {live}  # the two expired entries were dropped
+
+
 # ---------------------------------------------------------------------------
 # _resolve_and_match — happy path
 # ---------------------------------------------------------------------------

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -197,9 +197,9 @@ pre-decided inserts go through `insert_action_approval` in
   catalog actions added in later releases. Mitigated today by admin
   per-action `DENY`; the planned grant-time covered-actions expander will
   surface the scope.
-- **Grant lookup on the gated path.** Cached per session in-process
-  (`_GrantCache`, 60s TTL) so a run firing many actions hits Postgres
-  once, not per request. The TTL bounds staleness from the
+- **Grant lookup on the gated path.** Memoized per session in-process
+  (`cachetools.TTLCache` via `@cachedmethod`, 60s TTL) so a run firing
+  many actions hits Postgres once, not per request. The TTL bounds staleness from the
   RUNNING → terminal transition: an interactive follow-up on a finished
   scheduled session re-parks once the entry expires. The lookup itself
   is two indexed reads behind `asyncio.to_thread`.

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -125,13 +125,19 @@ unguarded after an `APPROVED` row is already committed.
 
 ## Data Model
 
-No new table. New columns:
+New table `scheduled_task_pre_approved_app` — one row per `(task, app)`
+grant:
 
-- `scheduled_task.pre_approved_app_ids` — JSONB list of `external_app`
-  ids, NOT NULL default `[]`. Grants are tiny, always accessed via the
-  task, and whole-list-replaced from the editor form, so a normalized
-  table buys nothing. Validated against the tenant's apps and deduped
-  at write time; stale entries are inert.
+- `scheduled_task_id` → `scheduled_task.id` (`ON DELETE CASCADE`) and
+  `external_app_id` → `external_app.id` (`ON DELETE CASCADE`), with a
+  `UNIQUE(scheduled_task_id, external_app_id)` constraint that keeps
+  grants idempotent and serves the per-task lookup. The FKs give real
+  referential integrity — a grant can't point at a removed app, and
+  removing either side drops the grant. `ScheduledTask.pre_approved_apps`
+  is the ORM collection; `pre_approved_app_ids` is a read-only accessor
+  over it, so the API contract (`list[int]`) is unchanged. The write
+  path replaces the whole set (`set_pre_approved_apps`), validated
+  against the tenant's apps and deduped order-preserving.
 - `action_approval.decided_via` — nullable (`user | pre_approval`,
   NULL for legacy/expired rows): the audit marker distinguishing a
   human click from a pre-approval. Kept separate from `decision` so
@@ -190,9 +196,12 @@ pre-decided inserts go through `insert_action_approval` in
   catalog actions added in later releases. Mitigated today by admin
   per-action `DENY`; the planned grant-time covered-actions expander will
   surface the scope.
-- **One extra DB round-trip per gated request on scheduled sessions.**
-  Acceptable — `ASK` is already the slow path (row insert + notify),
-  and the lookup is a single indexed join behind `asyncio.to_thread`.
+- **Grant lookup on the gated path.** Cached per session in-process
+  (`_GrantCache`, 60s TTL) so a run firing many actions hits Postgres
+  once, not per request. The TTL bounds staleness from the
+  RUNNING → terminal transition: an interactive follow-up on a finished
+  scheduled session re-parks once the entry expires. The lookup itself
+  is two indexed reads behind `asyncio.to_thread`.
 
 ## Planned (not in this PR)
 

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -137,7 +137,8 @@ grant:
   is the ORM collection; `pre_approved_app_ids` is a read-only accessor
   over it, so the API contract (`list[int]`) is unchanged. The write
   path replaces the whole set (`set_pre_approved_apps`), validated
-  against the tenant's apps and deduped order-preserving.
+  against the configured apps (via the tenant-scoped session) and
+  deduped order-preserving.
 - `action_approval.decided_via` — nullable (`user | pre_approval`,
   NULL for legacy/expired rows): the audit marker distinguishing a
   human click from a pre-approval. Kept separate from `decision` so

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -88,20 +88,40 @@ sandbox HTTPS ──► gate (mitmproxy) ── match → decisive policy
                     ├─ DENY ───► 403                      (unchanged)
                     ├─ ALWAYS ─► forward                  (unchanged)
                     └─ ASK
-                        │  session origin == SCHEDULED
-                        │  AND owning run RUNNING
-                        │  AND match.external_app_id ∈ task grants?
-                        ├─ yes ► insert action_approval pre-decided
-                        │        (APPROVED, decided_via=pre_approval),
-                        │        notify, forward — no park
-                        └─ no ─► park ≤ 180s              (unchanged)
+                        │  _resolve_auto_approval: first grant
+                        │  source to cover this request wins
+                        │  (today: RUNNING scheduled run whose
+                        │  task grants match.external_app_id)
+                        ├─ hit ► mint action_approval pre-decided
+                        │        (APPROVED, decided_via), notify,
+                        │        forward (fail-closed: dispatch raise
+                        │        → 403, never an unguarded forward)
+                        └─ none ► park ≤ 180s             (unchanged)
 ```
 
 The lookup runs once per gated request, threaded, before the pending
-row would be persisted. Any condition failing → existing park flow,
+row would be persisted. No source hitting → existing park flow,
 untouched. A partially-granted run degrades gracefully: requests to
 non-granted apps park and expire exactly as today — per-app isolation
 is the point.
+
+**Grant-source seam.** The short-circuit is not monolithic. In
+`gate.py`, `_try_auto_approve` is the generic orchestrator;
+`_resolve_auto_approval(db, ctx, match)` is the single extension point —
+grant sources are checked in order, first hit wins, `None` parks. Each
+source returns an `_AutoApproval` dataclass carrying `decided_via` plus
+the notification payload; `_try_auto_approve` mints the row and
+`_notify_auto_approved` are source-agnostic. The only source today is
+`_scheduled_task_grant` (app-level, RUNNING scheduled run). This is the
+seam future grant sources plug into — they add a `_resolve_auto_approval`
+source and reuse the mint/notify path unchanged.
+
+**Fail-closed dispatch.** mitmproxy forwards the original request on any
+unhandled addon exception, silently bypassing the gate. In `request()`,
+the auto-approved forward (`_dispatch_injection_or_block`) is wrapped in
+try/except that sets `http_403(INTERNAL_ERROR)` on any raise — so an
+unhandled exception cannot make the proxy forward the original request
+unguarded after an `APPROVED` row is already committed.
 
 ## Data Model
 
@@ -122,8 +142,8 @@ No new table. New columns:
 - `action_approval.external_app_id` — nullable FK (NULL for legacy
   rows), populated from `match.external_app_id` on every new gated
   insert. Needed because `app_name` is not unique (self-hosted
-  instances share an `app_type`); the run-history feedback loop and its
-  one-click enable key off this id.
+  instances share an `app_type`); the planned run-history feedback loop
+  keys its one-click enable off this id.
 
 The gate's grant lookup lives in `backend/onyx/db/scheduled_task.py`;
 pre-decided inserts go through `insert_action_approval` in
@@ -133,21 +153,10 @@ pre-decided inserts go through `insert_action_approval` in
 
 - `ScheduledTaskCreate` / `ScheduledTaskPatch` gain
   `pre_approved_app_ids: list[int]`; `ScheduledTaskDetail` returns it.
-  The write path validates ids against the tenant's apps and dedupes —
-  existence only; the credential and ≥1-`ASK` filters below are
-  editor-side advisory (a grant on a no-`ASK` app is inert, never
-  consulted).
-- `GET /api/build/scheduled-tasks/approvable-apps` (existing router,
-  `require_onyx_craft_enabled`): the external apps the user can
-  actually use (org credentials or `is_user_authenticated_for_app`)
-  that have ≥1 `ASK` action. Shape:
-  `{external_app_id, display_name, actions: [{action_type,
-  display_name}]}` — the FE keys toggles on `external_app_id` and
-  renders the action list in the disclosure expander.
-- `RunSummary` (the `/runs` payload) gains the apps whose approvals
-  expired during that run (`[{external_app_id, display_name}]`, joined
-  from EXPIRED `action_approval` rows via `session_id`) — this powers
-  the feedback loop.
+  The write path validates ids via `_validated_app_ids` and dedupes
+  (order-preserving) — existence only; a credential / ≥1-`ASK` filter is
+  editor-side advisory, since a grant on a no-`ASK` app is inert and
+  never consulted.
 - New `NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION`, emitted
   per `(run, app)` on the first unattended forward so chatty tasks
   don't flood the bell. Dedup rides `create_notification`'s existing
@@ -155,27 +164,15 @@ pre-decided inserts go through `insert_action_approval` in
   `(run_id, external_app_id)` pair — anything per-request in it would
   defeat the dedup.
 
-## UI
-
-- **Task editor** (`ScheduleTaskForm`,
-  `web/src/app/craft/v1/tasks/components/`): an "Approvals" section
-  with one toggle per approvable app — "Allow this task to use
-  **Slack** without asking" — plus a "see what this allows" expander
-  listing the covered actions, and warning copy on enable. Types in
-  `interfaces.ts`, client calls in `api.ts`.
-- **Task detail page**: shows enabled apps; run rows whose approvals
-  expired surface "Needed **Slack** approval" with one-click enable
-  (PATCHes the grant onto the task). Grounded in an action that
-  actually fired — no guessing.
-
 ## Lifecycle & Security
 
 - **Prompt edits clear grants.** A `PATCH` whose `prompt` value differs
   from the stored one resets `pre_approved_app_ids` to `[]` — the grant
   was made against a specific intent, and a rewritten prompt must not
-  inherit it. Resubmitting an identical prompt does not reset; the
-  editor warns and lets the user re-enable in the same submit. Schedule
-  changes do not reset grants; cadence doesn't change intent.
+  inherit it. Resubmitting an identical prompt does not reset, and grants
+  supplied in the same patch win over the reset (so the planned editor can
+  warn and re-enable in one submit). Schedule changes do not reset grants;
+  cadence doesn't change intent.
 - **The grant boundary is the app.** There is no cross-app
   "auto-approve everything" toggle — that would convert any prompt
   injection into write capability across every connected app.
@@ -190,18 +187,48 @@ pre-decided inserts go through `insert_action_approval` in
   supremacy, prompt-edit reset, and the unattended-forward
   notifications.
 - **An app grant covers actions the user never enumerated**, including
-  catalog actions added in later releases. Mitigated by the
-  covered-actions expander at grant time and admin per-action `DENY`.
+  catalog actions added in later releases. Mitigated today by admin
+  per-action `DENY`; the planned grant-time covered-actions expander will
+  surface the scope.
 - **One extra DB round-trip per gated request on scheduled sessions.**
   Acceptable — `ASK` is already the slow path (row insert + notify),
   and the lookup is a single indexed join behind `asyncio.to_thread`.
 
+## Planned (not in this PR)
+
+This PR is backend-only — no `web/` changes. The next increment is the
+feedback-loop UI plus the two read APIs that feed it:
+
+- **Task editor** (`ScheduleTaskForm`,
+  `web/src/app/craft/v1/tasks/components/`): an "Approvals" section, one
+  toggle per approvable app — "Allow this task to use **Slack** without
+  asking" — with a "see what this allows" expander and warning copy on
+  enable.
+- **Task detail page**: shows enabled apps; run rows whose approvals
+  expired surface "Needed **Slack** approval" with one-click enable
+  (PATCHes the grant onto the task). Grounded in an action that actually
+  fired — no guessing.
+- `GET /api/build/scheduled-tasks/approvable-apps`: the external apps the
+  user can use (org credentials or `is_user_authenticated_for_app`) with
+  ≥1 `ASK` action, for the editor toggles.
+- `RunSummary` expansion: the apps whose approvals expired during a run
+  (joined from EXPIRED `action_approval` rows via `session_id`,
+  resolvable through the shipped `external_app_id`), to drive the
+  one-click enable.
+
 ## Future Work
 
+The grant-source seam means future modes drop in as new
+`_resolve_auto_approval` sources without restructuring `request()`:
+
+- **Session-scoped grants** — (a) "auto-approve all for this session",
+  (b) per-app session grant, (c) per-action-type session grant (e.g.
+  "allow Slack send-message this session but not other Slack `ASK`
+  actions" — a source can scope on `match.decisive.action_type`, not
+  just `match.external_app_id`). The store backing session-scoped grants
+  is still to build; the gate integration point is the seam.
 - **"Allow for this task" on the live `ApprovalCard`** when the session
   resolves to a RUNNING scheduled run — approving also grants the app.
-- **Per-action "advanced" subset** within an app grant, if a real
-  customer asks.
 - **Payload-level constraints** (e.g. "only this channel").
 - **LLM prompt classification** to suggest which apps to pre-enable.
   Deferred: false negatives defeat the feature, false positives widen
@@ -209,17 +236,26 @@ pre-decided inserts go through `insert_action_approval` in
 
 ## Tests
 
-- **External dependency unit** (primary; existing homes):
-  - `tests/external_dependency_unit/craft/test_approval_gate.py`: ASK +
-    app granted + RUNNING run → pre-decided APPROVED row,
-    `decided_via=pre_approval`, no park; run SUCCEEDED → parks;
-    interactive-origin session → parks; matched app not in grants →
-    parks; `DENY` decisive → 403 regardless of grant.
-  - db-ops tests: prompt-edit PATCH resets grants; create/patch rejects
-    unknown app ids and dedupes.
-- **Integration**
-  (`tests/integration/tests/craft/test_scheduled_tasks_api.py`): create
-  task with grants, read back via detail; approvable-apps shape; an
-  expired approval surfaces a resolvable `external_app_id` on the run
-  payload (the feedback-loop join).
-- No Playwright — the editor section is a standard form addition.
+- **External dependency unit** (real SQL):
+  `tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py`
+  - `get_live_scheduled_run_grants`: RUNNING run returns
+    `(run_id, grants)`; non-RUNNING (SUCCEEDED / FAILED /
+    AWAITING_APPROVAL) → `None`; interactive / no-run session → `None`.
+  - `insert_action_approval`: pre-decided `APPROVED` vs default-pending.
+  - Prompt-edit reset: a differing prompt resets grants, an identical
+    prompt keeps them, grants supplied in the same patch win over the
+    reset.
+  - Create persistence + `_validated_app_ids` dedupe and unknown-id
+    rejection.
+- **Unit** (gate, stubbed DB):
+  `backend/tests/unit/sandbox_proxy/test_gate.py`
+  - Granted + RUNNING → skips park, mints the `PRE_APPROVAL` row,
+    notifies; non-RUNNING / not-granted / other-app / lookup-error all
+    park; `DENY` wins before the grant lookup is reached;
+    dispatch-failure-after-approval fails closed (403).
+- **End-to-end (manual, local kind cluster):** the gate path was
+  verified against the real proxy with a real Slack `chat.postMessage`
+  through the egress gate — a granted RUNNING run forwarded with injected
+  creds, a `gate.auto_approved` log line, a `PRE_APPROVAL` row, and the
+  notification; non-RUNNING and ungranted parked; `DENY` → 403.
+- No Playwright — no `web/` changes in this PR.

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -1,0 +1,225 @@
+# Scheduled Task Pre-Approvals
+
+## Objective
+
+Scheduled task runs execute headlessly. When a run's agent hits a gated
+external-app action (effective policy `ASK`), the egress proxy parks the
+request for `WAIT_TIMEOUT_S = 180` seconds waiting for a human decision.
+The task author is almost never present during a cron fire, so the
+approval row goes `EXPIRED`, the sandbox gets a `403`, and the run
+degrades or fails.
+
+Pre-approvals let the task author grant **app access at
+task-configuration time** ("this task will need Slack"): future runs of
+that task execute that app's gated actions without parking. Admin policy
+stays supreme and every unattended forward leaves an audit row and a
+notification.
+
+**Granularity is per external app, per task.** The gated-action catalog
+across the built-in providers is ~30 endpoints; a per-action checklist
+would force the user to guess which endpoints their prompt ends up
+hitting — they'd either under-check (run still expires) or bulk-check
+everything. "My agent needs Slack" is the user's actual mental model.
+It's also how the matcher is shaped: a `RequestMatch` resolves to
+exactly one app (`resolve_app_for_url`, first match wins), so an app
+grant covers every action in a match by construction.
+
+**Scope.** This targets the egress-proxy gate
+(`backend/onyx/sandbox_proxy/addons/gate.py`) only. The other approval
+mechanism touching scheduled runs — ACP `RequestPermissionRequest`,
+which marks the run `AWAITING_APPROVAL` (`executor.py`) — is owned by
+the approvals project and is unchanged.
+
+## Important Notes
+
+Constraints from the existing code that shape the design:
+
+- **The gate's verdict path** (`gate.py::_resolve_and_match`):
+  `DENY` → 403 immediately (no row); `ALWAYS` → forward silently (no
+  row); `ASK` → insert `action_approval` row (`decision=NULL`),
+  announce, notify, park. The pre-approval short-circuit slots into the
+  `ASK` branch only — admin `DENY` wins by construction, per action,
+  because it fires before pre-approval is ever consulted. Only catalog
+  actions with a stored `external_app_policy` row reach the matcher at
+  all; "gated" means a stored row with `ASK`.
+- **`SessionContext` does not carry `origin`** —
+  `resolve_session_by_id` (`sandbox_proxy/identity.py`) selects only
+  `BuildSession.id`. The short-circuit needs one new joined lookup:
+  `BuildSession → ScheduledTaskRun (session_id FK) → ScheduledTask`;
+  grants come along with the task row.
+- **`origin == SCHEDULED` is necessary but NOT sufficient.** A
+  `BuildSession` keeps `origin=SCHEDULED` forever, the session view
+  keeps the chat input available, and identity resolution intentionally
+  does not filter on status — so interactive follow-up turns into a
+  finished scheduled session would otherwise auto-approve. The
+  short-circuit therefore also requires the owning
+  `scheduled_task_run.status == RUNNING`. The executor writes
+  `session_id` and `RUNNING` in the same commit before any agent egress
+  can occur (`executor.py`), so there is no race on the other side.
+  This also means Run Now (including on a paused task) gets grants —
+  it produces a `RUNNING` run through the same executor.
+- **The gate runs on the mitmproxy asyncio event loop.** Sync DB work
+  in the request hook blocks all in-flight flows; the existing
+  ALWAYS/APPROVED forward path already goes through
+  `asyncio.to_thread`, and the new grant lookup follows the same
+  pattern.
+- **Pre-decided rows bend an existing invariant.** Today every
+  `action_approval` row starts `decision IS NULL` and
+  `try_record_decision`'s conditional UPDATE is the sole race arbiter.
+  Pre-approved rows are inserted already-`APPROVED`; there is no
+  competing decider for such a row, so this is safe — documented at the
+  insert site.
+- **Catalog/policy drift is safe by construction.** Policy changes
+  take effect immediately — evaluation is fresh per request, so
+  `ASK→ALWAYS` makes a grant moot and `ASK→DENY` blocks regardless of
+  it; grants referencing a deleted app are inert (the app no longer
+  resolves by URL).
+- **No LLM needed to assess "would this task require approvals".** The
+  set of apps with gated actions is fully deterministic: the tenant's
+  configured external apps × stored policies, filtered to apps with ≥1
+  `ASK` action — read from the same sources the matcher uses
+  (`get_policies` + `get_endpoint_catalog`), so the editor's list can
+  never disagree with the gate.
+
+## Architecture
+
+```
+sandbox HTTPS ──► gate (mitmproxy) ── match → decisive policy
+                    ├─ DENY ───► 403                      (unchanged)
+                    ├─ ALWAYS ─► forward                  (unchanged)
+                    └─ ASK
+                        │  session origin == SCHEDULED
+                        │  AND owning run RUNNING
+                        │  AND match.external_app_id ∈ task grants?
+                        ├─ yes ► insert action_approval pre-decided
+                        │        (APPROVED, decided_via=pre_approval),
+                        │        notify, forward — no park
+                        └─ no ─► park ≤ 180s              (unchanged)
+```
+
+The lookup runs once per gated request, threaded, before the pending
+row would be persisted. Any condition failing → existing park flow,
+untouched. A partially-granted run degrades gracefully: requests to
+non-granted apps park and expire exactly as today — per-app isolation
+is the point.
+
+## Data Model
+
+No new table. New columns:
+
+- `scheduled_task.pre_approved_app_ids` — JSONB list of `external_app`
+  ids, NOT NULL default `[]`. Grants are tiny, always accessed via the
+  task, and whole-list-replaced from the editor form, so a normalized
+  table buys nothing. Validated against the tenant's apps and deduped
+  at write time; stale entries are inert.
+- `action_approval.decided_via` — nullable (`user | pre_approval`,
+  NULL for legacy/expired rows): the audit marker distinguishing a
+  human click from a pre-approval. Kept separate from `decision` so
+  pre-approvals don't pollute terminal-decision semantics everywhere
+  `decision == APPROVED` is checked. It records the gate's verdict, not
+  delivery — credential injection can still fail the forward, and the
+  row stays `APPROVED`.
+- `action_approval.external_app_id` — nullable FK (NULL for legacy
+  rows), populated from `match.external_app_id` on every new gated
+  insert. Needed because `app_name` is not unique (self-hosted
+  instances share an `app_type`); the run-history feedback loop and its
+  one-click enable key off this id.
+
+The gate's grant lookup lives in `backend/onyx/db/scheduled_task.py`;
+pre-decided inserts go through `insert_action_approval` in
+`backend/onyx/server/features/build/db/action_approval.py`.
+
+## API
+
+- `ScheduledTaskCreate` / `ScheduledTaskPatch` gain
+  `pre_approved_app_ids: list[int]`; `ScheduledTaskDetail` returns it.
+  The write path validates ids against the tenant's apps and dedupes —
+  existence only; the credential and ≥1-`ASK` filters below are
+  editor-side advisory (a grant on a no-`ASK` app is inert, never
+  consulted).
+- `GET /api/build/scheduled-tasks/approvable-apps` (existing router,
+  `require_onyx_craft_enabled`): the external apps the user can
+  actually use (org credentials or `is_user_authenticated_for_app`)
+  that have ≥1 `ASK` action. Shape:
+  `{external_app_id, display_name, actions: [{action_type,
+  display_name}]}` — the FE keys toggles on `external_app_id` and
+  renders the action list in the disclosure expander.
+- `RunSummary` (the `/runs` payload) gains the apps whose approvals
+  expired during that run (`[{external_app_id, display_name}]`, joined
+  from EXPIRED `action_approval` rows via `session_id`) — this powers
+  the feedback loop.
+- New `NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION`, emitted
+  per `(run, app)` on the first unattended forward so chatty tasks
+  don't flood the bell. Dedup rides `create_notification`'s existing
+  `additional_data` key, which must carry only the stable
+  `(run_id, external_app_id)` pair — anything per-request in it would
+  defeat the dedup.
+
+## UI
+
+- **Task editor** (`ScheduleTaskForm`,
+  `web/src/app/craft/v1/tasks/components/`): an "Approvals" section
+  with one toggle per approvable app — "Allow this task to use
+  **Slack** without asking" — plus a "see what this allows" expander
+  listing the covered actions, and warning copy on enable. Types in
+  `interfaces.ts`, client calls in `api.ts`.
+- **Task detail page**: shows enabled apps; run rows whose approvals
+  expired surface "Needed **Slack** approval" with one-click enable
+  (PATCHes the grant onto the task). Grounded in an action that
+  actually fired — no guessing.
+
+## Lifecycle & Security
+
+- **Prompt edits clear grants.** A `PATCH` whose `prompt` value differs
+  from the stored one resets `pre_approved_app_ids` to `[]` — the grant
+  was made against a specific intent, and a rewritten prompt must not
+  inherit it. Resubmitting an identical prompt does not reset; the
+  editor warns and lets the user re-enable in the same submit. Schedule
+  changes do not reset grants; cadence doesn't change intent.
+- **The grant boundary is the app.** There is no cross-app
+  "auto-approve everything" toggle — that would convert any prompt
+  injection into write capability across every connected app.
+- **Only the task author can manage grants** — tasks are user-scoped
+  and runs execute as the author, so grants never cross users.
+
+## Risks
+
+- **Prompt injection against pre-approved writes is inherent.** A
+  poisoned context can drive a granted app's write with no human
+  checkpoint. Mitigations: per-app (not global) grants, `DENY`
+  supremacy, prompt-edit reset, and the unattended-forward
+  notifications.
+- **An app grant covers actions the user never enumerated**, including
+  catalog actions added in later releases. Mitigated by the
+  covered-actions expander at grant time and admin per-action `DENY`.
+- **One extra DB round-trip per gated request on scheduled sessions.**
+  Acceptable — `ASK` is already the slow path (row insert + notify),
+  and the lookup is a single indexed join behind `asyncio.to_thread`.
+
+## Future Work
+
+- **"Allow for this task" on the live `ApprovalCard`** when the session
+  resolves to a RUNNING scheduled run — approving also grants the app.
+- **Per-action "advanced" subset** within an app grant, if a real
+  customer asks.
+- **Payload-level constraints** (e.g. "only this channel").
+- **LLM prompt classification** to suggest which apps to pre-enable.
+  Deferred: false negatives defeat the feature, false positives widen
+  the attack surface.
+
+## Tests
+
+- **External dependency unit** (primary; existing homes):
+  - `tests/external_dependency_unit/craft/test_approval_gate.py`: ASK +
+    app granted + RUNNING run → pre-decided APPROVED row,
+    `decided_via=pre_approval`, no park; run SUCCEEDED → parks;
+    interactive-origin session → parks; matched app not in grants →
+    parks; `DENY` decisive → 403 regardless of grant.
+  - db-ops tests: prompt-edit PATCH resets grants; create/patch rejects
+    unknown app ids and dedupes.
+- **Integration**
+  (`tests/integration/tests/craft/test_scheduled_tasks_api.py`): create
+  task with grants, read back via detail; approvable-apps shape; an
+  expired approval surfaces a resolvable `external_app_id` on the run
+  payload (the feedback-loop join).
+- No Playwright — the editor section is a standard form addition.


### PR DESCRIPTION
## Description

Adds per-app pre-approval grants to scheduled tasks. The egress gate skips the approval park for a `RUNNING` scheduled run whose task grants the matched external app: it mints a pre-decided `action_approval` row (`decision=APPROVED`, `decided_via=PRE_APPROVAL`, `external_app_id` set), injects credentials, forwards, and fires a one-per-(run, app) notification. `decided_via` distinguishes pre-approved rows from human clicks. Editing a task's prompt resets its grants (a grant is tied to a specific intent). `DENY` still wins over a grant; if credential dispatch after pre-approval raises, the gate fails closed (403) rather than forwarding unguarded.

Grants live in a `scheduled_task_pre_approved_app` relation table (one row per `(task, app)`, FK to both with `ON DELETE CASCADE`, unique per pair) rather than a denormalized list — the API still exposes `pre_approved_app_ids: list[int]` via a read-only accessor, so referential integrity is enforced without changing the contract. The gate's grant lookup is memoized per session in an in-process TTL cache (`_GrantCache`, 60s) so a run firing many actions hits Postgres once; the TTL bounds staleness past a run's `RUNNING → terminal` transition, and the cache is consulted only after the session tag is validated against the resolving sandbox's user/tenant (no cross-session/tenant leakage).

The short-circuit is built as a grant-source seam (`_resolve_auto_approval` in `gate.py`), with scheduled-task grants as the only source today — so future auto-approval sources (session-scoped, per-action-type) drop in without restructuring. Design notes: `docs/craft/features/scheduled-tasks/pre-approvals.md`.

## How Has This Been Tested?

Committed unit + external-dependency-unit tests (incl. FK cascade/SET-NULL, cache keying + soft-cap pruning), plus a live E2E against the local kind cluster (real proxy + real Slack call from a real sandbox), re-verified on the current build:
- API: create/patch validation (unknown id → 400, order-preserving dedupe), prompt-change resets grants, grant-in-same-patch wins; the grant row lands in `scheduled_task_pre_approved_app` and round-trips through the read accessor.
- Gate happy path: RUNNING + granted → forwarded with injected creds, `gate.auto_approved` log, `APPROVED/PRE_APPROVAL/external_app_id` row, dedup-stable notification.
- Cache: deleting the grant row mid-TTL still auto-approves (served from cache), confirming the in-path memoization.
- Negatives: non-RUNNING run → parks; ungranted app → parks; `DENY` → 403 and the short-circuit does not fire.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-app pre-approvals to scheduled tasks so ASK-gated actions for granted apps on RUNNING runs auto-approve and forward without parking. Also records `external_app_id` and `decided_via` on approval rows for better linking and audit.

- **New Features**
  - Gate short-circuit: RUNNING + granted app → mint `APPROVED` (`decided_via=PRE_APPROVAL`, `external_app_id` set), inject creds, forward; `DENY` still blocks; non‑RUNNING or ungranted apps park. Sends one `SCHEDULED_TASK_PRE_APPROVED_ACTION` per (run, app); dispatch failures fail closed with 403.
  - API: create/patch accept `pre_approved_app_ids` (order‑preserving dedupe + validation against tenant apps); detail returns them. Editing `prompt` resets grants; grants in the same patch override the reset.
  - Internal: extracted an auto‑approval grant‑source seam; per‑session grant cache via `cachetools` TTL (60s, session‑keyed). Human approvals tag `decided_via=USER`. Persist `external_app_id` on all `action_approval` inserts. Grant updates are idempotent and reuse existing rows to avoid unique‑key collisions when re‑submitting existing grants (incl. prompt‑change + re‑include).

- **Migration**
  - Add `scheduled_task_pre_approved_app` (unique per (task, app), CASCADE FKs).
  - Add `action_approval.decided_via` (enum) and `action_approval.external_app_id` (FK, SET NULL). Run Alembic migrations.

<sup>Written for commit e2af433d2d5f19bbbdc942305e0968df6d55363e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

