### PR TITLE
fix(billing): handle past_due portal redirect on resubscribe

### DIFF
--- a/backend/ee/onyx/server/billing/service.py
+++ b/backend/ee/onyx/server/billing/service.py
@@ -174,7 +174,16 @@ async def create_checkout_session(
         body=body,
         error_message="Failed to create checkout session",
     )
-    return CreateCheckoutSessionResponse(stripe_checkout_url=data["url"])
+    # A success response always carries a url; a missing one is a contract
+    # violation we surface loudly rather than passing null to the client.
+    url = data.get("url")
+    if not url:
+        logger.error("Control plane returned no checkout URL")
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "Control plane returned no checkout URL",
+        )
+    return CreateCheckoutSessionResponse(stripe_checkout_url=url)
 
 
 async def create_customer_portal_session(

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -60,9 +60,15 @@ def fetch_stripe_checkout_session(
     data = response.json()
     if data.get("error"):
         raise Exception(data["error"])
+    # Both control-plane success branches (new checkout, payment-update portal)
+    # always include a url; a missing one is a contract violation, not a valid
+    # state to forward silently to the client.
+    url = data.get("url")
+    if not url:
+        raise Exception("Control plane returned no checkout URL")
     return StripeCheckoutSessionResult(
         session_id=data.get("sessionId"),
-        url=data.get("url"),
+        url=url,
         requires_payment_method_update=bool(data.get("requires_payment_method_update")),
     )
 

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -10,6 +10,7 @@ from ee.onyx.configs.app_configs import STRIPE_SECRET_KEY
 from ee.onyx.db.license import acquire_seat_lock
 from ee.onyx.server.tenants.access import generate_data_plane_token
 from ee.onyx.server.tenants.models import BillingInformation
+from ee.onyx.server.tenants.models import StripeCheckoutSessionResult
 from ee.onyx.server.tenants.models import SubscriptionStatusResponse
 from onyx.configs.app_configs import CONTROL_PLANE_API_BASE_URL
 from onyx.db.engine.sql_engine import get_session_with_shared_schema
@@ -33,7 +34,7 @@ def fetch_stripe_checkout_session(
     tenant_id: str,
     billing_period: Literal["monthly", "annual"] = "monthly",
     seats: int | None = None,
-) -> str:
+) -> StripeCheckoutSessionResult:
     token = generate_data_plane_token()
     headers = {
         "Authorization": f"Bearer {token}",
@@ -59,7 +60,11 @@ def fetch_stripe_checkout_session(
     data = response.json()
     if data.get("error"):
         raise Exception(data["error"])
-    return data["sessionId"]
+    return StripeCheckoutSessionResult(
+        session_id=data.get("sessionId"),
+        url=data.get("url"),
+        requires_payment_method_update=bool(data.get("requires_payment_method_update")),
+    )
 
 
 def fetch_tenant_stripe_information(tenant_id: str) -> dict:

--- a/backend/ee/onyx/server/tenants/billing_api.py
+++ b/backend/ee/onyx/server/tenants/billing_api.py
@@ -174,8 +174,8 @@ async def create_checkout_session(
     seats = request.seats if request else None
 
     try:
-        checkout_url = fetch_stripe_checkout_session(tenant_id, billing_period, seats)
-        return {"stripe_checkout_url": checkout_url}
+        result = fetch_stripe_checkout_session(tenant_id, billing_period, seats)
+        return {"stripe_checkout_url": result.url}
     except OnyxError:
         raise
     except Exception:
@@ -197,8 +197,12 @@ async def create_subscription_session(
             raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, "Tenant ID not found")
 
         billing_period = request.billing_period if request else "monthly"
-        session_id = fetch_stripe_checkout_session(tenant_id, billing_period)
-        return SubscriptionSessionResponse(sessionId=session_id)
+        result = fetch_stripe_checkout_session(tenant_id, billing_period)
+        return SubscriptionSessionResponse(
+            sessionId=result.session_id,
+            url=result.url,
+            requires_payment_method_update=result.requires_payment_method_update,
+        )
 
     except OnyxError:
         raise

--- a/backend/ee/onyx/server/tenants/models.py
+++ b/backend/ee/onyx/server/tenants/models.py
@@ -90,8 +90,18 @@ class ProductGatingResponse(BaseModel):
     error: str | None
 
 
+class StripeCheckoutSessionResult(BaseModel):
+    # url is always set on success; sessionId is null for the past_due/unpaid
+    # payment-method-update portal response.
+    session_id: str | None = None
+    url: str | None = None
+    requires_payment_method_update: bool = False
+
+
 class SubscriptionSessionResponse(BaseModel):
-    sessionId: str
+    sessionId: str | None = None
+    url: str | None = None
+    requires_payment_method_update: bool = False
 
 
 class CreateSubscriptionSessionRequest(BaseModel):

--- a/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
+++ b/backend/tests/unit/ee/onyx/server/billing/test_billing_service.py
@@ -186,6 +186,22 @@ class TestCreateCheckoutSession:
         assert call_kwargs["body"]["billing_period"] == "monthly"
         assert call_kwargs["body"]["email"] == "test@example.com"
 
+    @pytest.mark.asyncio
+    @patch("ee.onyx.server.billing.service._make_billing_request")
+    async def test_raises_when_no_url_returned(
+        self,
+        mock_request: AsyncMock,
+    ) -> None:
+        """A success response without a url surfaces a clear error, not null."""
+        from ee.onyx.server.billing.service import create_checkout_session
+
+        mock_request.return_value = {"sessionId": "cs_test_123"}
+
+        with pytest.raises(OnyxError) as exc_info:
+            await create_checkout_session(email="test@example.com")
+
+        assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
+
 
 class TestCreateCustomerPortalSession:
     """Tests for create_customer_portal_session service function."""

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
@@ -155,3 +155,80 @@ class TestGetStripePublishableKey:
             result2 = await get_stripe_publishable_key()
             # Should still return cached value
             assert result2.publishable_key == "pk_test_cached"
+
+
+class TestCreateSubscriptionSession:
+    """Tests for create_subscription_session endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_session_id_and_url_for_new_checkout(self) -> None:
+        """New-subscription checkout returns both sessionId and a hosted url."""
+        from ee.onyx.server.tenants.billing_api import create_subscription_session
+        from ee.onyx.server.tenants.models import StripeCheckoutSessionResult
+        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_123")
+        try:
+            with patch(
+                "ee.onyx.server.tenants.billing_api.fetch_stripe_checkout_session",
+                return_value=StripeCheckoutSessionResult(
+                    session_id="cs_test_123",
+                    url="https://checkout.stripe.com/session",
+                ),
+            ):
+                result = await create_subscription_session(request=None, _=MagicMock())
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        assert result.sessionId == "cs_test_123"
+        assert result.url == "https://checkout.stripe.com/session"
+        assert result.requires_payment_method_update is False
+
+    @pytest.mark.asyncio
+    async def test_handles_past_due_portal_response(self) -> None:
+        """past_due/unpaid tenants get a portal url with a null sessionId.
+
+        Regression: the response model used to require a non-null sessionId,
+        so this branch raised a ValidationError -> 500 on the Access Restricted
+        page (the control plane routes lapsed subs to the payment-update portal).
+        """
+        from ee.onyx.server.tenants.billing_api import create_subscription_session
+        from ee.onyx.server.tenants.models import StripeCheckoutSessionResult
+        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_123")
+        try:
+            with patch(
+                "ee.onyx.server.tenants.billing_api.fetch_stripe_checkout_session",
+                return_value=StripeCheckoutSessionResult(
+                    session_id=None,
+                    url="https://billing.stripe.com/portal",
+                    requires_payment_method_update=True,
+                ),
+            ):
+                result = await create_subscription_session(request=None, _=MagicMock())
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        assert result.sessionId is None
+        assert result.url == "https://billing.stripe.com/portal"
+        assert result.requires_payment_method_update is True
+
+    @pytest.mark.asyncio
+    async def test_wraps_upstream_failure_as_internal_error(self) -> None:
+        """Upstream failures surface as INTERNAL_ERROR, not an unhandled crash."""
+        from ee.onyx.server.tenants.billing_api import create_subscription_session
+        from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant_123")
+        try:
+            with patch(
+                "ee.onyx.server.tenants.billing_api.fetch_stripe_checkout_session",
+                side_effect=Exception("control plane 409"),
+            ):
+                with pytest.raises(OnyxError) as exc_info:
+                    await create_subscription_session(request=None, _=MagicMock())
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_api.py
@@ -232,3 +232,56 @@ class TestCreateSubscriptionSession:
             CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
         assert exc_info.value.error_code is OnyxErrorCode.INTERNAL_ERROR
+
+
+class TestFetchStripeCheckoutSession:
+    """Tests for the control-plane checkout-session proxy."""
+
+    def test_raises_when_control_plane_returns_no_url(self) -> None:
+        """A success response without a url is a contract violation, not silent."""
+        from ee.onyx.server.tenants.billing import fetch_stripe_checkout_session
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"sessionId": "cs_test_123"}
+
+        with (
+            patch(
+                "ee.onyx.server.tenants.billing.generate_data_plane_token",
+                return_value="cp_token",
+            ),
+            patch(
+                "ee.onyx.server.tenants.billing.requests.post",
+                return_value=mock_response,
+            ),
+        ):
+            with pytest.raises(Exception, match="no checkout URL"):
+                fetch_stripe_checkout_session("tenant_123")
+
+    def test_returns_full_result(self) -> None:
+        """Parses sessionId, url, and the payment-method-update flag."""
+        from ee.onyx.server.tenants.billing import fetch_stripe_checkout_session
+
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "sessionId": None,
+            "url": "https://billing.stripe.com/portal",
+            "requires_payment_method_update": True,
+        }
+
+        with (
+            patch(
+                "ee.onyx.server.tenants.billing.generate_data_plane_token",
+                return_value="cp_token",
+            ),
+            patch(
+                "ee.onyx.server.tenants.billing.requests.post",
+                return_value=mock_response,
+            ),
+        ):
+            result = fetch_stripe_checkout_session("tenant_123")
+
+        assert result.session_id is None
+        assert result.url == "https://billing.stripe.com/portal"
+        assert result.requires_payment_method_update is True

--- a/web/src/components/errorPages/AccessRestrictedPage.tsx
+++ b/web/src/components/errorPages/AccessRestrictedPage.tsx
@@ -6,7 +6,6 @@ import ErrorPageLayout from "@/components/errorPages/ErrorPageLayout";
 import { Button } from "@opal/components";
 import InlineExternalLink from "@/refresh-components/InlineExternalLink";
 import { logout } from "@/lib/user";
-import { loadStripe } from "@stripe/stripe-js";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { useLicense } from "@/hooks/useLicense";
 import { useSettingsContext } from "@/providers/SettingsProvider";
@@ -16,27 +15,25 @@ import { SvgLock } from "@opal/icons";
 
 const linkClassName = "text-action-link-05 hover:text-action-link-06 underline";
 
-const fetchStripePublishableKey = async (): Promise<string> => {
-  const response = await fetch("/api/tenants/stripe-publishable-key");
-  if (!response.ok) {
-    throw new Error("Failed to fetch Stripe publishable key");
-  }
-  const data = await response.json();
-  return data.publishable_key;
-};
+interface ResubscriptionSessionResponse {
+  sessionId: string | null;
+  url: string | null;
+  requires_payment_method_update: boolean;
+}
 
-const fetchResubscriptionSession = async () => {
-  const response = await fetch("/api/tenants/create-subscription-session", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  if (!response.ok) {
-    throw new Error("Failed to create resubscription session");
-  }
-  return response.json();
-};
+const fetchResubscriptionSession =
+  async (): Promise<ResubscriptionSessionResponse> => {
+    const response = await fetch("/api/tenants/create-subscription-session", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error("Failed to create resubscription session");
+    }
+    return response.json();
+  };
 
 export default function AccessRestricted() {
   const [isLoading, setIsLoading] = useState(false);
@@ -71,19 +68,15 @@ export default function AccessRestricted() {
     setIsLoading(true);
     setError(null);
     try {
-      const publishableKey = await fetchStripePublishableKey();
-      const { sessionId } = await fetchResubscriptionSession();
-      const stripe = await loadStripe(publishableKey);
-
-      if (stripe) {
-        await stripe.redirectToCheckout({ sessionId });
-      } else {
-        throw new Error("Stripe failed to load");
+      // `url` covers both the new-checkout and past_due payment-update responses.
+      const { url } = await fetchResubscriptionSession();
+      if (!url) {
+        throw new Error("No redirect URL returned");
       }
+      window.location.href = url;
     } catch (error) {
       console.error("Error creating resubscription session:", error);
       setError("Error opening resubscription page. Please try again later.");
-    } finally {
       setIsLoading(false);
     }
   };


### PR DESCRIPTION
## Description

**Bug:** The Access Restricted "Resubscribe" button returns 500 → *"Error opening resubscription page"* for any cloud tenant whose subscription is `past_due`/`unpaid` (e.g. lapsed trial with a failing card).

**Cause:** Since [#153](https://github.com/onyx-dot-app/danswer-control-plane/pull/153) the control plane routes those tenants to the Stripe payment-method-update portal, returning `{sessionId: null, url, requires_payment_method_update}`. The data-plane proxy read only `sessionId` and built `SubscriptionSessionResponse(sessionId=None)` against a required `str` → `ValidationError` → 500.

**Fix:**
- `fetch_stripe_checkout_session` returns the full result (`session_id`, `url`, `requires_payment_method_update`) instead of only `sessionId`.
- `SubscriptionSessionResponse` carries `url` + the flag; `sessionId` nullable.
- `AccessRestrictedPage` redirects to `url` (matches `CheckoutView`), which works for both new-checkout and payment-update responses; drops the deprecated `redirectToCheckout({sessionId})`.
- Fix `create_checkout_session` mislabeling `sessionId` as `stripe_checkout_url`.

No change to the Stripe flow or tenant resolution — resubscribe stays bound to the logged-in `tenant_id`, so the existing tenant is preserved.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check