### PR TITLE
fix(chat): make history compression resilient to message-tree forks

### DIFF
--- a/backend/onyx/chat/COMPRESSION.md
+++ b/backend/onyx/chat/COMPRESSION.md
@@ -9,8 +9,19 @@ Summaries are stored as `ChatMessage` records with two key fields:
 - `parent_message_id` → last message when compression triggered (places summary in the tree)
 - `last_summarized_message_id` → pointer to an older message up the chain (the cutoff). Messages after this are kept verbatim.
 
-**Why store summary as a separate message?** If we embedded the summary in the `last_summarized_message_id` message itself, that message would contain context from messages that came after it—context that doesn't exist in other branches. By creating the summary as a new message attached to the branch tip, it only applies to the specific branch where compression occurred. It's only back-pointed to by the
-branch which it applies to. All of this is necessary because we keep the last few messages verbatim and also to support branching logic.
+**Why store summary as a separate message?** If we embedded the summary in the `last_summarized_message_id` message itself, that message would contain context from messages that came after it—context that doesn't exist in other branches. By creating the summary as a new message hanging off the tree (never on the mainline — it doesn't update `latest_child_message_id`), the original history remains intact and branching keeps working.
+
+**Why match summaries by cutoff, not parent?** A summary applies to a branch when its
+cutoff (`last_summarized_message_id`) is on that branch. Every message has exactly one
+parent, so the path from the root to the cutoff is unique: any branch containing the
+cutoff shares the entire summarized prefix. Matching on the summary's
+`parent_message_id` instead (the original design) was fragile — `latest_child_message_id`
+is rewritten whenever a sibling is created, so any regenerate, edit, retry, or
+concurrent send after the summary's parent orphaned every existing summary. Affected
+sessions then re-summarized their full history at the end of every turn and their
+prompts were never truncated. Trade-off: the summarization prompt shows post-cutoff
+messages "for context only", so a summary reused across a fork may carry faint context
+from a sibling branch — accepted versus losing compression entirely.
 
 ### Progressive Summarization
 Subsequent compressions incorporate the existing summary text + new messages, preventing information loss in very long conversations.
@@ -32,17 +43,30 @@ Configurable ratios:
 
 ## Flow
 
-1. Trigger when `history_tokens > available * 0.75`
-2. Find existing summary for branch (if any)
-3. Split messages: older (summarize) / recent (keep 25%)
-4. Generate summary via LLM
-5. Save as `ChatMessage` with `parent_message_id` + `last_summarized_message_id`
+1. Trigger when `effective_tokens > available * 0.75`, where effective tokens are what
+   the next prompt will actually contain: applicable summary + post-cutoff messages
+   (the raw chain total would re-trigger every turn once a session ever crossed the
+   threshold, since already-summarized messages still count toward it)
+2. Acquire the per-session compression lock (skip if another compression is in flight —
+   concurrent turns/retries would otherwise duplicate the expensive summarization call)
+3. Find existing summary for branch (if any)
+4. Split messages: older (summarize) / recent (keep 25%); skip if the older portion is
+   below `MIN_TOKENS_TO_COMPRESS` (not worth an LLM round-trip)
+5. Generate summary via LLM
+6. Save as `ChatMessage` with `parent_message_id` + `last_summarized_message_id`
+
+If no summary applies at prompt-build time and the history exceeds the trigger
+threshold anyway (compression in flight, failed, or not yet run), the history is
+hard-trimmed to a recent suffix (`trim_history_to_token_budget`) so prompt size stays
+bounded regardless.
 
 ## Key Functions
 
 | Function | Purpose |
 |----------|---------|
 | `get_compression_params` | Check if compression needed based on token counts |
-| `find_summary_for_branch` | Find applicable summary by checking `parent_message_id` membership |
+| `find_summary_for_branch` | Find applicable summary by checking cutoff membership in the branch (highest cutoff wins) |
 | `get_messages_to_summarize` | Split messages at token budget boundary |
-| `compress_chat_history` | Orchestrate flow, save summary message |
+| `compress_chat_history` | Orchestrate flow under the per-session lock, save summary message |
+| `calculate_effective_history_tokens` | Prompt-effective token count (summary + post-cutoff) for the trigger |
+| `trim_history_to_token_budget` | Fallback hard-trim when no summary applies |

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -9,10 +9,12 @@ message when compression triggered, making it part of the tree structure.
 """
 
 from typing import NamedTuple
+from uuid import UUID
 
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.cache.factory import get_cache_backend
 from onyx.configs.chat_configs import COMPRESSION_TRIGGER_RATIO
 from onyx.configs.constants import MessageType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -40,6 +42,16 @@ logger = setup_logger()
 
 # Ratio of available context to allocate for recent messages after compression
 RECENT_MESSAGES_RATIO = 0.2
+
+# Skip compression when the messages to summarize total fewer tokens than this.
+# Each compression is a full LLM round-trip with fixed overhead (system prompt +
+# recent-context messages), so summarizing a trivial tail is pure waste.
+MIN_TOKENS_TO_COMPRESS = 1000
+
+# Auto-release window for the per-session compression lock. Generous enough for
+# a slow summarization LLM call; prevents a crashed holder from blocking the
+# session's compression forever.
+COMPRESSION_LOCK_TIMEOUT_SECONDS = 300
 
 
 class CompressionResult(BaseModel):
@@ -116,17 +128,31 @@ def find_summary_for_branch(
     chat_history: list[ChatMessage],
 ) -> ChatMessage | None:
     """
