### PR TITLE
feat(ci): cloud deploy dispatch on image build

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1502,6 +1502,42 @@ jobs:
             $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
             $IMAGES
 
+  # For cloud tags only: once all cloud images are built and pushed, notify the
+  # cloud-deployment-yamls repo (via repository_dispatch) so it can roll out the
+  # new image version.
+  dispatch-cloud-deployment:
+    needs:
+      - determine-builds
+      - merge-web-cloud
+      - merge-backend
+      - merge-model-server
+    if: needs.determine-builds.outputs.is-cloud-tag == 'true' && needs.determine-builds.outputs.is-test-run != 'true'
+    # NOTE: Github-hosted runners have about 20s faster queue times and are preferred here.
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.CLOUD_DEPLOYMENT_APP_ID }}
+          private-key: ${{ secrets.CLOUD_DEPLOYMENT_APP_PRIVATE_KEY }}
+          # Scope the token to the dispatch target. Keep these in sync with CLOUD_DEPLOYMENT_REPO.
+          owner: onyx-dot-app
+          repositories: cloud-deployment-yamls
+          permission-contents: write
+
+      - name: Trigger new-cloud-image dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          CLOUD_DEPLOYMENT_REPO: ${{ vars.CLOUD_DEPLOYMENT_REPO }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          gh api "repos/${CLOUD_DEPLOYMENT_REPO}/dispatches" \
+            -f event_type=new-cloud-image \
+            -F "client_payload[version]=${VERSION}"
+
   trivy-scan:
     needs:
       - determine-builds

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1502,9 +1502,6 @@ jobs:
             $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
             $IMAGES
 
-  # For cloud tags only: once all cloud images are built and pushed, notify the
-  # cloud-deployment-yamls repo (via repository_dispatch) so it can roll out the
-  # new image version.
   dispatch-cloud-deployment:
     needs:
       - determine-builds
@@ -1517,15 +1514,27 @@ jobs:
     timeout-minutes: 10
     permissions: {}
     steps:
+      - name: Resolve dispatch target
+        id: target
+        env:
+          CLOUD_DEPLOYMENT_REPO: ${{ vars.CLOUD_DEPLOYMENT_REPO }}
+        run: |
+          if [ -z "$CLOUD_DEPLOYMENT_REPO" ]; then
+            echo "::error::CLOUD_DEPLOYMENT_REPO is not set"
+            exit 1
+          fi
+          echo "owner=${CLOUD_DEPLOYMENT_REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "repo=${CLOUD_DEPLOYMENT_REPO#*/}" >> "$GITHUB_OUTPUT"
+
       - name: Mint GitHub App installation token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           client-id: ${{ vars.CLOUD_DEPLOYMENT_APP_ID }}
           private-key: ${{ secrets.CLOUD_DEPLOYMENT_APP_PRIVATE_KEY }}
-          # Scope the token to the dispatch target. Keep these in sync with CLOUD_DEPLOYMENT_REPO.
-          owner: onyx-dot-app
-          repositories: cloud-deployment-yamls
+          # Scope the token to the same repo the dispatch targets, derived from CLOUD_DEPLOYMENT_REPO.
+          owner: ${{ steps.target.outputs.owner }}
+          repositories: ${{ steps.target.outputs.repo }}
           permission-contents: write
 
       - name: Trigger new-cloud-image dispatch


### PR DESCRIPTION
## What

Adds a `dispatch-cloud-deployment` job to `.github/workflows/deployment.yml`. After the cloud images are built and pushed, it sends a `new-cloud-image` `repository_dispatch` event to the cloud deployment repo so it can roll out the new image version.

The dispatch payload mirrors:

```bash
gh api "repos/${CLOUD_DEPLOYMENT_REPO}/dispatches" \
  -f event_type=new-cloud-image \
  -F "client_payload[version]=${VERSION}"
```

where `VERSION` is the cloud tag (`github.ref_name`).

## Behavior

- **Cloud-only:** gated on `is-cloud-tag == 'true' && is-test-run != 'true'`.
- **Waits for the images:** `needs` the three cloud merges (`merge-web-cloud`, `merge-backend`, `merge-model-server`). Without `always()`, a failed/skipped merge skips the dispatch, so it only fires once all cloud images are pushed.
- **Auth:** mints a scoped GitHub App installation token via `actions/create-github-app-token` (Contents: write on the target repo), the minimum needed for `repository_dispatch`. The job runs with `permissions: {}`.

## Required configuration

These must be set on this repo before the job works:

| Kind | Name | Value |
|------|------|-------|
| Repo variable | `CLOUD_DEPLOYMENT_REPO` | `owner/repo` of the cloud deployment repository |
| Repo variable | `CLOUD_DEPLOYMENT_APP_ID` | GitHub App client ID |
| Repo secret | `CLOUD_DEPLOYMENT_APP_PRIVATE_KEY` | GitHub App private key |

The App must be installed on the target repo with Contents: write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
