### PR TITLE
fix(indexing): order get_last_attempt_for_cc_pair by time_created, not time_updated

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -45,7 +45,13 @@ def get_last_attempt_for_cc_pair(
     )
     if ignore_targeted_reindex:
         query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
-    return query.order_by(IndexAttempt.time_updated.desc()).first()
+    # Order by time_created, not time_updated: background maintenance tasks
+    # (e.g. checkpoint / index-attempt cleanup) mutate time_updated on old
+    # attempts. Ordering by time_updated would let such a freshly-touched old
+    # attempt masquerade as the most recent one, which breaks the "is this
+    # connector due for indexing?" check in should_index() and can silently
+    # stop a connector from ever re-indexing.
+    return query.order_by(IndexAttempt.time_created.desc()).first()
 
 
 def get_recent_completed_attempts_for_cc_pair(


### PR DESCRIPTION
## Problem

`get_last_attempt_for_cc_pair()` selects the "most recent" attempt with `ORDER BY time_updated DESC`. But background maintenance tasks (checkpoint / index-attempt cleanup) **mutate `time_updated` on old attempts** long after they complete. A freshly-touched old attempt then sorts as the latest, and `should_index()` derives *"time since last index"* from its (recently bumped) `time_updated` → the connector is judged **not due** and **silently stops re-indexing, indefinitely**.

## Repro / impact

Observed in production (Community Edition, v3.3.7): a Google Drive connector with `refresh_freq=24h` stopped indexing for ~6 days. `check_for_indexing` reported the cc_pair as `skipped_not_indexable` on every run. The day indexing stopped lined up exactly with the cleanup task first bumping `time_updated` of an attempt that was *older* than the last real run, making it sort first.

## Fix

Order by `time_created` (immutable, set at attempt creation) so the genuinely latest attempt is selected, instead of `time_updated` which background tasks mutate. One-line change.

The targeted-reindex filter test is unaffected — it relies on the `targeted_reindex_job_id` filter, not on ordering.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use time_created to pick the latest index attempt, not time_updated, so due-for-indexing checks aren’t fooled by maintenance tasks touching old attempts. This prevents connectors from silently stopping re-indexing and restores normal refresh cadence; targeted reindex filtering is unchanged.

<sup>Written for commit 4ee95e106a8d5e23b3a39ce611875a57e58c23da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

