### PR TITLE
feat(craft): redesign the Library (Your Files) modal

### DIFF
--- a/web/src/app/craft/components/UserLibraryModal.stories.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.stories.tsx
@@ -83,7 +83,7 @@ export const Empty: Story = {
   decorators: [withLibrary([])],
 };
 
-// Populated — file/folder rows with the "Sync to agent" toggle column.
+// Populated — file/folder rows with sizes and hover-revealed actions.
 export const WithFiles: Story = {
   decorators: [withLibrary(libraryTree)],
 };

--- a/web/src/app/craft/components/UserLibraryModal.stories.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { ReactNode } from "react";
+import { SWRConfig } from "swr";
+import UserLibraryModal from "@/app/craft/components/UserLibraryModal";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import type { LibraryEntry } from "@/app/craft/types/user-library";
+
+// Disable all SWR fetching so the modal renders purely from the provided
+// fallback data instead of hitting the live library API.
+const SWR_NO_FETCH = {
+  provider: () => new Map(),
+  revalidateOnMount: false,
+  revalidateIfStale: false,
+  revalidateOnFocus: false,
+  revalidateOnReconnect: false,
+};
+
+const libraryTree: LibraryEntry[] = [
+  {
+    id: "1",
+    name: "reports",
+    path: "user_library/reports",
+    is_directory: true,
+    file_size: null,
+    mime_type: null,
+    sync_enabled: true,
+    created_at: "2026-05-28T00:00:00Z",
+  },
+  {
+    id: "2",
+    name: "q2-financials.xlsx",
+    path: "user_library/reports/q2-financials.xlsx",
+    is_directory: false,
+    file_size: 812_000,
+    mime_type:
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    sync_enabled: true,
+    created_at: "2026-05-30T00:00:00Z",
+  },
+  {
+    id: "3",
+    name: "brand-guidelines.pdf",
+    path: "user_library/brand-guidelines.pdf",
+    is_directory: false,
+    file_size: 2_400_000,
+    mime_type: "application/pdf",
+    sync_enabled: false,
+    created_at: "2026-05-29T00:00:00Z",
+  },
+];
+
+function withLibrary(tree: LibraryEntry[]) {
+  return function Decorator(Story: () => ReactNode) {
+    return (
+      <SWRConfig
+        value={{
+          ...SWR_NO_FETCH,
+          fallback: { [SWR_KEYS.buildUserLibraryTree]: tree },
+        }}
+      >
+        <Story />
+      </SWRConfig>
+    );
+  };
+}
+
+const meta: Meta<typeof UserLibraryModal> = {
+  title: "Apps/Craft/User Library Modal",
+  component: UserLibraryModal,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    onClose: () => {},
+    onChanges: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UserLibraryModal>;
+
+// Empty state — the click/drag upload dropzone.
+export const Empty: Story = {
+  decorators: [withLibrary([])],
+};
+
+// Populated — file/folder rows with the "Sync to agent" toggle column.
+export const WithFiles: Story = {
+  decorators: [withLibrary(libraryTree)],
+};

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -330,14 +330,22 @@ export default function UserLibraryModal({
                   />
                 ) : (
                   <div className="flex flex-col gap-1.5">
-                    {/* Column caption clarifies what the per-row switch controls */}
-                    <div className="flex items-center justify-end px-2">
-                      <Text font="secondary-mono-label" color="text-03">
-                        Sync to agent
-                      </Text>
+                    {/* Column header — sits in the same fixed-width column as
+                        the toggles below so the label reads as their heading */}
+                    <div className="flex items-center px-2">
+                      <div className="min-w-0 flex-1" />
+                      <div className="flex w-24 shrink-0 justify-center">
+                        <Text
+                          font="secondary-mono-label"
+                          color="text-03"
+                          nowrap
+                        >
+                          Sync to agent
+                        </Text>
+                      </div>
                     </div>
                     <ShadowDiv className="max-h-[360px]">
-                      <div className="flex flex-col gap-0.5 pr-1">
+                      <div className="flex flex-col gap-0.5">
                         <LibraryTreeView
                           entries={hierarchicalTree}
                           expandedPaths={expandedPaths}
@@ -593,19 +601,21 @@ function LibraryTreeView({
                 />
               </div>
 
-              {/* Sync toggle (aligns under the "Sync to agent" column caption) */}
-              <Tooltip
-                tooltip={
-                  entry.sync_enabled
-                    ? "Synced to agent — click to disable"
-                    : "Not synced — click to enable"
-                }
-              >
-                <Switch
-                  checked={entry.sync_enabled}
-                  onCheckedChange={(checked) => onToggleSync(entry, checked)}
-                />
-              </Tooltip>
+              {/* Sync toggle — fixed-width column aligned under the header */}
+              <div className="flex w-24 shrink-0 justify-center">
+                <Tooltip
+                  tooltip={
+                    entry.sync_enabled
+                      ? "Synced to agent — click to disable"
+                      : "Not synced — click to enable"
+                  }
+                >
+                  <Switch
+                    checked={entry.sync_enabled}
+                    onCheckedChange={(checked) => onToggleSync(entry, checked)}
+                  />
+                </Tooltip>
+              </div>
             </div>
 
             {/* Children */}

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -13,11 +13,12 @@ import {
 } from "@/app/craft/services/apiServices";
 import { LibraryEntry } from "@/app/craft/types/user-library";
 import Modal from "@/refresh-components/Modal";
-import { Section } from "@/layouts/general-layouts";
+import { cn } from "@opal/utils";
 import {
   SvgFolder,
   SvgFolderOpen,
   SvgChevronRight,
+  SvgChevronDown,
   SvgUploadCloud,
   SvgTrash,
   SvgFileText,
@@ -33,7 +34,6 @@ import {
 } from "@opal/components";
 
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
-import IconButton from "@/refresh-components/buttons/IconButton";
 
 /**
  * Build a hierarchical tree from a flat list of library entries.
@@ -71,6 +71,13 @@ function buildTreeFromFlatList(flatList: LibraryEntry[]): LibraryEntry[] {
   return rootEntries;
 }
 
+function formatFileSize(bytes: number | null): string {
+  if (bytes === null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 interface UserLibraryModalProps {
   open: boolean;
   onClose: () => void;
@@ -88,8 +95,12 @@ export default function UserLibraryModal({
   const [entryToDelete, setEntryToDelete] = useState<LibraryEntry | null>(null);
   const [showNewFolderModal, setShowNewFolderModal] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
+  const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const uploadTargetPathRef = useRef<string>("/");
+  // dragenter/dragleave fire for every child element; count depth so the
+  // overlay only clears when the cursor truly leaves the drop region.
+  const dragDepth = useRef(0);
 
   // Fetch library tree
   const {
@@ -119,19 +130,15 @@ export default function UserLibraryModal({
     });
   }, []);
 
-  const handleFileUpload = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const files = event.target.files;
-      if (!files || files.length === 0) return;
+  const uploadFiles = useCallback(
+    async (fileArray: File[], targetPath: string) => {
+      if (fileArray.length === 0) return;
 
       setIsUploading(true);
       setUploadError(null);
 
-      const targetPath = uploadTargetPathRef.current;
-
       try {
-        const fileArray = Array.from(files);
-        // Check if it's a single zip file
+        // A lone .zip is expanded server-side; everything else uploads as-is.
         const firstFile = fileArray[0];
         if (
           fileArray.length === 1 &&
@@ -143,17 +150,27 @@ export default function UserLibraryModal({
           await uploadLibraryFiles(targetPath, fileArray);
         }
         mutate();
-        onChanges?.(); // Notify parent that changes were made
+        onChanges?.();
       } catch (err) {
         setUploadError(err instanceof Error ? err.message : "Upload failed");
       } finally {
         setIsUploading(false);
-        uploadTargetPathRef.current = "/";
-        // Reset input
-        event.target.value = "";
       }
     },
     [mutate, onChanges]
+  );
+
+  const handleFileInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const files = event.target.files;
+      if (!files || files.length === 0) return;
+      const targetPath = uploadTargetPathRef.current;
+      void uploadFiles(Array.from(files), targetPath).finally(() => {
+        uploadTargetPathRef.current = "/";
+        event.target.value = "";
+      });
+    },
+    [uploadFiles]
   );
 
   const handleUploadToFolder = useCallback((folderPath: string) => {
@@ -161,12 +178,43 @@ export default function UserLibraryModal({
     fileInputRef.current?.click();
   }, []);
 
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes("Files")) return;
+    e.preventDefault();
+    dragDepth.current += 1;
+    setIsDragging(true);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes("Files")) e.preventDefault();
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragDepth.current -= 1;
+    if (dragDepth.current <= 0) {
+      dragDepth.current = 0;
+      setIsDragging(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      dragDepth.current = 0;
+      setIsDragging(false);
+      const files = Array.from(e.dataTransfer.files);
+      if (files.length > 0) void uploadFiles(files, "/");
+    },
+    [uploadFiles]
+  );
+
   const handleToggleSync = useCallback(
     async (entry: LibraryEntry, enabled: boolean) => {
       try {
         await toggleLibraryFileSync(entry.id, enabled);
         mutate();
-        onChanges?.(); // Notify parent that changes were made
+        onChanges?.();
       } catch (err) {
         console.error("Failed to toggle sync:", err);
       }
@@ -180,7 +228,7 @@ export default function UserLibraryModal({
     try {
       await deleteLibraryFile(entryToDelete.id);
       mutate();
-      onChanges?.(); // Notify parent that changes were made
+      onChanges?.();
     } catch (err) {
       console.error("Failed to delete:", err);
     } finally {
@@ -206,13 +254,6 @@ export default function UserLibraryModal({
     }
   }, [mutate, newFolderName]);
 
-  const formatFileSize = (bytes: number | null): string => {
-    if (bytes === null) return "";
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  };
-
   const fileCount = hierarchicalTree.length;
 
   return (
@@ -226,109 +267,100 @@ export default function UserLibraryModal({
             onClose={onClose}
           />
           <Modal.Body>
-            <Section flexDirection="column" gap={1} alignItems="stretch">
-              {/* Upload error */}
-              {uploadError && (
-                <Section
-                  flexDirection="row"
-                  alignItems="center"
-                  justifyContent="start"
-                  padding={0.5}
-                  height="fit"
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hidden"
+              onChange={handleFileInputChange}
+              disabled={isUploading}
+            />
+
+            <div className="flex w-full flex-col gap-3">
+              {/* Toolbar: primary actions, right-aligned */}
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  prominence="secondary"
+                  icon={SvgFolderPlus}
+                  onClick={() => setShowNewFolderModal(true)}
                 >
-                  <Text font="secondary-body" color="text-05">
+                  New folder
+                </Button>
+                <Button
+                  icon={SvgUploadCloud}
+                  disabled={isUploading}
+                  onClick={() => handleUploadToFolder("/")}
+                >
+                  {isUploading ? "Uploading…" : "Upload"}
+                </Button>
+              </div>
+
+              {uploadError && (
+                <div className="rounded-8 border border-status-error-02 bg-status-error-01 px-3 py-2">
+                  <Text font="secondary-body" color="status-error-05">
                     {uploadError}
                   </Text>
-                </Section>
+                </div>
               )}
 
-              {/* File explorer */}
-              <Section flexDirection="column" alignItems="stretch">
-                {/* Action buttons */}
-                <Section
-                  flexDirection="row"
-                  justifyContent="end"
-                  gap={0.5}
-                  padding={0.5}
-                >
-                  <Button
-                    prominence="secondary"
-                    icon={SvgFolderPlus}
-                    onClick={() => setShowNewFolderModal(true)}
-                    tooltip="New Folder"
-                  />
-                  <input
-                    ref={fileInputRef}
-                    type="file"
-                    multiple
-                    style={{ display: "none" }}
-                    onChange={handleFileUpload}
-                    disabled={isUploading}
-                  />
-                  <Button
-                    disabled={isUploading}
-                    prominence="secondary"
-                    icon={SvgUploadCloud}
-                    onClick={() => handleUploadToFolder("/")}
-                    tooltip={isUploading ? "Uploading..." : "Upload"}
-                    aria-label={isUploading ? "Uploading..." : "Upload"}
-                  />
-                </Section>
-
-                {/* The exact cap is controlled by the backend env var
-                    MAX_EMBEDDED_IMAGES_PER_FILE (default 500). This copy is
-                    deliberately vague so it doesn't drift if the limit is
-                    tuned per-deployment; the precise number is surfaced in
-                    the rejection error the server returns. */}
-                <Section
-                  flexDirection="row"
-                  justifyContent="end"
-                  padding={0.5}
-                  height="fit"
-                >
-                  <Text font="secondary-body" color="text-03">
-                    PDFs with many embedded images may be rejected.
-                  </Text>
-                </Section>
-
+              {/* Drop region — accepts file drops in both empty and populated states */}
+              <div
+                className="relative"
+                onDragEnter={handleDragEnter}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+              >
                 {isLoading ? (
-                  <Section padding={2} height="fit">
+                  <div className="flex items-center justify-center py-12">
                     <Text font="secondary-body" color="text-03">
-                      Loading files...
+                      Loading files…
                     </Text>
-                  </Section>
+                  </div>
                 ) : error ? (
-                  <Section padding={2} height="fit">
-                    <Text font="secondary-body" color="text-03">
+                  <div className="flex items-center justify-center py-12">
+                    <Text font="secondary-body" color="status-error-05">
                       Failed to load files
                     </Text>
-                  </Section>
+                  </div>
                 ) : fileCount === 0 ? (
-                  <Section padding={2} height="fit" gap={0.5}>
-                    <SvgFileText size={32} className="stroke-text-02" />
-                    <Text font="secondary-body" color="text-03">
-                      No files uploaded yet
-                    </Text>
-                    <Text font="secondary-body" color="text-02">
-                      Upload Excel, Word, PowerPoint, or other files for your
-                      agent to work with
-                    </Text>
-                  </Section>
+                  <UploadDropzone
+                    onClick={() => handleUploadToFolder("/")}
+                    active={isDragging}
+                  />
                 ) : (
-                  <ShadowDiv style={{ maxHeight: "400px", padding: "0.5rem" }}>
-                    <LibraryTreeView
-                      entries={hierarchicalTree}
-                      expandedPaths={expandedPaths}
-                      onToggleFolder={toggleFolder}
-                      onToggleSync={handleToggleSync}
-                      onDelete={setEntryToDelete}
-                      onUploadToFolder={handleUploadToFolder}
-                      formatFileSize={formatFileSize}
-                    />
-                  </ShadowDiv>
+                  <div className="flex flex-col gap-1.5">
+                    {/* Column caption clarifies what the per-row switch controls */}
+                    <div className="flex items-center justify-end px-2">
+                      <Text font="secondary-mono-label" color="text-03">
+                        Sync to agent
+                      </Text>
+                    </div>
+                    <ShadowDiv className="max-h-[360px]">
+                      <div className="flex flex-col gap-0.5 pr-1">
+                        <LibraryTreeView
+                          entries={hierarchicalTree}
+                          expandedPaths={expandedPaths}
+                          onToggleFolder={toggleFolder}
+                          onToggleSync={handleToggleSync}
+                          onDelete={setEntryToDelete}
+                          onUploadToFolder={handleUploadToFolder}
+                        />
+                      </div>
+                    </ShadowDiv>
+                  </div>
                 )}
-              </Section>
-            </Section>
+
+                {/* Drag overlay — consistent feedback regardless of state */}
+                {isDragging && (
+                  <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-12 border-2 border-dashed border-action-link-04 bg-action-link-01/90">
+                    <Text font="main-ui-action" color="text-05">
+                      Drop files to upload
+                    </Text>
+                  </div>
+                )}
+              </div>
+            </div>
           </Modal.Body>
 
           <Modal.Footer>
@@ -375,7 +407,7 @@ export default function UserLibraryModal({
             }}
           />
           <Modal.Body>
-            <Section flexDirection="column" gap={0.5} alignItems="stretch">
+            <div className="flex flex-col items-stretch gap-2">
               <Text font="secondary-body" color="text-03">
                 Folder name
               </Text>
@@ -390,7 +422,7 @@ export default function UserLibraryModal({
                 }}
                 autoFocus
               />
-            </Section>
+            </div>
           </Modal.Body>
           <Modal.Footer>
             <Button
@@ -415,6 +447,42 @@ export default function UserLibraryModal({
   );
 }
 
+interface UploadDropzoneProps {
+  onClick: () => void;
+  active: boolean;
+}
+
+function UploadDropzone({ onClick, active }: UploadDropzoneProps) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === " " || e.key === "Enter") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className={cn(
+        "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-12 border border-dashed px-6 py-10 text-center transition-colors",
+        active
+          ? "border-action-link-04 bg-action-link-01"
+          : "border-border-03 bg-background-tint-02 hover:border-action-link-04 hover:bg-action-link-01"
+      )}
+    >
+      <SvgUploadCloud size={28} className="stroke-text-03" />
+      <Text font="main-ui-action" color="text-04">
+        Drag files here or click to upload
+      </Text>
+      <Text font="secondary-body" color="text-03">
+        Excel, Word, PowerPoint, PDF, or ZIP. PDFs with many embedded images may
+        be rejected.
+      </Text>
+    </div>
+  );
+}
+
 interface LibraryTreeViewProps {
   entries: LibraryEntry[];
   expandedPaths: Set<string>;
@@ -422,7 +490,6 @@ interface LibraryTreeViewProps {
   onToggleSync: (entry: LibraryEntry, enabled: boolean) => void;
   onDelete: (entry: LibraryEntry) => void;
   onUploadToFolder: (folderPath: string) => void;
-  formatFileSize: (bytes: number | null) => string;
   depth?: number;
 }
 
@@ -433,7 +500,6 @@ function LibraryTreeView({
   onToggleSync,
   onDelete,
   onUploadToFolder,
-  formatFileSize,
   depth = 0,
 }: LibraryTreeViewProps) {
   // Sort entries: directories first, then alphabetically
@@ -449,96 +515,63 @@ function LibraryTreeView({
         const isExpanded = expandedPaths.has(entry.path);
 
         return (
-          <Section
-            key={entry.id}
-            flexDirection="column"
-            alignItems="stretch"
-            gap={0}
-            height="fit"
-          >
-            <Section
-              flexDirection="row"
-              alignItems="center"
-              justifyContent="start"
-              gap={0.25}
-              height="fit"
-              padding={0.5}
-            >
-              {/* Indent spacer - inline style needed for dynamic depth */}
+          <div key={entry.id} className="flex flex-col">
+            <div className="group flex items-center gap-2 rounded-8 px-2 py-1.5 transition-colors hover:bg-background-tint-01">
+              {/* Indent for nesting depth */}
               {depth > 0 && (
                 <span
                   aria-hidden
-                  style={{
-                    display: "inline-block",
-                    width: `${depth * 1.25}rem`,
-                    flexShrink: 0,
-                  }}
+                  className="shrink-0"
+                  style={{ width: `${depth * 1.25}rem` }}
                 />
               )}
 
-              {/* Expand/collapse for directories */}
+              {/* Expand/collapse for directories (icon swap avoids a rotate style) */}
               {entry.is_directory ? (
-                // TODO(@raunakab): migrate to opal Button once it supports style prop
-                <IconButton
-                  icon={SvgChevronRight}
+                <Button
+                  prominence="tertiary"
+                  size="2xs"
+                  icon={isExpanded ? SvgChevronDown : SvgChevronRight}
                   onClick={() => onToggleFolder(entry.path)}
-                  small
                   tooltip={isExpanded ? "Collapse" : "Expand"}
-                  style={{
-                    transform: isExpanded ? "rotate(90deg)" : undefined,
-                    transition: "transform 150ms ease",
-                  }}
                 />
               ) : (
-                <Section width="fit" height="fit" gap={0} padding={0}>
-                  <SvgChevronRight size={12} style={{ visibility: "hidden" }} />
-                </Section>
+                <span aria-hidden className="w-5 shrink-0" />
               )}
 
-              {/* Icon */}
+              {/* Type icon */}
               {entry.is_directory ? (
                 isExpanded ? (
-                  <SvgFolderOpen size={16} className="stroke-text-03" />
+                  <SvgFolderOpen
+                    size={16}
+                    className="shrink-0 stroke-text-03"
+                  />
                 ) : (
-                  <SvgFolder size={16} className="stroke-text-03" />
+                  <SvgFolder size={16} className="shrink-0 stroke-text-03" />
                 )
               ) : (
-                <SvgFileText size={16} className="stroke-text-03" />
+                <SvgFileText size={16} className="shrink-0 stroke-text-03" />
               )}
 
               {/* Name */}
-              <Section
-                flexDirection="row"
-                alignItems="center"
-                justifyContent="start"
-                gap={0}
-                height="fit"
-              >
+              <div className="min-w-0 flex-1">
                 <Text font="secondary-body" color="text-04" maxLines={1}>
                   {entry.name}
                 </Text>
-              </Section>
+              </div>
 
               {/* File size */}
               {!entry.is_directory && entry.file_size !== null && (
-                <Section width="fit" height="fit" gap={0} padding={0}>
-                  <Text font="secondary-body" color="text-02" nowrap>
-                    {formatFileSize(entry.file_size)}
-                  </Text>
-                </Section>
+                <Text font="secondary-body" color="text-02" nowrap>
+                  {formatFileSize(entry.file_size)}
+                </Text>
               )}
 
-              {/* Actions */}
-              <Section
-                flexDirection="row"
-                alignItems="center"
-                justifyContent="end"
-                gap={0.25}
-                width="fit"
-                height="fit"
-              >
+              {/* Row actions — revealed on hover/focus */}
+              <div className="flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
                 {entry.is_directory && (
                   <Button
+                    prominence="tertiary"
                     size="sm"
                     icon={SvgUploadCloud}
                     onClick={(e) => {
@@ -552,19 +585,20 @@ function LibraryTreeView({
                 )}
                 <Button
                   variant="danger"
+                  prominence="tertiary"
                   size="sm"
                   icon={SvgTrash}
                   onClick={() => onDelete(entry)}
                   tooltip="Delete"
                 />
-              </Section>
+              </div>
 
-              {/* Sync toggle */}
+              {/* Sync toggle (aligns under the "Sync to agent" column caption) */}
               <Tooltip
                 tooltip={
                   entry.sync_enabled
-                    ? "Synced to sandbox - click to disable"
-                    : "Not synced - click to enable"
+                    ? "Synced to agent — click to disable"
+                    : "Not synced — click to enable"
                 }
               >
                 <Switch
@@ -572,7 +606,7 @@ function LibraryTreeView({
                   onCheckedChange={(checked) => onToggleSync(entry, checked)}
                 />
               </Tooltip>
-            </Section>
+            </div>
 
             {/* Children */}
             {entry.is_directory && isExpanded && entry.children && (
@@ -583,11 +617,10 @@ function LibraryTreeView({
                 onToggleSync={onToggleSync}
                 onDelete={onDelete}
                 onUploadToFolder={onUploadToFolder}
-                formatFileSize={formatFileSize}
                 depth={depth + 1}
               />
             )}
-          </Section>
+          </div>
         );
       })}
     </>

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -269,7 +269,7 @@ export default function UserLibraryModal({
   return (
     <>
       <Modal open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-        <Modal.Content width="xl" height="fit">
+        <Modal.Content width="lg" height="fit">
           <Modal.Header
             icon={SvgFileText}
             title="Your Files"

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -8,7 +8,6 @@ import {
   uploadLibraryFiles,
   uploadLibraryZip,
   createLibraryDirectory,
-  toggleLibraryFileSync,
   deleteLibraryFile,
 } from "@/app/craft/services/apiServices";
 import { LibraryEntry } from "@/app/craft/types/user-library";
@@ -24,14 +23,7 @@ import {
   SvgFileText,
   SvgFolderPlus,
 } from "@opal/icons";
-import {
-  Button,
-  InputTypeIn,
-  ShadowDiv,
-  Switch,
-  Text,
-  Tooltip,
-} from "@opal/components";
+import { Button, InputTypeIn, ShadowDiv, Text } from "@opal/components";
 
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
 
@@ -81,7 +73,7 @@ function formatFileSize(bytes: number | null): string {
 interface UserLibraryModalProps {
   open: boolean;
   onClose: () => void;
-  onChanges?: () => void; // Called when files are uploaded, deleted, or sync toggled
+  onChanges?: () => void; // Called when files are uploaded or deleted
 }
 
 export default function UserLibraryModal({
@@ -219,19 +211,6 @@ export default function UserLibraryModal({
     [uploadFiles, isUploading]
   );
 
-  const handleToggleSync = useCallback(
-    async (entry: LibraryEntry, enabled: boolean) => {
-      try {
-        await toggleLibraryFileSync(entry.id, enabled);
-        mutate();
-        onChanges?.();
-      } catch (err) {
-        console.error("Failed to toggle sync:", err);
-      }
-    },
-    [mutate, onChanges]
-  );
-
   const handleDeleteConfirm = useCallback(async () => {
     if (!entryToDelete) return;
 
@@ -339,34 +318,17 @@ export default function UserLibraryModal({
                     active={isDragging}
                   />
                 ) : (
-                  <div className="flex flex-col gap-1.5">
-                    {/* Column header — sits in the same fixed-width column as
-                        the toggles below so the label reads as their heading */}
-                    <div className="flex items-center px-2">
-                      <div className="min-w-0 flex-1" />
-                      <div className="flex w-24 shrink-0 justify-center">
-                        <Text
-                          font="secondary-mono-label"
-                          color="text-03"
-                          nowrap
-                        >
-                          Sync to agent
-                        </Text>
-                      </div>
+                  <ShadowDiv className="max-h-[360px]">
+                    <div className="flex flex-col gap-0.5">
+                      <LibraryTreeView
+                        entries={hierarchicalTree}
+                        expandedPaths={expandedPaths}
+                        onToggleFolder={toggleFolder}
+                        onDelete={setEntryToDelete}
+                        onUploadToFolder={handleUploadToFolder}
+                      />
                     </div>
-                    <ShadowDiv className="max-h-[360px]">
-                      <div className="flex flex-col gap-0.5">
-                        <LibraryTreeView
-                          entries={hierarchicalTree}
-                          expandedPaths={expandedPaths}
-                          onToggleFolder={toggleFolder}
-                          onToggleSync={handleToggleSync}
-                          onDelete={setEntryToDelete}
-                          onUploadToFolder={handleUploadToFolder}
-                        />
-                      </div>
-                    </ShadowDiv>
-                  </div>
+                  </ShadowDiv>
                 )}
 
                 {/* Drag overlay — consistent feedback regardless of state */}
@@ -505,7 +467,6 @@ interface LibraryTreeViewProps {
   entries: LibraryEntry[];
   expandedPaths: Set<string>;
   onToggleFolder: (path: string) => void;
-  onToggleSync: (entry: LibraryEntry, enabled: boolean) => void;
   onDelete: (entry: LibraryEntry) => void;
   onUploadToFolder: (folderPath: string) => void;
   depth?: number;
@@ -515,7 +476,6 @@ function LibraryTreeView({
   entries,
   expandedPaths,
   onToggleFolder,
-  onToggleSync,
   onDelete,
   onUploadToFolder,
   depth = 0,
@@ -610,22 +570,6 @@ function LibraryTreeView({
                   tooltip="Delete"
                 />
               </div>
-
-              {/* Sync toggle — fixed-width column aligned under the header */}
-              <div className="flex w-24 shrink-0 justify-center">
-                <Tooltip
-                  tooltip={
-                    entry.sync_enabled
-                      ? "Synced to agent — click to disable"
-                      : "Not synced — click to enable"
-                  }
-                >
-                  <Switch
-                    checked={entry.sync_enabled}
-                    onCheckedChange={(checked) => onToggleSync(entry, checked)}
-                  />
-                </Tooltip>
-              </div>
             </div>
 
             {/* Children */}
@@ -634,7 +578,6 @@ function LibraryTreeView({
                 entries={entry.children}
                 expandedPaths={expandedPaths}
                 onToggleFolder={onToggleFolder}
-                onToggleSync={onToggleSync}
                 onDelete={onDelete}
                 onUploadToFolder={onUploadToFolder}
                 depth={depth + 1}

--- a/web/src/app/craft/components/UserLibraryModal.tsx
+++ b/web/src/app/craft/components/UserLibraryModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useMemo } from "react";
+import { useState, useCallback, useRef, useMemo, useEffect } from "react";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
@@ -118,6 +118,15 @@ export default function UserLibraryModal({
     return buildTreeFromFlatList(tree);
   }, [tree]);
 
+  // Clear any in-progress drag state when the modal closes, so a drag that
+  // was interrupted by a close doesn't leave the overlay stuck on reopen.
+  useEffect(() => {
+    if (!open) {
+      dragDepth.current = 0;
+      setIsDragging(false);
+    }
+  }, [open]);
+
   const toggleFolder = useCallback((path: string) => {
     setExpandedPaths((prev) => {
       const newSet = new Set(prev);
@@ -203,10 +212,11 @@ export default function UserLibraryModal({
       e.preventDefault();
       dragDepth.current = 0;
       setIsDragging(false);
+      if (isUploading) return;
       const files = Array.from(e.dataTransfer.files);
       if (files.length > 0) void uploadFiles(files, "/");
     },
-    [uploadFiles]
+    [uploadFiles, isUploading]
   );
 
   const handleToggleSync = useCallback(


### PR DESCRIPTION
## Description

Redesign the Craft **Library ("Your Files")** modal for clarity and craft.

> 📚 Stacked on #11741 (both PRs touch `UserLibraryModal.tsx`). Review/merge #11741 first; base will retarget to `main` automatically once it merges.

- Replace the orphaned icon-only buttons with a labeled **New folder / Upload** toolbar
- Inviting **dropzone** empty state with **drag-and-drop** upload (recessed at rest, accent on hover/drag)
- A **"Sync to agent"** column caption so the per-file sync toggle is legible
- Tidier file rows with hover-revealed actions
- Full-width content + token-based spacing, replacing nested `Section` primitives

## Screenshots

The redesigned modal at the `lg` width — labeled **New folder / Upload** toolbar, an upload **dropzone** empty state, and a populated tree with the **Sync to agent** toggle column.

<img width="1200" height="820" alt="library-modal-empty" src="https://github.com/user-attachments/assets/805520e6-a656-407c-8745-31b01f7281b6" />

<img width="1200" height="820" alt="library-modal-populated" src="https://github.com/user-attachments/assets/47972856-bf74-4ca3-910e-dd1360e7691d" />


## How Has This Been Tested?

- `tsc --noEmit` (0 errors), ESLint + prettier clean.
- Manual Playwright QA: empty + populated states, click-to-upload, delete-confirm flow, hover-reveal actions, full-width layout. Real OS file-drag was not simulated, but the drop handlers are wired and typecheck.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Craft Library (“Your Files”) modal to make uploads clearer and faster. Adds drag-and-drop and a labeled toolbar; switches to lg modal width. Removed the per-file “Sync to agent” toggle pending a rework.

- **New Features**
  - Labeled toolbar with New folder and Upload.
  - Drag-and-drop uploads in empty and populated states with overlay; single .zip expands server-side.
  - Hover-revealed row actions.
  - Storybook stories for empty and populated states using SWR fallback.

- **Bug Fixes**
  - Block drag-and-drop while uploading to prevent double uploads.
  - Reset the drag overlay when the modal closes.

<sup>Written for commit ed9979311c06ad048f7010351608f76ad353ece2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




