### PR TITLE
chore(pre-commit): enable check-yaml hook and add prek to the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,6 +58,32 @@ RUN ln -sf "$(which fdfind)" /usr/local/bin/fd
 # (cmake, libxmlsec1-dev, pkg-config, postgresql-client).
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
+# Install prek (https://github.com/j178/prek) — a fast Rust reimplementation of
+# pre-commit and a drop-in replacement for it. Symlinked to `pre-commit` so the
+# repo's `.pre-commit-config.yaml` plus any `pre-commit ...` muscle memory and CI
+# invocations work unchanged. Fetched from the pinned GitHub release and verified
+# against the per-arch SHA256 the project publishes alongside each asset, matching
+# the supply-chain posture of the digest-pinned binaries elsewhere in this file.
+# Bumping PREK_VERSION requires updating BOTH checksums below (from the release's
+# *.tar.gz.sha256 assets); a mismatch fails the build closed.
+ARG PREK_VERSION=0.4.3
+RUN set -eux; \
+  case "$(dpkg --print-architecture)" in \
+    amd64) PREK_TRIPLE=x86_64-unknown-linux-gnu; \
+           PREK_SHA256=8a8210d64476657cac3e797afa109011d8d872c09e3a407f50c5a4dde063b381 ;; \
+    arm64) PREK_TRIPLE=aarch64-unknown-linux-gnu; \
+           PREK_SHA256=02e5731ce90e737bade91abef4c76c13495b9cc9290f609dfcb2e7b2a05b532e ;; \
+    *) echo "unsupported arch for prek: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL -o /tmp/prek.tar.gz \
+    "https://github.com/j178/prek/releases/download/v${PREK_VERSION}/prek-${PREK_TRIPLE}.tar.gz"; \
+  echo "${PREK_SHA256}  /tmp/prek.tar.gz" | sha256sum -c -; \
+  tar -xzf /tmp/prek.tar.gz -C /tmp; \
+  install -m 0755 "/tmp/prek-${PREK_TRIPLE}/prek" /usr/local/bin/prek; \
+  ln -s prek /usr/local/bin/pre-commit; \
+  rm -rf /tmp/prek.tar.gz "/tmp/prek-${PREK_TRIPLE}"; \
+  prek --version
+
 # Install bun (JavaScript package manager) from the bun_source stage defined at the top.
 COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,11 +61,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 # Install prek (https://github.com/j178/prek) — a fast Rust reimplementation of
 # pre-commit and a drop-in replacement for it. Symlinked to `pre-commit` so the
 # repo's `.pre-commit-config.yaml` plus any `pre-commit ...` muscle memory and CI
