### PR TITLE
chore: remove YAML validation section from CLAUDE.md

### DIFF
--- a/.devcontainer/claude-code/CLAUDE.md
+++ b/.devcontainer/claude-code/CLAUDE.md
@@ -33,12 +33,3 @@ In dev mode the frontend proxies `/api/*` straight to the backend (the dev-only 
 handler at `web/src/app/api/[...path]/route.ts`), so **`localhost:3000` serves both the UI and
 `/api`** — no reverse proxy needed. You can also hit the backend directly at `localhost:8080` (note:
 **no** `/api` prefix there — e.g. `/health`, `/auth/type`).
-
-## Validating YAML
-
-`pyyaml` is **not installed** here, so `python3 -c 'import yaml'` fails. To validate YAML, use the
-`check-yaml` pre-commit hook instead:
-
-```bash
-pre-commit run check-yaml --files path/to/file.yaml
-```


### PR DESCRIPTION
Removed YAML validation instructions from CLAUDE.md.

## Description

Now that we're caching the `.venv`, https://github.com/onyx-dot-app/onyx/commit/a2ffd01131b0fce9a83af85f67984b10d8a49b42, `pyyaml` is commonly installed in the devcontainer, so we can remove this.

I realized Claude wasn't just validating the yaml, but I think also uses `pyyaml` for parsing/working with yaml generally -- operations beyond just validating and I don't want to confuse it.

## How Has This Been Tested?

lgtm

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
