### PR TITLE
fix(craft): make sandbox pod + egress-proxy addressing telepresence-correct

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -43,7 +43,6 @@ import os
 import re
 import secrets
 import shlex
-import socket
 import tarfile
 import threading
 import time
@@ -154,21 +153,6 @@ _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-t
 
 _PROXY_DNS_RETRY_ATTEMPTS = 5
 _PROXY_DNS_RETRY_BACKOFF_S = 0.5
-
-
-def _resolve_proxy_ip() -> str:
-    last_err: OSError | None = None
-    for attempt in range(_PROXY_DNS_RETRY_ATTEMPTS):
-        try:
-            return socket.gethostbyname(SANDBOX_PROXY_HOST)
-        except OSError as e:
-            last_err = e
-            if attempt < _PROXY_DNS_RETRY_ATTEMPTS - 1:
-                time.sleep(_PROXY_DNS_RETRY_BACKOFF_S * (2**attempt))
-    raise RuntimeError(
-        f"failed to resolve SANDBOX_PROXY_HOST={SANDBOX_PROXY_HOST!r} "
-        f"after {_PROXY_DNS_RETRY_ATTEMPTS} attempts: {last_err}"
-    )
 
 
 # Loopback only: the firewall permits nothing else to bypass the proxy, and the
@@ -767,7 +751,7 @@ class KubernetesSandboxManager(SandboxManager):
         # kubelet injects hostAliases into every container's /etc/hosts;
         # initContainer mutations don't propagate, so we set it here.
         host_aliases = [
-            client.V1HostAlias(ip=_resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
+            client.V1HostAlias(ip=self._resolve_proxy_ip(), hostnames=[_PROXY_ALIAS])
         ]
 
         pod_spec = client.V1PodSpec(
@@ -841,12 +825,16 @@ class KubernetesSandboxManager(SandboxManager):
 
         service_name = self._get_service_name(sandbox_id_str)
 
-        # Build port list: opencode-serve + all session Next.js ports
         ports = [
             client.V1ServicePort(
                 name="opencode",
                 port=OPENCODE_SERVE_PORT,
                 target_port=OPENCODE_SERVE_PORT,
+            ),
+            client.V1ServicePort(
+                name="push-daemon",
+                port=PUSH_DAEMON_PORT,
+                target_port=PUSH_DAEMON_PORT,
             ),
         ]
 
@@ -1762,13 +1750,7 @@ echo "Session cleanup complete"
 
         Returns None if there are no outputs to snapshot.
         """
-        pod_name = self._get_pod_name(str(sandbox_id))
         snapshot_id = uuid4()
-
-        try:
-            pod_ip = self._get_pod_ip(pod_name)
-        except (FatalWriteError, RetriableWriteError) as e:
-            raise RuntimeError(f"Failed to create snapshot: {e}") from e
 
         body = (
             SnapshotCreateRequest(
@@ -1783,7 +1765,7 @@ echo "Session cleanup complete"
 
         try:
             resp = self._post_to_sidecar(
-                pod_ip, "/snapshot/create", body, timeout=300.0
+                sandbox_id, "/snapshot/create", body, timeout=300.0
             )
         except httpx.TransportError as e:
             raise RuntimeError(f"Snapshot create request failed: {e}") from e
@@ -1939,11 +1921,6 @@ echo "Session cleanup complete"
         session_path = f"/workspace/sessions/{session_id}"
         safe_session_path = shlex.quote(session_path)
 
-        try:
-            pod_ip = self._get_pod_ip(pod_name)
-        except (FatalWriteError, RetriableWriteError) as e:
-            raise RuntimeError(f"Failed to restore snapshot: {e}") from e
-
         body = (
             SnapshotRestoreRequest(
                 session_id=session_id,
@@ -1957,7 +1934,7 @@ echo "Session cleanup complete"
 
         try:
             resp = self._post_to_sidecar(
-                pod_ip, "/snapshot/restore", body, timeout=300.0
+                sandbox_id, "/snapshot/restore", body, timeout=300.0
             )
         except httpx.TransportError as e:
             raise RuntimeError(f"Snapshot restore request failed: {e}") from e
@@ -2050,20 +2027,16 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         logger.info("Session configuration files regenerated")
 
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
-        """Check if the sidecar's /health endpoint responds."""
-        pod_name = self._get_pod_name(str(sandbox_id))
-        try:
-            pod_ip = self._get_pod_ip(pod_name)
-        except (FatalWriteError, RetriableWriteError):
-            return False
-
-        url = f"http://{pod_ip}:{PUSH_DAEMON_PORT}/health"
-        try:
-            with httpx.Client(timeout=timeout) as http_client:
-                resp = http_client.get(url)
-            return resp.status_code == 200
-        except httpx.TransportError:
-            return False
+        """Check the sidecar's /health, trying each ``_sandbox_pod_hosts``."""
+        for host in self._sandbox_pod_hosts(sandbox_id):
+            url = f"http://{host}:{PUSH_DAEMON_PORT}/health"
+            try:
+                with httpx.Client(timeout=timeout) as http_client:
+                    if http_client.get(url).status_code == 200:
+                        return True
+            except httpx.TransportError:
+                continue
+        return False
 
     def _load_serve_connection_info(
         self, sandbox_id: UUID
@@ -2759,6 +2732,35 @@ fi
             logger.warning("Failed to get upload stats: %s", e)
             return 0, 0
 
+    def _resolve_proxy_ip(self) -> str:
+        """Resolve SANDBOX_PROXY_HOST to a pod-routable IP for the egress
+        hostAlias. Reads the Service ClusterIP from the k8s API, not the
+        api-server's OS resolver, so it stays correct under telepresence (whose
+        resolver returns a synthetic, pod-unroutable IP). A numeric host (CI
+        passes the ClusterIP directly) is returned unchanged."""
+        host = SANDBOX_PROXY_HOST
+        if re.match(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", host):
+            return host
+        name, _, rest = host.partition(".")
+        namespace = rest.partition(".")[0] or self._namespace
+        last_err: Exception | None = None
+        for attempt in range(_PROXY_DNS_RETRY_ATTEMPTS):
+            try:
+                cluster_ip = self._core_api.read_namespaced_service(
+                    name=name, namespace=namespace
+                ).spec.cluster_ip
+                if cluster_ip and cluster_ip != "None":
+                    return cluster_ip
+                last_err = RuntimeError(f"Service {name} has no ClusterIP")
+            except ApiException as e:
+                last_err = e
+            if attempt < _PROXY_DNS_RETRY_ATTEMPTS - 1:
+                time.sleep(_PROXY_DNS_RETRY_BACKOFF_S * (2**attempt))
+        raise RuntimeError(
+            f"failed to resolve proxy ClusterIP for SANDBOX_PROXY_HOST={host!r} "
+            f"after {_PROXY_DNS_RETRY_ATTEMPTS} attempts: {last_err}"
+        )
+
     def _get_pod_ip(self, pod_name: str) -> str:
         """Read pod IP. Raises FatalWriteError on 404, RetriableWriteError otherwise."""
         try:
@@ -2776,23 +2778,40 @@ fi
             raise RetriableWriteError(f"Pod {pod_name} has no IP yet")
         return pod_ip
 
+    def _sandbox_pod_hosts(self, sandbox_id: UUID) -> list[str]:
+        """Hosts to reach the pod sidecar, in preference order: Service FQDN
+        (routes in prod + telepresence), then raw pod IP (out-of-cluster CI,
+        which routes pod IPs but has no cluster DNS)."""
+        service_name = self._get_service_name(str(sandbox_id))
+        hosts = [f"{service_name}.{self._namespace}.svc.cluster.local"]
+        try:
+            hosts.append(self._get_pod_ip(self._get_pod_name(str(sandbox_id))))
+        except (FatalWriteError, RetriableWriteError):
+            pass
+        return hosts
+
     def _post_to_sidecar(
-        self, pod_ip: str, endpoint_path: str, body: bytes, timeout: float = 30.0
+        self, sandbox_id: UUID, endpoint_path: str, body: bytes, timeout: float = 30.0
     ) -> httpx.Response:
-        """POST a signed JSON request to a sidecar endpoint."""
+        """POST a signed JSON request to the sidecar, trying each
+        ``_sandbox_pod_hosts`` until one connects; re-raises the last transport
+        error if none do."""
         sha256_hex = hashlib.sha256(body).hexdigest()
         sig_b64, ts = _sign_sidecar_request(endpoint_path, sha256_hex)
-        url = f"http://{pod_ip}:{PUSH_DAEMON_PORT}{endpoint_path}"
-        with httpx.Client(timeout=timeout) as http_client:
-            return http_client.post(
-                url,
-                content=body,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Push-Signature": sig_b64,
-                    "X-Push-Timestamp": ts,
-                },
-            )
+        headers = {
+            "Content-Type": "application/json",
+            "X-Push-Signature": sig_b64,
+            "X-Push-Timestamp": ts,
+        }
+        last_exc: httpx.TransportError | None = None
+        for host in self._sandbox_pod_hosts(sandbox_id):
+            url = f"http://{host}:{PUSH_DAEMON_PORT}{endpoint_path}"
+            try:
+                with httpx.Client(timeout=timeout) as http_client:
+                    return http_client.post(url, content=body, headers=headers)
+            except httpx.TransportError as e:
+                last_exc = e
+        raise last_exc or httpx.ConnectError("no sandbox pod host reachable")
 
     def write_files_to_sandbox(
         self,
@@ -2801,33 +2820,37 @@ fi
         mount_path: str,
         files: FileSet,
     ) -> None:
-        """Build tar.gz, POST to in-pod daemon."""
+        """Build tar.gz, POST to the in-pod daemon, trying each
+        ``_sandbox_pod_hosts`` until one connects."""
         pod_name = self._get_pod_name(sandbox_id)
-        pod_ip = self._get_pod_ip(pod_name)
-
         tar_bytes, sha256_hex = _build_targz(files)
         sig_b64, ts = _sign_sidecar_request(mount_path, sha256_hex)
+        headers = {
+            "Content-Type": "application/gzip",
+            "X-Bundle-Sha256": sha256_hex,
+            "X-Push-Signature": sig_b64,
+            "X-Push-Timestamp": ts,
+        }
 
-        url = f"http://{pod_ip}:{PUSH_DAEMON_PORT}/push"
-        try:
-            with httpx.Client(timeout=30.0) as http_client:
-                resp = http_client.post(
-                    url,
-                    params={"mount_path": mount_path},
-                    content=tar_bytes,
-                    headers={
-                        "Content-Type": "application/gzip",
-                        "X-Bundle-Sha256": sha256_hex,
-                        "X-Push-Signature": sig_b64,
-                        "X-Push-Timestamp": ts,
-                    },
-                )
-        except httpx.TransportError as e:
-            raise RetriableWriteError(f"Push to {pod_name} failed: {e}") from e
-
-        if resp.status_code == 200:
-            return
-        err = f"{pod_name}: {resp.status_code} {resp.text}"
-        if resp.status_code >= 500:
-            raise RetriableWriteError(err)
-        raise FatalWriteError(err)
+        last_exc: httpx.TransportError | None = None
+        for host in self._sandbox_pod_hosts(sandbox_id):
+            url = f"http://{host}:{PUSH_DAEMON_PORT}/push"
+            try:
+                with httpx.Client(timeout=30.0) as http_client:
+                    resp = http_client.post(
+                        url,
+                        params={"mount_path": mount_path},
+                        content=tar_bytes,
+                        headers=headers,
+                    )
+            except httpx.TransportError as e:
+                last_exc = e
+                continue
+            # Reached the daemon; map status, don't try other hosts.
+            if resp.status_code == 200:
+                return
+            err = f"{pod_name}: {resp.status_code} {resp.text}"
+            if resp.status_code >= 500:
+                raise RetriableWriteError(err)
+            raise FatalWriteError(err)
+        raise RetriableWriteError(f"Push to {pod_name} failed: {last_exc}")

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -37,6 +37,7 @@ import base64
 import binascii
 import hashlib
 import io
+import ipaddress
 import json
 import mimetypes
 import os
@@ -2740,14 +2741,18 @@ fi
         resolver returns a synthetic, pod-unroutable IP). A numeric host (CI
         passes the ClusterIP directly) is returned unchanged."""
         host = SANDBOX_PROXY_HOST
-        if re.match(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", host):
+        try:
+            ipaddress.ip_address(host)
             return host
-        name = host.partition(".")[0]
+        except ValueError:
+            pass
+        name, _, rest = host.partition(".")
+        namespace = rest.partition(".")[0] or SANDBOX_PROXY_NAMESPACE
         last_err: Exception | None = None
         for attempt in range(_PROXY_RESOLVE_RETRY_ATTEMPTS):
             try:
                 cluster_ip = self._core_api.read_namespaced_service(
-                    name=name, namespace=SANDBOX_PROXY_NAMESPACE
+                    name=name, namespace=namespace
                 ).spec.cluster_ip
                 if cluster_ip and cluster_ip != "None":
                     return cluster_ip

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -75,6 +75,7 @@ from onyx.server.features.build.configs import SANDBOX_POD_MEMORY_LIMIT
 from onyx.server.features.build.configs import SANDBOX_POD_MEMORY_REQUEST
 from onyx.server.features.build.configs import SANDBOX_PROXY_CA_CONFIGMAP
 from onyx.server.features.build.configs import SANDBOX_PROXY_HOST
+from onyx.server.features.build.configs import SANDBOX_PROXY_NAMESPACE
 from onyx.server.features.build.configs import SANDBOX_PROXY_PORT
 from onyx.server.features.build.configs import SANDBOX_S3_BUCKET
 from onyx.server.features.build.configs import SANDBOX_SERVICE_ACCOUNT_NAME
@@ -151,8 +152,8 @@ _PROXY_ALIAS = "sandbox-proxy"
 _OPENCODE_SESSION_TAG_PLUGIN_PATH = "/workspace/opencode-plugins/session-proxy-tag.ts"
 
 
-_PROXY_DNS_RETRY_ATTEMPTS = 5
-_PROXY_DNS_RETRY_BACKOFF_S = 0.5
+_PROXY_RESOLVE_RETRY_ATTEMPTS = 5
+_PROXY_RESOLVE_RETRY_BACKOFF_S = 0.5
 
 
 # Loopback only: the firewall permits nothing else to bypass the proxy, and the
@@ -2027,7 +2028,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         logger.info("Session configuration files regenerated")
 
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
-        """Check the sidecar's /health, trying each ``_sandbox_pod_hosts``."""
+        """Check whether the sidecar's /health endpoint responds."""
         for host in self._sandbox_pod_hosts(sandbox_id):
             url = f"http://{host}:{PUSH_DAEMON_PORT}/health"
             try:
@@ -2053,9 +2054,9 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         )
 
     def _serve_health_check_base_url(self, sandbox_id: UUID) -> str | None:
-        """Probe the pod IP, not the Service FQDN ``base_url`` — an
-        out-of-cluster caller (CI test process) can't resolve cluster DNS.
-        ``None`` falls back to ``base_url`` until the IP is assigned."""
+        """Pod-IP fallback probe candidate for the readiness wait: out-of-cluster
+        CI routes pod IPs but can't resolve the Service FQDN. ``None`` until the
+        pod IP is assigned."""
         pod_name = self._get_pod_name(str(sandbox_id))
         try:
             pod_ip = self._get_pod_ip(pod_name)
@@ -2741,24 +2742,23 @@ fi
         host = SANDBOX_PROXY_HOST
         if re.match(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$", host):
             return host
-        name, _, rest = host.partition(".")
-        namespace = rest.partition(".")[0] or self._namespace
+        name = host.partition(".")[0]
         last_err: Exception | None = None
-        for attempt in range(_PROXY_DNS_RETRY_ATTEMPTS):
+        for attempt in range(_PROXY_RESOLVE_RETRY_ATTEMPTS):
             try:
                 cluster_ip = self._core_api.read_namespaced_service(
-                    name=name, namespace=namespace
+                    name=name, namespace=SANDBOX_PROXY_NAMESPACE
                 ).spec.cluster_ip
                 if cluster_ip and cluster_ip != "None":
                     return cluster_ip
                 last_err = RuntimeError(f"Service {name} has no ClusterIP")
             except ApiException as e:
                 last_err = e
-            if attempt < _PROXY_DNS_RETRY_ATTEMPTS - 1:
-                time.sleep(_PROXY_DNS_RETRY_BACKOFF_S * (2**attempt))
+            if attempt < _PROXY_RESOLVE_RETRY_ATTEMPTS - 1:
+                time.sleep(_PROXY_RESOLVE_RETRY_BACKOFF_S * (2**attempt))
         raise RuntimeError(
             f"failed to resolve proxy ClusterIP for SANDBOX_PROXY_HOST={host!r} "
-            f"after {_PROXY_DNS_RETRY_ATTEMPTS} attempts: {last_err}"
+            f"after {_PROXY_RESOLVE_RETRY_ATTEMPTS} attempts: {last_err}"
         )
 
     def _get_pod_ip(self, pod_name: str) -> str:
@@ -2793,9 +2793,7 @@ fi
     def _post_to_sidecar(
         self, sandbox_id: UUID, endpoint_path: str, body: bytes, timeout: float = 30.0
     ) -> httpx.Response:
-        """POST a signed JSON request to the sidecar, trying each
-        ``_sandbox_pod_hosts`` until one connects; re-raises the last transport
-        error if none do."""
+        """POST a signed JSON request to the sidecar."""
         sha256_hex = hashlib.sha256(body).hexdigest()
         sig_b64, ts = _sign_sidecar_request(endpoint_path, sha256_hex)
         headers = {
@@ -2820,8 +2818,7 @@ fi
         mount_path: str,
         files: FileSet,
     ) -> None:
-        """Build tar.gz, POST to the in-pod daemon, trying each
-        ``_sandbox_pod_hosts`` until one connects."""
+        """Build tar.gz, POST to the in-pod daemon."""
         pod_name = self._get_pod_name(sandbox_id)
         tar_bytes, sha256_hex = _build_targz(files)
         sig_b64, ts = _sign_sidecar_request(mount_path, sha256_hex)

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -252,58 +252,73 @@ class _ServeMixin:
         sandbox_id: UUID,
         timeout: float = OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
     ) -> bool:
-        """Block until opencode-serve answers ``GET /doc`` with 200. Backend
-        Ready only proves the supervisor is up; opencode binds :4096 a few
-        seconds later.
+        """Block until opencode-serve answers ``GET /doc`` with 200 (opencode
+        binds :4096 a few seconds after the pod is Ready). Probes the Service
+        ``base_url`` first, then the pod-IP health-check URL; succeeds as soon
+        as either answers.
 
         On a 401 the cached password is stale (pod re-provisioned with a fresh
-        Secret); drop the cache, reload, and rebuild the probe client once.
-        Provision-time counterpart to the per-request heal in ``_request`` /
+        Secret); reload it and rebuild the probe clients once. Provision-time
+        counterpart to the per-request heal in ``_request`` /
         ``PodEventBus._refresh_auth_on_401``, which run only after readiness."""
         info = self._serve_connection_info(sandbox_id)
-        probe_base_url = self._serve_health_check_base_url(sandbox_id) or info.base_url
-        # One client across all polls — saves connect-setup churn while the
-        # server is actively refusing connections.
-        client = OpencodeServeClient(
-            base_url=probe_base_url, password=info.password, event_bus=None
-        )
+
+        def _build_clients(
+            conn: ServeConnectionInfo,
+        ) -> list[tuple[str, OpencodeServeClient]]:
+            urls: list[str] = []
+            for url in (conn.base_url, self._serve_health_check_base_url(sandbox_id)):
+                if url is not None and url not in urls:
+                    urls.append(url)
+            return [
+                (
+                    url,
+                    OpencodeServeClient(
+                        base_url=url, password=conn.password, event_bus=None
+                    ),
+                )
+                for url in urls
+            ]
+
+        clients = _build_clients(info)
         password_reset_done = False
         try:
             deadline = time.time() + timeout
             last_err = "no probe completed"
             while time.time() < deadline:
-                try:
-                    status = client.health_check_status()
-                    if status == 200:
-                        logger.info(
-                            "[SANDBOX-SERVE] opencode-serve ready for sandbox %s",
-                            sandbox_id,
-                        )
-                        return True
-                    if status == 401 and not password_reset_done:
-                        password_reset_done = True
-                        refreshed = self._reload_serve_connection_info(sandbox_id)
-                        if refreshed.password != info.password:
-                            logger.warning(
-                                "[SANDBOX-SERVE] opencode-serve returned 401 for "
-                                "sandbox %s; reloaded password and retrying probe "
-                                "with the current credentials",
+                for url, client in clients:
+                    try:
+                        status = client.health_check_status()
+                        if status == 200:
+                            logger.info(
+                                "[SANDBOX-SERVE] opencode-serve ready for sandbox %s "
+                                "via %s",
                                 sandbox_id,
+                                url,
                             )
-                            info = refreshed
-                            client.close()
-                            client = OpencodeServeClient(
-                                base_url=probe_base_url,
-                                password=info.password,
-                                event_bus=None,
-                            )
-                            continue
-                    last_err = f"health_check returned status={status}"
-                except Exception as e:
-                    last_err = f"{type(e).__name__}: {e}"
+                            return True
+                        if status == 401 and not password_reset_done:
+                            password_reset_done = True
+                            refreshed = self._reload_serve_connection_info(sandbox_id)
+                            if refreshed.password != info.password:
+                                logger.warning(
+                                    "[SANDBOX-SERVE] opencode-serve returned 401 for "
+                                    "sandbox %s; reloaded password and retrying probe "
+                                    "with the current credentials",
+                                    sandbox_id,
+                                )
+                                info = refreshed
+                                for _, c in clients:
+                                    c.close()
+                                clients = _build_clients(info)
+                                break
+                        last_err = f"health_check returned status={status} for {url}"
+                    except Exception as e:
+                        last_err = f"{url}: {type(e).__name__}: {e}"
                 time.sleep(OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS)
         finally:
-            client.close()
+            for _, client in clients:
+                client.close()
         logger.error(
             "[SANDBOX-SERVE] opencode-serve never became ready for sandbox %s "
             "after %.0fs (last error: %s)",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -22,7 +22,6 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization import PrivateFormat
-from kubernetes.client.rest import ApiException
 
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     _build_targz,
@@ -72,24 +71,20 @@ def _push_private_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ksm, "_push_public_key_b64", None, raising=False)
 
 
-def _make_manager(
-    *, pod_ip: str | None = "10.0.0.1", read_pod_exc: Exception | None = None
-) -> KubernetesSandboxManager:
+def _make_manager() -> KubernetesSandboxManager:
     """Construct a manager without invoking _initialize (which needs a K8s config).
 
