### PR TITLE
feat: mcp oauth persists refresh info

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -438,6 +438,15 @@ class OnyxTokenStorage(TokenStorage):
                 self._oauth_context.token_expiry_time = (
                     float(expires_at) if expires_at is not None else None
                 )
+                # Re-seed discovered metadata so refresh targets the real token
+                # endpoint, not the SDK's `<origin>/token` fallback. Don't
+                # clobber a known provider's metadata set in make_oauth_provider.
+                if self._oauth_context.oauth_metadata is None:
+                    metadata_raw = config_data.get(MCPOAuthKeys.METADATA.value)
+                    if metadata_raw:
+                        self._oauth_context.oauth_metadata = (
+                            OAuthMetadata.model_validate(metadata_raw)
+                        )
             tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
             if tokens_raw:
                 return OAuthToken.model_validate(tokens_raw)
@@ -458,6 +467,15 @@ class OnyxTokenStorage(TokenStorage):
                 # No expires_in: drop any stale expiry so the next tool call
                 # doesn't see the just-refreshed token as expired.
                 config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
+            # Persist discovered metadata so the next per-call provider can
+            # refresh without repeating discovery.
+            if (
+                self._oauth_context is not None
+                and self._oauth_context.oauth_metadata is not None
+            ):
+                config_data[MCPOAuthKeys.METADATA.value] = (
+                    self._oauth_context.oauth_metadata.model_dump(mode="json")
+                )
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -365,9 +365,8 @@ def _token_dict_with_preserved_refresh(
     tokens: OAuthToken, existing_tokens_raw: dict[str, Any] | None
 ) -> dict[str, Any]:
     """Dump `tokens` for storage, carrying over a previously stored refresh
-    token when the new payload omits one. Providers like Google only issue a
-    refresh token on the first authorization, so persisting a refresh response
-    verbatim would wipe it and break every subsequent refresh."""
+    token when the new payload omits one (providers like Google only issue a
+    refresh token on the first authorization)."""
     token_dict = tokens.model_dump(mode="json")
     if token_dict.get("refresh_token") or not existing_tokens_raw:
         return token_dict
@@ -386,14 +385,12 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
 
 
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:
-    """Expose a KNOWN_PROVIDER server's admin-configured endpoints as SDK OAuth
-    metadata. Hydrated into the provider context before tool calls so the SDK
-    refreshes against the real token endpoint instead of its default
+    """Expose a KNOWN_PROVIDER server's configured endpoints as SDK OAuth
+    metadata so refresh targets the real token endpoint, not the SDK's
     `<server-origin>/token` fallback."""
-    if mcp_server.oauth_provider_mode != MCPOAuthProviderMode.KNOWN_PROVIDER:
-        return None
     if (
-        not mcp_server.oauth_authorization_endpoint
+        mcp_server.oauth_provider_mode != MCPOAuthProviderMode.KNOWN_PROVIDER
+        or not mcp_server.oauth_authorization_endpoint
         or not mcp_server.oauth_token_endpoint
     ):
         return None
@@ -413,10 +410,8 @@ class OnyxTokenStorage(TokenStorage):
     def __init__(self, connection_config_id: int, alt_config_id: int | None = None):
         self.alt_config_id = alt_config_id
         self.connection_config_id = connection_config_id
-        # Optional SDK context, bound by `make_oauth_provider`. When set,
-        # `get_tokens` hydrates its `token_expiry_time` from the same config
-        # read it already performs, so we never issue a separate query just to
-        # learn the token expiry.
+        # When bound, `get_tokens` hydrates its `token_expiry_time` from the
+        # config read it already does — no separate query for the expiry.
         self._oauth_context: OAuthContext | None = None
 
     def bind_oauth_context(self, context: OAuthContext) -> None:
