### PR TITLE
fix(craft): self-heal stale opencode-serve password across replicas

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1263,6 +1263,12 @@ class KubernetesSandboxManager(SandboxManager):
                     f"Timeout waiting for existing sandbox pod {pod_name} to become ready"
                 )
 
+            # Reusing a live pod: clear any stale tombstone so event-bus
+            # creation can attach. A stale password heals via the 401 path in
+            # the readiness probe below.
+            with self._event_buses_lock:
+                self._terminated_sandboxes.discard(sandbox_id)
+
             if not self._wait_for_opencode_serve_ready(sandbox_id):
                 raise RuntimeError(
                     f"opencode-serve never became ready in existing sandbox pod {pod_name}"

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -260,13 +260,18 @@ class PodEventBus:
 
     def _refresh_auth_on_401(self) -> None:
         """Reload auth so the ensuing reconnect uses the rotated password.
-        Best-effort: a failed reload leaves auth unchanged."""
+        No-op when the reloaded credential is unchanged (a genuine auth
+        failure, not a rotation) so we don't log a misleading "reloaded" on
+        every reconnect before the bus self-closes. Best-effort: a failed
+        reload leaves auth unchanged."""
         if self._reload_auth is None:
             return
         try:
             new_auth = self._reload_auth()
         except Exception as e:
             logger.warning("PodEventBus reload_auth failed after 401: %s", e)
+            return
+        if _auth_token(new_auth) == _auth_token(self._auth):
             return
         self._auth = new_auth
         logger.info("PodEventBus reloaded auth after 401 on %s/event", self._base_url)
@@ -333,6 +338,20 @@ class PodEventBus:
                         sid,
                         sub.dropped_count,
                     )
+
+
+def _auth_token(auth: httpx.Auth | None) -> str | None:
+    """Render an ``httpx.Auth`` to its Authorization header for value
+    comparison. ``httpx.Auth`` has no ``__eq__``, so we drive its public
+    ``auth_flow`` over a throwaway request — scheme-agnostic and not tied to
+    any private attribute. ``None`` if there's no auth or it sets no header."""
+    if auth is None:
+        return None
+    try:
+        signed = next(auth.auth_flow(httpx.Request("GET", "http://x")))
+        return signed.headers.get("authorization")
+    except Exception:
+        return None
 
 
 def _extract_session_id(evt: dict[str, Any]) -> str | None:

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -259,11 +259,10 @@ class PodEventBus:
                     self._dispatch(evt)
 
     def _refresh_auth_on_401(self) -> None:
-        """Reload auth so the ensuing reconnect uses the rotated password.
-        No-op when the reloaded credential is unchanged (a genuine auth
-        failure, not a rotation) so we don't log a misleading "reloaded" on
-        every reconnect before the bus self-closes. Best-effort: a failed
-        reload leaves auth unchanged."""
+        """Reload auth so the next reconnect uses the rotated password. No-op
+        when the credential is unchanged (genuine auth failure) to avoid a
+        misleading log on every reconnect. Best-effort: failed reload keeps
+        the current auth."""
         if self._reload_auth is None:
             return
         try:
@@ -341,10 +340,8 @@ class PodEventBus:
 
 
 def _auth_token(auth: httpx.Auth | None) -> str | None:
-    """Render an ``httpx.Auth`` to its Authorization header for value
-    comparison. ``httpx.Auth`` has no ``__eq__``, so we drive its public
-    ``auth_flow`` over a throwaway request — scheme-agnostic and not tied to
-    any private attribute. ``None`` if there's no auth or it sets no header."""
+    """Render auth to its Authorization header for comparison — ``httpx.Auth``
+    has no ``__eq__``, so drive its public ``auth_flow`` over a dummy request."""
     if auth is None:
         return None
     try:

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import field
 from queue import Empty
@@ -56,9 +57,12 @@ class PodEventBus:
         directory: str | None = None,
         connect_timeout: float = 10.0,
         event_read_timeout: float | None = None,
+        reload_auth: Callable[[], httpx.Auth | None] | None = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._auth = auth
+        # Re-fetch auth on a /event 401 — a peer pod rotated the password.
+        self._reload_auth = reload_auth
         # Opencode-serve's Instance.provide middleware scopes /event per
         # ?directory= query param. Without it, the SSE stream only sees the
         # default Instance (server.connected, server.heartbeat) — session
@@ -232,6 +236,8 @@ class PodEventBus:
             params=params,
             timeout=timeout,
         ) as response:
