### PR TITLE
feat(craft): Extend gmail external app capabilities

### DIFF
--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -18,11 +18,22 @@ class GmailAction(ExternalAppAction):
     MESSAGES_SEND = "gmail.messages.send"
     MESSAGES_MODIFY = "gmail.messages.modify"
     MESSAGES_TRASH = "gmail.messages.trash"
+    THREADS_READ = "gmail.threads.read"
+    ATTACHMENTS_READ = "gmail.attachments.read"
+    DRAFTS_READ = "gmail.drafts.read"
+    DRAFTS_CREATE = "gmail.drafts.create"
+    DRAFTS_UPDATE = "gmail.drafts.update"
+    DRAFTS_DELETE = "gmail.drafts.delete"
+    DRAFTS_SEND = "gmail.drafts.send"
 
 
 _USER = "/gmail/v1/users/{userId}"
 _MESSAGES = f"{_USER}/messages"
 _MESSAGE_ITEM = f"{_USER}/messages/{{messageId}}"
+_THREADS = f"{_USER}/threads"
+_THREAD_ITEM = f"{_USER}/threads/{{threadId}}"
+_DRAFTS = f"{_USER}/drafts"
+_DRAFT_ITEM = f"{_USER}/drafts/{{draftId}}"
 _ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         id=GmailAction.MESSAGES_READ,
@@ -66,6 +77,65 @@ _ENDPOINTS: list[EndpointSpec] = [
         description="Move a message to the trash.",
         matches=(RestRoute(method="POST", path=f"{_MESSAGE_ITEM}/trash"),),
     ),
