### PR TITLE
test(cli): mock LLM responses in CLI integration suite

### DIFF
--- a/backend/tests/integration/tests/cli/conftest.py
+++ b/backend/tests/integration/tests/cli/conftest.py
@@ -20,6 +20,25 @@ from fastapi.testclient import TestClient
 from tests.integration.common_utils.constants import API_SERVER_HOST
 from tests.integration.common_utils.constants import API_SERVER_PORT
 
+# Distinctive token tests assert on; the surrounding text is long enough to
+# exceed the small --max-output thresholds the truncation tests use.
+MOCK_LLM_TOKEN = "quick brown fox"
+MOCK_LLM_RESPONSE = f"The {MOCK_LLM_TOKEN} jumps over the lazy dog. " * 20
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _mock_llm_responses() -> Generator[None, None, None]:
+    # The CLI suite exercises the binary, not the model. Pin every chat
+    # completion to a fixed response so no test calls a real provider.
+    import onyx.llm.multi_llm as multi_llm
+
+    original = multi_llm.MOCK_LLM_RESPONSE
+    multi_llm.MOCK_LLM_RESPONSE = MOCK_LLM_RESPONSE
+    try:
+        yield
+    finally:
+        multi_llm.MOCK_LLM_RESPONSE = original
+
 
 @pytest.fixture(scope="session", autouse=True)
 def _cli_uvicorn_server(_test_client: TestClient) -> Generator[None, None, None]:

--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -5,6 +5,9 @@ These tests require a pre-built CLI binary passed via the ONYX_CLI_BINARY
 env var. In CI, the workflow builds the binary and mounts it into the test
 container. The tests are skipped when ONYX_CLI_BINARY is not set.
 
+LLM responses are mocked for the whole suite (see conftest), so the ``ask``
+tests assert on MOCK_LLM_TOKEN rather than calling a real provider.
+
 To run locally (requires Go toolchain + all Onyx services running):
 
     cd cli && go build -o /tmp/onyx-cli-test .
@@ -20,25 +23,24 @@ Test Suite:
 4.  test_ask_plain_text - Answer contains expected content
 5.  test_ask_json - NDJSON stream has correct event types
 6.  test_ask_quiet - Buffered output contains answer
-7.  test_ask_stdin_pipe - Piped context is used in the answer
-8.  test_ask_truncation - Output truncated with temp file path
-9.  test_ask_agent_id - Routes question to a specific persona
-10. test_ask_no_truncation - --max-output 0 disables truncation
-11. test_ask_not_configured - Missing PAT returns exit code 3
-12. test_configure_non_tty - Non-TTY returns exit code 2
-13. test_agents_list - Seeded persona appears in table output
-14. test_agents_json - Seeded persona appears in JSON output
-15. test_help_non_tty - No subcommand prints help, exits 0
-16. test_version_flag - Prints client and server version
-17. test_experiments - Lists feature flags
-18. test_search_returns_results - Search returns seeded document content
-19. test_search_raw - --raw outputs full SearchResponse as JSON
-20. test_search_truncation - --max-output truncates with temp file path
-21. test_search_no_query - No query returns exit code 2
-22. test_search_bad_pat - Invalid PAT returns exit code 4
-23. test_search_not_configured - Missing PAT returns exit code 3
-24. test_search_source_filter - --source filters results to matching source types
-25. test_search_agent_id - --agent-id scopes search to a persona's document sets
+7.  test_ask_truncation - Output truncated with temp file path
+8.  test_ask_agent_id - Routes question to a specific persona
+9.  test_ask_no_truncation - --max-output 0 disables truncation
+10. test_ask_not_configured - Missing PAT returns exit code 3
+11. test_configure_non_tty - Non-TTY returns exit code 2
+12. test_agents_list - Seeded persona appears in table output
+13. test_agents_json - Seeded persona appears in JSON output
+14. test_help_non_tty - No subcommand prints help, exits 0
+15. test_version_flag - Prints client and server version
+16. test_experiments - Lists feature flags
+17. test_search_returns_results - Search returns seeded document content
+18. test_search_raw - --raw outputs full SearchResponse as JSON
+19. test_search_truncation - --max-output truncates with temp file path
+20. test_search_no_query - No query returns exit code 2
+21. test_search_bad_pat - Invalid PAT returns exit code 4
+22. test_search_not_configured - Missing PAT returns exit code 3
+23. test_search_source_filter - --source filters results to matching source types
+24. test_search_agent_id - --agent-id scopes search to a persona's document sets
 """
 
 import json
@@ -60,6 +62,7 @@ from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestPersona
 from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.cli.conftest import MOCK_LLM_TOKEN
 
 _CLI_BINARY = os.environ.get("ONYX_CLI_BINARY")
 
@@ -179,12 +182,12 @@ def test_ask_plain_text(
     """Ask a question using the default persona (most common usage)."""
     result = run_cli(
         cli_binary,
-        ["ask", 'Respond with exactly the word "pineapple" and nothing else'],
+        ["ask", "Say the magic word"],
         pat=pat_token,
     )
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "pineapple" in result.stdout.lower()
+    assert MOCK_LLM_TOKEN in result.stdout.lower()
 
 
 def test_ask_json(
@@ -225,29 +228,12 @@ def test_ask_quiet(
     """Quiet mode buffers output and prints once."""
     result = run_cli(
         cli_binary,
-        ["ask", "--quiet", 'Respond with exactly "quiet_ok"'],
+        ["ask", "--quiet", "Answer the question"],
         pat=pat_token,
     )
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "quiet_ok" in result.stdout.lower()
-
-
-def test_ask_stdin_pipe(
-    cli_binary: Path,
-    pat_token: str,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001
-) -> None:
-    """Piped stdin content is used as context in the answer."""
-    result = run_cli(
-        cli_binary,
-        ["ask", "--prompt", "What is the secret code in the context below?"],
-        pat=pat_token,
-        stdin_data="The secret code is XRAY42.",
-    )
-
-    assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "XRAY42" in result.stdout
+    assert MOCK_LLM_TOKEN in result.stdout.lower()
 
 
 def test_ask_truncation(


### PR DESCRIPTION
## Description

The CLI integration suite called a real LLM provider on every `ask`. Pin chat completions to a fixed mock response for the whole suite (via a session fixture that sets `multi_llm.MOCK_LLM_RESPONSE`), so tests exercise the binary, not the model. `ask` assertions now check a shared token. No CLI code changed.

Removed `test_ask_stdin_pipe` — it only verified the model *used* piped context, which a static mock can't show, and the stdin-building logic is already covered by Go's `TestResolveQuestion`.

## How Has This Been Tested?

Ruff, ruff-format, and `ty` pass; full CLI integration suite runs in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mocked LLM responses across the CLI integration suite so tests stop calling real providers and consistently exercise the compiled binary. This makes the suite deterministic and faster; no CLI code changed.

- **Refactors**
  - Added a session fixture that sets `onyx.llm.multi_llm.MOCK_LLM_RESPONSE` to a fixed long string containing `MOCK_LLM_TOKEN`.
  - Updated `ask` tests to assert on `MOCK_LLM_TOKEN` instead of model output.
  - Removed `test_ask_stdin_pipe` (piped-context behavior can’t be validated with a static mock; input building is covered by Go tests).
  - Retained truncation coverage by using a long mock response.

<sup>Written for commit 1c778b8b5a8475c3c3ecce06adb3b499063bd162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

