### PR TITLE
feat(PAT): user-facing scope selection (API + settings UI)

### DIFF
--- a/backend/onyx/server/pat/api.py
+++ b/backend/onyx/server/pat/api.py
@@ -16,12 +16,39 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.pat.models import CreatedTokenResponse
 from onyx.server.pat.models import CreateTokenRequest
+from onyx.server.pat.models import PatScopeOption
+from onyx.server.pat.models import SELECTABLE_PAT_SCOPES
 from onyx.server.pat.models import TokenResponse
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 router = APIRouter(prefix="/user/pats")
+
+
+def _validate_assignable_scopes(scopes: list[Permission] | None) -> None:
+    """None = unrestricted; a provided list must be non-empty and assignable."""
+    if scopes is None:
+        return
+    if not scopes:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "A scoped token must include at least one scope.",
+        )
+    unsupported = [s for s in scopes if s not in SELECTABLE_PAT_SCOPES]
+    if unsupported:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Unsupported token scope(s): {', '.join(s.value for s in unsupported)}",
+        )
+
+
+@router.get("/scopes")
+def list_selectable_scopes(
+    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+) -> list[PatScopeOption]:
+    """The scopes a user may assign when minting a token, with display metadata."""
+    return list(SELECTABLE_PAT_SCOPES.values())
 
 
 @router.get("")
@@ -31,17 +58,7 @@ def list_tokens(
 ) -> list[TokenResponse]:
     """List all active user-created tokens for current user."""
     pats = list_user_pats(db_session, user.id, pat_type=PatType.USER)
-    return [
-        TokenResponse(
-            id=pat.id,
-            name=pat.name,
-            token_display=pat.token_display,
-            created_at=pat.created_at,
-            expires_at=pat.expires_at,
-            last_used_at=pat.last_used_at,
-        )
-        for pat in pats
-    ]
+    return [TokenResponse.model_validate(pat) for pat in pats]
 
 
 @router.post("")
@@ -51,12 +68,15 @@ def create_token(
     db_session: Session = Depends(get_session),
 ) -> CreatedTokenResponse:
     """Create new personal access token for current user."""
+    _validate_assignable_scopes(request.scopes)
+
     try:
         pat, raw_token = create_pat(
             db_session=db_session,
             user_id=user.id,
             name=request.name,
             expiration_days=request.expiration_days,
+            scopes=request.scopes,
         )
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
@@ -66,13 +86,8 @@ def create_token(
     logger.info("User %s created PAT '%s'", user.email, request.name)
 
     return CreatedTokenResponse(
-        id=pat.id,
-        name=pat.name,
-        token_display=pat.token_display,
+        **TokenResponse.model_validate(pat).model_dump(),
         token=raw_token,  # ONLY time we return the raw token!
-        created_at=pat.created_at,
-        expires_at=pat.expires_at,
-        last_used_at=pat.last_used_at,
     )
 
 

--- a/backend/onyx/server/pat/models.py
+++ b/backend/onyx/server/pat/models.py
@@ -3,7 +3,57 @@
 from datetime import datetime
 
 from pydantic import BaseModel
+from pydantic import computed_field
+from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import field_validator
+
+from onyx.auth.permissions import resolve_effective_permissions
+from onyx.db.enums import Permission
+from onyx.db.permissions import parse_permission_values
+
+# Assignable token scopes, grouped by `group_label`. `implies` is derived from the
+# permission closure and only drives the UI; require_permission re-derives it at
+# request time, which is the real grant.
+
+
+class PatScopeOption(BaseModel):
+    scope: Permission
+    group_label: str
+    label: str
+    description: str
+
+    @computed_field
+    @property
+    def implies(self) -> list[Permission]:
+        covered = resolve_effective_permissions({self.scope.value})
+        return sorted(Permission(v) for v in covered if v != self.scope.value)
+
+
+_ASSIGNABLE_SCOPES: list[PatScopeOption] = [
+    PatScopeOption(
+        scope=Permission.READ_SEARCH,
+        group_label="Search",
+        label="Read",
+        description="Use search and query endpoints.",
+    ),
+    PatScopeOption(
+        scope=Permission.READ_CHAT,
+        group_label="Chat",
+        label="Read",
+        description="View chat sessions and messages.",
+    ),
+    PatScopeOption(
+        scope=Permission.WRITE_CHAT,
+        group_label="Chat",
+        label="Write",
+        description="Create sessions and send messages.",
+    ),
+]
+
+SELECTABLE_PAT_SCOPES: dict[Permission, PatScopeOption] = {
+    option.scope: option for option in _ASSIGNABLE_SCOPES
+}
 
 
 class CreateTokenRequest(BaseModel):
@@ -15,15 +65,28 @@ class CreateTokenRequest(BaseModel):
         ge=1,
         description="Days until expiration. Common values: 7, 30, 365, or null (no expiration). Must be >= 1 if provided.",
     )
+    scopes: list[Permission] | None = Field(
+        None,
+        description="API-surface scopes to limit this token to. null = full user access.",
+    )
 
 
 class TokenResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     name: str
     token_display: str
     created_at: datetime
     expires_at: datetime | None
     last_used_at: datetime | None
+    scopes: list[Permission] | None
+
+    @field_validator("scopes", mode="before")
+    @classmethod
+    def _coerce_scopes(cls, value: list[str] | None) -> list[Permission] | None:
+        # Column stores raw strings; drop any no longer-valid permission.
+        return parse_permission_values(value) if value is not None else None
 
 
 class CreatedTokenResponse(TokenResponse):