+    EndpointSpec(
+        id=GmailAction.THREADS_READ,
+        normalised_name="Read threads",
+        description="List threads and read a single conversation thread.",
+        matches=(
+            RestRoute(method="GET", path=_THREADS),
+            RestRoute(method="GET", path=_THREAD_ITEM),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GmailAction.ATTACHMENTS_READ,
+        normalised_name="Read attachments",
+        description="Download an attachment from a message.",
+        matches=(
+            RestRoute(
+                method="GET", path=f"{_MESSAGE_ITEM}/attachments/{{attachmentId}}"
+            ),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GmailAction.DRAFTS_READ,
+        normalised_name="Read drafts",
+        description="List drafts and read a single draft.",
+        matches=(
+            RestRoute(method="GET", path=_DRAFTS),
+            RestRoute(method="GET", path=_DRAFT_ITEM),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GmailAction.DRAFTS_CREATE,
+        normalised_name="Create a draft",
+        # Drafts aren't sent, so creating one is a safe place for the agent to
+        # prepare an email for the user to review and send from Gmail.
+        description="Save a new draft email (not sent).",
+        matches=(RestRoute(method="POST", path=_DRAFTS),),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GmailAction.DRAFTS_UPDATE,
+        normalised_name="Update a draft",
+        description="Replace the contents of an existing draft (not sent).",
+        matches=(RestRoute(method="PUT", path=_DRAFT_ITEM),),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GmailAction.DRAFTS_DELETE,
+        normalised_name="Delete a draft",
+        description="Permanently delete a draft.",
+        matches=(RestRoute(method="DELETE", path=_DRAFT_ITEM),),
+    ),
+    EndpointSpec(
+        id=GmailAction.DRAFTS_SEND,
+        normalised_name="Send a draft",
+        description="Send an existing draft as an email.",
+        matches=(RestRoute(method="POST", path=f"{_DRAFTS}/send"),),
+    ),
 ]
 
 
@@ -73,12 +143,14 @@ class GmailProvider(GoogleOAuthProvider):
     spec = GoogleOAuthProvider.build_spec(
         app_type=ExternalAppType.GMAIL,
         app_name="Gmail",
-        # gmail.modify covers read, send, label, and trash — but not permanent
-        # delete, which keeps the integration safer by default.
+        # gmail.modify covers read, send, label, trash, threads, attachments, and
+        # the full draft lifecycle — but not permanent message delete, which keeps
+        # the integration safer by default.
         scope="https://www.googleapis.com/auth/gmail.modify",
         upstream_url_patterns=["https://gmail\\.googleapis\\.com/gmail/.*"],
         description=(
-            "Read, search, and send email from your Gmail account inside Onyx Craft."
+            "Read, search, send, and draft email from your Gmail account inside "
+            "Onyx Craft."
         ),
         google_api_name="Gmail API",
         endpoint_catalog=_ENDPOINTS,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/SKILL.md.template
@@ -1,6 +1,6 @@
 ---
 name: gmail
-description: Read, search, and send email from the connected user's Gmail via a light Gmail API wrapper.
+description: Read, search, send, and draft email from the connected user's Gmail via a light Gmail API wrapper.
 ---
 
 # Gmail
@@ -13,10 +13,14 @@ Call the Gmail API as the connected user via the bundled helper.
 
     python .opencode/skills/gmail/gmail_api.py <command> [args]
 
-Read commands auto-paginate and prune empty fields. `send`, `modify`, and
-`trash` are the only writes; there is no permanent delete. `me` is always the
+Read commands auto-paginate and prune empty fields. The writes are `send`,
+`modify`, `trash`, `draft-create`, `draft-update`, `draft-delete`, and
+`draft-send`; there is no permanent message delete. `me` is always the
 connected user. Use `--raw` to skip empty-field pruning; `python gmail_api.py
 <command> -h` shows its flags.
+
+Prefer drafts when an email needs the user's review: `draft-create` saves an
+email without sending it, so the user can check and send it from Gmail.
 
 ### List / search messages
 
@@ -33,6 +37,14 @@ Full message with decoded plain-text body.
 
 ```
 python gmail_api.py message <message_id>
+```
+
+### Read a thread
+
+A whole conversation, each message with its decoded plain-text body.
+
+```
+python gmail_api.py thread <thread_id>
 ```
 
 ### Send a message (write)
@@ -67,6 +79,47 @@ python gmail_api.py trash <message_id>
 
 ```
 python gmail_api.py profile
+```
+
+### Drafts
+
+List drafts (each summarised like a message), or read one with its decoded body.
+
+```
+python gmail_api.py drafts [--limit N]
+python gmail_api.py draft <draft_id>
+```
+
+### Create / update a draft (write, not sent)
+
+Saves an email without sending it — the user can review and send it from Gmail.
+`draft-update` replaces the whole draft.
+
+```
+python gmail_api.py draft-create to@x.com "Subject" "Body text" \
+    [--cc a@x.com,b@x.com] [--bcc c@x.com]
+python gmail_api.py draft-update <draft_id> to@x.com "Subject" "Body text" \
+    [--cc a@x.com,b@x.com] [--bcc c@x.com]
+```
+
+### Delete / send a draft (write)
+
+`draft-delete` permanently removes a draft. `draft-send` sends an existing draft
+as an email.
+
+```
+python gmail_api.py draft-delete <draft_id>
+python gmail_api.py draft-send <draft_id>
+```
+
+### Download an attachment
+
+Writes the decoded bytes to `--out`; without it, only the attachment size is
+reported (binary bytes are never printed to stdout). Attachment ids come from a
+message's payload parts (fetch the message first).
+
+```
+python gmail_api.py attachment <message_id> <attachment_id> --out path/to/file
 ```
 
 ## Output

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
@@ -231,7 +231,10 @@ def _message_detail(msg: dict[str, Any]) -> dict[str, Any]:
 
 def _draft_summary(draft: dict[str, Any]) -> dict[str, Any]:
     """Fetch the underlying message metadata for one listed draft."""
-    return {"draftId": draft.get("id"), **_message_summary(draft.get("message", {}))}
+    msg_ref = draft.get("message") or {}
+    if not msg_ref.get("id"):
+        return {"draftId": draft.get("id")}
+    return {"draftId": draft.get("id"), **_message_summary(msg_ref)}
 
 
 def _cmd_messages(a: argparse.Namespace) -> dict[str, Any]:
@@ -323,8 +326,11 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             # Binary bytes don't belong on stdout; require --out to materialise
             # them and otherwise just report what's available.
             return {"ok": True, "size": size, "saved": False, "out": None}
-        pad = "=" * (-len(data or "") % 4)
-        raw_bytes = base64.urlsafe_b64decode((data or "") + pad)
+        if not data:
+            # No bytes to write — don't leave a zero-byte file looking like success.
+            return {"ok": False, "error": "no_attachment_data", "size": size}
+        pad = "=" * (-len(data) % 4)
+        raw_bytes = base64.urlsafe_b64decode(data + pad)
         with open(a.out, "wb") as fh:
             fh.write(raw_bytes)
         return {"ok": True, "size": size, "saved": True, "out": a.out}

--- a/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/docker/skills/gmail/gmail_api.py
@@ -114,6 +114,30 @@ def _extract_plain_body(payload: dict[str, Any]) -> str:
     return ""
 
 
+def _build_raw(
+    to: str, subject: str, body: str, cc: str | None, bcc: str | None
+) -> str:
+    """Build a base64url-encoded RFC 2822 message for send / draft writes."""
+    em = EmailMessage()
+    em["To"] = to
+    em["Subject"] = subject
+    if cc:
+        em["Cc"] = cc
+    if bcc:
+        em["Bcc"] = bcc
+    em.set_content(body)
+    return base64.urlsafe_b64encode(em.as_bytes()).decode("ascii")
+
+
+def _add_compose_args(sp: argparse.ArgumentParser) -> None:
+    """The to/subject/body/cc/bcc args shared by `send` and the draft writes."""
+    sp.add_argument("to")
+    sp.add_argument("subject")
+    sp.add_argument("body")
+    sp.add_argument("--cc", help="comma-separated emails")
+    sp.add_argument("--bcc", help="comma-separated emails")
+
+
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="gmail_api.py", description="Gmail.")
     p.add_argument("--raw", action="store_true", help="don't prune empty fields")
@@ -128,11 +152,7 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("message_id")
 
     sp = sub.add_parser("send", help="send an email (write)")
-    sp.add_argument("to")
-    sp.add_argument("subject")
-    sp.add_argument("body")
-    sp.add_argument("--cc", help="comma-separated emails")
-    sp.add_argument("--bcc", help="comma-separated emails")
+    _add_compose_args(sp)
 
     sub.add_parser("labels", help="list labels")
 
@@ -145,6 +165,33 @@ def _build_parser() -> argparse.ArgumentParser:
     sp.add_argument("message_id")
 
     sub.add_parser("profile", help="the connected user's Gmail profile")
+
+    sp = sub.add_parser("thread", help="one conversation thread with decoded bodies")
+    sp.add_argument("thread_id")
+
+    sp = sub.add_parser("attachment", help="download a message attachment")
+    sp.add_argument("message_id")
+    sp.add_argument("attachment_id")
+    sp.add_argument("--out", help="write the decoded bytes to this file path")
+
+    sp = sub.add_parser("drafts", help="list drafts")
+    sp.add_argument("--limit", type=int, default=_DEFAULT_LIMIT)
+
+    sp = sub.add_parser("draft", help="one draft with decoded body")
+    sp.add_argument("draft_id")
+
+    sp = sub.add_parser("draft-create", help="save a new draft (write, not sent)")
+    _add_compose_args(sp)
+
+    sp = sub.add_parser("draft-update", help="replace a draft (write, not sent)")
+    sp.add_argument("draft_id")
+    _add_compose_args(sp)
+
+    sp = sub.add_parser("draft-delete", help="delete a draft (write)")
+    sp.add_argument("draft_id")
+
+    sp = sub.add_parser("draft-send", help="send an existing draft (write)")
+    sp.add_argument("draft_id")
 
     sp = sub.add_parser("call", help="raw Gmail request")
     sp.add_argument("method", choices=_METHODS)
@@ -167,6 +214,24 @@ def _message_summary(ref: dict[str, Any]) -> dict[str, Any]:
         "snippet": msg.get("snippet"),
         "headers": _headers_to_dict(msg.get("payload", {}).get("headers", [])),
     }
+
+
+def _message_detail(msg: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a `format=full` message to id/headers/decoded body."""
+    payload = msg.get("payload", {})
+    return {
+        "id": msg.get("id"),
+        "threadId": msg.get("threadId"),
+        "labelIds": msg.get("labelIds"),
+        "snippet": msg.get("snippet"),
+        "headers": _headers_to_dict(payload.get("headers", [])),
+        "body": _extract_plain_body(payload),
+    }
+
+
+def _draft_summary(draft: dict[str, Any]) -> dict[str, Any]:
+    """Fetch the underlying message metadata for one listed draft."""
+    return {"draftId": draft.get("id"), **_message_summary(draft.get("message", {}))}
 
 
 def _cmd_messages(a: argparse.Namespace) -> dict[str, Any]:
@@ -208,29 +273,10 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
             f"messages/{_seg(a.message_id)}",
             params={"format": "full"},
         )
-        payload = msg.get("payload", {})
-        return {
-            "ok": True,
-            "message": {
-                "id": msg.get("id"),
-                "threadId": msg.get("threadId"),
-                "labelIds": msg.get("labelIds"),
-                "snippet": msg.get("snippet"),
-                "headers": _headers_to_dict(payload.get("headers", [])),
-                "body": _extract_plain_body(payload),
-            },
-        }
+        return {"ok": True, "message": _message_detail(msg)}
 
     if a.cmd == "send":
-        em = EmailMessage()
-        em["To"] = a.to
-        em["Subject"] = a.subject
-        if a.cc:
-            em["Cc"] = a.cc
-        if a.bcc:
-            em["Bcc"] = a.bcc
-        em.set_content(a.body)
-        raw = base64.urlsafe_b64encode(em.as_bytes()).decode("ascii")
+        raw = _build_raw(a.to, a.subject, a.body, a.cc, a.bcc)
         sent = _req("POST", "messages/send", body={"raw": raw})
         return {"ok": True, "sent": sent}
 
@@ -255,6 +301,77 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
 
     if a.cmd == "profile":
         return {"ok": True, "profile": _req("GET", "profile")}
+
+    if a.cmd == "thread":
+        thread = _req("GET", f"threads/{_seg(a.thread_id)}", params={"format": "full"})
+        return {
+            "ok": True,
+            "thread": {
+                "id": thread.get("id"),
+                "messages": [_message_detail(m) for m in thread.get("messages") or []],
+            },
+        }
+
+    if a.cmd == "attachment":
+        att = _req(
+            "GET",
+            f"messages/{_seg(a.message_id)}/attachments/{_seg(a.attachment_id)}",
+        )
+        size = att.get("size")
+        data = att.get("data")
+        if not a.out:
+            # Binary bytes don't belong on stdout; require --out to materialise
+            # them and otherwise just report what's available.
+            return {"ok": True, "size": size, "saved": False, "out": None}
+        pad = "=" * (-len(data or "") % 4)
+        raw_bytes = base64.urlsafe_b64decode((data or "") + pad)
+        with open(a.out, "wb") as fh:
+            fh.write(raw_bytes)
+        return {"ok": True, "size": size, "saved": True, "out": a.out}
+
+    if a.cmd == "drafts":
+        listed = _list_ids("drafts", {}, "drafts", a.limit)
+        refs = listed["items"]
+        with ThreadPoolExecutor(
+            max_workers=min(_MAX_FETCH_WORKERS, len(refs) or 1)
+        ) as pool:
+            summaries = list(pool.map(_draft_summary, refs))
+        return {
+            "ok": True,
+            "items": summaries,
+            "count": len(summaries),
+            "truncated": listed["truncated"],
+        }
+
+    if a.cmd == "draft":
+        draft = _req("GET", f"drafts/{_seg(a.draft_id)}", params={"format": "full"})
+        return {
+            "ok": True,
+            "draft": {
+                "id": draft.get("id"),
+                "message": _message_detail(draft.get("message", {})),
+            },
+        }
+
+    if a.cmd == "draft-create":
+        raw = _build_raw(a.to, a.subject, a.body, a.cc, a.bcc)
+        draft = _req("POST", "drafts", body={"message": {"raw": raw}})
+        return {"ok": True, "draft": draft}
+
+    if a.cmd == "draft-update":
+        raw = _build_raw(a.to, a.subject, a.body, a.cc, a.bcc)
+        draft = _req(
+            "PUT", f"drafts/{_seg(a.draft_id)}", body={"message": {"raw": raw}}
+        )
+        return {"ok": True, "draft": draft}
+
+    if a.cmd == "draft-delete":
+        _req("DELETE", f"drafts/{_seg(a.draft_id)}")
+        return {"ok": True, "deleted": a.draft_id}
+
+    if a.cmd == "draft-send":
+        sent = _req("POST", "drafts/send", body={"id": a.draft_id})
+        return {"ok": True, "sent": sent}
 
     # `call` raw escape hatch
     body = None

--- a/backend/tests/unit/external_apps/test_gmail_catalog.py
+++ b/backend/tests/unit/external_apps/test_gmail_catalog.py
@@ -1,0 +1,77 @@
+"""The Gmail provider catalog: every route resolves to exactly the intended
+action (no collection/item/send cross-matching), and each action's
+``default_policy`` matches the design (reads + draft create/update auto-approve;
+draft delete/send require approval)."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.external_apps.providers.actions import path_matches
+from onyx.external_apps.providers.actions import RestRoute
+from onyx.external_apps.providers.gmail import GmailAction
+from onyx.external_apps.providers.registry import get_endpoint_catalog
+
+_CATALOG = get_endpoint_catalog(ExternalAppType.GMAIL)
+
+
+def _matching_actions(method: str, path: str) -> set[str]:
+    """Every catalog action whose REST routes recognise (method, path)."""
+    matched: set[str] = set()
+    for endpoint in _CATALOG:
+        for rule in endpoint.matches:
+            assert isinstance(rule, RestRoute)  # Gmail is REST-only
+            if rule.method == method and path_matches(rule.path, path):
+                matched.add(endpoint.id)
+                break
+    return matched
+
+
+@pytest.mark.parametrize(
+    "method, path, expected",
+    [
+        # Drafts — collection, item, and the /send action stay distinct.
+        ("GET", "/gmail/v1/users/me/drafts", {GmailAction.DRAFTS_READ}),
+        ("GET", "/gmail/v1/users/me/drafts/r123", {GmailAction.DRAFTS_READ}),
+        ("POST", "/gmail/v1/users/me/drafts", {GmailAction.DRAFTS_CREATE}),
+        ("PUT", "/gmail/v1/users/me/drafts/r123", {GmailAction.DRAFTS_UPDATE}),
+        ("DELETE", "/gmail/v1/users/me/drafts/r123", {GmailAction.DRAFTS_DELETE}),
+        ("POST", "/gmail/v1/users/me/drafts/send", {GmailAction.DRAFTS_SEND}),
+        # Threads — collection and item.
+        ("GET", "/gmail/v1/users/me/threads", {GmailAction.THREADS_READ}),
+        ("GET", "/gmail/v1/users/me/threads/t1", {GmailAction.THREADS_READ}),
+        # Attachments.
+        (
+            "GET",
+            "/gmail/v1/users/me/messages/m1/attachments/a1",
+            {GmailAction.ATTACHMENTS_READ},
+        ),
+        # The pre-existing message routes still resolve unchanged.
+        ("POST", "/gmail/v1/users/me/messages/send", {GmailAction.MESSAGES_SEND}),
+        ("GET", "/gmail/v1/users/me/messages/m1", {GmailAction.MESSAGES_READ}),
+    ],
+)
+def test_route_resolves_to_exactly_one_action(
+    method: str, path: str, expected: set[str]
+) -> None:
+    assert _matching_actions(method, path) == expected
+
+
+@pytest.mark.parametrize(
+    "action, expected_policy",
+    [
+        (GmailAction.DRAFTS_READ, EndpointPolicy.ALWAYS),
+        (GmailAction.DRAFTS_CREATE, EndpointPolicy.ALWAYS),
+        (GmailAction.DRAFTS_UPDATE, EndpointPolicy.ALWAYS),
+        (GmailAction.THREADS_READ, EndpointPolicy.ALWAYS),
+        (GmailAction.ATTACHMENTS_READ, EndpointPolicy.ALWAYS),
+        # Writes that delete or send real email require approval out of the box.
+        (GmailAction.DRAFTS_DELETE, EndpointPolicy.ASK),
+        (GmailAction.DRAFTS_SEND, EndpointPolicy.ASK),
+    ],
+)
+def test_default_policies(action: GmailAction, expected_policy: EndpointPolicy) -> None:
+    by_id = {endpoint.id: endpoint for endpoint in _CATALOG}
+    assert by_id[action].default_policy == expected_policy


### PR DESCRIPTION
## Description
Extends the capabilities of the gmail app to include drafts, threads and attachments

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the Gmail external app and skill to support threads, attachments, and the full draft lifecycle (create/update/delete/send) for safer composition and richer reads. Updates the endpoint catalog, CLI, and docs; adds tests to verify route-to-action mapping and default policies.

- **New Features**
  - Provider: adds thread/attachment read and draft read/create/update/delete/send endpoints; defaults to ALWAYS for reads and draft create/update, ASK for draft delete/send; scope remains `https://www.googleapis.com/auth/gmail.modify`; no permanent message delete.
  - CLI (`gmail_api.py`): new `thread`, `attachment` (writes bytes only to `--out`), `drafts`, `draft`, `draft-create`, `draft-update`, `draft-delete`, `draft-send`; shared compose args; decoded plain-text bodies for messages/threads/drafts; lists auto-paginate and prune empty fields.

<sup>Written for commit 95c3f35049348aefead748af256e60b71e33bfa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