-# invocations work unchanged. Fetched from the pinned GitHub release and verified
-# against the per-arch SHA256 the project publishes alongside each asset, matching
-# the supply-chain posture of the digest-pinned binaries elsewhere in this file.
-# Bumping PREK_VERSION requires updating BOTH checksums below (from the release's
-# *.tar.gz.sha256 assets); a mismatch fails the build closed.
+# invocations work unchanged.
 ARG PREK_VERSION=0.4.3
 RUN set -eux; \
   case "$(dpkg --print-architecture)" in \

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -33,3 +33,20 @@ In dev mode the frontend proxies `/api/*` straight to the backend (the dev-only 
 handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves both the UI and
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
+
+## Validating YAML
+
+`pyyaml` is **not installed** in this environment, so `python3 -c 'import yaml'` fails with
+`ModuleNotFoundError`. To validate YAML, use the `check-yaml` pre-commit hook instead — it
+runs in its own isolated env (the `pre-commit` command here is [prek](https://github.com/j178/prek),
+which installs `pyyaml` for the hook):
+
+```bash
+pre-commit run check-yaml --all-files        # all tracked YAML
+pre-commit run check-yaml --files path/to/file.yaml
+```
+
+It runs with `--unsafe` (syntax-only) so it tolerates the repo's intentional custom tags
+(CloudFormation `!Ref`, docker-compose `!reset`) and multi-document files; Helm chart templates
+under `deployment/helm/charts/onyx/templates*` are excluded since their Go templating isn't
+parseable as YAML.

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -37,7 +37,7 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 ## Validating YAML
 
 `pyyaml` is **not installed** here, so `python3 -c 'import yaml'` fails. To validate YAML, use the
-`check-yaml` pre-commit hook instead — it runs in its own env with `pyyaml` available:
+`check-yaml` pre-commit hook instead:
 
 ```bash
 pre-commit run check-yaml --all-files        # all tracked YAML

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -40,6 +40,5 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 `check-yaml` pre-commit hook instead:
 
 ```bash
-pre-commit run check-yaml --all-files        # all tracked YAML
 pre-commit run check-yaml --files path/to/file.yaml
 ```

--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -36,17 +36,10 @@ handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves b
 
 ## Validating YAML
 
-`pyyaml` is **not installed** in this environment, so `python3 -c 'import yaml'` fails with
-`ModuleNotFoundError`. To validate YAML, use the `check-yaml` pre-commit hook instead — it
-runs in its own isolated env (the `pre-commit` command here is [prek](https://github.com/j178/prek),
-which installs `pyyaml` for the hook):
+`pyyaml` is **not installed** here, so `python3 -c 'import yaml'` fails. To validate YAML, use the
+`check-yaml` pre-commit hook instead — it runs in its own env with `pyyaml` available:
 
 ```bash
 pre-commit run check-yaml --all-files        # all tracked YAML
 pre-commit run check-yaml --files path/to/file.yaml
 ```
-
-It runs with `--unsafe` (syntax-only) so it tolerates the repo's intentional custom tags
-(CloudFormation `!Ref`, docker-compose `!reset`) and multi-document files; Helm chart templates
-under `deployment/helm/charts/onyx/templates*` are excluded since their Go templating isn't
-parseable as YAML.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:616f411af60ef8e868d3b486c00484d539096e7012bb4ac173ace15979f6950e",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:f8fbf8e1014b0eaa1ba200d9a6a9c7a6c937e0ccfe72644d0d5fcd40618e08e6",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,12 +104,11 @@ repos:
         args: ["--maxkb=1500"]
       - id: check-yaml
         name: Check YAML
-        # --unsafe checks syntax only (no construction), which tolerates the
-        # custom tags this repo relies on intentionally — CloudFormation
-        # (`!Ref`, `!GetAtt`) and docker-compose (`!reset`) — and implies
-        # --allow-multiple-documents so multi-doc files (e.g. vendored CRDs)
-        # pass too. Helm chart templates are still excluded: their Go
-        # templating (`{{ ... }}`) is not parseable as YAML at all.
+        # --unsafe relaxes check-yaml to syntax-only, so it accepts the
+        # non-standard YAML this repo uses on purpose: custom tags
+        # (CloudFormation `!Ref`, docker-compose `!reset`) and multi-document
+        # files (e.g. vendored CRDs). Helm chart templates are excluded instead —
+        # their Go templating (`{{ ... }}`) isn't parseable as YAML at all.
         args: ["--unsafe"]
         exclude: >-
           (?x)^deployment/helm/charts/onyx/(templates|templates_disabled)/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,6 +102,17 @@ repos:
       - id: check-added-large-files
         name: Check for added large files
         args: ["--maxkb=1500"]
+      - id: check-yaml
+        name: Check YAML
+        # --unsafe checks syntax only (no construction), which tolerates the
+        # custom tags this repo relies on intentionally — CloudFormation
+        # (`!Ref`, `!GetAtt`) and docker-compose (`!reset`) — and implies
+        # --allow-multiple-documents so multi-doc files (e.g. vendored CRDs)
+        # pass too. Helm chart templates are still excluded: their Go
+        # templating (`{{ ... }}`) is not parseable as YAML at all.
+        args: ["--unsafe"]
+        exclude: >-
+          (?x)^deployment/helm/charts/onyx/(templates|templates_disabled)/
 
   - repo: https://github.com/rhysd/actionlint
     rev: a443f344ff32813837fa49f7aa6cbc478d770e62 # frozen: v1.7.9


### PR DESCRIPTION
## Description

Enables the `check-yaml` pre-commit hook and makes `pre-commit` available inside the dev container.

- **Enable `check-yaml`** in `.pre-commit-config.yaml` (under the existing `pre-commit/pre-commit-hooks` repo). It runs with `--unsafe` (syntax-only) so it tolerates the custom YAML tags this repo uses intentionally — CloudFormation (`!Ref`, `!GetAtt`) and docker-compose (`!reset`) — and `--unsafe` implies `--allow-multiple-documents`, so multi-document files (e.g. the vendored CNPG CRDs) pass too. Helm chart templates under `deployment/helm/charts/onyx/templates*` are excluded because their Go templating (`{{ ... }}`) isn't parseable as YAML at all.
- **Install [prek](https://github.com/j178/prek)** in `.devcontainer/Dockerfile` — a fast Rust drop-in replacement for `pre-commit` — pinned to `v0.4.3`, arch-aware (amd64/arm64), and SHA256-verified against the per-arch checksums the project publishes (matching the supply-chain posture of the other pinned binaries in the file rather than piping `curl | sh`). It's symlinked to `/usr/local/bin/pre-commit` so `pre-commit ...` and CI invocations work unchanged. Bumping `PREK_VERSION` requires updating both checksums; a mismatch fails the build closed.
- **Document** in the devcontainer `CLAUDE.md` overlay that `pyyaml` isn't installed in the container and that YAML should be validated via the `check-yaml` hook (`pre-commit run check-yaml`).

## How Has This Been Tested?

- Ran `pre-commit run check-yaml --all-files` across the repo (via `uvx pre-commit`, since the image isn't rebuilt yet): **passes** on all tracked YAML.
- Confirmed it still flags genuinely malformed YAML under `--unsafe` (not a no-op).
- Verified the prek release end-to-end: download + SHA256 match against the official `*.tar.gz.sha256` assets (amd64 + arm64), and simulated the exact Dockerfile `RUN` block — `pre-commit --version` reports `prek 0.4.3` through the symlink.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds YAML syntax checking via the `check-yaml` hook and ships `prek` in the devcontainer so `pre-commit` runs fast and works out of the box.

- **New Features**
  - Enabled `check-yaml` with `--unsafe`; Helm chart templates are excluded. Simplified the hook comment to only explain `--unsafe`.
  - Added `prek` v0.4.3 to the devcontainer, symlinked as `pre-commit` and SHA256-verified per arch. Updated docs to note `pyyaml` isn’t installed and to validate via `pre-commit run check-yaml --files <path/to/file.yaml>`.

<sup>Written for commit cd39937aa96cb8e91383cce6e4c46bbd83f7072b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

