### PR TITLE
fix(web): stop deriving doc_updated_at from Last-Modified

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -2,8 +2,6 @@ import ipaddress
 import random
 import socket
 import time
-from datetime import datetime
-from datetime import timezone
 from enum import Enum
 from typing import Any
 from typing import cast
@@ -290,15 +288,6 @@ def _read_urls_file(location: str) -> list[str]:
     return urls
 
 
-def _get_datetime_from_last_modified_header(last_modified: str) -> datetime | None:
-    try:
-        return datetime.strptime(last_modified, "%a, %d %b %Y %H:%M:%S %Z").replace(
-            tzinfo=timezone.utc
-        )
-    except (ValueError, TypeError):
-        return None
-
-
 def _handle_cookies(context: BrowserContext, url: str) -> None:
     """Handle cookies for the given URL to help with bot detection"""
     try:
@@ -442,8 +431,14 @@ class WebConnector(LoadConnector, SlimConnector):
                 initial_url, headers=DEFAULT_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS
             )
             page_text, metadata = extract_pdf_text(response.content)
-            last_modified = response.headers.get("Last-Modified")
 
+            # doc_updated_at is intentionally left unset for web documents. The HTTP
+            # Last-Modified header is an unreliable change signal: CDN/SSR origins
+            # (e.g. Vercel ISR) regenerate it on every fetch, so it advances on each
+            # crawl even when content is identical. A spurious advance bypasses the
+            # content-hash dedup gate in the indexing pipeline, forcing pointless
+            # re-indexing. The content hash is the authoritative change signal for
+            # web docs (see DocumentBase.content_hash).
             result.doc = Document(
                 id=initial_url,
                 sections=[TextSection(link=initial_url, text=page_text)],
@@ -451,11 +446,6 @@ class WebConnector(LoadConnector, SlimConnector):
                 semantic_identifier=initial_url.rstrip("/").split("/")[-1]
                 or initial_url,
                 metadata=metadata,
-                doc_updated_at=(
-                    _get_datetime_from_last_modified_header(last_modified)
-                    if last_modified
-                    else None
-                ),
             )
 
             return result
@@ -488,9 +478,6 @@ class WebConnector(LoadConnector, SlimConnector):
             except TimeoutError:
                 pass
 
-            last_modified = (
-                page_response.header_value("Last-Modified") if page_response else None
-            )
             final_url = page.url
             if final_url != initial_url:
                 protected_url_check(final_url)
@@ -607,17 +594,15 @@ class WebConnector(LoadConnector, SlimConnector):
 
             session_ctx.content_hashes.add(hashed_text)
 
+            # doc_updated_at is intentionally left unset — see the comment in the PDF
+            # branch above. The HTTP Last-Modified header is an unreliable change
+            # signal for web content, so we rely on the content hash for dedup.
             result.doc = Document(
                 id=initial_url,
                 sections=[TextSection(link=initial_url, text=parsed_html.cleaned_text)],
                 source=DocumentSource.WEB,
                 semantic_identifier=parsed_html.title or initial_url,
                 metadata={},
-                doc_updated_at=(
-                    _get_datetime_from_last_modified_header(last_modified)
-                    if last_modified
-                    else None
-                ),
             )
         finally:
             page.close()

