### PR TITLE
refactor(ods): standardize deploy-target resolution across deploy subcommands

### DIFF
--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -1,0 +1,207 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+)
+
+const (
+	// Polling configuration shared by the deploy subcommands. The "discover"
+	// phase polls fast for a short window because a run usually appears within
+	// seconds of pushing the tag / dispatching the workflow.
+	runDiscoveryInterval = 5 * time.Second
+	runDiscoveryTimeout  = 2 * time.Minute
+	runProgressInterval  = 30 * time.Second
+)
+
+// resolveDeployTarget returns the deploy target repo and workflow to use,
+// preferring explicit flags, then saved config, then prompting the user on
+// first-time setup. The selector picks which config section to read from and
+// persist to (e.g. DeployEdge vs DeployWiki), so each subcommand keeps its own
+// saved target while sharing this resolution logic. Any newly-prompted values
+// are persisted back to the config file so subsequent runs are non-interactive.
+func resolveDeployTarget(flagRepo, flagWorkflow string, selector func(*config.Config) *config.DeployTarget) (string, string) {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("Failed to load ods config: %v", err)
+	}
+	section := selector(cfg)
+
+	repo := flagRepo
+	if repo == "" {
+		repo = section.TargetRepo
+	}
+	workflow := flagWorkflow
+	if workflow == "" {
+		workflow = section.TargetWorkflow
+	}
+
+	prompted := false
+	if repo == "" {
+		log.Infof("First-time setup: ods will save your deploy target to %s", paths.ConfigFilePath())
+		repo = prompt.String("Deploy target repo (owner/name): ")
+		prompted = true
+	}
+	if workflow == "" {
+		workflow = prompt.String("Deploy workflow filename (e.g. some-workflow.yml): ")
+		prompted = true
+	}
+
+	if prompted {
+		section.TargetRepo = repo
+		section.TargetWorkflow = workflow
+		if err := config.Save(cfg); err != nil {
+			log.Fatalf("Failed to save ods config: %v", err)
+		}
+		log.Infof("Saved deploy target to %s", paths.ConfigFilePath())
+	}
+
+	return repo, workflow
+}
+
+// workflowRun is a partial representation of a `gh run list` JSON entry.
+type workflowRun struct {
+	DatabaseID int64  `json:"databaseId"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	URL        string `json:"url"`
+	Event      string `json:"event"`
+	HeadBranch string `json:"headBranch"`
+}
+
+// latestWorkflowRunID returns the highest databaseId for runs of the given
+// workflow filtered by event (and optional branch). Returns 0 if no runs
+// exist yet, which is a valid state.
+func latestWorkflowRunID(repo, workflowFile, event, branch string) (int64, error) {
+	runs, err := listWorkflowRuns(repo, workflowFile, event, branch, 10)
+	if err != nil {
+		return 0, err
+	}
+	var maxID int64
+	for _, r := range runs {
+		if r.DatabaseID > maxID {
+			maxID = r.DatabaseID
+		}
+	}
+	return maxID, nil
+}
+
+func listWorkflowRuns(repo, workflowFile, event, branch string, limit int) ([]workflowRun, error) {
+	args := []string{
+		"run", "list",
+		"-R", repo,
+		"--workflow", workflowFile,
+		"--limit", fmt.Sprintf("%d", limit),
+		"--json", "databaseId,status,conclusion,url,event,headBranch",
+	}
+	if event != "" {
+		args = append(args, "--event", event)
+	}
+	if branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh run list failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("gh run list failed: %w", err)
+	}
+	var runs []workflowRun
+	if err := json.Unmarshal(output, &runs); err != nil {
+		return nil, fmt.Errorf("failed to parse gh run list output: %w", err)
+	}
+	// Sort newest-first by databaseId for predictable iteration.
+	sort.Slice(runs, func(i, j int) bool { return runs[i].DatabaseID > runs[j].DatabaseID })
+	return runs, nil
+}
+
+// waitForNewRun polls until a workflow run with databaseId > priorRunID
+// appears, or the discovery timeout fires.
+func waitForNewRun(repo, workflowFile, event, branch string, priorRunID int64) (*workflowRun, error) {
+	deadline := time.Now().Add(runDiscoveryTimeout)
+	for {
+		runs, err := listWorkflowRuns(repo, workflowFile, event, branch, 5)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range runs {
+			if r.DatabaseID > priorRunID {
+				return &r, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("no new run appeared within %s", runDiscoveryTimeout)
+		}
+		time.Sleep(runDiscoveryInterval)
+	}
+}
+
+// waitForRunCompletion polls a specific run until it reaches a terminal
+// status. Returns an error if the run does not conclude with success or the
+// timeout fires.
+func waitForRunCompletion(repo string, runID int64, timeout time.Duration, label string) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		run, err := getRun(repo, runID)
+		if err != nil {
+			return err
+		}
+		log.Infof("[%s] run %d status=%s conclusion=%s", label, runID, run.Status, run.Conclusion)
+		if run.Status == "completed" {
+			if run.Conclusion == "success" {
+				return nil
+			}
+			return fmt.Errorf("%s run %d concluded with status %q (see %s)", label, runID, run.Conclusion, run.URL)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%s run %d did not complete within %s (see %s)", label, runID, timeout, run.URL)
+		}
+		time.Sleep(runProgressInterval)
+	}
+}
+
+func getRun(repo string, runID int64) (*workflowRun, error) {
+	cmd := exec.Command(
+		"gh", "run", "view", fmt.Sprintf("%d", runID),
+		"-R", repo,
+		"--json", "databaseId,status,conclusion,url,event,headBranch",
+	)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh run view failed: %w: %s", err, string(exitErr.Stderr))
+		}
+		return nil, fmt.Errorf("gh run view failed: %w", err)
+	}
+	var run workflowRun
+	if err := json.Unmarshal(output, &run); err != nil {
+		return nil, fmt.Errorf("failed to parse gh run view output: %w", err)
+	}
+	return &run, nil
+}
+
+// dispatchWorkflow fires a workflow_dispatch event for the given workflow with
+// the supplied string inputs.
+func dispatchWorkflow(repo, workflowFile string, inputs map[string]string) error {
+	args := []string{"workflow", "run", workflowFile, "-R", repo}
+	for k, v := range inputs {
+		args = append(args, "-f", fmt.Sprintf("%s=%s", k, v))
+	}
+	cmd := exec.Command("gh", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh workflow run failed: %w: %s", err, string(output))
+	}
+	return nil
+}

--- a/tools/ods/cmd/deploy_common.go
+++ b/tools/ods/cmd/deploy_common.go
@@ -25,24 +25,26 @@ const (
 
 // resolveDeployTarget returns the deploy target repo and workflow to use,
 // preferring explicit flags, then saved config, then prompting the user on
-// first-time setup. The selector picks which config section to read from and
-// persist to (e.g. DeployEdge vs DeployWiki), so each subcommand keeps its own
-// saved target while sharing this resolution logic. Any newly-prompted values
-// are persisted back to the config file so subsequent runs are non-interactive.
-func resolveDeployTarget(flagRepo, flagWorkflow string, selector func(*config.Config) *config.DeployTarget) (string, string) {
+// first-time setup. The repo is shared by all deploy subcommands (read from and
+// persisted to config.Deploy.TargetRepo), so it is only entered once; the
+// workflowSelector picks which per-command section holds the workflow filename
+// (e.g. DeployEdge vs DeployWiki). Any newly-prompted values are persisted back
+// to the config file so subsequent runs are non-interactive.
+func resolveDeployTarget(flagRepo, flagWorkflow string, workflowSelector func(*config.Config) *string) (string, string) {
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("Failed to load ods config: %v", err)
 	}
-	section := selector(cfg)
+	repoPtr := &cfg.Deploy.TargetRepo
+	workflowPtr := workflowSelector(cfg)
 
 	repo := flagRepo
 	if repo == "" {
-		repo = section.TargetRepo
+		repo = *repoPtr
 	}
 	workflow := flagWorkflow
 	if workflow == "" {
-		workflow = section.TargetWorkflow
+		workflow = *workflowPtr
 	}
 
 	prompted := false
@@ -57,8 +59,8 @@ func resolveDeployTarget(flagRepo, flagWorkflow string, selector func(*config.Co
 	}
 
 	if prompted {
-		section.TargetRepo = repo
-		section.TargetWorkflow = workflow
+		*repoPtr = repo
+		*workflowPtr = workflow
 		if err := config.Save(cfg); err != nil {
 			log.Fatalf("Failed to save ods config: %v", err)
 		}

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -49,9 +49,10 @@ All GitHub operations run through the gh CLI, so authorization is enforced
 by your gh credentials and GitHub's repo/workflow permissions.
 
 On first run, you'll be prompted for the deploy target repo and workflow
-filename. These are saved to the ods config file (~/.config/onyx-dev/config.json
-on Linux/macOS) and reused on subsequent runs. Pass --target-repo or
---target-workflow to override the saved values.
+filename, saved to the ods config file (~/.config/onyx-dev/config.json on
+Linux/macOS) and reused on subsequent runs. The target repo is shared across
+all deploy subcommands; the workflow filename is per-subcommand. Pass
+--target-repo or --target-workflow to override the saved values.
 
 Example usage:
 
@@ -62,7 +63,7 @@ Example usage:
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.TargetRepo, "target-repo", "", "GitHub repo (owner/name) hosting the deploy workflow; overrides saved config")
+	cmd.Flags().StringVar(&opts.TargetRepo, "target-repo", "", "GitHub repo (owner/name) hosting the deploy workflows; shared across deploy subcommands; overrides saved config")
 	cmd.Flags().StringVar(&opts.TargetWorkflow, "target-workflow", "", "Filename of the deploy workflow within the target repo; overrides saved config")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform local operations only; skip pushing the tag and dispatching workflows")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
@@ -77,7 +78,7 @@ func deployEdge(opts *DeployEdgeOptions) {
 	deployRepo, deployWorkflow := resolveDeployTarget(
 		opts.TargetRepo,
 		opts.TargetWorkflow,
-		func(c *config.Config) *config.DeployTarget { return &c.DeployEdge },
+		func(c *config.Config) *string { return &c.DeployEdge.TargetWorkflow },
 	)
 
 	if opts.DryRun {

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-	"os/exec"
-	"sort"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -12,7 +8,6 @@ import (
 
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
-	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
 
@@ -21,15 +16,9 @@ const (
 	deploymentWorkflowFile = "deployment.yml"
 	edgeTagName            = "edge"
 
-	// Polling configuration. Build runs typically take 20-30 minutes; deploys
-	// are much shorter. The "discover" phase polls fast for a short window
-	// because the run usually appears within seconds of pushing the tag /
-	// dispatching the workflow.
-	runDiscoveryInterval = 5 * time.Second
-	runDiscoveryTimeout  = 2 * time.Minute
-	runProgressInterval  = 30 * time.Second
-	buildPollTimeout     = 60 * time.Minute
-	deployPollTimeout    = 30 * time.Minute
+	// Build runs typically take 20-30 minutes; deploys are much shorter.
+	buildPollTimeout  = 60 * time.Minute
+	deployPollTimeout = 30 * time.Minute
 )
 
 // DeployEdgeOptions holds options for the deploy edge command.
@@ -85,7 +74,11 @@ Example usage:
 func deployEdge(opts *DeployEdgeOptions) {
 	git.CheckGitHubCLI()
 
-	deployRepo, deployWorkflow := resolveDeployTarget(opts)
+	deployRepo, deployWorkflow := resolveDeployTarget(
+		opts.TargetRepo,
+		opts.TargetWorkflow,
+		func(c *config.Config) *config.DeployTarget { return &c.DeployEdge },
+	)
 
 	if opts.DryRun {
 		log.Warning("=== DRY RUN MODE: tag push and workflow dispatch will be skipped (read-only gh and git fetch still run) ===")
@@ -170,184 +163,4 @@ func deployEdge(opts *DeployEdgeOptions) {
 		log.Fatalf("Deploy did not complete successfully: %v", err)
 	}
 	log.Info("Deploy completed successfully.")
-}
-
-// resolveDeployTarget returns the deploy target repo and workflow to use,
-// preferring explicit flags, then saved config, then prompting the user on
-// first-time setup. Any newly-prompted values are persisted back to the
-// config file so subsequent runs are non-interactive.
-func resolveDeployTarget(opts *DeployEdgeOptions) (string, string) {
-	cfg, err := config.Load()
-	if err != nil {
-		log.Fatalf("Failed to load ods config: %v", err)
-	}
-
-	repo := opts.TargetRepo
-	if repo == "" {
-		repo = cfg.DeployEdge.TargetRepo
-	}
-	workflow := opts.TargetWorkflow
-	if workflow == "" {
-		workflow = cfg.DeployEdge.TargetWorkflow
-	}
-
-	prompted := false
-	if repo == "" {
-		log.Infof("First-time setup: ods will save your deploy target to %s", paths.ConfigFilePath())
-		repo = prompt.String("Deploy target repo (owner/name): ")
-		prompted = true
-	}
-	if workflow == "" {
-		workflow = prompt.String("Deploy workflow filename (e.g. some-workflow.yml): ")
-		prompted = true
-	}
-
-	if prompted {
-		cfg.DeployEdge.TargetRepo = repo
-		cfg.DeployEdge.TargetWorkflow = workflow
-		if err := config.Save(cfg); err != nil {
-			log.Fatalf("Failed to save ods config: %v", err)
-		}
-		log.Infof("Saved deploy target to %s", paths.ConfigFilePath())
-	}
-
-	return repo, workflow
-}
-
-// workflowRun is a partial representation of a `gh run list` JSON entry.
-type workflowRun struct {
-	DatabaseID int64  `json:"databaseId"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
-	URL        string `json:"url"`
-	Event      string `json:"event"`
-	HeadBranch string `json:"headBranch"`
-}
-
-// latestWorkflowRunID returns the highest databaseId for runs of the given
-// workflow filtered by event (and optional branch). Returns 0 if no runs
-// exist yet, which is a valid state.
-func latestWorkflowRunID(repo, workflowFile, event, branch string) (int64, error) {
-	runs, err := listWorkflowRuns(repo, workflowFile, event, branch, 10)
-	if err != nil {
-		return 0, err
-	}
-	var maxID int64
-	for _, r := range runs {
-		if r.DatabaseID > maxID {
-			maxID = r.DatabaseID
-		}
-	}
-	return maxID, nil
-}
-
-func listWorkflowRuns(repo, workflowFile, event, branch string, limit int) ([]workflowRun, error) {
-	args := []string{
-		"run", "list",
-		"-R", repo,
-		"--workflow", workflowFile,
-		"--limit", fmt.Sprintf("%d", limit),
-		"--json", "databaseId,status,conclusion,url,event,headBranch",
-	}
-	if event != "" {
-		args = append(args, "--event", event)
-	}
-	if branch != "" {
-		args = append(args, "--branch", branch)
-	}
-	cmd := exec.Command("gh", args...)
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("gh run list failed: %w: %s", err, string(exitErr.Stderr))
-		}
-		return nil, fmt.Errorf("gh run list failed: %w", err)
-	}
-	var runs []workflowRun
-	if err := json.Unmarshal(output, &runs); err != nil {
-		return nil, fmt.Errorf("failed to parse gh run list output: %w", err)
-	}
-	// Sort newest-first by databaseId for predictable iteration.
-	sort.Slice(runs, func(i, j int) bool { return runs[i].DatabaseID > runs[j].DatabaseID })
-	return runs, nil
-}
-
-// waitForNewRun polls until a workflow run with databaseId > priorRunID
-// appears, or the discovery timeout fires.
-func waitForNewRun(repo, workflowFile, event, branch string, priorRunID int64) (*workflowRun, error) {
-	deadline := time.Now().Add(runDiscoveryTimeout)
-	for {
-		runs, err := listWorkflowRuns(repo, workflowFile, event, branch, 5)
-		if err != nil {
-			return nil, err
-		}
-		for _, r := range runs {
-			if r.DatabaseID > priorRunID {
-				return &r, nil
-			}
-		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("no new run appeared within %s", runDiscoveryTimeout)
-		}
-		time.Sleep(runDiscoveryInterval)
-	}
-}
-
-// waitForRunCompletion polls a specific run until it reaches a terminal
-// status. Returns an error if the run does not conclude with success or the
-// timeout fires.
-func waitForRunCompletion(repo string, runID int64, timeout time.Duration, label string) error {
-	deadline := time.Now().Add(timeout)
-	for {
-		run, err := getRun(repo, runID)
-		if err != nil {
-			return err
-		}
-		log.Infof("[%s] run %d status=%s conclusion=%s", label, runID, run.Status, run.Conclusion)
-		if run.Status == "completed" {
-			if run.Conclusion == "success" {
-				return nil
-			}
-			return fmt.Errorf("%s run %d concluded with status %q (see %s)", label, runID, run.Conclusion, run.URL)
-		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("%s run %d did not complete within %s (see %s)", label, runID, timeout, run.URL)
-		}
-		time.Sleep(runProgressInterval)
-	}
-}
-
-func getRun(repo string, runID int64) (*workflowRun, error) {
-	cmd := exec.Command(
-		"gh", "run", "view", fmt.Sprintf("%d", runID),
-		"-R", repo,
-		"--json", "databaseId,status,conclusion,url,event,headBranch",
-	)
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("gh run view failed: %w: %s", err, string(exitErr.Stderr))
-		}
-		return nil, fmt.Errorf("gh run view failed: %w", err)
-	}
-	var run workflowRun
-	if err := json.Unmarshal(output, &run); err != nil {
-		return nil, fmt.Errorf("failed to parse gh run view output: %w", err)
-	}
-	return &run, nil
-}
-
-// dispatchWorkflow fires a workflow_dispatch event for the given workflow with
-// the supplied string inputs.
-func dispatchWorkflow(repo, workflowFile string, inputs map[string]string) error {
-	args := []string{"workflow", "run", workflowFile, "-R", repo}
-	for k, v := range inputs {
-		args = append(args, "-f", fmt.Sprintf("%s=%s", k, v))
-	}
-	cmd := exec.Command("gh", args...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("gh workflow run failed: %w: %s", err, string(output))
-	}
-	return nil
 }

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/config"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/git"
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
 )
