### PR TITLE
feat(deployment): add opt-in local Langfuse dev tracing stack

### DIFF
--- a/deployment/docker_compose/dev/README.md
+++ b/deployment/docker_compose/dev/README.md
@@ -1,0 +1,96 @@
+# Supplemental dev containers
+
+This directory holds **opt-in** Docker Compose stacks that a developer can stand up
+*alongside* the normal Onyx dev services for local testing. They are not part of any
+Onyx deployment — bring them up only when you need them.
+
+| Stack | File | What it gives you |
+| --- | --- | --- |
+| Langfuse | `docker-compose.langfuse.yml` | A local, self-hosted [Langfuse](https://langfuse.com) v3 instance for viewing LLM traces |
+
+---
+
+## Langfuse (LLM tracing)
+
+Onyx already emits LLM/embedding/rerank traces (see `backend/onyx/tracing/`). When
+`LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` are set, `setup_tracing()`
+(`backend/onyx/tracing/setup.py`) ships those traces to Langfuse. This stack gives you a
+local Langfuse to send them to instead of Langfuse Cloud.
+
+It runs the full Langfuse **v3** stack (required by the pinned `langfuse==3.10.0` SDK):
+`langfuse-web`, `langfuse-worker`, and namespaced Postgres / ClickHouse / Redis / MinIO.
+These are isolated on a private `langfuse-internal` network and do **not** touch Onyx's
+own `relational_db` / `cache` / `minio`. Only `langfuse-web` is additionally attached to
+Onyx's `onyx_default` network so the backend can reach it by hostname.
+
+### 1. Start it
+
+Run from the **host** (there is no Docker daemon inside the dev container). The Onyx dev
+services must already be up, since this attaches to their `onyx_default` network:
+
+```bash
+docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml up -d --wait
+```
+
+First boot takes a minute or two while ClickHouse migrations run. On first boot Langfuse
+is seeded (headless init) with a deterministic org, project, user, and API keys so there
+is nothing to click through.
+
+### 2. Point the Onyx backend at it
+
+Add these to `.vscode/.env` (the env the in-container backend reads):
+
+```bash
+LANGFUSE_HOST=http://langfuse-web:3000
+LANGFUSE_PUBLIC_KEY=pk-lf-onyx-local-dev
+LANGFUSE_SECRET_KEY=sk-lf-onyx-local-dev
+```
+
+Then **restart `ods backend api`** — tracing is initialized once at startup, so a restart
+is required to pick up the new env. For traces from background (Celery) LLM calls, restart
+the relevant worker too. On success the backend log
+(`backend/log/api_server_debug.log`) prints:
+
+```
+Tracing initialized with providers: langfuse
+```
+
+> If you run the backend on the **host** rather than in the dev container, use
+> `LANGFUSE_HOST=http://localhost:3001` instead.
+
+### 3. View traces
+
+Open the UI at <http://localhost:3001> and log in with the seeded credentials:
+
+- **Email:** `dev@onyx.app`
+- **Password:** `onyxlocaldev`
+
+Trigger an LLM call (e.g. send a chat at <http://localhost:3000>) and the corresponding
+trace/generation appears under the **Onyx Local Dev** project within a few seconds.
+
+### Ports
+
+| Host port | Service | Notes |
+| --- | --- | --- |
+| `3001` | `langfuse-web` | Langfuse UI + ingestion API |
+| `9090` / `9091` | `langfuse-minio` | Blob store API / console (browser-facing media links) |
+
+Postgres / ClickHouse / Redis are intentionally **not** published to the host — they're
+only reachable inside the `langfuse-internal` network, avoiding conflicts with Onyx's dev
+ports (5432, 6379, 9000, …).
+
+### Teardown / reset
+
+```bash
+# Stop, keep data (and the seeded keys):
+docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml down
+
+# Stop and wipe all Langfuse data (re-seeds keys on next boot):
+docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml down -v
+```
+
+### ⚠️ Local-dev only
+
+Every credential and key baked into `docker-compose.langfuse.yml` (the API keys, the
+`ENCRYPTION_KEY`, DB passwords, etc.) is a hardcoded local-dev default. Never reuse any of
+them outside local development.

--- a/deployment/docker_compose/dev/docker-compose.langfuse.yml
+++ b/deployment/docker_compose/dev/docker-compose.langfuse.yml
@@ -1,0 +1,206 @@
+# Self-hosted Langfuse (v3) for local LLM-tracing development.
+#
+# This is a SUPPLEMENTAL, opt-in stack — it is NOT part of the main Onyx
+# deployment. Bring it up when you want to view the traces that Onyx already
+# emits (see backend/onyx/tracing/) against a local Langfuse instance instead
+# of Langfuse Cloud.
+#
+# Quick start (run from the host — there is no Docker daemon inside the dev
+# container):
+#   docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml up -d --wait
+#
+# Then add the following to .vscode/.env and restart `ods backend api`:
+#   LANGFUSE_HOST=http://langfuse-web:3000
+#   LANGFUSE_PUBLIC_KEY=pk-lf-onyx-local-dev
+#   LANGFUSE_SECRET_KEY=sk-lf-onyx-local-dev
+#
+# Open the UI at http://localhost:3001 (login: dev@onyx.app / onyxlocaldev).
+#
+# See README.md in this directory for full details.
+#
+# NOTE: every credential below is a hardcoded LOCAL-DEV default. Do not reuse
+# any of these values outside of local development.
+
+name: onyx-langfuse-dev
+
+# Shared backing-store config for both the web and worker containers. All
+# hostnames point at the namespaced `langfuse-*` services on the private
+# `langfuse-internal` network so they never collide with Onyx's own
+# relational_db / cache / minio services.
+x-langfuse-env: &langfuse-env
+  DATABASE_URL: postgresql://postgres:postgres@langfuse-postgres:5432/postgres
+  SALT: onyx-local-salt
+  # 64 hex chars (256-bit). Local-dev only — generate a real one for any
+  # non-local use with: openssl rand -hex 32
+  ENCRYPTION_KEY: 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+  TELEMETRY_ENABLED: "false"
+  LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "false"
+
+  CLICKHOUSE_MIGRATION_URL: clickhouse://langfuse-clickhouse:9000
+  CLICKHOUSE_URL: http://langfuse-clickhouse:8123
+  CLICKHOUSE_USER: clickhouse
+  CLICKHOUSE_PASSWORD: clickhouse
+  CLICKHOUSE_CLUSTER_ENABLED: "false"
+
+  REDIS_HOST: langfuse-redis
+  REDIS_PORT: "6379"
+  REDIS_AUTH: myredissecret
+  REDIS_TLS_ENABLED: "false"
+
+  # Blob storage (events + media) lives in the namespaced MinIO. The event
+  # endpoint is reached over the internal network; the media endpoint is
+  # browser-facing so it uses the published host port.
+  LANGFUSE_S3_EVENT_UPLOAD_BUCKET: langfuse
+  LANGFUSE_S3_EVENT_UPLOAD_REGION: auto
+  LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: minio
+  LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: miniosecret
+  LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+  LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+  LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: langfuse
+  LANGFUSE_S3_MEDIA_UPLOAD_REGION: auto
+  LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: minio
+  LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: miniosecret
+  LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://localhost:9090
+  LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+
+services:
+  langfuse-web:
+    image: docker.io/langfuse/langfuse:3
+    restart: unless-stopped
+    depends_on: &langfuse-depends-on
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    networks:
+      - langfuse-internal
+      - onyx
+    ports:
+      # Host 3001 -> container 3000 (3000 is taken by the Onyx frontend).
+      - "3001:3000"
+    environment:
+      <<: *langfuse-env
+      NEXTAUTH_SECRET: onyx-local-nextauth-secret
+      NEXTAUTH_URL: http://localhost:3001
+      # Headless init: seed a deterministic org/project/user + API keys on the
+      # very first boot so the keys above can be pasted straight into .env.
+      LANGFUSE_INIT_ORG_ID: onyx-local
+      LANGFUSE_INIT_ORG_NAME: Onyx Local
+      LANGFUSE_INIT_PROJECT_ID: onyx-local
+      LANGFUSE_INIT_PROJECT_NAME: Onyx Local Dev
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: pk-lf-onyx-local-dev
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: sk-lf-onyx-local-dev
+      LANGFUSE_INIT_USER_EMAIL: dev@onyx.app
+      LANGFUSE_INIT_USER_NAME: Onyx Dev
+      LANGFUSE_INIT_USER_PASSWORD: onyxlocaldev
+
+  langfuse-worker:
+    image: docker.io/langfuse/langfuse-worker:3
+    restart: unless-stopped
+    depends_on: *langfuse-depends-on
+    networks:
+      - langfuse-internal
+    environment:
+      <<: *langfuse-env
+
+  langfuse-postgres:
+    image: docker.io/postgres:17
+    restart: unless-stopped
+    networks:
+      - langfuse-internal
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      TZ: UTC
+      PGTZ: UTC
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  langfuse-clickhouse:
+    image: docker.io/clickhouse/clickhouse-server
+    restart: unless-stopped
+    user: "101:101"
+    networks:
+      - langfuse-internal
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: clickhouse
+      CLICKHOUSE_PASSWORD: clickhouse
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      - langfuse_clickhouse_logs:/var/log/clickhouse-server
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 1s
+
+  langfuse-redis:
+    image: docker.io/redis:7
+    restart: unless-stopped
+    networks:
+      - langfuse-internal
+    command: >
+      --requirepass myredissecret
+      --maxmemory-policy noeviction
+    volumes:
+      - langfuse_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 10s
+      retries: 10
+
+  langfuse-minio:
+    image: cgr.dev/chainguard/minio
+    restart: unless-stopped
+    networks:
+      - langfuse-internal
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: miniosecret
+    ports:
+      # Browser-facing so media links (LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT) resolve.
+      # 9090/9091 avoid Onyx's dev MinIO (9004/9005) and model server (9000).
+      - "9090:9000"
+      - "127.0.0.1:9091:9001"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 1s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+
+networks:
+  # Private network for Langfuse's own backing services.
+  langfuse-internal:
+    driver: bridge
+  # Onyx's compose network, so the in-container backend can reach the Langfuse
+  # web server at http://langfuse-web:3000. Created by the main Onyx stack.
+  onyx:
+    external: true
+    name: onyx_default
+
+volumes:
+  langfuse_postgres_data:
+  langfuse_clickhouse_data:
+  langfuse_clickhouse_logs:
+  langfuse_redis_data:
+  langfuse_minio_data:


### PR DESCRIPTION
## What

Adds a supplemental, **opt-in** `deployment/docker_compose/dev/` directory — a home for developer-only stacks you stand up alongside the normal Onyx dev services — with a self-hosted **Langfuse v3** stack as the first one.

Onyx already emits LLM/embedding/rerank traces via `backend/onyx/tracing/` (shipped to Langfuse whenever `LANGFUSE_PUBLIC_KEY` + `LANGFUSE_SECRET_KEY` are set). Until now there was no easy way to *view* them locally without Langfuse Cloud. This gives you a local Langfuse to point at.

## Details

- **Langfuse v3** is required by the pinned `langfuse==3.10.0` SDK (v2's single-container setup won't work). The stack runs `langfuse-web`, `langfuse-worker`, and namespaced Postgres / ClickHouse / Redis / MinIO.
- All backing services are namespaced `langfuse-*` on a private `langfuse-internal` network, so they never collide with Onyx's own `relational_db` / `cache` / `minio`.
- Only `langfuse-web` is attached to the external `onyx_default` network, so the in-container backend reaches it at `http://langfuse-web:3000`. UI is published on host port **3001** (3000 is the Onyx frontend); MinIO on 9090/9091; Postgres/ClickHouse/Redis are not published.
- **Headless init** (`LANGFUSE_INIT_*`) pre-seeds a deterministic org/project/user and `pk-lf-onyx-local-dev` / `sk-lf-onyx-local-dev` keys on first boot — zero UI clicks.
- All baked-in credentials are clearly marked **local-dev-only** defaults.

## How to use

1. From the host: `docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml up -d --wait`
2. Add to `.vscode/.env`, then restart `ods backend api`:
   ```
   LANGFUSE_HOST=http://langfuse-web:3000
   LANGFUSE_PUBLIC_KEY=pk-lf-onyx-local-dev
   LANGFUSE_SECRET_KEY=sk-lf-onyx-local-dev
   ```
   Backend logs `Tracing initialized with providers: langfuse` on success.
3. View traces at http://localhost:3001 (`dev@onyx.app` / `onyxlocaldev`).

## Testing

Dev tooling only (compose + docs), no application code — the existing `setup_tracing()` logic is already covered by `backend/tests/unit/onyx/tracing/test_tracing_setup.py`. The compose was validated with PyYAML (anchors/merge-keys resolve, `depends_on` health conditions propagate, `onyx` maps to external `onyx_default`, `INIT_*` keys are web-only, `ENCRYPTION_KEY` is valid 64-hex). End-to-end boot + live-trace round-trip should be confirmed once on a host with a Docker daemon (no daemon in the dev container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an opt-in local Langfuse v3 Docker Compose stack to view Onyx LLM/embedding/rerank traces locally without Langfuse Cloud. This is dev-only and runs alongside existing Onyx services with no changes to application code.

- **New Features**
  - Added `deployment/docker_compose/dev/docker-compose.langfuse.yml` and README for a local Langfuse v3 stack compatible with `langfuse==3.10.0`.
  - Isolated `langfuse-*` services on a private `langfuse-internal` network; only `langfuse-web` joins `onyx_default`.
  - UI exposed on `localhost:3001`; backend reaches `http://langfuse-web:3000`; MinIO on `9090/9091`; no DB/Redis ports published.
  - Headless init seeds a deterministic org, project, user, and dev API keys on first boot.

- **Migration**
  - Start: `docker compose -f deployment/docker_compose/dev/docker-compose.langfuse.yml up -d --wait`
  - Configure backend in `.vscode/.env` and restart: `LANGFUSE_HOST=http://langfuse-web:3000`, `LANGFUSE_PUBLIC_KEY=pk-lf-onyx-local-dev`, `LANGFUSE_SECRET_KEY=sk-lf-onyx-local-dev`
  - View traces at http://localhost:3001 (email `dev@onyx.app`, password `onyxlocaldev`)

<sup>Written for commit a7118810142bd319bfc6443cfb8deef2bd2c6b67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

