### PR TITLE
feat(ods): add `celery` command to run all workers locally

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -220,6 +220,57 @@ ods backend model_server
 ods backend model_server --port 9001
 ```
 
+### `celery` - Run Celery Workers
+
+Run Onyx celery workers with environment loaded from `.vscode/.env` (same env
+handling and EE defaults as `backend`). With no arguments, starts every worker
+in the "Run All Onyx Services" debug compound; pass worker names to run a
+subset, or `--all` to also include the `monitoring` worker.
+
+Each worker runs through `backend/scripts/dev_celery_reload.py` for hot-reload
+on changes under `backend/onyx` and `backend/ee`. All workers stream to one
+terminal with a per-worker prefix, and a single `Ctrl-C` stops them all.
+
+```shell
+ods celery [worker...]
+```
+
+**Available workers:**
+
+`primary`, `light`, `heavy`, `docfetching`, `docprocessing`,
+`user_file_processing`, `scheduled_tasks`, `beat`, `monitoring`
+
+(`monitoring` is excluded from the default set, matching the launch compound.)
+
+**Flags:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--all` | `false` | Run every worker, including `monitoring` |
+| `--no-reload` | `false` | Disable hot-reload (run celery directly) |
+| `--no-ee` | `false` | Disable Enterprise Edition features (enabled by default) |
+| `--loglevel` | `INFO` | Celery log level |
+
+**Examples:**
+
+```shell
+# Start the full dev worker set
+ods celery
+
+# Start only specific workers
+ods celery primary beat
+
+# Include the monitoring worker
+ods celery --all
+
+# Run without hot-reload
+ods celery docfetching docprocessing --no-reload
+```
+
+This pairs with `ods compose dev --infra`, `ods backend api`,
+`ods backend model_server`, and `ods web dev` to run the full stack on the host
+with hot-reload — no devcontainer or VS Code launch compound required.
+
 ### `web` - Run Frontend Scripts
 
 Run bun scripts from `web/package.json` without manually changing directories.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -268,10 +268,6 @@ ods background --all
 ods background docfetching docprocessing --no-reload
 ```
 
-This pairs with `ods compose dev --infra`, `ods backend api`,
-`ods backend model_server`, and `ods web dev` to run the full stack on the host
-with hot-reload — no devcontainer or VS Code launch compound required.
-
 ### `web` - Run Frontend Scripts
 
 Run bun scripts from `web/package.json` without manually changing directories.

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -220,19 +220,20 @@ ods backend model_server
 ods backend model_server --port 9001
 ```
 
-### `celery` - Run Celery Workers
+### `background` - Run Background (Celery) Workers
 
-Run Onyx celery workers with environment loaded from `.vscode/.env` (same env
-handling and EE defaults as `backend`). With no arguments, starts every worker
-in the "Run All Onyx Services" debug compound; pass worker names to run a
-subset, or `--all` to also include the `monitoring` worker.
+Run Onyx background celery workers with environment loaded from `.vscode/.env`
+(same env handling and EE defaults as `backend`). With no arguments, starts
+every worker in the "Run All Onyx Services" debug compound; pass worker names to
+run a subset, or `--all` to also include the `monitoring` worker.
 
 Each worker runs through `backend/scripts/dev_celery_reload.py` for hot-reload
 on changes under `backend/onyx` and `backend/ee`. All workers stream to one
-terminal with a per-worker prefix, and a single `Ctrl-C` stops them all.
+terminal with a per-worker prefix, and a single `Ctrl-C` stops them all (press
+again to force kill).
 
 ```shell
-ods celery [worker...]
+ods background [worker...]
 ```
 
 **Available workers:**
@@ -255,16 +256,16 @@ ods celery [worker...]
 
 ```shell
 # Start the full dev worker set
-ods celery
+ods background
 
 # Start only specific workers
-ods celery primary beat
+ods background primary beat
 
 # Include the monitoring worker
-ods celery --all
+ods background --all
 
 # Run without hot-reload
-ods celery docfetching docprocessing --no-reload
+ods background docfetching docprocessing --no-reload
 ```
 
 This pairs with `ods compose dev --infra`, `ods backend api`,

