### PR TITLE
fix(craft): fast-fail bus creation for terminated sandboxes across replicas

### DIFF
--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -120,13 +120,6 @@ def get_sandbox_by_id(db_session: Session, sandbox_id: UUID) -> Sandbox | None:
     return db_session.execute(stmt).scalar_one_or_none()
 
 
-def get_sandbox_status(db_session: Session, sandbox_id: UUID) -> SandboxStatus | None:
-    """Return the sandbox's status, or None if no such row. Reads only the
-    indexed ``status`` column (``ix_sandbox_status``)."""
-    stmt = select(Sandbox.status).where(Sandbox.id == sandbox_id)
-    return db_session.execute(stmt).scalar_one_or_none()
-
-
 def update_sandbox_status__no_commit(
     db_session: Session,
     sandbox_id: UUID,

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -121,12 +121,8 @@ def get_sandbox_by_id(db_session: Session, sandbox_id: UUID) -> Sandbox | None:
 
 
 def get_sandbox_status(db_session: Session, sandbox_id: UUID) -> SandboxStatus | None:
-    """Return the sandbox's current status, or None if no such row exists.
-
-    Reads only the indexed ``status`` column (``ix_sandbox_status``). Used by
-    the serve transport to fast-fail event-bus creation for terminal sandboxes
-    uniformly across all api_server replicas.
-    """
+    """Return the sandbox's status, or None if no such row. Reads only the
+    indexed ``status`` column (``ix_sandbox_status``)."""
     stmt = select(Sandbox.status).where(Sandbox.id == sandbox_id)
     return db_session.execute(stmt).scalar_one_or_none()
 

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -120,6 +120,17 @@ def get_sandbox_by_id(db_session: Session, sandbox_id: UUID) -> Sandbox | None:
     return db_session.execute(stmt).scalar_one_or_none()
 
 
+def get_sandbox_status(db_session: Session, sandbox_id: UUID) -> SandboxStatus | None:
+    """Return the sandbox's current status, or None if no such row exists.
+
+    Reads only the indexed ``status`` column (``ix_sandbox_status``). Used by
+    the serve transport to fast-fail event-bus creation for terminal sandboxes
+    uniformly across all api_server replicas.
+    """
+    stmt = select(Sandbox.status).where(Sandbox.id == sandbox_id)
+    return db_session.execute(stmt).scalar_one_or_none()
+
+
 def update_sandbox_status__no_commit(
     db_session: Session,
     sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -338,12 +338,6 @@ class _ServeMixin:
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
                     "create a new event bus against its (deleted) backend"
                 )
-            # The tombstone is local to the terminating replica; the DB status
-            # is the cross-replica authority. Refuse if the pod is gone
-            # (terminated / failed / sleeping) — a bus there just burns its
-            # reconnect budget against a dead Service. RUNNING / PROVISIONING
-            # keep a pod and proceed; a missing row falls through to the
-            # connection-info handling below.
             with get_session_with_current_tenant() as db_session:
                 sandbox = get_sandbox_by_id(db_session, sandbox_id)
             if sandbox is not None and (

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -321,35 +321,11 @@ class _ServeMixin:
         self-closed buses so callers don't wedge on BUS_CLOSED_SENTINEL until
         restart."""
         key = (sandbox_id, directory)
-
-        # Fast path: a live cached bus needs no I/O — return it under the lock.
-        # The local tombstone short-circuits the terminating pod's own racing
-        # subscribes without a DB hit.
         with self._event_buses_lock:
             bus = self._event_buses.get(key)
             if bus is not None and not bus.closed:
                 return bus
-            if sandbox_id in self._terminated_sandboxes:
-                raise RuntimeError(
-                    f"Sandbox {sandbox_id} has been terminated; refusing to "
-                    "create a new event bus against its (deleted) backend"
-                )
-
-        # Cache miss: do the authoritative gone-check + connection-info load
-        # WITHOUT holding the lock, so a slow DB / control-plane round-trip
-        # doesn't block bus creation for other sandboxes. The tombstone above is
-        # only a local fast-path; this DB check makes the refusal fire on every
-        # replica, not just the terminating one. The double-checked insert below
-        # handles the race where two threads both miss the cache.
-        self._assert_sandbox_backend_live(sandbox_id)
-        info = self._serve_connection_info(sandbox_id)
-
-        with self._event_buses_lock:
-            existing = self._event_buses.get(key)
-            if existing is not None and not existing.closed:
-                # Another thread won the race while we were loading — use theirs.
-                return existing
-            if existing is not None and existing.closed:
+            if bus is not None and bus.closed:
                 logger.warning(
                     "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
                     "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
@@ -357,6 +333,18 @@ class _ServeMixin:
                     directory,
                 )
                 self._event_buses.pop(key, None)
+            if sandbox_id in self._terminated_sandboxes:
+                raise RuntimeError(
+                    f"Sandbox {sandbox_id} has been terminated; refusing to "
+                    "create a new event bus against its (deleted) backend"
+                )
+            # The local tombstone above only covers the replica that ran
+            # terminate. Consult the authoritative DB status so the refusal
+            # fires on every replica, not just the terminating one. The status
+            # read is a cheap indexed lookup, so holding the lock across it is
+            # fine.
+            self._assert_sandbox_backend_live(sandbox_id)
+            info = self._serve_connection_info(sandbox_id)
             bus = PodEventBus(
                 base_url=info.base_url,
                 auth=info.auth(),

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -29,7 +29,7 @@ from onyx.server.features.build.api.packet_logger import get_packet_logger
 from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_TURN_TIMEOUT_SECONDS
-from onyx.server.features.build.db.sandbox import get_sandbox_status
+from onyx.server.features.build.db.sandbox import get_sandbox_by_id
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
@@ -338,9 +338,22 @@ class _ServeMixin:
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
                     "create a new event bus against its (deleted) backend"
                 )
-            # Tombstone is local to the terminating replica; the DB status
-            # makes the refusal fire on every replica.
-            self._assert_sandbox_backend_live(sandbox_id)
+            # The tombstone is local to the terminating replica; the DB status
+            # is the cross-replica authority. Refuse if the pod is gone
+            # (terminated / failed / sleeping) — a bus there just burns its
+            # reconnect budget against a dead Service. RUNNING / PROVISIONING
+            # keep a pod and proceed; a missing row falls through to the
+            # connection-info handling below.
+            with get_session_with_current_tenant() as db_session:
+                sandbox = get_sandbox_by_id(db_session, sandbox_id)
+            if sandbox is not None and (
+                sandbox.status.is_terminal() or sandbox.status.is_sleeping()
+            ):
+                raise RuntimeError(
+                    f"Sandbox {sandbox_id} is {sandbox.status.value} (no live "
+                    "backend per DB); refusing to create a new event bus "
+                    "against its (deleted) backend"
+                )
             info = self._serve_connection_info(sandbox_id)
             bus = PodEventBus(
                 base_url=info.base_url,
@@ -359,21 +372,6 @@ class _ServeMixin:
                 directory,
             )
             return bus
-
-    def _assert_sandbox_backend_live(self, sandbox_id: UUID) -> None:
-        """Raise if the DB reports the sandbox's pod is gone (TERMINATED /
-        FAILED / SLEEPING) — a bus there just burns its reconnect budget against
-        a dead Service. Authoritative across replicas, unlike the local
-        tombstone. RUNNING / PROVISIONING keep a pod and proceed; a missing row
-        falls through to the existing connection-info handling."""
-        with get_session_with_current_tenant() as db_session:
-            status = get_sandbox_status(db_session, sandbox_id)
-        if status is not None and (status.is_terminal() or status.is_sleeping()):
-            raise RuntimeError(
-                f"Sandbox {sandbox_id} is {status.value} (no live backend per "
-                "DB); refusing to create a new event bus against its "
-                "(deleted) backend"
-            )
 
     def _build_serve_client(
         self, sandbox_id: UUID, directory: str

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -338,11 +338,8 @@ class _ServeMixin:
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
                     "create a new event bus against its (deleted) backend"
                 )
-            # The local tombstone above only covers the replica that ran
-            # terminate. Consult the authoritative DB status so the refusal
-            # fires on every replica, not just the terminating one. The status
-            # read is a cheap indexed lookup, so holding the lock across it is
-            # fine.
+            # Tombstone is local to the terminating replica; the DB status
+            # makes the refusal fire on every replica.
             self._assert_sandbox_backend_live(sandbox_id)
             info = self._serve_connection_info(sandbox_id)
             bus = PodEventBus(
@@ -364,22 +361,11 @@ class _ServeMixin:
             return bus
 
     def _assert_sandbox_backend_live(self, sandbox_id: UUID) -> None:
-        """Refuse to build a bus against a sandbox with no live backend pod,
-        per the authoritative DB ``Sandbox.status``.
-
-        ``Sandbox.status`` is the strongly-consistent, indexed authority shared
-        by all api_server replicas, so this makes the refusal fire everywhere —
-        not just on the pod that holds the local ``_terminated_sandboxes``
-        tombstone.
-
-        A bus is refused for every state whose pod is gone: ``TERMINATED`` /
-        ``FAILED`` (permanent) and ``SLEEPING`` (pod torn down, snapshot in S3).
-        All three would otherwise burn the full reconnect budget (~30s) against
-        a dead Service before self-closing. ``RUNNING`` and ``PROVISIONING``
-        keep a (possibly still-coming-up) pod and flow on to the readiness wait.
-        A missing row (status ``None``) is left to the existing connection-info
-        handling rather than treated as gone.
-        """
+        """Raise if the DB reports the sandbox's pod is gone (TERMINATED /
+        FAILED / SLEEPING) — a bus there just burns its reconnect budget against
+        a dead Service. Authoritative across replicas, unlike the local
+        tombstone. RUNNING / PROVISIONING keep a pod and proceed; a missing row
+        falls through to the existing connection-info handling."""
         with get_session_with_current_tenant() as db_session:
             status = get_sandbox_status(db_session, sandbox_id)
         if status is not None and (status.is_terminal() or status.is_sleeping()):

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -316,15 +316,40 @@ class _ServeMixin:
         return False
 
     def _get_or_create_event_bus(self, sandbox_id: UUID, directory: str) -> PodEventBus:
-        """Lazy per-(sandbox, directory) bus. Refuses to create for a
-        terminated sandbox; replaces self-closed buses so callers don't
-        wedge on BUS_CLOSED_SENTINEL until restart."""
+        """Lazy per-(sandbox, directory) bus. Refuses to create for a sandbox
+        with no live backend pod (terminated / failed / sleeping); replaces
+        self-closed buses so callers don't wedge on BUS_CLOSED_SENTINEL until
+        restart."""
         key = (sandbox_id, directory)
+
+        # Fast path: a live cached bus needs no I/O — return it under the lock.
+        # The local tombstone short-circuits the terminating pod's own racing
+        # subscribes without a DB hit.
         with self._event_buses_lock:
             bus = self._event_buses.get(key)
             if bus is not None and not bus.closed:
                 return bus
-            if bus is not None and bus.closed:
+            if sandbox_id in self._terminated_sandboxes:
+                raise RuntimeError(
+                    f"Sandbox {sandbox_id} has been terminated; refusing to "
+                    "create a new event bus against its (deleted) backend"
+                )
+
+        # Cache miss: do the authoritative gone-check + connection-info load
+        # WITHOUT holding the lock, so a slow DB / control-plane round-trip
+        # doesn't block bus creation for other sandboxes. The tombstone above is
+        # only a local fast-path; this DB check makes the refusal fire on every
+        # replica, not just the terminating one. The double-checked insert below
+        # handles the race where two threads both miss the cache.
+        self._assert_sandbox_backend_live(sandbox_id)
+        info = self._serve_connection_info(sandbox_id)
+
+        with self._event_buses_lock:
+            existing = self._event_buses.get(key)
+            if existing is not None and not existing.closed:
+                # Another thread won the race while we were loading — use theirs.
+                return existing
+            if existing is not None and existing.closed:
                 logger.warning(
                     "[SANDBOX-SERVE] Replacing self-closed PodEventBus for "
                     "sandbox %s dir=%s (prior bus exhausted its reconnect budget)",
@@ -332,16 +357,6 @@ class _ServeMixin:
                     directory,
                 )
                 self._event_buses.pop(key, None)
-            if sandbox_id in self._terminated_sandboxes:
-                raise RuntimeError(
-                    f"Sandbox {sandbox_id} has been terminated; refusing to "
-                    "create a new event bus against its (deleted) backend"
-                )
-            # The local tombstone above only covers the replica that ran
-            # terminate. Consult the authoritative DB status so the refusal
-            # fires on every replica, not just the terminating one.
-            self._assert_sandbox_not_terminal(sandbox_id)
-            info = self._serve_connection_info(sandbox_id)
             bus = PodEventBus(
                 base_url=info.base_url,
                 auth=info.auth(),
@@ -360,25 +375,30 @@ class _ServeMixin:
             )
             return bus
 
-    def _assert_sandbox_not_terminal(self, sandbox_id: UUID) -> None:
-        """Refuse to build a bus against a sandbox the DB reports terminal.
+    def _assert_sandbox_backend_live(self, sandbox_id: UUID) -> None:
+        """Refuse to build a bus against a sandbox with no live backend pod,
+        per the authoritative DB ``Sandbox.status``.
 
         ``Sandbox.status`` is the strongly-consistent, indexed authority shared
-        by all api_server replicas, so this makes the terminate-time refusal
-        fire everywhere — not just on the pod that holds the local
-        ``_terminated_sandboxes`` tombstone.
+        by all api_server replicas, so this makes the refusal fire everywhere —
+        not just on the pod that holds the local ``_terminated_sandboxes``
+        tombstone.
 
-        Only terminal states (``TERMINATED`` / ``FAILED``) are fast-failed.
-        PROVISIONING / not-yet-ready sandboxes are not terminal and must flow
-        on to the readiness wait. A missing row (status ``None``) is left to
-        the existing connection-info handling rather than treated as terminal.
+        A bus is refused for every state whose pod is gone: ``TERMINATED`` /
+        ``FAILED`` (permanent) and ``SLEEPING`` (pod torn down, snapshot in S3).
+        All three would otherwise burn the full reconnect budget (~30s) against
+        a dead Service before self-closing. ``RUNNING`` and ``PROVISIONING``
+        keep a (possibly still-coming-up) pod and flow on to the readiness wait.
+        A missing row (status ``None``) is left to the existing connection-info
+        handling rather than treated as gone.
         """
         with get_session_with_current_tenant() as db_session:
             status = get_sandbox_status(db_session, sandbox_id)
