### PR TITLE
chore(devcontainer): upgrade image to default python 3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,11 +32,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   openssh-client \
   pkg-config \
   postgresql-client \
-  python3-venv \
   ripgrep \
   socat \
   sudo \
-  supervisor \
   unzip \
   wget \
   zsh \
@@ -120,11 +118,11 @@ RUN apt-get update \
 
 # Install Python 3.13 via uv into a stable, image-level path so venvs
 # created in bind-mounted workspaces survive across `docker run`s.
-# Ubuntu 26.04's system Python is 3.14, but onnxruntime only ships
-# cp311–cp313 wheels, so the repo pins 3.13 (the top of that range)
-# via .python-version.
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
-RUN uv python install 3.13
+RUN UV_PYTHON_BIN_DIR=/usr/local/bin uv python install 3.13 \
+  && ln -s python3.13 /usr/local/bin/python3 \
+  && ln -s python3.13 /usr/local/bin/python \
+  && python --version
 
 # Create non-root dev user with passwordless sudo
 RUN useradd -m -s /bin/zsh dev && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:f8fbf8e1014b0eaa1ba200d9a6a9c7a6c937e0ccfe72644d0d5fcd40618e08e6",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:ea89d6cdb709fdbd62c4ff7fc26aa559029868d0b4bad4bd503661d3709c5a05",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Onyx Dev Sandbox",
-  "image": "onyxdotapp/onyx-devcontainer@sha256:ea89d6cdb709fdbd62c4ff7fc26aa559029868d0b4bad4bd503661d3709c5a05",
+  "image": "onyxdotapp/onyx-devcontainer@sha256:6d62918d6ddcc5e1fca5d5d010a5bb9c3c4c5d8890ead6c6d395e929494555b4",
   "runArgs": [
     "--cap-add=NET_ADMIN",
     "--cap-add=NET_RAW",


### PR DESCRIPTION
## Summary

Bumps the devcontainer image digest to the build that defaults to **Python 3.13** instead of 3.11.

- `onyxdotapp/onyx-devcontainer@sha256:f8fbf8e…` → `@sha256:ea89d6c…`

## Test plan

```
$ docker run -it --rm onyxdotapp/onyx-devcontainer:latest python --version
Python 3.13.13
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the VS Code devcontainer to default to Python 3.13. Updates the `onyxdotapp/onyx-devcontainer` image, installs 3.13 via `uv` into `/usr/local/bin`, symlinks `python`/`python3` to 3.13, and removes `python3-venv` and `supervisor`.

- **Migration**
  - Rebuild the devcontainer and verify `python --version` shows 3.13.

<sup>Written for commit a5885a1587634caed19aa36485384fd67565c204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