@@ -432,9 +427,8 @@ class OnyxTokenStorage(TokenStorage):
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
-            # The SDK never derives expiry from stored tokens, so hydrate it
-            # here (while we hold the config) to drive its proactive-refresh
-            # decision. None clears any prior value (token has no known expiry).
+            # The SDK never derives expiry from stored tokens; hydrate it here
+            # to drive its refresh decision (None = no known expiry).
             if self._oauth_context is not None:
                 expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
                 self._oauth_context.token_expiry_time = (
@@ -457,9 +451,8 @@ class OnyxTokenStorage(TokenStorage):
             if expires_at is not None:
                 config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = expires_at
             else:
-                # Refresh response omitted expires_in; clear the stale absolute
-                # expiry so the next tool call does not treat the just-refreshed
-                # token as expired and trigger another needless refresh.
+                # No expires_in: drop any stale expiry so the next tool call
+                # doesn't see the just-refreshed token as expired.
                 config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
@@ -607,17 +600,12 @@ def make_oauth_provider(
         callback_handler=callback_handler,
     )
 
-    # A fresh provider is built per tool call, so its in-memory context starts
-    # empty. Hydrate the two fields the SDK needs for a silent refresh:
-    #   1. Absolute token expiry — without it `is_token_valid()` defaults to True
-    #      (the SDK never sets expiry from stored tokens), so the proactive
-    #      refresh branch never fires and an expired token only fails on a 401,
-    #      which routes to full re-auth ("Please Reconnect") rather than refresh.
-    #      Bound to the storage so it is filled from the config read `get_tokens`
-    #      already does, rather than an extra query.
-    #   2. KNOWN_PROVIDER OAuth metadata — without it the refresh request falls
-    #      back to `<server-origin>/token`, which is wrong whenever the auth
-    #      server lives on a different host (e.g. GCP).
+    # A fresh provider per tool call starts with an empty context, so the SDK
+    # can't silently refresh without two hydrated fields: an absolute token
+    # expiry (else `is_token_valid()` stays True and refresh never fires) and,
+    # for known providers, the real OAuth metadata (else refresh hits the wrong
+    # `<server-origin>/token`). Expiry is bound through storage so it rides the
+    # config read `get_tokens` already does.
     storage.bind_oauth_context(provider.context)
     known_metadata = _known_provider_oauth_metadata(mcp_server)
     if known_metadata is not None:
@@ -1123,9 +1111,8 @@ async def process_oauth_callback(
         user_config_data[MCPOAuthKeys.TOKENS.value] = oauth_token.model_dump(
             mode="json"
         )
-        # `exchange_oauth_code_for_token` computes an absolute `expires_at` that
-        # `OAuthToken` drops on validation; persist it so later tool calls can
-        # tell when the token is stale and refresh proactively.
+        # `OAuthToken` drops the absolute `expires_at` from the payload on
+        # validation; persist it so later tool calls know when to refresh.
         expires_at = token_payload.get("expires_at") or _absolute_token_expiry(
             oauth_token
         )

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -18,6 +18,7 @@ from fastapi import HTTPException
 from fastapi import Request
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth import TokenStorage
+from mcp.client.auth.oauth2 import OAuthContext
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
 from mcp.shared.auth import OAuthMetadata
@@ -404,17 +405,6 @@ def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | N
     )
 
 
-def _read_stored_token_expiry(connection_config_id: int) -> float | None:
-    """Read the persisted absolute access-token expiry for a connection config,
-    used to hydrate a fresh OAuth provider's expiry so the SDK enters its
-    refresh branch when the token is actually stale."""
-    with get_session_with_current_tenant() as db_session:
-        config = get_connection_config_by_id(connection_config_id, db_session)
-        config_data = extract_connection_data(config)
-        expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
-        return float(expires_at) if expires_at is not None else None
-
-
 class OnyxTokenStorage(TokenStorage):
     """
     store auth info in a particular user's connection config in postgres
@@ -423,6 +413,14 @@ class OnyxTokenStorage(TokenStorage):
     def __init__(self, connection_config_id: int, alt_config_id: int | None = None):
         self.alt_config_id = alt_config_id
         self.connection_config_id = connection_config_id
+        # Optional SDK context, bound by `make_oauth_provider`. When set,
+        # `get_tokens` hydrates its `token_expiry_time` from the same config
+        # read it already performs, so we never issue a separate query just to
+        # learn the token expiry.
+        self._oauth_context: OAuthContext | None = None
+
+    def bind_oauth_context(self, context: OAuthContext) -> None:
+        self._oauth_context = context
 
     def _ensure_connection_config(self, db_session: Session) -> MCPConnectionConfig:
         config = get_connection_config_by_id(self.connection_config_id, db_session)
@@ -434,6 +432,14 @@ class OnyxTokenStorage(TokenStorage):
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
+            # The SDK never derives expiry from stored tokens, so hydrate it
+            # here (while we hold the config) to drive its proactive-refresh
+            # decision. None clears any prior value (token has no known expiry).
+            if self._oauth_context is not None:
+                expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+                self._oauth_context.token_expiry_time = (
+                    float(expires_at) if expires_at is not None else None
+                )
             tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
             if tokens_raw:
                 return OAuthToken.model_validate(tokens_raw)
@@ -450,6 +456,11 @@ class OnyxTokenStorage(TokenStorage):
             expires_at = _absolute_token_expiry(tokens)
             if expires_at is not None:
                 config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = expires_at
+            else:
+                # Refresh response omitted expires_in; clear the stale absolute
+                # expiry so the next tool call does not treat the just-refreshed
+                # token as expired and trigger another needless refresh.
+                config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
@@ -581,6 +592,7 @@ def make_oauth_provider(
         r.delete(key_auth_url(user_id), key_state(user_id))
         return code, state_obj.state
 
+    storage = OnyxTokenStorage(connection_config_id, admin_config_id)
     provider = OAuthClientProvider(
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
@@ -590,7 +602,7 @@ def make_oauth_provider(
             response_types=["code"],
             scope=REQUESTED_SCOPE,  # TODO: do we need to pass this in? maybe make configurable
         ),
-        storage=OnyxTokenStorage(connection_config_id, admin_config_id),
+        storage=storage,
         redirect_handler=redirect_handler,
         callback_handler=callback_handler,
     )
@@ -601,12 +613,12 @@ def make_oauth_provider(
     #      (the SDK never sets expiry from stored tokens), so the proactive
     #      refresh branch never fires and an expired token only fails on a 401,
     #      which routes to full re-auth ("Please Reconnect") rather than refresh.
+    #      Bound to the storage so it is filled from the config read `get_tokens`
+    #      already does, rather than an extra query.
     #   2. KNOWN_PROVIDER OAuth metadata — without it the refresh request falls
     #      back to `<server-origin>/token`, which is wrong whenever the auth
     #      server lives on a different host (e.g. GCP).
-    stored_expiry = _read_stored_token_expiry(connection_config_id)
-    if stored_expiry is not None:
-        provider.context.token_expiry_time = stored_expiry
+    storage.bind_oauth_context(provider.context)
     known_metadata = _known_provider_oauth_metadata(mcp_server)
     if known_metadata is not None:
         provider.context.oauth_metadata = known_metadata

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -102,6 +102,10 @@ from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
+# Refresh slightly before the real expiry to absorb network latency and clock
+# skew between us and the provider, avoiding edge-of-expiry 401s.
+TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
+
 
 _SSRF_HINT_NEVER_ALLOWED = (
     " localhost, unspecified, and link-local/cloud-metadata addresses are never "
@@ -381,7 +385,7 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
     survives a reload into a fresh OAuth provider (see TOKEN_EXPIRES_AT)."""
     if tokens.expires_in is None:
         return None
-    return time.time() + tokens.expires_in
+    return time.time() + tokens.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
 
 
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -4,8 +4,10 @@ import datetime
 import hashlib
 import ipaddress
 import json
+import time
 from enum import Enum
 from secrets import token_urlsafe
+from typing import Any
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -18,6 +20,7 @@ from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth import TokenStorage
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthClientMetadata
+from mcp.shared.auth import OAuthMetadata
 from mcp.shared.auth import OAuthToken
 from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
@@ -357,6 +360,61 @@ def key_client_info(user_id: str) -> str:
 REQUESTED_SCOPE: str | None = None
 
 
+def _token_dict_with_preserved_refresh(
+    tokens: OAuthToken, existing_tokens_raw: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Dump `tokens` for storage, carrying over a previously stored refresh
+    token when the new payload omits one. Providers like Google only issue a
+    refresh token on the first authorization, so persisting a refresh response
+    verbatim would wipe it and break every subsequent refresh."""
+    token_dict = tokens.model_dump(mode="json")
+    if token_dict.get("refresh_token") or not existing_tokens_raw:
+        return token_dict
+    existing_refresh = existing_tokens_raw.get("refresh_token")
+    if existing_refresh:
+        token_dict["refresh_token"] = existing_refresh
+    return token_dict
+
+
+def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
+    """Resolve the relative `expires_in` to an absolute unix timestamp so it
+    survives a reload into a fresh OAuth provider (see TOKEN_EXPIRES_AT)."""
+    if tokens.expires_in is None:
+        return None
+    return time.time() + tokens.expires_in
+
+
+def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:
+    """Expose a KNOWN_PROVIDER server's admin-configured endpoints as SDK OAuth
+    metadata. Hydrated into the provider context before tool calls so the SDK
+    refreshes against the real token endpoint instead of its default
+    `<server-origin>/token` fallback."""
+    if mcp_server.oauth_provider_mode != MCPOAuthProviderMode.KNOWN_PROVIDER:
+        return None
+    if (
+        not mcp_server.oauth_authorization_endpoint
+        or not mcp_server.oauth_token_endpoint
+    ):
+        return None
+    parsed = urlparse(mcp_server.oauth_authorization_endpoint)
+    return OAuthMetadata(
+        issuer=f"{parsed.scheme}://{parsed.netloc}",  # ty: ignore[invalid-argument-type]
+        authorization_endpoint=mcp_server.oauth_authorization_endpoint,  # ty: ignore[invalid-argument-type]
+        token_endpoint=mcp_server.oauth_token_endpoint,  # ty: ignore[invalid-argument-type]
+    )
+
+
+def _read_stored_token_expiry(connection_config_id: int) -> float | None:
+    """Read the persisted absolute access-token expiry for a connection config,
+    used to hydrate a fresh OAuth provider's expiry so the SDK enters its
+    refresh branch when the token is actually stale."""
+    with get_session_with_current_tenant() as db_session:
+        config = get_connection_config_by_id(connection_config_id, db_session)
+        config_data = extract_connection_data(config)
+        expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+        return float(expires_at) if expires_at is not None else None
+
+
 class OnyxTokenStorage(TokenStorage):
     """
     store auth info in a particular user's connection config in postgres
@@ -385,7 +443,13 @@ class OnyxTokenStorage(TokenStorage):
         with get_session_with_current_tenant() as db_session:
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
-            config_data[MCPOAuthKeys.TOKENS.value] = tokens.model_dump(mode="json")
+            existing_tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
+            config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
+                tokens, existing_tokens_raw
+            )
+            expires_at = _absolute_token_expiry(tokens)
+            if expires_at is not None:
+                config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = expires_at
             config_data["headers"] = {
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
@@ -517,7 +581,7 @@ def make_oauth_provider(
         r.delete(key_auth_url(user_id), key_state(user_id))
         return code, state_obj.state
 
-    return OAuthClientProvider(
+    provider = OAuthClientProvider(
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
             client_name=f"Onyx - {mcp_server.name}",
@@ -530,6 +594,23 @@ def make_oauth_provider(
         redirect_handler=redirect_handler,
         callback_handler=callback_handler,
     )
+
+    # A fresh provider is built per tool call, so its in-memory context starts
+    # empty. Hydrate the two fields the SDK needs for a silent refresh:
+    #   1. Absolute token expiry — without it `is_token_valid()` defaults to True
+    #      (the SDK never sets expiry from stored tokens), so the proactive
+    #      refresh branch never fires and an expired token only fails on a 401,
+    #      which routes to full re-auth ("Please Reconnect") rather than refresh.
+    #   2. KNOWN_PROVIDER OAuth metadata — without it the refresh request falls
+    #      back to `<server-origin>/token`, which is wrong whenever the auth
+    #      server lives on a different host (e.g. GCP).
+    stored_expiry = _read_stored_token_expiry(connection_config_id)
+    if stored_expiry is not None:
+        provider.context.token_expiry_time = stored_expiry
+    known_metadata = _known_provider_oauth_metadata(mcp_server)
+    if known_metadata is not None:
+        provider.context.oauth_metadata = known_metadata
+    return provider
 
 
 def _build_headers_from_template(
@@ -1030,6 +1111,14 @@ async def process_oauth_callback(
         user_config_data[MCPOAuthKeys.TOKENS.value] = oauth_token.model_dump(
             mode="json"
         )
+        # `exchange_oauth_code_for_token` computes an absolute `expires_at` that
+        # `OAuthToken` drops on validation; persist it so later tool calls can
+        # tell when the token is stale and refresh proactively.
+        expires_at = token_payload.get("expires_at") or _absolute_token_expiry(
+            oauth_token
+        )
+        if expires_at is not None:
+            user_config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = float(expires_at)
         user_config_data["headers"] = {
             "Authorization": f"{oauth_token.token_type} {oauth_token.access_token}"
         }
@@ -1143,9 +1232,9 @@ def save_user_credentials(
                 header_substitutions=request.credentials,
             )
             for oauth_field_key in MCPOAuthKeys:
-                field_key: Literal["client_info", "tokens", "metadata"] = (
-                    oauth_field_key.value
-                )
+                field_key: Literal[
+                    "client_info", "tokens", "metadata", "token_expires_at"
+                ] = oauth_field_key.value
                 if field_val := auth_template_dict.get(field_key):
                     config_data[field_key] = field_val
 

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -59,6 +59,11 @@ class MCPOAuthKeys(str, Enum):
     CLIENT_INFO = "client_info"
     TOKENS = "tokens"
     METADATA = "metadata"
+    # Absolute unix timestamp (seconds) when the stored access token expires.
+    # The SDK's `OAuthToken` only carries the relative `expires_in`, which is
+    # meaningless once reloaded from storage; we persist the absolute value so
+    # a fresh per-tool-call provider can decide whether to refresh.
+    TOKEN_EXPIRES_AT = "token_expires_at"
 
 
 class MCPConnectionData(TypedDict):
@@ -80,6 +85,7 @@ class MCPConnectionData(TypedDict):
     client_info: NotRequired[dict[str, Any]]  # OAuthClientInformationFull
     tokens: NotRequired[dict[str, Any]]  # OAuthToken
     metadata: NotRequired[dict[str, Any]]  # OAuthClientMetadata
+    token_expires_at: NotRequired[float]  # absolute unix expiry for `tokens`
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -59,10 +59,8 @@ class MCPOAuthKeys(str, Enum):
     CLIENT_INFO = "client_info"
     TOKENS = "tokens"
     METADATA = "metadata"
-    # Absolute unix timestamp (seconds) when the stored access token expires.
-    # The SDK's `OAuthToken` only carries the relative `expires_in`, which is
-    # meaningless once reloaded from storage; we persist the absolute value so
-    # a fresh per-tool-call provider can decide whether to refresh.
+    # Absolute unix expiry for the stored token. `OAuthToken` only carries the
+    # relative `expires_in`, which is meaningless once reloaded from storage.
     TOKEN_EXPIRES_AT = "token_expires_at"
 
 

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -163,8 +163,8 @@ def test_known_provider_oauth_metadata_uses_configured_token_endpoint() -> None:
         _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER)
     )
     assert metadata is not None
-    # The whole point: refresh must hit the configured endpoint, not the SDK's
-    # `<server-origin>/token` fallback (which would be mcp.example.com/token).
+    # Refresh must hit the configured endpoint, not the SDK's
+    # `<server-origin>/token` fallback (mcp.example.com/token).
     assert str(metadata.token_endpoint) == "https://accounts.example.com/oauth/token"
     assert (
         str(metadata.authorization_endpoint)

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -1,3 +1,4 @@
+import time
 from types import SimpleNamespace
 from typing import cast
 from urllib.parse import parse_qs
@@ -5,12 +6,18 @@ from urllib.parse import urlparse
 
 import pytest
 from mcp.shared.auth import OAuthClientInformationFull
+from mcp.shared.auth import OAuthToken
 
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
+from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp.api import _absolute_token_expiry
+from onyx.server.features.mcp.api import _known_provider_oauth_metadata
 from onyx.server.features.mcp.api import _mcp_known_provider_flow_params
+from onyx.server.features.mcp.api import _token_dict_with_preserved_refresh
+from onyx.server.features.mcp.api import make_oauth_provider
 
 
 def _make_mcp_server_stub(
@@ -19,6 +26,7 @@ def _make_mcp_server_stub(
     token_endpoint: str | None = "https://accounts.example.com/oauth/token",
     scopes: list[str] | None = None,
     params: dict[str, str] | None = None,
+    provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.KNOWN_PROVIDER,
 ) -> DbMCPServer:
     return cast(
         DbMCPServer,
@@ -27,7 +35,10 @@ def _make_mcp_server_stub(
             oauth_token_endpoint=token_endpoint,
             oauth_scopes_override=scopes,
             oauth_additional_auth_params=params,
+            oauth_provider_mode=provider_mode,
             server_url="https://mcp.example.com/mcp",
+            name="Example MCP",
+            id=1,
         ),
     )
 
@@ -139,3 +150,123 @@ def test_known_provider_code_exchange_sends_code_verifier(
     assert "expires_at" in token_payload
     assert captured["data"]["code_verifier"] == "verifier-123"
     assert captured["data"]["client_secret"] == "secret-123"
+
+
+def test_known_provider_oauth_metadata_uses_configured_token_endpoint() -> None:
+    metadata = _known_provider_oauth_metadata(
+        _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER)
+    )
+    assert metadata is not None
+    # The whole point: refresh must hit the configured endpoint, not the SDK's
+    # `<server-origin>/token` fallback (which would be mcp.example.com/token).
+    assert str(metadata.token_endpoint) == "https://accounts.example.com/oauth/token"
+    assert (
+        str(metadata.authorization_endpoint)
+        == "https://accounts.example.com/oauth/authorize"
+    )
+
+
+def test_known_provider_oauth_metadata_none_for_auto_discovery() -> None:
+    assert (
+        _known_provider_oauth_metadata(
+            _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY)
+        )
+        is None
+    )
+
+
+def test_known_provider_oauth_metadata_none_without_endpoints() -> None:
+    assert (
+        _known_provider_oauth_metadata(_make_mcp_server_stub(token_endpoint=None))
+        is None
+    )
+
+
+def test_preserves_existing_refresh_token_when_response_omits_it() -> None:
+    new_tokens = OAuthToken(
+        access_token="new-access", token_type="Bearer", expires_in=3600
+    )
+    result = _token_dict_with_preserved_refresh(
+        new_tokens, {"refresh_token": "old-refresh"}
+    )
+    assert result["refresh_token"] == "old-refresh"
+    assert result["access_token"] == "new-access"
+
+
+def test_keeps_new_refresh_token_when_present() -> None:
+    new_tokens = OAuthToken(
+        access_token="a", token_type="Bearer", refresh_token="new-refresh"
+    )
+    result = _token_dict_with_preserved_refresh(
+        new_tokens, {"refresh_token": "old-refresh"}
+    )
+    assert result["refresh_token"] == "new-refresh"
+
+
+def test_no_refresh_token_when_none_stored() -> None:
+    new_tokens = OAuthToken(access_token="a", token_type="Bearer")
+    assert (
+        _token_dict_with_preserved_refresh(new_tokens, None).get("refresh_token")
+        is None
+    )
+
+
+def test_absolute_token_expiry_from_expires_in() -> None:
+    before = time.time()
+    expiry = _absolute_token_expiry(
+        OAuthToken(access_token="a", token_type="Bearer", expires_in=3600)
+    )
+    assert expiry is not None
+    assert before + 3600 <= expiry <= time.time() + 3600
+
+
+def test_absolute_token_expiry_none_without_expires_in() -> None:
+    assert (
+        _absolute_token_expiry(OAuthToken(access_token="a", token_type="Bearer"))
+        is None
+    )
+
+
+def test_make_oauth_provider_hydrates_known_provider_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Stored token expired a minute ago.
+    monkeypatch.setattr(
+        "onyx.server.features.mcp.api._read_stored_token_expiry",
+        lambda _config_id: time.time() - 60,
+    )
+    provider = make_oauth_provider(
+        _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER),
+        user_id="user-1",
+        return_path="/return",
+        connection_config_id=1,
+        admin_config_id=None,
+    )
+    assert provider.context.oauth_metadata is not None
+    assert (
+        str(provider.context.oauth_metadata.token_endpoint)
+        == "https://accounts.example.com/oauth/token"
+    )
+    # Guard the SDK contract: our hydrated expiry must land where the SDK reads
+    # it, so a present-but-expired token is reported invalid and the SDK's
+    # proactive refresh branch fires.
+    provider.context.current_tokens = OAuthToken(access_token="a", token_type="Bearer")
+    assert provider.context.is_token_valid() is False
+
+
+def test_make_oauth_provider_auto_discovery_leaves_context_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.server.features.mcp.api._read_stored_token_expiry",
+        lambda _config_id: None,
+    )
+    provider = make_oauth_provider(
+        _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY),
+        user_id="user-1",
+        return_path="/return",
+        connection_config_id=1,
+        admin_config_id=None,
+    )
+    assert provider.context.oauth_metadata is None
+    assert provider.context.token_expiry_time is None

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -7,10 +7,14 @@ from typing import Iterator
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
+import httpx
 import pytest
 from mcp.client.auth import OAuthClientProvider
 from mcp.shared.auth import OAuthClientInformationFull
+from mcp.shared.auth import OAuthMetadata
 from mcp.shared.auth import OAuthToken
+from pydantic import AnyHttpUrl
+from pydantic import AnyUrl
 
 import onyx.server.features.mcp.api as mcp_api
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
@@ -223,7 +227,10 @@ def test_absolute_token_expiry_from_expires_in() -> None:
         OAuthToken(access_token="a", token_type="Bearer", expires_in=3600)
     )
     assert expiry is not None
-    assert before + 3600 <= expiry <= time.time() + 3600
+    # The expiry is `now + expires_in` pulled back by the refresh buffer so we
+    # refresh slightly early; bound the assertion the same way.
+    buffer = mcp_api.TOKEN_EXPIRY_BUFFER_SECONDS
+    assert before + 3600 - buffer <= expiry <= time.time() + 3600 - buffer
 
 
 def test_absolute_token_expiry_none_without_expires_in() -> None:
@@ -256,7 +263,7 @@ def _patch_config_read(
     monkeypatch.setattr(
         mcp_api.OnyxTokenStorage,
         "_ensure_connection_config",
-        lambda _self, _db: object(),
+        lambda _self, _db: SimpleNamespace(id=1),
     )
     monkeypatch.setattr(mcp_api, "extract_connection_data", lambda _config: config_data)
 
@@ -311,3 +318,215 @@ def test_get_tokens_clears_stale_expiry_when_absent(
     )
     asyncio.run(provider.context.storage.get_tokens())
     assert provider.context.token_expiry_time is None
+
+
+# --- Discovered OAuth metadata persistence (AUTO_DISCOVERY cross-host refresh) ---
+
+
+_DISCOVERED_METADATA = OAuthMetadata(
+    issuer=cast(AnyHttpUrl, "https://idp.other-host.com"),
+    authorization_endpoint=cast(AnyHttpUrl, "https://idp.other-host.com/authorize"),
+    token_endpoint=cast(AnyHttpUrl, "https://idp.other-host.com/token"),
+)
+
+
+def _patch_config_store(
+    monkeypatch: pytest.MonkeyPatch, config_data: dict[str, object]
+) -> None:
+    """Like `_patch_config_read`, but also stubs the write path so `set_tokens`
+    persists into the same in-memory `config_data` dict (`extract_connection_data`
+    returns it, so mutations land in place; the update is a no-op)."""
+    _patch_config_read(monkeypatch, config_data)
+    monkeypatch.setattr(
+        mcp_api, "update_connection_config", lambda *_args, **_kwargs: None
+    )
+
+
+def test_get_tokens_rehydrates_discovered_metadata_for_auto_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    assert provider.context.oauth_metadata is None
+    _patch_config_read(
+        monkeypatch,
+        {
+            MCPOAuthKeys.METADATA.value: _DISCOVERED_METADATA.model_dump(mode="json"),
+            MCPOAuthKeys.TOKENS.value: {"access_token": "a", "token_type": "Bearer"},
+        },
+    )
+    asyncio.run(provider.context.storage.get_tokens())
+    # Cross-host AUTO_DISCOVERY now refreshes against the discovered endpoint
+    # instead of the SDK's `<server-origin>/token` fallback.
+    assert provider.context.oauth_metadata is not None
+    assert (
+        str(provider.context.oauth_metadata.token_endpoint)
+        == "https://idp.other-host.com/token"
+    )
+
+
+def test_get_tokens_does_not_override_known_provider_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+    # A stale/different persisted metadata must not displace the configured
+    # known-provider endpoints that make_oauth_provider injected.
+    _patch_config_read(
+        monkeypatch,
+        {
+            MCPOAuthKeys.METADATA.value: _DISCOVERED_METADATA.model_dump(mode="json"),
+            MCPOAuthKeys.TOKENS.value: {"access_token": "a", "token_type": "Bearer"},
+        },
+    )
+    asyncio.run(provider.context.storage.get_tokens())
+    assert provider.context.oauth_metadata is not None
+    assert (
+        str(provider.context.oauth_metadata.token_endpoint)
+        == "https://accounts.example.com/oauth/token"
+    )
+
+
+def test_set_tokens_persists_discovered_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    # Simulate the SDK having discovered the auth server during the 401 flow.
+    provider.context.oauth_metadata = _DISCOVERED_METADATA
+    config_data: dict[str, object] = {}
+    _patch_config_store(monkeypatch, config_data)
+    asyncio.run(
+        provider.context.storage.set_tokens(
+            OAuthToken(access_token="a", token_type="Bearer", expires_in=3600)
+        )
+    )
+    persisted = cast(dict, config_data.get(MCPOAuthKeys.METADATA.value))
+    assert isinstance(persisted, dict)
+    assert persisted["token_endpoint"] == "https://idp.other-host.com/token"
+
+
+# --- End-to-end proactive refresh through the SDK's async_auth_flow ---
+
+
+def _seed_refreshable_config(expires_at: float) -> dict[str, object]:
+    """Stored state for a user whose access token is expired but refreshable."""
+    client_info = OAuthClientInformationFull(
+        client_id="client-123",
+        client_secret="secret-123",
+        redirect_uris=[cast(AnyUrl, "https://app.example.com/mcp/oauth/callback")],
+    )
+    return {
+        MCPOAuthKeys.CLIENT_INFO.value: client_info.model_dump(mode="json"),
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: expires_at,
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "access-old",
+            "token_type": "Bearer",
+            "refresh_token": "refresh-old",
+        },
+    }
+
+
+async def _drive_refresh(
+    provider: OAuthClientProvider,
+    refresh_status: int,
+    refresh_body: dict[str, object],
+) -> tuple[httpx.Request, httpx.Request | None]:
+    """Drive `async_auth_flow` through its proactive-refresh branch: take the
+    first yielded request (the refresh), feed it the given response, and return
+    that refresh request plus the next request the SDK would send."""
+    request = httpx.Request("POST", "https://mcp.example.com/mcp")
+    flow = provider.async_auth_flow(request)
+    refresh_request = await anext(flow)
+    refresh_response = httpx.Response(
+        status_code=refresh_status, json=refresh_body, request=refresh_request
+    )
+    try:
+        next_request: httpx.Request | None = await flow.asend(refresh_response)
+    except StopAsyncIteration:
+        next_request = None
+    await flow.aclose()
+    return refresh_request, next_request
+
+
+def test_proactive_refresh_targets_configured_endpoint_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+    config_data = _seed_refreshable_config(expires_at=time.time() - 60)
+    _patch_config_store(monkeypatch, config_data)
+
+    refresh_request, authed_request = asyncio.run(
+        _drive_refresh(
+            provider,
+            refresh_status=200,
+            refresh_body={
+                "access_token": "access-new",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "refresh-new",
+            },
+        )
+    )
+
+    # Refresh must hit the configured token endpoint, not <server-origin>/token.
+    assert str(refresh_request.url) == "https://accounts.example.com/oauth/token"
+    assert b"grant_type=refresh_token" in refresh_request.content
+    assert b"refresh-old" in refresh_request.content
+    # The in-flight request is retried with the freshly minted token.
+    assert authed_request is not None
+    assert authed_request.headers.get("Authorization") == "Bearer access-new"
+    # The new token + a future expiry are persisted for the next call.
+    persisted_tokens = cast(dict, config_data[MCPOAuthKeys.TOKENS.value])
+    assert persisted_tokens["access_token"] == "access-new"
+    assert persisted_tokens["refresh_token"] == "refresh-new"
+    assert cast(float, config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value]) > time.time()
+
+
+def test_proactive_refresh_preserves_refresh_token_when_response_omits_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+    config_data = _seed_refreshable_config(expires_at=time.time() - 60)
+    _patch_config_store(monkeypatch, config_data)
+
+    _, authed_request = asyncio.run(
+        _drive_refresh(
+            provider,
+            refresh_status=200,
+            refresh_body={
+                "access_token": "access-new",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            },
+        )
+    )
+
+    assert authed_request is not None
+    persisted_tokens = cast(dict, config_data[MCPOAuthKeys.TOKENS.value])
+    assert persisted_tokens["access_token"] == "access-new"
+    # Providers that only issue a refresh token once keep working.
+    assert persisted_tokens["refresh_token"] == "refresh-old"
+
+
+def test_proactive_refresh_failure_clears_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+    config_data = _seed_refreshable_config(expires_at=time.time() - 60)
+    _patch_config_store(monkeypatch, config_data)
+
+    refresh_request, authed_request = asyncio.run(
+        _drive_refresh(
+            provider,
+            refresh_status=400,
+            refresh_body={"error": "invalid_grant"},
+        )
+    )
+
+    # A rejected refresh clears the in-memory token so the SDK falls through to
+    # re-auth (which surfaces as "please reconnect" at the tool layer) rather
+    # than retrying a dead access token.
+    assert str(refresh_request.url) == "https://accounts.example.com/oauth/token"
+    assert provider.context.current_tokens is None
+    assert authed_request is not None, (
+        "SDK no longer yields original request on refresh failure"
+    )
+    assert authed_request.headers.get("Authorization") is None

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -1,13 +1,18 @@
+import asyncio
 import time
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import cast
+from typing import Iterator
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
 import pytest
+from mcp.client.auth import OAuthClientProvider
 from mcp.shared.auth import OAuthClientInformationFull
 from mcp.shared.auth import OAuthToken
 
+import onyx.server.features.mcp.api as mcp_api
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.db.enums import MCPOAuthProviderMode
@@ -18,6 +23,7 @@ from onyx.server.features.mcp.api import _known_provider_oauth_metadata
 from onyx.server.features.mcp.api import _mcp_known_provider_flow_params
 from onyx.server.features.mcp.api import _token_dict_with_preserved_refresh
 from onyx.server.features.mcp.api import make_oauth_provider
+from onyx.server.features.mcp.models import MCPOAuthKeys
 
 
 def _make_mcp_server_stub(
@@ -227,46 +233,81 @@ def test_absolute_token_expiry_none_without_expires_in() -> None:
     )
 
 
-def test_make_oauth_provider_hydrates_known_provider_context(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # Stored token expired a minute ago.
-    monkeypatch.setattr(
-        "onyx.server.features.mcp.api._read_stored_token_expiry",
-        lambda _config_id: time.time() - 60,
-    )
-    provider = make_oauth_provider(
-        _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER),
+def _build_provider(provider_mode: MCPOAuthProviderMode) -> OAuthClientProvider:
+    return make_oauth_provider(
+        _make_mcp_server_stub(provider_mode=provider_mode),
         user_id="user-1",
         return_path="/return",
         connection_config_id=1,
         admin_config_id=None,
     )
+
+
+def _patch_config_read(
+    monkeypatch: pytest.MonkeyPatch, config_data: dict[str, object]
+) -> None:
+    """Stub out the DB layer so OnyxTokenStorage.get_tokens reads `config_data`."""
+
+    @contextmanager
+    def _fake_session() -> Iterator[object]:
+        yield object()
+
+    monkeypatch.setattr(mcp_api, "get_session_with_current_tenant", _fake_session)
+    monkeypatch.setattr(
+        mcp_api.OnyxTokenStorage,
+        "_ensure_connection_config",
+        lambda _self, _db: object(),
+    )
+    monkeypatch.setattr(mcp_api, "extract_connection_data", lambda _config: config_data)
+
+
+def test_make_oauth_provider_sets_known_provider_metadata_and_binds_storage() -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
     assert provider.context.oauth_metadata is not None
+    # Refresh must target the configured endpoint, not `<server-origin>/token`.
     assert (
         str(provider.context.oauth_metadata.token_endpoint)
         == "https://accounts.example.com/oauth/token"
     )
-    # Guard the SDK contract: our hydrated expiry must land where the SDK reads
-    # it, so a present-but-expired token is reported invalid and the SDK's
-    # proactive refresh branch fires.
-    provider.context.current_tokens = OAuthToken(access_token="a", token_type="Bearer")
+    # Storage is wired to hydrate expiry from the config read it already does.
+    storage = cast(mcp_api.OnyxTokenStorage, provider.context.storage)
+    assert storage._oauth_context is provider.context
+
+
+def test_make_oauth_provider_auto_discovery_leaves_metadata_unset() -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    assert provider.context.oauth_metadata is None
+    assert provider.context.token_expiry_time is None
+
+
+def test_get_tokens_hydrates_expiry_and_invalidates_expired_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
+    past = time.time() - 60
+    _patch_config_read(
+        monkeypatch,
+        {
+            MCPOAuthKeys.TOKEN_EXPIRES_AT.value: past,
+            MCPOAuthKeys.TOKENS.value: {"access_token": "a", "token_type": "Bearer"},
+        },
+    )
+    tokens = asyncio.run(provider.context.storage.get_tokens())
+    # Guards the SDK contract: hydrated expiry lands where is_token_valid reads
+    # it, so a present-but-expired token is reported invalid (refresh fires).
+    assert provider.context.token_expiry_time == past
+    provider.context.current_tokens = tokens
     assert provider.context.is_token_valid() is False
 
 
-def test_make_oauth_provider_auto_discovery_leaves_context_unset(
+def test_get_tokens_clears_stale_expiry_when_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        "onyx.server.features.mcp.api._read_stored_token_expiry",
-        lambda _config_id: None,
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    provider.context.token_expiry_time = 999.0  # stale value from a prior load
+    _patch_config_read(
+        monkeypatch,
+        {MCPOAuthKeys.TOKENS.value: {"access_token": "a", "token_type": "Bearer"}},
     )
-    provider = make_oauth_provider(
-        _make_mcp_server_stub(provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY),
-        user_id="user-1",
-        return_path="/return",
-        connection_config_id=1,
-        admin_config_id=None,
-    )
-    assert provider.context.oauth_metadata is None
+    asyncio.run(provider.context.storage.get_tokens())
     assert provider.context.token_expiry_time is None


### PR DESCRIPTION
## Description

Fix silent OAuth token refresh for MCP tool calls, which previously broke for any KNOWN_PROVIDER server whose authorization host differs from the MCP server host (e.g. GCP Logging) because each per-tool-call provider was rebuilt with an empty context. We now hydrate the SDK provider with the configured token endpoint and a persisted absolute token expiry so the proactive-refresh branch actually fires against the correct endpoint, and we preserve the stored refresh token when a refresh response omits one. 

## How Has This Been Tested?

Adds unit coverage for the new helpers and the SDK-context hydration.
## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent OAuth token refresh for MCP tool calls when the auth server is on a different host. We now persist expiry and OAuth metadata, and hydrate the SDK provider so proactive refresh hits the right endpoint, keeps refresh tokens, and refreshes slightly before expiry.

- **Bug Fixes**
  - Inject configured OAuth metadata for `KNOWN_PROVIDER`; leave unset for `AUTO_DISCOVERY`. Persist and rehydrate discovered metadata for `AUTO_DISCOVERY` without overriding known-provider settings.
  - Persist absolute expiry as `token_expires_at`; bind storage to provider context to hydrate `token_expiry_time`; refresh ~30s early; clear stale expiries.
  - Preserve the stored `refresh_token` when a refresh response omits it; persist discovered metadata on `set_tokens`.
  - Ensure proactive refresh targets the configured `token_endpoint`, retries with the new token, and persists updated tokens/expiry. Added unit tests covering metadata handling, expiry hydration/invalidations, refresh-token preservation, and end-to-end proactive refresh.

<sup>Written for commit 0e7813b28f0c51577b830952650c14701aeade69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

