### PR TITLE
refactor(craft): migrate `Text` component to Opal

### DIFF
--- a/web/lib/opal/src/components/text/README.md
+++ b/web/lib/opal/src/components/text/README.md
@@ -7,40 +7,57 @@ inline markdown rendering via `RichStr` — pass `markdown("*bold* text")` as ch
 
 ## Props
 
-| Prop | Type | Default | Description |
-|---|---|---|---|
-| `font` | `TextFont` | `"main-ui-body"` | Font preset (size, weight, line-height) |
-| `color` | `TextColor` | `"text-04"` | Text color |
-| `as` | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"` | HTML tag to render |
-| `nowrap` | `boolean` | `false` | Prevent text wrapping |
-| `children` | `string \| RichStr` | — | Plain string or `markdown()` for inline markdown |
+| Prop       | Type                                            | Default          | Description                                                                                    |
+| ---------- | ----------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------- |
+| `font`     | `TextFont`                                      | `"main-ui-body"` | Font preset (size, weight, line-height)                                                        |
+| `color`    | `TextColor`                                     | `"text-04"`      | Text color                                                                                     |
+| `as`       | `"p" \| "span" \| "li" \| "h1" \| "h2" \| "h3"` | `"span"`         | HTML tag to render                                                                             |
+| `nowrap`   | `boolean`                                       | `false`          | Prevent text wrapping                                                                          |
+| `maxLines` | `number`                                        | —                | Truncate to N lines with an ellipsis (`1` = single-line truncate; `2+` = `-webkit-line-clamp`) |
+| `children` | `string \| RichStr`                             | —                | Plain string or `markdown()` for inline markdown                                               |
+
+> **No `className` or `style`.** `Text` strips both (its props extend `WithoutStyles`); every
+> aspect of its appearance is driven by `font`, `color`, `nowrap`, and `maxLines`. For layout
+> concerns (margin, flex, width, alignment) wrap `Text` in a container or move the utility class
+> to the parent — don't reach for `className`. All other HTML attributes (`id`, `onClick`,
+> `title`, `aria-*`, `data-*`) pass straight through to the rendered element.
 
 ### `TextFont`
 
-| Value | Size | Weight | Line-height |
-|---|---|---|---|
-| `"heading-h1"` | 48px | 600 | 64px |
-| `"heading-h2"` | 24px | 600 | 36px |
-| `"heading-h3"` | 18px | 600 | 28px |
-| `"heading-h3-muted"` | 18px | 500 | 28px |
-| `"main-content-body"` | 16px | 450 | 24px |
-| `"main-content-muted"` | 16px | 400 | 24px |
-| `"main-content-emphasis"` | 16px | 700 | 24px |
-| `"main-content-mono"` | 16px | 400 | 23px |
-| `"main-ui-body"` | 14px | 500 | 20px |
-| `"main-ui-muted"` | 14px | 400 | 20px |
-| `"main-ui-action"` | 14px | 600 | 20px |
-| `"main-ui-mono"` | 14px | 400 | 20px |
-| `"secondary-body"` | 12px | 400 | 18px |
-| `"secondary-action"` | 12px | 600 | 18px |
-| `"secondary-mono"` | 12px | 400 | 18px |
-| `"figure-small-label"` | 10px | 600 | 14px |
-| `"figure-small-value"` | 10px | 400 | 14px |
-| `"figure-keystroke"` | 11px | 400 | 16px |
+| Value                     | Size | Weight | Line-height |
+| ------------------------- | ---- | ------ | ----------- |
+| `"heading-h1"`            | 48px | 600    | 64px        |
+| `"heading-h2"`            | 24px | 600    | 36px        |
+| `"heading-h3"`            | 18px | 600    | 28px        |
+| `"heading-h3-muted"`      | 18px | 500    | 28px        |
+| `"main-content-body"`     | 16px | 450    | 24px        |
+| `"main-content-muted"`    | 16px | 400    | 24px        |
+| `"main-content-emphasis"` | 16px | 700    | 24px        |
+| `"main-content-mono"`     | 16px | 400    | 23px        |
+| `"main-ui-body"`          | 14px | 500    | 20px        |
+| `"main-ui-muted"`         | 14px | 400    | 20px        |
+| `"main-ui-action"`        | 14px | 600    | 20px        |
+| `"main-ui-mono"`          | 14px | 400    | 20px        |
+| `"secondary-body"`        | 12px | 400    | 18px        |
+| `"secondary-action"`      | 12px | 600    | 18px        |
+| `"secondary-mono"`        | 12px | 400    | 18px        |
+| `"figure-small-label"`    | 10px | 600    | 14px        |
+| `"figure-small-value"`    | 10px | 400    | 14px        |
+| `"figure-keystroke"`      | 11px | 400    | 16px        |
 
 ### `TextColor`
 
-`"text-01" | "text-02" | "text-03" | "text-04" | "text-05" | "text-inverted-01" | "text-inverted-02" | "text-inverted-03" | "text-inverted-04" | "text-inverted-05" | "text-light-03" | "text-light-05" | "text-dark-03" | "text-dark-05"`
+Default: `"text-04"`. Within each numbered scale, `05` is the strongest/most prominent and lower
+numbers are progressively fainter.
+
+| Group              | Values                                                           | When to use                                                                                       |
+| ------------------ | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Primary            | `text-01`, `text-02`, `text-03`, `text-04`, `text-05`            | Default text on standard light surfaces — `05` for emphasis, `01` for the faintest metadata       |
+| Inverted           | `text-inverted-01` … `text-inverted-05`                          | Text on dark or colored surfaces; flips with theme (light in light mode, dark in dark mode)       |
+| Fixed light / dark | `text-light-03`, `text-light-05`, `text-dark-03`, `text-dark-05` | A fixed light or dark text color that does **not** flip with the theme                            |
+| Status — error     | `status-error-01`, `status-error-02`, `status-error-05`          | Error / destructive messaging (e.g. validation errors)                                            |
+| Status — success   | `status-success-01`, `status-success-02`, `status-success-05`    | Success / confirmation messaging                                                                  |
+| Special            | `inherit`                                                        | Inherit the surrounding text color (no color class applied) — useful when a parent sets the color |
 
 ## Usage Examples
 

--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -112,6 +112,13 @@ const INVERTED_COLORS: TextColor[] = [
   "text-inverted-05",
 ];
 
