### PR TITLE
fix: accept empty choices packet from LLM

### DIFF
--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -137,25 +137,23 @@ def _parse_message_tool_calls(
     return parsed_tool_calls
 
 
-def _validate_and_extract_base_fields(
+def _extract_id_and_created(
     response_data: dict[str, Any], error_prefix: str
-) -> tuple[str, str, dict[str, Any]]:
-    """
-    Validate and extract common fields (id, created, first choice) from a LiteLLM response.
-
-    Returns:
-        Tuple of (id, created, choice_data)
-    """
+) -> tuple[str, str]:
     response_id = response_data.get("id")
     created = response_data.get("created")
     if response_id is None or created is None:
         raise ValueError(f"{error_prefix} must include 'id' and 'created'.")
+    return str(response_id), str(created)
 
+
+def _require_first_choice(
+    response_data: dict[str, Any], error_prefix: str
+) -> dict[str, Any]:
     choices: list[dict[str, Any]] = response_data.get("choices") or []
     if not choices:
         raise ValueError(f"{error_prefix} must include at least one choice.")
-
-    return str(response_id), str(created), choices[0] or {}
+    return choices[0] or {}
 
 
 def _usage_from_usage_data(usage_data: dict[str, Any]) -> Usage:
@@ -181,9 +179,15 @@ def from_litellm_model_response_stream(
     Convert a LiteLLM ModelResponseStream into the simplified Onyx representation.
     """
     response_data = response.model_dump()
-    response_id, created, choice_data = _validate_and_extract_base_fields(
+    response_id, created = _extract_id_and_created(
         response_data, "LiteLLM response stream"
     )
+
+    # OpenAI (and other providers) emit a final usage-only chunk with an empty
+    # `choices` array when stream_options.include_usage is set. Treat it as an
+    # empty-delta chunk that still carries usage rather than failing the stream.
+    choices: list[dict[str, Any]] = response_data.get("choices") or []
+    choice_data: dict[str, Any] = (choices[0] or {}) if choices else {}
 
     delta_data: dict[str, Any] = choice_data.get("delta") or {}
     parsed_delta = Delta(
@@ -214,9 +218,8 @@ def from_litellm_model_response(
     Convert a LiteLLM ModelResponse into the simplified Onyx representation.
     """
     response_data = response.model_dump()
-    response_id, created, choice_data = _validate_and_extract_base_fields(
-        response_data, "LiteLLM response"
-    )
+    response_id, created = _extract_id_and_created(response_data, "LiteLLM response")
+    choice_data = _require_first_choice(response_data, "LiteLLM response")
 
     message_data: dict[str, Any] = choice_data.get("message") or {}
     parsed_tool_calls = _parse_message_tool_calls(message_data.get("tool_calls"))

--- a/backend/tests/unit/onyx/llm/test_model_response.py
+++ b/backend/tests/unit/onyx/llm/test_model_response.py
@@ -170,6 +170,23 @@ def _build_multiple_tool_calls_payload() -> dict:
     }
 
 
+def _build_usage_only_chunk_payload() -> dict:
+    # Final chunk OpenAI emits when stream_options.include_usage is set: empty
+    # `choices` array plus usage. litellm forwards it through verbatim.
+    return {
+        "id": "chatcmpl-usage-only",
+        "created": 1762544600,
+        "model": "gpt-5.1",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 11,
+            "completion_tokens": 22,
+            "total_tokens": 33,
+        },
+    }
+
+
 def _build_non_streaming_response_payload() -> dict:
     return {
         "id": "chatcmpl-abc123",
@@ -293,6 +310,23 @@ def test_from_litellm_model_response_stream_parses_multiple_tool_calls() -> None
             name="web_search",
         ),
     )
+
+
+def test_from_litellm_model_response_stream_handles_empty_choices_usage_chunk() -> None:
+    response = from_litellm_model_response_stream(
+        _make_stream_double(_build_usage_only_chunk_payload())
+    )
+
+    assert isinstance(response, ModelResponseStream)
+    assert response.id == "chatcmpl-usage-only"
+    assert response.created == "1762544600"
+    assert response.choice.finish_reason is None
+    assert response.choice.delta.content is None
+    assert response.choice.delta.tool_calls == []
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 11
+    assert response.usage.completion_tokens == 22
+    assert response.usage.total_tokens == 33
 
 
 def test_from_litellm_model_response_parses_basic_message() -> None:


### PR DESCRIPTION
## Description

We were not supporting packets with empty choices array, which is a thing openai documents they do when streaming back to a call where include_usage is True

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept usage-only stream chunks with an empty `choices` array and parse their usage without errors, fixing streaming when `include_usage` is enabled via `litellm`. Non-streaming responses still require at least one choice.

- **Bug Fixes**
  - Allow empty `choices` in stream parsing; capture `usage` and emit an empty delta.
  - Added unit test for usage-only chunk; non-stream parsing remains strict.

<sup>Written for commit a39cad1ca4fe19b1ae61f9db4a7db0971a53c782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

