### PR TITLE
ci(playwright): extract shared setup/teardown into composite actions

### DIFF
--- a/.github/actions/save-docker-logs/action.yml
+++ b/.github/actions/save-docker-logs/action.yml
@@ -1,0 +1,42 @@
+name: "Save Docker logs"
+description: >
+  Dumps `docker compose logs` to a file and uploads it as a build artifact. Pass
+  the same -f overrides used to bring the stack up so services defined only in
+  override files are captured. Call with `if: success() || failure()` so logs are
+  captured even when the test step failed. Inner steps repeat that condition
+  because composite steps are otherwise skipped once the job is in a failed state.
+inputs:
+  label:
+    description: >
+      Distinguishes this job's log artifact (e.g. the matrix project, 'lite', or
+      'oauth-okta'). Combined with the run id to form the artifact name.
+    required: true
+  compose-files:
+    description: >
+      The `-f <file>` overrides to pass to `docker compose`, matching the set used
+      at startup. Leave empty to use the default docker-compose.yml only.
+    required: false
+    default: ""
+runs:
+  using: "composite"
+  steps:
+    - name: Save Docker logs
+      if: success() || failure()
+      shell: bash
+      env:
+        WORKSPACE: ${{ github.workspace }}
+        COMPOSE_FILES: ${{ inputs.compose-files }}
+      run: |
+        cd deployment/docker_compose
+        # COMPOSE_FILES is a list of `-f <file>` tokens that must word-split into
+        # separate args, so it is intentionally left unquoted.
+        # shellcheck disable=SC2086
+        docker compose ${COMPOSE_FILES} logs > docker-compose.log
+        mv docker-compose.log "${WORKSPACE}/docker-compose.log"
+
+    - name: Upload logs
+      if: success() || failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: docker-logs-${{ inputs.label }}-${{ github.run_id }}
+        path: ${{ github.workspace }}/docker-compose.log