@@ -13,18 +14,18 @@ import (
 const (
 	wikiBuildRepo       = "onyx-dot-app/agent-wiki"
 	wikiBuildWorkflow   = "nightly-build.yml"
-	wikiDeployRepo      = "onyx-dot-app/cloud-deployment-yamls"
-	wikiDeployWorkflow  = "dev-wiki-deploy.yml"
 	wikiBuildPollLimit  = 30 * time.Minute
 	wikiDeployPollLimit = 20 * time.Minute
 )
 
 // DeployWikiOptions holds options for the deploy wiki command.
 type DeployWikiOptions struct {
-	DryRun       bool
-	Yes          bool
-	NoWaitDeploy bool
-	NoBuild      bool
+	TargetRepo     string
+	TargetWorkflow string
+	DryRun         bool
+	Yes            bool
+	NoWaitDeploy   bool
+	NoBuild        bool
 }
 
 // NewDeployWikiCommand creates the `ods deploy wiki` command.
@@ -40,13 +41,18 @@ This command will:
   1. Dispatch the nightly-build.yml workflow in onyx-dot-app/agent-wiki
      (builds and pushes onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD)
   2. Wait for the build workflow to finish
-  3. Dispatch the dev-wiki-deploy.yml workflow in onyx-dot-app/cloud-deployment-yamls
-     with version_tag=nightly-latest-YYYYMMDD (today's UTC date)
+  3. Dispatch the configured deploy workflow with version_tag=nightly-latest-YYYYMMDD
+     (today's UTC date)
   4. Wait for the deploy workflow to finish
 
 All GitHub operations run through the gh CLI, so authorization is enforced
 by your gh credentials and GitHub's repo/workflow permissions. A kickoff
 Slack message will appear in #monitor-deployments.
+
+On first run, you'll be prompted for the deploy target repo and workflow
+filename. These are saved to the ods config file (~/.config/onyx-dev/config.json
+on Linux/macOS) and reused on subsequent runs. Pass --target-repo or
+--target-workflow to override the saved values.
 
 Pass --no-build to skip step 1 and just deploy whatever's already on
 Docker Hub for today's tag.
@@ -60,6 +66,8 @@ Example usage:
 		},
 	}
 
+	cmd.Flags().StringVar(&opts.TargetRepo, "target-repo", "", "GitHub repo (owner/name) hosting the deploy workflow; overrides saved config")
+	cmd.Flags().StringVar(&opts.TargetWorkflow, "target-workflow", "", "Filename of the deploy workflow within the target repo; overrides saved config")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform local operations only; skip dispatching workflows")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
 	cmd.Flags().BoolVar(&opts.NoWaitDeploy, "no-wait-deploy", false, "Do not wait for the deploy workflow to finish after dispatching it")
@@ -70,6 +78,12 @@ Example usage:
 
 func deployWiki(opts *DeployWikiOptions) {
 	git.CheckGitHubCLI()
+
+	deployRepo, deployWorkflow := resolveDeployTarget(
+		opts.TargetRepo,
+		opts.TargetWorkflow,
+		func(c *config.Config) *config.DeployTarget { return &c.DeployWiki },
+	)
 
 	if opts.DryRun {
 		log.Warning("=== DRY RUN MODE: workflow dispatches will be skipped ===")
@@ -100,11 +114,11 @@ func deployWiki(opts *DeployWikiOptions) {
 	}
 
 	if opts.DryRun {
-		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, wikiDeployRepo, versionTag)
+		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", deployWorkflow, deployRepo, versionTag)
 		return
 	}
 
-	runDeploy(versionTag, opts.NoWaitDeploy)
+	runDeploy(deployRepo, deployWorkflow, versionTag, opts.NoWaitDeploy)
 }
 
 func runBuild() {
@@ -132,20 +146,20 @@ func runBuild() {
 	log.Info("Build completed successfully.")
 }
 
-func runDeploy(versionTag string, noWait bool) {
-	priorRunID, err := latestWorkflowRunID(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
+func runDeploy(deployRepo, deployWorkflow, versionTag string, noWait bool) {
+	priorRunID, err := latestWorkflowRunID(deployRepo, deployWorkflow, "workflow_dispatch", "")
 	if err != nil {
 		log.Fatalf("Failed to query existing deploy runs: %v", err)
 	}
 	log.Debugf("Most recent prior deploy run id: %d", priorRunID)
 
-	log.Infof("Dispatching %s with version_tag=%s...", wikiDeployWorkflow, versionTag)
-	if err := dispatchWorkflow(wikiDeployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
+	log.Infof("Dispatching %s with version_tag=%s...", deployWorkflow, versionTag)
+	if err := dispatchWorkflow(deployRepo, deployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
 		log.Fatalf("Failed to dispatch deploy workflow: %v", err)
 	}
 
 	log.Info("Waiting for deploy workflow to start...")
-	deployRun, err := waitForNewRun(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
+	deployRun, err := waitForNewRun(deployRepo, deployWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find dispatched deploy run: %v", err)
 	}
@@ -157,7 +171,7 @@ func runDeploy(versionTag string, noWait bool) {
 		return
 	}
 
-	if err := waitForRunCompletion(wikiDeployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
+	if err := waitForRunCompletion(deployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
 		log.Fatalf("Deploy did not complete successfully: %v", err)
 	}
 	log.Info("Deploy completed successfully.")

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -50,9 +50,10 @@ by your gh credentials and GitHub's repo/workflow permissions. A kickoff
 Slack message will appear in #monitor-deployments.
 
 On first run, you'll be prompted for the deploy target repo and workflow
-filename. These are saved to the ods config file (~/.config/onyx-dev/config.json
-on Linux/macOS) and reused on subsequent runs. Pass --target-repo or
---target-workflow to override the saved values.
+filename, saved to the ods config file (~/.config/onyx-dev/config.json on
+Linux/macOS) and reused on subsequent runs. The target repo is shared across
+all deploy subcommands; the workflow filename is per-subcommand. Pass
+--target-repo or --target-workflow to override the saved values.
 
 Pass --no-build to skip step 1 and just deploy whatever's already on
 Docker Hub for today's tag.
@@ -66,7 +67,7 @@ Example usage:
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.TargetRepo, "target-repo", "", "GitHub repo (owner/name) hosting the deploy workflow; overrides saved config")
+	cmd.Flags().StringVar(&opts.TargetRepo, "target-repo", "", "GitHub repo (owner/name) hosting the deploy workflows; shared across deploy subcommands; overrides saved config")
 	cmd.Flags().StringVar(&opts.TargetWorkflow, "target-workflow", "", "Filename of the deploy workflow within the target repo; overrides saved config")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Perform local operations only; skip dispatching workflows")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
@@ -82,7 +83,7 @@ func deployWiki(opts *DeployWikiOptions) {
 	deployRepo, deployWorkflow := resolveDeployTarget(
 		opts.TargetRepo,
 		opts.TargetWorkflow,
-		func(c *config.Config) *config.DeployTarget { return &c.DeployWiki },
+		func(c *config.Config) *string { return &c.DeployWiki.TargetWorkflow },
 	)
 
 	if opts.DryRun {

--- a/tools/ods/internal/config/config.go
+++ b/tools/ods/internal/config/config.go
@@ -9,8 +9,9 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
-// DeployEdgeConfig holds the persisted settings for `ods deploy edge`.
-type DeployEdgeConfig struct {
+// DeployTarget holds a persisted deploy workflow target (the repo hosting the
+// workflow and the workflow filename). Shared by the `ods deploy` subcommands.
+type DeployTarget struct {
 	TargetRepo     string `json:"target_repo,omitempty"`
 	TargetWorkflow string `json:"target_workflow,omitempty"`
 }
@@ -18,7 +19,8 @@ type DeployEdgeConfig struct {
 // Config is the top-level on-disk schema for ~/.config/onyx-dev/config.json.
 // New per-command sections should be added as additional fields.
 type Config struct {
-	DeployEdge DeployEdgeConfig `json:"deploy_edge,omitempty"`
+	DeployEdge DeployTarget `json:"deploy_edge,omitempty"`
+	DeployWiki DeployTarget `json:"deploy_wiki,omitempty"`
 }
 
 // Load reads the config file. Returns a zero-valued Config if the file does

--- a/tools/ods/internal/config/config.go
+++ b/tools/ods/internal/config/config.go
@@ -9,18 +9,25 @@ import (
 	"github.com/onyx-dot-app/onyx/tools/ods/internal/paths"
 )
 
-// DeployTarget holds a persisted deploy workflow target (the repo hosting the
-// workflow and the workflow filename). Shared by the `ods deploy` subcommands.
-type DeployTarget struct {
-	TargetRepo     string `json:"target_repo,omitempty"`
+// DeployConfig holds deploy settings shared by every `ods deploy` subcommand.
+type DeployConfig struct {
+	// TargetRepo is the GitHub repo (owner/name) hosting the deploy workflows.
+	// It is shared across subcommands since they deploy from the same repo.
+	TargetRepo string `json:"target_repo,omitempty"`
+}
+
+// DeployCommandConfig holds the per-subcommand deploy settings.
+type DeployCommandConfig struct {
+	// TargetWorkflow is the deploy workflow filename for this subcommand.
 	TargetWorkflow string `json:"target_workflow,omitempty"`
 }
 
 // Config is the top-level on-disk schema for ~/.config/onyx-dev/config.json.
 // New per-command sections should be added as additional fields.
 type Config struct {
-	DeployEdge DeployTarget `json:"deploy_edge,omitempty"`
-	DeployWiki DeployTarget `json:"deploy_wiki,omitempty"`
+	Deploy     DeployConfig        `json:"deploy,omitempty"`
+	DeployEdge DeployCommandConfig `json:"deploy_edge,omitempty"`
+	DeployWiki DeployCommandConfig `json:"deploy_wiki,omitempty"`
 }
 
 // Load reads the config file. Returns a zero-valued Config if the file does


### PR DESCRIPTION
## What

Standardize how the `ods deploy` subcommands resolve their deploy target — the repo hosting the deploy workflow and the workflow filename.

`ods deploy edge` already resolved its target via **explicit flags → saved config → first-run prompt** (persisted to `~/.config/onyx-dev/config.json`). `ods deploy wiki` previously hardcoded its target. This makes wiki use the same mechanism, so neither subcommand bakes a deploy target into the source — it lives in each user's local config.

The **target repo is shared** across subcommands (they deploy from the same repo, so it's entered once), while each subcommand keeps its **own workflow filename**.

## Config shape

```jsonc
{
  "deploy":      { "target_repo": "..." },      // shared by all deploy subcommands
  "deploy_edge": { "target_workflow": "..." },  // per-subcommand
  "deploy_wiki": { "target_workflow": "..." }
}
```

## Changes

- **config**: split deploy settings into a shared `deploy` section (the repo) plus per-command `deploy_edge` / `deploy_wiki` sections (the workflow).
- **`deploy_common.go`** (new): shared `resolveDeployTarget` — always reads/persists the repo from the shared section and takes a per-command selector for the workflow — plus the `gh` workflow plumbing both subcommands already shared.
- **deploy edge**: behavior unchanged; now calls the shared resolver.
- **deploy wiki**: drop the hardcoded deploy target, add `--target-repo` / `--target-workflow` flags, resolve via the shared path. The build side (`agent-wiki` / `nightly-build.yml`) stays fixed, mirroring how edge fixes its own build side.

## Behavior change

`ods deploy wiki` was zero-config; it now prompts on first run (like edge) and saves the result. Because the repo is shared, if you've already configured `edge`, `wiki` only asks for its workflow filename. Override anytime with the new flags.

## Testing

Reviewed by inspection — verified no leftover/duplicate symbols and that every import is used. The dev container has no Go toolchain, so `go build ./...` / `gofmt` were not run locally; relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