+            if response.status_code == 401:
+                self._refresh_auth_on_401()
             response.raise_for_status()
             self.stream_ready.set()
             logger.info(
@@ -251,6 +257,19 @@ class PodEventBus:
                     if evt is None:
                         continue
                     self._dispatch(evt)
+
+    def _refresh_auth_on_401(self) -> None:
+        """Reload auth so the ensuing reconnect uses the rotated password.
+        Best-effort: a failed reload leaves auth unchanged."""
+        if self._reload_auth is None:
+            return
+        try:
+            new_auth = self._reload_auth()
+        except Exception as e:
+            logger.warning("PodEventBus reload_auth failed after 401: %s", e)
+            return
+        self._auth = new_auth
+        logger.info("PodEventBus reloaded auth after 401 on %s/event", self._base_url)
 
     def _dispatch(self, evt: dict[str, Any]) -> None:
         etype = evt.get("type")

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -774,10 +774,15 @@ class OpencodeServeClient:
         client_info: dict[str, Any] | None = None,
         timeouts: ClientTimeouts | None = None,
         transport: httpx.BaseTransport | None = None,
+        reload_password: Callable[[], str | None] | None = None,
     ) -> None:
         """``event_bus`` is required for :meth:`send_message`; unary
         methods (ensure_session, list_messages, abort) work without one
-        — tests can omit it when exercising the unary surface only."""
+        — tests can omit it when exercising the unary surface only.
+
+        ``reload_password`` re-fetches the password from its source of truth,
+        invoked on a 401 to self-heal a peer-pod password rotation. ``None``
+        disables the self-heal (e.g. health probes)."""
         self._base_url = base_url.rstrip("/")
         self._password = password
         self._client_info = client_info or {
@@ -785,16 +790,22 @@ class OpencodeServeClient:
             "version": "1.0.0",
         }
         self._timeouts = timeouts or ClientTimeouts()
-        self._auth: httpx.BasicAuth | None = (
+        self._reload_password = reload_password
+        self._event_bus = event_bus
+        # transport is for tests (httpx.MockTransport); stored so
+        # _apply_password can rebuild the client without losing it.
+        self._transport = transport
+        self._auth: httpx.BasicAuth | None = None
+        self._http = self._make_http_client(password)
+
+    def _make_http_client(self, password: str | None) -> httpx.Client:
+        self._auth = (
             httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
         )
-        self._event_bus = event_bus
-        # transport is for tests (httpx.MockTransport). Unary only —
-        # SSE subscription is owned by the bus.
-        self._http = httpx.Client(
+        return httpx.Client(
             base_url=self._base_url,
             auth=self._auth,
-            transport=transport,
+            transport=self._transport,
             timeout=httpx.Timeout(
                 connect=self._timeouts.connect_timeout,
                 read=self._timeouts.request_timeout,
@@ -802,6 +813,14 @@ class OpencodeServeClient:
                 pool=self._timeouts.connect_timeout,
             ),
         )
+
+    def _apply_password(self, password: str | None) -> None:
+        """Rebuild the http client with a fresh password (auth is bound at
+        construction); close the old one to avoid a pool leak."""
+        old = self._http
+        self._password = password
+        self._http = self._make_http_client(password)
+        old.close()
 
     # ----- session lifecycle ----------------------------------------
 
@@ -869,6 +888,38 @@ class OpencodeServeClient:
         assert last_exc is not None
         raise last_exc
 
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        idempotent: bool = False,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Unary request with cold-pod retry plus a one-shot password reload
+        on 401 (a peer pod rotated the password, staling our cache). Retrying
+        is safe even for a non-idempotent POST: a 401 is rejected before
+        processing, so the server never saw the body. An unchanged reload is a
+        genuine auth failure — return it for the caller to surface."""
+        r = self._http_with_cold_pod_retry(
+            method, path, idempotent=idempotent, **kwargs
+        )
+        if r.status_code != 401 or self._reload_password is None:
+            return r
+        new_password = self._reload_password()
+        if new_password == self._password:
+            return r
+        logger.info(
+            "[SESSION-LIFECYCLE] 401 on %s %s; reloaded opencode password and "
+            "retrying (peer pod likely rotated it)",
+            method,
+            path,
+        )
+        self._apply_password(new_password)
+        return self._http_with_cold_pod_retry(
+            method, path, idempotent=idempotent, **kwargs
+        )
+
     def ensure_session(
         self,
         opencode_session_id: str | None,
@@ -896,7 +947,7 @@ class OpencodeServeClient:
         if opencode_session_id:
             # GET is idempotent — safe to retry on either ConnectError or
             # RemoteProtocolError.
-            r = self._http_with_cold_pod_retry(
+            r = self._request(
                 "GET",
                 f"/session/{opencode_session_id}",
                 params=directory_params,
@@ -931,7 +982,7 @@ class OpencodeServeClient:
         # = server never saw it) keeps the call safe; a
         # RemoteProtocolError after a half-handled POST could leak an
         # orphan opencode session.
-        r = self._http_with_cold_pod_retry(
+        r = self._request(
             "POST",
             "/session",
             params=directory_params,
@@ -979,9 +1030,11 @@ class OpencodeServeClient:
         streaming and only populated post-terminator. Use this only for
         the post-terminator fallback in the reconnect path.
         """
-        r = self._http.get(
+        r = self._request(
+            "GET",
             f"/session/{opencode_session_id}/message",
             params={"directory": directory},
+            idempotent=True,
         )
         _raise_for_status(r, "session messages")
         data = r.json()
@@ -1008,7 +1061,7 @@ class OpencodeServeClient:
     ) -> dict[str, Any] | None:
         """GET /session/{id}/message/{id}. None on any failure (never raises)."""
         try:
-            r = self._http_with_cold_pod_retry(
+            r = self._request(
                 "GET",
                 f"/session/{opencode_session_id}/message/{message_id}",
                 params={"directory": directory},
@@ -1229,10 +1282,13 @@ class OpencodeServeClient:
         body: dict[str, Any] = {"parts": [{"type": "text", "text": message}]}
         if model_provider and model_id:
             body["model"] = {"providerID": model_provider, "modelID": model_id}
-        r = self._http.post(
+        # idempotent=False: only the 401 reload retries this POST.
+        r = self._request(
+            "POST",
             f"/session/{opencode_session_id}/prompt_async",
             params={"directory": directory},
             json=body,
+            idempotent=False,
         )
         _raise_for_status(r, "prompt_async")
 

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -828,12 +828,18 @@ class OpencodeServeClient:
 
     # ----- session lifecycle ----------------------------------------
 
-    def health_check(self) -> bool:
+    def health_check_status(self) -> int | None:
+        """HTTP status from ``GET /doc``, or ``None`` on transport error — lets
+        the readiness probe tell a 401 (stale password) from a not-yet-listening
+        pod (transport error)."""
         try:
             r = self._http.get("/doc", timeout=self._timeouts.connect_timeout)
-            return r.status_code == 200
+            return r.status_code
         except httpx.HTTPError:
-            return False
+            return None
+
+    def health_check(self) -> bool:
+        return self.health_check_status() == 200
 
     # Cold-pod retry tunables — short window, total worst-case ~1.5s.
     _COLD_POD_RETRIES = 3

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -795,13 +795,16 @@ class OpencodeServeClient:
         # transport is for tests (httpx.MockTransport); stored so
         # _apply_password can rebuild the client without losing it.
         self._transport = transport
-        self._auth: httpx.BasicAuth | None = None
-        self._http = self._make_http_client(password)
+        self._auth = self._basic_auth(password)
+        self._http = self._make_http_client()
 
-    def _make_http_client(self, password: str | None) -> httpx.Client:
-        self._auth = (
-            httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
-        )
+    @staticmethod
+    def _basic_auth(password: str | None) -> httpx.BasicAuth | None:
+        return httpx.BasicAuth(OPENCODE_SERVER_USERNAME, password) if password else None
+
+    def _make_http_client(self) -> httpx.Client:
+        """Build a client bound to the current ``self._auth``. Pure — callers
+        set ``self._auth`` first."""
         return httpx.Client(
             base_url=self._base_url,
             auth=self._auth,
@@ -819,7 +822,8 @@ class OpencodeServeClient:
         construction); close the old one to avoid a pool leak."""
         old = self._http
         self._password = password
-        self._http = self._make_http_client(password)
+        self._auth = self._basic_auth(password)
+        self._http = self._make_http_client()
         old.close()
 
     # ----- session lifecycle ----------------------------------------

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -243,28 +243,56 @@ class _ServeMixin:
     ) -> bool:
         """Block until opencode-serve answers ``GET /doc`` with 200. Backend
         Ready only proves the supervisor is up; opencode binds :4096 a few
-        seconds later."""
+        seconds later.
+
+        On a 401 the cached password is stale (pod re-provisioned with a fresh
+        Secret); drop the cache, reload, and rebuild the probe client once.
+        Provision-time counterpart to the per-request heal in ``_request`` /
+        ``PodEventBus._refresh_auth_on_401``, which run only after readiness."""
         info = self._serve_connection_info(sandbox_id)
         probe_base_url = self._serve_health_check_base_url(sandbox_id) or info.base_url
         # One client across all polls — saves connect-setup churn while the
         # server is actively refusing connections.
-        with OpencodeServeClient(
+        client = OpencodeServeClient(
             base_url=probe_base_url, password=info.password, event_bus=None
-        ) as client:
+        )
+        password_reset_done = False
+        try:
             deadline = time.time() + timeout
             last_err = "no probe completed"
             while time.time() < deadline:
                 try:
-                    if client.health_check():
+                    status = client.health_check_status()
+                    if status == 200:
                         logger.info(
                             "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
                             sandbox_id,
                         )
                         return True
-                    last_err = "health_check returned False"
+                    if status == 401 and not password_reset_done:
+                        password_reset_done = True
+                        refreshed = self._reload_serve_connection_info(sandbox_id)
+                        if refreshed.password != info.password:
+                            logger.warning(
+                                "[SANDBOX-SERVE] opencode-serve returned 401 for "
+                                "sandbox %s; reloaded password and retrying probe "
+                                "with the current credentials",
+                                sandbox_id,
+                            )
+                            info = refreshed
+                            client.close()
+                            client = OpencodeServeClient(
+                                base_url=probe_base_url,
+                                password=info.password,
+                                event_bus=None,
+                            )
+                            continue
+                    last_err = f"health_check returned status={status}"
                 except Exception as e:
                     last_err = f"{type(e).__name__}: {e}"
                 time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
+        finally:
+            client.close()
         logger.error(
             "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
             "after %.0fs (last error: %s)",

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -137,6 +137,13 @@ class _ServeMixin:
         with self._serve_conn_info_lock:
             self._serve_conn_info.pop(sandbox_id, None)
 
+    def _reload_serve_connection_info(self, sandbox_id: UUID) -> ServeConnectionInfo:
+        """Drop the local cache and reload from the source of truth. The 401
+        self-heal path: a peer api_server pod re-provisioned the sandbox and
+        rotated the password, so local invalidation alone never reaches us."""
+        self._invalidate_serve_connection_info(sandbox_id)
+        return self._serve_connection_info(sandbox_id)
+
     def _serve_health_check_base_url(self, sandbox_id: UUID) -> str | None:  # noqa: ARG002
         """Override to probe a different URL during the readiness wait than the
         persistent ``base_url``. Default ``None`` → use ``base_url``."""
@@ -295,6 +302,10 @@ class _ServeMixin:
                 auth=info.auth(),
                 directory=directory,
                 event_read_timeout=OPENCODE_SERVE_EVENT_READ_TIMEOUT,
+                # Self-heal a 401 mid-stream (peer pod rotated the password).
+                reload_auth=lambda: self._reload_serve_connection_info(
+                    sandbox_id
+                ).auth(),
             )
             self._event_buses[key] = bus
             logger.info(
@@ -313,6 +324,10 @@ class _ServeMixin:
             base_url=info.base_url,
             password=info.password,
             event_bus=bus,
+            # Self-heal a 401 on any unary call (peer pod rotated the password).
+            reload_password=lambda: self._reload_serve_connection_info(
+                sandbox_id
+            ).password,
         )
 
     def _close_session_buses(self, sandbox_id: UUID, session_id: UUID) -> None:

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -60,6 +60,7 @@ from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from tests.external_dependency_unit.craft._test_helpers import default_llm_config
 
@@ -411,3 +412,95 @@ def test_terminate_then_subscribe_refuses(
             pool.manager.terminate(sandbox_id)
         except Exception:
             pass
+
+
+# ----------------------------------------------------------------------
+# Stale-password 401 self-heal
+#
+# A peer api_server replica's cached opencode password goes stale after a
+# re-provision rotates the per-pod Secret; K8s never pushes the new value into
+# a running container's env. Each heal site must recover against the REAL
+# opencode-serve (a genuine 401) by reloading the password from the backend
+# (here: docker inspect). We mimic the stale-cache state by poisoning the
+# in-memory cache with a wrong password — byte-identical to the post-rotation
+# state, but deterministic (no flaky re-provision timing).
+# ----------------------------------------------------------------------
+
+
+def _poison_password_cache(
+    manager: DockerSandboxManager, sandbox_id: UUID
+) -> ServeConnectionInfo:
+    """Overwrite the cached ``ServeConnectionInfo`` with a wrong password and
+    return the real one (read fresh from docker inspect) so callers can assert
+    the heal restored it."""
+    real = manager._load_serve_connection_info(sandbox_id)
+    assert real is not None and real.password, "expected a real cached password"
+    stale = ServeConnectionInfo(
+        base_url=real.base_url, password=f"{real.password}-stale"
+    )
+    with manager._serve_conn_info_lock:
+        manager._serve_conn_info[sandbox_id] = stale
+    return real
+
+
+def _restore_password_cache(
+    manager: DockerSandboxManager, sandbox_id: UUID, real: ServeConnectionInfo
+) -> None:
+    with manager._serve_conn_info_lock:
+        manager._serve_conn_info[sandbox_id] = real
+
+
+def test_stale_password_heals_on_readiness_probe(
+    _pool_container: _PoolContainer,
+) -> None:
+    """``_wait_for_opencode_serve_ready`` probes with the stale password, gets
+    a real 401, reloads from docker inspect, and rebuilds the probe client —
+    instead of collapsing the 401 into "not ready" and polling to timeout."""
+    pool = _pool_container
+    real = _poison_password_cache(pool.manager, pool.sandbox_id)
+    try:
+        assert pool.manager._wait_for_opencode_serve_ready(pool.sandbox_id) is True
+        # Heal reloaded the current password into the cache.
+        assert (
+            pool.manager._serve_connection_info(pool.sandbox_id).password
+            == real.password
+        )
+    finally:
+        _restore_password_cache(pool.manager, pool.sandbox_id, real)
+
+
+def test_stale_password_heals_on_unary_call(handle: _Handle) -> None:
+    """A unary serve call (``ensure_opencode_session`` → POST /session) hits a
+    real 401 with the stale password, reloads, and retries once via
+    ``_request`` — so it still returns a valid opencode session id."""
+    real = _poison_password_cache(handle.manager, handle.sandbox_id)
+    try:
+        opencode_session_id = handle.manager.ensure_opencode_session(
+            handle.sandbox_id, handle.session_id
+        )
+        assert opencode_session_id, "ensure_opencode_session must heal and return an id"
+        assert (
+            handle.manager._serve_connection_info(handle.sandbox_id).password
+            == real.password
+        )
+    finally:
+        _restore_password_cache(handle.manager, handle.sandbox_id, real)
+
+
+def test_stale_password_heals_event_bus(handle: _Handle) -> None:
+    """The event-bus ``/event`` stream hits a real 401 with the stale password;
+    the reader reloads auth and reconnects rather than burning its reconnect
+    budget. ``stream_ready`` becomes set once it heals. The per-session bus is
+    closed by the ``handle`` fixture's workspace cleanup."""
+    directory = handle.manager._session_directory(handle.session_id)
+    real = _poison_password_cache(handle.manager, handle.sandbox_id)
+    bus = None
+    try:
+        bus = handle.manager._get_or_create_event_bus(handle.sandbox_id, directory)
+        assert bus.stream_ready.wait(timeout=20.0), (
+            "event bus never became ready after a 401 — reload_auth heal failed"
+        )
+    finally:
+        if bus is not None:
+            bus.close()
+        _restore_password_cache(handle.manager, handle.sandbox_id, real)

--- a/backend/tests/unit/build/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/build/test_opencode_serve_ready_password_reset.py
@@ -1,0 +1,125 @@
+"""Regression tests for the "sandbox stuck initializing" bug.
+
+opencode-serve sits behind HTTP Basic auth whose password lives in a per-pod
+k8s Secret, read into the container's env at start. The api_server caches that
+password in memory. When a pod is re-provisioned with a fresh Secret, the cached
+password goes stale — and K8s never pushes Secret updates into a running
+container's env. Previously the readiness probe just saw a non-200 and polled
+the same stale password until timeout ("opencode-serve never became ready"),
+leaving the sandbox stuck "initializing".
+
+``_wait_for_opencode_serve_ready`` now probes with the cached password first and,
+on a 401, re-reads the current password from the backend and retries once.
+"""
+
+from unittest import mock
+from uuid import uuid4
+
+from onyx.server.features.build.sandbox import serve_transport
+from onyx.server.features.build.sandbox.kubernetes import (
+    kubernetes_sandbox_manager as k8s_mod,
+)
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
+
+_STALE_PW = "stale-password"
+_FRESH_PW = "fresh-password"
+
+
+class _FakeProbeClient:
+    """Stand-in for OpencodeServeClient: 200 only for the fresh password."""
+
+    created: list["_FakeProbeClient"] = []
+
+    def __init__(
+        self,
+        base_url: str,
+        password: str | None,
+        *,
+        event_bus: object = None,  # noqa: ARG002
+    ):
+        self.base_url = base_url
+        self.password = password
+        self.closed = False
+        _FakeProbeClient.created.append(self)
+
+    def health_check_status(self) -> int:
+        return 200 if self.password == _FRESH_PW else 401
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_manager() -> KubernetesSandboxManager:
+    # Bypass __init__ (which builds a real k8s client) — we only exercise the
+    # in-process serve-transport plumbing.
+    mgr = object.__new__(KubernetesSandboxManager)
+    mgr._init_serve_state()
+    mgr._namespace = "onyx-sandboxes"
+    return mgr
+
+
+def test_wait_for_opencode_serve_ready_resets_password_on_401() -> None:
+    mgr = _make_manager()
+    sandbox_id = uuid4()
+
+    _FakeProbeClient.created.clear()
+    with (
+        mock.patch.object(mgr, "_serve_health_check_base_url", return_value=None),
+        # First load returns the stale cached password; after the 401-triggered
+        # invalidation, the reload returns the current one.
+        mock.patch.object(
+            mgr,
+            "_load_serve_connection_info",
+            side_effect=[
+                ServeConnectionInfo(base_url="http://pod:4096", password=_STALE_PW),
+                ServeConnectionInfo(base_url="http://pod:4096", password=_FRESH_PW),
+            ],
+        ) as load_mock,
+        mock.patch.object(serve_transport, "OpencodeServeClient", _FakeProbeClient),
+    ):
+        ready = mgr._wait_for_opencode_serve_ready(sandbox_id, timeout=5.0)
+
+    assert ready is True
+    # Probed with the stale password, got 401, rebuilt with the fresh one.
+    assert [c.password for c in _FakeProbeClient.created] == [_STALE_PW, _FRESH_PW]
+    assert _FakeProbeClient.created[0].closed is True
+    assert _FakeProbeClient.created[1].closed is True
+    # Cache was reloaded from the backend exactly once after invalidation.
+    assert load_mock.call_count == 2
+
+
+def test_reuse_existing_pod_clears_stale_tombstone() -> None:
+    mgr = _make_manager()
+    sandbox_id = uuid4()
+
+    # A prior terminate in this process tombstoned the sandbox; reusing a live
+    # pod must clear it so event-bus creation can attach again.
+    mgr._terminated_sandboxes.add(sandbox_id)
+
+    with (
+        mock.patch.object(k8s_mod, "SANDBOX_API_SERVER_URL", "http://api"),
+        mock.patch.object(k8s_mod, "SANDBOX_PROXY_HOST", "proxy.local"),
+        mock.patch.object(mgr, "_pod_exists_and_healthy", return_value=True),
+        mock.patch.object(mgr, "_ensure_service_exists"),
+        mock.patch.object(mgr, "_wait_for_pod_ready", return_value=True),
+        mock.patch.object(mgr, "_wait_for_opencode_serve_ready", return_value=True),
+    ):
+        info = mgr.provision(
+            sandbox_id=sandbox_id,
+            user_id=uuid4(),
+            tenant_id="public",
+            llm_config=LLMProviderConfig(
+                provider="openai",
+                model_name="gpt-5-mini",
+                api_key="sk-test",
+                api_base=None,
+            ),
+            onyx_pat="pat-test",
+        )
+
+    assert info.sandbox_id == sandbox_id
+    assert sandbox_id not in mgr._terminated_sandboxes

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -593,3 +593,26 @@ def test_read_one_stream_401_without_reload_auth_just_raises(
             bus._read_one_stream()
     finally:
         bus.close()
+
+
+def test_read_one_stream_401_no_op_when_credential_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuine auth failure (reload returns the same credential) must not
+    swap auth — otherwise every reconnect logs a misleading "reloaded"."""
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    current = httpx.BasicAuth("opencode", "same-pw")
+
+    bus = PodEventBus(
+        base_url="http://test.invalid:4096",
+        auth=current,
+        # Distinct object, same credential — the 401 is genuine, not a rotation.
+        reload_auth=lambda: httpx.BasicAuth("opencode", "same-pw"),
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            bus._read_one_stream()
+    finally:
+        bus.close()
+
+    assert bus._auth is current

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -533,3 +533,63 @@ def test_dispatch_under_concurrent_subscribers(bus: PodEventBus) -> None:
     sub = bus.subscribe("ses_other")
     bus._dispatch(_make_event("message.part.delta", sessionID="ses_other"))
     assert sub.queue.get_nowait() is not None
+
+
+# ---------------------------------------------------------------------------
+# 401 self-heal: a peer api_server pod rotated the opencode password, so the
+# bus's cached auth is stale. The reader must reload auth before reconnecting
+# rather than burning its whole reconnect budget on 401s.
+# ---------------------------------------------------------------------------
+
+
+class _Status401Stream:
+    """Stand-in for ``httpx.stream`` whose response is a 401."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self._args = args
+        self._kwargs = kwargs
+
+    def __enter__(self) -> httpx.Response:
+        return httpx.Response(401, request=httpx.Request("GET", self._args[1]))
+
+    def __exit__(self, *_: Any) -> None:
+        return None
+
+
+def test_read_one_stream_reloads_auth_on_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    fresh = httpx.BasicAuth("opencode", "fresh-pw")
+    reloads: list[int] = []
+
+    def reload_auth() -> httpx.Auth:
+        reloads.append(1)
+        return fresh
+
+    bus = PodEventBus(
+        base_url="http://test.invalid:4096",
+        auth=httpx.BasicAuth("opencode", "stale-pw"),
+        reload_auth=reload_auth,
+    )
+    try:
+        # 401 → reload auth, then raise_for_status bubbles up to trigger reconnect.
+        with pytest.raises(httpx.HTTPStatusError):
+            bus._read_one_stream()
+    finally:
+        bus.close()
+
+    assert reloads == [1]
+    assert bus._auth is fresh
+
+
+def test_read_one_stream_401_without_reload_auth_just_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    bus = PodEventBus(base_url="http://test.invalid:4096", auth=None)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            bus._read_one_stream()
+    finally:
+        bus.close()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_client_401_reload.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_client_401_reload.py
@@ -1,0 +1,61 @@
+"""Focused test: OpencodeServeClient self-heals a 401 by reloading the password."""
+
+from __future__ import annotations
+
+import httpx
+
+from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
+
+
+def test_request_reloads_password_on_401_and_retries() -> None:
+    calls: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.headers.get("authorization"))
+        # First call (stale password) → 401; retry (fresh password) → 200.
+        if len(calls) == 1:
+            return httpx.Response(401)
+        return httpx.Response(200, json={"id": "ses_new"})
+
+    reloads: list[int] = []
+
+    def reload_password() -> str:
+        reloads.append(1)
+        return "fresh-pw"
+
+    client = OpencodeServeClient(
+        base_url="http://test.invalid:4096",
+        password="stale-pw",
+        transport=httpx.MockTransport(handler),
+        reload_password=reload_password,
+    )
+    sid = client.ensure_session(None, directory="/workspace/sessions/x")
+    assert sid == "ses_new"
+    assert len(calls) == 2, calls
+    assert calls[0] != calls[1], "auth header should change after reload"
+    assert len(reloads) == 1
+    client.close()
+
+
+def test_request_does_not_retry_when_password_unchanged() -> None:
+    n = 0
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal n
+        n += 1
+        return httpx.Response(401)
+
+    client = OpencodeServeClient(
+        base_url="http://test.invalid:4096",
+        password="same",
+        transport=httpx.MockTransport(handler),
+        reload_password=lambda: "same",
+    )
+    # 401 with unchanged password → no retry, surfaces as HTTPStatusError.
+    try:
+        client.ensure_session(None, directory="/workspace/sessions/x")
+        assert False, "expected HTTPStatusError"
+    except httpx.HTTPStatusError:
+        pass
+    assert n == 1, n
+    client.close()


### PR DESCRIPTION
## Description

The per-pod `ServeConnectionInfo` cache in the opencode-serve transport invalidates **only locally**. When a peer `api_server` replica re-provisions a sandbox and rotates the opencode password (stored in the shared per-pod K8s Secret), every other replica keeps sending the stale password and gets `401`s until its process restarts — the sandbox looks dead on N-1 of N replicas.

This treats a `401` as the deterministic signal that the cached password is stale, then reloads from the source of truth (the Secret) and retries once. The `base_url` is deterministic/immutable for a sandbox, so only the password participates in the reload.

- **`serve_transport.py`**: add `_reload_serve_connection_info` (drop the local cache + reload from source of truth); wire reload callbacks into both the `OpencodeServeClient` and the `PodEventBus`.
- **`serve_client.py`**: route hot-path unary calls (`ensure_session`, `get_message`, `list_messages`, `prompt_async`) through a `_request` wrapper that reloads + retries once on `401`. Safe even for the non-idempotent prompt POST — a `401` is rejected before processing, so the server never enqueues the turn.
- **`event_bus.py`**: refresh auth on a `/event` stream `401` so the reader self-heals instead of burning its reconnect budget and self-closing.

Scope is limited to `conn_info`. The related cross-replica gaps in `_prompt_locks` (a real corruption bug) and `_terminated_sandboxes` (a resource nuisance) are documented as separate follow-up plans and intentionally not addressed here.

## How Has This Been Tested?

- New unit tests `backend/tests/unit/.../test_serve_client_401_reload.py`: `401` → reload → retry with fresh auth; and no-retry when the reloaded password is unchanged (genuine auth failure surfaces).
- New unit tests in `test_event_bus.py`: bus reloads auth on a `/event` `401`; and just raises when no `reload_auth` is configured.
- `uv run pytest backend/tests/unit/onyx/server/features/build/sandbox/` — 4 new tests pass; the only failures are 6 pre-existing `test_send_message_with_bus` flakes that fail identically on `main` (their bus reader resolves real DNS for `test.invalid`).
- `ruff format` / `ruff check` clean; `mypy` error count unchanged vs `main` (pre-existing `SandboxEvent`-alias noise only).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals stale `opencode-serve` passwords across replicas by reloading auth on 401 and retrying once, including during the readiness probe. Keeps sessions, `/event` streams, and provisioning stable after peer pods rotate credentials, and avoids false “reloaded” logs on genuine auth failures.

- Bug Fixes
  - `serve_transport.py` + `kubernetes_sandbox_manager.py`: added `_reload_serve_connection_info`; readiness probe uses `health_check_status` to detect 401, reloads the password, and rebuilds the probe client once; clears stale tombstones when reusing a live pod so the event bus can attach.
  - `serve_client.py`: routed hot-path calls through `_request` to reload password on 401 and retry once; rebuilds `httpx.Client` via `_apply_password` using `_basic_auth` and a pure `_make_http_client`; added `health_check_status`; safe for `prompt_async`.
  - `event_bus.py`: refreshes auth on `/event` 401 and only swaps when the credential actually changed (compares via public `auth_flow`) to avoid misleading logs.
  - Tests: added unit tests for readiness-probe reset, 401 reload paths, unchanged-credential guard, and tombstone clearing; plus Docker E2E tests that poison the local cache and verify healing in the readiness probe, a unary call, and the event bus.

<sup>Written for commit 09d03005c8a5f1d88ceff25ce50750bab2278e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

