### PR TITLE
fix: forward user identifier to OpenRouter activity tracking via extra_body

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -660,37 +660,47 @@ class LitellmLLM(LLM):
             user_identity=user_identity,
         )
 
-        # OpenRouter sticky routing: inject session_id into extra_body so that
-        # OpenRouter pins all turns of a conversation to the same upstream provider,
-        # enabling prompt cache hits across turns.
+        # OpenRouter: inject session_id and user into extra_body.
+        #
+        # session_id — sticky routing: pins all turns of a conversation to the
+        # same upstream provider, enabling prompt cache hits across turns.
         # Without this, OpenRouter may alternate between e.g. Anthropic and Google
         # for the same model, causing cache misses on every other turn.
         # See: https://openrouter.ai/docs/features/provider-routing#session-id
         #
-        # Gated on SEND_USER_METADATA_TO_LLM_PROVIDER for consistency with the
-        # user/session metadata handled in build_litellm_passthrough_kwargs: an
-        # operator who opted out of sending session identifiers to providers
-        # should not have the session_id forwarded to OpenRouter either.
+        # user — activity tracking: OpenRouter reads the user identifier from
+        # extra_body for its per-user activity logs; the top-level LiteLLM
+        # `user` parameter is forwarded to the upstream model but is not picked
+        # up by OpenRouter's own tracking dashboard.
+        #
+        # Both are gated on SEND_USER_METADATA_TO_LLM_PROVIDER: an operator who
+        # opted out of sending session/user identifiers to providers should not
+        # have them forwarded to OpenRouter either.
         if (
             SEND_USER_METADATA_TO_LLM_PROVIDER
             and self._model_provider == LlmProviderNames.OPENROUTER
             and user_identity is not None
-            and user_identity.session_id
         ):
-            if passthrough_kwargs is self._model_kwargs:
-                passthrough_kwargs = copy.deepcopy(self._model_kwargs)
-            existing_extra_body = passthrough_kwargs.get("extra_body") or {}
-            if isinstance(existing_extra_body, dict):
-                passthrough_kwargs["extra_body"] = {
-                    **existing_extra_body,
-                    "session_id": user_identity.session_id,
-                }
-            else:
-                logger.warning(
-                    "OpenRouter sticky routing: extra_body is not a dict (%s), "
-                    "skipping session_id injection",
-                    type(existing_extra_body).__name__,
-                )
+            extra_body_updates: dict[str, str] = {}
+            if user_identity.session_id:
+                extra_body_updates["session_id"] = user_identity.session_id
+            if user_identity.user_id:
+                extra_body_updates["user"] = user_identity.user_id
+            if extra_body_updates:
+                if passthrough_kwargs is self._model_kwargs:
+                    passthrough_kwargs = copy.deepcopy(self._model_kwargs)
+                existing_extra_body = passthrough_kwargs.get("extra_body") or {}
+                if isinstance(existing_extra_body, dict):
+                    passthrough_kwargs["extra_body"] = {
+                        **existing_extra_body,
+                        **extra_body_updates,
+                    }
+                else:
+                    logger.warning(
+                        "OpenRouter extra_body injection: extra_body is not a dict (%s), "
+                        "skipping session_id/user injection",
+                        type(existing_extra_body).__name__,
+                    )
 
         try:
             # NOTE: must pass in None instead of empty strings otherwise litellm


### PR DESCRIPTION
## Summary

Extends the OpenRouter `extra_body` injection introduced in #11660 to also include the `user` identifier, enabling per-user cost tracking in the OpenRouter activity dashboard.

**Problem:** LiteLLM forwards the top-level `user` parameter to the upstream model, but OpenRouter's own activity dashboard reads the user identifier from `extra_body` — not from the top-level field. As a result, the `user` column in OpenRouter activity logs is always empty, making it impossible for operators to attribute and track costs per user.

**Fix:** When `SEND_USER_METADATA_TO_LLM_PROVIDER=true`, `user_identity.user_id` is now injected into `extra_body` alongside the existing `session_id`. Both fields share the same gate and the same injection block, so the logic stays consolidated and the operator opt-out is respected for both.

## Changes

- `backend/onyx/llm/multi_llm.py`: merged the `session_id` and `user` injections into a single `extra_body_updates` dict; added `user_identity.user_id` → `"user"` key so it appears in OpenRouter activity logs.

## Test plan

- [ ] Set `SEND_USER_METADATA_TO_LLM_PROVIDER=true` and configure an OpenRouter LLM provider
- [ ] Send chat messages; verify the `user` column in the [OpenRouter activity CSV](https://openrouter.ai/activity) shows the user's identifier
- [ ] Verify `session_id` sticky routing still works (cache hits across conversation turns)
- [ ] With `SEND_USER_METADATA_TO_LLM_PROVIDER=false` (default), verify neither `user` nor `session_id` is injected

Related: #11659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects the user identifier into `extra_body` for `OpenRouter` requests (alongside `session_id`) when `SEND_USER_METADATA_TO_LLM_PROVIDER=true`, enabling per-user cost tracking. Fixes empty `user` values in the OpenRouter activity dashboard while keeping sticky routing.

- **Bug Fixes**
  - Add `user_identity.user_id` to `extra_body.user` for `OpenRouter` when the flag is enabled.
  - Merge `session_id` and `user` injection into one block; only applies when `extra_body` is a dict, otherwise logs a warning.
  - Respects the same opt-out gate; default behavior unchanged.

<sup>Written for commit cc85f3ecd2bda919f88787e351590eb411b204b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

