### PR TITLE
feat(auth): make auth cookie name configurable via AUTH_COOKIE_NAME

### DIFF
--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -10,6 +10,7 @@ from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
 from onyx.auth.users import auth_backend
 from onyx.auth.users import get_redis_strategy
 from onyx.auth.users import User
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email
 from onyx.utils.logger import setup_logger
@@ -47,7 +48,7 @@ async def impersonate_user(
 
     response = await auth_backend.transport.get_login_response(token)
     response.set_cookie(
-        key="fastapiusersauth",
+        key=FASTAPI_USERS_AUTH_COOKIE_NAME,
         value=token,
         httponly=True,
         secure=True,

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import re
 import socket
@@ -31,8 +32,12 @@ DEFAULT_BOOST = 0
 PUBLIC_API_TAGS: list[str | Enum] = ["public"]
 
 # Cookies
+# Configurable via env so multiple deployments sharing a hostname (e.g. parallel
+# local worktrees on different ports of localhost) can keep their auth cookies
+# separate — cookies are scoped by host, not port. The frontend reads the same
+# AUTH_COOKIE_NAME so the Next proxy / auth checks look for the matching cookie.
 FASTAPI_USERS_AUTH_COOKIE_NAME = (
-    "fastapiusersauth"  # Currently a constant, but logic allows for configuration
+    os.environ.get("AUTH_COOKIE_NAME") or "fastapiusersauth"
 )
 TENANT_ID_COOKIE_NAME = "onyx_tid"  # tenant id - for workaround cases
 ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user"

--- a/web/src/app/api/[...path]/route.ts
+++ b/web/src/app/api/[...path]/route.ts
@@ -1,4 +1,7 @@
-import { INTERNAL_URL } from "@/lib/constants";
+import {
+  INTERNAL_URL,
+  SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
+} from "@/lib/constants";
 import { NextRequest, NextResponse } from "next/server";
 
 /* NextJS is annoying and makes use use a separate function for
@@ -96,7 +99,7 @@ async function handleRequest(request: NextRequest, path: string[]) {
       // Inject the debug auth cookie for local development against remote backend
       // Get from cloud site: DevTools → Application → Cookies → fastapiusersauth
       const existingCookies = headers.get("cookie") || "";
-      const debugCookie = `fastapiusersauth=${process.env.DEBUG_AUTH_COOKIE}`;
+      const debugCookie = `${SERVER_SIDE_ONLY__AUTH_COOKIE_NAME}=${process.env.DEBUG_AUTH_COOKIE}`;
       headers.set(
         "cookie",
         existingCookies ? `${existingCookies}; ${debugCookie}` : debugCookie

--- a/web/src/app/api/[...path]/route.ts
+++ b/web/src/app/api/[...path]/route.ts
@@ -97,7 +97,7 @@ async function handleRequest(request: NextRequest, path: string[]) {
       process.env.NODE_ENV === "development"
     ) {
       // Inject the debug auth cookie for local development against remote backend
-      // Get from cloud site: DevTools → Application → Cookies → fastapiusersauth
+      // Get from cloud site: DevTools → Application → Cookies → <AUTH_COOKIE_NAME, default: fastapiusersauth>
       const existingCookies = headers.get("cookie") || "";
       const debugCookie = `${SERVER_SIDE_ONLY__AUTH_COOKIE_NAME}=${process.env.DEBUG_AUTH_COOKIE}`;
       headers.set(

--- a/web/src/app/auth/logout/route.ts
+++ b/web/src/app/auth/logout/route.ts
@@ -1,4 +1,5 @@
 import { getAuthTypeMetadataSS, logoutSS } from "@/lib/userSS";
+import { SERVER_SIDE_ONLY__AUTH_COOKIE_NAME } from "@/lib/constants";
 import { NextRequest } from "next/server";
 
 export const POST = async (request: NextRequest) => {
@@ -16,7 +17,7 @@ export const POST = async (request: NextRequest) => {
   // the correct thing to do for Redis/Postgres backends — the server-side
   // Set-Cookie from FastAPI never reaches the browser since logoutSS is a
   // server-to-server fetch.
-  const cookiesToDelete = ["fastapiusersauth"];
+  const cookiesToDelete = [SERVER_SIDE_ONLY__AUTH_COOKIE_NAME];
   const cookieOptions = {
     path: "/",
     secure: process.env.NODE_ENV === "production",

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -30,6 +30,13 @@ export const NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED =
 
 export const TENANT_ID_COOKIE_NAME = "onyx_tid";
 
+// Name of the FastAPI-Users auth cookie. Configurable via env (shared with the
+// backend's AUTH_COOKIE_NAME) so deployments sharing a hostname — e.g. parallel
+// local worktrees on different ports of localhost — keep separate auth cookies.
+// Server-side only: read in middleware, route handlers, and server components.
+export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
+  process.env.AUTH_COOKIE_NAME || "fastapiusersauth";
+
 export const SEARCH_TYPE_COOKIE_NAME = "search_type";
 export const AGENTIC_SEARCH_TYPE_COOKIE_NAME = "agentic_type";
 

--- a/web/src/lib/userSS.ts
+++ b/web/src/lib/userSS.ts
@@ -2,7 +2,11 @@ import { cookies } from "next/headers";
 import { User } from "./types";
 import { buildUrl, UrlBuilder } from "./utilsSS";
 import { ReadonlyRequestCookies } from "next/dist/server/web/spec-extension/adapters/request-cookies";
-import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "./constants";
+import {
+  AuthType,
+  NEXT_PUBLIC_CLOUD_ENABLED,
+  SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
+} from "./constants";
 
 export interface AuthTypeMetadata {
   authType: AuthType;
@@ -183,9 +187,9 @@ export const processCookies = (cookies: ReadonlyRequestCookies): string => {
   if (process.env.DEBUG_AUTH_COOKIE && process.env.NODE_ENV === "development") {
     const hasAuthCookie = cookieString
       .split(/;\s*/)
-      .some((c) => c.startsWith("fastapiusersauth="));
+      .some((c) => c.startsWith(`${SERVER_SIDE_ONLY__AUTH_COOKIE_NAME}=`));
     if (!hasAuthCookie) {
-      const debugCookie = `fastapiusersauth=${process.env.DEBUG_AUTH_COOKIE}`;
+      const debugCookie = `${SERVER_SIDE_ONLY__AUTH_COOKIE_NAME}=${process.env.DEBUG_AUTH_COOKIE}`;
       cookieString = cookieString
         ? `${cookieString}; ${debugCookie}`
         : debugCookie;

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -4,10 +4,10 @@ import {
   AuthType,
   SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED,
   SERVER_SIDE_ONLY__AUTH_TYPE,
+  SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
 } from "./lib/constants";
 
 // Authentication cookie names (matches backend constants)
-const FASTAPI_USERS_AUTH_COOKIE_NAME = "fastapiusersauth";
 const ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user";
 
 // Protected route prefixes (require authentication)
@@ -65,7 +65,7 @@ export async function proxy(request: NextRequest) {
   );
 
   if (isProtectedRoute && !isPublicRoute) {
-    const authCookie = request.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME);
+    const authCookie = request.cookies.get(SERVER_SIDE_ONLY__AUTH_COOKIE_NAME);
     const anonymousCookie = request.cookies.get(ANONYMOUS_USER_COOKIE_NAME);
 
     // Allow access if user has either a regular auth cookie or anonymous user cookie


### PR DESCRIPTION
## Description

The FastAPI-Users auth cookie name was a hardcoded `"fastapiusersauth"` constant on the backend, duplicated as string literals across the Next server. Browser cookies are scoped by **host, not port**, so multiple deployments sharing a hostname (e.g. parallel local dev worktrees on different ports of `localhost`) all share one auth cookie and clobber each other's sessions.

This makes the cookie name configurable via a single `AUTH_COOKIE_NAME` env var, defaulting to `"fastapiusersauth"` so behavior is **unchanged when unset**:

- **Backend** — `FASTAPI_USERS_AUTH_COOKIE_NAME` now reads `AUTH_COOKIE_NAME` (in `configs/constants.py`). The cloud impersonation endpoint (`ee/.../tenants/admin_api.py`) previously hardcoded the literal `"fastapiusersauth"` in `set_cookie`; it now uses the constant. The other consumers (`CookieTransport`, the readers in `manage/users.py` / `redis_pool.py`, and the anonymous-user `delete_cookie`) already used the constant and pick this up automatically.
- **Frontend** — added `SERVER_SIDE_ONLY__AUTH_COOKIE_NAME` (reads the same `AUTH_COOKIE_NAME`) in `lib/constants.ts`, used by the middleware auth check (`proxy.ts`), debug-cookie injection (`userSS.ts`), the API proxy (`api/[...path]/route.ts`), and logout cookie clearing (`auth/logout/route.ts`). Backend and Next must agree on the name, so both read the one env var.

Setting a distinct `AUTH_COOKIE_NAME` per deployment/worktree lets you stay logged into several at once in the same browser.

## How Has This Been Tested?

- Backend `ty` (type check) and `ruff` lint/format pass on the changed files.
- Frontend `oxlint` / `oxfmt` pass; verified no **new** TypeScript errors are introduced (the working tree has pre-existing, unrelated `tsc` errors in generated `.next` types / a missing `copy-to-clipboard` dep / a `craft/v1` route typing — confirmed identical with these changes stashed).
- Verified the env mapping is consistent end-to-end (backend constant + `SERVER_SIDE_ONLY__AUTH_COOKIE_NAME`) and that an unset `AUTH_COOKIE_NAME` falls back to `"fastapiusersauth"` (no behavior change).
- Not yet exercised: a live multi-worktree simultaneous-login run in a browser.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the FastAPI auth cookie name configurable via `AUTH_COOKIE_NAME` (defaults to `fastapiusersauth`) to prevent session collisions across deployments sharing a hostname. Backend and Next now read the same env var to stay in sync.

- **New Features**
  - Backend: `FASTAPI_USERS_AUTH_COOKIE_NAME` now reads `AUTH_COOKIE_NAME`; the impersonation endpoint uses this constant.
  - Frontend: added `SERVER_SIDE_ONLY__AUTH_COOKIE_NAME` (reads `AUTH_COOKIE_NAME`) and used it in the Next proxy/middleware, API route, debug-cookie injection, and logout.

- **Migration**
  - Optionally set a unique `AUTH_COOKIE_NAME` per deployment/worktree when sharing a hostname.

<sup>Written for commit 3888b3c2fc977f4114db5032b70f81f82739360d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

