### PR TITLE
fix(tenants): allow /enterprise-settings for gated tenants

### DIFF
--- a/backend/ee/onyx/configs/multi_tenant_gating_config.py
+++ b/backend/ee/onyx/configs/multi_tenant_gating_config.py
@@ -31,6 +31,7 @@ MULTI_TENANT_GATING_ALLOWED_PREFIXES: frozenset[str] = frozenset(
         "/health",
         "/me",
         "/settings",
+        "/enterprise-settings",
         "/billing",
         "/admin/billing",
         "/tenants/billing-information",


### PR DESCRIPTION
## Description

**Bug:** Every gated cloud tenant sees "Maintenance in Progress" instead of the Access Restricted / resubscribe page — so they can't even pay to come back. ~5,100 tenants affected.

**Cause:** #11253 added server-side gating (402 on non-allowlisted paths). The allowlist omits `/enterprise-settings`, which `SettingsProvider` fetches on every cloud page load (`EE_ENABLED` always true). It treats any non-401/403 settings error as fatal → renders Maintenance before `AccessRestrictedPage` can mount.

**Fix:** Add `/enterprise-settings` to `MULTI_TENANT_GATING_ALLOWED_PREFIXES`. Read-only, same class as `/settings`. `/admin/enterprise-settings/*` stays gated (prefix doesn't match).

## How Has This Been Tested?

## Additional Options
- [x] Override Linear Check
- [ ] This PR should be considered for cherry-picking