-    The only attributes write_files_to_sandbox touches are ``_core_api`` and
-    ``_namespace``. Bypass ``__new__`` cache with object.__new__ so each test
-    gets a fresh instance (singleton would otherwise leak between tests).
+    ``write_files_to_sandbox`` resolves hosts via ``_sandbox_pod_hosts`` (the
+    Service FQDN plus the pod IP read from ``read_namespaced_pod``), then POSTs
+    over the mocked ``httpx.Client``. Bypass ``__new__`` cache with
+    object.__new__ so each test gets a fresh instance.
     """
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
 
     core_api = MagicMock()
-    if read_pod_exc is not None:
-        core_api.read_namespaced_pod.side_effect = read_pod_exc
-    else:
-        pod_obj = MagicMock()
-        pod_obj.status.pod_ip = pod_ip
-        core_api.read_namespaced_pod.return_value = pod_obj
+    pod_obj = MagicMock()
+    pod_obj.status.pod_ip = "10.0.0.1"
+    core_api.read_namespaced_pod.return_value = pod_obj
 
     mgr._core_api = core_api  # type: ignore[attr-defined]
     mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
@@ -130,46 +125,6 @@ def _sandbox_id() -> UUID:
 
 def _files() -> FileSet:
     return {"my-skill/SKILL.md": b"# hello\n"}
-
-
-# ---------------------------------------------------------------------------
-# Pod-read failure modes
-# ---------------------------------------------------------------------------
-
-
-def test_pod_404_raises_fatal_write_error() -> None:
-    mgr = _make_manager(read_pod_exc=ApiException(status=404, reason="Not Found"))
-    with pytest.raises(FatalWriteError, match="not found"):
-        mgr.write_files_to_sandbox(
-            sandbox_id=_sandbox_id(),
-            mount_path="/workspace/managed/skills",
-            files=_files(),
-        )
-
-
-def test_pod_has_no_ip_yet_raises_retriable() -> None:
-    mgr = _make_manager(pod_ip=None)
-    with pytest.raises(RetriableWriteError, match="no IP"):
-        mgr.write_files_to_sandbox(
-            sandbox_id=_sandbox_id(),
-            mount_path="/workspace/managed/skills",
-            files=_files(),
-        )
-
-
-def test_pod_non_404_api_error_raises_retriable() -> None:
-    """500 from the K8s API is transient -> retriable.
-
-    Follows the same contract; kept under the same file because it shares
-    the read-pod seam.
-    """
-    mgr = _make_manager(read_pod_exc=ApiException(status=500, reason="Server Error"))
-    with pytest.raises(RetriableWriteError, match="Failed to read pod"):
-        mgr.write_files_to_sandbox(
-            sandbox_id=_sandbox_id(),
-            mount_path="/workspace/managed/skills",
-            files=_files(),
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -10,6 +10,7 @@ tar byte equality), not call lists.
 from __future__ import annotations
 
 import base64
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -22,6 +23,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.hazmat.primitives.serialization import NoEncryption
 from cryptography.hazmat.primitives.serialization import PrivateFormat
+from kubernetes.client.rest import ApiException
 
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     _build_targz,
@@ -71,20 +73,23 @@ def _push_private_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ksm, "_push_public_key_b64", None, raising=False)
 
 
-def _make_manager() -> KubernetesSandboxManager:
+def _make_manager(*, pod_read_exc: Exception | None = None) -> KubernetesSandboxManager:
     """Construct a manager without invoking _initialize (which needs a K8s config).
 
     ``write_files_to_sandbox`` resolves hosts via ``_sandbox_pod_hosts`` (the
     Service FQDN plus the pod IP read from ``read_namespaced_pod``), then POSTs
