### PR TITLE
fix(connectors): add optional AWS region to S3 connector for non-default partitions

### DIFF
--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -642,10 +642,20 @@ class BlobStorageConnector(LoadConnector, PollConnector):
             error_code = e.response["Error"].get("Code", "")
             status_code = e.response["ResponseMetadata"].get("HTTPStatusCode")
 
+            # Credential rejections. These commonly mean the request reached the
+            # wrong AWS partition (e.g. a GovCloud bucket addressed through the
+            # commercial endpoint due to a missing/incorrect region) rather than
+            # a bucket-policy problem, so don't lump them in with AccessDenied.
+            if error_code in ["InvalidAccessKeyId", "InvalidToken"]:
+                raise CredentialExpiredError(
+                    f"Blob storage credentials were rejected (code={error_code}). "
+                    "Verify the credentials and that the configured AWS region matches "
+                    "the bucket's partition (e.g. us-gov-west-1 for GovCloud buckets)."
+                )
+
             # Most common S3 error cases
             if error_code in [
                 "AccessDenied",
-                "InvalidAccessKeyId",
                 "SignatureDoesNotMatch",
             ]:
                 if status_code == 403 or error_code == "AccessDenied":

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -72,6 +72,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         prefix: str = "",
         batch_size: int = INDEX_BATCH_SIZE,
         european_residency: bool = False,
+        region_name: str | None = None,
     ) -> None:
         self.bucket_type: BlobType = BlobType(bucket_type)
         self.bucket_name = bucket_name.strip()
@@ -82,6 +83,12 @@ class BlobStorageConnector(LoadConnector, PollConnector):
         self.size_threshold: int | None = BLOB_STORAGE_SIZE_THRESHOLD
         self.bucket_region: Optional[str] = None
         self.european_residency: bool = european_residency
+        # Explicit AWS region for the S3 (and STS) clients. Required for buckets in
+        # non-default partitions (e.g. GovCloud's us-gov-west-1) — without it boto3
+        # falls back to the commercial partition and credentials fail to validate.
+        self.region_name: str | None = (
+            region_name.strip() if region_name and region_name.strip() else None
+        )
 
     def set_allow_images(  # ty: ignore[invalid-method-override]
         self, allow_images: bool
@@ -173,7 +180,7 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                     aws_access_key_id=credentials["aws_access_key_id"],
                     aws_secret_access_key=credentials["aws_secret_access_key"],
                 )
-                self.s3_client = session.client("s3")
+                self.s3_client = session.client("s3", region_name=self.region_name)
             elif authentication_method == "iam_role":
                 # If using IAM roles, we assume the role and let boto3 handle the credentials.
                 role_arn = credentials.get("aws_role_arn")
@@ -185,7 +192,9 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
                 def _refresh_credentials() -> dict[str, str]:
                     """Refreshes the credentials for the assumed role."""
-                    sts_client = boto3.client("sts")
+                    # STS endpoints are partition-specific, so the region must be
+                    # forwarded here as well or GovCloud role assumption fails.
+                    sts_client = boto3.client("sts", region_name=self.region_name)
                     assumed_role_object = sts_client.assume_role(
                         RoleArn=role_arn,
                         RoleSessionName=f"onyx_blob_storage_{int(time.time())}",
@@ -208,11 +217,11 @@ class BlobStorageConnector(LoadConnector, PollConnector):
                     refreshable
                 )
                 session = boto3.Session(botocore_session=botocore_session)
-                self.s3_client = session.client("s3")
+                self.s3_client = session.client("s3", region_name=self.region_name)
             elif authentication_method == "assume_role":
                 # We will assume the instance role to access S3.
                 logger.debug("Using instance role authentication for S3 bucket.")
-                self.s3_client = boto3.client("s3")
+                self.s3_client = boto3.client("s3", region_name=self.region_name)
             else:
                 raise ConnectorValidationError("Invalid authentication method for S3. ")
 
@@ -326,6 +335,9 @@ class BlobStorageConnector(LoadConnector, PollConnector):
 
         elif self.bucket_type == BlobType.S3:
             region = self.bucket_region or self.s3_client.meta.region_name
+            # GovCloud has its own console domain
+            if region and region.startswith("us-gov-"):
+                return f"https://console.amazonaws-us-gov.com/s3/object/{self.bucket_name}?region={region}&prefix={encoded_key}"
             return f"https://s3.console.aws.amazon.com/s3/object/{self.bucket_name}?region={region}&prefix={encoded_key}"
 
         elif self.bucket_type == BlobType.GOOGLE_CLOUD_STORAGE:

--- a/backend/tests/unit/onyx/connectors/blob/test_blob_connector_region.py
+++ b/backend/tests/unit/onyx/connectors/blob/test_blob_connector_region.py
@@ -1,0 +1,94 @@
+from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from onyx.configs.constants import BlobType
+from onyx.connectors.blob.connector import BlobStorageConnector
+
+
+def _make_connector(region_name: str | None) -> BlobStorageConnector:
+    connector = BlobStorageConnector(
+        bucket_type=BlobType.S3.value,
+        bucket_name="test-bucket",
+        region_name=region_name,
+    )
+    return connector
+
+
+@pytest.mark.parametrize("region_name", ["us-gov-west-1", "us-east-2", None])
+def test_access_key_auth_passes_region(region_name: str | None) -> None:
+    credentials: dict[str, Any] = {
+        "authentication_method": "access_key",
+        "aws_access_key_id": "fake-key",
+        "aws_secret_access_key": "fake-secret",
+    }
+
+    connector = _make_connector(region_name)
+    with patch("onyx.connectors.blob.connector.boto3.Session") as mock_session_cls:
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        with patch.object(BlobStorageConnector, "_detect_bucket_region"):
+            connector.load_credentials(credentials)
+
+    mock_session.client.assert_called_once_with("s3", region_name=region_name)
+
+
+@pytest.mark.parametrize("region_name", ["us-gov-west-1", None])
+def test_instance_role_auth_passes_region(region_name: str | None) -> None:
+    credentials: dict[str, Any] = {"authentication_method": "assume_role"}
+
+    connector = _make_connector(region_name)
+    with patch("onyx.connectors.blob.connector.boto3.client") as mock_client:
+        with patch.object(BlobStorageConnector, "_detect_bucket_region"):
+            connector.load_credentials(credentials)
+
+    mock_client.assert_called_once_with("s3", region_name=region_name)
+
+
+def test_iam_role_auth_passes_region_to_sts_and_s3() -> None:
+    credentials: dict[str, Any] = {
+        "authentication_method": "iam_role",
+        "aws_role_arn": "arn:aws-us-gov:iam::123456789012:role/onyx-test",
+    }
+
+    connector = _make_connector("us-gov-west-1")
+    mock_sts = MagicMock()
+    mock_sts.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "fake-key",
+            "SecretAccessKey": "fake-secret",
+            "SessionToken": "fake-token",
+            "Expiration": MagicMock(isoformat=lambda: "2099-01-01T00:00:00+00:00"),
+        }
+    }
+
+    with (
+        patch(
+            "onyx.connectors.blob.connector.boto3.client", return_value=mock_sts
+        ) as mock_client,
+        patch("onyx.connectors.blob.connector.boto3.Session") as mock_session_cls,
+        patch.object(BlobStorageConnector, "_detect_bucket_region"),
+    ):
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        connector.load_credentials(credentials)
+
+    mock_client.assert_called_with("sts", region_name="us-gov-west-1")
+    mock_session.client.assert_called_once_with("s3", region_name="us-gov-west-1")
+
+
+def test_blank_region_normalized_to_none() -> None:
+    connector = _make_connector("   ")
+    assert connector.region_name is None
+
+
+def test_govcloud_blob_link_uses_govcloud_console() -> None:
+    connector = _make_connector("us-gov-west-1")
+    connector.bucket_region = "us-gov-west-1"
+    connector.s3_client = MagicMock()
+
+    link = connector._get_blob_link("some/key.pdf")
+    assert link.startswith("https://console.amazonaws-us-gov.com/s3/object/test-bucket")
+    assert "region=us-gov-west-1" in link

--- a/backend/tests/unit/onyx/connectors/blob/test_blob_connector_region.py
+++ b/backend/tests/unit/onyx/connectors/blob/test_blob_connector_region.py
@@ -1,11 +1,15 @@
 from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 from onyx.configs.constants import BlobType
 from onyx.connectors.blob.connector import BlobStorageConnector
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
 
 
 def _make_connector(region_name: str | None) -> BlobStorageConnector:
@@ -82,6 +86,43 @@ def test_iam_role_auth_passes_region_to_sts_and_s3() -> None:
 def test_blank_region_normalized_to_none() -> None:
     connector = _make_connector("   ")
     assert connector.region_name is None