--- a/.github/actions/setup-playwright-web/action.yml
+++ b/.github/actions/setup-playwright-web/action.yml
@@ -1,0 +1,36 @@
+name: "Setup Playwright (web/bun)"
+description: >
+  Installs bun, the web project's node dependencies, and the Playwright chromium
+  browser for the bun-based e2e suite, caching the browser binaries. Run after
+  actions/checkout; assumes the repo is checked out and web/bun.lock exists.
+inputs:
+  bun-version:
+    description: "bun version to install."
+    required: false
+    default: "1.3.13"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install node dependencies
+      shell: bash
+      working-directory: ./web
+      run: bun install --frozen-lockfile
+
+    - name: Cache playwright cache
+      # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
+      uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-bun-${{ hashFiles('web/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-bun-
+
+    - name: Install playwright browsers
+      shell: bash
+      working-directory: ./web
+      run: bunx playwright install chromium

--- a/.github/actions/upload-playwright-results/action.yml
+++ b/.github/actions/upload-playwright-results/action.yml
@@ -1,0 +1,36 @@
+name: "Upload Playwright results"
+description: >
+  Uploads the Playwright output (test results + trace.zip files) and, optionally,
+  the screenshots directory produced by an e2e run. Call with `if: always()` so
+  artifacts are captured even when the test step failed. Inner steps carry their
+  own `always()` because composite steps are otherwise skipped once the job is in
+  a failed state.
+inputs:
+  label:
+    description: >
+      Distinguishes this job's artifacts (e.g. the matrix project, 'lite', or
+      'oauth-okta'). Combined with the run id to form the artifact name.
+    required: true
+  upload-screenshots:
+    description: "Whether to also upload web/output/screenshots/ (suites like lite produce none)."
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Upload test results
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      if: always()
+      with:
+        # Includes test results and trace.zip files
+        name: playwright-test-results-${{ inputs.label }}-${{ github.run_id }}
+        path: ./web/output/playwright/
+        retention-days: 30
+
+    - name: Upload screenshots
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      if: ${{ always() && inputs.upload-screenshots == 'true' }}
+      with:
+        name: playwright-screenshots-${{ inputs.label }}-${{ github.run_id }}
+        path: ./web/output/screenshots/
+        retention-days: 30

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -115,6 +115,9 @@ jobs:
               - '.github/workflows/pr-playwright-tests.yml'
               - '.github/actions/setup-test-license/**'
               - '.github/actions/login-ecr-pullthrough-cache/**'
+              - '.github/actions/setup-playwright-web/**'
+              - '.github/actions/upload-playwright-results/**'
+              - '.github/actions/save-docker-logs/**'
             mcp_oauth:
               - 'backend/onyx/server/features/mcp/**'
               - 'backend/tests/integration/mock_services/mcp_test_server/**'
@@ -334,27 +337,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        with:
-          bun-version: "1.3.13"
-
-      - name: Install node dependencies
-        working-directory: ./web
-        run: bun install --frozen-lockfile
-
-      - name: Cache playwright cache
-        # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-bun-
-
-      - name: Install playwright browsers
-        working-directory: ./web
-        run: bunx playwright install chromium
+      - name: Setup Playwright (web)
+        uses: ./.github/actions/setup-playwright-web
 
       - name: Setup test license
         uses: ./.github/actions/setup-test-license
@@ -434,21 +418,11 @@ jobs:
         run: |
           bunx playwright test --project ${PROJECT}
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - name: Upload Playwright results
         if: always()
+        uses: ./.github/actions/upload-playwright-results
         with:
-          # Includes test results and trace.zip files
-          name: playwright-test-results-${{ matrix.project }}-${{ github.run_id }}
-          path: ./web/output/playwright/
-          retention-days: 30
-
-      - name: Upload screenshots
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
-        with:
-          name: playwright-screenshots-${{ matrix.project }}-${{ github.run_id }}
-          path: ./web/output/screenshots/
-          retention-days: 30
+          label: ${{ matrix.project }}
 
       # --- Visual Regression Diff ---
       - name: Configure AWS credentials
@@ -567,24 +541,20 @@ jobs:
             echo "No screenshots to upload for ${PROJECT} — skipping baseline update."
           fi
 
-      # save before stopping the containers so the logs can be captured
+      # save before stopping the containers so the logs can be captured. pass the
+      # same -f overrides as `up` so services defined only in the override files
+      # (mock MCP/IdP) are captured.
       - name: Save Docker logs
         if: success() || failure()
-        env:
-          WORKSPACE: ${{ github.workspace }}
-        run: |
-          cd deployment/docker_compose
-          # Pass the same -f overrides as `up` so the mock MCP/IdP services
-          # (defined only in the override files) are included in the logs.
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mcp-oauth-test.yml -f docker-compose.mcp-api-key-test.yml -f docker-compose.mcp-per-user-key-test.yml logs > docker-compose.log
-          mv docker-compose.log ${WORKSPACE}/docker-compose.log
-
-      - name: Upload logs
-        if: success() || failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: ./.github/actions/save-docker-logs
         with:
-          name: docker-logs-${{ matrix.project }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/docker-compose.log
+          label: ${{ matrix.project }}
+          compose-files: >-
+            -f docker-compose.yml
+            -f docker-compose.dev.yml
+            -f docker-compose.mcp-oauth-test.yml
+            -f docker-compose.mcp-api-key-test.yml
+            -f docker-compose.mcp-per-user-key-test.yml
 
   # Validates the MCP OAuth spec against the REAL Okta org (the mock IdP run in
   # playwright-tests is a deterministic stand-in). Runs only when OAuth-relevant
@@ -621,27 +591,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        with:
-          bun-version: "1.3.13"
-
-      - name: Install node dependencies
-        working-directory: ./web
-        run: bun install --frozen-lockfile
-
-      - name: Cache playwright cache
-        # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-bun-
-
-      - name: Install playwright browsers
-        working-directory: ./web
-        run: bunx playwright install chromium
+      - name: Setup Playwright (web)
+        uses: ./.github/actions/setup-playwright-web
 
       - name: Setup test license
         uses: ./.github/actions/setup-test-license
@@ -724,36 +675,23 @@ jobs:
         working-directory: ./web
         run: bunx playwright test mcp_oauth_flow --project admin
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - name: Upload Playwright results
         if: always()
+        uses: ./.github/actions/upload-playwright-results
         with:
-          name: playwright-test-results-oauth-okta-${{ github.run_id }}
-          path: ./web/output/playwright/
-          retention-days: 30
-
-      - name: Upload screenshots
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        if: always()
-        with:
-          name: playwright-screenshots-oauth-okta-${{ github.run_id }}
-          path: ./web/output/screenshots/
-          retention-days: 30
+          label: oauth-okta
 
       - name: Save Docker logs
         if: success() || failure()
-        env:
-          WORKSPACE: ${{ github.workspace }}
-        run: |
-          cd deployment/docker_compose
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.mcp-oauth-test.yml -f docker-compose.mcp-api-key-test.yml -f docker-compose.mcp-per-user-key-test.yml logs > docker-compose.log
-          mv docker-compose.log ${WORKSPACE}/docker-compose.log
-
-      - name: Upload logs
-        if: success() || failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: ./.github/actions/save-docker-logs
         with:
-          name: docker-logs-oauth-okta-${{ github.run_id }}
-          path: ${{ github.workspace }}/docker-compose.log
+          label: oauth-okta
+          compose-files: >-
+            -f docker-compose.yml
+            -f docker-compose.dev.yml
+            -f docker-compose.mcp-oauth-test.yml
+            -f docker-compose.mcp-api-key-test.yml
+            -f docker-compose.mcp-per-user-key-test.yml
 
   playwright-tests-lite:
     needs: [build-web-image, build-backend-image]
@@ -775,27 +713,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2 # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        with:
-          bun-version: "1.3.13"
-
-      - name: Install node dependencies
-        working-directory: ./web
-        run: bun install --frozen-lockfile
-
-      - name: Cache playwright cache
-        # zizmor: ignore[cache-poisoning] ephemeral runners; no release artifacts
-        uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-bun-${{ hashFiles('web/bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-bun-
-
-      - name: Install playwright browsers
-        working-directory: ./web
-        run: bunx playwright install chromium
+      - name: Setup Playwright (web)
+        uses: ./.github/actions/setup-playwright-web
 
       - name: Setup test license
         uses: ./.github/actions/setup-test-license
@@ -840,28 +759,18 @@ jobs:
         working-directory: ./web
         run: bunx playwright test --project lite
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      - name: Upload Playwright results
         if: always()
+        uses: ./.github/actions/upload-playwright-results
         with:
-          name: playwright-test-results-lite-${{ github.run_id }}
-          path: ./web/output/playwright/
-          retention-days: 30
+          label: lite
+          upload-screenshots: "false"
 
       - name: Save Docker logs
         if: success() || failure()
-        env:
-          WORKSPACE: ${{ github.workspace }}
-        run: |
-          cd deployment/docker_compose
-          docker compose logs > docker-compose.log
-          mv docker-compose.log ${WORKSPACE}/docker-compose.log
-
-      - name: Upload logs
-        if: success() || failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: ./.github/actions/save-docker-logs
         with:
-          name: docker-logs-lite-${{ github.run_id }}
-          path: ${{ github.workspace }}/docker-compose.log
+          label: lite
 
   # Post a single combined visual regression comment after all matrix jobs finish
   visual-regression-comment:


### PR DESCRIPTION
## Description

The three Playwright jobs in `pr-playwright-tests.yml` (`playwright-tests`, `playwright-tests-oauth-okta`, `playwright-tests-lite`) had grown 3–4 near-identical copies of the same client setup and artifact/log teardown. This extracts the duplicated bits into composite actions under `.github/actions/`:

- **`setup-playwright-web`** — bun + `bun install` + Playwright browser cache + `playwright install chromium`. Byte-for-byte identical across all three jobs; collapses 4 steps → 1 `uses`.
- **`upload-playwright-results`** — uploads the Playwright output (results + traces) and, via an `upload-screenshots` toggle, the screenshots dir (lite produces none).
- **`save-docker-logs`** — dumps `docker compose logs` and uploads them, parameterized by a `compose-files` input so each job passes the same `-f` override set it started with.

**Deliberately left inline:** the stack bring-up (`.env` creation, `docker compose up --wait`, seed dev license). The compose-file set and env are load-bearing context for understanding what each suite actually runs against, so hiding them behind an action would hurt readability more than it helps. Only the "capture artifacts" boilerplate was extracted.

Net **−91 lines** in the workflow (40 insertions / 131 deletions). Each new action dir is added to the `playwright` paths-filter so edits to them retrigger the suite.

Notes:
- Inner steps of the composite actions carry their own `always()` / `success() || failure()` conditions — composite steps are otherwise skipped once the job is in a failed state, which would drop artifacts/logs exactly when they're most useful.
- Artifact names, retention, and the `-f` override sets are unchanged, so produced artifacts are identical to before.

## How Has This Been Tested?

- `actionlint` on the workflow — clean.
- `zizmor` (the repo's pinned security linter, which audits `action.yml` files too) on all three new actions + the workflow — "No findings to report."
- Confirmed the folded `compose-files` scalar resolves to the exact original single-line `-f docker-compose.yml -f docker-compose.dev.yml …` string.
- Full validation happens on this PR's own Playwright run.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted shared Playwright setup and teardown into composite GitHub Actions to remove duplication across three CI jobs. This simplifies the workflow, keeps outputs consistent, and still uploads results/logs on failures.

- **Refactors**
  - Added `setup-playwright-web`, `upload-playwright-results`, and `save-docker-logs` composite actions under `.github/actions/`.
  - Replaced repeated steps in `pr-playwright-tests.yml` with `uses` calls; kept stack bring-up inline for clarity.
  - Preserved artifact names, retention, and `docker compose -f` sets; outputs and logs are unchanged.
  - Ensured uploads/logs run on failure via `always()` and `success() || failure()` within composite steps.
  - Net −91 lines in the workflow; added new action dirs to the `playwright` paths-filter.

<sup>Written for commit cf3923e3ef05f5cf0d5c6ce29375d92ba0530a83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

