### PR TITLE
fix(craft): use real Google Drive logo for external app

### DIFF
--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -4,6 +4,7 @@ import {
   SvgGmail,
   SvgGithub,
   SvgGoogleCalendar,
+  SvgGoogleDrive,
 } from "@opal/logos";
 import { SvgPlug } from "@opal/icons";
 import { IconFunctionComponent } from "@opal/types";
@@ -22,6 +23,7 @@ const _BUILT_IN_LOGOS: Partial<Record<ExternalAppType, IconFunctionComponent>> =
   {
     SLACK: SvgSlack,
     GOOGLE_CALENDAR: SvgGoogleCalendar,
+    GOOGLE_DRIVE: SvgGoogleDrive,
     GMAIL: SvgGmail,
     LINEAR: SvgLinear,
     GITHUB: SvgGithub,


### PR DESCRIPTION
## Description

The Craft external-apps UI (`/craft/v1/apps`) was rendering the generic plug icon for the Google Drive app because `GOOGLE_DRIVE` was missing from the built-in logo map in `web/src/app/craft/v1/apps/registry.ts`, falling through to the `SvgPlug` default.

This adds the `GOOGLE_DRIVE` → `SvgGoogleDrive` mapping. Since `getAppTypeLogo()` is the single source of truth for app-type icons, the real Drive logo now shows everywhere external apps render it (the apps page tiles/rows and the user credentials modal) — no per-call-site changes needed.

## How Has This Been Tested?

Ran the web server locally against the existing backend and confirmed the Google Drive tile/row on `/craft/v1/apps` now shows the real multicolor Drive logo instead of the plug. TypeScript check passes via pre-commit.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Google Drive icon in the Craft external-apps UI. Add `GOOGLE_DRIVE` → `SvgGoogleDrive` in the logo registry so the real Drive logo appears instead of the generic plug across the apps page and credentials modal.

<sup>Written for commit 14bfe43712f558feac4938df50eb249d8b5e199a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

