### PR TITLE
feat(craft): distinguish live skills & approvals with a comet edge

### DIFF
--- a/web/src/app/craft/components/CometEdge.stories.tsx
+++ b/web/src/app/craft/components/CometEdge.stories.tsx
@@ -30,9 +30,7 @@ const meta: Meta<typeof CometEdge> = {
 export default meta;
 type Story = StoryObj<typeof CometEdge>;
 
-// A real, completed CraftToolCall — so the card renders its normal chrome and
-// does NOT add its own (skill-in-flight) comet. The only comet on screen is
-// the wrapping CometEdge, fully driven by the story controls.
+// Completed call: no self-comet, so the only comet is the wrapping CometEdge.
 function toolCall(overrides: Partial<ToolCallState>): ToolCallState {
   return {
     id: "tool-1",
@@ -103,14 +101,12 @@ export const SkillInFlight: Story = {
   ),
 };
 
-// The real ApprovalCard — it wraps itself in a comet edge while pending and
-// settles to a solid edge on a decision, so no outer CometEdge here.
+// Real ApprovalCard — supplies its own comet, so no outer CometEdge.
 export const AwaitingApproval: Story = {
   render: () => <ApprovalCard approval={SLACK_APPROVAL} defaultOpen />,
 };
 
-// Decided ApprovalCards — settled solid edge + label (seeded via
-// defaultDecision, since real approvals drop from /live once decided).
+// Decided ApprovalCards (seeded via defaultDecision).
 export const Approved: Story = {
   render: () => (
     <ApprovalCard
@@ -131,9 +127,8 @@ export const Denied: Story = {
   ),
 };
 
-// Click the card's Approve / Reject to watch the live comet cross-fade into a
-// solid edge on a real ApprovalCard. A story-scoped fetch stub resolves the
-// decision request so the settle sticks; Reset re-mounts a pending card.
+// Click Approve/Reject to watch the settle cross-fade; a fetch stub makes it
+// stick, Reset re-mounts a pending card.
 export const SettleTransition: Story = {
   render: function SettleTransitionStory() {
     const [instance, setInstance] = useState(0);

--- a/web/src/app/craft/components/CometEdge.stories.tsx
+++ b/web/src/app/craft/components/CometEdge.stories.tsx
@@ -1,0 +1,186 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useState } from "react";
+import { Button } from "@opal/components";
+import CometEdge from "@/app/craft/components/CometEdge";
+import CraftToolCard from "@/app/craft/components/tool-cards/CraftToolCard";
+import ApprovalCard from "@/app/craft/components/approvals/ApprovalCard";
+import type { ToolCallState } from "@/app/craft/types/displayTypes";
+import type { ApprovalView } from "@/app/craft/types/approvals";
+
+const meta: Meta<typeof CometEdge> = {
+  title: "Apps/Craft/Comet Edge",
+  component: CometEdge,
+  tags: ["autodocs"],
+  argTypes: {
+    tone: { control: "select", options: ["info", "success", "error"] },
+    speedSeconds: { control: { type: "range", min: 1, max: 8, step: 0.2 } },
+    radius: { control: { type: "range", min: 0, max: 20, step: 1 } },
+    active: { control: "boolean" },
+    settled: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[560px] p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CometEdge>;
+
+// A real, completed CraftToolCall — so the card renders its normal chrome and
+// does NOT add its own (skill-in-flight) comet. The only comet on screen is
+// the wrapping CometEdge, fully driven by the story controls.
+function toolCall(overrides: Partial<ToolCallState>): ToolCallState {
+  return {
+    id: "tool-1",
+    kind: "search",
+    toolName: "websearch",
+    title: "Searching the web",
+    description: "q3 cloud market share",
+    command: "",
+    status: "completed",
+    rawOutput:
+      "## Gartner — Cloud market share Q3\nhttps://gartner.com/...\nAWS 31%, Azure 25%, GCP 11%.\n\n## Canalys\nhttps://canalys.com/...\nTotal spend up 21% YoY.",
+    ...overrides,
+  };
+}
+
+const SKILL_CALL = toolCall({
+  kind: "other",
+  toolName: "skill",
+  title: "Running skill",
+  description: "Deep, multi-source research",
+  skillName: "deep-research",
+});
+
+// A real pending approval — ApprovalCard supplies its own comet edge.
+const SLACK_APPROVAL: ApprovalView = {
+  approval_id: "appr-01HX3K9M4Q7W2",
+  session_id: "sess-01HX3K9M4Q7W2",
+  actions: [
+    {
+      action_type: "slack.messages.write",
+      display_name: "Post a message",
+      description: "Post a message to a channel or conversation.",
+      policy: "ASK",
+    },
+  ],
+  app_name: "Slack",
+  payload: {
+    channel: "#sales-ops",
+    text: "Heads up — 3 enterprise deals slipped to Q4 on procurement review. Recovery playbook in thread. 🧵",
+  },
+  created_at: "2026-05-28T15:42:11Z",
+  decision: null,
+  decided_at: null,
+  is_live: true,
+};
+
+export const Playground: Story = {
+  args: {
+    active: true,
+    settled: false,
+    tone: "info",
+    speedSeconds: 2.6,
+    radius: 8,
+  },
+  render: (args) => (
+    <CometEdge {...args}>
+      <CraftToolCard toolCall={SKILL_CALL} />
+    </CometEdge>
+  ),
+};
+
+export const SkillInFlight: Story = {
+  args: { active: true, tone: "info", speedSeconds: 2.6 },
+  render: (args) => (
+    <CometEdge {...args}>
+      <CraftToolCard toolCall={SKILL_CALL} />
+    </CometEdge>
+  ),
+};
+
+// The real ApprovalCard — it wraps itself in a comet edge while pending and
+// settles to a solid edge on a decision, so no outer CometEdge here.
+export const AwaitingApproval: Story = {
+  render: () => <ApprovalCard approval={SLACK_APPROVAL} defaultOpen />,
+};
+
+// Decided ApprovalCards — settled solid edge + label (seeded via
+// defaultDecision, since real approvals drop from /live once decided).
+export const Approved: Story = {
+  render: () => (
+    <ApprovalCard
+      approval={SLACK_APPROVAL}
+      defaultOpen
+      defaultDecision="APPROVED"
+    />
+  ),
+};
+
+export const Denied: Story = {
+  render: () => (
+    <ApprovalCard
+      approval={SLACK_APPROVAL}
+      defaultOpen
+      defaultDecision="REJECTED"
+    />
+  ),
+};
+
+// Click the card's Approve / Reject to watch the live comet cross-fade into a
+// solid edge on a real ApprovalCard. A story-scoped fetch stub resolves the
+// decision request so the settle sticks; Reset re-mounts a pending card.
+export const SettleTransition: Story = {
+  render: function SettleTransitionStory() {
+    const [instance, setInstance] = useState(0);
+    useEffect(() => {
+      const realFetch = window.fetch;
+      window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/approvals/") && url.includes("/decision")) {
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return realFetch(input, init);
+      }) as typeof window.fetch;
+      return () => {
+        window.fetch = realFetch;
+      };
+    }, []);
+    return (
+      <div className="flex flex-col gap-4">
+        <ApprovalCard key={instance} approval={SLACK_APPROVAL} defaultOpen />
+        <Button
+          prominence="tertiary"
+          size="sm"
+          onClick={() => setInstance((n) => n + 1)}
+        >
+          Reset
+        </Button>
+      </div>
+    );
+  },
+};
+
+// Comet speeds side by side on real tool cards, to dial in the live cadence.
+export const SpeedComparison: Story = {
+  render: () => (
+    <div className="flex flex-col gap-5">
+      {[
+        { speed: 1.6, note: "fast" },
+        { speed: 2.6, note: "skill in flight" },
+        { speed: 3.6, note: "approval — slow patrol" },
+      ].map(({ speed, note }) => (
+        <CometEdge key={speed} active tone="info" speedSeconds={speed}>
+          <CraftToolCard toolCall={toolCall({ description: note })} />
+        </CometEdge>
+      ))}
+    </div>
+  ),
+};

--- a/web/src/app/craft/components/CometEdge.tsx
+++ b/web/src/app/craft/components/CometEdge.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { type CSSProperties, type ReactNode } from "react";
+import { cn } from "@opal/utils";
+
+type CometTone = "info" | "success" | "error";
+
+interface CometEdgeProps {
+  children: ReactNode;
+  /** Animate a comet traveling the perimeter (live activity). */
+  active?: boolean;
+  /** Draw a solid colored edge with no travel (a settled outcome). */
+  settled?: boolean;
+  /** Edge color. @default "info" */
+  tone?: CometTone;
+  /** Seconds for one full lap — lower is faster. @default 3.6 */
+  speedSeconds?: number;
+  /** Corner radius in px; match the wrapped card (rounded-08 = 8). @default 8 */
+  radius?: number;
+  className?: string;
+}
+
+const TONE_VAR: Record<CometTone, string> = {
+  info: "var(--status-info-05)",
+  success: "var(--status-success-05)",
+  error: "var(--status-error-05)",
+};
+
+// Geometry shared by both stacked strokes (full-bleed rounded rect).
+const RECT_PROPS = {
+  x: "0",
+  y: "0",
+  width: "100%",
+  height: "100%",
+  pathLength: 100,
+} as const;
+
+/**
+ * CometEdge - Wraps a card and overlays a hairline "comet" that runs its
+ * border. The comet is a single `<rect>` sized at 100% of the wrapper, so it
+ * resizes natively with the card — no JS measurement — and stays smooth while
+ * the card animates open/closed. `pathLength={100}` normalizes the dash so the
+ * comet is one seamless segment at any size.
+ *
+ * Two strokes are always stacked when shown: the traveling comet (live,
+ * info-blue) and a solid colored edge. Their opacities cross-fade between
+ * `active` and `settled`, so a live approval visibly settles into a solid
+ * green / red edge (`tone`) once it resolves.
+ */
+export default function CometEdge({
+  children,
+  active = false,
+  settled = false,
+  tone = "info",
+  speedSeconds = 3.6,
+  radius = 8,
+  className,
+}: CometEdgeProps) {
+  const show = active || settled;
+
+  return (
+    <div className={cn("relative", className)} style={{ borderRadius: radius }}>
+      {children}
+      {show && (
+        <svg
+          aria-hidden
+          className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+          style={
+            {
+              // Live comet is always the "working" color; the settle color is
+              // the resolved outcome (success / error).
+              "--comet-color": "var(--status-info-05)",
+              "--comet-settle-color": TONE_VAR[tone],
+              "--comet-speed": `${speedSeconds}s`,
+            } as CSSProperties
+          }
+        >
+          <rect
+            {...RECT_PROPS}
+            rx={radius}
+            ry={radius}
+            className="craft-comet"
+            // Pause the travel when this stroke isn't the visible one (settled)
+            // so it isn't animating invisibly at opacity 0.
+            style={{
+              opacity: active ? 1 : 0,
+              animationPlayState: active ? "running" : "paused",
+            }}
+          />
+          <rect
+            {...RECT_PROPS}
+            rx={radius}
+            ry={radius}
+            className="craft-comet-static"
+            style={{ opacity: settled ? 1 : 0 }}
+          />
+        </svg>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/craft/components/CometEdge.tsx
+++ b/web/src/app/craft/components/CometEdge.tsx
@@ -7,15 +7,14 @@ type CometTone = "info" | "success" | "error";
 
 interface CometEdgeProps {
   children: ReactNode;
-  /** Animate a comet traveling the perimeter (live activity). */
+  /** Animate the traveling comet (live). */
   active?: boolean;
-  /** Draw a solid colored edge with no travel (a settled outcome). */
+  /** Solid colored edge, no travel (a settled outcome). */
   settled?: boolean;
-  /** Edge color. @default "info" */
   tone?: CometTone;
-  /** Seconds for one full lap — lower is faster. @default 3.6 */
+  /** Seconds per lap; lower is faster. */
   speedSeconds?: number;
-  /** Corner radius in px; match the wrapped card (rounded-08 = 8). @default 8 */
+  /** px; match the wrapped card (rounded-08 = 8). */
   radius?: number;
   className?: string;
 }
@@ -26,7 +25,6 @@ const TONE_VAR: Record<CometTone, string> = {
   error: "var(--status-error-05)",
 };
 
-// Geometry shared by both stacked strokes (full-bleed rounded rect).
 const RECT_PROPS = {
   x: "0",
   y: "0",
@@ -36,16 +34,9 @@ const RECT_PROPS = {
 } as const;
 
 /**
- * CometEdge - Wraps a card and overlays a hairline "comet" that runs its
- * border. The comet is a single `<rect>` sized at 100% of the wrapper, so it
- * resizes natively with the card — no JS measurement — and stays smooth while
- * the card animates open/closed. `pathLength={100}` normalizes the dash so the
- * comet is one seamless segment at any size.
- *
- * Two strokes are always stacked when shown: the traveling comet (live,
- * info-blue) and a solid colored edge. Their opacities cross-fade between
- * `active` and `settled`, so a live approval visibly settles into a solid
- * green / red edge (`tone`) once it resolves.
+ * Hairline comet on a card border — travels while `active`, then cross-fades
+ * to a solid `tone` edge when `settled`. The comet is a full-size `<rect>`, so
+ * it resizes with the card; `pathLength={100}` keeps the dash seamless.
  */
 export default function CometEdge({
   children,
@@ -67,8 +58,7 @@ export default function CometEdge({
           className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
           style={
             {
-              // Live comet is always the "working" color; the settle color is
-              // the resolved outcome (success / error).
+              // Comet is always the live "working" color; tone is the settled edge.
               "--comet-color": "var(--status-info-05)",
               "--comet-settle-color": TONE_VAR[tone],
               "--comet-speed": `${speedSeconds}s`,
@@ -80,8 +70,7 @@ export default function CometEdge({
             rx={radius}
             ry={radius}
             className="craft-comet"
-            // Pause the travel when this stroke isn't the visible one (settled)
-            // so it isn't animating invisibly at opacity 0.
+            // Pause travel when hidden so it isn't animating at opacity 0.
             style={{
               opacity: active ? 1 : 0,
               animationPlayState: active ? "running" : "paused",

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -29,6 +29,9 @@ import PayloadView from "@/app/craft/components/approvals/PayloadView";
 import CometEdge from "@/app/craft/components/CometEdge";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
+// Hold the settled edge so the cross-fade is visible before the row unmounts.
+const SETTLE_HOLD_MS = 800;
+
 interface ApprovalCardProps {
   approval: ApprovalView;
   defaultOpen?: boolean;
@@ -100,8 +103,6 @@ export default function ApprovalCard({
 
   const decided = decision !== null;
   const approved = decision === "APPROVED";
-  // Hold the settled edge so the cross-fade is visible before unmount.
-  const SETTLE_HOLD_MS = 800;
 
   async function decide(next: ApprovalSubmitDecision) {
     setSubmitting(true);
@@ -114,11 +115,14 @@ export default function ApprovalCard({
       }, SETTLE_HOLD_MS);
     } catch (e) {
       // 409 = already resolved (by someone else, or expired by the
-      // proxy). Same UX as a successful submit: refetch and unmount.
+      // proxy). Same UX as a successful submit: hold the settle, then refetch.
       if (e instanceof ApprovalConflictError) {
-        void mutate(swrKey);
+        settleTimer.current = setTimeout(() => {
+          void mutate(swrKey);
+        }, SETTLE_HOLD_MS);
         return;
       }
+      console.error("Failed to submit approval decision:", e);
       if (mountedRef.current) {
         setDecision(null);
         setErrorMessage(
@@ -154,11 +158,6 @@ export default function ApprovalCard({
         )}
       >
         <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          {/*
-           * Two triggers (header + chevron) because action buttons can't
-           * nest inside a trigger (invalid HTML) and shouldn't toggle the
-           * collapse. `data-approval-trigger` scopes the row's hover tint.
-           */}
           <div
             className={cn(
               "flex items-center gap-1 pr-2 transition-colors",

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -32,9 +32,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 interface ApprovalCardProps {
   approval: ApprovalView;
   defaultOpen?: boolean;
-  /** Seed an already-decided state (settled edge + label). For Storybook —
-   *  production approvals always start pending and drop from /live once
-   *  decided. */
+  /** Seed a decided state for Storybook (real approvals start pending). */
   defaultDecision?: ApprovalSubmitDecision | null;
 }
 
@@ -81,8 +79,7 @@ export default function ApprovalCard({
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(defaultOpen);
-  // The decided outcome, set optimistically on click so the comet settles
-  // into a solid edge before the row drops from /live.
+  // Optimistic decision so the comet settles before the row drops from /live.
   const [decision, setDecision] = useState<ApprovalSubmitDecision | null>(
     defaultDecision
   );
@@ -103,8 +100,7 @@ export default function ApprovalCard({
 
   const decided = decision !== null;
   const approved = decision === "APPROVED";
-  // Hold the settled edge briefly so the cross-fade is visible before the
-  // approval drops from /live and this card unmounts.
+  // Hold the settled edge so the cross-fade is visible before unmount.
   const SETTLE_HOLD_MS = 800;
 
   async function decide(next: ApprovalSubmitDecision) {

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -5,7 +5,12 @@ import { useSWRConfig } from "swr";
 
 import { Button, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgChevronDown, SvgLoader } from "@opal/icons";
+import {
+  SvgAlertCircle,
+  SvgCheckSquare,
+  SvgChevronDown,
+  SvgLoader,
+} from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
@@ -21,11 +26,16 @@ import {
   ApprovalView,
 } from "@/app/craft/types/approvals";
 import PayloadView from "@/app/craft/components/approvals/PayloadView";
+import CometEdge from "@/app/craft/components/CometEdge";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 interface ApprovalCardProps {
   approval: ApprovalView;
   defaultOpen?: boolean;
+  /** Seed an already-decided state (settled edge + label). For Storybook —
+   *  production approvals always start pending and drop from /live once
+   *  decided. */
+  defaultDecision?: ApprovalSubmitDecision | null;
 }
 
 // Single-action: name the action; multi-action: just count them. The
@@ -65,30 +75,47 @@ function ActionList({ actions }: { actions: ApprovalAction[] }) {
 export default function ApprovalCard({
   approval,
   defaultOpen = false,
+  defaultDecision = null,
 }: ApprovalCardProps) {
   const { mutate } = useSWRConfig();
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  // The decided outcome, set optimistically on click so the comet settles
+  // into a solid edge before the row drops from /live.
+  const [decision, setDecision] = useState<ApprovalSubmitDecision | null>(
+    defaultDecision
+  );
 
   // Guards setState after the post-decision SWR revalidation drops
   // this row from /live and the card unmounts mid-await.
   const mountedRef = useRef(true);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     return () => {
       mountedRef.current = false;
+      if (settleTimer.current) clearTimeout(settleTimer.current);
     };
   }, []);
 
   const headline = approvalHeadline(approval);
   const swrKey = SWR_KEYS.buildSessionLiveApprovals(approval.session_id);
 
-  async function decide(decision: ApprovalSubmitDecision) {
+  const decided = decision !== null;
+  const approved = decision === "APPROVED";
+  // Hold the settled edge briefly so the cross-fade is visible before the
+  // approval drops from /live and this card unmounts.
+  const SETTLE_HOLD_MS = 800;
+
+  async function decide(next: ApprovalSubmitDecision) {
     setSubmitting(true);
     setErrorMessage(null);
+    setDecision(next);
     try {
-      await postApprovalDecision(approval.approval_id, decision);
-      void mutate(swrKey);
+      await postApprovalDecision(approval.approval_id, next);
+      settleTimer.current = setTimeout(() => {
+        void mutate(swrKey);
+      }, SETTLE_HOLD_MS);
     } catch (e) {
       // 409 = already resolved (by someone else, or expired by the
       // proxy). Same UX as a successful submit: refetch and unmount.
@@ -97,6 +124,7 @@ export default function ApprovalCard({
         return;
       }
       if (mountedRef.current) {
+        setDecision(null);
         setErrorMessage(
           e instanceof Error ? e.message : "Failed to submit decision"
         );
@@ -113,75 +141,114 @@ export default function ApprovalCard({
   }
 
   return (
-    <div className="rounded-08 border border-status-info-03 overflow-hidden bg-background-neutral-00">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        {/*
-         * Two triggers (header + chevron) because action buttons can't
-         * nest inside a trigger (invalid HTML) and shouldn't toggle the
-         * collapse. `data-approval-trigger` scopes the row's hover tint.
-         */}
-        <div
-          className={cn(
-            "flex items-center gap-1 pr-2 transition-colors",
-            "has-[[data-approval-trigger]:hover]:bg-background-tint-02"
-          )}
-        >
-          <CollapsibleTrigger asChild>
-            <button
-              data-approval-trigger
-              className="flex items-center gap-2 min-w-0 flex-1 text-left px-3 py-2"
-            >
-              <SvgLoader className="size-4 shrink-0 stroke-status-info-05 animate-spin" />
-              <Text font="main-ui-muted" color="text-04" nowrap>
-                {headline}
-              </Text>
-            </button>
-          </CollapsibleTrigger>
-          <Button
-            prominence="primary"
-            size="sm"
-            disabled={submitting}
-            onClick={() => decide("APPROVED")}
+    <CometEdge
+      active={!decided}
+      settled={decided}
+      tone={decided ? (approved ? "success" : "error") : "info"}
+      speedSeconds={3.6}
+    >
+      <div
+        className={cn(
+          "rounded-08 border overflow-hidden bg-background-neutral-00 transition-colors",
+          decided
+            ? approved
+              ? "border-status-success-03"
+              : "border-status-error-03"
+            : "border-status-info-03"
+        )}
+      >
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          {/*
+           * Two triggers (header + chevron) because action buttons can't
+           * nest inside a trigger (invalid HTML) and shouldn't toggle the
+           * collapse. `data-approval-trigger` scopes the row's hover tint.
+           */}
+          <div
+            className={cn(
+              "flex items-center gap-1 pr-2 transition-colors",
+              "has-[[data-approval-trigger]:hover]:bg-background-tint-02"
+            )}
           >
-            Approve
-          </Button>
-          <Button
-            prominence="secondary"
-            size="sm"
-            disabled={submitting}
-            onClick={() => decide("REJECTED")}
-          >
-            Reject
-          </Button>
-          <CollapsibleTrigger asChild>
-            <button
-              data-approval-trigger
-              aria-label={isOpen ? "Hide details" : "Show details"}
-              className="p-1.5"
-            >
-              <SvgChevronDown
-                className={cn(
-                  "size-4 stroke-text-03 transition-transform duration-150",
-                  !isOpen && "-rotate-90"
+            <CollapsibleTrigger asChild>
+              <button
+                data-approval-trigger
+                className="flex items-center gap-2 min-w-0 flex-1 text-left px-3 py-2"
+              >
+                {decided ? (
+                  approved ? (
+                    <SvgCheckSquare className="size-4 shrink-0 stroke-status-success-05" />
+                  ) : (
+                    <SvgAlertCircle className="size-4 shrink-0 stroke-status-error-05" />
+                  )
+                ) : (
+                  <SvgLoader className="size-4 shrink-0 stroke-status-info-05 animate-spin" />
                 )}
-              />
-            </button>
-          </CollapsibleTrigger>
-        </div>
-        <CollapsibleContent>
-          <div className="p-2 flex flex-col gap-3">
-            <ActionList actions={approval.actions} />
-            <PayloadView payload={approval.payload} />
-            {errorMessage && (
-              <div className="text-status-error-05">
-                <Text font="secondary-body" color="inherit">
-                  {errorMessage}
+                <Text font="main-ui-muted" color="text-04" nowrap>
+                  {headline}
+                </Text>
+              </button>
+            </CollapsibleTrigger>
+            {decided ? (
+              <div
+                className={cn(
+                  "px-2",
+                  approved ? "text-status-success-05" : "text-status-error-05"
+                )}
+              >
+                <Text font="main-ui-action" color="inherit" nowrap>
+                  {approved ? "Approved" : "Rejected"}
                 </Text>
               </div>
+            ) : (
+              <>
+                <Button
+                  prominence="primary"
+                  size="sm"
+                  disabled={submitting}
+                  onClick={() => decide("APPROVED")}
+                >
+                  Approve
+                </Button>
+                <Button
+                  prominence="secondary"
+                  size="sm"
+                  disabled={submitting}
+                  onClick={() => decide("REJECTED")}
+                >
+                  Reject
+                </Button>
+              </>
             )}
+            <CollapsibleTrigger asChild>
+              <button
+                data-approval-trigger
+                aria-label={isOpen ? "Hide details" : "Show details"}
+                className="p-1.5"
+              >
+                <SvgChevronDown
+                  className={cn(
+                    "size-4 stroke-text-03 transition-transform duration-150",
+                    !isOpen && "-rotate-90"
+                  )}
+                />
+              </button>
+            </CollapsibleTrigger>
           </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+          <CollapsibleContent>
+            <div className="p-2 flex flex-col gap-3">
+              <ActionList actions={approval.actions} />
+              <PayloadView payload={approval.payload} />
+              {errorMessage && (
+                <div className="text-status-error-05">
+                  <Text font="secondary-body" color="inherit">
+                    {errorMessage}
+                  </Text>
+                </div>
+              )}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </CometEdge>
   );
 }

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
@@ -227,6 +227,41 @@ export const WithSkillBadge: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────────────────
+// Skill invocations — a skill in flight gets a traveling comet edge (the live
+// signal). Once it completes the comet is gone; only the check remains.
+// Regular tool calls never get the comet, even mid-flight.
+// ──────────────────────────────────────────────────────────────────────────
+
+export const SkillInFlight: Story = {
+  args: {
+    toolCall: call({
+      kind: "other",
+      toolName: "skill",
+      title: "Running skill",
+      description: "Deep, multi-source research",
+      skillName: "deep-research",
+      status: "in_progress",
+    }),
+  },
+};
+
+export const SkillCompleted: Story = {
+  args: {
+    toolCall: call({
+      kind: "other",
+      toolName: "skill",
+      title: "Running skill",
+      description: "Review the current diff for correctness bugs",
+      command: "/code-review medium",
+      skillName: "code-review",
+      status: "completed",
+      rawOutput:
+        "Found 2 must-fix and 3 should-consider findings. See full review for details.",
+    }),
+  },
+};
+
+// ──────────────────────────────────────────────────────────────────────────
 // Behavioral overrides — defaultOpen, dense mode.
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
@@ -227,9 +227,7 @@ export const WithSkillBadge: Story = {
 };
 
 // ──────────────────────────────────────────────────────────────────────────
-// Skill invocations — a skill in flight gets a traveling comet edge (the live
-// signal). Once it completes the comet is gone; only the check remains.
-// Regular tool calls never get the comet, even mid-flight.
+// Skill invocations — comet while in flight, gone once complete.
 // ──────────────────────────────────────────────────────────────────────────
 
 export const SkillInFlight: Story = {

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -162,9 +162,7 @@ function renderStatusIcon(toolCall: ToolCallState) {
       />
     );
   }
-  // A finished skill leads with its sparkle identity (in brand blue) rather
-  // than the same completion check every tool row shows — the distinguishing
-  // mark for a skill card, in a group or standalone.
+  // Finished skill leads with its sparkle, not the generic completion check.
   if (isSkillInvocation(toolCall) && toolCall.status === "completed") {
     return (
       <SvgSparkle
@@ -207,8 +205,7 @@ export default function CraftToolCard({
     <div className="flex items-center gap-2 min-w-0 w-full">
       {renderStatusIcon(toolCall)}
       <span className="truncate min-w-0">{renderPrimary(toolCall)}</span>
-      {/* Skill badge + chevron are pinned right so the badge aligns vertically
-          across rows regardless of how long the primary text is. */}
+      {/* Pinned right so the skill badge aligns across rows. */}
       <span className="ml-auto flex items-center gap-2 shrink-0">
         {toolCall.skillName && toolCall.toolName !== "skill" && (
           <SkillBadge name={toolCall.skillName} />
@@ -232,19 +229,13 @@ export default function CraftToolCard({
     expandable && "transition-colors hover:bg-background-tint-02"
   );
 
-  // Skill work in flight gets a comet edge — the live signal. A skill
-  // invocation (`toolName === "skill"`) or a tool call made inside a skill
-  // (carries `skillName`) both count; a plain tool call never does.
-  // Suppressed when nested in a group — the group carries the comet instead
-  // (its `overflow-hidden` would clip a per-row comet).
+  // Comet only on standalone skill work; nested rows defer to the group's comet.
   const isSkillInFlight =
     !nested &&
     isSkillCall(toolCall) &&
     (toolCall.status === "pending" || toolCall.status === "in_progress");
 
-  // A standalone skill invocation keeps a thin border at rest so it stays
-  // distinct from plain tool cards even after the comet stops. Grouped skill
-  // rows stay borderless — the group carries the border.
+  // Thin border keeps a standalone skill distinct once the comet stops.
   const skillCard = !nested && isSkillInvocation(toolCall);
 
   const card = (

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -207,18 +207,22 @@ export default function CraftToolCard({
     <div className="flex items-center gap-2 min-w-0 w-full">
       {renderStatusIcon(toolCall)}
       <span className="truncate min-w-0">{renderPrimary(toolCall)}</span>
-      {toolCall.skillName && toolCall.toolName !== "skill" && (
-        <SkillBadge name={toolCall.skillName} />
-      )}
-      {/* Chevron always rendered to reserve space so the row doesn't shift. */}
-      <SvgChevronDown
-        aria-hidden={!expandable}
-        className={cn(
-          "size-4 stroke-text-03 transition-transform duration-150 shrink-0 ml-auto",
-          !isOpen && "-rotate-90",
-          !expandable && "invisible"
+      {/* Skill badge + chevron are pinned right so the badge aligns vertically
+          across rows regardless of how long the primary text is. */}
+      <span className="ml-auto flex items-center gap-2 shrink-0">
+        {toolCall.skillName && toolCall.toolName !== "skill" && (
+          <SkillBadge name={toolCall.skillName} />
         )}
-      />
+        {/* Chevron always rendered to reserve space so the row doesn't shift. */}
+        <SvgChevronDown
+          aria-hidden={!expandable}
+          className={cn(
+            "size-4 stroke-text-03 transition-transform duration-150 shrink-0",
+            !isOpen && "-rotate-90",
+            !expandable && "invisible"
+          )}
+        />
+      </span>
     </div>
   );
 

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.tsx
@@ -3,12 +3,13 @@
 import { useState, type ReactNode } from "react";
 import { Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import { SvgChevronDown } from "@opal/icons";
+import { SvgChevronDown, SvgSparkle } from "@opal/icons";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
+import CometEdge from "@/app/craft/components/CometEdge";
 import SkillBadge from "@/app/craft/components/tool-cards/SkillBadge";
 import BashBody from "@/app/craft/components/tool-cards/BashBody";
 import DiffBody from "@/app/craft/components/tool-cards/DiffBody";
@@ -21,6 +22,8 @@ import GenericBody from "@/app/craft/components/tool-cards/GenericBody";
 import {
   getStatusDisplay,
   getToolIcon,
+  isSkillCall,
+  isSkillInvocation,
   SvgLoader,
 } from "@/app/craft/components/tool-cards/helpers";
 import type { ToolCallState } from "@/app/craft/types/displayTypes";
@@ -159,6 +162,16 @@ function renderStatusIcon(toolCall: ToolCallState) {
       />
     );
   }
+  // A finished skill leads with its sparkle identity (in brand blue) rather
+  // than the same completion check every tool row shows — the distinguishing
+  // mark for a skill card, in a group or standalone.
+  if (isSkillInvocation(toolCall) && toolCall.status === "completed") {
+    return (
+      <SvgSparkle
+        className={cn(baseClass, "stroke-status-info-05 fill-status-info-05")}
+      />
+    );
+  }
   const StatusIcon = statusDisplay.icon;
   if (StatusIcon) {
     return <StatusIcon className={cn(baseClass, statusDisplay.iconClass)} />;
@@ -215,10 +228,26 @@ export default function CraftToolCard({
     expandable && "transition-colors hover:bg-background-tint-02"
   );
 
-  return (
+  // Skill work in flight gets a comet edge — the live signal. A skill
+  // invocation (`toolName === "skill"`) or a tool call made inside a skill
+  // (carries `skillName`) both count; a plain tool call never does.
+  // Suppressed when nested in a group — the group carries the comet instead
+  // (its `overflow-hidden` would clip a per-row comet).
+  const isSkillInFlight =
+    !nested &&
+    isSkillCall(toolCall) &&
+    (toolCall.status === "pending" || toolCall.status === "in_progress");
+
+  // A standalone skill invocation keeps a thin border at rest so it stays
+  // distinct from plain tool cards even after the comet stops. Grouped skill
+  // rows stay borderless — the group carries the border.
+  const skillCard = !nested && isSkillInvocation(toolCall);
+
+  const card = (
     <div
       className={cn(
         "rounded-08",
+        skillCard && !failed && "border-[0.5px] border-border-01",
         failed &&
           (nested
             ? "bg-status-error-00"
@@ -237,4 +266,13 @@ export default function CraftToolCard({
       )}
     </div>
   );
+
+  if (isSkillInFlight) {
+    return (
+      <CometEdge active tone="info" speedSeconds={2.6}>
+        {card}
+      </CometEdge>
+    );
+  }
+  return card;
 }

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
@@ -130,6 +130,68 @@ export const SingleStep: Story = {
   },
 };
 
+// A finished skill group keeps its thin border (the comet is gone). This is
+// what an auto-approved external-app invocation looks like at rest.
+export const CompletedSkill: Story = {
+  args: {
+    defaultOpen: true,
+    toolCalls: [
+      call("g-skill-done-1", {
+        kind: "other",
+        toolName: "skill",
+        title: "Running skill",
+        description: "Post to Slack",
+        skillName: "slack",
+        status: "completed",
+      }),
+      call("g-skill-done-curl", {
+        kind: "execute",
+        toolName: "bash",
+        description: "post message",
+        command: "curl -X POST https://slack.com/api/chat.postMessage ...",
+        skillName: "slack",
+        status: "completed",
+        rawOutput: '{"ok": true, "ts": "1717436531.001"}',
+      }),
+    ],
+  },
+};
+
+// A group that involves an in-flight skill gets a comet edge around the whole
+// block (the skill invocation + the tool calls it makes inside it).
+export const WithActiveSkill: Story = {
+  args: {
+    defaultOpen: true,
+    toolCalls: [
+      call("g-skill-1", {
+        kind: "other",
+        toolName: "skill",
+        title: "Running skill",
+        description: "Deep, multi-source research",
+        skillName: "deep-research",
+        status: "in_progress",
+      }),
+      call("g-skill-grep", {
+        kind: "search",
+        toolName: "grep",
+        title: "Searching content",
+        description: "cloud revenue",
+        skillName: "deep-research",
+        status: "completed",
+        rawOutput: "12 matches across 4 files",
+      }),
+      call("g-skill-fetch", {
+        kind: "other",
+        toolName: "websearch",
+        title: "Searching the web",
+        description: "q3 cloud market share",
+        skillName: "deep-research",
+        status: "in_progress",
+      }),
+    ],
+  },
+};
+
 export const ManyCalls: Story = {
   args: {
     toolCalls: [

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
@@ -130,8 +130,7 @@ export const SingleStep: Story = {
   },
 };
 
-// A finished skill group keeps its thin border (the comet is gone). This is
-// what an auto-approved external-app invocation looks like at rest.
+// Finished skill group at rest: thin border, no comet.
 export const CompletedSkill: Story = {
   args: {
     defaultOpen: true,
@@ -157,8 +156,7 @@ export const CompletedSkill: Story = {
   },
 };
 
-// A group that involves an in-flight skill gets a comet edge around the whole
-// block (the skill invocation + the tool calls it makes inside it).
+// In-flight skill group: comet around the whole block.
 export const WithActiveSkill: Story = {
   args: {
     defaultOpen: true,

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -10,7 +10,11 @@ import {
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
 import CraftToolCard from "@/app/craft/components/tool-cards/CraftToolCard";
-import { SvgLoader } from "@/app/craft/components/tool-cards/helpers";
+import CometEdge from "@/app/craft/components/CometEdge";
+import {
+  isSkillCall,
+  SvgLoader,
+} from "@/app/craft/components/tool-cards/helpers";
 import type { ToolCallState } from "@/app/craft/types/displayTypes";
 
 interface CraftToolGroupProps {
@@ -56,6 +60,10 @@ export default function CraftToolGroup({
     defaultOpen ?? aggregate === "in_progress"
   );
   const failedCount = toolCalls.filter((t) => t.status === "failed").length;
+  // A group that involves a skill stays distinct from plain tool groups: a
+  // comet while it runs, and a thin border that persists once it's done.
+  const skillGroup = toolCalls.some(isSkillCall);
+  const skillActive = aggregate === "in_progress" && skillGroup;
 
   // Fold closed once a message follows; fire once so a manual re-open sticks.
   const didAutoCollapse = useRef(false);
@@ -67,47 +75,58 @@ export default function CraftToolGroup({
   }, [autoCollapse]);
 
   return (
-    <div className="rounded-08 overflow-hidden">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger asChild>
-          <button
-            className={cn(
-              "w-full text-left px-3 py-2 rounded-md",
-              "transition-colors hover:bg-background-tint-02"
-            )}
-          >
-            <div className="flex items-center gap-2 min-w-0 w-full">
-              {renderStatusIcon(toolCalls)}
-              <Text font="main-ui-muted" color="text-04" nowrap>
-                Working
-              </Text>
-              <span className="ml-auto shrink-0 flex items-center gap-2">
-                {failedCount > 0 && (
-                  <Tag title={`${failedCount} failed`} size="sm" color="red" />
-                )}
-                <Tag
-                  title={`${toolCalls.length} calls`}
-                  size="sm"
-                  color="gray"
+    <CometEdge active={skillActive} tone="info" speedSeconds={2.6}>
+      <div
+        className={cn(
+          "rounded-08 overflow-hidden",
+          skillGroup && "border-[0.5px] border-border-01"
+        )}
+      >
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              className={cn(
+                "w-full text-left px-3 py-2 rounded-md",
+                "transition-colors hover:bg-background-tint-02"
+              )}
+            >
+              <div className="flex items-center gap-2 min-w-0 w-full">
+                {renderStatusIcon(toolCalls)}
+                <Text font="main-ui-muted" color="text-04" nowrap>
+                  Working
+                </Text>
+                <span className="ml-auto shrink-0 flex items-center gap-2">
+                  {failedCount > 0 && (
+                    <Tag
+                      title={`${failedCount} failed`}
+                      size="sm"
+                      color="red"
+                    />
+                  )}
+                  <Tag
+                    title={`${toolCalls.length} calls`}
+                    size="sm"
+                    color="gray"
+                  />
+                </span>
+                <SvgChevronDown
+                  className={cn(
+                    "size-4 stroke-text-03 transition-transform duration-150 shrink-0",
+                    !isOpen && "-rotate-90"
+                  )}
                 />
-              </span>
-              <SvgChevronDown
-                className={cn(
-                  "size-4 stroke-text-03 transition-transform duration-150 shrink-0",
-                  !isOpen && "-rotate-90"
-                )}
-              />
+              </div>
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="flex flex-col border-t-[0.5px] border-border-01">
+              {toolCalls.map((toolCall) => (
+                <CraftToolCard key={toolCall.id} toolCall={toolCall} nested />
+              ))}
             </div>
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="flex flex-col border-t-[0.5px] border-border-01">
-            {toolCalls.map((toolCall) => (
-              <CraftToolCard key={toolCall.id} toolCall={toolCall} nested />
-            ))}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </CometEdge>
   );
 }

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.tsx
@@ -60,8 +60,7 @@ export default function CraftToolGroup({
     defaultOpen ?? aggregate === "in_progress"
   );
   const failedCount = toolCalls.filter((t) => t.status === "failed").length;
-  // A group that involves a skill stays distinct from plain tool groups: a
-  // comet while it runs, and a thin border that persists once it's done.
+  // Skill groups get a comet while running and a thin border at rest.
   const skillGroup = toolCalls.some(isSkillCall);
   const skillActive = aggregate === "in_progress" && skillGroup;
 

--- a/web/src/app/craft/components/tool-cards/helpers.ts
+++ b/web/src/app/craft/components/tool-cards/helpers.ts
@@ -93,19 +93,12 @@ export function isTerminalStatus(status: ToolCallStatus): boolean {
   );
 }
 
-/**
- * A skill invocation — the "Using <skill> skill" card. Drives the skill-only
- * chrome (leading sparkle, thin border).
- */
+/** The "Using <skill> skill" invocation card (drives the sparkle + border). */
 export function isSkillInvocation(toolCall: ToolCallState): boolean {
   return toolCall.toolName === "skill";
 }
 
-/**
- * Skill-related work: the invocation itself, or a tool call made inside a
- * skill (carries `skillName`). Drives the comet edge (a card in flight, a
- * group that involves a skill).
- */
+/** The invocation or a tool call made inside a skill (drives the comet edge). */
 export function isSkillCall(toolCall: ToolCallState): boolean {
   return toolCall.toolName === "skill" || !!toolCall.skillName;
 }

--- a/web/src/app/craft/components/tool-cards/helpers.ts
+++ b/web/src/app/craft/components/tool-cards/helpers.ts
@@ -94,6 +94,23 @@ export function isTerminalStatus(status: ToolCallStatus): boolean {
 }
 
 /**
+ * A skill invocation — the "Using <skill> skill" card. Drives the skill-only
+ * chrome (leading sparkle, thin border).
+ */
+export function isSkillInvocation(toolCall: ToolCallState): boolean {
+  return toolCall.toolName === "skill";
+}
+
+/**
+ * Skill-related work: the invocation itself, or a tool call made inside a
+ * skill (carries `skillName`). Drives the comet edge (a card in flight, a
+ * group that involves a skill).
+ */
+export function isSkillCall(toolCall: ToolCallState): boolean {
+  return toolCall.toolName === "skill" || !!toolCall.skillName;
+}
+
+/**
  * Returns the language hint to use for syntax highlighting in the body.
  * Uses the file path's extension when present, falls back to the tool kind.
  */

--- a/web/src/app/css/comet.css
+++ b/web/src/app/css/comet.css
@@ -1,0 +1,43 @@
+/*
+ * Comet edge — a single hairline "comet" that travels the perimeter of a
+ * card. Used by CometEdge.tsx to signal live activity (a skill in flight, an
+ * approval awaiting a decision). The path is normalized to pathLength=100, so
+ * the dash pattern + travel distance are size-independent and seamless.
+ *
+ * Two strokes are stacked: the traveling comet (live) and a solid edge
+ * (settled). CometEdge cross-fades their opacity to "settle" the live comet
+ * into a solid colored edge once an outcome is known (approved / denied).
+ */
+
+@keyframes craft-comet-travel {
+  to {
+    stroke-dashoffset: -100;
+  }
+}
+
+.craft-comet {
+  fill: none;
+  stroke: var(--comet-color, var(--status-info-05));
+  stroke-width: 1;
+  stroke-linecap: round;
+  /* 16 visible + 84 gap = 100 (one comet per lap). */
+  stroke-dasharray: 16 84;
+  animation: craft-comet-travel var(--comet-speed, 3.6s) linear infinite;
+  transition: opacity 0.45s ease;
+}
+
+/* Settled state: a solid colored edge, no travel (approved / denied). */
+.craft-comet-static {
+  fill: none;
+  stroke: var(--comet-settle-color, var(--status-success-05));
+  stroke-width: 1;
+  transition: opacity 0.45s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .craft-comet {
+    animation: none;
+    /* Hold a longer static glow segment so the live state still reads. */
+    stroke-dasharray: 34 66;
+  }
+}

--- a/web/src/app/css/comet.css
+++ b/web/src/app/css/comet.css
@@ -1,13 +1,4 @@
-/*
- * Comet edge — a single hairline "comet" that travels the perimeter of a
- * card. Used by CometEdge.tsx to signal live activity (a skill in flight, an
- * approval awaiting a decision). The path is normalized to pathLength=100, so
- * the dash pattern + travel distance are size-independent and seamless.
- *
- * Two strokes are stacked: the traveling comet (live) and a solid edge
- * (settled). CometEdge cross-fades their opacity to "settle" the live comet
- * into a solid colored edge once an outcome is known (approved / denied).
- */
+/* Comet edge — see CometEdge.tsx. Dash is normalized to pathLength=100. */
 
 @keyframes craft-comet-travel {
   to {
@@ -20,13 +11,13 @@
   stroke: var(--comet-color, var(--status-info-05));
   stroke-width: 1;
   stroke-linecap: round;
-  /* 16 visible + 84 gap = 100 (one comet per lap). */
+  /* 16 + 84 = 100: one comet per lap. */
   stroke-dasharray: 16 84;
   animation: craft-comet-travel var(--comet-speed, 3.6s) linear infinite;
   transition: opacity 0.45s ease;
 }
 
-/* Settled state: a solid colored edge, no travel (approved / denied). */
+/* Settled: solid colored edge, no travel. */
 .craft-comet-static {
   fill: none;
   stroke: var(--comet-settle-color, var(--status-success-05));
@@ -37,7 +28,7 @@
 @media (prefers-reduced-motion: reduce) {
   .craft-comet {
     animation: none;
-    /* Hold a longer static glow segment so the live state still reads. */
+    /* Longer static segment so the live state still reads. */
     stroke-dasharray: 34 66;
   }
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -3,6 +3,7 @@
 @import "./css/button.css" layer(base);
 @import "./css/content-editable.css" layer(base);
 @import "./css/card.css" layer(base);
+@import "./css/comet.css" layer(base);
 @import "./css/color-swatch.css" layer(base);
 @import "./css/divider.css" layer(base);
 @import "./css/general-layouts.css" layer(base);


### PR DESCRIPTION
## Description

Adds a **comet edge** — a hairline stroke that travels a card's border — as a shared "live" signal in Craft, and gives skill cards a treatment distinct from plain tool cards.

- **`CometEdge`**: a size-agnostic SVG `<rect>` (pathLength-normalized dash) that runs a comet around a card while `active`, then cross-fades to a solid colored edge when `settled`. Resizes natively with the card (no JS measurement), so it stays smooth as cards expand/collapse.
- **Skills**: a skill invocation (or a tool call made inside a skill) gets the comet while in flight, and at rest keeps a thin border + a blue sparkle leading icon so it reads as distinct from tool cards. Applied at both the standalone-card and the "Working" group level. Skill-origin tags are right-aligned so they line up across rows.
- **Approvals**: `ApprovalCard` shows the comet while pending and settles to a solid green/red edge on approve/reject — optimistic, with a short hold before the row drops from `/live`. Adds a `defaultDecision` prop for previewing decided states.
- Centralizes skill detection in `isSkillInvocation` / `isSkillCall` helpers.

## Screenshots

_From Storybook (`Apps/Craft`)._

**Skill running** — comet travels the border, thin border + code-formatted skill name; skill-origin tags aligned right:

![Skill running](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/sexy-cards-comet-shots/docs/screenshots/comet/skill-active.png?v=2)

**Skill finished** — comet gone, persistent thin border + blue sparkle identity icon:

![Skill completed](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/sexy-cards-comet-shots/docs/screenshots/comet/skill-completed.png?v=2)

**Approval awaiting decision** — comet on a pending ApprovalCard:

![Approval pending](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/sexy-cards-comet-shots/docs/screenshots/comet/approval-pending.png)

**Approval settled** — cross-fades to a solid green edge on approve (red on reject):

![Approval approved](https://raw.githubusercontent.com/onyx-dot-app/onyx/assets/sexy-cards-comet-shots/docs/screenshots/comet/approval-approved.png)

## How Has This Been Tested?

- Storybook stories under `Apps/Craft/Comet Edge`, `Tool Cards`, and `Approvals` covering in-flight, completed, awaiting-approval, approved/denied, and the live settle transition.
- `oxfmt`, `oxlint`, and `tsc --noEmit` all pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