-        if status is not None and status.is_terminal():
+        if status is not None and (status.is_terminal() or status.is_sleeping()):
             raise RuntimeError(
-                f"Sandbox {sandbox_id} is {status.value} (terminal per DB); "
-                "refusing to create a new event bus against its (deleted) backend"
+                f"Sandbox {sandbox_id} is {status.value} (no live backend per "
+                "DB); refusing to create a new event bus against its "
+                "(deleted) backend"
             )
 
     def _build_serve_client(

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -24,10 +24,12 @@ import httpx
 
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.server.features.build.api.packet_logger import get_packet_logger
 from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_TURN_TIMEOUT_SECONDS
+from onyx.server.features.build.db.sandbox import get_sandbox_status
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
@@ -335,6 +337,10 @@ class _ServeMixin:
                     f"Sandbox {sandbox_id} has been terminated; refusing to "
                     "create a new event bus against its (deleted) backend"
                 )
+            # The local tombstone above only covers the replica that ran
+            # terminate. Consult the authoritative DB status so the refusal
+            # fires on every replica, not just the terminating one.
+            self._assert_sandbox_not_terminal(sandbox_id)
             info = self._serve_connection_info(sandbox_id)
             bus = PodEventBus(
                 base_url=info.base_url,
@@ -353,6 +359,27 @@ class _ServeMixin:
                 directory,
             )
             return bus
