### PR TITLE
feat(devcontainer): cache the Python venv in a named volume

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
     "source=${localEnv:HOME}/.config/nvim,target=/home/dev/.config/nvim,type=bind,readonly",
     "source=onyx-devcontainer-cache,target=/home/dev/.cache,type=volume",
     "source=onyx-devcontainer-local,target=/home/dev/.local,type=volume",
+    "source=onyx-devcontainer-venv,target=/workspace/.venv,type=volume",
     "source=onyx-devcontainer-web-node-modules,target=/workspace/web/node_modules,type=volume",
     "source=onyx-devcontainer-web-next,target=/workspace/web/.next,type=volume"
   ],

--- a/.devcontainer/init-dev-user.sh
+++ b/.devcontainer/init-dev-user.sh
@@ -70,7 +70,7 @@ fi
 # Chown the mountpoint to match the workspace owner so the dev user can
 # write into them. Non-recursive: contents are created by the dev user
 # (e.g. via `bun install`) and don't need re-chown on every start.
-for vol in /workspace/web/node_modules /workspace/web/.next; do
+for vol in /workspace/web/node_modules /workspace/web/.next /workspace/.venv; do
     [ -d "$vol" ] || continue
     if ! chown "$WS_UID":"$WS_GID" "$vol" 2>&1; then
         echo "warning: failed to chown $vol" >&2


### PR DESCRIPTION
## What

Mounts a persistent named volume (`onyx-devcontainer-venv`) at `/workspace/.venv` so the `uv`-managed virtualenv is cached across container rebuilds, instead of living on the slower host bind mount. This mirrors the existing `web/node_modules` and `web/.next` cache volumes.

## Why

Today `.venv` lands under the bind-mounted `/workspace`, so a `Rebuild Container` means re-running a full `uv sync` from scratch (and the venv sits on the slower host mount). Caching it on a Docker volume persists it across rebuilds.

## Changes

- **`devcontainer.json`** — add `source=onyx-devcontainer-venv,target=/workspace/.venv,type=volume`.
- **`init-dev-user.sh`** — add `/workspace/.venv` to the Phase 1.5 chown loop. Fresh named volumes come up root-owned; this lets the `dev` user run `uv sync` into it.

`UV_LINK_MODE=copy` is already set in `containerEnv`, which is required here — uv's cache lives on the separate `onyx-devcontainer-cache` volume and can't hardlink across to the venv volume, so it must copy.

## Notes

- **First start is empty**: the volume starts empty, so `uv sync --frozen` still needs to run once to populate it (per CLAUDE.md). Left manual rather than wiring a `postCreateCommand`.
- **Shadows host `.venv`**: the volume hides any `/workspace/.venv` on the host — desirable, since a host-built venv (esp. macOS) isn't valid inside the Linux container.
- **Shared across containers**: like `node_modules`/`.next`, a single named volume is shared by every container that mounts it. Running multiple branch/worktree containers concurrently means they share one venv; `uv sync --frozen` on start reconciles, same tradeoff already accepted for the node volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts a named Docker volume `onyx-devcontainer-venv` at `/workspace/.venv` to cache the `uv` virtualenv across devcontainer rebuilds and move it off the slower host bind mount. Updates `init-dev-user.sh` to chown the mount so the `dev` user can run `uv sync`.

- **Migration**
  - On first start, run `uv sync --frozen` to populate the empty volume.
  - The volume hides any host `/workspace/.venv` and is shared across containers.

<sup>Written for commit d0ead663e69c88a568a721247d7e2f33917a583a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