--- a/tools/ods/cmd/background.go
+++ b/tools/ods/cmd/background.go
@@ -19,7 +19,7 @@ import (
 
 // celeryWorker describes a single celery worker (or beat) process. The fields
 // mirror the "Celery <name>" configurations in .vscode/launch.json so that
-// `ods celery` launches the same set of processes as the "Run All Onyx
+// `ods background` launches the same set of processes as the "Run All Onyx
 // Services" debug compound.
 type celeryWorker struct {
 	name        string // logical worker name, also used for --hostname and CLI selection
@@ -33,7 +33,7 @@ type celeryWorker struct {
 // celeryWorkers is the canonical worker list, kept in sync with the celery
 // configurations in .vscode/launch.json. `monitoring` is excluded from the
 // default set to match the "Run All Onyx Services" compound, but can be run
-// explicitly (`ods celery monitoring`) or via --all.
+// explicitly (`ods background monitoring`) or via --all.
 var celeryWorkers = []celeryWorker{
 	{name: "primary", command: "worker", concurrency: "4", prefetch: "1", queues: "celery", inDefault: true},
 	{name: "light", command: "worker", concurrency: "64", prefetch: "8", queues: "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration", inDefault: true},
@@ -46,21 +46,21 @@ var celeryWorkers = []celeryWorker{
 	{name: "monitoring", command: "worker", concurrency: "1", prefetch: "1", queues: "monitoring", inDefault: false},
 }
 
-// CeleryOptions holds options for the celery command.
-type CeleryOptions struct {
+// BackgroundOptions holds options for the background command.
+type BackgroundOptions struct {
 	NoEE     bool
 	NoReload bool
 	LogLevel string
 	All      bool
 }
 
-func NewCeleryCommand() *cobra.Command {
-	opts := &CeleryOptions{}
+func NewBackgroundCommand() *cobra.Command {
+	opts := &BackgroundOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "celery [worker...]",
-		Short: "Run Onyx celery workers (with hot-reload)",
-		Long: `Run Onyx celery workers with environment from .vscode/.env.
+		Use:   "background [worker...]",
+		Short: "Run Onyx background (celery) workers (with hot-reload)",
+		Long: `Run Onyx background celery workers with environment from .vscode/.env.
 
 With no arguments, starts every worker in the "Run All Onyx Services" debug
 compound (primary, light, heavy, docfetching, docprocessing,
@@ -79,12 +79,12 @@ Available workers:
   user_file_processing, scheduled_tasks, beat, monitoring
 
 Examples:
-  ods celery
-  ods celery primary beat
-  ods celery --all
-  ods celery docfetching docprocessing --no-reload`,
+  ods background
+  ods background primary beat
+  ods background --all
+  ods background docfetching docprocessing --no-reload`,
 		Run: func(cmd *cobra.Command, args []string) {
-			runCelery(selectCeleryWorkers(args, opts.All), opts)
+			runBackground(selectCeleryWorkers(args, opts.All), opts)
 		},
 	}
 
@@ -165,7 +165,7 @@ func (w celeryWorker) celeryArgs(loglevel string) []string {
 	return args
 }
 
-func runCelery(workers []celeryWorker, opts *CeleryOptions) {
+func runBackground(workers []celeryWorker, opts *BackgroundOptions) {
 	if len(workers) == 0 {
 		log.Fatal("No celery workers selected")
 	}

--- a/tools/ods/cmd/celery.go
+++ b/tools/ods/cmd/celery.go
@@ -228,7 +228,7 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 			// A partial startup would leave a silently degraded stack, so tear
 			// down the workers we did start and fail.
 			log.Errorf("Failed to start celery %s: %v", w.name, err)
-			terminateCeleryWorkers(cmds)
+			signalCeleryWorkers(cmds, syscall.SIGTERM)
 			wg.Wait()
 			os.Exit(1)
 		}
@@ -245,25 +245,28 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 		}(svcCmd, w.name, stdout, stderr)
 	}
 
-	// Forward the first interrupt to every worker's process group, then wait
-	// for them to drain.
-	sigCh := make(chan os.Signal, 1)
+	// First interrupt asks workers to drain (SIGTERM); a second escalates to
+	// SIGKILL so a hung worker can't trap us in wg.Wait() forever.
+	sigCh := make(chan os.Signal, 2)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigCh
-		log.Info("Shutting down celery workers...")
-		terminateCeleryWorkers(cmds)
+		log.Info("Shutting down celery workers... (press Ctrl-C again to force kill)")
+		signalCeleryWorkers(cmds, syscall.SIGTERM)
+		<-sigCh
+		log.Info("Force killing celery workers...")
+		signalCeleryWorkers(cmds, syscall.SIGKILL)
 	}()
 
 	wg.Wait()
 }
 
-// terminateCeleryWorkers sends SIGTERM to each worker's process group, stopping
-// the whole tree (uv -> python -> watchfiles fork -> celery).
-func terminateCeleryWorkers(cmds []*exec.Cmd) {
+// signalCeleryWorkers sends sig to each worker's process group, reaching the
+// whole tree (uv -> python -> watchfiles fork -> celery).
+func signalCeleryWorkers(cmds []*exec.Cmd, sig syscall.Signal) {
 	for _, c := range cmds {
 		if c.Process != nil {
-			_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
+			_ = syscall.Kill(-c.Process.Pid, sig)
 		}
 	}
 }

--- a/tools/ods/cmd/celery.go
+++ b/tools/ods/cmd/celery.go
@@ -1,0 +1,303 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+)
+
+// celeryWorker describes a single celery worker (or beat) process. The fields
+// mirror the "Celery <name>" configurations in .vscode/launch.json so that
+// `ods celery` launches the same set of processes as the "Run All Onyx
+// Services" debug compound.
+type celeryWorker struct {
+	name        string // logical worker name, also used for --hostname and CLI selection
+	command     string // celery subcommand: "worker" or "beat"
+	concurrency string // --concurrency value; empty omits the flag (celery default)
+	prefetch    string // --prefetch-multiplier value; empty omits the flag
+	queues      string // comma-separated -Q queues; empty omits the flag (beat)
+	inDefault   bool   // part of the default set run when no workers are named
+}
+
+// celeryWorkers is the canonical worker list, kept in sync with the celery
+// configurations in .vscode/launch.json. `monitoring` is excluded from the
+// default set to match the "Run All Onyx Services" compound, but can be run
+// explicitly (`ods celery monitoring`) or via --all.
+var celeryWorkers = []celeryWorker{
+	{name: "primary", command: "worker", concurrency: "4", prefetch: "1", queues: "celery", inDefault: true},
+	{name: "light", command: "worker", concurrency: "64", prefetch: "8", queues: "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration", inDefault: true},
+	{name: "heavy", command: "worker", concurrency: "4", prefetch: "1", queues: "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox", inDefault: true},
+	{name: "docfetching", command: "worker", prefetch: "1", queues: "connector_doc_fetching", inDefault: true},
+	{name: "docprocessing", command: "worker", prefetch: "1", queues: "docprocessing", inDefault: true},
+	{name: "user_file_processing", command: "worker", concurrency: "2", prefetch: "1", queues: "user_file_processing,user_file_project_sync,user_file_delete", inDefault: true},
+	{name: "scheduled_tasks", command: "worker", concurrency: "4", prefetch: "1", queues: "scheduled_tasks", inDefault: true},
+	{name: "beat", command: "beat", inDefault: true},
+	{name: "monitoring", command: "worker", concurrency: "1", prefetch: "1", queues: "monitoring", inDefault: false},
+}
+
+// CeleryOptions holds options for the celery command.
+type CeleryOptions struct {
+	NoEE     bool
+	NoReload bool
+	LogLevel string
+	All      bool
+}
+
+func NewCeleryCommand() *cobra.Command {
+	opts := &CeleryOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "celery [worker...]",
+		Short: "Run Onyx celery workers (with hot-reload)",
+		Long: `Run Onyx celery workers with environment from .vscode/.env.
+
+With no arguments, starts every worker in the "Run All Onyx Services" debug
+compound (primary, light, heavy, docfetching, docprocessing,
+user_file_processing, scheduled_tasks, beat). Pass worker names to run only a
+subset, or --all to additionally include the monitoring worker.
+
+Each worker runs through scripts/dev_celery_reload.py for hot-reload on changes
+under backend/onyx and backend/ee (disable with --no-reload). All workers stream
+to this terminal with a per-worker prefix; Ctrl-C stops them all.
+
+Enterprise Edition features are enabled by default for development, with license
+enforcement disabled.
+
+Available workers:
+  primary, light, heavy, docfetching, docprocessing,
+  user_file_processing, scheduled_tasks, beat, monitoring
+
+Examples:
+  ods celery
+  ods celery primary beat
+  ods celery --all
+  ods celery docfetching docprocessing --no-reload`,
+		Run: func(cmd *cobra.Command, args []string) {
+			runCelery(selectCeleryWorkers(args, opts.All), opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.NoEE, "no-ee", false, "Disable Enterprise Edition features (enabled by default)")
+	cmd.Flags().BoolVar(&opts.NoReload, "no-reload", false, "Disable hot-reload (run celery directly)")
+	cmd.Flags().BoolVar(&opts.All, "all", false, "Run every worker, including monitoring")
+	cmd.Flags().StringVar(&opts.LogLevel, "loglevel", "INFO", "Celery log level")
+
+	return cmd
+}
+
+// selectCeleryWorkers resolves the worker list from positional args. With no
+// args it returns the default set (or all workers when --all is set).
+func selectCeleryWorkers(args []string, all bool) []celeryWorker {
+	if all {
+		return celeryWorkers
+	}
+
+	if len(args) == 0 {
+		var defaults []celeryWorker
+		for _, w := range celeryWorkers {
+			if w.inDefault {
+				defaults = append(defaults, w)
+			}
+		}
+		return defaults
+	}
+
+	byName := make(map[string]celeryWorker, len(celeryWorkers))
+	for _, w := range celeryWorkers {
+		byName[w.name] = w
+	}
+
+	var selected []celeryWorker
+	for _, name := range args {
+		w, ok := byName[name]
+		if !ok {
+			log.Fatalf("Unknown celery worker %q. Available: %s", name, allCeleryWorkerNames())
+		}
+		selected = append(selected, w)
+	}
+	return selected
+}
+
+func allCeleryWorkerNames() string {
+	names := make([]string, len(celeryWorkers))
+	for i, w := range celeryWorkers {
+		names[i] = w.name
+	}
+	return strings.Join(names, ", ")
+}
+
+// celeryArgs builds the argument list forwarded to the celery CLI for a worker.
+func (w celeryWorker) celeryArgs(loglevel string) []string {
+	args := []string{
+		"-A", "onyx.background.celery.versioned_apps." + w.name,
+		w.command,
+		"--loglevel=" + loglevel,
+	}
+	if w.command != "worker" {
+		return args
+	}
+
+	args = append(args, "--pool=threads")
+	if w.concurrency != "" {
+		args = append(args, "--concurrency="+w.concurrency)
+	}
+	if w.prefetch != "" {
+		args = append(args, "--prefetch-multiplier="+w.prefetch)
+	}
+	args = append(args, "--hostname="+w.name+"@%n")
+	if w.queues != "" {
+		args = append(args, "-Q", w.queues)
+	}
+	return args
+}
+
+func runCelery(workers []celeryWorker, opts *CeleryOptions) {
+	if len(workers) == 0 {
+		log.Fatal("No celery workers selected")
+	}
+
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find git root: %v", err)
+	}
+	backendDir := filepath.Join(root, "backend")
+
+	envFile := ensureBackendEnvFile(root)
+	fileVars := loadBackendEnvFile(envFile)
+	fileVars = append(fileVars, eeEnvDefaults(opts.NoEE)...)
+	mergedEnv := mergeEnv(os.Environ(), fileVars)
+	log.Debugf("Applied %d env vars from %s (shell takes precedence)", len(fileVars), envFile)
+
+	names := make([]string, len(workers))
+	for i, w := range workers {
+		names[i] = w.name
+	}
+	log.Infof("Starting %d celery worker(s): %s", len(workers), strings.Join(names, ", "))
+	if !opts.NoReload {
+		log.Info("Hot-reload enabled (use --no-reload to disable)")
+	}
+	if !opts.NoEE {
+		log.Info("Enterprise Edition enabled (use --no-ee to disable)")
+	}
+
+	// Shared mutex so concurrent workers never interleave a partial line.
+	var writeMu sync.Mutex
+	colorize := isCharDevice(os.Stdout)
+
+	var wg sync.WaitGroup
+	var cmds []*exec.Cmd
+	for i, w := range workers {
+		celeryCLIArgs := w.celeryArgs(opts.LogLevel)
+
+		var runArgs []string
+		if opts.NoReload {
+			runArgs = append([]string{"run", "celery"}, celeryCLIArgs...)
+		} else {
+			runArgs = append([]string{"run", "python", "scripts/dev_celery_reload.py"}, celeryCLIArgs...)
+		}
+
+		svcCmd := exec.Command("uv", runArgs...)
+		svcCmd.Dir = backendDir
+		svcCmd.Env = mergedEnv
+		// Own process group so we can signal the whole tree (uv -> python ->
+		// watchfiles fork -> celery) on shutdown.
+		svcCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+		prefix := celeryPrefix(w.name, i, colorize)
+		svcCmd.Stdout = &linePrefixWriter{w: os.Stdout, prefix: prefix, mu: &writeMu}
+		svcCmd.Stderr = &linePrefixWriter{w: os.Stderr, prefix: prefix, mu: &writeMu}
+
+		log.Debugf("[%s] uv %s", w.name, strings.Join(runArgs, " "))
+		if err := svcCmd.Start(); err != nil {
+			log.Errorf("Failed to start celery %s: %v", w.name, err)
+			continue
+		}
+
+		cmds = append(cmds, svcCmd)
+		wg.Add(1)
+		go func(c *exec.Cmd, name string) {
+			defer wg.Done()
+			if err := c.Wait(); err != nil {
+				log.Debugf("celery %s exited: %v", name, err)
+			}
+		}(svcCmd, w.name)
+	}
+
+	if len(cmds) == 0 {
+		log.Fatal("No celery workers started")
+	}
+
+	// Forward the first interrupt to every worker's process group, then wait
+	// for them to drain.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		log.Info("Shutting down celery workers...")
+		for _, c := range cmds {
+			if c.Process != nil {
+				_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
+// linePrefixWriter buffers bytes until a newline, then writes the complete line
+// prefixed with the worker label. The shared mutex serializes writes across all
+// workers so lines never interleave.
+type linePrefixWriter struct {
+	w      io.Writer
+	prefix string
+	mu     *sync.Mutex
+	buf    []byte
+}
+
+func (p *linePrefixWriter) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, c := range b {
+		if c != '\n' {
+			p.buf = append(p.buf, c)
+			continue
+		}
+		_, _ = fmt.Fprintf(p.w, "%s%s\n", p.prefix, p.buf)
+		p.buf = p.buf[:0]
+	}
+	return len(b), nil
+}
+
+var celeryPrefixColors = []string{
+	"\033[36m", "\033[32m", "\033[33m", "\033[35m", "\033[34m",
+	"\033[31m", "\033[96m", "\033[92m", "\033[95m",
+}
+
+const celeryColorReset = "\033[0m"
+
+func celeryPrefix(name string, index int, colorize bool) string {
+	label := fmt.Sprintf("%-20s | ", name)
+	if !colorize {
+		return label
+	}
+	return celeryPrefixColors[index%len(celeryPrefixColors)] + label + celeryColorReset
+}
+
+func isCharDevice(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}

--- a/tools/ods/cmd/celery.go
+++ b/tools/ods/cmd/celery.go
@@ -100,6 +100,9 @@ Examples:
 // args it returns the default set (or all workers when --all is set).
 func selectCeleryWorkers(args []string, all bool) []celeryWorker {
 	if all {
+		if len(args) > 0 {
+			log.Fatal("--all cannot be combined with named workers")
+		}
 		return celeryWorkers
 	}
 

--- a/tools/ods/cmd/celery.go
+++ b/tools/ods/cmd/celery.go
@@ -218,8 +218,10 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 		svcCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 		prefix := celeryPrefix(w.name, i, colorize)
-		svcCmd.Stdout = &linePrefixWriter{w: os.Stdout, prefix: prefix, mu: &writeMu}
-		svcCmd.Stderr = &linePrefixWriter{w: os.Stderr, prefix: prefix, mu: &writeMu}
+		stdout := &linePrefixWriter{w: os.Stdout, prefix: prefix, mu: &writeMu}
+		stderr := &linePrefixWriter{w: os.Stderr, prefix: prefix, mu: &writeMu}
+		svcCmd.Stdout = stdout
+		svcCmd.Stderr = stderr
 
 		log.Debugf("[%s] uv %s", w.name, strings.Join(runArgs, " "))
 		if err := svcCmd.Start(); err != nil {
@@ -233,12 +235,14 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 
 		cmds = append(cmds, svcCmd)
 		wg.Add(1)
-		go func(c *exec.Cmd, name string) {
+		go func(c *exec.Cmd, name string, out, errw *linePrefixWriter) {
 			defer wg.Done()
+			defer out.Flush()
+			defer errw.Flush()
 			if err := c.Wait(); err != nil {
 				log.Debugf("celery %s exited: %v", name, err)
 			}
-		}(svcCmd, w.name)
+		}(svcCmd, w.name, stdout, stderr)
 	}
 
 	// Forward the first interrupt to every worker's process group, then wait
@@ -286,6 +290,18 @@ func (p *linePrefixWriter) Write(b []byte) (int, error) {
 		p.buf = p.buf[:0]
 	}
 	return len(b), nil
+}
+
+// Flush emits any buffered partial line (output not terminated by a newline,
+// e.g. a final crash message) so it isn't lost when the worker exits.
+func (p *linePrefixWriter) Flush() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.buf) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(p.w, "%s%s\n", p.prefix, p.buf)
+	p.buf = p.buf[:0]
 }
 
 var celeryPrefixColors = []string{

--- a/tools/ods/cmd/celery.go
+++ b/tools/ods/cmd/celery.go
@@ -223,8 +223,12 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 
 		log.Debugf("[%s] uv %s", w.name, strings.Join(runArgs, " "))
 		if err := svcCmd.Start(); err != nil {
+			// A partial startup would leave a silently degraded stack, so tear
+			// down the workers we did start and fail.
 			log.Errorf("Failed to start celery %s: %v", w.name, err)
-			continue
+			terminateCeleryWorkers(cmds)
+			wg.Wait()
+			os.Exit(1)
 		}
 
 		cmds = append(cmds, svcCmd)
@@ -237,10 +241,6 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 		}(svcCmd, w.name)
 	}
 
-	if len(cmds) == 0 {
-		log.Fatal("No celery workers started")
-	}
-
 	// Forward the first interrupt to every worker's process group, then wait
 	// for them to drain.
 	sigCh := make(chan os.Signal, 1)
@@ -248,14 +248,20 @@ func runCelery(workers []celeryWorker, opts *CeleryOptions) {
 	go func() {
 		<-sigCh
 		log.Info("Shutting down celery workers...")
-		for _, c := range cmds {
-			if c.Process != nil {
-				_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
-			}
-		}
+		terminateCeleryWorkers(cmds)
 	}()
 
 	wg.Wait()
+}
+
+// terminateCeleryWorkers sends SIGTERM to each worker's process group, stopping
+// the whole tree (uv -> python -> watchfiles fork -> celery).
+func terminateCeleryWorkers(cmds []*exec.Cmd) {
+	for _, c := range cmds {
+		if c.Process != nil {
+			_ = syscall.Kill(-c.Process.Pid, syscall.SIGTERM)
+		}
+	}
 }
 
 // linePrefixWriter buffers bytes until a newline, then writes the complete line

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -47,6 +47,7 @@ func NewRootCommand() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(NewBackendCommand())
+	cmd.AddCommand(NewCeleryCommand())
 	cmd.AddCommand(NewCheckLazyImportsCommand())
 	cmd.AddCommand(NewCherryPickCommand())
 	cmd.AddCommand(NewDBCommand())

--- a/tools/ods/cmd/root.go
+++ b/tools/ods/cmd/root.go
@@ -47,7 +47,7 @@ func NewRootCommand() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(NewBackendCommand())
-	cmd.AddCommand(NewCeleryCommand())
+	cmd.AddCommand(NewBackgroundCommand())
 	cmd.AddCommand(NewCheckLazyImportsCommand())
 	cmd.AddCommand(NewCherryPickCommand())
 	cmd.AddCommand(NewDBCommand())


### PR DESCRIPTION
## Description

Adds a new `ods celery` command that launches the Onyx celery workers in a single process, mirroring the **"Run All Onyx Services"** debug compound in `.vscode/launch.json`.

- **No args** → runs the full dev worker set: `primary, light, heavy, docfetching, docprocessing, user_file_processing, scheduled_tasks, beat` (the same set, and same queues/concurrency/prefetch, as the launch compound). `monitoring` is excluded from the default to match the compound.
- **Named args** → run only a subset, e.g. `ods celery primary beat`.
- **`--all`** → additionally include the `monitoring` worker.
- **Hot-reload by default** via `backend/scripts/dev_celery_reload.py` (watches `backend/onyx` + `backend/ee`); `--no-reload` runs celery directly.
- All workers stream to one terminal with a per-worker colored prefix, and a single `Ctrl-C` tears down every worker's process group cleanly.
- Reuses `backend`'s env handling — loads `.vscode/.env`, EE-on with license enforcement off, shell vars take precedence. Flags: `--no-ee`, `--no-reload`, `--all`, `--loglevel`.

This completes the host-side full-stack dev loop alongside `ods compose dev --infra`, `ods backend api`, `ods backend model_server`, and `ods web dev` — no devcontainer or VS Code launch compound required.

Files:
- `tools/ods/cmd/celery.go` — new command (worker table kept in sync with launch.json, arg builder, multi-process runner with prefixed output + signal handling)
- `tools/ods/cmd/root.go` — register `NewCeleryCommand()`
- `tools/ods/README.md` — new `celery` section

## How Has This Been Tested?

- `go build ./...`, `go vet`, `gofmt`, and `golangci-lint` (via pre-commit) all clean.
- Verified `--help` output and the unknown-worker error path.
- Live smoke test against running Redis: started `beat` — env loaded from `.vscode/.env`, EE enabled, Redis readiness probe succeeded, scheduler dispatching due tasks, per-worker prefix rendered, and `Ctrl-C` confirmed-stopped the process group.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ods background` to run all Onyx background (Celery) workers locally with hot-reload in one terminal, mirroring the "Run All Onyx Services" compound. This completes the host-side dev loop without the devcontainer or VS Code launch compound.

- **New Features**
  - Default worker set matches the launch compound (excludes `monitoring`); select workers by name or use `--all`.
  - Hot-reload via `backend/scripts/dev_celery_reload.py`; disable with `--no-reload`. Use `ods background` (renamed from `ods celery`) to match the `background` compose service.
  - Unified, color-prefixed logs; graceful shutdown on Ctrl-C.
  - Env handling: loads `.vscode/.env`, EE enabled by default. Flags: `--no-ee`, `--no-reload`, `--all`, `--loglevel`. Docs in `tools/ods/README.md`.

- **Bug Fixes**
  - Reject `--all` when combined with named workers.
  - Fail fast if any worker fails to start; tear down started workers and exit non-zero.
  - Flush buffered partial lines on worker exit.
  - Second Ctrl-C escalates to SIGKILL for stuck process groups.

<sup>Written for commit a13cdeaf2a346532adab0ff1e70f851e22f07210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

