### PR TITLE
chore: remove internal infra references from public repo

### DIFF
--- a/deployment/aws_ecs_fargate/cloudformation/onyx_cluster_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/onyx_cluster_template.yaml
@@ -10,7 +10,7 @@ Parameters:
     Default: onyx
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
 
 Resources:
   ECSCluster:

--- a/deployment/aws_ecs_fargate/cloudformation/onyx_efs_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/onyx_efs_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Default: production
   VpcID:
     Type: String
-    Default: vpc-0f230ca52bb04c722 
+    Description: "The ID of the VPC to deploy into"
   SubnetIDs:
     Type: CommaDelimitedList
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_api_server_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_api_server_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-backend-api-server

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_background_server_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_backend_background_server_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-backend-background-server

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-model-server-indexing

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-model-server-inference

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_nginx_service_template.yaml
@@ -7,7 +7,7 @@ Parameters:
       Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
       Type: String
-      Default: vpc-098cfa79d637dabff
+      Description: "The ID of the VPC to deploy into"
   HostedZoneId:
       Type: String
       Default: ''

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_postgres_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_postgres_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-postgres

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_redis_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_redis_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-redis

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_vespaengine_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_vespaengine_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-vespaengine

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_web_server_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_web_server_service_template.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: "Comma-delimited list of at least two subnet IDs in different Availability Zones"
   VpcID:
     Type: String
-    Default: vpc-098cfa79d637dabff
+    Description: "The ID of the VPC to deploy into"
   ServiceName:
     Type: String
     Default: onyx-web-server

--- a/docs/craft/infra/sidecar-reimplementation.md
+++ b/docs/craft/infra/sidecar-reimplementation.md
@@ -264,7 +264,7 @@ All other methods continue to exec into the `sandbox` container.
 
 No changes needed.
 
-#### 6b. Production — `cloud-deployment-yamls/danswer/`
+#### 6b. Production (internal deployment repo)
 
 **`serviceaccount/sandbox-file-sync-sa.yaml`** — add `skip-containers`:
 
@@ -280,13 +280,13 @@ metadata:
     app.kubernetes.io/part-of: onyx
     app.kubernetes.io/managed-by: ArgoCD
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::855178474906:role/SandboxFileSyncRole-onyx-cloud-craft
+    eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<SANDBOX_FILE_SYNC_ROLE>
     eks.amazonaws.com/skip-containers: "sandbox"
 automountServiceAccountToken: true
 ```
 
 
-#### 6c. Dev — `cloud-deployment-yamls/customers/onyx/`
+#### 6c. Dev (internal deployment repo)
 
 The `sandbox-file-sync` SA for craft-dev needs the same `skip-containers: "sandbox"` annotation.
 

--- a/tools/ods/cmd/deploy_edge.go
+++ b/tools/ods/cmd/deploy_edge.go
@@ -159,7 +159,7 @@ func deployEdge(opts *DeployEdgeOptions) {
 		log.Fatalf("Failed to find dispatched deploy run: %v", err)
 	}
 	log.Infof("Deploy run started: %s", deployRun.URL)
-	log.Info("A kickoff Slack message will appear in #monitor-deployments.")
+	log.Info("A kickoff Slack message will appear in the deployments Slack channel.")
 
 	if opts.NoWaitDeploy {
 		log.Info("--no-wait-deploy set; not waiting for deploy completion.")

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -12,26 +11,13 @@ import (
 )
 
 const (
+	wikiBuildRepo       = "onyx-dot-app/agent-wiki"
 	wikiBuildWorkflow   = "nightly-build.yml"
+	wikiDeployRepo      = "onyx-dot-app/cloud-deployment-yamls"
 	wikiDeployWorkflow  = "dev-wiki-deploy.yml"
 	wikiBuildPollLimit  = 30 * time.Minute
 	wikiDeployPollLimit = 20 * time.Minute
-
-	wikiBuildRepoEnv  = "ODS_WIKI_BUILD_REPO"
-	wikiDeployRepoEnv = "ODS_WIKI_DEPLOY_REPO"
 )
-
-// wikiRepos returns the GitHub repos (org/name) hosting the wiki build and
-// deploy workflows. They are read from the environment rather than hardcoded
-// so that internal repo names don't live in this public repository.
-func wikiRepos() (string, string) {
-	buildRepo := os.Getenv(wikiBuildRepoEnv)
-	deployRepo := os.Getenv(wikiDeployRepoEnv)
-	if buildRepo == "" || deployRepo == "" {
-		log.Fatalf("%s and %s must be set to the org/name of the wiki build and deploy repos", wikiBuildRepoEnv, wikiDeployRepoEnv)
-	}
-	return buildRepo, deployRepo
-}
 
 // DeployWikiOptions holds options for the deploy wiki command.
 type DeployWikiOptions struct {
@@ -51,21 +37,16 @@ func NewDeployWikiCommand() *cobra.Command {
 		Long: `Build a fresh nightly image of agent-wiki and deploy it to dev-wiki.
 
 This command will:
-  1. Dispatch the nightly-build.yml workflow in the wiki build repo
-     ($ODS_WIKI_BUILD_REPO), which builds and pushes the
-     nightly-latest-YYYYMMDD images
+  1. Dispatch the nightly-build.yml workflow in onyx-dot-app/agent-wiki
+     (builds and pushes onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD)
   2. Wait for the build workflow to finish
-  3. Dispatch the dev-wiki-deploy.yml workflow in the wiki deploy repo
-     ($ODS_WIKI_DEPLOY_REPO) with version_tag=nightly-latest-YYYYMMDD
-     (today's UTC date)
+  3. Dispatch the dev-wiki-deploy.yml workflow in onyx-dot-app/cloud-deployment-yamls
+     with version_tag=nightly-latest-YYYYMMDD (today's UTC date)
   4. Wait for the deploy workflow to finish
-
-Requires $ODS_WIKI_BUILD_REPO and $ODS_WIKI_DEPLOY_REPO to be set to the
-org/name of the wiki build and deploy repos.
 
 All GitHub operations run through the gh CLI, so authorization is enforced
 by your gh credentials and GitHub's repo/workflow permissions. A kickoff
-Slack message will appear in the deployments Slack channel.
+Slack message will appear in #monitor-deployments.
 
 Pass --no-build to skip step 1 and just deploy whatever's already on
 Docker Hub for today's tag.
@@ -89,7 +70,6 @@ Example usage:
 
 func deployWiki(opts *DeployWikiOptions) {
 	git.CheckGitHubCLI()
-	buildRepo, deployRepo := wikiRepos()
 
 	if opts.DryRun {
 		log.Warning("=== DRY RUN MODE: workflow dispatches will be skipped ===")
@@ -113,71 +93,71 @@ func deployWiki(opts *DeployWikiOptions) {
 
 	if !opts.NoBuild {
 		if opts.DryRun {
-			log.Warnf("[DRY RUN] Would dispatch %s in %s", wikiBuildWorkflow, buildRepo)
+			log.Warnf("[DRY RUN] Would dispatch %s in %s", wikiBuildWorkflow, wikiBuildRepo)
 		} else {
-			runBuild(buildRepo)
+			runBuild()
 		}
 	}
 
 	if opts.DryRun {
-		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, deployRepo, versionTag)
+		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, wikiDeployRepo, versionTag)
 		return
 	}
 
-	runDeploy(deployRepo, versionTag, opts.NoWaitDeploy)
+	runDeploy(versionTag, opts.NoWaitDeploy)
 }
 
-func runBuild(buildRepo string) {
-	priorRunID, err := latestWorkflowRunID(buildRepo, wikiBuildWorkflow, "workflow_dispatch", "")
+func runBuild() {
+	priorRunID, err := latestWorkflowRunID(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "")
 	if err != nil {
 		log.Fatalf("Failed to query existing build runs: %v", err)
 	}
 	log.Debugf("Most recent prior build run id: %d", priorRunID)
 
-	log.Infof("Dispatching %s in %s...", wikiBuildWorkflow, buildRepo)
-	if err := dispatchWorkflow(buildRepo, wikiBuildWorkflow, nil); err != nil {
+	log.Infof("Dispatching %s in %s...", wikiBuildWorkflow, wikiBuildRepo)
+	if err := dispatchWorkflow(wikiBuildRepo, wikiBuildWorkflow, nil); err != nil {
 		log.Fatalf("Failed to dispatch build workflow: %v", err)
 	}
 
 	log.Info("Waiting for build workflow to start...")
-	buildRun, err := waitForNewRun(buildRepo, wikiBuildWorkflow, "workflow_dispatch", "", priorRunID)
+	buildRun, err := waitForNewRun(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find triggered build run: %v", err)
 	}
 	log.Infof("Build run started: %s", buildRun.URL)
 
-	if err := waitForRunCompletion(buildRepo, buildRun.DatabaseID, wikiBuildPollLimit, "build"); err != nil {
+	if err := waitForRunCompletion(wikiBuildRepo, buildRun.DatabaseID, wikiBuildPollLimit, "build"); err != nil {
 		log.Fatalf("Build did not complete successfully: %v", err)
 	}
 	log.Info("Build completed successfully.")
 }
 
-func runDeploy(deployRepo string, versionTag string, noWait bool) {
-	priorRunID, err := latestWorkflowRunID(deployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
+func runDeploy(versionTag string, noWait bool) {
+	priorRunID, err := latestWorkflowRunID(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
 	if err != nil {
 		log.Fatalf("Failed to query existing deploy runs: %v", err)
 	}
 	log.Debugf("Most recent prior deploy run id: %d", priorRunID)
 
 	log.Infof("Dispatching %s with version_tag=%s...", wikiDeployWorkflow, versionTag)
-	if err := dispatchWorkflow(deployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
+	if err := dispatchWorkflow(wikiDeployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
 		log.Fatalf("Failed to dispatch deploy workflow: %v", err)
 	}
 
 	log.Info("Waiting for deploy workflow to start...")
-	deployRun, err := waitForNewRun(deployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
+	deployRun, err := waitForNewRun(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find dispatched deploy run: %v", err)
 	}
 	log.Infof("Deploy run started: %s", deployRun.URL)
-	log.Info("A kickoff Slack message will appear in the deployments Slack channel.")
+	log.Info("A kickoff Slack message will appear in #monitor-deployments.")
 
 	if noWait {
 		log.Info("--no-wait-deploy set; not waiting for deploy completion.")
 		return
 	}
 
-	if err := waitForRunCompletion(deployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
+	if err := waitForRunCompletion(wikiDeployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
 		log.Fatalf("Deploy did not complete successfully: %v", err)
 	}
 	log.Info("Deploy completed successfully.")

--- a/tools/ods/cmd/deploy_wiki.go
+++ b/tools/ods/cmd/deploy_wiki.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -11,13 +12,26 @@ import (
 )
 
 const (
-	wikiBuildRepo       = "onyx-dot-app/agent-wiki"
 	wikiBuildWorkflow   = "nightly-build.yml"
-	wikiDeployRepo      = "onyx-dot-app/cloud-deployment-yamls"
 	wikiDeployWorkflow  = "dev-wiki-deploy.yml"
 	wikiBuildPollLimit  = 30 * time.Minute
 	wikiDeployPollLimit = 20 * time.Minute
+
+	wikiBuildRepoEnv  = "ODS_WIKI_BUILD_REPO"
+	wikiDeployRepoEnv = "ODS_WIKI_DEPLOY_REPO"
 )
+
+// wikiRepos returns the GitHub repos (org/name) hosting the wiki build and
+// deploy workflows. They are read from the environment rather than hardcoded
+// so that internal repo names don't live in this public repository.
+func wikiRepos() (string, string) {
+	buildRepo := os.Getenv(wikiBuildRepoEnv)
+	deployRepo := os.Getenv(wikiDeployRepoEnv)
+	if buildRepo == "" || deployRepo == "" {
+		log.Fatalf("%s and %s must be set to the org/name of the wiki build and deploy repos", wikiBuildRepoEnv, wikiDeployRepoEnv)
+	}
+	return buildRepo, deployRepo
+}
 
 // DeployWikiOptions holds options for the deploy wiki command.
 type DeployWikiOptions struct {
@@ -37,16 +51,21 @@ func NewDeployWikiCommand() *cobra.Command {
 		Long: `Build a fresh nightly image of agent-wiki and deploy it to dev-wiki.
 
 This command will:
-  1. Dispatch the nightly-build.yml workflow in onyx-dot-app/agent-wiki
-     (builds and pushes onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD)
+  1. Dispatch the nightly-build.yml workflow in the wiki build repo
+     ($ODS_WIKI_BUILD_REPO), which builds and pushes the
+     nightly-latest-YYYYMMDD images
   2. Wait for the build workflow to finish
-  3. Dispatch the dev-wiki-deploy.yml workflow in onyx-dot-app/cloud-deployment-yamls
-     with version_tag=nightly-latest-YYYYMMDD (today's UTC date)
+  3. Dispatch the dev-wiki-deploy.yml workflow in the wiki deploy repo
+     ($ODS_WIKI_DEPLOY_REPO) with version_tag=nightly-latest-YYYYMMDD
+     (today's UTC date)
   4. Wait for the deploy workflow to finish
+
+Requires $ODS_WIKI_BUILD_REPO and $ODS_WIKI_DEPLOY_REPO to be set to the
+org/name of the wiki build and deploy repos.
 
 All GitHub operations run through the gh CLI, so authorization is enforced
 by your gh credentials and GitHub's repo/workflow permissions. A kickoff
-Slack message will appear in #monitor-deployments.
+Slack message will appear in the deployments Slack channel.
 
 Pass --no-build to skip step 1 and just deploy whatever's already on
 Docker Hub for today's tag.
@@ -70,6 +89,7 @@ Example usage:
 
 func deployWiki(opts *DeployWikiOptions) {
 	git.CheckGitHubCLI()
+	buildRepo, deployRepo := wikiRepos()
 
 	if opts.DryRun {
 		log.Warning("=== DRY RUN MODE: workflow dispatches will be skipped ===")
@@ -93,71 +113,71 @@ func deployWiki(opts *DeployWikiOptions) {
 
 	if !opts.NoBuild {
 		if opts.DryRun {
-			log.Warnf("[DRY RUN] Would dispatch %s in %s", wikiBuildWorkflow, wikiBuildRepo)
+			log.Warnf("[DRY RUN] Would dispatch %s in %s", wikiBuildWorkflow, buildRepo)
 		} else {
-			runBuild()
+			runBuild(buildRepo)
 		}
 	}
 
 	if opts.DryRun {
-		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, wikiDeployRepo, versionTag)
+		log.Warnf("[DRY RUN] Would dispatch %s in %s with version_tag=%s", wikiDeployWorkflow, deployRepo, versionTag)
 		return
 	}
 
-	runDeploy(versionTag, opts.NoWaitDeploy)
+	runDeploy(deployRepo, versionTag, opts.NoWaitDeploy)
 }
 
-func runBuild() {
-	priorRunID, err := latestWorkflowRunID(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "")
+func runBuild(buildRepo string) {
+	priorRunID, err := latestWorkflowRunID(buildRepo, wikiBuildWorkflow, "workflow_dispatch", "")
 	if err != nil {
 		log.Fatalf("Failed to query existing build runs: %v", err)
 	}
 	log.Debugf("Most recent prior build run id: %d", priorRunID)
 
-	log.Infof("Dispatching %s in %s...", wikiBuildWorkflow, wikiBuildRepo)
-	if err := dispatchWorkflow(wikiBuildRepo, wikiBuildWorkflow, nil); err != nil {
+	log.Infof("Dispatching %s in %s...", wikiBuildWorkflow, buildRepo)
+	if err := dispatchWorkflow(buildRepo, wikiBuildWorkflow, nil); err != nil {
 		log.Fatalf("Failed to dispatch build workflow: %v", err)
 	}
 
 	log.Info("Waiting for build workflow to start...")
-	buildRun, err := waitForNewRun(wikiBuildRepo, wikiBuildWorkflow, "workflow_dispatch", "", priorRunID)
+	buildRun, err := waitForNewRun(buildRepo, wikiBuildWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find triggered build run: %v", err)
 	}
 	log.Infof("Build run started: %s", buildRun.URL)
 
-	if err := waitForRunCompletion(wikiBuildRepo, buildRun.DatabaseID, wikiBuildPollLimit, "build"); err != nil {
+	if err := waitForRunCompletion(buildRepo, buildRun.DatabaseID, wikiBuildPollLimit, "build"); err != nil {
 		log.Fatalf("Build did not complete successfully: %v", err)
 	}
 	log.Info("Build completed successfully.")
 }
 
-func runDeploy(versionTag string, noWait bool) {
-	priorRunID, err := latestWorkflowRunID(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
+func runDeploy(deployRepo string, versionTag string, noWait bool) {
+	priorRunID, err := latestWorkflowRunID(deployRepo, wikiDeployWorkflow, "workflow_dispatch", "")
 	if err != nil {
 		log.Fatalf("Failed to query existing deploy runs: %v", err)
 	}
 	log.Debugf("Most recent prior deploy run id: %d", priorRunID)
 
 	log.Infof("Dispatching %s with version_tag=%s...", wikiDeployWorkflow, versionTag)
-	if err := dispatchWorkflow(wikiDeployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
+	if err := dispatchWorkflow(deployRepo, wikiDeployWorkflow, map[string]string{"version_tag": versionTag}); err != nil {
 		log.Fatalf("Failed to dispatch deploy workflow: %v", err)
 	}
 
 	log.Info("Waiting for deploy workflow to start...")
-	deployRun, err := waitForNewRun(wikiDeployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
+	deployRun, err := waitForNewRun(deployRepo, wikiDeployWorkflow, "workflow_dispatch", "", priorRunID)
 	if err != nil {
 		log.Fatalf("Failed to find dispatched deploy run: %v", err)
 	}
 	log.Infof("Deploy run started: %s", deployRun.URL)
-	log.Info("A kickoff Slack message will appear in #monitor-deployments.")
+	log.Info("A kickoff Slack message will appear in the deployments Slack channel.")
 
 	if noWait {
 		log.Info("--no-wait-deploy set; not waiting for deploy completion.")
 		return
 	}
 
-	if err := waitForRunCompletion(wikiDeployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
+	if err := waitForRunCompletion(deployRepo, deployRun.DatabaseID, wikiDeployPollLimit, "deploy"); err != nil {
 		log.Fatalf("Deploy did not complete successfully: %v", err)
 	}
 	log.Info("Deploy completed successfully.")


### PR DESCRIPTION
## Description

Repo-hygiene sweep removing internal infrastructure identifiers that shouldn't live in the public repo:

- `docs/craft/infra/sidecar-reimplementation.md`: replace private deployment-repo paths with generic references, and replace a real IAM role ARN (including the AWS account ID) with placeholders.
- `tools/ods/cmd/deploy_edge.go`: genericize an internal Slack channel name in log output.
- `deployment/aws_ecs_fargate/cloudformation/*`: the 11 templates had real VPC IDs hardcoded as the `VpcID` parameter default. The default is removed so the parameter is now required (with a description) — anyone deploying these templates was already required to supply their own VPC for a working deployment.

A follow-up PR will move the hardcoded repo names in `tools/ods/cmd/deploy_wiki.go` into the existing ods config mechanism (`~/.config/onyx-dev/config.json`, same first-run prompt-and-save pattern as `deploy_edge`) without breaking the current zero-setup workflow.

## How Has This Been Tested?

- `go build ./...` and `go vet ./...` pass in `tools/ods`.
- `git grep` confirms zero remaining occurrences of the removed identifiers in the touched files.
- Pre-commit hooks pass (golangci-lint reported 0 issues on `cli/` and `tools/ods/`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check