### PR TITLE
feat(craft): show Onyx-branded logo in Craft chat

### DIFF
--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -221,7 +221,7 @@ export default function BuildMessageList({
     return (
       <div key={message.id} className="flex items-start gap-3 py-4">
         <div className="shrink-0 h-9 flex items-center">
-          <Logo folded size={24} />
+          <Logo onyxBranded folded size={24} />
         </div>
         <div className="flex-1 flex flex-col gap-2 min-w-0">
           {savedRender ? (
@@ -287,7 +287,7 @@ export default function BuildMessageList({
         {showStreamingArea && (
           <div className="flex items-start gap-3 py-4">
             <div className="shrink-0 mt-2">
-              <Logo folded size={24} />
+              <Logo onyxBranded folded size={24} />
             </div>
             <div className="flex-1 flex flex-col gap-2 min-w-0">
               {streamRender?.pinnedTodo && (

--- a/web/src/app/craft/components/BuildWelcome.tsx
+++ b/web/src/app/craft/components/BuildWelcome.tsx
@@ -53,7 +53,7 @@ export default function BuildWelcome({
               and nudge the wordmark down (~0.21 × size) to share Craft's
               baseline. */}
           <div className="flex flex-row items-baseline gap-2">
-            <Logo size={28} className="translate-y-[6px]" />
+            <Logo onyxBranded size={28} className="translate-y-[6px]" />
             <Text font="heading-h2" color="text-05">
               Craft
             </Text>

--- a/web/src/refresh-components/Logo.tsx
+++ b/web/src/refresh-components/Logo.tsx
@@ -15,9 +15,17 @@ export interface LogoProps {
   folded?: boolean;
   size?: number;
   className?: string;
+  // Always render the real Onyx logo, ignoring enterprise white-label settings
+  // (custom logo / application name). Used by Onyx-branded surfaces like Craft.
+  onyxBranded?: boolean;
 }
 
-export default function Logo({ folded, size, className }: LogoProps) {
+export default function Logo({
+  folded,
+  size,
+  className,
+  onyxBranded,
+}: LogoProps) {
   const resolvedSize = size ?? DEFAULT_LOGO_SIZE_PX;
   const settings = useSettingsContext();
   const logoDisplayStyle = settings.enterpriseSettings?.logo_display_style;
@@ -33,6 +41,14 @@ export default function Logo({ folded, size, className }: LogoProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [settings.enterpriseSettings]
   );
+
+  if (onyxBranded) {
+    return folded ? (
+      <SvgOnyxLogo size={resolvedSize} className={cn("shrink-0", className)} />
+    ) : (
+      <SvgOnyxLogoTyped size={resolvedSize} className={className} />
+    );
+  }
 
   const logo = settings.enterpriseSettings?.use_custom_logo ? (
     <div


### PR DESCRIPTION
## Description

Craft is an Onyx-branded surface, so its **chat** should always show the real Onyx logo — not a customer's white-labeled logo or application name. This applies to **all deployments** (cloud and self-hosted, EE or not).

Adds an opt-in `onyxBranded` prop to the shared `Logo` component (`web/src/refresh-components/Logo.tsx`). When set, it bypasses enterprise white-label settings (`use_custom_logo`, `application_name`, `logo_display_style`) and always renders the Onyx SVG mark — `SvgOnyxLogoTyped` (full wordmark) when unfolded, `SvgOnyxLogo` (folded mark) when folded.

Opted in from the two Craft **chat** surfaces:
- **Welcome screen** (`BuildWelcome.tsx`) — full Onyx wordmark + "Craft"
- **Agent message list** (`BuildMessageList.tsx`) — folded mark next to each response

Fixes this

<img width="240" height="75" alt="Screenshot 2026-06-04 at 10 09 32" src="https://github.com/user-attachments/assets/db8edd8a-deba-46c1-a623-114d867f60dd" />

The **sidebar is intentionally left untouched** and continues to respect enterprise white-labeling.

## How Has This Been Tested?

- `tsc --noEmit` passes (no new type errors).
- Pre-commit hooks pass: `oxfmt`, `oxlint`, TypeScript type check.
- Change is a frontend-only prop addition; the `onyxBranded` early-return is placed after all hook calls to respect the rules of hooks.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)