### PR TITLE
fix: add frame-ancestors CSP and X-Frame-Options to prevent clickjacking

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -4,13 +4,10 @@ const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 
 const { buildCspHeader } = require("./src/lib/security-headers");
 
-// Base CSP without frame-ancestors. Clickjacking protection (frame-ancestors
-// + X-Frame-Options) is emitted at request time from src/proxy.ts so it can
-// be disabled at runtime via DISABLE_FRAME_PROTECTION — headers defined here
-// are baked into the build manifest and cannot be toggled without a rebuild.
-// This header only takes effect on routes the proxy does not cover (static
-// assets, /api), since proxy-set headers replace same-named headers from
-// here. Do NOT add frame-ancestors back to this one.
+// Fallback CSP for routes the proxy doesn't cover (static assets, /api).
+// frame-ancestors + X-Frame-Options live in src/proxy.ts (runtime-toggleable
+// via DISABLE_FRAME_PROTECTION); headers here are baked in at build time, so
+// do NOT add frame-ancestors back.
 const baseCspHeader = buildCspHeader(null);
 
 /** @type {import('next').NextConfig} */

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -2,20 +2,31 @@
 const { withSentryConfig } = require("@sentry/nextjs");
 const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 
-const cspHeader = `
+// frame-ancestors controls who may embed a page in an iframe (clickjacking
+// protection). Pages get 'self' only, except the /nrf pages which are
+// embedded by the Chrome extension (new tab + side panel). The extension's
+// origin can't be pinned to an ID since unpacked dev installs and store
+// installs have different IDs, so the chrome-extension: scheme is allowed
+// for those routes only.
+function buildCspHeader(frameAncestors) {
+  return `
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     font-src 'self' https://fonts.gstatic.com;
     object-src 'none';
     base-uri 'self';
     form-action 'self';
-    frame-ancestors 'self' chrome-extension:;
+    frame-ancestors ${frameAncestors};
     ${
       process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" &&
       process.env.NODE_ENV !== "development"
         ? "upgrade-insecure-requests;"
         : ""
     }
-`;
+`.replace(/\n/g, "");
+}
+
+const strictCspHeader = buildCspHeader("'self'");
+const extensionEmbeddableCspHeader = buildCspHeader("'self' chrome-extension:");
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -49,10 +60,6 @@ const nextConfig = {
         source: "/(.*)",
         headers: [
           {
-            key: "Content-Security-Policy",
-            value: cspHeader.replace(/\n/g, ""),
-          },
-          {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
           },
@@ -68,7 +75,7 @@ const nextConfig = {
             // Legacy fallback for browsers without CSP frame-ancestors
             // support. Modern browsers ignore this header when
             // frame-ancestors is present, so the chrome-extension:
-            // allowance above still applies (e.g. for the /nrf pages).
+            // allowance still applies for the /nrf pages.
             key: "X-Frame-Options",
             value: "SAMEORIGIN",
           },
@@ -76,6 +83,29 @@ const nextConfig = {
             key: "Permissions-Policy",
             value:
               "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(self), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()",
+          },
+        ],
+      },
+      {
+        // Strict CSP for everything except the extension-embedded /nrf pages.
+        // The lookahead must exclude exactly /nrf and /nrf/* so those routes
+        // get only the relaxed CSP below (two CSP headers would be enforced
+        // as their intersection, which would break the extension embed).
+        source: "/((?!nrf$|nrf/).*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: strictCspHeader,
+          },
+        ],
+      },
+      {
+        // :path* is zero-or-more, so this also matches bare /nrf
+        source: "/nrf/:path*",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: extensionEmbeddableCspHeader,
           },
         ],
       },

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -6,7 +6,7 @@ const { buildCspHeader } = require("./src/lib/security-headers");
 
 // Fallback CSP for routes the proxy doesn't cover (static assets, /api).
 // frame-ancestors + X-Frame-Options live in src/proxy.ts, where the
