### PR TITLE
feat(craft): pre-approved apps UI for scheduled tasks

### DIFF
--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -161,9 +161,8 @@ def update_scheduled_task(
         ``next_run_at`` is recomputed from ``now``.
       - If ``status`` transitions to PAUSED, ``next_run_at`` is set to NULL.
       - If ``status`` transitions to ACTIVE, ``next_run_at`` is recomputed.
-      - If ``prompt`` changes value, ``pre_approved_app_ids`` resets to []
-        (a grant is tied to a specific intent). Grants in the same patch
-        still win.
+      - ``pre_approved_app_ids`` follows normal patch semantics: supplied
+        replaces the set, omitted leaves it unchanged.
 
     Raises:
         OnyxError(NOT_FOUND): the task does not exist or is not owned by
@@ -176,11 +175,8 @@ def update_scheduled_task(
     schedule_changed = False
     if name is not None:
         task.name = name
-    if prompt is not None and prompt != task.prompt:
+    if prompt is not None:
         task.prompt = prompt
-        # Prompt change resets grants unless this same patch supplies new ones.
-        if pre_approved_app_ids is None:
-            pre_approved_app_ids = []
     if pre_approved_app_ids is not None:
         set_pre_approved_apps(task, pre_approved_app_ids)
     if editor_mode is not None:

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -1,5 +1,5 @@
 """Scheduled-task pre-approvals (ext-dep): real SQL for the grant lookup,
-the pre-decided insert, and the prompt-edit reset rule.
+the pre-decided insert, and the grant patch semantics.
 
 The gate-side short-circuit behavior (skip park / fall through / DENY
 ordering) is covered with stubs in ``tests/unit/sandbox_proxy/test_gate.py``;
@@ -211,56 +211,37 @@ def test_insert_default_row_stays_pending(
 
 
 # ---------------------------------------------------------------------------
-# update_scheduled_task — prompt-edit reset rule
+# update_scheduled_task — grant patch semantics
 # ---------------------------------------------------------------------------
 
 
-def test_prompt_value_change_resets_grants(
+def test_prompt_change_preserves_grants(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
-    user = make_user(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[_make_app(db_session)])
-
-    updated = update_scheduled_task(
-        db_session=db_session,
-        task_id=task.id,
-        user_id=user.id,
-        prompt="exfiltrate everything",
-    )
-    db_session.commit()
-
-    assert updated.pre_approved_app_ids == []
-
-
-def test_identical_prompt_resubmit_keeps_grants(
-    db_session: Session,
-    tenant_context: None,  # noqa: ARG001
-) -> None:
-    """The editor round-trips the prompt on every save; an unchanged value
-    must not wipe grants."""
+    """Grants are explicit state surfaced as checkboxes in the editor: a
+    prompt edit that omits ``pre_approved_app_ids`` leaves them untouched."""
     user = make_user(db_session)
     app = _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app], prompt="same")
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app], prompt="orig")
 
     updated = update_scheduled_task(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
-        prompt="same",
-        name="renamed",
+        prompt="a rewritten prompt",
     )
     db_session.commit()
 
     assert updated.pre_approved_app_ids == [app]
 
 
-def test_grants_in_same_patch_win_over_prompt_reset(
+def test_supplied_grants_replace_existing(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
-    """The editor's re-enable-in-the-same-submit flow: a prompt change plus
-    explicit grants in one patch keeps the supplied grants."""
+    """Supplying ``pre_approved_app_ids`` replaces the set wholesale —
+    dropping omitted apps and adding new ones."""
     user = make_user(db_session)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
     task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
@@ -269,7 +250,6 @@ def test_grants_in_same_patch_win_over_prompt_reset(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
-        prompt="a different prompt",
         pre_approved_app_ids=[app_b],
     )
     db_session.commit()
@@ -293,29 +273,6 @@ def test_resubmitting_existing_grant_is_idempotent(
         task_id=task.id,
         user_id=user.id,
         pre_approved_app_ids=[app_a, app_b],  # app_a already granted
-    )
-    db_session.commit()
-
-    assert set(updated.pre_approved_app_ids) == {app_a, app_b}
-
-
-def test_prompt_change_plus_reincluded_grant_is_idempotent(
-    db_session: Session,
-    tenant_context: None,  # noqa: ARG001
-) -> None:
-    """Prompt change + re-including a granted app in one patch must not
-    orphan+reinsert the same (task, app) key. The reset-then-set must resolve
-    to a single grant write, not two."""
-    user = make_user(db_session)
-    app_a, app_b = _make_app(db_session), _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a], prompt="orig")
-
-    updated = update_scheduled_task(
-        db_session=db_session,
-        task_id=task.id,
-        user_id=user.id,
-        prompt="changed",
-        pre_approved_app_ids=[app_a, app_b],  # app_a re-included AND prompt changed
     )
     db_session.commit()
 

--- a/docs/craft/features/scheduled-tasks/pre-approvals.md
+++ b/docs/craft/features/scheduled-tasks/pre-approvals.md
@@ -173,13 +173,12 @@ pre-decided inserts go through `insert_action_approval` in
 
 ## Lifecycle & Security
 
-- **Prompt edits clear grants.** A `PATCH` whose `prompt` value differs
-  from the stored one resets `pre_approved_app_ids` to `[]` — the grant
-  was made against a specific intent, and a rewritten prompt must not
-  inherit it. Resubmitting an identical prompt does not reset, and grants
-  supplied in the same patch win over the reset (so the planned editor can
-  warn and re-enable in one submit). Schedule changes do not reset grants;
-  cadence doesn't change intent.
+- **Grants are explicit and visible.** They are managed as checkboxes in
+  the task editor and follow normal `PATCH` semantics — supplying
+  `pre_approved_app_ids` replaces the set, omitting it leaves grants
+  unchanged. Editing the prompt does not alter grants: the granted apps
+  are shown alongside the prompt, so the author keeps or clears them as a
+  deliberate, in-view choice rather than relying on an automatic reset.
 - **The grant boundary is the app.** There is no cross-app
   "auto-approve everything" toggle — that would convert any prompt
   injection into write capability across every connected app.
@@ -191,8 +190,8 @@ pre-decided inserts go through `insert_action_approval` in
 - **Prompt injection against pre-approved writes is inherent.** A
   poisoned context can drive a granted app's write with no human
   checkpoint. Mitigations: per-app (not global) grants, `DENY`
-  supremacy, prompt-edit reset, and the unattended-forward
-  notifications.
+  supremacy, grants shown in-editor next to the prompt, and the
+  unattended-forward notifications.
 - **An app grant covers actions the user never enumerated**, including
   catalog actions added in later releases. Mitigated today by admin
   per-action `DENY`; the planned grant-time covered-actions expander will
@@ -252,9 +251,9 @@ The grant-source seam means future modes drop in as new
     `(run_id, grants)`; non-RUNNING (SUCCEEDED / FAILED /
     AWAITING_APPROVAL) → `None`; interactive / no-run session → `None`.
   - `insert_action_approval`: pre-decided `APPROVED` vs default-pending.
-  - Prompt-edit reset: a differing prompt resets grants, an identical
-    prompt keeps them, grants supplied in the same patch win over the
-    reset.
+  - Grant patch semantics: a prompt edit preserves grants, supplied
+    `pre_approved_app_ids` replaces the set, and re-submitting an existing
+    grant is idempotent (no unique-key collision).
   - Create persistence + `_validated_app_ids` dedupe and unknown-id
     rejection.
 - **Unit** (gate, stubbed DB):

--- a/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
@@ -99,5 +99,6 @@ function toFormInitial(detail: ScheduledTaskDetail): ScheduleTaskFormInitial {
     prompt: detail.prompt,
     mode,
     payload,
+    preApprovedAppIds: detail.pre_approved_app_ids,
   };
 }

--- a/web/src/app/craft/v1/tasks/[id]/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/page.tsx
@@ -189,7 +189,9 @@ export default function ScheduledTaskDetailPage() {
           </Text>
         ) : (
           <div className="flex flex-col gap-6">
-            <PreApprovedAppsSummary appIds={data.pre_approved_app_ids} />
+            {data.pre_approved_app_ids.length > 0 && (
+              <PreApprovedAppsSummary appIds={data.pre_approved_app_ids} />
+            )}
             <RunHistoryTable taskId={data.id} />
           </div>
         )}

--- a/web/src/app/craft/v1/tasks/[id]/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
   updateScheduledTask,
 } from "@/app/craft/v1/tasks/api";
 import RunHistoryTable from "@/app/craft/v1/tasks/components/RunHistoryTable";
+import PreApprovedAppsSummary from "@/app/craft/v1/tasks/components/PreApprovedAppsSummary";
 import { TaskStatusBadge } from "@/app/craft/v1/tasks/components/StatusBadge";
 import { TASKS_PATH, taskEditPath } from "@/app/craft/v1/tasks/constants";
 import type {
@@ -187,7 +188,10 @@ export default function ScheduledTaskDetailPage() {
             Failed to load scheduled task.
           </Text>
         ) : (
-          <RunHistoryTable taskId={data.id} />
+          <div className="flex flex-col gap-6">
+            <PreApprovedAppsSummary appIds={data.pre_approved_app_ids} />
+            <RunHistoryTable taskId={data.id} />
+          </div>
         )}
       </SettingsLayouts.Body>
 

--- a/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
@@ -19,7 +19,7 @@ export default function PreApprovalPicker({
   selectedIds,
   onChange,
 }: PreApprovalPickerProps) {
-  const { data, isLoading } = useUserExternalApps();
+  const { data, isLoading, error } = useUserExternalApps();
 
   const selected = new Set(selectedIds);
   const toggle = useCallback(
@@ -37,6 +37,16 @@ export default function PreApprovalPicker({
       <Card variant="tertiary">
         <Text font="secondary-body" color="text-03">
           Loading apps…
+        </Text>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card variant="tertiary">
+        <Text font="secondary-body" color="text-03">
+          Couldn’t load your apps. Refresh to try again.
         </Text>
       </Card>
     );

--- a/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback } from "react";
+import { Checkbox, Text } from "@opal/components";
+import { cn } from "@opal/utils";
+import Card from "@/refresh-components/cards/Card";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import {
+  getAppTypeLogo,
+  type ExternalAppUserResponse,
+} from "@/app/craft/v1/apps/registry";
+
+interface PreApprovalPickerProps {
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+}
+
+export default function PreApprovalPicker({
+  selectedIds,
+  onChange,
+}: PreApprovalPickerProps) {
+  const { data, isLoading } = useUserExternalApps();
+
+  const selected = new Set(selectedIds);
+  const toggle = useCallback(
+    (id: number) => {
+      const next = new Set(selectedIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      onChange(Array.from(next));
+    },
+    [selectedIds, onChange]
+  );
+
+  if (isLoading) {
+    return (
+      <Card variant="tertiary">
+        <Text font="secondary-body" color="text-03">
+          Loading apps…
+        </Text>
+      </Card>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <Card variant="tertiary">
+        <Text font="secondary-body" color="text-03">
+          No external apps are enabled for your org yet. Ask an admin to enable
+          one.
+        </Text>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      {data.map((app) => (
+        <PreApprovalRow
+          key={app.id}
+          app={app}
+          checked={selected.has(app.id)}
+          onToggle={() => toggle(app.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PreApprovalRowProps {
+  app: ExternalAppUserResponse;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+function PreApprovalRow({ app, checked, onToggle }: PreApprovalRowProps) {
+  const Logo = getAppTypeLogo(app.app_type);
+  return (
+    <div
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={app.name}
+      tabIndex={0}
+      onClick={onToggle}
+      onKeyDown={(e) => {
+        if (e.key === " " || e.key === "Enter") {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+      className={cn(
+        "rounded-12 cursor-pointer transition-shadow",
+        checked && "ring-2 ring-action-link-04"
+      )}
+      data-testid={`pre-approval-app-${app.id}`}
+    >
+      <Card>
+        <div className="flex items-center gap-3 w-full">
+          <Logo className="w-8 h-8" />
+          <div className="flex-1 flex flex-col gap-0.5 min-w-0">
+            <Text font="main-ui-action">{app.name}</Text>
+            <Text font="secondary-body" color="text-03">
+              {app.description}
+            </Text>
+          </div>
+          {/* Visual only — the row owns clicks/keys so the control never
+              double-toggles. */}
+          <div className="pointer-events-none">
+            <Checkbox checked={checked} />
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/app/craft/v1/tasks/components/PreApprovedAppsSummary.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovedAppsSummary.tsx
@@ -11,8 +11,10 @@ interface PreApprovedAppsSummaryProps {
 export default function PreApprovedAppsSummary({
   appIds,
 }: PreApprovedAppsSummaryProps) {
-  const { data } = useUserExternalApps();
+  const { data, isLoading } = useUserExternalApps();
   if (appIds.length === 0) return null;
+  // Wait for names so the tags never flash raw "App #id" fallbacks.
+  if (isLoading) return null;
 
   const byId = new Map((data ?? []).map((app) => [app.id, app]));
   return (

--- a/web/src/app/craft/v1/tasks/components/PreApprovedAppsSummary.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovedAppsSummary.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Tag, Text } from "@opal/components";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import { getAppTypeLogo } from "@/app/craft/v1/apps/registry";
+
+interface PreApprovedAppsSummaryProps {
+  appIds: number[];
+}
+
+export default function PreApprovedAppsSummary({
+  appIds,
+}: PreApprovedAppsSummaryProps) {
+  const { data } = useUserExternalApps();
+  if (appIds.length === 0) return null;
+
+  const byId = new Map((data ?? []).map((app) => [app.id, app]));
+  return (
+    <div className="flex flex-col gap-2">
+      <Text font="main-ui-action" color="text-03">
+        Pre-approved apps
+      </Text>
+      <div className="flex flex-wrap gap-2">
+        {appIds.map((id) => {
+          const app = byId.get(id);
+          return (
+            <Tag
+              key={id}
+              icon={app ? getAppTypeLogo(app.app_type) : undefined}
+              title={app?.name ?? `App #${id}`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -197,8 +197,6 @@ export default function ScheduleTaskForm({
             prompt: trimmedPrompt,
             editor_mode: mode,
             editor_payload: storagePayload,
-            // Always sent: the backend clears grants on a prompt change unless
-            // this same patch re-supplies them.
             pre_approved_app_ids: preApprovedAppIds,
           };
           const updated: ScheduledTaskDetail = await updateScheduledTask(

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -12,6 +12,7 @@ import * as GeneralLayouts from "@/layouts/general-layouts";
 import { toast } from "@/hooks/useToast";
 import { SvgClock } from "@opal/icons";
 import ScheduleEditor from "@/app/craft/v1/tasks/components/ScheduleEditor";
+import PreApprovalPicker from "@/app/craft/v1/tasks/components/PreApprovalPicker";
 import {
   compileLocalPayloadToUtcCron,
   localPayloadToUtcPayload,
@@ -44,6 +45,7 @@ export interface ScheduleTaskFormInitial {
   prompt: string;
   mode: EditorMode;
   payload: EditorPayload;
+  preApprovedAppIds: number[];
 }
 
 interface ScheduleTaskFormProps {
@@ -70,6 +72,9 @@ export default function ScheduleTaskForm({
   const [prompt, setPrompt] = useState(initial.prompt);
   const [mode, setMode] = useState<EditorMode>(initial.mode);
   const [payload, setPayload] = useState<EditorPayload>(initial.payload);
+  const [preApprovedAppIds, setPreApprovedAppIds] = useState<number[]>(
+    initial.preApprovedAppIds
+  );
   const [saving, setSaving] = useState(false);
   const [nameTouched, setNameTouched] = useState(false);
   const [promptTouched, setPromptTouched] = useState(false);
@@ -192,6 +197,9 @@ export default function ScheduleTaskForm({
             prompt: trimmedPrompt,
             editor_mode: mode,
             editor_payload: storagePayload,
+            // Always sent: the backend clears grants on a prompt change unless
+            // this same patch re-supplies them.
+            pre_approved_app_ids: preApprovedAppIds,
           };
           const updated: ScheduledTaskDetail = await updateScheduledTask(
             initial.taskId,
@@ -206,6 +214,7 @@ export default function ScheduleTaskForm({
             editor_mode: mode,
             editor_payload: storagePayload,
             run_immediately: runImmediately,
+            pre_approved_app_ids: preApprovedAppIds,
           };
           await createScheduledTask(body);
           toast.success(
@@ -229,6 +238,7 @@ export default function ScheduleTaskForm({
       initial.taskId,
       mode,
       payload,
+      preApprovedAppIds,
       router,
       trimmedName,
       trimmedPrompt,
@@ -358,6 +368,20 @@ export default function ScheduleTaskForm({
             />
           </InputVertical>
         </GeneralLayouts.Section>
+
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+        <GeneralLayouts.Section>
+          <InputVertical
+            title="Pre-approved apps"
+            description="Selected apps can act without pausing for approval while this task runs on its own. Note: an app you don't pre-approve will pause mid-run to ask for your approval. The run may stall or fail if you do not approve an action request."
+          >
+            <PreApprovalPicker
+              selectedIds={preApprovedAppIds}
+              onChange={setPreApprovedAppIds}
+            />
+          </InputVertical>
+        </GeneralLayouts.Section>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );
@@ -370,5 +394,6 @@ export function defaultFormInitial(): ScheduleTaskFormInitial {
     prompt: "",
     mode: "interval",
     payload: { unit: "hours", every: 1 },
+    preApprovedAppIds: [],
   };
 }

--- a/web/src/app/craft/v1/tasks/interfaces.ts
+++ b/web/src/app/craft/v1/tasks/interfaces.ts
@@ -78,6 +78,7 @@ export interface ScheduledTaskDetail {
   next_run_at: string | null;
   next_runs: string[];
   last_run: ScheduledRunSummary | null;
+  pre_approved_app_ids: number[];
   created_at: string;
   updated_at: string;
 }
@@ -89,6 +90,7 @@ export interface ScheduledTaskCreateBody {
   editor_payload: EditorPayload;
   status?: ScheduledTaskStatus;
   run_immediately?: boolean;
+  pre_approved_app_ids?: number[];
 }
 
 export interface ScheduledTaskPatchBody {
@@ -97,6 +99,7 @@ export interface ScheduledTaskPatchBody {
   editor_mode?: EditorMode;
   editor_payload?: EditorPayload;
   status?: ScheduledTaskStatus;
+  pre_approved_app_ids?: number[];
 }
 
 export interface ScheduledTaskListResponse {


### PR DESCRIPTION
## Description

UI for selecting which external apps a scheduled task may act on without pausing for approval during unattended runs (backend gate landed in #11674).

- Adds `pre_approved_app_ids` to the scheduled-task TS interfaces.
- `PreApprovalPicker` — 2-column multi-select of the user's external apps in the create/edit form.
- `PreApprovedAppsSummary` — read-only tags on the detail page.
- Makes grants **explicit, visible state**: drops the backend's prompt-edit auto-reset so `pre_approved_app_ids` follows normal PATCH semantics (supplied replaces, omitted unchanged). The granted apps are shown as checkboxes beside the prompt, so the author keeps/clears them deliberately rather than via a hidden reset the editor always defeated.

## How Has This Been Tested?

Manual E2E via Playwright against a live stack: create with grant, detail tags, edit (prompt change + add/remove grants), deselect-all clears, delete. Also verified directly that a prompt-changing PATCH omitting `pre_approved_app_ids` now preserves grants. Ext-dep tests updated to pin the explicit grant patch semantics (run in CI). `tsc`/`oxlint`/`oxfmt`/`ruff`/`ty` pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check