--- a/backend/tests/unit/onyx/connectors/web/test_doc_updated_at.py
+++ b/backend/tests/unit/onyx/connectors/web/test_doc_updated_at.py
@@ -1,0 +1,77 @@
+"""Unit test: the web connector must not derive doc_updated_at from Last-Modified.
+
+A server's HTTP Last-Modified header is an unreliable change signal — CDN/SSR
+origins (e.g. Vercel ISR) regenerate it on every fetch, so it advances on each
+crawl even when content is identical. Letting it populate doc_updated_at makes the
+indexing pipeline's timestamp gate bypass the content-hash dedup, forcing endless
+re-indexing of unchanged pages. Web documents must leave doc_updated_at unset and
+rely on the content hash instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.connectors.models import Document
+from onyx.connectors.web.connector import WEB_CONNECTOR_VALID_SETTINGS
+from onyx.connectors.web.connector import WebConnector
+from onyx.file_processing.html_utils import ParsedHTML
+
+BASE_URL = "http://example.com"
+# A perfectly parseable Last-Modified value. If the connector ever reads it again,
+# doc_updated_at would become non-None and this test would fail.
+LAST_MODIFIED = "Wed, 21 Oct 2026 07:28:00 GMT"
+
+
+def _make_page_mock() -> MagicMock:
+    page = MagicMock()
+    page.url = BASE_URL + "/"
+    response = MagicMock()
+    response.status = 200
+    # The server DOES send Last-Modified — the connector must still ignore it.
+    response.header_value.side_effect = (
+        lambda h: LAST_MODIFIED if h == "Last-Modified" else None
+    )
+    page.goto.return_value = response
+    page.content.return_value = "<html><body><p>static</p></body></html>"
+    return page
+
+
+def _make_playwright_mock() -> MagicMock:
+    playwright = MagicMock()
+    playwright.stop = MagicMock()
+    return playwright
+
+
+@patch("onyx.connectors.web.connector.web_html_cleanup")
+@patch("onyx.connectors.web.connector.check_internet_connection")
+@patch("onyx.connectors.web.connector.requests.head")
+@patch("onyx.connectors.web.connector.start_playwright")
+def test_doc_updated_at_is_none_even_with_last_modified_header(
+    mock_start_playwright: MagicMock,
+    mock_head: MagicMock,
+    _mock_check: MagicMock,
+    mock_cleanup: MagicMock,
+) -> None:
+    page = _make_page_mock()
+    context = MagicMock()
+    context.new_page.return_value = page
+    mock_start_playwright.return_value = (_make_playwright_mock(), context)
+    mock_head.return_value.headers = {"content-type": "text/html"}
+    mock_cleanup.return_value = ParsedHTML(title="Static Page", cleaned_text="static")
+
+    connector = WebConnector(
+        base_url=BASE_URL + "/",
+        web_connector_type=WEB_CONNECTOR_VALID_SETTINGS.SINGLE.value,
+    )
+
+    docs = [
+        doc
+        for batch in connector.load_from_state()
+        for doc in batch
+        if isinstance(doc, Document)
+    ]
+
+    assert len(docs) == 1
+    assert docs[0].doc_updated_at is None


### PR DESCRIPTION
## Problem

Static web content was being re-indexed and re-pushed (via the `DOCUMENT_PUSH` hook) on **every crawl**, despite the content-hash dedup check that's supposed to skip unchanged documents.

https://linear.app/onyx-app/issue/ENG-4118/agent-wiki

## Root cause

The indexing pipeline has a two-gate dedup in `get_docs_to_update` (`indexing_pipeline.py`):

- **Gate 1 — timestamp skip** (disabled in prod; every real caller passes `ignore_time_skip=True`)
- **Gate 2 — content-hash skip**, but only `if not timestamp_advanced`. A timestamp advance is treated as authoritative evidence of change and **deliberately bypasses the hash check**.

The web connector sets `doc_updated_at` from the HTTP `Last-Modified` header. For CDN/SSR origins (e.g. Vercel ISR, which backs `docs.onyx.app`) that header is regenerated on every fetch, so it advances on each crawl even when the page content is identical. The advancing timestamp marks `timestamp_advanced = True`, the hash gate is skipped, and the page is re-indexed → re-pushed.

### Verified on `onyx-st-dev`

- `docs.onyx.app` returns a fresh, content-independent `Last-Modified` per fetch (confirmed via live `curl` — distinct recent values across unchanged pages, `x-vercel-cache: BYPASS`).
- DB: 275 of 348 web docs carry a non-null `doc_updated_at`, clustered at recent crawl times (~5s apart, matching the crawler walking pages sequentially) — not authoring dates. Those are exactly the docs taking the bypass path.

## Fix

Stop deriving `doc_updated_at` from `Last-Modified` in the web connector (both the HTML and PDF branches), and remove the now-unused helper. Web documents now leave `doc_updated_at` unset and rely on the content hash for dedup — which is exactly what `DocumentBase.content_hash`'s docstring already assumes for connectors without a trustworthy update timestamp.

This fixes the root waste (re-chunking, re-embedding, contextual-RAG calls, Vespa rewrites) rather than just suppressing the push. For other connectors (GitHub/GDrive/Slack) `doc_updated_at` is a genuine change signal and keeps its authority — only the web connector is changed.

## Tests

Added `backend/tests/unit/onyx/connectors/web/test_doc_updated_at.py`: asserts the web connector leaves `doc_updated_at` unset **even when the server sends a `Last-Modified` header** (regression guard). Existing web connector unit tests still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop using HTTP Last-Modified to set `doc_updated_at` in the web connector so unchanged pages aren’t re-indexed on every crawl. Web docs now rely on the content hash for dedup, fixing repeated pushes.

- **Bug Fixes**
  - Ignore `Last-Modified` for HTML and PDF; leave `doc_updated_at` unset for web documents to prevent bypassing the content-hash gate.
  - Removed the `Last-Modified` parsing helper and related code.
  - Added a unit test to ensure `doc_updated_at` stays unset even when the header is present.

<sup>Written for commit 831bd311c28fe56e194539c4601c8c8c020bf4e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