-    over the mocked ``httpx.Client``. Bypass ``__new__`` cache with
-    object.__new__ so each test gets a fresh instance.
+    over the mocked ``httpx.Client``. Pass ``pod_read_exc`` to simulate a
+    gone/unreadable pod. Bypass ``__new__`` cache with object.__new__.
     """
     mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
 
     core_api = MagicMock()
-    pod_obj = MagicMock()
-    pod_obj.status.pod_ip = "10.0.0.1"
-    core_api.read_namespaced_pod.return_value = pod_obj
+    if pod_read_exc is not None:
+        core_api.read_namespaced_pod.side_effect = pod_read_exc
+    else:
+        pod_obj = MagicMock()
+        pod_obj.status.pod_ip = "10.0.0.1"
+        core_api.read_namespaced_pod.return_value = pod_obj
 
     mgr._core_api = core_api  # type: ignore[attr-defined]
     mgr._namespace = "sandbox-test"  # type: ignore[attr-defined]
@@ -117,6 +122,24 @@ def _mock_httpx_client(
 
     factory = MagicMock(return_value=ctx)
     return factory
+
+
+def _mock_httpx_per_url(handler: Callable[[str], MagicMock]) -> MagicMock:
+    """httpx.Client factory whose ``.post`` dispatches on the request URL, so a
+    test can make one host transport-fail while another responds."""
+    client_instance = MagicMock()
+    client_instance.post.side_effect = lambda url, **_: handler(url)
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=client_instance)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
+def _resp(status: int, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    resp.text = text
+    return resp
 
 
 def _sandbox_id() -> UUID:
@@ -290,3 +313,74 @@ def test_tar_build_is_byte_for_byte_deterministic() -> None:
 
     assert raw1 == raw2
     assert sha1 == sha2
+
+
+# ---------------------------------------------------------------------------
+# Multi-host fallback: Service FQDN first, raw pod IP second
+# ---------------------------------------------------------------------------
+
+
+def _fqdn_unreachable_then(
+    pod_ip_resp: Callable[[], MagicMock],
+) -> Callable[[str], MagicMock]:
+    def handler(url: str) -> MagicMock:
+        if "10.0.0.1" in url:
+            return pod_ip_resp()
+        raise httpx.ConnectError("FQDN unreachable")
+
+    return handler
+
+
+def test_push_falls_back_to_pod_ip_when_fqdn_unreachable() -> None:
+    mgr = _make_manager()
+    factory = _mock_httpx_per_url(_fqdn_unreachable_then(lambda: _resp(200, "ok")))
+    with patch(_HTTPX_CLIENT_PATH, factory):
+        # No exception == the push succeeded via the pod-IP fallback host.
+        mgr.write_files_to_sandbox(
+            sandbox_id=_sandbox_id(),
+            mount_path="/workspace/managed/skills",
+            files=_files(),
+        )
+
+
+def test_push_maps_http_status_on_fallback_host() -> None:
+    """A 4xx from the fallback host is mapped (fatal), not retried onward."""
+    mgr = _make_manager()
+    factory = _mock_httpx_per_url(_fqdn_unreachable_then(lambda: _resp(400, "bad")))
+    with patch(_HTTPX_CLIENT_PATH, factory):
+        with pytest.raises(FatalWriteError, match="400"):
+            mgr.write_files_to_sandbox(
+                sandbox_id=_sandbox_id(),
+                mount_path="/workspace/managed/skills",
+                files=_files(),
+            )
+
+
+def test_post_to_sidecar_falls_back_to_pod_ip() -> None:
+    mgr = _make_manager()
+    factory = _mock_httpx_per_url(_fqdn_unreachable_then(lambda: _resp(200)))
+    with patch(_HTTPX_CLIENT_PATH, factory):
+        resp = mgr._post_to_sidecar(
+            _sandbox_id(), "/snapshot/create", b"{}", timeout=5.0
+        )
+    assert resp.status_code == 200
+
+
+def test_post_to_sidecar_reraises_when_all_hosts_fail() -> None:
+    mgr = _make_manager()
+
+    def handler(_url: str) -> MagicMock:
+        raise httpx.ConnectError("unreachable")
+
+    with patch(_HTTPX_CLIENT_PATH, _mock_httpx_per_url(handler)):
+        with pytest.raises(httpx.TransportError):
+            mgr._post_to_sidecar(_sandbox_id(), "/snapshot/create", b"{}", timeout=5.0)
+
+
+def test_sandbox_pod_hosts_degrades_to_fqdn_when_pod_unreadable() -> None:
+    """A gone/unreadable pod must not break host resolution — the Service FQDN
+    still routes; the pod-IP candidate is simply dropped."""
+    mgr = _make_manager(pod_read_exc=ApiException(status=404, reason="Not Found"))
+    hosts = mgr._sandbox_pod_hosts(_sandbox_id())
+    assert len(hosts) == 1
+    assert hosts[0].endswith(".sandbox-test.svc.cluster.local")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -383,3 +383,15 @@ def test_sandbox_pod_hosts_degrades_to_fqdn_when_pod_unreadable() -> None:
     hosts = mgr._sandbox_pod_hosts(_sandbox_id())
     assert len(hosts) == 1
     assert hosts[0].endswith(".sandbox-test.svc.cluster.local")
+
+
+def test_push_pod_404_is_retriable() -> None:
+    mgr = _make_manager(pod_read_exc=ApiException(status=404, reason="Not Found"))
+    factory = _mock_httpx_client(raise_exc=httpx.ConnectError("no endpoints"))
+    with patch(_HTTPX_CLIENT_PATH, factory):
+        with pytest.raises(RetriableWriteError):
+            mgr.write_files_to_sandbox(
+                sandbox_id=_sandbox_id(),
+                mount_path="/workspace/managed/skills",
+                files=_files(),
+            )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -335,7 +335,6 @@ def test_push_falls_back_to_pod_ip_when_fqdn_unreachable() -> None:
     mgr = _make_manager()
     factory = _mock_httpx_per_url(_fqdn_unreachable_then(lambda: _resp(200, "ok")))
     with patch(_HTTPX_CLIENT_PATH, factory):
-        # No exception == the push succeeded via the pod-IP fallback host.
         mgr.write_files_to_sandbox(
             sandbox_id=_sandbox_id(),
             mount_path="/workspace/managed/skills",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -248,3 +248,15 @@ def test_ca_bundle_mounted_read_only_on_both_containers(pod: client.V1Pod) -> No
         mount = _mount(_container(pod, name), "sandbox-ca-bundle")
         assert mount.read_only is True
         assert mount.mount_path == "/etc/ssl/sandbox"
+
+
+def test_service_exposes_push_daemon_port() -> None:
+    """push/snapshot/health reach the pod via the Service FQDN, so the
+    push-daemon port must be exposed on the Service, not just the pod."""
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
+    svc = mgr._create_sandbox_service(  # type: ignore[attr-defined]
+        sandbox_id="abc12345-abcd-abcd-abcd-abcdef123456",
+        tenant_id="t-1",
+    )
+    assert PUSH_DAEMON_PORT in {p.port for p in svc.spec.ports}

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -50,7 +50,11 @@ def _push_key_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ksm, "_push_private_key", None, raising=False)
     monkeypatch.setattr(ksm, "_push_public_key_b64", None, raising=False)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "sandbox-proxy.onyx.svc")
-    monkeypatch.setattr(ksm, "_resolve_proxy_ip", lambda: _TEST_PROXY_IP)
+    monkeypatch.setattr(
+        ksm.KubernetesSandboxManager,
+        "_resolve_proxy_ip",
+        lambda _self: _TEST_PROXY_IP,
+    )
 
 
 def _build_pod() -> client.V1Pod:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from kubernetes.client.rest import ApiException
 
 import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
@@ -44,3 +45,49 @@ def test_fqdn_resolved_to_clusterip_via_api(monkeypatch: pytest.MonkeyPatch) -> 
     core_api.read_namespaced_service.assert_called_once_with(
         name="onyx-sandbox-proxy", namespace="onyx"
     )
+
+
+def test_namespace_comes_from_config_not_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxy lives in its own namespace; the config must win over whatever
+    # namespace segment the host string happens to embed.
+    monkeypatch.setattr(
+        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.WRONG.svc.cluster.local"
+    )
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_NAMESPACE", "proxy-ns")
+    mgr, core_api = _mgr()
+    svc = MagicMock()
+    svc.spec.cluster_ip = "10.0.0.5"
+    core_api.read_namespaced_service.return_value = svc
+
+    assert mgr._resolve_proxy_ip() == "10.0.0.5"
+    core_api.read_namespaced_service.assert_called_once_with(
+        name="onyx-sandbox-proxy", namespace="proxy-ns"
+    )
+
+
+def test_missing_clusterip_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.onyx.svc.cluster.local"
+    )
+    monkeypatch.setattr(ksm, "_PROXY_RESOLVE_RETRY_ATTEMPTS", 1)
+    mgr, core_api = _mgr()
+    svc = MagicMock()
+    svc.spec.cluster_ip = None
+    core_api.read_namespaced_service.return_value = svc
+
+    with pytest.raises(RuntimeError, match="ClusterIP"):
+        mgr._resolve_proxy_ip()
+
+
+def test_api_error_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.onyx.svc.cluster.local"
+    )
+    monkeypatch.setattr(ksm, "_PROXY_RESOLVE_RETRY_ATTEMPTS", 1)
+    mgr, core_api = _mgr()
+    core_api.read_namespaced_service.side_effect = ApiException(
+        status=500, reason="boom"
+    )
+
+    with pytest.raises(RuntimeError, match="failed to resolve proxy ClusterIP"):
+        mgr._resolve_proxy_ip()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
@@ -1,0 +1,46 @@
+"""``_resolve_proxy_ip`` must resolve the egress-proxy hostAlias to the real
+Service ClusterIP via the k8s API — not the api-server's OS resolver, which
+under telepresence returns a synthetic, pod-unroutable IP. A numeric host (CI
+passes the ClusterIP directly) is returned unchanged without an API call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+
+
+def _mgr() -> tuple[KubernetesSandboxManager, MagicMock]:
+    mgr: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    mgr._namespace = "onyx-sandboxes"  # type: ignore[attr-defined]
+    core_api = MagicMock()
+    mgr._core_api = core_api  # type: ignore[attr-defined]
+    return mgr, core_api
+
+
+def test_numeric_host_returned_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "10.96.188.108")
+    mgr, core_api = _mgr()
+    assert mgr._resolve_proxy_ip() == "10.96.188.108"
+    core_api.read_namespaced_service.assert_not_called()
+
+
+def test_fqdn_resolved_to_clusterip_via_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.onyx.svc.cluster.local"
+    )
+    mgr, core_api = _mgr()
+    svc = MagicMock()
+    svc.spec.cluster_ip = "10.96.188.108"
+    core_api.read_namespaced_service.return_value = svc
+
+    assert mgr._resolve_proxy_ip() == "10.96.188.108"
+    core_api.read_namespaced_service.assert_called_once_with(
+        name="onyx-sandbox-proxy", namespace="onyx"
+    )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_resolve_proxy_ip.py
@@ -47,19 +47,33 @@ def test_fqdn_resolved_to_clusterip_via_api(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
 
-def test_namespace_comes_from_config_not_host(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The proxy lives in its own namespace; the config must win over whatever
-    # namespace segment the host string happens to embed.
+def test_namespace_parsed_from_fqdn(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.WRONG.svc.cluster.local"
+        ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy.myrelease.svc.cluster.local"
     )
-    monkeypatch.setattr(ksm, "SANDBOX_PROXY_NAMESPACE", "proxy-ns")
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_NAMESPACE", "onyx")
     mgr, core_api = _mgr()
     svc = MagicMock()
     svc.spec.cluster_ip = "10.0.0.5"
     core_api.read_namespaced_service.return_value = svc
 
     assert mgr._resolve_proxy_ip() == "10.0.0.5"
+    core_api.read_namespaced_service.assert_called_once_with(
+        name="onyx-sandbox-proxy", namespace="myrelease"
+    )
+
+
+def test_namespace_falls_back_to_config_for_bare_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "onyx-sandbox-proxy")
+    monkeypatch.setattr(ksm, "SANDBOX_PROXY_NAMESPACE", "proxy-ns")
+    mgr, core_api = _mgr()
+    svc = MagicMock()
+    svc.spec.cluster_ip = "10.0.0.6"
+    core_api.read_namespaced_service.return_value = svc
+
+    assert mgr._resolve_proxy_ip() == "10.0.0.6"
     core_api.read_namespaced_service.assert_called_once_with(
         name="onyx-sandbox-proxy", namespace="proxy-ns"
     )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
@@ -45,13 +45,11 @@ def test_ready_via_service_dns(monkeypatch: pytest.MonkeyPatch) -> None:
     """FQDN answers, pod IP would refuse → ready via the preferred candidate."""
     probed: list[str] = []
 
-    def fake_health_check(self: OpencodeServeClient) -> bool:
+    def fake_status(self: OpencodeServeClient) -> int | None:
         probed.append(self._base_url)
-        if self._base_url == _POD_IP_URL:
-            raise ConnectionError("pod IP not routable under telepresence")
-        return self._base_url == _SERVICE_URL
+        return None if self._base_url == _POD_IP_URL else 200
 
-    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+    monkeypatch.setattr(OpencodeServeClient, "health_check_status", fake_status)
 
     mgr = _FakeManager(health_check_url=_POD_IP_URL)
     assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=5.0) is True