-// DISABLE_NRF_PAGE switch can vary them at runtime; headers here are baked
+// ENABLE_NRF_PAGE switch can vary them at runtime; headers here are baked
 // in at build time, so do NOT add frame-ancestors back.
 const baseCspHeader = buildCspHeader(null);
 

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -8,6 +8,7 @@ const cspHeader = `
     object-src 'none';
     base-uri 'self';
     form-action 'self';
+    frame-ancestors 'self' chrome-extension:;
     ${
       process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" &&
       process.env.NODE_ENV !== "development"
@@ -62,6 +63,14 @@ const nextConfig = {
           {
             key: "X-Content-Type-Options",
             value: "nosniff",
+          },
+          {
+            // Legacy fallback for browsers without CSP frame-ancestors
+            // support. Modern browsers ignore this header when
+            // frame-ancestors is present, so the chrome-extension:
+            // allowance above still applies (e.g. for the /nrf pages).
+            key: "X-Frame-Options",
+            value: "SAMEORIGIN",
           },
           {
             key: "Permissions-Policy",

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -2,31 +2,16 @@
 const { withSentryConfig } = require("@sentry/nextjs");
 const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 
-// frame-ancestors controls who may embed a page in an iframe (clickjacking
-// protection). Pages get 'self' only, except the /nrf pages which are
-// embedded by the Chrome extension (new tab + side panel). The extension's
-// origin can't be pinned to an ID since unpacked dev installs and store
-// installs have different IDs, so the chrome-extension: scheme is allowed
-// for those routes only.
-function buildCspHeader(frameAncestors) {
-  return `
-    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-    font-src 'self' https://fonts.gstatic.com;
-    object-src 'none';
-    base-uri 'self';
-    form-action 'self';
-    frame-ancestors ${frameAncestors};
-    ${
-      process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" &&
-      process.env.NODE_ENV !== "development"
-        ? "upgrade-insecure-requests;"
-        : ""
-    }
-`.replace(/\n/g, "");
-}
+const { buildCspHeader } = require("./src/lib/security-headers");
 
-const strictCspHeader = buildCspHeader("'self'");
-const extensionEmbeddableCspHeader = buildCspHeader("'self' chrome-extension:");
+// Base CSP without frame-ancestors. Clickjacking protection (frame-ancestors
+// + X-Frame-Options) is emitted at request time from src/proxy.ts so it can
+// be disabled at runtime via DISABLE_FRAME_PROTECTION — headers defined here
+// are baked into the build manifest and cannot be toggled without a rebuild.
+// This header only takes effect on routes the proxy does not cover (static
+// assets, /api), since proxy-set headers replace same-named headers from
+// here. Do NOT add frame-ancestors back to this one.
+const baseCspHeader = buildCspHeader(null);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -60,6 +45,10 @@ const nextConfig = {
         source: "/(.*)",
         headers: [
           {
+            key: "Content-Security-Policy",
+            value: baseCspHeader,
+          },
+          {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
           },
@@ -72,40 +61,9 @@ const nextConfig = {
             value: "nosniff",
           },
           {
-            // Legacy fallback for browsers without CSP frame-ancestors
-            // support. Modern browsers ignore this header when
-            // frame-ancestors is present, so the chrome-extension:
-            // allowance still applies for the /nrf pages.
-            key: "X-Frame-Options",
-            value: "SAMEORIGIN",
-          },
-          {
             key: "Permissions-Policy",
             value:
               "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(self), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()",
-          },
-        ],
-      },
-      {
-        // Strict CSP for everything except the extension-embedded /nrf pages.
-        // The lookahead must exclude exactly /nrf and /nrf/* so those routes
-        // get only the relaxed CSP below (two CSP headers would be enforced
-        // as their intersection, which would break the extension embed).
-        source: "/((?!nrf$|nrf/).*)",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: strictCspHeader,
-          },
-        ],
-      },
-      {
-        // :path* is zero-or-more, so this also matches bare /nrf
-        source: "/nrf/:path*",
-        headers: [
-          {
-            key: "Content-Security-Policy",
-            value: extensionEmbeddableCspHeader,
           },
         ],
       },

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -5,9 +5,9 @@ const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 const { buildCspHeader } = require("./src/lib/security-headers");
 
 // Fallback CSP for routes the proxy doesn't cover (static assets, /api).
-// frame-ancestors + X-Frame-Options live in src/proxy.ts (runtime-toggleable
-// via DISABLE_FRAME_PROTECTION); headers here are baked in at build time, so
-// do NOT add frame-ancestors back.
+// frame-ancestors + X-Frame-Options live in src/proxy.ts, where the
+// DISABLE_NRF_PAGE switch can vary them at runtime; headers here are baked
+// in at build time, so do NOT add frame-ancestors back.
 const baseCspHeader = buildCspHeader(null);
 
 /** @type {import('next').NextConfig} */

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -44,6 +44,17 @@ export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
 export const SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION =
   process.env.DISABLE_FRAME_PROTECTION?.toLowerCase() === "true";
 
+// All-or-nothing runtime switch for the /nrf pages (the surfaces the Chrome
+// extension embeds in its new-tab and side-panel iframes). When true,
+// src/proxy.ts redirects /nrf and /nrf/* to / and stops emitting the relaxed
+// "frame-ancestors 'self' chrome-extension:" CSP, so the whole app is
+// strictly 'self' — nothing is extension-embeddable. Lets security-conscious
+// deployments that don't use the extension remove that surface entirely.
+// Same runtime semantics as DISABLE_FRAME_PROTECTION above: env change +
+// restart, no rebuild. Server-side only: read in the proxy (middleware).
+export const SERVER_SIDE_ONLY__DISABLE_NRF_PAGE =
+  process.env.DISABLE_NRF_PAGE?.toLowerCase() === "true";
+
 export const SEARCH_TYPE_COOKIE_NAME = "search_type";
 export const AGENTIC_SEARCH_TYPE_COOKIE_NAME = "agentic_type";
 

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -37,12 +37,13 @@ export const TENANT_ID_COOKIE_NAME = "onyx_tid";
 export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
   process.env.AUTH_COOKIE_NAME || "fastapiusersauth";
 
-// All-or-nothing runtime switch (env change + restart, no rebuild):
-// src/proxy.ts redirects /nrf* to / and drops the chrome-extension:
-// frame-ancestors allowance, so nothing in the app is embeddable by the
-// Chrome extension.
-export const SERVER_SIDE_ONLY__DISABLE_NRF_PAGE =
-  process.env.DISABLE_NRF_PAGE?.toLowerCase() === "true";
+// All-or-nothing runtime switch (env change + restart, no rebuild) for the
+// /nrf pages the Chrome extension embeds. Off by default: src/proxy.ts
+// redirects /nrf* to / and emits no chrome-extension: frame-ancestors
+// allowance, so nothing in the app is extension-embeddable until a
+// deployment opts in.
+export const SERVER_SIDE_ONLY__NRF_PAGE_ENABLED =
+  process.env.ENABLE_NRF_PAGE?.toLowerCase() === "true";
 
 export const SEARCH_TYPE_COOKIE_NAME = "search_type";
 export const AGENTIC_SEARCH_TYPE_COOKIE_NAME = "agentic_type";

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -37,14 +37,10 @@ export const TENANT_ID_COOKIE_NAME = "onyx_tid";
 export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
   process.env.AUTH_COOKIE_NAME || "fastapiusersauth";
 
-// Runtime kill switch for the clickjacking headers (frame-ancestors + XFO)
-// emitted by src/proxy.ts; flipped with an env change + restart, no rebuild.
-export const SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION =
-  process.env.DISABLE_FRAME_PROTECTION?.toLowerCase() === "true";
-
-// All-or-nothing runtime switch: src/proxy.ts redirects /nrf* to / and drops
-// the chrome-extension: frame-ancestors allowance, so nothing in the app is
-// embeddable by the Chrome extension.
+// All-or-nothing runtime switch (env change + restart, no rebuild):
+// src/proxy.ts redirects /nrf* to / and drops the chrome-extension:
+// frame-ancestors allowance, so nothing in the app is embeddable by the
+// Chrome extension.
 export const SERVER_SIDE_ONLY__DISABLE_NRF_PAGE =
   process.env.DISABLE_NRF_PAGE?.toLowerCase() === "true";
 

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -37,21 +37,14 @@ export const TENANT_ID_COOKIE_NAME = "onyx_tid";
 export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
   process.env.AUTH_COOKIE_NAME || "fastapiusersauth";
 
-// Runtime kill switch for the clickjacking protection headers (CSP
-// frame-ancestors + X-Frame-Options) emitted by src/proxy.ts. Read at server
-// start, so it can be flipped with an env change + restart — no rebuild.
-// Server-side only: read in the proxy (middleware).
+// Runtime kill switch for the clickjacking headers (frame-ancestors + XFO)
+// emitted by src/proxy.ts; flipped with an env change + restart, no rebuild.
 export const SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION =
   process.env.DISABLE_FRAME_PROTECTION?.toLowerCase() === "true";
 
-// All-or-nothing runtime switch for the /nrf pages (the surfaces the Chrome
-// extension embeds in its new-tab and side-panel iframes). When true,
-// src/proxy.ts redirects /nrf and /nrf/* to / and stops emitting the relaxed
-// "frame-ancestors 'self' chrome-extension:" CSP, so the whole app is
-// strictly 'self' — nothing is extension-embeddable. Lets security-conscious
-// deployments that don't use the extension remove that surface entirely.
-// Same runtime semantics as DISABLE_FRAME_PROTECTION above: env change +
-// restart, no rebuild. Server-side only: read in the proxy (middleware).
+// All-or-nothing runtime switch: src/proxy.ts redirects /nrf* to / and drops
+// the chrome-extension: frame-ancestors allowance, so nothing in the app is
+// embeddable by the Chrome extension.
 export const SERVER_SIDE_ONLY__DISABLE_NRF_PAGE =
   process.env.DISABLE_NRF_PAGE?.toLowerCase() === "true";
 

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -37,6 +37,13 @@ export const TENANT_ID_COOKIE_NAME = "onyx_tid";
 export const SERVER_SIDE_ONLY__AUTH_COOKIE_NAME =
   process.env.AUTH_COOKIE_NAME || "fastapiusersauth";
 
+// Runtime kill switch for the clickjacking protection headers (CSP
+// frame-ancestors + X-Frame-Options) emitted by src/proxy.ts. Read at server
+// start, so it can be flipped with an env change + restart — no rebuild.
+// Server-side only: read in the proxy (middleware).
+export const SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION =
+  process.env.DISABLE_FRAME_PROTECTION?.toLowerCase() === "true";
+
 export const SEARCH_TYPE_COOKIE_NAME = "search_type";
 export const AGENTIC_SEARCH_TYPE_COOKIE_NAME = "agentic_type";
 

--- a/web/src/lib/security-headers.js
+++ b/web/src/lib/security-headers.js
@@ -1,0 +1,37 @@
+// Shared between next.config.js (build-time fallback headers) and
+// src/proxy.ts (runtime headers). Must stay CommonJS so next.config.js can
+// require() it.
+//
+// Why the split: headers defined in next.config.js are resolved once at
+// `next build` and baked into the routes manifest, so they cannot be toggled
+// at runtime. The clickjacking protection (frame-ancestors / X-Frame-Options)
+// needs a runtime kill switch (DISABLE_FRAME_PROTECTION), so it is emitted
+// from src/proxy.ts instead. Middleware-set headers fully REPLACE same-named
+// headers from next.config.js, so proxy.ts must emit the complete CSP — this
+// module is the single source of truth for the policy itself.
+
+/**
+ * Build the Content-Security-Policy header value.
+ *
+ * @param {string | null} frameAncestors - value for the frame-ancestors
+ *   directive (e.g. "'self'"), or null to omit the directive entirely.
+ * @returns {string}
+ */
+function buildCspHeader(frameAncestors) {
+  return `
+    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+    font-src 'self' https://fonts.gstatic.com;
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    ${frameAncestors ? `frame-ancestors ${frameAncestors};` : ""}
+    ${
+      process.env.NEXT_PUBLIC_CLOUD_ENABLED === "true" &&
+      process.env.NODE_ENV !== "development"
+        ? "upgrade-insecure-requests;"
+        : ""
+    }
+`.replace(/\n/g, "");
+}
+
+module.exports = { buildCspHeader };

--- a/web/src/lib/security-headers.js
+++ b/web/src/lib/security-headers.js
@@ -1,20 +1,11 @@
-// Shared between next.config.js (build-time fallback headers) and
-// src/proxy.ts (runtime headers). Must stay CommonJS so next.config.js can
-// require() it.
-//
-// Why the split: headers defined in next.config.js are resolved once at
-// `next build` and baked into the routes manifest, so they cannot be toggled
-// at runtime. The clickjacking protection (frame-ancestors / X-Frame-Options)
-// needs a runtime kill switch (DISABLE_FRAME_PROTECTION), so it is emitted
-// from src/proxy.ts instead. Middleware-set headers fully REPLACE same-named
-// headers from next.config.js, so proxy.ts must emit the complete CSP — this
-// module is the single source of truth for the policy itself.
+// Single source of truth for the CSP, shared by next.config.js (build-time
+// fallback) and src/proxy.ts (runtime). Must stay CommonJS for the require()
+// in next.config.js. Proxy-set headers fully REPLACE same-named config
+// headers, so the proxy must emit the complete CSP — never a partial one.
 
 /**
- * Build the Content-Security-Policy header value.
- *
- * @param {string | null} frameAncestors - value for the frame-ancestors
- *   directive (e.g. "'self'"), or null to omit the directive entirely.
+ * @param {string | null} frameAncestors - frame-ancestors directive value
+ *   (e.g. "'self'"), or null to omit the directive.
  * @returns {string}
  */
 function buildCspHeader(frameAncestors) {

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -5,7 +5,9 @@ import {
   SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED,
   SERVER_SIDE_ONLY__AUTH_TYPE,
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
+  SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION,
 } from "./lib/constants";
+import { buildCspHeader } from "./lib/security-headers";
 
 // Authentication cookie names (matches backend constants)
 const ANONYMOUS_USER_COOKIE_NAME = "onyx_anonymous_user";
@@ -20,24 +22,13 @@ const PUBLIC_ROUTES = ["/auth", "/anonymous", "/_next", "/api"];
 // be run before the config is defined e.g. if we try and do a .map it will complain
 export const config = {
   matcher: [
-    // Auth-protected routes (for middleware auth check)
-    "/app/:path*",
-    "/admin/:path*",
-    "/agents/:path*",
-    "/connector/:path*",
-
-    // Enterprise Edition routes (for /ee rewriting)
-    // These are ONLY the EE-specific routes that should be rewritten
-    "/admin/groups/:path*",
-    "/admin/performance/usage/:path*",
-    "/admin/performance/query-history/:path*",
-    "/admin/theme/:path*",
-    "/admin/performance/custom-analytics/:path*",
-    "/admin/standard-answer/:path*",
-    "/agents/stats/:path*",
-
-    // Cloud only
-    "/admin/billing/:path*",
+    // Match everything except /api (proxied to the backend — framing headers
+    // are meaningless on API responses and the proxy would add per-request
+    // overhead) and Next.js internals/static assets. The catch-all is needed
+    // so the clickjacking protection headers below cover every page; the
+    // auth check and /ee rewriting are still gated on their route prefixes
+    // inside proxy() itself.
+    "/((?!api$|api/|_next/|favicon.ico).*)",
   ],
 };
 
@@ -51,6 +42,47 @@ const EE_ROUTES = [
   "/admin/standard-answer",
   "/agents/stats",
 ];
+
+// frame-ancestors controls who may embed a page in an iframe (clickjacking
+// protection). Pages get 'self' only, except the /nrf pages which are
+// embedded by the Chrome extension (new tab + side panel). The extension's
+// origin can't be pinned to an ID since unpacked dev installs and store
+// installs have different IDs, so the chrome-extension: scheme is allowed
+// for those routes only.
+//
+// These headers are emitted here rather than from next.config.js headers()
+// because config headers are resolved at build time — emitting them at
+// request time is what makes the DISABLE_FRAME_PROTECTION kill switch work
+// without a rebuild. Headers set here REPLACE same-named headers from
+// next.config.js, which is why the full CSP (shared via security-headers.js)
+// is emitted and not just the frame-ancestors directive.
+const STRICT_CSP_HEADER = buildCspHeader("'self'");
+const EXTENSION_EMBEDDABLE_CSP_HEADER = buildCspHeader(
+  "'self' chrome-extension:"
+);
+
+function withFrameProtectionHeaders(
+  request: NextRequest,
+  response: NextResponse
+): NextResponse {
+  if (SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION) {
+    return response;
+  }
+
+  const pathname = request.nextUrl.pathname;
+  const isExtensionEmbeddable =
+    pathname === "/nrf" || pathname.startsWith("/nrf/");
+
+  response.headers.set(
+    "Content-Security-Policy",
+    isExtensionEmbeddable ? EXTENSION_EMBEDDABLE_CSP_HEADER : STRICT_CSP_HEADER
+  );
+  // Legacy fallback for browsers without CSP frame-ancestors support. Modern
+  // browsers ignore this header when frame-ancestors is present, so the
+  // chrome-extension: allowance still applies for the /nrf pages.
+  response.headers.set("X-Frame-Options", "SAMEORIGIN");
+  return response;
+}
 
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
@@ -74,7 +106,10 @@ export async function proxy(request: NextRequest) {
       // Preserve full URL including query params and hash for deep linking
       const fullPath = pathname + request.nextUrl.search + request.nextUrl.hash;
       loginUrl.searchParams.set("next", fullPath);
-      return NextResponse.redirect(loginUrl);
+      return withFrameProtectionHeaders(
+        request,
+        NextResponse.redirect(loginUrl)
+      );
     }
   }
 
@@ -82,9 +117,9 @@ export async function proxy(request: NextRequest) {
   if (SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED) {
     if (EE_ROUTES.some((route) => pathname.startsWith(route))) {
       const newUrl = new URL(`/ee${pathname}`, request.url);
-      return NextResponse.rewrite(newUrl);
+      return withFrameProtectionHeaders(request, NextResponse.rewrite(newUrl));
     }
   }
 
-  return NextResponse.next();
+  return withFrameProtectionHeaders(request, NextResponse.next());
 }

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -6,6 +6,7 @@ import {
   SERVER_SIDE_ONLY__AUTH_TYPE,
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
   SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION,
+  SERVER_SIDE_ONLY__DISABLE_NRF_PAGE,
 } from "./lib/constants";
 import { buildCspHeader } from "./lib/security-headers";
 
@@ -61,6 +62,10 @@ const EXTENSION_EMBEDDABLE_CSP_HEADER = buildCspHeader(
   "'self' chrome-extension:"
 );
 
+function isNrfRoute(pathname: string): boolean {
+  return pathname === "/nrf" || pathname.startsWith("/nrf/");
+}
+
 function withFrameProtectionHeaders(
   request: NextRequest,
   response: NextResponse
@@ -70,8 +75,10 @@ function withFrameProtectionHeaders(
   }
 
   const pathname = request.nextUrl.pathname;
+  // With the /nrf pages disabled there is no extension-embeddable surface,
+  // so every route (including the /nrf redirect itself) gets the strict CSP.
   const isExtensionEmbeddable =
-    pathname === "/nrf" || pathname.startsWith("/nrf/");
+    !SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname);
 
   response.headers.set(
     "Content-Security-Policy",
@@ -86,6 +93,19 @@ function withFrameProtectionHeaders(
 
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
+
+  // All-or-nothing switch for the extension-embeddable /nrf pages. When
+  // disabled, the pages are unreachable and (via withFrameProtectionHeaders
+  // above) the chrome-extension: frame-ancestors allowance is never emitted,
+  // so no part of the app can be framed by the extension. The redirect
+  // target / carries frame-ancestors 'self', so inside an extension iframe
+  // the browser refuses to render it.
+  if (SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname)) {
+    return withFrameProtectionHeaders(
+      request,
+      NextResponse.redirect(new URL("/", request.url))
+    );
+  }
 
   // Auth Check: Fast-fail at edge if no cookie (defense in depth)
   // Note: Layouts still do full verification (token validity, roles, etc.)

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -5,7 +5,6 @@ import {
   SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED,
   SERVER_SIDE_ONLY__AUTH_TYPE,
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
-  SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION,
   SERVER_SIDE_ONLY__DISABLE_NRF_PAGE,
 } from "./lib/constants";
 import { buildCspHeader } from "./lib/security-headers";
@@ -45,8 +44,8 @@ const EE_ROUTES = [
 // pages embedded by the Chrome extension iframes — the extension ID differs
 // between store and unpacked installs, so the scheme is allowed instead.
 // Emitted here (not next.config.js, which is resolved at build time) so the
-// DISABLE_* env switches work at runtime; see security-headers.js for why
-// the full CSP must be emitted.
+// DISABLE_NRF_PAGE env switch works at runtime; see security-headers.js for
+// why the full CSP must be emitted.
 const STRICT_CSP_HEADER = buildCspHeader("'self'");
 const EXTENSION_EMBEDDABLE_CSP_HEADER = buildCspHeader(
   "'self' chrome-extension:"
@@ -60,10 +59,6 @@ function withFrameProtectionHeaders(
   request: NextRequest,
   response: NextResponse
 ): NextResponse {
-  if (SERVER_SIDE_ONLY__DISABLE_FRAME_PROTECTION) {
-    return response;
-  }
-
   const pathname = request.nextUrl.pathname;
   const isExtensionEmbeddable =
     !SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname);

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -5,7 +5,7 @@ import {
   SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED,
   SERVER_SIDE_ONLY__AUTH_TYPE,
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
-  SERVER_SIDE_ONLY__DISABLE_NRF_PAGE,
+  SERVER_SIDE_ONLY__NRF_PAGE_ENABLED,
 } from "./lib/constants";
 import { buildCspHeader } from "./lib/security-headers";
 
@@ -40,12 +40,12 @@ const EE_ROUTES = [
   "/agents/stats",
 ];
 
-// Clickjacking protection. Pages get frame-ancestors 'self', except the /nrf
-// pages embedded by the Chrome extension iframes — the extension ID differs
-// between store and unpacked installs, so the scheme is allowed instead.
-// Emitted here (not next.config.js, which is resolved at build time) so the
-// DISABLE_NRF_PAGE env switch works at runtime; see security-headers.js for
-// why the full CSP must be emitted.
+// Clickjacking protection. Pages get frame-ancestors 'self'; deployments
+// that opt in via ENABLE_NRF_PAGE relax the /nrf pages to chrome-extension:
+// so the Chrome extension can embed them (its ID differs between store and
+// unpacked installs, so the scheme is allowed instead). Emitted here (not
+// next.config.js, which is resolved at build time) so the switch works at
+// runtime; see security-headers.js for why the full CSP must be emitted.
 const STRICT_CSP_HEADER = buildCspHeader("'self'");
 const EXTENSION_EMBEDDABLE_CSP_HEADER = buildCspHeader(
   "'self' chrome-extension:"
@@ -61,7 +61,7 @@ function withFrameProtectionHeaders(
 ): NextResponse {
   const pathname = request.nextUrl.pathname;
   const isExtensionEmbeddable =
-    !SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname);
+    SERVER_SIDE_ONLY__NRF_PAGE_ENABLED && isNrfRoute(pathname);
 
   response.headers.set(
     "Content-Security-Policy",
@@ -76,10 +76,10 @@ function withFrameProtectionHeaders(
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // With /nrf disabled the pages are unreachable and the chrome-extension:
-  // allowance is never emitted, so the extension can't frame anything — the
-  // redirect target / carries frame-ancestors 'self'.
-  if (SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname)) {
+  // Unless a deployment opts in, the /nrf pages are unreachable and the
+  // chrome-extension: allowance is never emitted, so the extension can't
+  // frame anything — the redirect target / carries frame-ancestors 'self'.
+  if (!SERVER_SIDE_ONLY__NRF_PAGE_ENABLED && isNrfRoute(pathname)) {
     return withFrameProtectionHeaders(
       request,
       NextResponse.redirect(new URL("/", request.url))

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -23,12 +23,9 @@ const PUBLIC_ROUTES = ["/auth", "/anonymous", "/_next", "/api"];
 // be run before the config is defined e.g. if we try and do a .map it will complain
 export const config = {
   matcher: [
-    // Match everything except /api (proxied to the backend — framing headers
-    // are meaningless on API responses and the proxy would add per-request
-    // overhead) and Next.js internals/static assets. The catch-all is needed
-    // so the clickjacking protection headers below cover every page; the
-    // auth check and /ee rewriting are still gated on their route prefixes
-    // inside proxy() itself.
+    // Everything except /api and Next internals/static assets, so the frame
+    // protection headers cover every page. Auth check and /ee rewriting are
+    // still gated on their route prefixes inside proxy().
     "/((?!api$|api/|_next/|favicon.ico).*)",
   ],
 };
@@ -44,19 +41,12 @@ const EE_ROUTES = [
   "/agents/stats",
 ];
 
-// frame-ancestors controls who may embed a page in an iframe (clickjacking
-// protection). Pages get 'self' only, except the /nrf pages which are
-// embedded by the Chrome extension (new tab + side panel). The extension's
-// origin can't be pinned to an ID since unpacked dev installs and store
-// installs have different IDs, so the chrome-extension: scheme is allowed
-// for those routes only.
-//
-// These headers are emitted here rather than from next.config.js headers()
-// because config headers are resolved at build time — emitting them at
-// request time is what makes the DISABLE_FRAME_PROTECTION kill switch work
-// without a rebuild. Headers set here REPLACE same-named headers from
-// next.config.js, which is why the full CSP (shared via security-headers.js)
-// is emitted and not just the frame-ancestors directive.
+// Clickjacking protection. Pages get frame-ancestors 'self', except the /nrf
+// pages embedded by the Chrome extension iframes — the extension ID differs
+// between store and unpacked installs, so the scheme is allowed instead.
+// Emitted here (not next.config.js, which is resolved at build time) so the
+// DISABLE_* env switches work at runtime; see security-headers.js for why
+// the full CSP must be emitted.
 const STRICT_CSP_HEADER = buildCspHeader("'self'");
 const EXTENSION_EMBEDDABLE_CSP_HEADER = buildCspHeader(
   "'self' chrome-extension:"
@@ -75,8 +65,6 @@ function withFrameProtectionHeaders(
   }
 
   const pathname = request.nextUrl.pathname;
-  // With the /nrf pages disabled there is no extension-embeddable surface,
-  // so every route (including the /nrf redirect itself) gets the strict CSP.
   const isExtensionEmbeddable =
     !SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname);
 
@@ -84,9 +72,8 @@ function withFrameProtectionHeaders(
     "Content-Security-Policy",
     isExtensionEmbeddable ? EXTENSION_EMBEDDABLE_CSP_HEADER : STRICT_CSP_HEADER
   );
-  // Legacy fallback for browsers without CSP frame-ancestors support. Modern
-  // browsers ignore this header when frame-ancestors is present, so the
-  // chrome-extension: allowance still applies for the /nrf pages.
+  // Legacy fallback; browsers ignore XFO when frame-ancestors is present,
+  // so the /nrf extension allowance above still applies.
   response.headers.set("X-Frame-Options", "SAMEORIGIN");
   return response;
 }
@@ -94,12 +81,9 @@ function withFrameProtectionHeaders(
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
-  // All-or-nothing switch for the extension-embeddable /nrf pages. When
-  // disabled, the pages are unreachable and (via withFrameProtectionHeaders
-  // above) the chrome-extension: frame-ancestors allowance is never emitted,
-  // so no part of the app can be framed by the extension. The redirect
-  // target / carries frame-ancestors 'self', so inside an extension iframe
-  // the browser refuses to render it.
+  // With /nrf disabled the pages are unreachable and the chrome-extension:
+  // allowance is never emitted, so the extension can't frame anything — the
+  // redirect target / carries frame-ancestors 'self'.
   if (SERVER_SIDE_ONLY__DISABLE_NRF_PAGE && isNrfRoute(pathname)) {
     return withFrameProtectionHeaders(
       request,


### PR DESCRIPTION
## Description

Fixes Oneleet pentest finding **ON-011 (Clickjacking)** — https://linear.app/onyx-app/issue/ENG-4132

The app previously sent no framing restrictions, so any external website could load Onyx in an iframe and overlay UI to hijack clicks.

### What this adds

- **CSP `frame-ancestors 'self'` on all page routes + `X-Frame-Options: SAMEORIGIN`** (always on) — no external site or extension can frame the app. XFO is the legacy fallback; modern browsers ignore it when `frame-ancestors` is present.
- **`ENABLE_NRF_PAGE=true`** — opt-in runtime switch (env change + pod restart, no image rebuild) for the `/nrf` + `/nrf/*` pages the Chrome extension embeds in its new-tab and side-panel iframes. When enabled, those routes (and only those) get `frame-ancestors 'self' chrome-extension:` — the extension's ID can't be pinned because unpacked dev installs and store installs have different IDs, so the scheme allowance is scoped to just these routes.
- **Default (unset): the extension surface is off** — `/nrf` and `/nrf/*` redirect to `/` and the `chrome-extension:` allowance is never emitted, so the whole app is strictly `frame-ancestors 'self'`. This closes the residual concern that *any* Chrome extension (not just ours) could frame `/nrf`. Deployments that use the Onyx Chrome extension must set `ENABLE_NRF_PAGE=true`.

The finding's remediation (the headers) is unconditional — the switch only controls the extension-embeddable surface. Note the session cookie is already `SameSite=Lax` (fastapi-users default), covering the finding's cookie recommendation.

> ⚠️ **Deploy note:** this changes default behavior — the Chrome extension's new-tab/side-panel embed stops working until the deployment sets `ENABLE_NRF_PAGE=true` on the web container. Cloud should set it before/with rollout if we want the extension to keep working there.

### Why the headers are emitted from `src/proxy.ts` (middleware) instead of `next.config.js`

`headers()` in `next.config.js` is resolved once at `next build` and baked into the routes manifest, so the route-dependent CSP couldn't be varied by a runtime switch there. The proxy runs per-request and reads the env at server start, which is what makes `ENABLE_NRF_PAGE` a runtime toggle.

Two consequences of that, verified empirically (dev **and** production standalone build):

- Proxy-set headers fully **replace** same-named `next.config.js` headers (both `set` and `append`), so the proxy must emit the complete CSP, not just a `frame-ancestors`-only policy (which would clobber `style-src` etc.). The CSP is built in a shared module (`src/lib/security-headers.js`) used by both `next.config.js` and the proxy so the two can't drift.
- The proxy matcher is expanded to a catch-all (excluding `/api` and Next internals/static assets, where framing headers are meaningless) so every page is covered. The existing auth fast-fail and /ee rewriting are already gated on their route prefixes inside `proxy()`, so they are unaffected by the wider matcher.

`next.config.js` keeps a base CSP (without `frame-ancestors`) as the build-time fallback for routes the proxy doesn't cover (static assets, `/api`) — same coverage as before this PR.

Verified non-impacts:
- Desktop app (Tauri) navigates its webview top-level (`window.location.href`), not via iframe, and has zero references to `/nrf` — unaffected in both switch states.
- The Chrome extension is the only consumer of `/nrf` (`extensions/chrome` sets iframe src to `<domain>/nrf` and `/nrf/side-panel`); nothing in the web app navigates into `/nrf`.
- Internal iframes (PDF previews via blob/API URLs, craft sandbox previews) load non-Next-served content — unaffected.

## How Has This Been Tested?

Curl matrix against `next dev` and the **production standalone build** (`next build` + `node .next/standalone/server.js`):

- Default (unset): `/`, `/auth/login`, `/app` (authed) → exactly one CSP header with `frame-ancestors 'self'` + `X-Frame-Options: SAMEORIGIN`; `/nrf` and `/nrf/side-panel` → 307 to `/` with the strict CSP; `/nrf-other` still 404s normally (route boundary respected); auth-redirect (307) responses also carry the headers.
- `ENABLE_NRF_PAGE=true` at runtime (no rebuild): `/nrf`, `/nrf/side-panel` → 200 with `frame-ancestors 'self' chrome-extension:`; everything else still strict.
- `bunx tsc --noEmit` and production `next build` pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
