### PR TITLE
chore: [Running GitHub actions for #11579]

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -108,6 +108,12 @@ ONYX_QUERY_HISTORY_TYPE = QueryHistoryType(
     (os.environ.get("ONYX_QUERY_HISTORY_TYPE") or QueryHistoryType.NORMAL.value).lower()
 )
 
+# Visibility-only: hides the Query History page from the admin sidebar; the
+# history APIs + recording stay on (unlike ONYX_QUERY_HISTORY_TYPE=disabled).
+HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL = (
+    os.environ.get("HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL", "").lower() == "true"
+)
+
 #####
 # Web Configs
 #####

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -89,6 +89,9 @@ class Settings(BaseModel):
     auto_scroll: bool | None = False
     query_history_type: QueryHistoryType | None = None
 
+    # Visibility-only: hides the sidebar page; query-history APIs + recording stay on.
+    hide_query_history_from_admin_panel: bool = False
+
     # Image processing settings
     image_extraction_and_analysis_enabled: bool | None = True
     image_analysis_max_size_mb: int | None = 20

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -3,6 +3,7 @@ from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_USER_KNOWLEDGE
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
+from onyx.configs.app_configs import HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import ONYX_QUERY_HISTORY_TYPE
 from onyx.configs.app_configs import SHOW_EXTRA_CONNECTORS
@@ -60,6 +61,7 @@ def load_settings() -> Settings:
 
     settings.show_extra_connectors = SHOW_EXTRA_CONNECTORS
     settings.opensearch_indexing_enabled = ENABLE_OPENSEARCH_INDEXING_FOR_ONYX
+    settings.hide_query_history_from_admin_panel = HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL
 
     # Resolve context-aware defaults for token threshold.
     # None = admin hasn't set a value yet → use context-aware default.

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -289,6 +289,9 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 
 ## Miscellaneous
 # ONYX_QUERY_HISTORY_TYPE=
+# Hide the Query History page from the admin sidebar (visibility-only; the history
+# APIs + recording keep working, unlike ONYX_QUERY_HISTORY_TYPE=disabled).
+# HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL=true
 # CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS=
 # VESPA_LANGUAGE_OVERRIDE=
 

--- a/web/src/interfaces/settings.ts
+++ b/web/src/interfaces/settings.ts
@@ -34,6 +34,9 @@ export interface Settings {
   temperature_override_enabled: boolean;
   query_history_type: QueryHistoryType;
 
+  // Visibility-only: hides the sidebar page; query-history APIs + recording stay on.
+  hide_query_history_from_admin_panel?: boolean;
+
   deep_research_enabled?: boolean;
   multi_model_chat_enabled?: boolean;
   search_ui_enabled?: boolean;

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -148,7 +148,10 @@ function buildItems(
   // 7. Usage (admin only)
   if (!isCurator) {
     addGated(SECTIONS.USAGE, ADMIN_ROUTES.USAGE, Tier.BUSINESS);
-    if (settings?.settings.query_history_type !== "disabled") {
+    if (
+      settings?.settings.query_history_type !== "disabled" &&
+      !settings?.settings.hide_query_history_from_admin_panel
+    ) {
       addGated(SECTIONS.USAGE, ADMIN_ROUTES.QUERY_HISTORY, Tier.BUSINESS);
     }
   }


### PR DESCRIPTION
This PR runs GitHub Actions CI for #11579.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a visibility-only toggle to hide the Query History page from the admin sidebar via HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL, without disabling query history APIs or recording. The flag is exposed in /settings and respected by the web admin sidebar; the env template is updated.

- **New Features**
  - Backend: added HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL; surfaced as hide_query_history_from_admin_panel in /settings; default is false.
  - Web: added hide_query_history_from_admin_panel to the Settings interface; AdminSidebar hides Query History when query_history_type !== "disabled" and the flag is true.

- **Migration**
  - Set HIDE_QUERY_HISTORY_FROM_ADMIN_PANEL=true in your environment (e.g., docker-compose) to hide the page. No other changes needed.

<sup>Written for commit e936ff14904196a757bb70f6ccc0d214a72dcd32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