--- a/backend/tests/integration/common_utils/managers/pat.py
+++ b/backend/tests/integration/common_utils/managers/pat.py
@@ -17,30 +17,53 @@ class PATManager:
     """Manager for creating and managing Personal Access Tokens in tests."""
 
     @staticmethod
+    def create_response(
+        name: str,
+        expiration_days: int | None,
+        user_performing_action: DATestUser,
+        scopes: list[Permission] | None = None,
+    ) -> httpx.Response:
+        """Call the create-token API and return the raw response (no status check)."""
+        body: dict[str, object] = {"name": name, "expiration_days": expiration_days}
+        if scopes is not None:
+            body["scopes"] = [scope.value for scope in scopes]
+        return client.post(
+            f"{API_SERVER_URL}/user/pats",
+            json=body,
+            headers=user_performing_action.headers,
+            cookies=user_performing_action.cookies,
+            timeout=60,
+        )
+
+    @staticmethod
     def create(
         name: str,
         expiration_days: int | None,
         user_performing_action: DATestUser,
+        scopes: list[Permission] | None = None,
     ) -> DATestPAT:
-        """Create a Personal Access Token for a user.
+        """Create a Personal Access Token for a user via the API.
 
-        Args:
-            name: Name of the token
-            expiration_days: Number of days until expiration (None for never)
-            user_performing_action: User creating the token
-
-        Returns:
-            DATestPAT with PAT data including the raw token
+        scopes=None mints an unrestricted token (full user access); a list scopes
+        it to those permissions. Returns the DATestPAT including the raw token.
         """
-        response = client.post(
-            f"{API_SERVER_URL}/user/pats",
-            json={"name": name, "expiration_days": expiration_days},
+        response = PATManager.create_response(
+            name, expiration_days, user_performing_action, scopes
+        )
+        response.raise_for_status()
+        return DATestPAT(**response.json())
+
+    @staticmethod
+    def selectable_scopes(user_performing_action: DATestUser) -> list[dict[str, str]]:
+        """Fetch the scopes a user may assign when minting a token."""
+        response = client.get(
+            f"{API_SERVER_URL}/user/pats/scopes",
             headers=user_performing_action.headers,
             cookies=user_performing_action.cookies,
             timeout=60,
         )
         response.raise_for_status()
-        return DATestPAT(**response.json())
+        return response.json()
 
     @staticmethod
     def create_scoped(

--- a/backend/tests/integration/common_utils/test_models.py
+++ b/backend/tests/integration/common_utils/test_models.py
@@ -39,6 +39,7 @@ class DATestPAT(BaseModel):
     created_at: str
     expires_at: str | None = None
     last_used_at: str | None = None
+    scopes: list[str] | None = None
 
 
 class DATestScimToken(BaseModel):

--- a/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
+++ b/backend/tests/integration/tests/permissions/test_pat_scope_assignment.py
@@ -1,0 +1,65 @@
+"""Integration tests for assigning scopes when minting a PAT via the user API."""
+
+from onyx.db.enums import Permission
+from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.test_models import DATestUser
+
+# The scopes a user may assign today (admin scopes are intentionally excluded).
+EXPECTED_SELECTABLE_SCOPES = {
+    Permission.READ_SEARCH.value,
+    Permission.READ_CHAT.value,
+    Permission.WRITE_CHAT.value,
+}
+
+
+def test_selectable_scopes_endpoint(permission_basic_user: DATestUser) -> None:
+    options = PATManager.selectable_scopes(permission_basic_user)
+    assert {option["scope"] for option in options} == EXPECTED_SELECTABLE_SCOPES
+    assert all(option["label"] and option["description"] for option in options)
+
+
+def test_scope_implications(permission_basic_user: DATestUser) -> None:
+    by_scope = {
+        o["scope"]: o for o in PATManager.selectable_scopes(permission_basic_user)
+    }
+    # write:chat implies read:chat (write superset of read); reads imply nothing.
+    assert by_scope[Permission.WRITE_CHAT.value]["implies"] == [
+        Permission.READ_CHAT.value
+    ]
+    assert by_scope[Permission.READ_CHAT.value]["implies"] == []
+    assert by_scope[Permission.READ_SEARCH.value]["implies"] == []
+
+
+def test_scopes_round_trip(permission_basic_user: DATestUser) -> None:
+    scopes = [Permission.READ_SEARCH, Permission.READ_CHAT]
+    expected = {s.value for s in scopes}
+    created = PATManager.create(
+        "scoped-token", None, permission_basic_user, scopes=scopes
+    )
+    assert created.scopes is not None and set(created.scopes) == expected
+
+    listed = next(
+        pat for pat in PATManager.list(permission_basic_user) if pat.id == created.id
+    )
+    assert listed.scopes is not None and set(listed.scopes) == expected
+
+
+def test_unscoped_token_is_unrestricted(permission_basic_user: DATestUser) -> None:
+    created = PATManager.create("full-token", None, permission_basic_user)
+    assert created.scopes is None
+
+
+def test_empty_scopes_rejected(permission_basic_user: DATestUser) -> None:
+    response = PATManager.create_response(
+        "empty-token", None, permission_basic_user, scopes=[]
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "INVALID_INPUT"
+
+
+def test_non_selectable_scope_rejected(permission_basic_user: DATestUser) -> None:
+    response = PATManager.create_response(
+        "admin-token", None, permission_basic_user, scopes=[Permission.READ_ADMIN]
+    )
+    assert response.status_code == 400
+    assert response.json()["error_code"] == "INVALID_INPUT"

--- a/docs/craft/features/pat-scopes/pat-scopes.md
+++ b/docs/craft/features/pat-scopes/pat-scopes.md
@@ -103,8 +103,10 @@ Sequenced so enforcement is complete before any scoped token exists:
    the effort: the search-scoped sandbox PAT reaches `POST /search` (via `onyx-cli search`) and `/me`,
    and nothing else.
 
-Setting scopes when minting a PAT is currently internal (a `create_pat` argument); a user-facing
-API/UI and surfacing scopes on token listings are follow-ups.
+Users select scopes when minting a token. `POST /user/pats` accepts a `scopes` list (omitted /
+`null` = full access; an empty list is rejected), `GET /user/pats` returns each token's scopes, and
+`GET /user/pats/scopes` lists the assignable scopes that back the settings-page selector. Search,
+read-chat, and write-chat are assignable today; admin scopes follow once their routes are guarded.
 
 ## Tests
 

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -81,6 +81,7 @@ export const SWR_KEYS = {
   userProjects: "/api/user/projects",
   recentFiles: "/api/user/files/recent",
   userPats: "/api/user/pats",
+  userPatScopes: "/api/user/pats/scopes",
   notifications: "/api/notifications",
 
   // ── Users ─────────────────────────────────────────────────────────────────

--- a/web/src/refresh-pages/SettingsPage.tsx
+++ b/web/src/refresh-pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useCallback, useEffect, useState } from "react";
+import { useRef, useCallback, useEffect, useMemo, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { Section, AttachmentItemLayout } from "@/layouts/general-layouts";
 import {
@@ -41,12 +41,11 @@ import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import useFilter from "@/hooks/useFilter";
-import { Button, Divider } from "@opal/components";
+import { Button, Divider, Checkbox, Text } from "@opal/components";
 import useFederatedOAuthStatus from "@/hooks/useFederatedOAuthStatus";
 import useCCPairs from "@/hooks/useCCPairs";
 import { ValidSources } from "@/lib/types";
 import { ConnectorCredentialPairStatus } from "@/app/admin/connector/[ccPairId]/types";
-import Text from "@/refresh-components/texts/Text";
 import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
 import Modal, { BasicModalFooter } from "@/refresh-components/Modal";
 import { Code, CopyButton } from "@opal/components";
@@ -78,12 +77,122 @@ interface PAT {
   created_at: string;
   expires_at: string | null;
   last_used_at: string | null;
+  scopes: string[] | null;
 }
+
+interface PatScopeOption {
+  scope: string;
+  group_label: string;
+  label: string;
+  description: string;
+  implies: string[];
+}
+
+type AccessMode = "full" | "limited";
 
 interface CreatedTokenState {
   id: number;
   token: string;
   name: string;
+}
+
+interface ScopeGroup {
+  label: string;
+  rows: PatScopeOption[];
+}
+
+interface ScopeSelectorProps {
+  scopeOptions: PatScopeOption[];
+  selectedScopes: string[];
+  toggleScope: (scope: string) => void;
+  scopesError: boolean;
+  disabled: boolean;
+}
+
+// Data-driven from the /scopes payload, so new scopes need no change here.
+function ScopeSelector({
+  scopeOptions,
+  selectedScopes,
+  toggleScope,
+  scopesError,
+  disabled,
+}: ScopeSelectorProps) {
+  const groups = useMemo(() => {
+    const byLabel = new Map<string, ScopeGroup>();
+    for (const option of scopeOptions) {
+      const group = byLabel.get(option.group_label);
+      if (group) {
+        group.rows.push(option);
+      } else {
+        byLabel.set(option.group_label, {
+          label: option.group_label,
+          rows: [option],
+        });
+      }
+    }
+    return Array.from(byLabel.values());
+  }, [scopeOptions]);
+
+  if (scopesError) {
+    return (
+      <Text font="secondary-body" color="text-03">
+        Couldn&apos;t load permissions.
+      </Text>
+    );
+  }
+  if (scopeOptions.length === 0) {
+    return (
+      <Text font="secondary-body" color="text-03">
+        Loading permissions...
+      </Text>
+    );
+  }
+
+  // scope -> label of a selected scope that implies it (so it's auto-included).
+  const lockedBy = new Map<string, string>();
+  for (const scope of selectedScopes) {
+    const option = scopeOptions.find((o) => o.scope === scope);
+    option?.implies.forEach((implied) => lockedBy.set(implied, option.label));
+  }
+
+  return (
+    <div className="grid grid-cols-2 items-start">
+      {groups.map((group) => (
+        <div key={group.label} className="flex flex-col items-start gap-1">
+          <Text font="main-ui-action" color="text-04">
+            {group.label}
+          </Text>
+          {group.rows.map((option) => {
+            const lockReason = lockedBy.get(option.scope);
+            const locked = lockReason !== undefined;
+            return (
+              <div key={option.scope} className="flex items-start gap-2 pl-2">
+                <Checkbox
+                  checked={selectedScopes.includes(option.scope) || locked}
+                  disabled={disabled || locked}
+                  onCheckedChange={() => toggleScope(option.scope)}
+                  aria-label={`${group.label} ${option.label}`}
+                />
+                <div className="flex flex-col">
+                  <Text font="main-ui-body" color="text-04">
+                    {locked
+                      ? `${option.label} (included with ${lockReason})`
+                      : option.label}
+                  </Text>
+                  {/* Fixed 2-line slot so every row is the same height. */}
+                  <div className="h-8 overflow-hidden">
+                    <Text font="secondary-body" color="text-03" maxLines={2}>
+                      {option.description}
+                    </Text>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 interface PATModalProps {
@@ -92,6 +201,12 @@ interface PATModalProps {
   setNewTokenName: (name: string) => void;
   expirationDays: string;
   setExpirationDays: (days: string) => void;
+  accessMode: AccessMode;
+  setAccessMode: (mode: AccessMode) => void;
+  scopeOptions: PatScopeOption[];
+  scopesError: boolean;
+  selectedScopes: string[];
+  toggleScope: (scope: string) => void;
   onClose: () => void;
   onCreate: () => void;
   createdToken: CreatedTokenState | null;
@@ -103,6 +218,12 @@ function PATModal({
   setNewTokenName,
   expirationDays,
   setExpirationDays,
+  accessMode,
+  setAccessMode,
+  scopeOptions,
+  scopesError,
+  selectedScopes,
+  toggleScope,
   onClose,
   onCreate,
   createdToken,
@@ -145,7 +266,11 @@ function PATModal({
       onClose={onClose}
       submit={
         <Button
-          disabled={isCreating || !newTokenName.trim()}
+          disabled={
+            isCreating ||
+            !newTokenName.trim() ||
+            (accessMode === "limited" && selectedScopes.length === 0)
+          }
           onClick={onCreate}
         >
           {isCreating ? "Creating Token..." : "Create Token"}
@@ -195,6 +320,38 @@ function PATModal({
             </InputSelect.Content>
           </InputSelect>
         </InputVertical>
+        <InputVertical
+          title="Permissions"
+          subDescription={
+            accessMode === "full"
+              ? "Inherits all of your permissions."
+              : "Limit this token to specific capabilities."
+          }
+          withLabel
+        >
+          <InputSelect
+            value={accessMode}
+            onValueChange={(value) => setAccessMode(value as AccessMode)}
+            disabled={isCreating}
+          >
+            <InputSelect.Trigger placeholder="Select permissions" />
+            <InputSelect.Content>
+              <InputSelect.Item value="full">Full access</InputSelect.Item>
+              <InputSelect.Item value="limited">
+                Limited access
+              </InputSelect.Item>
+            </InputSelect.Content>
+          </InputSelect>
+        </InputVertical>
+        {accessMode === "limited" && (
+          <ScopeSelector
+            scopeOptions={scopeOptions}
+            selectedScopes={selectedScopes}
+            toggleScope={toggleScope}
+            scopesError={scopesError}
+            disabled={isCreating}
+          />
+        )}
       </Section>
     </ConfirmationModalLayout>
   );
@@ -289,11 +446,13 @@ function GeneralSettings() {
           }
         >
           <Section gap={0.5} alignItems="start">
-            <Text>
+            <Text color="text-05">
               All your chat sessions and history will be permanently deleted.
               Deletion cannot be undone.
             </Text>
-            <Text>Are you sure you want to delete all chats?</Text>
+            <Text color="text-05">
+              Are you sure you want to delete all chats?
+            </Text>
           </Section>
         </ConfirmationModalLayout>
       )}
@@ -1140,6 +1299,8 @@ function AccountsAccessSettings() {
   const [isCreating, setIsCreating] = useState(false);
   const [newTokenName, setNewTokenName] = useState("");
   const [expirationDays, setExpirationDays] = useState<string>("30");
+  const [accessMode, setAccessMode] = useState<AccessMode>("full");
+  const [selectedScopes, setSelectedScopes] = useState<string[]>([]);
   const [newlyCreatedToken, setNewlyCreatedToken] =
     useState<CreatedTokenState | null>(null);
   const [tokenToDelete, setTokenToDelete] = useState<PAT | null>(null);
@@ -1165,6 +1326,31 @@ function AccountsAccessSettings() {
     }
   );
 
+  const { data: scopeOptions = [], error: scopeOptionsError } = useSWR<
+    PatScopeOption[]
+  >(
+    showTokensSection && canCreateTokens ? SWR_KEYS.userPatScopes : null,
+    errorHandlingFetcher,
+    { fallbackData: [] }
+  );
+
+  const scopeLabels = useMemo(
+    () =>
+      new Map(
+        scopeOptions.map((o) => [
+          o.scope,
+          `${o.label} ${o.group_label.toLowerCase()}`,
+        ])
+      ),
+    [scopeOptions]
+  );
+
+  const toggleScope = useCallback((scope: string) => {
+    setSelectedScopes((prev) =>
+      prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
+    );
+  }, []);
+
   // Use filter hook for searching tokens
   const {
     query,
@@ -1178,6 +1364,12 @@ function AccountsAccessSettings() {
       toast.error("Failed to load tokens");
     }
   }, [error]);
+
+  useEffect(() => {
+    if (scopeOptionsError) {
+      toast.error("Failed to load permission options");
+    }
+  }, [scopeOptionsError]);
 
   const createPAT = useCallback(async () => {
     if (!newTokenName.trim()) {
@@ -1194,6 +1386,7 @@ function AccountsAccessSettings() {
           name: newTokenName,
           expiration_days:
             expirationDays === "null" ? null : parseInt(expirationDays),
+          scopes: accessMode === "limited" ? selectedScopes : null,
         }),
       });
 
@@ -1217,7 +1410,7 @@ function AccountsAccessSettings() {
     } finally {
       setIsCreating(false);
     }
-  }, [newTokenName, expirationDays, mutate]);
+  }, [newTokenName, expirationDays, accessMode, selectedScopes, mutate]);
 
   const deletePAT = useCallback(
     async (patId: number) => {
@@ -1285,10 +1478,18 @@ function AccountsAccessSettings() {
           setNewTokenName={setNewTokenName}
           expirationDays={expirationDays}
           setExpirationDays={setExpirationDays}
+          accessMode={accessMode}
+          setAccessMode={setAccessMode}
+          scopeOptions={scopeOptions}
+          scopesError={Boolean(scopeOptionsError)}
+          selectedScopes={selectedScopes}
+          toggleScope={toggleScope}
           onClose={() => {
             setShowCreateModal(false);
             setNewTokenName("");
             setExpirationDays("30");
+            setAccessMode("full");
+            setSelectedScopes([]);
             setNewlyCreatedToken(null);
           }}
           onCreate={createPAT}
@@ -1311,13 +1512,12 @@ function AccountsAccessSettings() {
           }
         >
           <Section gap={0.5} alignItems="start">
-            <Text>
-              Any application using the token{" "}
-              <Text className="font-bold!">{tokenToDelete.name}</Text>{" "}
-              <Text secondaryMono>({tokenToDelete.token_display})</Text> will
-              lose access to Onyx. This action cannot be undone.
+            <Text color="text-05">
+              {`Any application using the token ${tokenToDelete.name} (${tokenToDelete.token_display}) will lose access to Onyx. This action cannot be undone.`}
             </Text>
-            <Text>Are you sure you want to revoke this token?</Text>
+            <Text color="text-05">
+              Are you sure you want to revoke this token?
+            </Text>
           </Section>
         </ConfirmationModalLayout>
       )}
@@ -1433,7 +1633,7 @@ function AccountsAccessSettings() {
               description="Your account email address."
               center
             >
-              <Text>{user?.email ?? "anonymous"}</Text>
+              <Text color="text-05">{user?.email ?? "anonymous"}</Text>
             </InputHorizontal>
 
             {showPasswordSection && (
@@ -1469,7 +1669,7 @@ function AccountsAccessSettings() {
                   <Section flexDirection="row" padding={0.25} gap={0.5}>
                     {pats.length === 0 ? (
                       <Section padding={0.5} alignItems="start">
-                        <Text text03 secondaryBody>
+                        <Text font="secondary-body" color="text-03">
                           {isLoading
                             ? "Loading tokens..."
                             : "No access tokens created."}
@@ -1517,9 +1717,21 @@ function AccountsAccessSettings() {
                         }`;
                       }
 
-                      const middleText = `Created ${daysSinceCreation} day${
-                        daysSinceCreation === 1 ? "" : "s"
-                      } ago - ${expiryText}`;
+                      const scopeText =
+                        pat.scopes === null
+                          ? "Full access"
+                          : pat.scopes
+                              .map((scope) => scopeLabels.get(scope) ?? scope)
+                              .join(", ");
+
+                      const createdText =
+                        daysSinceCreation === 0
+                          ? "Created today"
+                          : `Created ${daysSinceCreation} day${
+                              daysSinceCreation === 1 ? "" : "s"
+                            } ago`;
+
+                      const middleText = `${createdText} - ${expiryText} - ${scopeText}`;
 
                       return (
                         <Interactive.Container
@@ -1553,7 +1765,7 @@ function AccountsAccessSettings() {
             ) : (
               <Card>
                 <Section flexDirection="row" justifyContent="between">
-                  <Text text03 secondaryBody>
+                  <Text font="secondary-body" color="text-03">
                     Access tokens require an active paid subscription.
                   </Text>
                   <Button prominence="secondary" href="/admin/billing">
@@ -1644,14 +1856,11 @@ function FederatedConnectorCard({
           }
         >
           <Section gap={0.5} alignItems="start">
-            <Text>
-              Onyx will no longer be able to access or search content from your{" "}
-              <Text className="font-bold!">{sourceMetadata.displayName}</Text>{" "}
-              account.
+            <Text color="text-05">
+              {`Onyx will no longer be able to access or search content from your ${sourceMetadata.displayName} account.`}
             </Text>
-            <Text>
-              You can still continue existing sessions referencing{" "}
-              {sourceMetadata.displayName} content.
+            <Text color="text-05">
+              {`You can still continue existing sessions referencing ${sourceMetadata.displayName} content.`}
             </Text>
           </Section>
         </ConfirmationModalLayout>

--- a/web/tests/e2e/auth/pat_management.spec.ts
+++ b/web/tests/e2e/auth/pat_management.spec.ts
@@ -4,6 +4,9 @@
  */
 import { test, expect } from "@playwright/test";
 import { loginAsRandomUser } from "@tests/e2e/utils/auth";
+import { PATManagementPage } from "@tests/e2e/pages/PATManagementPage";
+
+const ME_URL = "http://localhost:3000/api/me";
 
 test("PAT Complete Workflow", async ({ page }, testInfo) => {
   // Skip in admin project - we test with fresh user auth
@@ -18,118 +21,47 @@ test("PAT Complete Workflow", async ({ page }, testInfo) => {
   await page.goto("/app");
   await page.waitForLoadState("networkidle");
 
-  // Click on user dropdown and open settings (same pattern as other tests)
-  await page.locator("#onyx-user-dropdown").click();
-  await page.getByText("Settings").first().click();
-
-  // Wait for settings modal to appear (first page has "Full Name" section)
-  await expect(page.getByText("Full Name")).toBeVisible();
-
-  await page
-    .locator('a[href="/app/settings/accounts-access"]')
-    .click({ force: true });
-
-  // Wait for PAT page to load (button is unique to the PAT section)
-  await expect(page.locator('button:has-text("New Access Token")')).toBeVisible(
-    {
-      timeout: 10000,
-    }
-  );
-
-  await page.locator('button:has-text("New Access Token")').first().click();
+  const pat = new PATManagementPage(page);
+  await pat.goto();
 
   const tokenName = `E2E Test Token ${Date.now()}`;
-  const nameInput = page
-    .locator('input[placeholder*="Name your token"]')
-    .first();
-  await nameInput.fill(tokenName);
+  await pat.openCreateModal();
+  await pat.fillName(tokenName);
+  await pat.selectExpiration("7 days");
+  await pat.submit();
 
-  // Click the Radix UI combobox for expiration (not a select element)
-  const expirationCombobox = page.locator(
-    'button[role="combobox"][aria-label*="expiration"]'
-  );
-  if (await expirationCombobox.isVisible()) {
-    await expirationCombobox.click();
-    // Wait for dropdown and select 7 days option using role=option
-    await page.getByRole("option", { name: "7 days" }).click();
-  }
-
-  await page.locator('button:has-text("Create Token")').first().click();
-
-  const tokenDisplay = page
-    .locator("code")
-    .filter({ hasText: "onyx_pat_" })
-    .first();
-  await tokenDisplay.waitFor({ state: "visible", timeout: 5000 });
-
-  const tokenValue = await tokenDisplay.textContent();
+  const tokenValue = await pat.waitForCreatedToken();
   expect(tokenValue).toContain("onyx_pat_");
 
-  // Grant clipboard permissions before copying
   await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
-
-  // Copy the newly created token via the footer "Copy Token" button
-  await page.getByRole("button", { name: "Copy Token" }).click();
-
-  // Wait a moment for clipboard to be written and verify
+  await pat.copyCreatedToken();
   await page.waitForTimeout(500);
   const clipboardText = await page.evaluate(() =>
     navigator.clipboard.readText()
   );
   expect(clipboardText).toBe(tokenValue);
 
-  // Close the modal
-  await page.keyboard.press("Escape");
-  await expect(page.getByText(tokenName).first()).toBeVisible({
-    timeout: 5000,
-  });
+  await pat.close();
+  await pat.expectListed(tokenName);
 
-  // Test the PAT token works by making an API request in a new context (no session cookies)
+  // The token authenticates as its owner (fresh context, no session cookies).
   const testContext = await page.context().browser()!.newContext();
-  const apiResponse = await testContext.request.get(
-    "http://localhost:3000/api/me",
-    {
-      headers: {
-        Authorization: `Bearer ${tokenValue}`,
-      },
-    }
-  );
+  const apiResponse = await testContext.request.get(ME_URL, {
+    headers: { Authorization: `Bearer ${tokenValue}` },
+  });
   expect(apiResponse.ok()).toBeTruthy();
-  const userData = await apiResponse.json();
-  expect(userData.email).toBe(email);
+  expect((await apiResponse.json()).email).toBe(email);
   await testContext.close();
 
-  // Find and click the delete button using the aria-label with token name
-  const deleteButton = page.locator(
-    `button[aria-label="Delete token ${tokenName}"]`
-  );
-  await deleteButton.click();
+  await pat.revokeToken(tokenName);
+  await pat.expectNotListed(tokenName);
 
-  const confirmButton = page.locator('button:has-text("Revoke")').first();
-  await confirmButton.waitFor({ state: "visible", timeout: 3000 });
-  await confirmButton.click();
-
-  // Wait for the modal to close (it contains the token name in its text)
-  await expect(confirmButton).not.toBeVisible({ timeout: 3000 });
-
-  // Now verify the token is no longer in the list
-  await expect(page.locator(`p:text-is("${tokenName}")`)).not.toBeVisible({
-    timeout: 5000,
+  const revokedContext = await page.context().browser()!.newContext();
+  const revokedResponse = await revokedContext.request.get(ME_URL, {
+    headers: { Authorization: `Bearer ${tokenValue}` },
   });
-
-  // Create a new context without cookies to test the revoked token
-  const newContext = await page.context().browser()!.newContext();
-  const revokedApiResponse = await newContext.request.get(
-    "http://localhost:3000/api/me",
-    {
-      headers: {
-        Authorization: `Bearer ${tokenValue}`,
-      },
-    }
-  );
-  await newContext.close();
-  // Revoked tokens return 403 Forbidden (as per backend tests)
-  expect(revokedApiResponse.status()).toBe(403);
+  await revokedContext.close();
+  expect(revokedResponse.status()).toBe(403);
 });
 
 test("PAT Multiple Tokens Management", async ({ page }, testInfo) => {
@@ -145,23 +77,8 @@ test("PAT Multiple Tokens Management", async ({ page }, testInfo) => {
   await page.goto("/app");
   await page.waitForLoadState("networkidle");
 
-  // Click on user dropdown and open settings (same pattern as other tests)
-  await page.locator("#onyx-user-dropdown").click();
-  await page.getByText("Settings").first().click();
-
-  // Wait for settings modal to appear (first page has "Full Name" section)
-  await expect(page.getByText("Full Name")).toBeVisible();
-
-  await page
-    .locator('a[href="/app/settings/accounts-access"]')
-    .click({ force: true });
-
-  // Wait for PAT page to load (button is unique to the PAT section)
-  await expect(page.locator('button:has-text("New Access Token")')).toBeVisible(
-    {
-      timeout: 10000,
-    }
-  );
+  const pat = new PATManagementPage(page);
+  await pat.goto();
 
   const tokens = [
     { name: `Token 1 - ${Date.now()}`, expiration: "7 days" },
@@ -170,69 +87,63 @@ test("PAT Multiple Tokens Management", async ({ page }, testInfo) => {
   ];
 
   for (const token of tokens) {
-    // Click "New Access Token" button to open the modal
-    await page.locator('button:has-text("New Access Token")').first().click();
-
-    // Fill in the token name
-    const nameInput = page
-      .locator('input[placeholder*="Name your token"]')
-      .first();
-    await nameInput.fill(token.name);
-
-    // Click the Radix UI combobox for expiration (not a select element)
-    const expirationCombobox = page.locator(
-      'button[role="combobox"][aria-label*="expiration"]'
-    );
-    if (await expirationCombobox.isVisible()) {
-      await expirationCombobox.click();
-      // Wait for dropdown and select the option using role=option
-      await page.getByRole("option", { name: token.expiration }).click();
-    }
-
-    // Create the token
-    await page.locator('button:has-text("Create Token")').first().click();
-
-    // Wait for token to be created (code block with token appears)
-    await page
-      .locator("code")
-      .filter({ hasText: "onyx_pat_" })
-      .first()
-      .waitFor({ state: "visible", timeout: 5000 });
-
-    // Close the modal
-    await page.keyboard.press("Escape");
-
-    // Wait for token to appear in the list
-    await expect(page.getByText(token.name).first()).toBeVisible({
-      timeout: 5000,
-    });
+    await pat.openCreateModal();
+    await pat.fillName(token.name);
+    await pat.selectExpiration(token.expiration);
+    await pat.submit();
+    await pat.waitForCreatedToken();
+    await pat.close();
+    await pat.expectListed(token.name);
   }
 
-  // Verify all tokens are visible in the list
   for (const token of tokens) {
-    await expect(page.getByText(token.name).first()).toBeVisible();
+    await pat.expectListed(token.name);
   }
 
-  // Delete the second token using its aria-label
-  const deleteButton = page.locator(
-    `button[aria-label="Delete token ${tokens[1]!.name}"]`
+  await pat.revokeToken(tokens[1]!.name);
+  await pat.expectNotListed(tokens[1]!.name);
+  await pat.expectListed(tokens[0]!.name);
+  await pat.expectListed(tokens[2]!.name);
+});
+
+test("PAT Scoped Token (limited access)", async ({ page }, testInfo) => {
+  test.skip(
+    testInfo.project.name === "admin",
+    "Test requires clean user auth state"
   );
-  await deleteButton.click();
 
-  // Click "Revoke" to confirm deletion
-  const confirmButton = page.locator('button:has-text("Revoke")').first();
-  await confirmButton.waitFor({ state: "visible", timeout: 3000 });
-  await confirmButton.click();
+  await page.context().clearCookies();
+  await loginAsRandomUser(page);
 
-  // Wait for the modal to close
-  await expect(confirmButton).not.toBeVisible({ timeout: 3000 });
+  await page.goto("/app");
+  await page.waitForLoadState("networkidle");
 
-  // Now verify the deleted token is no longer in the list
-  await expect(page.getByText(tokens[1]!.name)).not.toBeVisible({
-    timeout: 5000,
+  const pat = new PATManagementPage(page);
+  await pat.goto();
+
+  const tokenName = `Scoped Token ${Date.now()}`;
+  await pat.openCreateModal();
+  await pat.fillName(tokenName);
+  await pat.chooseLimitedAccess();
+  await pat.toggleScope("Search Read");
+  await pat.submit();
+
+  const tokenValue = await pat.waitForCreatedToken();
+  await pat.close();
+
+  await pat.expectRowText(/Created today.*Read search/);
+
+  // The scoped token reaches the scope-exempt /me but is denied on a
+  // BASIC_ACCESS route, proving the UI actually scoped it (not full access).
+  const ctx = await page.context().browser()!.newContext();
+  const meResponse = await ctx.request.get(ME_URL, {
+    headers: { Authorization: `Bearer ${tokenValue}` },
   });
-
-  // Verify the other two tokens are still visible
-  await expect(page.getByText(tokens[0]!.name).first()).toBeVisible();
-  await expect(page.getByText(tokens[2]!.name).first()).toBeVisible();
+  expect(meResponse.ok()).toBeTruthy();
+  const patsResponse = await ctx.request.get(
+    "http://localhost:3000/api/user/pats",
+    { headers: { Authorization: `Bearer ${tokenValue}` } }
+  );
+  expect(patsResponse.status()).toBe(403);
+  await ctx.close();
 });

--- a/web/tests/e2e/pages/PATManagementPage.ts
+++ b/web/tests/e2e/pages/PATManagementPage.ts
@@ -1,0 +1,128 @@
+/**
+ * Page Object Model for the Personal Access Token (PAT) management UI on the
+ * account settings page (/app/settings/accounts-access).
+ *
+ * Encapsulates the "Create Access Token" modal (name, expiration, the Full /
+ * Limited permissions selector and its scope checkboxes) and the token list
+ * (viewing, copying, and revoking tokens) so specs stay declarative.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+
+const TOKEN_PREFIX = "onyx_pat_";
+
+export class PATManagementPage {
+  readonly page: Page;
+  readonly newTokenButton: Locator;
+  readonly nameInput: Locator;
+  readonly createButton: Locator;
+  readonly tokenDisplay: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.newTokenButton = page.locator('button:has-text("New Access Token")');
+    this.nameInput = page.locator('input[placeholder*="Name your token"]');
+    this.createButton = page.locator('button:has-text("Create Token")');
+    this.tokenDisplay = page.locator("code").filter({ hasText: TOKEN_PREFIX });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  /** Open Settings from the user dropdown and land on the access-tokens page. */
+  async goto(): Promise<void> {
+    await this.page.locator("#onyx-user-dropdown").click();
+    await this.page.getByText("Settings").first().click();
+    await expect(this.page.getByText("Full Name")).toBeVisible();
+    await this.page
+      .locator('a[href="/app/settings/accounts-access"]')
+      .click({ force: true });
+    await expect(this.newTokenButton).toBeVisible({ timeout: 10000 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Create-token modal
+  // ---------------------------------------------------------------------------
+
+  async openCreateModal(): Promise<void> {
+    await this.newTokenButton.first().click();
+  }
+
+  async fillName(name: string): Promise<void> {
+    await this.nameInput.first().fill(name);
+  }
+
+  /** Pick an expiration; the combobox defaults to "30 days". */
+  async selectExpiration(optionLabel: string): Promise<void> {
+    await this.page
+      .getByRole("combobox")
+      .filter({ hasText: "30 days" })
+      .click();
+    await this.page.getByRole("option", { name: optionLabel }).click();
+  }
+
+  /** Switch the permissions selector from its "Full access" default to Limited. */
+  async chooseLimitedAccess(): Promise<void> {
+    await this.page
+      .getByRole("combobox")
+      .filter({ hasText: "Full access" })
+      .click();
+    await this.page.getByRole("option", { name: "Limited access" }).click();
+  }
+
+  /** Toggle a scope checkbox by its accessible name, e.g. "Search Read". */
+  async toggleScope(name: string): Promise<void> {
+    await this.page.getByRole("checkbox", { name }).click();
+  }
+
+  async submit(): Promise<void> {
+    await this.createButton.first().click();
+  }
+
+  async waitForCreatedToken(): Promise<string> {
+    const display = this.tokenDisplay.first();
+    await display.waitFor({ state: "visible", timeout: 5000 });
+    return (await display.textContent()) ?? "";
+  }
+
+  async copyCreatedToken(): Promise<void> {
+    await this.page.getByRole("button", { name: "Copy Token" }).click();
+  }
+
+  async close(): Promise<void> {
+    await this.page.keyboard.press("Escape");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Token list
+  // ---------------------------------------------------------------------------
+
+  async expectListed(name: string): Promise<void> {
+    await expect(this.page.getByText(name).first()).toBeVisible({
+      timeout: 5000,
+    });
+  }
+
+  async expectNotListed(name: string): Promise<void> {
+    await expect(this.page.locator(`p:text-is("${name}")`)).not.toBeVisible({
+      timeout: 5000,
+    });
+  }
+
+  async expectRowText(pattern: RegExp): Promise<void> {
+    await expect(this.page.getByText(pattern).first()).toBeVisible({
+      timeout: 5000,
+    });
+  }
+
+  async revokeToken(name: string): Promise<void> {
+    await this.page
+      .locator(`button[aria-label="Delete token ${name}"]`)
+      .click();
+    const confirm = this.page.locator('button:has-text("Revoke")').first();
+    await confirm.waitFor({ state: "visible", timeout: 3000 });
+    await confirm.click();
+    await expect(confirm).not.toBeVisible({ timeout: 3000 });
+  }
+}


### PR DESCRIPTION
## Description
<img width="527" height="719" alt="image" src="https://github.com/user-attachments/assets/fc0c457f-b683-44d0-a8c1-0c27726e5d21" />

Lets users scope a Personal Access Token instead of every token inheriting full account access. Exposes the existing `scopes` plumbing on the user-facing API and adds a selector to the Create Access Token modal:

- `POST /user/pats` accepts a `scopes` list (omitted/`null` = full access; empty list rejected); `GET /user/pats` returns each token's scopes; new `GET /user/pats/scopes` lists the assignable scopes.
- Settings modal: a **Permissions** dropdown (Full / Limited) revealing scope checkboxes (Search / Read chat / Write chat); token rows show their scope. Admin scopes are omitted until their routes are guarded.
- Also migrates `SettingsPage.tsx` off the deprecated `@/refresh-components/texts/Text` to the Opal `Text`, and shows "Created today" for same-day tokens.

## How Has This Been Tested?

- Integration (`test_pat_scope_assignment.py`): scopes round-trip through create→list, unscoped = unrestricted, empty/non-selectable scopes rejected with `INVALID_INPUT`, `/scopes` returns the assignable set.
- E2E (`pat_management.spec.ts`): mints a Search-scoped token through the modal and proves enforcement (`/me` 200, `/user/pats` 403); also fixed the pre-existing expiration-combobox selector that was silently skipping.
- `ruff`/`ty` and `oxfmt`/`oxlint`/`tsc` clean on changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-facing scopes for Personal Access Tokens so users can mint limited tokens. Includes API endpoints and a settings UI with implied-scope handling and scope labels on token rows.

- **New Features**
  - API: `POST /user/pats` accepts `scopes` (null = full; empty or non-selectable rejected); `GET /user/pats` and create responses include each token’s `scopes`; `GET /user/pats/scopes` lists assignable scopes with `group_label`, `label`, `description`, and derived `implies` (e.g., Write chat implies Read chat).
  - UI: Permissions dropdown (Full / Limited) with grouped scope checkboxes; selecting a write scope auto-includes its read and shows it as locked; create disabled until a Limited token has at least one scope; token rows show “Created today”, expiry, and scope labels (e.g., “Read search”); admin scopes are hidden for now.

- **Refactors**
  - Migrated settings text to `@opal/components` `Text`.

<sup>Written for commit acab6b46882edde474e93f5435cced0178d0678d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