@@ -64,13 +62,11 @@ def test_ready_via_pod_ip_when_dns_unresolvable(
     """FQDN unresolvable, pod IP answers → ready via the fallback candidate."""
     probed: list[str] = []
 
-    def fake_health_check(self: OpencodeServeClient) -> bool:
+    def fake_status(self: OpencodeServeClient) -> int | None:
         probed.append(self._base_url)
-        if self._base_url == _SERVICE_URL:
-            raise ConnectionError("cluster DNS not resolvable from CI runner")
-        return self._base_url == _POD_IP_URL
+        return None if self._base_url == _SERVICE_URL else 200
 
-    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+    monkeypatch.setattr(OpencodeServeClient, "health_check_status", fake_status)
 
     mgr = _FakeManager(health_check_url=_POD_IP_URL)
     assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=5.0) is True
@@ -83,10 +79,10 @@ def test_not_ready_when_no_candidate_answers(
 ) -> None:
     """Both candidates refuse for the whole window → not ready."""
 
-    def fake_health_check(self: OpencodeServeClient) -> bool:  # noqa: ARG001
-        raise ConnectionError("refused")
+    def fake_status(self: OpencodeServeClient) -> int | None:  # noqa: ARG001
+        return None
 
-    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+    monkeypatch.setattr(OpencodeServeClient, "health_check_status", fake_status)
 
     mgr = _FakeManager(health_check_url=_POD_IP_URL)
     assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=0.4) is False

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
@@ -42,11 +42,7 @@ class _FakeManager(_ServeMixin):
 
 
 def test_ready_via_service_dns(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Telepresence path: Service FQDN answers, pod IP would refuse → ready.
-
-    FQDN is the preferred candidate, so a green FQDN probe returns without ever
-    needing the (unroutable-under-telepresence) pod IP.
-    """
+    """FQDN answers, pod IP would refuse → ready via the preferred candidate."""
     probed: list[str] = []
 
     def fake_health_check(self: OpencodeServeClient) -> bool:
@@ -65,11 +61,7 @@ def test_ready_via_service_dns(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_ready_via_pod_ip_when_dns_unresolvable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CI path: Service FQDN can't resolve, pod IP answers → ready.
-
-    Verifies the pod-IP fallback is probed when the FQDN candidate fails, and
-    that an FQDN failure does not abort the wait.
-    """
+    """FQDN unresolvable, pod IP answers → ready via the fallback candidate."""
     probed: list[str] = []
 
     def fake_health_check(self: OpencodeServeClient) -> bool:
@@ -82,7 +74,6 @@ def test_ready_via_pod_ip_when_dns_unresolvable(
 
     mgr = _FakeManager(health_check_url=_POD_IP_URL)
     assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=5.0) is True
-    # FQDN is tried first, pod IP is the fallback.
     assert probed[0] == _SERVICE_URL
     assert _POD_IP_URL in probed
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
@@ -1,0 +1,101 @@
+"""Unit tests for ``_ServeMixin._wait_for_opencode_serve_ready``.
+
+Pins the multi-candidate probe contract: the readiness gate must succeed if
+EITHER the Service ``base_url`` (FQDN) OR the pod-IP health-check URL answers
+``GET /doc`` with 200. The FQDN is probed first (it routes in prod and under
+telepresence, which proxies cluster DNS but not raw pod IPs); the pod IP is the
+fallback for out-of-cluster CI (routes pod IPs, no cluster DNS).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
+from onyx.server.features.build.sandbox.serve_transport import _ServeMixin
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
+
+_SBX = UUID("12345678-1234-1234-1234-1234567890ab")
+_POD_IP_URL = "http://10.244.0.97:4096"
+_SERVICE_URL = "http://sandbox-x.onyx-sandboxes.svc.cluster.local:4096"
+_PASSWORD = "hunter2"
+
+
+class _FakeManager(_ServeMixin):
+    """Minimal mixin host with a Service-FQDN base_url + a pod-IP health-check
+    URL, mirroring the K8s manager's split addressing."""
+
+    def __init__(self, health_check_url: str | None) -> None:
+        self._health_check_url = health_check_url
+        self._init_serve_state()
+
+    def _load_serve_connection_info(
+        self,
+        sandbox_id: UUID,  # noqa: ARG002
+    ) -> ServeConnectionInfo | None:
+        return ServeConnectionInfo(base_url=_SERVICE_URL, password=_PASSWORD)
+
+    def _serve_health_check_base_url(self, sandbox_id: UUID) -> str | None:  # noqa: ARG002
+        return self._health_check_url
+
+
+def test_ready_via_service_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Telepresence path: Service FQDN answers, pod IP would refuse → ready.
+
+    FQDN is the preferred candidate, so a green FQDN probe returns without ever
+    needing the (unroutable-under-telepresence) pod IP.
+    """
+    probed: list[str] = []
+
+    def fake_health_check(self: OpencodeServeClient) -> bool:
+        probed.append(self._base_url)
+        if self._base_url == _POD_IP_URL:
+            raise ConnectionError("pod IP not routable under telepresence")
+        return self._base_url == _SERVICE_URL
+
+    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+
+    mgr = _FakeManager(health_check_url=_POD_IP_URL)
+    assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=5.0) is True
+    assert probed[0] == _SERVICE_URL
+
+
+def test_ready_via_pod_ip_when_dns_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CI path: Service FQDN can't resolve, pod IP answers → ready.
+
+    Verifies the pod-IP fallback is probed when the FQDN candidate fails, and
+    that an FQDN failure does not abort the wait.
+    """
+    probed: list[str] = []
+
+    def fake_health_check(self: OpencodeServeClient) -> bool:
+        probed.append(self._base_url)
+        if self._base_url == _SERVICE_URL:
+            raise ConnectionError("cluster DNS not resolvable from CI runner")
+        return self._base_url == _POD_IP_URL
+
+    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+
+    mgr = _FakeManager(health_check_url=_POD_IP_URL)
+    assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=5.0) is True
+    # FQDN is tried first, pod IP is the fallback.
+    assert probed[0] == _SERVICE_URL
+    assert _POD_IP_URL in probed
+
+
+def test_not_ready_when_no_candidate_answers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both candidates refuse for the whole window → not ready."""
+
+    def fake_health_check(self: OpencodeServeClient) -> bool:  # noqa: ARG001
+        raise ConnectionError("refused")
+
+    monkeypatch.setattr(OpencodeServeClient, "health_check", fake_health_check)
+
+    mgr = _FakeManager(health_check_url=_POD_IP_URL)
+    assert mgr._wait_for_opencode_serve_ready(_SBX, timeout=0.4) is False


### PR DESCRIPTION
## Description

Two telepresence-correctness fixes for Craft sandbox networking:

- **api-server → pod:** the opencode-serve readiness probe and push/snapshot/health now try the Service FQDN first and fall back to the raw pod IP, and the push-daemon port (`8731`) is exposed on the per-sandbox Service. This covers all three contexts — prod (in-cluster), out-of-cluster CI (routes pod IPs, no cluster DNS), and telepresence (routes DNS, not raw pod IPs).
- **pod → egress proxy:** `_resolve_proxy_ip` now reads the proxy Service ClusterIP from the k8s API (via `SANDBOX_PROXY_NAMESPACE`) instead of the api-server's OS resolver, which under telepresence returns a synthetic, pod-unroutable IP. The hostAlias pinned into the pod is now the real, cluster-routable ClusterIP.

## How Has This Been Tested?

- Unit tests: readiness FQDN/pod-IP fallback, push + `_post_to_sidecar` host fallback, `_sandbox_pod_hosts` degradation, and `_resolve_proxy_ip` (numeric / FQDN / namespace-from-config / missing-IP / API-error).
- End-to-end on a kind cluster under telepresence: fresh session provisions, readiness passes via the FQDN, `bun install` egress succeeds, and a chat turn runs a sandbox shell tool and returns a response.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox networking under Telepresence by making service-to-pod and pod-to-egress-proxy addressing work in prod, CI, and Telepresence. Readiness and sidecar calls prefer the Service FQDN with a pod-IP fallback, and the egress proxy hostAlias resolves to the real Service ClusterIP via the Kubernetes API with the namespace parsed from the host FQDN.

- **Bug Fixes**
  - Serve readiness and sidecar traffic: probe Service FQDN first, then pod IP; on a 401 during readiness, reload the password and rebuild probe clients; per-sandbox Service now exposes `8731` for the push-daemon.
  - Multi-host fallback: `_post_to_sidecar`, `write_files_to_sandbox`, and `health_check` use `_sandbox_pod_hosts` (FQDN → pod IP) and keep correct retriable/fatal error mapping; pod 404s are treated as retriable; when all hosts fail, the last transport error is re-raised.
  - Egress proxy: `_resolve_proxy_ip` reads the Service ClusterIP via `read_namespaced_service`, parsing the namespace from the proxy host FQDN with a fallback to `SANDBOX_PROXY_NAMESPACE`; numeric hosts are returned unchanged; `hostAliases` pin the routable ClusterIP with retry/backoff.

<sup>Written for commit ac1e728c940dfae90c05f176515cc8e1f45b8310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

