### PR TITLE
fix(craft): grant scheduled-tasks worker sandbox push access

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.16
+version: 0.5.17
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,12 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Allow disabling the bundled `redis-operator` subchart
-        independently of the Redis instance via `redisOperator.enabled`. Leave it
-        unset to keep the existing behavior (operator follows `redis.enabled`);
-        set it to `false` to skip the bundled operator and have an existing
-        cluster-wide redis-operator reconcile the chart's Redis CR.
+    - kind: fixed
+      description: Grant the scheduled-tasks worker the same sandbox access as the
+        api_server (it provisions sandboxes headlessly). Inject the restricted
+        `sandboxPushSecret` (`ONYX_SANDBOX_PUSH_PRIVATE_KEY`) into the worker and
+        allow its pods as an ingress source in the sandbox-push NetworkPolicy.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
@@ -87,6 +87,7 @@ spec:
             {{- end }}
           env:
             {{- include "onyx.envSecrets" . | nindent 12}}
+            {{- include "onyx.envSecretsRestricted" . | nindent 12}}
             {{- with .Values.celery_worker_scheduled_tasks.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
+++ b/deployment/helm/charts/onyx/templates/network-policy-sandbox-push.yaml
@@ -18,6 +18,15 @@ spec:
           podSelector:
             matchLabels:
               app: api-server
+        # The scheduled-tasks worker provisions + drives sandboxes headlessly
+        # (run_scheduled_task → ensure_sandbox_running), so it needs the same
+        # push / opencode-serve / dev-server connectivity as the api_server.
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ $.Release.Namespace }}
+          podSelector:
+            matchLabels:
+              app: celery-worker-scheduled-tasks
         {{- if .Values.sandboxPushPolicy.allowTelepresenceAmbassador }}
         # Local-dev only (enabled via values-localdev.yaml): when an api_server
         # is intercepted by telepresence, outbound traffic from the developer's

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1346,7 +1346,7 @@ auth:
   # Generate with: python3 -c "import base64; from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey as K; from cryptography.hazmat.primitives.serialization import *; print(base64.b64encode(K.generate().private_bytes(Encoding.Raw,PrivateFormat.Raw,NoEncryption())).decode())"
   sandboxPushSecret:
     enabled: false
-    allPods: false  # Only inject into API server pods
+    allPods: false  # Restricted: only injected into pods that provision sandboxes (API server + scheduled-tasks worker)
     secretName: 'onyx-sandbox-push-secret'
     existingSecret: ""
     secretKeys:


### PR DESCRIPTION
## Description

The scheduled-tasks Celery worker provisions and drives sandboxes headlessly (`run_scheduled_task` → `ensure_sandbox_running` → `provision()`), so it needs the same sandbox access as the api_server. Two pieces were missing in the Helm chart:

1. **Push private key secret** — `provision()` calls `_create_sandbox_pod` → `_get_push_key_pair()`, which raises `RuntimeError` if `ONYX_SANDBOX_PUSH_PRIVATE_KEY` is unset. That secret (`sandboxPushSecret`, `allPods: false`) was only injected into api-server pods via `onyx.envSecretsRestricted`; the worker used `onyx.envSecrets`, which skips `allPods: false` entries.
2. **NetworkPolicy** — `network-policy-sandbox-push` only allowed `app: api-server` pods to reach sandbox pods on ports 8731 (push daemon), 4096 (opencode-serve), and the Next.js dev range. Even with the secret, the worker would be blocked.

Changes:
- `celery-worker-scheduled-tasks.yaml`: add `onyx.envSecretsRestricted` so the worker receives `ONYX_SANDBOX_PUSH_PRIVATE_KEY` (the only `allPods: false` secret today).
- `network-policy-sandbox-push.yaml`: add `app: celery-worker-scheduled-tasks` as an allowed ingress source in the release namespace.
- `values.yaml`: update the `sandboxPushSecret` comment — no longer api-server-only.

## How Has This Been Tested?

`helm template` renders both changed templates correctly:
- worker now mounts `ONYX_SANDBOX_PUSH_PRIVATE_KEY` from `onyx-sandbox-push-secret`
- NetworkPolicy now lists both `app: api-server` and `app: celery-worker-scheduled-tasks`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)