### PR TITLE
chore: [Running GitHub actions for #11580]

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -408,8 +408,13 @@ class DockerSandboxManager(SandboxManager):
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = super().__new__(cls)
-                    cls._instance._initialize()
+                    # Publish to the cache only after _initialize() succeeds, so a
+                    # transient init failure (e.g. the Docker socket briefly
+                    # unavailable) can't leave a half-built singleton that every
+                    # later caller reuses; the next call retries instead.
+                    instance = super().__new__(cls)
+                    instance._initialize()
+                    cls._instance = instance
         return cls._instance
 
     def _initialize(self) -> None:

--- a/backend/tests/unit/build/test_docker_sandbox_manager_singleton.py
+++ b/backend/tests/unit/build/test_docker_sandbox_manager_singleton.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+import pytest
+
+from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    DockerSandboxManager,
+)
+
+
+def test_failed_initialize_does_not_poison_singleton() -> None:
+    """A failed ``_initialize()`` must not cache a half-built singleton: ``__new__``
+    publishes to the class cache only after init succeeds, and a later construction
+    retries once the transient condition clears."""
+    DockerSandboxManager._instance = None
+    try:
+        attempts = {"count": 0}
+
+        def flaky_initialize(_self: DockerSandboxManager) -> None:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise RuntimeError("transient docker socket failure")
+            # second attempt succeeds (no-op)
+
+        with patch.object(DockerSandboxManager, "_initialize", flaky_initialize):
+            with pytest.raises(RuntimeError, match="transient docker socket failure"):
+                DockerSandboxManager()
+
+            # failed init left nothing cached
+            assert DockerSandboxManager._instance is None
+
+            # next construction retries and becomes the cached instance
+            manager = DockerSandboxManager()
+            assert manager is DockerSandboxManager._instance
+            assert attempts["count"] == 2
+    finally:
+        DockerSandboxManager._instance = None


### PR DESCRIPTION
This PR runs GitHub Actions CI for #11580.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent caching a half-initialized `DockerSandboxManager` so transient init failures don’t poison the singleton. Adds a unit test and runs CI for #11580.

- **Bug Fixes**
  - Set `DockerSandboxManager._instance` only after `_initialize()` succeeds, so failures don’t leave a broken cached instance.
  - Added a unit test that verifies a failed init is not cached and the next construction succeeds.

<sup>Written for commit 96db6740124a5975b0966abd5d85c6bc3d996f97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

