### PR TITLE
fix(craft): tolerate unknown SANDBOX_BACKEND values instead of crashing

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -8,7 +8,18 @@ class SandboxBackend(str, Enum):
     DOCKER = "docker"
 
 
-SANDBOX_BACKEND = SandboxBackend(os.environ.get("SANDBOX_BACKEND", "kubernetes"))
+SANDBOX_BACKEND = SandboxBackend.KUBERNETES
+_env_sandbox_backend = os.environ.get("SANDBOX_BACKEND", "").strip()
+if _env_sandbox_backend:
+    try:
+        SANDBOX_BACKEND = SandboxBackend(_env_sandbox_backend.lower())
+    except ValueError:
+        raise ValueError(
+            f"Invalid SANDBOX_BACKEND={_env_sandbox_backend!r}. Valid values: "
+            f"{', '.join(b.value for b in SandboxBackend)}. Unset it to use the "
+            f"default, or align it with this release if you recently changed "
+            f"image versions."
+        )
 
 _THIS_FILE = Path(__file__)
 

--- a/backend/tests/unit/build/test_sandbox_backend_parsing.py
+++ b/backend/tests/unit/build/test_sandbox_backend_parsing.py
@@ -1,0 +1,62 @@
+import importlib
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from onyx.server.features.build import configs
+
+
+@pytest.fixture(autouse=True)
+def _restore_configs() -> Iterator[None]:
+    # SANDBOX_BACKEND is resolved at module import, so each case reloads the
+    # module under a chosen env. Reload once more afterwards with the var cleared
+    # to leave clean module state for other tests.
+    yield
+    os.environ.pop("SANDBOX_BACKEND", None)
+    importlib.reload(configs)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("kubernetes", "kubernetes"),
+        ("docker", "docker"),
+        ("DOCKER", "docker"),
+        ("  docker  ", "docker"),
+    ],
+)
+def test_sandbox_backend_valid(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND.value == expected
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_sandbox_backend_blank_uses_default(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND == reloaded.SandboxBackend.KUBERNETES
+
+
+def test_sandbox_backend_unset_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND == reloaded.SandboxBackend.KUBERNETES
+
+
+@pytest.mark.parametrize("raw", ["local", "not-a-backend", "k8s"])
+def test_sandbox_backend_unknown_fails_fast(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    with pytest.raises(ValueError) as exc_info:
+        importlib.reload(configs)
+    # error names the bad value and the valid options
+    assert raw in str(exc_info.value)
+    assert "kubernetes" in str(exc_info.value)
+    assert "docker" in str(exc_info.value)

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -86,7 +86,6 @@ services:
       # Onyx Craft configuration (disabled by default, set ENABLE_CRAFT=true in .env to enable)
       # Use --include-craft with install script, or manually set in .env file
       - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - OUTPUTS_TEMPLATE_PATH=${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
       - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
       - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}
@@ -171,7 +170,6 @@ services:
       - API_SERVER_HOST=${API_SERVER_HOST:-api_server}
       # Onyx Craft configuration (set up automatically on container startup)
       - ENABLE_CRAFT=${ENABLE_CRAFT:-false}
-      - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - OUTPUTS_TEMPLATE_PATH=${OUTPUTS_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs}
       - VENV_TEMPLATE_PATH=${VENV_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/venv}
       - WEB_TEMPLATE_PATH=${WEB_TEMPLATE_PATH:-/app/onyx/server/features/build/sandbox/kubernetes/docker/templates/outputs/web}


### PR DESCRIPTION
## Description

Upgrading Onyx (e.g. v3 → v4.0.5) can crash the API server on startup with:

```
ValueError: 'docker' is not a valid SandboxBackend
CRITICAL: Exiting due to uncaught exception ...
```

**Root cause:** `backend/onyx/server/features/build/configs.py` resolves the backend at import with a bare `SandboxBackend(os.environ.get("SANDBOX_BACKEND", ...))`. When deployment files and the running image disagree on the valid enum set, the unknown value raises an uncaught `ValueError` and hard-kills the server with no indication of what to fix. This bites both directions of version skew:

- **Newer files → older image:** `main`'s `docker-compose.yml`/`install.sh` default `SANDBOX_BACKEND=docker`, but the `docker` backend doesn't exist in v4.0.x images (it landed after v4.0.5 was cut) → crash. (This is the customer-reported failure.)
- **Older config → newer image:** `local` was the default in every v4.0.x release, but it was removed from the enum on `main` → a v4.0.x→next upgrade carrying `local` crashes the same way.

### Changes

1. **Fail fast with a clear message** (`configs.py`): validate `SANDBOX_BACKEND` explicitly — unset/blank uses the default, and an unrecognized value raises an error that names the bad value, the valid options for this version, and the likely version-skew cause. No silent fallback and no value remapping — the operator is told exactly what to set.
2. **Compose hygiene** (`docker-compose.yml`): remove the `SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}` default from the base compose. It's already set by the Craft overlay (`docker-compose.craft.yml`), so non-Craft installs no longer get a Craft-specific value forced onto them. (The default leaked into the base file in #11285.)

## How Has This Been Tested?

- New unit test `backend/tests/unit/build/test_sandbox_backend_parsing.py` (10 cases): valid values + casing/whitespace, unset/blank → default, and unknown values (`local`, `not-a-backend`, `k8s`) → `ValueError` whose message names the bad value and valid options.
- `docker compose config` verified: base compose (non-Craft) sets no `SANDBOX_BACKEND`; base + craft overlay still resolves to `docker`.
- Reproduced the original crash on a live v4.0.5 stack with `SANDBOX_BACKEND=docker` (502 / CRITICAL exit) before the change.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check