+const STATUS_COLORS: TextColor[] = [
+  "status-error-01",
+  "status-error-02",
+  "status-error-05",
+  "status-success-05",
+];
+
 export const AllColors: Story = {
   render: () => (
     <div className="space-y-2">
@@ -138,6 +145,23 @@ export const InvertedColors: Story = {
             className="w-56 shrink-0 font-secondary-body"
             style={{ color: "rgba(255,255,255,0.5)" }}
           >
+            {color}
+          </span>
+          <Text font="main-ui-body" color={color}>
+            The quick brown fox
+          </Text>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const StatusColors: Story = {
+  render: () => (
+    <div className="space-y-2">
+      {STATUS_COLORS.map((color) => (
+        <div key={color} className="flex items-baseline gap-4">
+          <span className="w-56 shrink-0 font-secondary-body text-text-03">
             {color}
           </span>
           <Text font="main-ui-body" color={color}>

--- a/web/lib/opal/src/components/text/Text.stories.tsx
+++ b/web/lib/opal/src/components/text/Text.stories.tsx
@@ -116,6 +116,8 @@ const STATUS_COLORS: TextColor[] = [
   "status-error-01",
   "status-error-02",
   "status-error-05",
+  "status-success-01",
+  "status-success-02",
   "status-success-05",
 ];
 

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -43,7 +43,11 @@ type TextColor =
   | "text-light-03"
   | "text-light-05"
   | "text-dark-03"
-  | "text-dark-05";
+  | "text-dark-05"
+  | "status-error-01"
+  | "status-error-02"
+  | "status-error-05"
+  | "status-success-05";
 
 interface TextProps extends WithoutStyles<
   Omit<HTMLAttributes<HTMLElement>, "color" | "children">
@@ -109,6 +113,10 @@ const COLOR_CONFIG: Record<TextColor, string | null> = {
   "text-light-05": "text-text-light-05",
   "text-dark-03": "text-text-dark-03",
   "text-dark-05": "text-text-dark-05",
+  "status-error-01": "text-status-error-01",
+  "status-error-02": "text-status-error-02",
+  "status-error-05": "text-status-error-05",
+  "status-success-05": "text-status-success-05",
 };
 
 // ---------------------------------------------------------------------------

--- a/web/lib/opal/src/components/text/components.tsx
+++ b/web/lib/opal/src/components/text/components.tsx
@@ -47,6 +47,8 @@ type TextColor =
   | "status-error-01"
   | "status-error-02"
   | "status-error-05"
+  | "status-success-01"
+  | "status-success-02"
   | "status-success-05";
 
 interface TextProps extends WithoutStyles<
@@ -116,6 +118,8 @@ const COLOR_CONFIG: Record<TextColor, string | null> = {
   "status-error-01": "text-status-error-01",
   "status-error-02": "text-status-error-02",
   "status-error-05": "text-status-error-05",
+  "status-success-01": "text-status-success-01",
+  "status-success-02": "text-status-success-02",
   "status-success-05": "text-status-success-05",
 };
 

--- a/web/src/app/craft/components/AgentSwitcher.tsx
+++ b/web/src/app/craft/components/AgentSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Popover, PopoverMenu, Text } from "@opal/components";
+import { Popover, PopoverMenu, Text, LineItemButton } from "@opal/components";
 import {
   SvgChevronDown,
   SvgCpu,
@@ -9,7 +9,6 @@ import {
   SvgAlertTriangle,
 } from "@opal/icons";
 import { cn } from "@opal/utils";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import {
   useSubagents,
   useViewedSubagentSessionId,
@@ -129,23 +128,27 @@ export default function AgentSwitcher() {
       <Popover.Content side="bottom" align="start">
         <PopoverMenu>
           {[
-            <LineItem
+            <LineItemButton
               key="main"
-              selected={!isViewingSubagent}
+              sizePreset="main-ui"
+              variant="section"
+              state={!isViewingSubagent ? "selected" : "empty"}
               onClick={selectMainAgent}
-            >
-              {titleLabel ?? "Main agent"}
-            </LineItem>,
+              title={titleLabel ?? "Main agent"}
+            />,
             ...sorted.map((s) => (
-              <LineItem
+              <LineItemButton
                 key={s.sessionId}
+                sizePreset="main-ui"
+                variant="section"
                 icon={SvgCpu}
-                selected={s.sessionId === viewedSubagentSessionId}
+                state={
+                  s.sessionId === viewedSubagentSessionId ? "selected" : "empty"
+                }
                 onClick={() => selectSubagent(s.sessionId)}
                 rightChildren={<SubagentStatus subagent={s} />}
-              >
-                {s.name || s.subagentType || "subagent"}
-              </LineItem>
+                title={s.name || s.subagentType || "subagent"}
+              />
             )),
           ]}
         </PopoverMenu>

--- a/web/src/app/craft/components/BigButton.tsx
+++ b/web/src/app/craft/components/BigButton.tsx
@@ -2,7 +2,7 @@
 
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "@opal/utils";
-import LegacyText from "@/refresh-components/texts/Text";
+import RefreshText from "@/refresh-components/texts/Text";
 
 export interface BigButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   // Subvariants
@@ -91,13 +91,13 @@ const BigButton = forwardRef<HTMLButtonElement, BigButtonProps>(
         type="button"
         {...props}
       >
-        <LegacyText
+        <RefreshText
           mainContentEmphasis
           className={cn("whitespace-nowrap", getTextOverride())}
           as="span"
         >
           {children}
-        </LegacyText>
+        </RefreshText>
       </button>
     );
   }

--- a/web/src/app/craft/components/BigButton.tsx
+++ b/web/src/app/craft/components/BigButton.tsx
@@ -2,7 +2,7 @@
 
 import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import LegacyText from "@/refresh-components/texts/Text";
 
 export interface BigButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   // Subvariants
@@ -91,13 +91,13 @@ const BigButton = forwardRef<HTMLButtonElement, BigButtonProps>(
         type="button"
         {...props}
       >
-        <Text
+        <LegacyText
           mainContentEmphasis
           className={cn("whitespace-nowrap", getTextOverride())}
           as="span"
         >
           {children}
-        </Text>
+        </LegacyText>
       </button>
     );
   }

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -7,10 +7,8 @@ import {
   SvgChevronRight,
   SvgPlug,
 } from "@opal/icons";
-import Text from "@/refresh-components/texts/Text";
-import { Popover, PopoverMenu } from "@opal/components";
+import { Text, Popover, PopoverMenu, LineItemButton } from "@opal/components";
 import { Switch } from "@opal/components";
-import LineItem from "@/refresh-components/buttons/LineItem";
 import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
   BuildLlmSelection,
@@ -265,8 +263,10 @@ export function BuildLLMPopover({
         key={`${option.providerKey}-${option.modelName}`}
         ref={isSelected ? selectedItemRef : undefined}
       >
-        <LineItem
-          selected={isSelected}
+        <LineItemButton
+          sizePreset="main-ui"
+          variant="section"
+          state={isSelected ? "selected" : "empty"}
           description={description}
           onClick={() => applySelection(option)}
           rightChildren={
@@ -274,9 +274,8 @@ export function BuildLLMPopover({
               <SvgCheck className="h-4 w-4 stroke-action-link-05 shrink-0" />
             ) : null
           }
-        >
-          {option.displayName}
-        </LineItem>
+          title={option.displayName}
+        />
       </div>
     );
   };
@@ -304,7 +303,7 @@ export function BuildLLMPopover({
             <Section gap={0.5}>
               {/* Toggle for recommended only */}
               <div className="flex items-center justify-between py-3 gap-3 border-b border-border-01 px-1">
-                <Text secondaryBody text03>
+                <Text font="secondary-body" color="text-03">
                   Recommended Models Only
                 </Text>
                 <Switch
@@ -318,7 +317,7 @@ export function BuildLLMPopover({
                 {groupedOptions.length === 0
                   ? [
                       <div key="empty" className="py-3 px-2">
-                        <Text secondaryBody text03>
+                        <Text font="secondary-body" color="text-03">
                           No models found
                         </Text>
                       </div>,
@@ -334,7 +333,7 @@ export function BuildLLMPopover({
                             groupedOptions[0]!.options.map(renderModelItem)
                           ) : (
                             <div className="flex items-center justify-between px-2 py-2">
-                              <Text secondaryBody text03>
+                              <Text font="secondary-body" color="text-03">
                                 Not configured
                               </Text>
                               <button
@@ -379,14 +378,15 @@ export function BuildLLMPopover({
                                     <div className="flex items-center justify-center size-5 shrink-0">
                                       <ModelIcon size={16} />
                                     </div>
-                                    <Text
-                                      secondaryBody
-                                      text03
-                                      nowrap
-                                      className="px-0.5"
-                                    >
-                                      {group.displayName}
-                                    </Text>
+                                    <span className="px-0.5">
+                                      <Text
+                                        font="secondary-body"
+                                        color="text-03"
+                                        nowrap
+                                      >
+                                        {group.displayName}
+                                      </Text>
+                                    </span>
                                   </div>
                                   <div className="flex-1" />
                                   {!group.isConfigured && (
@@ -417,7 +417,10 @@ export function BuildLLMPopover({
                                       group.options.map(renderModelItem)
                                     ) : (
                                       <div className="py-1.5 px-3">
-                                        <Text secondaryBody text03>
+                                        <Text
+                                          font="secondary-body"
+                                          color="text-03"
+                                        >
                                           Not configured
                                         </Text>
                                       </div>

--- a/web/src/app/craft/components/ConnectDataBanner.tsx
+++ b/web/src/app/craft/components/ConnectDataBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   SvgConfluence,
   SvgGithub,
@@ -78,7 +78,7 @@ export default function ConnectDataBanner({
         </div>
 
         <div className="flex items-center justify-center gap-1">
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             Connect your data
           </Text>
           <SvgChevronRight className="h-4 w-4 text-text-03" />

--- a/web/src/app/craft/components/FileBrowser.tsx
+++ b/web/src/app/craft/components/FileBrowser.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import {
   Collapsible,
   CollapsibleContent,
@@ -91,7 +90,7 @@ function DirectoryNode({
           ) : (
             <SvgFolder className="size-4 stroke-text-03" />
           )}
-          <Text mainContentMono text04 className="truncate">
+          <Text font="main-content-mono" color="text-04" maxLines={1}>
             {entry.name}
           </Text>
         </button>
@@ -99,7 +98,7 @@ function DirectoryNode({
       <CollapsibleContent>
         {error && (
           <div style={{ paddingLeft: `${paddingLeft + 1.25}rem` }}>
-            <Text secondaryBody className="text-status-error-01">
+            <Text font="secondary-body" color="status-error-01">
               {error}
             </Text>
           </div>
@@ -169,13 +168,17 @@ function FileNode({ entry, sessionId, depth, onPreview }: FileNodeProps) {
       style={{ paddingLeft: `${paddingLeft + 1.25}rem` }}
     >
       <SvgFileSmall className="size-4 stroke-text-03 shrink-0" />
-      <Text mainContentMono text04 className="truncate flex-1">
-        {entry.name}
-      </Text>
-      {entry.size !== null && (
-        <Text secondaryBody text03 className="shrink-0">
-          {formatSize(entry.size)}
+      <div className="flex-1 min-w-0">
+        <Text font="main-content-mono" color="text-04" maxLines={1}>
+          {entry.name}
         </Text>
+      </div>
+      {entry.size !== null && (
+        <div className="shrink-0">
+          <Text font="secondary-body" color="text-03">
+            {formatSize(entry.size)}
+          </Text>
+        </div>
       )}
       <div className="flex flex-row gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
         {canPreview && (
@@ -269,7 +272,7 @@ export default function FileBrowser({ sessionId }: FileBrowserProps) {
                 <SvgChevronRight className="size-4 stroke-text-03" />
               )}
               <SvgHardDrive className="size-4 stroke-text-03" />
-              <Text mainUiAction text03>
+              <Text font="main-ui-action" color="text-03">
                 Workspace Files
               </Text>
             </button>
@@ -277,14 +280,18 @@ export default function FileBrowser({ sessionId }: FileBrowserProps) {
           <CollapsibleContent>
             <div className="p-1 max-h-[50vh] overflow-auto">
               {error && (
-                <Text secondaryBody className="text-status-error-01 p-2">
-                  {error}
-                </Text>
+                <div className="p-2">
+                  <Text font="secondary-body" color="status-error-01">
+                    {error}
+                  </Text>
+                </div>
               )}
               {rootEntries?.length === 0 && (
-                <Text secondaryBody text03 className="p-2 text-center">
-                  No files yet
-                </Text>
+                <div className="p-2 text-center">
+                  <Text font="secondary-body" color="text-03">
+                    No files yet
+                  </Text>
+                </div>
               )}
               {rootEntries?.map((entry) =>
                 entry.is_directory ? (

--- a/web/src/app/craft/components/FilePreviewModal.tsx
+++ b/web/src/app/craft/components/FilePreviewModal.tsx
@@ -2,8 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Modal from "@/refresh-components/Modal";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import {
   SvgFileText,
   SvgDownloadCloud,
@@ -71,7 +70,7 @@ export default function FilePreviewModal({
               <SvgSimpleLoader />
             </div>
           ) : error ? (
-            <Text secondaryBody className="text-status-error-01">
+            <Text font="secondary-body" color="status-error-01">
               {error}
             </Text>
           ) : isImage ? (

--- a/web/src/app/craft/components/IntroContent.tsx
+++ b/web/src/app/craft/components/IntroContent.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { motion } from "motion/react";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { OnyxLogoTypeIcon } from "@/components/icons/icons";
-import LegacyText from "@/refresh-components/texts/Text";
+import RefreshText from "@/refresh-components/texts/Text";
 import BigButton from "@/app/craft/components/BigButton";
 
 interface BuildModeIntroContentProps {
@@ -41,7 +41,7 @@ export default function BuildModeIntroContent({
                 style={{ transform: "translateX(-0.6em)" }}
               >
                 <span className="relative inline-block leading-[3.5]">
-                  <LegacyText
+                  <RefreshText
                     headingH1
                     className="text-9xl! text-white! relative inline-block"
                     style={{
@@ -50,7 +50,7 @@ export default function BuildModeIntroContent({
                     }}
                   >
                     Craft
-                  </LegacyText>
+                  </RefreshText>
                 </span>
                 <span
                   className="pointer-events-none absolute top-3 -right-14 text-[1em] uppercase tracking-[0.2em] text-white!"

--- a/web/src/app/craft/components/IntroContent.tsx
+++ b/web/src/app/craft/components/IntroContent.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { motion } from "motion/react";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { OnyxLogoTypeIcon } from "@/components/icons/icons";
-import Text from "@/refresh-components/texts/Text";
+import LegacyText from "@/refresh-components/texts/Text";
 import BigButton from "@/app/craft/components/BigButton";
 
 interface BuildModeIntroContentProps {
@@ -41,7 +41,7 @@ export default function BuildModeIntroContent({
                 style={{ transform: "translateX(-0.6em)" }}
               >
                 <span className="relative inline-block leading-[3.5]">
-                  <Text
+                  <LegacyText
                     headingH1
                     className="text-9xl! text-white! relative inline-block"
                     style={{
@@ -50,7 +50,7 @@ export default function BuildModeIntroContent({
                     }}
                   >
                     Craft
-                  </Text>
+                  </LegacyText>
                 </span>
                 <span
                   className="pointer-events-none absolute top-3 -right-14 text-[1em] uppercase tracking-[0.2em] text-white!"

--- a/web/src/app/craft/components/OpencodeDebugLogs.tsx
+++ b/web/src/app/craft/components/OpencodeDebugLogs.tsx
@@ -2,8 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { SvgCheck, SvgCopy, SvgTerminal, SvgTrash } from "@opal/icons";
-import { Button, InputTypeIn } from "@opal/components";
-import Text from "@/refresh-components/texts/Text";
+import { Button, InputTypeIn, Text } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
 import { useSettingsContext } from "@/providers/SettingsProvider";
 import { cn } from "@opal/utils";
@@ -362,7 +361,7 @@ function StatusBar({
     <div className="flex items-center gap-3 px-3 py-2">
       <div className="flex items-center gap-2 shrink-0">
         <StatusDot status={status} paused={paused} />
-        <Text secondaryBody nowrap>
+        <Text font="secondary-body" color="text-05" nowrap>
           {stateLabel}
         </Text>
         {status !== "connecting" && status !== "error" && (
@@ -371,7 +370,7 @@ function StatusBar({
               className="h-3 w-px bg-border-02 shrink-0"
               aria-hidden="true"
             />
-            <Text secondaryBody nowrap>
+            <Text font="secondary-body" color="text-05" nowrap>
               {filtered
                 ? `${visibleLines.toLocaleString()} / ${totalLines.toLocaleString()} lines`
                 : `${totalLines.toLocaleString()} lines`}
@@ -452,7 +451,9 @@ function LogContent({ scrollRef, onScroll, lines, empty }: LogContentProps) {
     >
       {empty !== null ? (
         <div className="flex h-full items-center justify-center select-none">
-          <Text secondaryBody>{empty}</Text>
+          <Text font="secondary-body" color="text-05">
+            {empty}
+          </Text>
         </div>
       ) : (
         lines.map((line) => <LogRow key={line.id} line={line} />)

--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/app/craft/services/apiServices";
 import { getFileIcon } from "@/lib/utils";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgGlobe, SvgHardDrive, SvgFiles, SvgX } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import CraftingLoader from "@/app/craft/components/CraftingLoader";
@@ -438,9 +438,7 @@ const BuildOutputPanel = memo(({ onClose, isOpen }: BuildOutputPanelProps) => {
                           : "stroke-text-03"
                     )}
                   />
-                  <Text
-                    className={cn("truncate", isDisabled && "text-text-02")}
-                  >
+                  <Text color={isDisabled ? "text-02" : "text-05"} maxLines={1}>
                     {tab.label}
                   </Text>
                   {/* Right curved joint */}
@@ -502,7 +500,9 @@ const BuildOutputPanel = memo(({ onClose, isOpen }: BuildOutputPanelProps) => {
                           isActive ? "stroke-text-04" : "stroke-text-03"
                         )}
                       />
-                      <Text className="truncate text-sm">{tab.fileName}</Text>
+                      <Text font="secondary-body" color="text-05" maxLines={1}>
+                        {tab.fileName}
+                      </Text>
                       {/* Close button */}
                       <button
                         onClick={(e) => handlePanelTabClose(e, tab)}

--- a/web/src/app/craft/components/ShareButton.tsx
+++ b/web/src/app/craft/components/ShareButton.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Popover, Text } from "@opal/components";
 import { SvgLink, SvgCopy, SvgCheck, SvgX } from "@opal/icons";
 import { setSessionSharing } from "@/app/craft/services/apiServices";
 import type { SharingScope } from "@/app/craft/types/streamingTypes";
 import { cn } from "@opal/utils";
-import { Popover } from "@opal/components";
-import Truncated from "@/refresh-components/texts/Truncated";
 import { Section } from "@/layouts/general-layouts";
 import { ContentAction } from "@opal/layouts";
 
@@ -156,9 +153,9 @@ export default function ShareButton({
                   height="fit"
                 >
                   <div className="min-w-0 flex-1 overflow-hidden">
-                    <Truncated secondaryBody text03>
+                    <Text font="secondary-body" color="text-03" maxLines={1}>
                       {shareUrl}
-                    </Truncated>
+                    </Text>
                   </div>
                   <Button
                     variant="action"

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { useUsageLimits } from "@/app/craft/hooks/useUsageLimits";
 import { CRAFT_SEARCH_PARAM_NAMES } from "@/app/craft/services/searchParams";
-import { SidebarTab } from "@opal/components";
-import Text from "@/refresh-components/texts/Text";
+import { SidebarTab, Text } from "@opal/components";
+import RefreshText from "@/refresh-components/texts/Text";
 import SidebarWrapper from "@/sections/sidebar/SidebarWrapper";
 import SidebarBody from "@/sections/sidebar/SidebarBody";
 import SidebarSection from "@/sections/sidebar/SidebarSection";
@@ -92,9 +92,11 @@ function DeletingMessage() {
   }, []);
 
   return (
-    <Text as="p" text03 className="animate-subtle-pulse">
-      {DELETING_MESSAGES[messageIndex]}
-    </Text>
+    <span className="animate-subtle-pulse">
+      <Text as="p" color="text-03">
+        {DELETING_MESSAGES[messageIndex]}
+      </Text>
+    </span>
   );
 }
 
@@ -244,7 +246,8 @@ function BuildSessionButton({
                 onClose={() => setRenaming(false)}
               />
             ) : shouldAnimate ? (
-              <Text
+              // Opal Text takes string children only; this wraps <TypewriterText>.
+              <RefreshText
                 as="p"
                 data-state={isActive ? "active" : "inactive"}
                 className="line-clamp-1 break-all text-left"
@@ -256,7 +259,7 @@ function BuildSessionButton({
                   animateOnMount={true}
                   onAnimationComplete={() => setShouldAnimate(false)}
                 />
-              </Text>
+              </RefreshText>
             ) : (
               historyItem.title
             )}
@@ -298,11 +301,11 @@ function BuildSessionButton({
           }
         >
           {deleteSuccess ? (
-            <Text as="p" text03>
+            <Text as="p" color="text-03">
               Build deleted successfully.
             </Text>
           ) : deleteError ? (
-            <Text as="p" text03 className="text-status-error-02">
+            <Text as="p" color="status-error-02">
               {deleteError}
             </Text>
           ) : isDeleting ? (
@@ -466,7 +469,7 @@ const MemoizedBuildSidebarInner = memo(
             <SidebarSection title={sessionsTitle}>
               {sessionHistory.length === 0 ? (
                 <div className="pl-2 pr-1.5 py-1">
-                  <Text text01>
+                  <Text color="text-01">
                     Start building! Session history will appear here.
                   </Text>
                 </div>

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -92,11 +92,11 @@ function DeletingMessage() {
   }, []);
 
   return (
-    <span className="animate-subtle-pulse">
+    <div className="animate-subtle-pulse">
       <Text as="p" color="text-03">
         {DELETING_MESSAGES[messageIndex]}
       </Text>
-    </span>
+    </div>
   );
 }
 

--- a/web/src/app/craft/components/ToggleWarningModal.tsx
+++ b/web/src/app/craft/components/ToggleWarningModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
+import { markdown } from "@opal/utils";
 import { RECOMMENDED_CRAFT_MODEL_LABEL } from "@/app/craft/onboarding/constants";
 
 interface ToggleWarningModalProps {
@@ -32,20 +33,17 @@ export function ToggleWarningModal({
         <div className="p-6 flex flex-col gap-6">
           {/* Header */}
           <div className="flex items-center justify-center">
-            <Text headingH2 text05>
+            <Text font="heading-h2" color="text-05">
               Show all models?
             </Text>
           </div>
 
           {/* Message */}
-          <div className="flex justify-center">
-            <Text mainUiBody text04 className="text-center">
-              We recommend using{" "}
-              <strong>{RECOMMENDED_CRAFT_MODEL_LABEL}</strong> for Crafting.
-              <br />
-              Other models may have reduced capabilities for code creation,
-              <br />
-              data analysis, and artifact creation.
+          <div className="flex justify-center text-center">
+            <Text font="main-ui-body" color="text-04">
+              {markdown(
+                `We recommend using **${RECOMMENDED_CRAFT_MODEL_LABEL}** for Crafting.\nOther models may have reduced capabilities for code creation,\ndata analysis, and artifact creation.`
+              )}
             </Text>
           </div>
 
@@ -59,7 +57,7 @@ export function ToggleWarningModal({
               }}
               className="px-4 py-2 rounded-12 bg-background-neutral-01 border border-border-02 hover:opacity-90 transition-colors"
             >
-              <Text mainUiBody text05>
+              <Text font="main-ui-body" color="text-05">
                 Show All Models
               </Text>
             </button>
@@ -71,10 +69,7 @@ export function ToggleWarningModal({
               }}
               className="px-4 py-2 rounded-12 bg-black dark:bg-white hover:opacity-90 transition-colors"
             >
-              <Text
-                mainUiAction
-                className="text-text-light-05 dark:text-text-dark-05"
-              >
+              <Text font="main-ui-action" color="text-inverted-05">
                 Keep Recommended
               </Text>
             </button>

--- a/web/src/app/craft/components/UpgradePlanModal.tsx
+++ b/web/src/app/craft/components/UpgradePlanModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgAlertTriangle } from "@opal/icons";
 import { UsageLimits } from "@/app/craft/types/streamingTypes";
 
@@ -35,25 +35,14 @@ export default function UpgradePlanModal({
           <div className="flex-1 flex flex-col items-center justify-center gap-6">
             <SvgAlertTriangle className="w-16 h-16 text-status-warning-02" />
 
-            <div className="flex flex-col items-center gap-2 text-center">
-              <Text headingH2 text05>
+            <div className="flex flex-col items-center gap-2 text-center max-w-sm">
+              <Text font="heading-h2" color="text-05">
                 You've reached your message limit
               </Text>
-              <Text mainUiBody text03 className="max-w-sm">
-                {isPaidUser ? (
-                  <>
-                    You've used all {limits?.limit ?? 25} messages for this
-                    week. Your message limit will automatically reset at the
-                    start of each week, allowing you to continue crafting with
-                    Onyx.
-                  </>
-                ) : (
-                  <>
-                    You've used all {limits?.limit ?? 5} free messages available
-                    in your trial. You've reached the limit for your free
-                    account.
-                  </>
-                )}
+              <Text font="main-ui-body" color="text-03">
+                {isPaidUser
+                  ? `You've used all ${limits?.limit ?? 25} messages for this week. Your message limit will automatically reset at the start of each week, allowing you to continue crafting with Onyx.`
+                  : `You've used all ${limits?.limit ?? 5} free messages available in your trial. You've reached the limit for your free account.`}
               </Text>
             </div>
           </div>
@@ -64,7 +53,9 @@ export default function UpgradePlanModal({
               onClick={onClose}
               className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
             >
-              <Text mainUiAction>Got it</Text>
+              <Text font="main-ui-action" color="text-05">
+                Got it
+              </Text>
             </button>
           </div>
         </div>

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -12,7 +12,6 @@ import {
   deleteLibraryFile,
 } from "@/app/craft/services/apiServices";
 import { LibraryEntry } from "@/app/craft/types/user-library";
-import Text from "@/refresh-components/texts/Text";
 import Modal from "@/refresh-components/Modal";
 import { Section } from "@/layouts/general-layouts";
 import {
@@ -29,6 +28,7 @@ import {
   InputTypeIn,
   ShadowDiv,
   Switch,
+  Text,
   Tooltip,
 } from "@opal/components";
 
@@ -236,7 +236,9 @@ export default function UserLibraryModal({
                   padding={0.5}
                   height="fit"
                 >
-                  <Text secondaryBody>{uploadError}</Text>
+                  <Text font="secondary-body" color="text-05">
+                    {uploadError}
+                  </Text>
                 </Section>
               )}
 
@@ -284,30 +286,30 @@ export default function UserLibraryModal({
                   padding={0.5}
                   height="fit"
                 >
-                  <Text secondaryBody text03>
+                  <Text font="secondary-body" color="text-03">
                     PDFs with many embedded images may be rejected.
                   </Text>
                 </Section>
 
                 {isLoading ? (
                   <Section padding={2} height="fit">
-                    <Text secondaryBody text03>
+                    <Text font="secondary-body" color="text-03">
                       Loading files...
                     </Text>
                   </Section>
                 ) : error ? (
                   <Section padding={2} height="fit">
-                    <Text secondaryBody text03>
+                    <Text font="secondary-body" color="text-03">
                       Failed to load files
                     </Text>
                   </Section>
                 ) : fileCount === 0 ? (
                   <Section padding={2} height="fit" gap={0.5}>
                     <SvgFileText size={32} className="stroke-text-02" />
-                    <Text secondaryBody text03>
+                    <Text font="secondary-body" color="text-03">
                       No files uploaded yet
                     </Text>
-                    <Text secondaryBody text02>
+                    <Text font="secondary-body" color="text-02">
                       Upload Excel, Word, PowerPoint, or other files for your
                       agent to work with
                     </Text>
@@ -374,7 +376,7 @@ export default function UserLibraryModal({
           />
           <Modal.Body>
             <Section flexDirection="column" gap={0.5} alignItems="stretch">
-              <Text secondaryBody text03>
+              <Text font="secondary-body" color="text-03">
                 Folder name
               </Text>
               <InputTypeIn
@@ -512,7 +514,7 @@ function LibraryTreeView({
                 gap={0}
                 height="fit"
               >
-                <Text secondaryBody text04 className="truncate">
+                <Text font="secondary-body" color="text-04" maxLines={1}>
                   {entry.name}
                 </Text>
               </Section>
@@ -520,7 +522,7 @@ function LibraryTreeView({
               {/* File size */}
               {!entry.is_directory && entry.file_size !== null && (
                 <Section width="fit" height="fit" gap={0} padding={0}>
-                  <Text secondaryBody text02 style={{ whiteSpace: "nowrap" }}>
+                  <Text font="secondary-body" color="text-02" nowrap>
                     {formatFileSize(entry.file_size)}
                   </Text>
                 </Section>

--- a/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
+++ b/web/src/app/craft/components/output-panel/ArtifactsTab.tsx
@@ -3,8 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Text, Button } from "@opal/components";
 import {
   SvgGlobe,
   SvgDownloadCloud,
@@ -127,10 +126,10 @@ export default function ArtifactsTab({
         padding={2}
       >
         <SvgFiles size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           No artifacts yet
         </Text>
-        <Text secondaryBody text02>
+        <Text font="secondary-body" color="text-02">
           Output files and web apps will appear here
         </Text>
       </Section>
@@ -150,10 +149,10 @@ export default function ArtifactsTab({
               <SvgGlobe size={24} className="stroke-text-02 shrink-0" />
 
               <div className="flex-1 min-w-0 flex items-center gap-2">
-                <Text secondaryBody text04 className="truncate">
+                <Text font="secondary-body" color="text-04" maxLines={1}>
                   {artifact.name}
                 </Text>
-                <Text secondaryBody text02>
+                <Text font="secondary-body" color="text-02">
                   Next.js Application
                 </Text>
               </div>
@@ -243,11 +242,11 @@ function OutputEntryRow({
         <FileIcon size={20} className="stroke-text-02 shrink-0" />
 
         <div className="flex-1 min-w-0 flex items-center gap-2">
-          <Text secondaryBody text04 className="truncate">
+          <Text font="secondary-body" color="text-04" maxLines={1}>
             {entry.name}
           </Text>
           {!entry.is_directory && entry.size !== null ? (
-            <Text secondaryBody text02>
+            <Text font="secondary-body" color="text-02">
               {formatFileSize(entry.size)}
             </Text>
           ) : null}

--- a/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
+++ b/web/src/app/craft/components/output-panel/FilePreviewContent.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { fetchFileContent } from "@/app/craft/services/apiServices";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import ImagePreview from "@/app/craft/components/output-panel/ImagePreview";
@@ -179,7 +179,7 @@ function FetchedFilePreview({
           justifyContent="center"
           padding={2}
         >
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             Loading file...
           </Text>
         </Section>
@@ -187,7 +187,7 @@ function FetchedFilePreview({
     }
     return (
       <div className="p-4">
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           Loading file...
         </Text>
       </div>
@@ -204,10 +204,10 @@ function FetchedFilePreview({
           padding={2}
         >
           <SvgFileText size={48} className="stroke-text-02" />
-          <Text headingH3 text03>
+          <Text font="heading-h3" color="text-03">
             Error loading file
           </Text>
-          <Text secondaryBody text02>
+          <Text font="secondary-body" color="text-02">
             {error.message}
           </Text>
         </Section>
@@ -215,8 +215,8 @@ function FetchedFilePreview({
     }
     return (
       <div className="p-4">
-        <Text secondaryBody text02>
-          Error: {error.message}
+        <Text font="secondary-body" color="text-02">
+          {`Error: ${error.message}`}
         </Text>
       </div>
     );
@@ -231,7 +231,7 @@ function FetchedFilePreview({
           justifyContent="center"
           padding={2}
         >
-          <Text secondaryBody text03>
+          <Text font="secondary-body" color="text-03">
             No content
           </Text>
         </Section>
@@ -239,7 +239,7 @@ function FetchedFilePreview({
     }
     return (
       <div className="p-4">
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           No content
         </Text>
       </div>
@@ -256,18 +256,20 @@ function FetchedFilePreview({
           padding={2}
         >
           <SvgFileText size={48} className="stroke-text-02" />
-          <Text headingH3 text03>
+          <Text font="heading-h3" color="text-03">
             Cannot preview file
           </Text>
-          <Text secondaryBody text02 className="text-center max-w-md">
-            {data.error}
-          </Text>
+          <div className="text-center max-w-md">
+            <Text font="secondary-body" color="text-02">
+              {data.error}
+            </Text>
+          </div>
         </Section>
       );
     }
     return (
-      <div className="p-4">
-        <Text secondaryBody text02 className="text-center">
+      <div className="p-4 text-center">
+        <Text font="secondary-body" color="text-02">
           {data.error}
         </Text>
       </div>

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -12,7 +12,7 @@ import { fetchDirectoryListing } from "@/app/craft/services/apiServices";
 import { FileSystemEntry } from "@/app/craft/types/streamingTypes";
 import { getFileIcon } from "@/lib/utils";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   SvgHardDrive,
   SvgFolder,
@@ -288,10 +288,10 @@ export default function FilesTab({
         padding={2}
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           {isProvisioning ? "Preparing sandbox..." : "No files yet"}
         </Text>
-        <Text secondaryBody text02>
+        <Text font="secondary-body" color="text-02">
           {isProvisioning
             ? "Setting up your development environment"
             : "Files created during the build will appear here"}
@@ -309,10 +309,10 @@ export default function FilesTab({
         padding={2}
       >
         <SvgHardDrive size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           Error loading files
         </Text>
-        <Text secondaryBody text02>
+        <Text font="secondary-body" color="text-02">
           {error.message}
         </Text>
       </Section>
@@ -327,7 +327,7 @@ export default function FilesTab({
         justifyContent="center"
         padding={2}
       >
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           Loading files...
         </Text>
       </Section>
@@ -353,7 +353,7 @@ export default function FilesTab({
           ) : (
             <SvgFileText size={16} className="stroke-text-03" />
           )}
-          <Text secondaryBody text04 className="truncate">
+          <Text font="secondary-body" color="text-04" maxLines={1}>
             {previewingFile.fileName}
           </Text>
         </div>
@@ -384,7 +384,7 @@ export default function FilesTab({
             justifyContent="center"
             padding={2}
           >
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               No files in this directory
             </Text>
           </Section>
@@ -542,19 +542,17 @@ function FileTreeNode({
               )}
 
               {/* Name */}
-              <Text
-                secondaryBody
-                text04
-                className="truncate flex-1 text-left ml-1"
-              >
-                {entry.name}
-              </Text>
+              <span className="flex-1 text-left ml-1 min-w-0">
+                <Text font="secondary-body" color="text-04" maxLines={1}>
+                  {entry.name}
+                </Text>
+              </span>
 
               {/* File size */}
               {!entry.is_directory && entry.size !== null && (
-                <Text text02 className="ml-2 mr-2 shrink-0">
-                  {formatFileSize(entry.size)}
-                </Text>
+                <span className="ml-2 mr-2 shrink-0">
+                  <Text color="text-02">{formatFileSize(entry.size)}</Text>
+                </span>
               )}
             </button>
 
@@ -580,7 +578,7 @@ function FileTreeNode({
                   className="flex items-center py-1"
                   style={{ paddingLeft: `${(depth + 1) * 20 + 24}px` }}
                 >
-                  <Text secondaryBody text02>
+                  <Text font="secondary-body" color="text-02">
                     Loading...
                   </Text>
                 </div>

--- a/web/src/app/craft/components/output-panel/ImagePreview.tsx
+++ b/web/src/app/craft/components/output-panel/ImagePreview.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgImage } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 
@@ -37,10 +37,10 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
         padding={2}
       >
         <SvgImage size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           Failed to load image
         </Text>
-        <Text secondaryBody text02>
+        <Text font="secondary-body" color="text-02">
           The image could not be displayed
         </Text>
       </Section>
@@ -52,7 +52,7 @@ export default function ImagePreview({ src, fileName }: ImagePreviewProps) {
       <div className="flex-1 flex items-center justify-center p-4">
         {imageLoading && (
           <div className="absolute">
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               Loading image...
             </Text>
           </div>

--- a/web/src/app/craft/components/output-panel/PdfPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PdfPreview.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { getArtifactUrl } from "@/lib/build/client";
@@ -82,12 +82,14 @@ export default function PdfPreview({
         padding={2}
       >
         <SvgFileText size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           Cannot preview PDF
         </Text>
-        <Text secondaryBody text02 className="text-center max-w-md">
-          The PDF file could not be loaded.
-        </Text>
+        <div className="text-center max-w-md">
+          <Text font="secondary-body" color="text-02">
+            The PDF file could not be loaded.
+          </Text>
+        </div>
       </Section>
     );
   }
@@ -100,7 +102,7 @@ export default function PdfPreview({
         justifyContent="center"
         padding={2}
       >
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           Loading PDF...
         </Text>
       </Section>

--- a/web/src/app/craft/components/output-panel/PptxPreview.tsx
+++ b/web/src/app/craft/components/output-panel/PptxPreview.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgChevronLeft, SvgChevronRight, SvgFileText } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import { fetchPptxPreview } from "@/app/craft/services/apiServices";
@@ -86,7 +86,7 @@ export default function PptxPreview({
         justifyContent="center"
         padding={2}
       >
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           Converting presentation...
         </Text>
       </Section>
@@ -102,12 +102,14 @@ export default function PptxPreview({
         padding={2}
       >
         <SvgFileText size={48} className="stroke-text-02" />
-        <Text headingH3 text03>
+        <Text font="heading-h3" color="text-03">
           Cannot preview presentation
         </Text>
-        <Text secondaryBody text02 className="text-center max-w-md">
-          {error.message}
-        </Text>
+        <div className="text-center max-w-md">
+          <Text font="secondary-body" color="text-02">
+            {error.message}
+          </Text>
+        </div>
       </Section>
     );
   }
@@ -121,7 +123,7 @@ export default function PptxPreview({
         padding={2}
       >
         <SvgFileText size={48} className="stroke-text-02" />
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           No slides in this presentation
         </Text>
       </Section>
@@ -137,7 +139,7 @@ export default function PptxPreview({
       <div className="flex-1 flex items-center justify-center p-4 overflow-hidden">
         {imageLoading && (
           <div className="absolute">
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               Loading slide...
             </Text>
           </div>
@@ -169,8 +171,8 @@ export default function PptxPreview({
           >
             <SvgChevronLeft size={16} className="stroke-text-02" />
           </button>
-          <Text secondaryBody text03>
-            Slide {currentSlide + 1} of {slideCount}
+          <Text font="secondary-body" color="text-03">
+            {`Slide ${currentSlide + 1} of ${slideCount}`}
           </Text>
           <button
             onClick={goToNext}

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Text, Button } from "@opal/components";
 import {
   SvgDownloadCloud,
   SvgLoader,
@@ -147,9 +146,11 @@ export default function UrlBar({
               </button>
             </Tooltip>
           )}
-          <Text secondaryBody text03 className="min-w-0 flex-1 truncate">
-            {displayUrl}
-          </Text>
+          <div className="min-w-0 flex-1">
+            <Text font="secondary-body" color="text-03" maxLines={1}>
+              {displayUrl}
+            </Text>
+          </div>
         </div>
         {/* Export button — shown for downloadable file previews (e.g. markdown → docx) */}
         {onDownload && (

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/analytics";
 import { SvgArrowRight, SvgArrowLeft, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   OnboardingModalMode,
   OnboardingStep,
@@ -338,7 +338,9 @@ export default function BuildOnboardingModal({
                   className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
                 >
                   <SvgArrowLeft className="w-4 h-4" />
-                  <Text mainUiAction>Back</Text>
+                  <Text font="main-ui-action" color="text-05">
+                    Back
+                  </Text>
                 </button>
               )}
             </div>
@@ -376,12 +378,8 @@ export default function BuildOnboardingModal({
                 )}
               >
                 <Text
-                  mainUiAction
-                  className={cn(
-                    !isSubmitting
-                      ? "text-white dark:text-black"
-                      : "text-text-02"
-                  )}
+                  font="main-ui-action"
+                  color={!isSubmitting ? "text-inverted-05" : "text-02"}
                 >
                   {isLastStep
                     ? isSubmitting
@@ -405,7 +403,9 @@ export default function BuildOnboardingModal({
                     disabled={isConnecting}
                     className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
                   >
-                    <Text mainUiAction>Skip</Text>
+                    <Text font="main-ui-action" color="text-05">
+                      Skip
+                    </Text>
                     <SvgArrowRight className="w-4 h-4" />
                   </button>
                 )}
@@ -422,12 +422,12 @@ export default function BuildOnboardingModal({
                   )}
                 >
                   <Text
-                    mainUiAction
-                    className={cn(
+                    font="main-ui-action"
+                    color={
                       canTestConnection && !isConnecting
-                        ? "text-white dark:text-black"
-                        : "text-text-02"
-                    )}
+                        ? "text-inverted-05"
+                        : "text-02"
+                    }
                   >
                     {isConnecting ? "Connecting..." : "Connect"}
                   </Text>
@@ -441,7 +441,7 @@ export default function BuildOnboardingModal({
                 onClick={isLastStep ? handleSubmit : handleNext}
                 className="flex items-center gap-1.5 px-4 py-2 rounded-12 bg-black dark:bg-white text-white dark:text-black hover:opacity-90 transition-colors"
               >
-                <Text mainUiAction className="text-white dark:text-black">
+                <Text font="main-ui-action" color="text-inverted-05">
                   {isLastStep ? "Done" : "Continue"}
                 </Text>
                 {!isLastStep && (

--- a/web/src/app/craft/onboarding/components/NoLlmProvidersModal.tsx
+++ b/web/src/app/craft/onboarding/components/NoLlmProvidersModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgLock, SvgArrowRight } from "@opal/icons";
 import { logout } from "@/lib/user";
 import { cn } from "@opal/utils";
@@ -51,15 +51,15 @@ export default function NoLlmProvidersModal({
             </div>
 
             {/* Header */}
-            <div className="flex flex-col items-center gap-2 text-center">
-              <Text headingH2 text05>
+            <div className="flex flex-col items-center gap-2 text-center max-w-sm">
+              <Text font="heading-h2" color="text-05">
                 LLM Provider Required
               </Text>
-              <Text mainUiBody text03 className="max-w-sm">
+              <Text font="main-ui-body" color="text-03">
                 Onyx Craft requires an LLM provider to be configured, but only
                 admins can set this up.
-                <br />
-                <br />
+              </Text>
+              <Text font="main-ui-body" color="text-03">
                 Please ask your admin to configure an LLM provider, or create a
                 new Onyx account to become an admin yourself!
               </Text>
@@ -73,7 +73,9 @@ export default function NoLlmProvidersModal({
               onClick={onClose}
               className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
             >
-              <Text mainUiAction>Go Back</Text>
+              <Text font="main-ui-action" color="text-05">
+                Go Back
+              </Text>
             </button>
             <button
               type="button"
@@ -87,10 +89,8 @@ export default function NoLlmProvidersModal({
               )}
             >
               <Text
-                mainUiAction
-                className={cn(
-                  !isLoading ? "text-white dark:text-black" : "text-text-02"
-                )}
+                font="main-ui-action"
+                color={!isLoading ? "text-inverted-05" : "text-02"}
               >
                 {isLoading ? "Signing out..." : "Create a new account"}
               </Text>

--- a/web/src/app/craft/onboarding/components/NotAllowedModal.tsx
+++ b/web/src/app/craft/onboarding/components/NotAllowedModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import { SvgLock, SvgArrowRight } from "@opal/icons";
 import { logout } from "@/lib/user";
 import { cn } from "@opal/utils";
@@ -47,15 +47,15 @@ export default function NotAllowedModal({
             </div>
 
             {/* Header */}
-            <div className="flex flex-col items-center gap-2 text-center">
-              <Text headingH2 text05>
+            <div className="flex flex-col items-center gap-2 text-center max-w-sm">
+              <Text font="heading-h2" color="text-05">
                 Custom Crafting Restricted
               </Text>
-              <Text mainUiBody text03 className="max-w-sm">
+              <Text font="main-ui-body" color="text-03">
                 Unfortunately, connecting your own data to Craft requires admin
                 permissions.
-                <br />
-                <br />
+              </Text>
+              <Text font="main-ui-body" color="text-03">
                 Luckily, you can create a new Onyx account to become an admin
                 and craft with your own data!
               </Text>
@@ -69,7 +69,9 @@ export default function NotAllowedModal({
               onClick={onClose}
               className="flex items-center gap-1.5 px-4 py-2 rounded-12 border border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-02 transition-colors"
             >
-              <Text mainUiAction>Go Back</Text>
+              <Text font="main-ui-action" color="text-05">
+                Go Back
+              </Text>
             </button>
             <button
               type="button"
@@ -83,10 +85,8 @@ export default function NotAllowedModal({
               )}
             >
               <Text
-                mainUiAction
-                className={cn(
-                  !isLoading ? "text-white dark:text-black" : "text-text-02"
-                )}
+                font="main-ui-action"
+                color={!isLoading ? "text-inverted-05" : "text-02"}
               >
                 {isLoading ? "Signing out..." : "Create a new account"}
               </Text>

--- a/web/src/app/craft/onboarding/components/OnboardingInfoPages.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingInfoPages.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 
 interface OnboardingInfoPagesProps {
   step: "page1" | "page2";
@@ -11,8 +11,8 @@ export default function OnboardingInfoPages({
 }: OnboardingInfoPagesProps) {
   if (step === "page1") {
     return (
-      <div className="flex-1 flex flex-col gap-6 items-center justify-center">
-        <Text headingH2 text05>
+      <div className="flex-1 flex flex-col gap-6 items-center justify-center text-center">
+        <Text font="heading-h2" color="text-05">
           What is Onyx Craft?
         </Text>
         <img
@@ -20,11 +20,14 @@ export default function OnboardingInfoPages({
           alt="Onyx Craft"
           className="max-w-full h-auto rounded-12"
         />
-        <Text mainContentBody text04 className="text-center">
-          Beautiful dashboards, slides, and reports.
-          <br />
-          Built by AI agents that know your world. Privately and securely.
-        </Text>
+        <div className="flex flex-col items-center">
+          <Text font="main-content-body" color="text-04">
+            Beautiful dashboards, slides, and reports.
+          </Text>
+          <Text font="main-content-body" color="text-04">
+            Built by AI agents that know your world. Privately and securely.
+          </Text>
+        </div>
       </div>
     );
   }
@@ -32,7 +35,7 @@ export default function OnboardingInfoPages({
   // Page 2
   return (
     <div className="flex-1 flex flex-col gap-6 items-center justify-center">
-      <Text headingH2 text05>
+      <Text font="heading-h2" color="text-05">
         Let's get started!
       </Text>
       <img

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -3,8 +3,7 @@
 import { SvgCheckCircle } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { Disabled } from "@opal/core";
-import Text from "@/refresh-components/texts/Text";
-import { Tooltip } from "@opal/components";
+import { Text, Tooltip } from "@opal/components";
 import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
   BUILD_MODE_PROVIDERS as PROVIDERS,
@@ -45,11 +44,13 @@ function SelectableButton({
               : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
           )}
         >
-          <Text mainUiAction>{children}</Text>
+          <Text font="main-ui-action" color="text-05">
+            {String(children)}
+          </Text>
         </button>
       </Disabled>
       {subtext && (
-        <Text figureSmallLabel text02>
+        <Text font="figure-small-label" color="text-02">
           {subtext}
         </Text>
       )}
@@ -92,11 +93,13 @@ function ModelSelectButton({
               : "border-border-01 bg-background-tint-00 text-text-04 hover:bg-background-tint-01"
           )}
         >
-          <Text mainUiAction>{label}</Text>
+          <Text font="main-ui-action" color="text-05">
+            {label}
+          </Text>
         </button>
       </Disabled>
       {recommended && (
-        <Text figureSmallLabel text02>
+        <Text font="figure-small-label" color="text-02">
           Recommended
         </Text>
       )}
@@ -168,14 +171,14 @@ export default function OnboardingLlmSetup({
     <div className="flex-1 flex flex-col gap-6 justify-between">
       {/* Header */}
       <div className="flex items-center justify-center">
-        <Text headingH2 text05>
+        <Text font="heading-h2" color="text-05">
           Connect your LLM
         </Text>
       </div>
 
       {/* Provider selection */}
       <div className="flex flex-col gap-3 items-center">
-        <Text mainUiBody text04>
+        <Text font="main-ui-body" color="text-04">
           Provider
         </Text>
         <div className="flex justify-center gap-3 w-full max-w-md">
@@ -210,7 +213,7 @@ export default function OnboardingLlmSetup({
 
       {/* Model selection */}
       <div className="flex flex-col gap-3 items-center">
-        <Text mainUiBody text04>
+        <Text font="main-ui-body" color="text-04">
           Default Model
         </Text>
         <div className="flex justify-center gap-3 flex-wrap w-full max-w-md">
@@ -230,7 +233,7 @@ export default function OnboardingLlmSetup({
 
       {/* API Key input */}
       <div className="flex flex-col gap-3 items-center">
-        <Text mainUiBody text04>
+        <Text font="main-ui-body" color="text-04">
           API Key
         </Text>
         <div className="w-full max-w-md">
@@ -247,7 +250,7 @@ export default function OnboardingLlmSetup({
           {/* Message area */}
           <div className="min-h-8 flex justify-center pt-4">
             {connectionStatus === "error" && (
-              <Text secondaryBody className="text-red-500">
+              <Text font="secondary-body" color="status-error-05">
                 {errorMessage}
               </Text>
             )}
@@ -258,7 +261,7 @@ export default function OnboardingLlmSetup({
               )}
             >
               <SvgCheckCircle className="w-4 h-4 stroke-status-success-05 shrink-0" />
-              <Text secondaryBody className="text-status-success-05">
+              <Text font="secondary-body" color="status-success-05">
                 Success!
               </Text>
             </div>

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -16,7 +16,7 @@ export type { ProviderKey };
 interface SelectableButtonProps {
   selected: boolean;
   onClick: () => void;
-  children: React.ReactNode;
+  children: string;
   subtext?: string;
   disabled?: boolean;
   tooltip?: string;
@@ -45,7 +45,7 @@ function SelectableButton({
           )}
         >
           <Text font="main-ui-action" color="text-05">
-            {String(children)}
+            {children}
           </Text>
         </button>
       </Disabled>

--- a/web/src/app/craft/v1/apps/oauth/callback/page.tsx
+++ b/web/src/app/craft/v1/apps/oauth/callback/page.tsx
@@ -5,8 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import type { Route } from "next";
 import { mutate as globalMutate } from "swr";
 import { SettingsLayouts } from "@opal/layouts";
-import Card from "@/refresh-components/cards/Card";
-import { Button, Text } from "@opal/components";
+import { Button, Card, Text } from "@opal/components";
 import { SvgPlug } from "@opal/icons";
 import { CRAFT_APPS_PATH } from "@/app/craft/v1/constants";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -65,7 +64,7 @@ export default function ExternalAppsOAuthCallbackPage() {
         description="Finishing the OAuth handshake…"
       />
       <SettingsLayouts.Body>
-        <Card>
+        <Card background="light" border="solid" rounding="lg">
           <div className="flex flex-col gap-2">
             {status === "exchanging" && (
               <Text font="main-content-body">

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -7,9 +7,8 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import useOnMount from "@/hooks/useOnMount";
 import { cn } from "@opal/utils";
-import { Button, InputTypeIn, Text } from "@opal/components";
+import { Button, Card, InputTypeIn, Text } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
-import Card from "@/refresh-components/cards/Card";
 import { SvgCheckCircle, SvgPlug, SvgSettings } from "@opal/icons";
 import {
   ExternalAppUserResponse,
@@ -97,7 +96,7 @@ function AppConnections({ query }: AppConnectionsProps) {
 
   if (data === undefined) {
     return (
-      <Card variant="tertiary">
+      <Card background="none" border="dashed" rounding="lg">
         <Text font="main-content-body">Loading…</Text>
       </Card>
     );
@@ -105,7 +104,7 @@ function AppConnections({ query }: AppConnectionsProps) {
 
   if (data.length === 0) {
     return (
-      <Card variant="tertiary">
+      <Card background="none" border="dashed" rounding="lg">
         <Text font="main-content-body" color="text-03">
           No external apps are enabled for your org yet. Ask an admin to enable
           one.
@@ -231,7 +230,7 @@ function ProviderConnectCard({
           highlight && "ring-2 ring-action-link-04"
         )}
       >
-        <Card>
+        <Card background="light" border="solid" rounding="lg">
           {variant === "row" ? (
             <div className="flex items-center gap-3 w-full">
               <Logo className="w-8 h-8" />

--- a/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SettingsLayouts } from "@opal/layouts";
 import { SvgClock, SvgSimpleLoader } from "@opal/icons";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import ScheduleTaskForm, {
   type ScheduleTaskFormInitial,
 } from "@/app/craft/v1/tasks/components/ScheduleTaskForm";
@@ -41,7 +41,7 @@ export default function EditScheduledTaskPage() {
           divider
         />
         <SettingsLayouts.Body>
-          <Text mainUiBody text03>
+          <Text font="main-ui-body" color="text-03">
             Missing task id.
           </Text>
         </SettingsLayouts.Body>
@@ -64,7 +64,7 @@ export default function EditScheduledTaskPage() {
               <SvgSimpleLoader className="h-6 w-6" />
             </div>
           ) : (
-            <Text mainUiBody text03>
+            <Text font="main-ui-body" color="text-03">
               Failed to load scheduled task.
             </Text>
           )}

--- a/web/src/app/craft/v1/tasks/[id]/page.tsx
+++ b/web/src/app/craft/v1/tasks/[id]/page.tsx
@@ -4,8 +4,7 @@ import { useCallback, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import { SettingsLayouts } from "@opal/layouts";
-import Text from "@/refresh-components/texts/Text";
-import { Button } from "@opal/components";
+import { Button, Text } from "@opal/components";
 import { toast } from "@/hooks/useToast";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import {
@@ -116,7 +115,7 @@ export default function ScheduledTaskDetailPage() {
           backButton={handleBack}
         />
         <SettingsLayouts.Body>
-          <Text mainUiBody text03>
+          <Text font="main-ui-body" color="text-03">
             Missing task id.
           </Text>
         </SettingsLayouts.Body>
@@ -184,7 +183,7 @@ export default function ScheduledTaskDetailPage() {
             <SvgSimpleLoader className="h-6 w-6" />
           </div>
         ) : error || !data ? (
-          <Text mainUiBody text03>
+          <Text font="main-ui-body" color="text-03">
             Failed to load scheduled task.
           </Text>
         ) : (

--- a/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
+++ b/web/src/app/craft/v1/tasks/components/PreApprovalPicker.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useCallback } from "react";
-import { Checkbox, Text } from "@opal/components";
+import { Card, Checkbox, Text } from "@opal/components";
 import { cn } from "@opal/utils";
-import Card from "@/refresh-components/cards/Card";
 import useUserExternalApps from "@/hooks/useUserExternalApps";
 import {
   getAppTypeLogo,
@@ -34,7 +33,7 @@ export default function PreApprovalPicker({
 
   if (isLoading) {
     return (
-      <Card variant="tertiary">
+      <Card background="none" border="dashed" rounding="lg">
         <Text font="secondary-body" color="text-03">
           Loading apps…
         </Text>
@@ -44,7 +43,7 @@ export default function PreApprovalPicker({
 
   if (error) {
     return (
-      <Card variant="tertiary">
+      <Card background="none" border="dashed" rounding="lg">
         <Text font="secondary-body" color="text-03">
           Couldn’t load your apps. Refresh to try again.
         </Text>
@@ -54,7 +53,7 @@ export default function PreApprovalPicker({
 
   if (!data || data.length === 0) {
     return (
-      <Card variant="tertiary">
+      <Card background="none" border="dashed" rounding="lg">
         <Text font="secondary-body" color="text-03">
           No external apps are enabled for your org yet. Ask an admin to enable
           one.
@@ -104,7 +103,7 @@ function PreApprovalRow({ app, checked, onToggle }: PreApprovalRowProps) {
       )}
       data-testid={`pre-approval-app-${app.id}`}
     >
-      <Card>
+      <Card background="light" border="solid" rounding="lg">
         <div className="flex items-center gap-3 w-full">
           <Logo className="w-8 h-8" />
           <div className="flex-1 flex flex-col gap-0.5 min-w-0">

--- a/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
+++ b/web/src/app/craft/v1/tasks/components/RunHistoryTable.tsx
@@ -9,8 +9,13 @@ import {
 } from "react";
 import useSWR from "swr";
 import { useRouter } from "next/navigation";
-import Text from "@/refresh-components/texts/Text";
-import { Button, Table, Tooltip, createTableColumns } from "@opal/components";
+import {
+  Button,
+  Table,
+  Text,
+  Tooltip,
+  createTableColumns,
+} from "@opal/components";
 import SvgLock from "@opal/icons/lock";
 import { SvgSimpleLoader } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
@@ -71,10 +76,10 @@ function buildColumns() {
       cell: (value, row) => (
         <NonClickableCell reason={getNonClickableReason(row)}>
           <div className="flex flex-col gap-0.5">
-            <Text mainUiBody text05 nowrap>
+            <Text font="main-ui-body" color="text-05" nowrap>
               {formatAbsolute(value)}
             </Text>
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               {formatRelativeShort(value)}
             </Text>
           </div>
@@ -114,7 +119,7 @@ function buildColumns() {
       width: { weight: 12 },
       cell: (row) => (
         <NonClickableCell reason={getNonClickableReason(row)}>
-          <Text mainUiBody text03 nowrap>
+          <Text font="main-ui-body" color="text-03" nowrap>
             {formatRunDuration(row.started_at, row.finished_at)}
           </Text>
         </NonClickableCell>
@@ -126,7 +131,7 @@ function buildColumns() {
       width: { weight: 38 },
       cell: (row) => (
         <NonClickableCell reason={getNonClickableReason(row)}>
-          <Text mainUiBody text03>
+          <Text font="main-ui-body" color="text-03">
             {row.summary ?? row.skip_reason ?? row.error_class ?? "—"}
           </Text>
         </NonClickableCell>
@@ -138,7 +143,7 @@ function buildColumns() {
       enableSorting: false,
       cell: (value, row) => (
         <NonClickableCell reason={getNonClickableReason(row)}>
-          <Text mainUiBody text03 nowrap>
+          <Text font="main-ui-body" color="text-03" nowrap>
             {value === "MANUAL_RUN_NOW" ? "Run Now" : "Schedule"}
           </Text>
         </NonClickableCell>
@@ -225,7 +230,7 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
   if (error) {
     return (
       <Section gap={0.5}>
-        <Text mainUiBody text03>
+        <Text font="main-ui-body" color="text-03">
           Failed to load run history.
         </Text>
         <Button
@@ -242,10 +247,12 @@ export default function RunHistoryTable({ taskId }: RunHistoryTableProps) {
 
   if (allRuns.length === 0) {
     return (
-      <Text mainUiBody text03 className="py-6 text-center">
-        No runs yet. The task will create one each time it fires, or use Run Now
-        above.
-      </Text>
+      <div className="py-6 text-center">
+        <Text font="main-ui-body" color="text-03">
+          No runs yet. The task will create one each time it fires, or use Run
+          Now above.
+        </Text>
+      </div>
     );
   }
 

--- a/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleEditor.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
-import Text from "@/refresh-components/texts/Text";
-import { InputTypeIn } from "@opal/components";
+import { InputTypeIn, Tabs, Text } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
-import SimpleTabs from "@/refresh-components/SimpleTabs";
 import { Section } from "@/layouts/general-layouts";
 import { cn } from "@opal/utils";
 import type {
@@ -81,10 +79,11 @@ export default function ScheduleEditor({
     [mode, payload, onPayloadChange]
   );
 
+  const tabEntries = Object.entries(tabContent);
+
   return (
     <Section gap={0.5}>
-      <SimpleTabs
-        tabs={tabContent}
+      <Tabs
         value={mode}
         onValueChange={(value) => {
           const next = value as EditorMode;
@@ -100,9 +99,22 @@ export default function ScheduleEditor({
             onPayloadChange(DEFAULT_DAILY_WEEKLY);
           }
         }}
-      />
+      >
+        <Tabs.List>
+          {tabEntries.map(([key, tab]) => (
+            <Tabs.Trigger key={key} value={key}>
+              {tab.name}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        {tabEntries.map(([key, tab]) => (
+          <Tabs.Content key={key} value={key}>
+            {tab.content}
+          </Tabs.Content>
+        ))}
+      </Tabs>
       {error && (
-        <Text mainUiBody text03 className="text-status-error-05">
+        <Text font="main-ui-body" color="status-error-05">
           {error}
         </Text>
       )}
@@ -144,7 +156,7 @@ function IntervalEditor({ payload, onChange }: IntervalEditorProps) {
   return (
     <Section gap={0.5}>
       <div className="flex items-center gap-2 flex-wrap">
-        <Text mainUiBody text05>
+        <Text font="main-ui-body" color="text-05">
           Every
         </Text>
         <div className="w-28">
@@ -201,7 +213,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
   return (
     <Section gap={0.5}>
       <div className="flex items-center gap-2">
-        <Text mainUiBody text05>
+        <Text font="main-ui-body" color="text-05">
           At
         </Text>
         <div className="w-44">
@@ -216,7 +228,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
         </div>
       </div>
       <div className="flex flex-col gap-1">
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           On these days
         </Text>
         <div className="flex items-center gap-1 flex-wrap">
@@ -249,7 +261,7 @@ function DailyWeeklyEditor({ payload, onChange }: DailyWeeklyEditorProps) {
             );
           })}
         </div>
-        <Text secondaryBody text03>
+        <Text font="secondary-body" color="text-03">
           {scheduleNote}
         </Text>
       </div>

--- a/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
+++ b/web/src/app/craft/v1/tasks/components/ScheduleTaskForm.tsx
@@ -2,10 +2,8 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import Text from "@/refresh-components/texts/Text";
-import { InputTypeIn } from "@opal/components";
+import { Button, Divider, InputTypeIn, Text } from "@opal/components";
 import InputTextArea from "@/refresh-components/inputs/InputTextArea";
-import { Button, Divider } from "@opal/components";
 import { Disabled } from "@opal/core";
 import { SettingsLayouts, InputVertical } from "@opal/layouts";
 import * as GeneralLayouts from "@/layouts/general-layouts";
@@ -312,7 +310,7 @@ export default function ScheduleTaskForm({
               variant={shownNameError ? "error" : undefined}
             />
             {shownNameError && (
-              <Text secondaryBody text03 className="text-status-error-05">
+              <Text font="secondary-body" color="status-error-05">
                 {shownNameError}
               </Text>
             )}
@@ -346,7 +344,7 @@ export default function ScheduleTaskForm({
               onClose={closeSkillPicker}
             />
             {shownPromptError && (
-              <Text secondaryBody text03 className="text-status-error-05">
+              <Text font="secondary-body" color="status-error-05">
                 {shownPromptError}
               </Text>
             )}

--- a/web/src/app/craft/v1/tasks/components/StatusBadge.tsx
+++ b/web/src/app/craft/v1/tasks/components/StatusBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@opal/utils";
-import Text from "@/refresh-components/texts/Text";
+import { Text } from "@opal/components";
 import {
   SvgAlertCircle,
   SvgCheckCircle,
@@ -38,7 +38,7 @@ export function TaskStatusBadge({ status }: TaskStatusBadgeProps) {
         size={12}
         className={isActive ? "text-status-success-05" : "text-text-03"}
       />
-      <Text figureSmallLabel text03>
+      <Text font="figure-small-label" color="text-03">
         {isActive ? "Active" : "Paused"}
       </Text>
     </div>
@@ -119,7 +119,7 @@ export function RunStatusBadge({ status }: RunStatusBadgeProps) {
       data-testid={`run-status-${status}`}
     >
       <Icon size={12} className={display.iconClassName} />
-      <Text figureSmallLabel text03>
+      <Text font="figure-small-label" color="text-03">
         {display.label}
       </Text>
     </div>

--- a/web/src/app/craft/v1/tasks/page.tsx
+++ b/web/src/app/craft/v1/tasks/page.tsx
@@ -5,8 +5,13 @@ import useSWR from "swr";
 import { useRouter } from "next/navigation";
 import { SettingsLayouts } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
-import Text from "@/refresh-components/texts/Text";
-import { Button, Table, Tooltip, createTableColumns } from "@opal/components";
+import {
+  Button,
+  Table,
+  Text,
+  Tooltip,
+  createTableColumns,
+} from "@opal/components";
 import { IllustrationContent } from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import { toast } from "@/hooks/useToast";
@@ -54,7 +59,7 @@ function buildColumns(handlers: RowActionHandlers) {
       weight: 25,
       enableSorting: false,
       cell: (value) => (
-        <Text mainUiBody text05 nowrap>
+        <Text font="main-ui-body" color="text-05" nowrap>
           {value}
         </Text>
       ),
@@ -64,7 +69,7 @@ function buildColumns(handlers: RowActionHandlers) {
       weight: 22,
       enableSorting: false,
       cell: (value) => (
-        <Text mainUiBody text03 nowrap>
+        <Text font="main-ui-body" color="text-03" nowrap>
           {value}
         </Text>
       ),
@@ -82,7 +87,7 @@ function buildColumns(handlers: RowActionHandlers) {
       cell: (lastRun) => {
         if (!lastRun) {
           return (
-            <Text mainUiBody text03>
+            <Text font="main-ui-body" color="text-03">
               —
             </Text>
           );
@@ -90,7 +95,7 @@ function buildColumns(handlers: RowActionHandlers) {
         return (
           <div className="flex flex-col gap-0.5">
             <RunStatusBadge status={lastRun.status} />
-            <Text secondaryBody text03>
+            <Text font="secondary-body" color="text-03">
               {formatRelativeShort(lastRun.started_at)}
             </Text>
           </div>
@@ -104,14 +109,14 @@ function buildColumns(handlers: RowActionHandlers) {
       cell: (nextRunAt) => {
         if (!nextRunAt) {
           return (
-            <Text mainUiBody text03>
+            <Text font="main-ui-body" color="text-03">
               —
             </Text>
           );
         }
         return (
           <Tooltip tooltip={formatAbsolute(nextRunAt)} side="top">
-            <Text mainUiBody text03 nowrap>
+            <Text font="main-ui-body" color="text-03" nowrap>
               {formatRelativeShort(nextRunAt)}
             </Text>
           </Tooltip>
@@ -206,7 +211,7 @@ export default function ScheduledTasksListPage() {
           </div>
         ) : error ? (
           <Section gap={0.5}>
-            <Text mainUiBody text03>
+            <Text font="main-ui-body" color="text-03">
               Failed to load scheduled tasks.
             </Text>
             <Button


### PR DESCRIPTION
## Description

Migrate the Onyx Craft surface from legacy `@/refresh-components` to the Opal design system (`@opal/components`) wherever a faithful equivalent exists: `Text`, `Truncated`→`Text maxLines`, `Card`, `IconButton`→`Button`, `LineItem`→`LineItemButton`, `SimpleTabs`→`Tabs`.

Components without an Opal equivalent (`Modal`, `Collapsible`, most inputs, `Logo`, `Keycap`, …) and the few cases Opal can't express (`IconButton` with `className`/`iconClassName`/`style`, `LineItem` `danger`, decorative `text-9xl`) intentionally remain on `refresh-components`.

The only shared-lib change: add the status colors actually used (`status-error-01/02/05`, `status-success-05`) to Opal `Text`'s `TextColor` enum (additive — safe for existing consumers).

## How Has This Been Tested?

**Static:** Full project `tsc --noEmit` → 0 errors; ESLint clean across all 37 changed files; oxfmt / oxlint / TypeScript pre-commit hooks pass.

**Visual regression (Playwright, before/after):** each key surface was captured on this branch and on a clean `origin/main` checkout and compared — all pixel-identical:

| Surface | Migrated components | Result |
|---|---|---|
| Main chat (`/craft`) | Text — BuildWelcome, SideBar, OutputPanel, IntroContent | ✅ identical |
| Apps (`/craft/v1/apps`) | `Card` (tertiary → dashed) | ✅ identical |
| Scheduled Tasks (`/craft/v1/tasks`) | Text, table headers, empty state | ✅ identical |
| New Task (`/craft/v1/tasks/new`) | `SimpleTabs` → `Tabs`, `Card` (PreApprovalPicker), Text | ✅ identical |

**Functional spot-checks:** LLM model popover (`LineItem` → `LineItemButton`) renders with selected-state + chevrons; scheduler tabs switch correctly (Interval ↔ Daily / Weekly); the `ToggleWarningModal` — re-authored to render its body via `markdown()` — shows the correct bold + line breaks and a readable white-on-black "Keep Recommended" button (`text-inverted-05`).

No visual regressions found.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)