-    Find the most recent summary that applies to the current branch.
+    Find the best summary that applies to the current branch.
 
-    A summary applies if its parent_message_id is in the current chat history,
-    meaning it was created on this branch.
+    A summary applies if its cutoff (``last_summarized_message_id``) is in the
+    current chat history. Every message has exactly one parent, so the path from
+    the root to the cutoff is unique — any branch containing the cutoff shares
+    the entire summarized prefix, and the summary stays valid even if the tree
+    forked after it was created (regenerate, edit, retry, concurrent sends).
+
+    Matching on the summary's ``parent_message_id`` (previous behavior) was
+    fragile: ``latest_child_message_id`` is rewritten whenever a sibling is
+    created, so any fork after the summary's parent silently orphaned every
+    existing summary. Affected sessions then re-summarized their full history
+    at the end of every turn and their prompts were never truncated.
+
+    Note: the summarization prompt shows post-cutoff messages "for context
+    only", so a summary reused across a fork may carry faint context from a
+    sibling branch. Accepted trade-off versus losing compression entirely.
 
     Args:
         db_session: Database session
         chat_history: Branch-aware list of messages
 
     Returns:
-        The applicable summary message, or None if no summary exists for this branch
+        The applicable summary with the highest cutoff (most summarization
+        progress, ties broken by recency), or None if none applies.
     """
     if not chat_history:
         return None
@@ -134,23 +160,88 @@ def find_summary_for_branch(
     history_ids = {m.id for m in chat_history}
     chat_session_id = chat_history[0].chat_session_id
 
-    # Query all summaries for this session (typically few), then filter in Python.
-    # Order by time_sent descending to get the most recent summary first.
+    # Query all summaries for this session (typically few), then filter in
+    # Python to avoid an IN clause over large histories. Highest cutoff first
+    # so the first applicable summary is the one with the most progress.
     summaries = (
         db_session.query(ChatMessage)
         .filter(
             ChatMessage.chat_session_id == chat_session_id,
             ChatMessage.last_summarized_message_id.isnot(None),
         )
-        .order_by(ChatMessage.time_sent.desc())
+        .order_by(
+            ChatMessage.last_summarized_message_id.desc(),
+            ChatMessage.time_sent.desc(),
+        )
         .all()
     )
-    # Optimization to avoid using IN clause for large histories
     for summary in summaries:
-        if summary.parent_message_id in history_ids:
+        if summary.last_summarized_message_id in history_ids:
             return summary
 
     return None
+
+
+def calculate_effective_history_tokens(
+    chat_history: list[ChatMessage],
+    existing_summary: ChatMessage | None,
+) -> int:
+    """
+    Token count of what the next prompt will actually contain: the applicable
+    summary (if any) plus the messages after its cutoff.
+
+    Using the raw chain total instead (previous behavior) meant that once a
+    session ever crossed the compression threshold, compression re-triggered at
+    the end of every subsequent turn — already-summarized messages still count
+    toward the raw total even though they never reach the prompt.
+    """
+    if not existing_summary or not existing_summary.last_summarized_message_id:
+        return calculate_total_history_tokens(chat_history)
+
+    cutoff_id = existing_summary.last_summarized_message_id
+    post_cutoff_tokens = sum(
+        m.token_count or 0 for m in chat_history if m.id > cutoff_id
+    )
+    return post_cutoff_tokens + (existing_summary.token_count or 0)
+
+
+def trim_history_to_token_budget(
+    chat_history: list[ChatMessage],
+    token_budget: int,
+) -> tuple[list[ChatMessage], list[ChatMessage]]:
+    """
+    Keep the longest suffix of ``chat_history`` that fits in ``token_budget``,
+    aligned to start at a USER message (mirroring the compression cutoff rule).
+    The most recent message is always kept, even if over budget.
+
+    This is the emergency fallback for when no summary applies to the branch:
+    it bounds prompt size instead of shipping the entire raw history to the LLM
+    on every agent-loop iteration.
+
+    Returns:
+        (kept_messages, dropped_messages) — both in original order.
+    """
+    kept: list[ChatMessage] = []
+    tokens_used = 0
+
+    for msg in reversed(chat_history):
+        msg_tokens = msg.token_count or 0
+        if tokens_used + msg_tokens > token_budget and kept:
+            break
+        kept.insert(0, msg)
+        tokens_used += msg_tokens
+
+    # Align the cut to right before a user message so the LLM never sees a
+    # conversation that opens mid-exchange (e.g. with a dangling tool response).
+    while kept and kept[0].message_type != MessageType.USER:
+        kept.pop(0)
+
+    if not kept:
+        kept = chat_history[-1:]
+
+    kept_ids = {m.id for m in kept}
+    dropped = [m for m in chat_history if m.id not in kept_ids]
+    return kept, dropped
 
 
 def get_messages_to_summarize(
@@ -375,6 +466,43 @@ def compress_chat_history(
 
     chat_session_id = chat_history[0].chat_session_id
 
+    # Only one compression per session at a time. Concurrent turns on the same
+    # session (rapid-fire sends, regenerates, retries) would otherwise each run
+    # their own expensive summarization LLM call over largely the same messages.
+    lock = get_cache_backend().lock(
+        f"chat_compression_lock:{chat_session_id}",
+        timeout=COMPRESSION_LOCK_TIMEOUT_SECONDS,
+    )
+    if not lock.acquire(blocking=False):
+        logger.info(
+            "Skipping compression for session %s: another compression is in flight",
+            chat_session_id,
+        )
+        return CompressionResult(summary_created=False, messages_summarized=0)
+
+    try:
+        return _compress_chat_history_locked(
+            chat_history=chat_history,
+            llm=llm,
+            compression_params=compression_params,
+            chat_session_id=chat_session_id,
+        )
+    finally:
+        try:
+            lock.release()
+        except Exception:
+            logger.warning(
+                "Failed to release compression lock for session %s", chat_session_id
+            )
+
+
+def _compress_chat_history_locked(
+    chat_history: list[ChatMessage],
+    llm: LLM,
+    compression_params: CompressionParams,
+    chat_session_id: UUID | None,
+) -> CompressionResult:
+    """Body of compress_chat_history; caller holds the per-session lock."""
     logger.info(
         "Starting compression for session %s, history_len=%s, tokens_for_recent=%s",
         chat_session_id,
@@ -410,6 +538,23 @@ def compress_chat_history(
 
             if not summary_content.older_messages:
                 logger.debug("No messages to summarize, skipping compression")
+                return CompressionResult(summary_created=False, messages_summarized=0)
+
+            # Not worth a full LLM round-trip to summarize a trivial tail. Also
+            # serves as the double-check after acquiring the lock: if a
+            # concurrent compression just finished, the re-found summary leaves
+            # only the newest messages here.
+            older_tokens = calculate_total_history_tokens(
+                summary_content.older_messages
+            )
+            if older_tokens < MIN_TOKENS_TO_COMPRESS:
+                logger.info(
+                    "Skipping compression for session %s: only %s tokens to "
+                    "summarize (min %s)",
+                    chat_session_id,
+                    older_tokens,
+                    MIN_TOKENS_TO_COMPRESS,
+                )
                 return CompressionResult(summary_created=False, messages_summarized=0)
 
             # LLM call runs with no DB connection held.

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CacheLock
 from onyx.configs.chat_configs import COMPRESSION_TRIGGER_RATIO
 from onyx.configs.constants import MessageType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -469,16 +470,29 @@ def compress_chat_history(
     # Only one compression per session at a time. Concurrent turns on the same
     # session (rapid-fire sends, regenerates, retries) would otherwise each run
     # their own expensive summarization LLM call over largely the same messages.
-    lock = get_cache_backend().lock(
-        f"chat_compression_lock:{chat_session_id}",
-        timeout=COMPRESSION_LOCK_TIMEOUT_SECONDS,
-    )
-    if not lock.acquire(blocking=False):
-        logger.info(
-            "Skipping compression for session %s: another compression is in flight",
-            chat_session_id,
+    # Compression is best-effort: cache backend trouble must never break the
+    # turn, so on lock infrastructure errors we proceed without dedup instead
+    # of propagating (or silently dropping compression).
+    lock: CacheLock | None = None
+    try:
+        lock = get_cache_backend().lock(
+            f"chat_compression_lock:{chat_session_id}",
+            timeout=COMPRESSION_LOCK_TIMEOUT_SECONDS,
         )
-        return CompressionResult(summary_created=False, messages_summarized=0)
+        if not lock.acquire(blocking=False):
+            logger.info(
+                "Skipping compression for session %s: another compression is in flight",
+                chat_session_id,
+            )
+            return CompressionResult(summary_created=False, messages_summarized=0)
+    except Exception:
+        logger.warning(
+            "Compression lock unavailable for session %s; "
+            "proceeding without concurrency dedup",
+            chat_session_id,
+            exc_info=True,
+        )
+        lock = None
 
     try:
         return _compress_chat_history_locked(
@@ -488,19 +502,25 @@ def compress_chat_history(
             chat_session_id=chat_session_id,
         )
     finally:
-        try:
-            lock.release()
-        except Exception:
-            logger.warning(
-                "Failed to release compression lock for session %s", chat_session_id
-            )
+        if lock is not None:
+            try:
+                # The lock auto-expires after COMPRESSION_LOCK_TIMEOUT_SECONDS;
+                # if compression outlived it, another holder may own it now —
+                # releasing would raise (e.g. redis LockNotOwnedError).
+                if lock.owned():
+                    lock.release()
+            except Exception:
+                logger.warning(
+                    "Failed to release compression lock for session %s",
+                    chat_session_id,
+                )
 
 
 def _compress_chat_history_locked(
     chat_history: list[ChatMessage],
     llm: LLM,
     compression_params: CompressionParams,
-    chat_session_id: UUID | None,
+    chat_session_id: UUID,
 ) -> CompressionResult:
     """Body of compress_chat_history; caller holds the per-session lock."""
     logger.info(

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -31,10 +31,12 @@ from onyx.chat.chat_utils import create_chat_session_from_request
 from onyx.chat.chat_utils import get_custom_agent_prompt
 from onyx.chat.chat_utils import is_last_assistant_message_clarification
 from onyx.chat.chat_utils import load_all_chat_files
+from onyx.chat.compression import calculate_effective_history_tokens
 from onyx.chat.compression import calculate_total_history_tokens
 from onyx.chat.compression import compress_chat_history
 from onyx.chat.compression import find_summary_for_branch
 from onyx.chat.compression import get_compression_params
+from onyx.chat.compression import trim_history_to_token_budget
 from onyx.chat.emitter import Emitter
 from onyx.chat.llm_loop import EmptyLLMResponseError
 from onyx.chat.llm_loop import run_llm_loop
@@ -57,6 +59,7 @@ from onyx.chat.stop_signal_checker import is_connected as check_stop_signal
 from onyx.chat.stop_signal_checker import reset_cancel_status
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
+from onyx.configs.chat_configs import COMPRESSION_TRIGGER_RATIO
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import MessageType
@@ -873,6 +876,45 @@ def build_chat_turn(
         and forced_tool_id == search_tool_id
     ):
         forced_tool_id = None
+
+    # Fallback guard: if no summary applies to this branch (compression hasn't
+    # run yet, is in flight, or has repeatedly failed) and the history alone
+    # already exceeds the compression trigger, hard-trim to a recent suffix.
+    # Without this, every agent-loop iteration ships the entire raw history to
+    # the LLM — unbounded prompt cost and latency for the rest of the session.
+    if summary_message is None:
+        history_tokens = calculate_total_history_tokens(chat_history)
+        trim_budget = int(
+            (llm_max_context_window - reserved_token_count) * COMPRESSION_TRIGGER_RATIO
+        )
+        if trim_budget > 0 and history_tokens > trim_budget:
+            chat_history, dropped_messages = trim_history_to_token_budget(
+                chat_history, trim_budget
+            )
+            for msg in dropped_messages:
+                if not msg.files:
+                    continue
+                for fd in msg.files:
+                    file_id = fd.get("id")
+                    if not file_id:
+                        continue
+                    summarized_file_metadata.setdefault(
+                        file_id,
+                        FileToolMetadata(
+                            file_id=file_id,
+                            filename=fd.get("name") or "unknown",
+                            approx_char_count=0,
+                        ),
+                    )
+            logger.warning(
+                "No applicable summary for session %s with %s history tokens; "
+                "hard-trimmed %s of %s messages to fit %s token budget",
+                chat_session.id,
+                history_tokens,
+                len(dropped_messages),
+                len(dropped_messages) + len(chat_history),
+                trim_budget,
+            )
 
     # TODO(nmgarza5): Once summarization is done, we don't need to load all files from the beginning.
     # Load all files needed for this chat chain into memory.
@@ -1709,11 +1751,18 @@ def llm_loop_completion_handle(
             chat_session_id=chat_session_id,
             db_session=db_session,
         )
-        total_tokens = calculate_total_history_tokens(updated_chat_history)
+        # Trigger on what the next prompt would actually contain (summary +
+        # post-cutoff messages), not the raw chain total. The raw total keeps
+        # counting already-summarized messages, which would re-trigger
+        # compression at the end of every turn for the rest of the session.
+        existing_summary = find_summary_for_branch(db_session, updated_chat_history)
+        effective_tokens = calculate_effective_history_tokens(
+            updated_chat_history, existing_summary
+        )
 
     compression_params = get_compression_params(
         max_input_tokens=llm.config.max_input_tokens,
-        current_history_tokens=total_tokens,
+        current_history_tokens=effective_tokens,
         reserved_tokens=reserved_tokens,
     )
     if compression_params.should_compress:

--- a/backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py
+++ b/backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py
@@ -325,3 +325,39 @@ class TestCompressionForkResilience:
             current_history_tokens=effective_tokens,
             reserved_tokens=0,
         ).should_compress
+
+    def test_cache_backend_failure_does_not_break_compression(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """Compression is best-effort: a cache outage must not propagate —
+        it degrades to running without the concurrency lock."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        db_session.expire_all()
+        history = create_chat_history_chain(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        params = CompressionParams(should_compress=True, tokens_for_recent=2000)
+
+        with (
+            patch(
+                "onyx.chat.compression.get_cache_backend",
+                side_effect=ConnectionError("cache backend down"),
+            ),
+            patch(
+                "onyx.chat.compression.generate_summary",
+                return_value="canned summary",
+            ) as mock_generate,
+        ):
+            result = compress_chat_history(
+                chat_history=history,
+                llm=MagicMock(),
+                compression_params=params,
+            )
+
+        assert result.error is None
+        assert result.summary_created is True
+        assert mock_generate.call_count == 1

--- a/backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py
+++ b/backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py
@@ -1,0 +1,327 @@
+"""External-dependency-unit tests for chat history compression.
+
+Reproduces (against real Postgres + cache backend) the failure mode where a
+session's summaries were orphaned by message-tree forks: any regenerate, retry,
+or concurrent send re-points ``latest_child_message_id``, and summaries matched
+on ``parent_message_id`` fell off the mainline. Affected sessions re-summarized
+their entire history at the end of every turn and their prompts were never
+truncated.
+
+Run with:
+    python -m dotenv -f .vscode/.env run -- pytest \
+        backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.cache.factory import get_cache_backend
+from onyx.chat.chat_utils import create_chat_history_chain
+from onyx.chat.compression import calculate_effective_history_tokens
+from onyx.chat.compression import compress_chat_history
+from onyx.chat.compression import COMPRESSION_LOCK_TIMEOUT_SECONDS
+from onyx.chat.compression import CompressionParams
+from onyx.chat.compression import find_summary_for_branch
+from onyx.chat.compression import get_compression_params
+from onyx.configs.constants import MessageType
+from onyx.db.chat import create_chat_session
+from onyx.db.chat import create_new_chat_message
+from onyx.db.chat import get_or_create_root_message
+from onyx.db.models import ChatMessage
+from onyx.db.models import User
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def test_user(db_session: Session) -> User:
+    return create_test_user(db_session, "compression_fork")
+
+
+@pytest.fixture
+def chat_session_id(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001 — keeps tenant contextvar set for the test
+    test_user: User,
+) -> Generator[UUID, None, None]:
+    session = create_chat_session(
+        db_session=db_session,
+        description="compression fork test",
+        user_id=test_user.id,
+        persona_id=None,
+    )
+    yield session.id
+
+
+def _add_turns(
+    db_session: Session,
+    chat_session_id: UUID,
+    parent: ChatMessage,
+    num_turns: int,
+    tokens_per_message: int = 500,
+    label: str = "turn",
+) -> ChatMessage:
+    """Append ``num_turns`` USER/ASSISTANT exchanges after ``parent``."""
+    tip = parent
+    for i in range(num_turns):
+        tip = create_new_chat_message(
+            chat_session_id=chat_session_id,
+            parent_message=tip,
+            message=f"{label} user message {i}",
+            token_count=tokens_per_message,
+            message_type=MessageType.USER,
+            db_session=db_session,
+        )
+        tip = create_new_chat_message(
+            chat_session_id=chat_session_id,
+            parent_message=tip,
+            message=f"{label} assistant message {i}",
+            token_count=tokens_per_message,
+            message_type=MessageType.ASSISTANT,
+            db_session=db_session,
+        )
+    return tip
+
+
+def _compress(
+    db_session: Session,
+    chat_session_id: UUID,
+    summary_text: str = "canned summary",
+    tokens_for_recent: int | None = None,
+) -> tuple[int, int | None]:
+    """Run compression with a patched summarization LLM call.
+
+    Returns (messages_summarized, cutoff_id_of_applicable_summary_afterwards).
+    """
+    # Tests reuse one session; expire so relationship attributes
+    # (latest_child_message) reflect prior commits, as in a fresh
+    # per-request session.
+    db_session.expire_all()
+    history = create_chat_history_chain(
+        chat_session_id=chat_session_id, db_session=db_session
+    )
+    total_tokens = sum(m.token_count or 0 for m in history)
+    params = CompressionParams(
+        should_compress=True,
+        tokens_for_recent=(
+            tokens_for_recent
+            if tokens_for_recent is not None
+            else int(total_tokens * 0.2)
+        ),
+    )
+
+    with patch(
+        "onyx.chat.compression.generate_summary", return_value=summary_text
+    ) as mock_generate:
+        result = compress_chat_history(
+            chat_history=history,
+            llm=MagicMock(),
+            compression_params=params,
+        )
+        llm_called = mock_generate.call_count
+
+    db_session.expire_all()
+    history = create_chat_history_chain(
+        chat_session_id=chat_session_id, db_session=db_session
+    )
+    summary = find_summary_for_branch(db_session, history)
+    cutoff = summary.last_summarized_message_id if summary else None
+    assert result.error is None
+    assert llm_called <= 1
+    return result.messages_summarized, cutoff
+
+
+class TestCompressionForkResilience:
+    def test_summary_survives_regeneration_fork(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """A regenerate (sibling message) must not orphan existing summaries."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        tip = _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        summarized_1, cutoff_1 = _compress(db_session, chat_session_id)
+        assert summarized_1 > 0
+        assert cutoff_1 is not None
+
+        # Simulate a regenerate: attach a sibling at the tip's parent. This
+        # re-points latest_child_message_id, moving the mainline off the
+        # branch the summary's parent pointer references.
+        parent_of_tip = db_session.get(ChatMessage, tip.parent_message_id)
+        assert parent_of_tip is not None
+        regen_tip = create_new_chat_message(
+            chat_session_id=chat_session_id,
+            parent_message=parent_of_tip,
+            message="regenerated assistant message",
+            token_count=500,
+            message_type=MessageType.ASSISTANT,
+            db_session=db_session,
+        )
+
+        # The test reuses one session; expire so relationship attributes
+        # (latest_child_message) reflect the just-committed fork, as they
+        # would in a fresh per-request session.
+        db_session.expire_all()
+        history = create_chat_history_chain(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        history_ids = {m.id for m in history}
+        assert regen_tip.id in history_ids, "fork should be on the mainline"
+        assert tip.id not in history_ids, "old tip should be off the mainline"
+
+        summary = find_summary_for_branch(db_session, history)
+        assert summary is not None, "summary must survive the fork"
+        assert summary.last_summarized_message_id == cutoff_1
+
+    def test_cutoff_advances_instead_of_full_recompression(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """Subsequent compressions must be progressive, not from scratch."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        tip = _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        summarized_1, cutoff_1 = _compress(db_session, chat_session_id)
+        assert summarized_1 > 0
+        assert cutoff_1 is not None
+
+        # Fork (regenerate), then continue the conversation past the fork.
+        parent_of_tip = db_session.get(ChatMessage, tip.parent_message_id)
+        assert parent_of_tip is not None
+        _add_turns(
+            db_session,
+            chat_session_id,
+            parent_of_tip,
+            num_turns=10,
+            label="post-fork",
+        )
+
+        summarized_2, cutoff_2 = _compress(db_session, chat_session_id)
+
+        assert summarized_2 > 0
+        assert summarized_2 < summarized_1 + 10, (
+            "second compression must only cover post-cutoff messages, "
+            "not re-summarize the whole session"
+        )
+        assert cutoff_2 is not None and cutoff_1 is not None
+        assert cutoff_2 > cutoff_1, "cutoff must advance"
+
+    def test_tiny_tail_skips_llm_call(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """Re-running compression with a trivial new tail must not call the LLM."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        tip = _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        # Compress with a tiny recent budget so the cutoff lands at the very
+        # end of the history — everything is summarized.
+        summarized_1, _ = _compress(db_session, chat_session_id, tokens_for_recent=100)
+        assert summarized_1 > 0
+
+        # One small follow-up exchange (100 tokens total, below
+        # MIN_TOKENS_TO_COMPRESS) — not worth an LLM round-trip.
+        _add_turns(
+            db_session,
+            chat_session_id,
+            tip,
+            num_turns=1,
+            tokens_per_message=50,
+            label="tiny",
+        )
+
+        db_session.expire_all()
+        history = create_chat_history_chain(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        params = CompressionParams(should_compress=True, tokens_for_recent=0)
+        with patch(
+            "onyx.chat.compression.generate_summary", return_value="unused"
+        ) as mock_generate:
+            result = compress_chat_history(
+                chat_history=history,
+                llm=MagicMock(),
+                compression_params=params,
+            )
+
+        assert result.summary_created is False
+        assert mock_generate.call_count == 0
+
+    def test_concurrent_compression_skipped_via_lock(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """A second compression for the same session must no-op while one is in flight."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        db_session.expire_all()
+        history = create_chat_history_chain(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        params = CompressionParams(should_compress=True, tokens_for_recent=1000)
+
+        lock = get_cache_backend().lock(
+            f"chat_compression_lock:{chat_session_id}",
+            timeout=COMPRESSION_LOCK_TIMEOUT_SECONDS,
+        )
+        assert lock.acquire(blocking=False)
+        try:
+            with patch(
+                "onyx.chat.compression.generate_summary", return_value="unused"
+            ) as mock_generate:
+                result = compress_chat_history(
+                    chat_history=history,
+                    llm=MagicMock(),
+                    compression_params=params,
+                )
+        finally:
+            lock.release()
+
+        assert result.summary_created is False
+        assert mock_generate.call_count == 0
+
+    def test_effective_tokens_prevent_per_turn_retrigger(
+        self, db_session: Session, chat_session_id: UUID
+    ) -> None:
+        """Once compressed, the trigger must consider the prompt-effective size."""
+        root = get_or_create_root_message(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        _add_turns(db_session, chat_session_id, root, num_turns=10)
+
+        summarized, _ = _compress(db_session, chat_session_id)
+        assert summarized > 0
+
+        db_session.expire_all()
+        history = create_chat_history_chain(
+            chat_session_id=chat_session_id, db_session=db_session
+        )
+        summary = find_summary_for_branch(db_session, history)
+        assert summary is not None
+
+        raw_tokens = sum(m.token_count or 0 for m in history)
+        effective_tokens = calculate_effective_history_tokens(history, summary)
+        assert effective_tokens < raw_tokens
+
+        # With the raw total the old trigger would fire again immediately;
+        # with the effective total it must not.
+        max_input = int(raw_tokens / 0.75) - 100  # threshold just under raw
+        assert get_compression_params(
+            max_input_tokens=max_input,
+            current_history_tokens=raw_tokens,
+            reserved_tokens=0,
+        ).should_compress
+        assert not get_compression_params(
+            max_input_tokens=max_input,
+            current_history_tokens=effective_tokens,
+            reserved_tokens=0,
+        ).should_compress

--- a/backend/tests/unit/onyx/chat/test_compression.py
+++ b/backend/tests/unit/onyx/chat/test_compression.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from onyx.chat.compression import _build_llm_messages_for_summarization
+from onyx.chat.compression import calculate_effective_history_tokens
 from onyx.chat.compression import find_summary_for_branch
 from onyx.chat.compression import generate_summary
 from onyx.chat.compression import get_compression_params
 from onyx.chat.compression import get_messages_to_summarize
 from onyx.chat.compression import SummaryContent
+from onyx.chat.compression import trim_history_to_token_budget
 from onyx.configs.constants import MessageType
 from onyx.llm.models import AssistantMessage
 from onyx.llm.models import SystemMessage
@@ -505,3 +507,162 @@ def test_generate_summary_messages_are_separate() -> None:
     # 3 older user messages + 1 cutoff + 1 recent + 1 reminder = at least 3 user messages
     assert user_count >= 3
     assert assistant_count >= 1  # At least one assistant message from older_messages
+
+
+def test_find_summary_survives_fork_after_summary_parent() -> None:
+    """A summary must stay applicable when the branch forks after its parent.
+
+    Regression test: summaries used to be matched on parent_message_id, which
+    falls off the mainline whenever a sibling is created (regenerate, retry,
+    concurrent send). The summarized prefix (root -> cutoff) is unique, so
+    cutoff membership is the correct applicability test.
+    """
+    # Summary was created when the branch tip was message 5; the user then
+    # regenerated, so the live branch is 1, 2, 3, 4, 8, 9 (fork after 4).
+    forked_branch_history = [
+        create_mock_message(1, "msg1", 100),
+        create_mock_message(2, "msg2", 100),
+        create_mock_message(3, "msg3", 100),
+        create_mock_message(4, "msg4", 100),
+        create_mock_message(8, "regenerated", 100),
+        create_mock_message(9, "reply", 100),
+    ]
+
+    summary = create_mock_message(
+        id=100,
+        message="Summary of msgs 1-2",
+        token_count=50,
+        parent_message_id=5,  # dead branch tip — NOT in current history
+        last_summarized_message_id=2,  # cutoff IS in current history
+    )
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        summary
+    ]
+
+    result = find_summary_for_branch(
+        mock_db,
+        forked_branch_history,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == summary
+
+
+def test_find_summary_prefers_highest_applicable_cutoff() -> None:
+    """Among applicable summaries, the one with the most progress wins."""
+    branch_history = [create_mock_message(i, f"msg{i}", 100) for i in range(1, 7)]
+
+    early_summary = create_mock_message(
+        id=100,
+        message="Summary up to 2",
+        token_count=50,
+        parent_message_id=3,
+        last_summarized_message_id=2,
+    )
+    later_summary = create_mock_message(
+        id=101,
+        message="Summary up to 4",
+        token_count=50,
+        parent_message_id=5,
+        last_summarized_message_id=4,
+    )
+    off_branch_summary = create_mock_message(
+        id=102,
+        message="Summary from another branch",
+        token_count=50,
+        parent_message_id=50,
+        last_summarized_message_id=40,  # not in current history
+    )
+
+    # Query orders by cutoff desc; first applicable should be returned.
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        off_branch_summary,
+        later_summary,
+        early_summary,
+    ]
+
+    result = find_summary_for_branch(
+        mock_db,
+        branch_history,  # ty: ignore[invalid-argument-type]
+    )
+
+    assert result == later_summary
+
+
+def test_effective_history_tokens_without_summary() -> None:
+    history = [create_mock_message(i, f"msg{i}", 100) for i in range(1, 5)]
+    assert (
+        calculate_effective_history_tokens(history, None)  # ty: ignore[invalid-argument-type]
+        == 400
+    )
+
+
+def test_effective_history_tokens_with_summary() -> None:
+    """Only the summary + post-cutoff messages should count toward the trigger."""
+    history = [create_mock_message(i, f"msg{i}", 100) for i in range(1, 11)]
+    summary = create_mock_message(
+        id=100,
+        message="Summary up to 8",
+        token_count=30,
+        parent_message_id=10,
+        last_summarized_message_id=8,
+    )
+
+    # Messages 9, 10 (200 tokens) + summary (30 tokens)
+    assert (
+        calculate_effective_history_tokens(history, summary)  # ty: ignore[invalid-argument-type]
+        == 230
+    )
+
+
+def test_trim_history_keeps_recent_suffix_within_budget() -> None:
+    history = [
+        create_mock_message(1, "u1", 100, MessageType.USER),
+        create_mock_message(2, "a1", 100, MessageType.ASSISTANT),
+        create_mock_message(3, "u2", 100, MessageType.USER),
+        create_mock_message(4, "a2", 100, MessageType.ASSISTANT),
+        create_mock_message(5, "u3", 100, MessageType.USER),
+        create_mock_message(6, "a3", 100, MessageType.ASSISTANT),
+    ]
+
+    kept, dropped = trim_history_to_token_budget(
+        history,  # ty: ignore[invalid-argument-type]
+        token_budget=350,
+    )
+
+    # 350-token budget fits 3 messages; alignment to a USER start keeps 5, 6.
+    assert [m.id for m in kept] == [5, 6]
+    assert [m.id for m in dropped] == [1, 2, 3, 4]
+
+
+def test_trim_history_never_returns_empty() -> None:
+    """Even a single over-budget message must be kept."""
+    history = [
+        create_mock_message(1, "a", 100, MessageType.ASSISTANT),
+        create_mock_message(2, "huge", 100000, MessageType.USER),
+    ]
+
+    kept, dropped = trim_history_to_token_budget(
+        history,  # ty: ignore[invalid-argument-type]
+        token_budget=50,
+    )
+
+    assert [m.id for m in kept] == [2]
+    assert [m.id for m in dropped] == [1]
+
+
+def test_trim_history_noop_when_under_budget() -> None:
+    history = [
+        create_mock_message(1, "u1", 100, MessageType.USER),
+        create_mock_message(2, "a1", 100, MessageType.ASSISTANT),
+    ]
+
+    kept, dropped = trim_history_to_token_budget(
+        history,  # ty: ignore[invalid-argument-type]
+        token_budget=500,
+    )
+
+    assert [m.id for m in kept] == [1, 2]
+    assert dropped == []


### PR DESCRIPTION
## Description

Chat-history compression breaks permanently for any session whose message tree forks (regenerate, edit a message, retry, or two messages sent concurrently — including frontend retries after a dropped stream).

**Root cause:** `find_summary_for_branch` matched summaries on `parent_message_id` membership in the mainline. `latest_child_message_id` is rewritten whenever a sibling is created, so any fork after a summary's parent orphans every existing summary. From then on the session:
- re-summarizes its **entire history** at the end of **every turn** (observed: 80–150s LLM call summarizing 336 messages, repeatedly, with the cutoff never advancing — 16 dead summary rows in a single session), and
- never truncates its prompt (observed: ~220k-token prompts on every agent-loop iteration).

These runaway turns can occupy threadpool workers/DB sessions for minutes and, under a CPU limit, throttle the api-server hard enough to fail liveness probes — the resulting kill triggers a frontend retry, which forks the tree again and feeds the loop.

**Changes** (all in CE `backend/onyx/chat/`):
1. **Fork-proof summary matching** — match on cutoff (`last_summarized_message_id`) membership in the branch. Every message has exactly one parent, so the root→cutoff path is unique: any branch containing the cutoff shares the entire summarized prefix. Highest applicable cutoff wins. Trade-off (documented in COMPRESSION.md): the summarizer sees post-cutoff messages "for context only", so a reused summary may carry faint context from a sibling branch — accepted versus losing compression entirely.
2. **Per-session compression lock + min-size guard** — concurrent turns no longer run duplicate summarization calls; tails under `MIN_TOKENS_TO_COMPRESS` skip the LLM round-trip.
3. **Prompt-effective trigger** — end-of-turn trigger now counts what the next prompt actually contains (summary + post-cutoff messages) instead of the raw chain total, which kept re-triggering compression every turn once a session ever crossed the threshold.
4. **Hard-trim fallback** — if no summary applies at prompt-build time and history exceeds the trigger threshold (compression in flight, failed, or not yet run), trim to a recent suffix so prompt size stays bounded; dropped messages' file metadata feeds the existing forgotten-file mechanism.

## How Has This Been Tested?

- New external-dependency-unit suite `backend/tests/external_dependency_unit/chat/test_compression_fork_resilience.py` (real Postgres + cache backend): summary survives a regeneration fork; cutoff advances instead of full recompression; trivial tails skip the LLM call; concurrent compression no-ops under the lock; effective-token trigger doesn't re-fire post-compression. 5/5 passing.
- Extended `backend/tests/unit/onyx/chat/test_compression.py` with fork-resilience matching, highest-cutoff selection, effective-token math, and hard-trim behavior (26/26 passing, existing tests unchanged).
- `pre-commit` (ty, ruff, ruff format) clean on all touched files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat-history compression so it works across message-tree forks and stops re-summarizing full histories, keeping prompts bounded and reducing latency. This prevents runaway turns that could throttle the API server.

- **Bug Fixes**
  - Match summaries by cutoff membership in the branch (highest applicable cutoff wins) so regenerate/edit/retry/concurrent sends don’t orphan summaries.
  - Trigger compression on prompt-effective tokens (summary + post-cutoff), not the raw chain total.
  - Hard-trim history when no summary applies to keep the prompt within budget; dropped files feed the forgotten-file flow.

- **Performance**
  - Per-session cache lock dedups concurrent summarization; fails open on cache outages and checks lock ownership before release.
  - Skip compression when the older portion is below a minimum token threshold.

<sup>Written for commit 08c7e7665b17c7abdf0dc9b091354aac1ec7b9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