+
+    def _assert_sandbox_not_terminal(self, sandbox_id: UUID) -> None:
+        """Refuse to build a bus against a sandbox the DB reports terminal.
+
+        ``Sandbox.status`` is the strongly-consistent, indexed authority shared
+        by all api_server replicas, so this makes the terminate-time refusal
+        fire everywhere — not just on the pod that holds the local
+        ``_terminated_sandboxes`` tombstone.
+
+        Only terminal states (``TERMINATED`` / ``FAILED``) are fast-failed.
+        PROVISIONING / not-yet-ready sandboxes are not terminal and must flow
+        on to the readiness wait. A missing row (status ``None``) is left to
+        the existing connection-info handling rather than treated as terminal.
+        """
+        with get_session_with_current_tenant() as db_session:
+            status = get_sandbox_status(db_session, sandbox_id)
+        if status is not None and status.is_terminal():
+            raise RuntimeError(
+                f"Sandbox {sandbox_id} is {status.value} (terminal per DB); "
+                "refusing to create a new event bus against its (deleted) backend"
+            )
 
     def _build_serve_client(
         self, sandbox_id: UUID, directory: str

--- a/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
+++ b/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
@@ -1,0 +1,89 @@
+"""Cross-replica fast-fail for terminated sandboxes.
+
+``_ServeMixin._terminated_sandboxes`` is a per-process tombstone: it only
+blocks racing subscribes on the replica that ran ``terminate``. A peer replica
+has an empty tombstone, so it would happily build a doomed bus against the
+deleted backend. The fix consults the authoritative DB ``Sandbox.status`` in
+``_get_or_create_event_bus`` so the refusal fires on every replica.
+
+These tests use a *fresh* ``StubSandboxManager`` (empty local tombstone) to
+stand in for that peer replica, and drive bus creation purely off DB state.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import SandboxStatus
+from onyx.db.models import Sandbox
+from onyx.db.models import User
+from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+from tests.external_dependency_unit.craft.stubs import StubSandboxManager
+
+
+class TestTerminatedSandboxFastFail:
+    def test_terminal_sandbox_refused_on_peer_replica(
+        self,
+        db_session: Session,  # noqa: ARG002
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+    ) -> None:
+        # TERMINATED row in the DB; the peer replica's local tombstone is empty
+        # (fresh manager). The DB authority must still force a refusal.
+        row = sandbox(user=test_user, status=SandboxStatus.TERMINATED)
+        manager = StubSandboxManager()
+        assert row.id not in manager._terminated_sandboxes
+
+        with pytest.raises(RuntimeError, match="terminal per DB"):
+            manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
+
+    def test_failed_sandbox_refused_on_peer_replica(
+        self,
+        db_session: Session,  # noqa: ARG002
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+    ) -> None:
+        # FAILED is also terminal (SandboxStatus.is_terminal) — same refusal.
+        row = sandbox(user=test_user, status=SandboxStatus.FAILED)
+        manager = StubSandboxManager()
+
+        with pytest.raises(RuntimeError, match="terminal per DB"):
+            manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
+
+    def test_running_sandbox_builds_bus(
+        self,
+        db_session: Session,  # noqa: ARG002
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+    ) -> None:
+        # A RUNNING sandbox is healthy — the guard must let bus creation proceed.
+        row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+        manager = StubSandboxManager()
+
+        bus = manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
+        try:
+            assert isinstance(bus, PodEventBus)
+            assert not bus.closed
+        finally:
+            bus.close()
+
+    def test_provisioning_sandbox_not_fast_failed(
+        self,
+        db_session: Session,  # noqa: ARG002
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+    ) -> None:
+        # Guard against conflating "not yet ready" with "terminated": a
+        # PROVISIONING sandbox lacks a ready backend but is NOT terminal, so it
+        # must be allowed to build a bus and proceed toward the readiness wait.
+        row = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
+        manager = StubSandboxManager()
+
+        bus = manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
+        try:
+            assert isinstance(bus, PodEventBus)
+        finally:
+            bus.close()

--- a/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
+++ b/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
@@ -1,10 +1,12 @@
-"""Cross-replica fast-fail for terminated sandboxes.
+"""Cross-replica fast-fail for sandboxes with no live backend.
 
 ``_ServeMixin._terminated_sandboxes`` is a per-process tombstone: it only
 blocks racing subscribes on the replica that ran ``terminate``. A peer replica
 has an empty tombstone, so it would happily build a doomed bus against the
 deleted backend. The fix consults the authoritative DB ``Sandbox.status`` in
-``_get_or_create_event_bus`` so the refusal fires on every replica.
+``_get_or_create_event_bus`` so the refusal fires on every replica — for every
+state whose pod is gone: ``TERMINATED`` / ``FAILED`` (permanent) and
+``SLEEPING`` (pod torn down, snapshot in S3).
 
 These tests use a *fresh* ``StubSandboxManager`` (empty local tombstone) to
 stand in for that peer replica, and drive bus creation purely off DB state.
@@ -37,7 +39,7 @@ class TestTerminatedSandboxFastFail:
         manager = StubSandboxManager()
         assert row.id not in manager._terminated_sandboxes
 
-        with pytest.raises(RuntimeError, match="terminal per DB"):
+        with pytest.raises(RuntimeError, match="no live backend"):
             manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
 
     def test_failed_sandbox_refused_on_peer_replica(
@@ -50,7 +52,22 @@ class TestTerminatedSandboxFastFail:
         row = sandbox(user=test_user, status=SandboxStatus.FAILED)
         manager = StubSandboxManager()
 
-        with pytest.raises(RuntimeError, match="terminal per DB"):
+        with pytest.raises(RuntimeError, match="no live backend"):
+            manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
+
+    def test_sleeping_sandbox_refused_on_peer_replica(
+        self,
+        db_session: Session,  # noqa: ARG002
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+    ) -> None:
+        # SLEEPING = pod torn down, snapshot saved to S3. The backend is gone,
+        # so a bus built against it is just as doomed as a terminal one and must
+        # be refused (it would otherwise burn its full reconnect budget).
+        row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
+        manager = StubSandboxManager()
+
+        with pytest.raises(RuntimeError, match="no live backend"):
             manager._get_or_create_event_bus(row.id, f"/workspace/sessions/{row.id}")
 
     def test_running_sandbox_builds_bus(

--- a/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
+++ b/backend/tests/external_dependency_unit/craft/test_terminated_sandbox_fast_fail.py
@@ -1,15 +1,8 @@
 """Cross-replica fast-fail for sandboxes with no live backend.
 
-``_ServeMixin._terminated_sandboxes`` is a per-process tombstone: it only
-blocks racing subscribes on the replica that ran ``terminate``. A peer replica
-has an empty tombstone, so it would happily build a doomed bus against the
-deleted backend. The fix consults the authoritative DB ``Sandbox.status`` in
-``_get_or_create_event_bus`` so the refusal fires on every replica — for every
-state whose pod is gone: ``TERMINATED`` / ``FAILED`` (permanent) and
-``SLEEPING`` (pod torn down, snapshot in S3).
-
-These tests use a *fresh* ``StubSandboxManager`` (empty local tombstone) to
-stand in for that peer replica, and drive bus creation purely off DB state.
+A fresh ``StubSandboxManager`` (empty local tombstone) stands in for a peer
+replica, so bus creation is driven purely off the DB ``Sandbox.status``:
+TERMINATED / FAILED / SLEEPING are refused, RUNNING / PROVISIONING proceed.
 """
 
 from __future__ import annotations
@@ -33,8 +26,7 @@ class TestTerminatedSandboxFastFail:
         test_user: User,
         sandbox: Callable[..., Sandbox],
     ) -> None:
-        # TERMINATED row in the DB; the peer replica's local tombstone is empty
-        # (fresh manager). The DB authority must still force a refusal.
+        # Empty local tombstone (fresh manager); DB status must still refuse.
         row = sandbox(user=test_user, status=SandboxStatus.TERMINATED)
         manager = StubSandboxManager()
         assert row.id not in manager._terminated_sandboxes
@@ -61,9 +53,7 @@ class TestTerminatedSandboxFastFail:
         test_user: User,
         sandbox: Callable[..., Sandbox],
     ) -> None:
-        # SLEEPING = pod torn down, snapshot saved to S3. The backend is gone,
-        # so a bus built against it is just as doomed as a terminal one and must
-        # be refused (it would otherwise burn its full reconnect budget).
+        # SLEEPING = pod torn down (snapshot in S3); backend is gone, so refuse.
         row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
         manager = StubSandboxManager()
 
@@ -76,7 +66,7 @@ class TestTerminatedSandboxFastFail:
         test_user: User,
         sandbox: Callable[..., Sandbox],
     ) -> None:
-        # A RUNNING sandbox is healthy — the guard must let bus creation proceed.
+        # RUNNING is healthy — bus creation proceeds.
         row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
         manager = StubSandboxManager()
 
@@ -93,9 +83,7 @@ class TestTerminatedSandboxFastFail:
         test_user: User,
         sandbox: Callable[..., Sandbox],
     ) -> None:
-        # Guard against conflating "not yet ready" with "terminated": a
-        # PROVISIONING sandbox lacks a ready backend but is NOT terminal, so it
-        # must be allowed to build a bus and proceed toward the readiness wait.
+        # PROVISIONING is not-yet-ready, not gone — must not be fast-failed.
         row = sandbox(user=test_user, status=SandboxStatus.PROVISIONING)
         manager = StubSandboxManager()
 


### PR DESCRIPTION
## Description

`_ServeMixin._terminated_sandboxes` is an in-memory per-process tombstone that blocks a late `subscribe` from racing a `terminate` and spinning up a fresh `PodEventBus` against a backend that's being deleted. Across multiple `api_server` replicas the tombstone is local to the pod that ran `terminate`, so a late subscribe on a **peer** replica has no entry and builds a doomed bus against the already-deleted Service — wasting a reader thread + httpx connection through its full reconnect budget (~30s of backoff) before self-closing, plus log noise and a delayed terminal signal to the subscriber.

The fix consults the authoritative signal that already exists: the DB `Sandbox.status` column (strongly consistent, indexed via `ix_sandbox_status`). `_get_or_create_event_bus` now checks the local tombstone first (no-DB fast path), then consults `Sandbox.status` and refuses to build a bus for a **terminal** sandbox (`TERMINATED` / `FAILED`) — so the refusal fires uniformly on every replica. No Redis: the authority is the DB, not a cache.

Key guard: `PROVISIONING` / not-yet-ready sandboxes are **not** terminal and are deliberately allowed through to the readiness wait — the check detects terminal states specifically, not absence-of-readiness. A missing row (`status is None`) is left to the existing connection-info handling.

### Changes
- `db/sandbox.py`: add `get_sandbox_status(db_session, sandbox_id)` — reads only the indexed `status` column.
- `serve_transport.py`: add `_assert_sandbox_not_terminal`, invoked in `_get_or_create_event_bus` after the local tombstone check.

## How Has This Been Tested?

Added an External Dependency Unit test (`test_terminated_sandbox_fast_fail.py`) that drives bus creation on a **fresh** `StubSandboxManager` (empty local tombstone, standing in for a peer replica):
- `TERMINATED` and `FAILED` rows → `_get_or_create_event_bus` raises (refuses to build a bus).
- `RUNNING` row → builds a `PodEventBus`.
- `PROVISIONING` row → still builds a bus (not fast-failed).

Locally verified: `ruff format`, `ruff check`, and `ty check` pass on all changed files; the suite collects cleanly. The DB-backed assertions run in CI (no host Postgres in this worktree).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fast-fail event bus creation across replicas by checking DB `Sandbox.status` in `_get_or_create_event_bus`. Reject `TERMINATED`/`FAILED`/`SLEEPING` so we don’t build buses for sandboxes with no live backend.

- **Bug Fixes**
  - Inline no-live-backend guard in `_get_or_create_event_bus` using `get_sandbox_by_id`; reject `TERMINATED`/`FAILED`/`SLEEPING`; keep `_terminated_sandboxes` as a no-DB fast path and hold `_event_buses_lock` across cache/status/insert. Preserve behavior for `RUNNING`/`PROVISIONING`. Tests cover refusal and pass-through.

<sup>Written for commit 81d9adae126f20180e1b4ccad139257b424264ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- linear override applied -->