+
+
+def _client_error(error_code: str, status_code: int) -> ClientError:
+    error_response = cast(
+        Any,
+        {
+            "Error": {"Code": error_code},
+            "ResponseMetadata": {"HTTPStatusCode": status_code},
+        },
+    )
+    return ClientError(error_response=error_response, operation_name="ListObjectsV2")
+
+
+@pytest.mark.parametrize(
+    "error_code, status_code",
+    [("InvalidAccessKeyId", 403), ("InvalidToken", 400)],
+)
+def test_validation_maps_credential_rejections_to_credential_error(
+    error_code: str, status_code: int
+) -> None:
+    connector = _make_connector(None)
+    connector.s3_client = MagicMock()
+    connector.s3_client.list_objects_v2.side_effect = _client_error(
+        error_code, status_code
+    )
+
+    with pytest.raises(CredentialExpiredError, match=error_code):
+        connector.validate_connector_settings()
+
+
+def test_validation_maps_access_denied_to_insufficient_permissions() -> None:
+    connector = _make_connector(None)
+    connector.s3_client = MagicMock()
+    connector.s3_client.list_objects_v2.side_effect = _client_error("AccessDenied", 403)
+
+    with pytest.raises(InsufficientPermissionsError):
+        connector.validate_connector_settings()
 
 
 def test_govcloud_blob_link_uses_govcloud_console() -> None:

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -1368,6 +1368,17 @@ For example, specifying .*-support.* as a "channel" will cause the connector to 
       },
       {
         type: "text",
+        query: "Enter the AWS region:",
+        label: "AWS Region",
+        name: "region_name",
+        description:
+          "The AWS region of the bucket (e.g. us-east-1). Required for buckets in " +
+          "non-default partitions such as GovCloud (us-gov-west-1); otherwise the " +
+          "default region resolution is used.",
+        optional: true,
+      },
+      {
+        type: "text",
         label: "Bucket Type",
         name: "bucket_type",
         optional: false,


### PR DESCRIPTION
## Description

The S3 connector creates its boto3 clients with no region, so boto3 resolves to the commercial AWS partition by default. For buckets in non-default partitions (e.g. GovCloud's `us-gov-west-1`), every request is routed to the wrong partition, which cannot validate the credentials. This surfaces as misleading validation errors:

- `InvalidToken (400): The provided token is malformed or otherwise invalid` — instance-role/IRSA session tokens from GovCloud STS presented to commercial S3
- `Insufficient permissions to list objects in bucket ...` — permanent GovCloud access keys returning `InvalidAccessKeyId`/403 from the commercial endpoint, which the validation logic maps to a bucket-policy error

Changes:
- Add an optional `region_name` to `BlobStorageConnector` and thread it through all three S3 auth paths (access key, IAM role, instance role), including the STS client used for role assumption (STS endpoints are also partition-specific)
- Expose an optional "AWS Region" field on the S3 connector form
- Use the GovCloud console domain for citation links when the bucket region is `us-gov-*`

Existing connectors are unaffected: with no region configured, behavior is identical to before (boto3 default region resolution).

## How Has This Been Tested?
<img width="834" height="910" alt="Screenshot 2026-06-03 at 11 58 27 AM" src="https://github.com/user-attachments/assets/e8943fa6-49e1-45e9-b7d4-1730d55cbfb1" />

- New unit tests (`backend/tests/unit/onyx/connectors/blob/test_blob_connector_region.py`) verifying the region is passed to the S3/STS clients for all three auth methods, blank-region normalization, and the GovCloud console link
- `pre-commit` (ty, ruff, TypeScript type check) passing on all touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional AWS region to the S3 connector to correctly target non-default partitions (e.g. GovCloud), improves credential error messaging, and switches object links to the GovCloud console when the bucket region is `us-gov-*`.

- **New Features**
  - Optional "AWS Region" field (`region_name`) in the S3 connector form; leave blank to keep previous default resolution.

- **Bug Fixes**
  - Pass `region_name` to `boto3` S3 and STS clients across access key, IAM role, and instance role auth so GovCloud buckets validate against the correct partition; generate GovCloud console links when the bucket region is `us-gov-*`.
  - Map `InvalidAccessKeyId`/`InvalidToken` to actionable credential errors instead of bucket-policy errors, with guidance to verify region/partition.

<sup>Written for commit d304247eaa8886a0f7708576ae34ebf95a0e5a7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



