### PR TITLE
fix: sanitize CSV exports against spreadsheet formula injection

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -20,6 +20,7 @@ from onyx.db.tasks import mark_task_as_finished_with_id
 from onyx.db.tasks import mark_task_as_started_with_id
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.settings.store import load_settings
+from onyx.utils.csv_utils import sanitize_csv_row
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -71,7 +72,9 @@ def export_query_history_task(
                     snapshot.user_email = ONYX_ANONYMIZED_EMAIL
 
                 writer.writerows(
-                    qa_pair.to_json()
+                    # Sanitize to prevent CSV/formula injection against
+                    # whoever opens the export in a spreadsheet (ON-008).
+                    sanitize_csv_row(qa_pair.to_json())
                     for qa_pair in QuestionAnswerPairSnapshot.from_chat_session_snapshot(
                         snapshot
                     )

--- a/backend/ee/onyx/server/reporting/usage_export_generation.py
+++ b/backend/ee/onyx/server/reporting/usage_export_generation.py
@@ -21,6 +21,7 @@ from onyx.db.users import get_all_users
 from onyx.file_store.constants import MAX_IN_MEMORY_SIZE
 from onyx.file_store.file_store import FileStore
 from onyx.file_store.file_store import get_default_file_store
+from onyx.utils.csv_utils import sanitize_csv_cell_or_none
 
 
 def generate_chat_messages_report(
@@ -64,14 +65,18 @@ def generate_chat_messages_report(
             db_session, period
         ):
             for chat_message_skeleton in chat_message_skeleton_batch:
+                # assistant_name and user_email are user-supplied — sanitize
+                # to prevent CSV/formula injection against whoever opens the
+                # report in a spreadsheet. The remaining fields are
+                # system-generated (UUIDs, enums, timestamps, ints).
                 csvwriter.writerow(
                     [
                         chat_message_skeleton.chat_session_id,
                         chat_message_skeleton.user_id,
                         chat_message_skeleton.flow_type,
                         chat_message_skeleton.time_sent.isoformat(),
-                        chat_message_skeleton.assistant_name,
-                        chat_message_skeleton.user_email,
+                        sanitize_csv_cell_or_none(chat_message_skeleton.assistant_name),
+                        sanitize_csv_cell_or_none(chat_message_skeleton.user_email),
                         chat_message_skeleton.number_of_tokens,
                         chat_message_skeleton.llm_model,
                     ]

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -120,6 +120,7 @@ from onyx.server.models import MinimalUserSnapshot
 from onyx.server.models import UserGroupInfo
 from onyx.server.usage_limits import is_tenant_on_trial_fn
 from onyx.server.utils import BasicAuthenticationError
+from onyx.utils.csv_utils import sanitize_csv_cell
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from onyx.utils.variable_functionality import (
@@ -413,11 +414,13 @@ def download_users_csv(
     # Write CSV header
     writer.writerow(["Email", "Role", "Status"])
 
-    # Write user data
+    # Write user data. Emails are user-supplied (a local part can legally
+    # start with a formula trigger like `=`), so sanitize to prevent
+    # CSV/formula injection against the admin opening the export.
     for user in users:
         writer.writerow(
             [
-                user.email,
+                sanitize_csv_cell(user.email),
                 user.role.value if user.role else "",
                 "Active" if user.is_active else "Inactive",
             ]

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -34,12 +34,14 @@ def sanitize_csv_cell(value: str) -> str:
     return value
 
 
+def sanitize_csv_cell_or_none(value: str | None) -> str | None:
+    """sanitize_csv_cell that passes None through."""
+    return sanitize_csv_cell(value) if value is not None else None
+
+
 def sanitize_csv_row(row: Mapping[str, str | None]) -> dict[str, str | None]:
     """Apply sanitize_csv_cell to every non-None value of a CSV row dict."""
-    return {
-        key: sanitize_csv_cell(value) if value is not None else None
-        for key, value in row.items()
-    }
+    return {key: sanitize_csv_cell_or_none(value) for key, value in row.items()}
 
 
 class ParsedRow(BaseModel):

--- a/backend/onyx/utils/csv_utils.py
+++ b/backend/onyx/utils/csv_utils.py
@@ -1,6 +1,7 @@
 import csv
 import io
 from collections.abc import Generator
+from collections.abc import Mapping
 
 from pydantic import BaseModel
 
@@ -14,6 +15,31 @@ _CSV_FIELD_SIZE_LIMIT_BYTES = 128 * 1024 * 1024
 csv.field_size_limit(_CSV_FIELD_SIZE_LIMIT_BYTES)
 
 _NEWLINE_CSV_ERROR = "new-line character seen in unquoted field"
+
+# Leading characters that spreadsheet software (Excel, LibreOffice, Google
+# Sheets) interprets as the start of a formula. Exporting user-supplied text
+# beginning with one of these enables CSV/formula injection (e.g. DDE payloads
+# like `=cmd|' /C calc'!A1`) against whoever opens the export.
+_FORMULA_PREFIX_CHARS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def sanitize_csv_cell(value: str) -> str:
+    """Neutralize spreadsheet formula injection in a CSV cell.
+
+    Prefixes values that start with a formula-trigger character with a
+    single quote, which spreadsheet software treats as "render as text".
+    """
+    if value.startswith(_FORMULA_PREFIX_CHARS):
+        return "'" + value
+    return value
+
+
+def sanitize_csv_row(row: Mapping[str, str | None]) -> dict[str, str | None]:
+    """Apply sanitize_csv_cell to every non-None value of a CSV row dict."""
+    return {
+        key: sanitize_csv_cell(value) if value is not None else None
+        for key, value in row.items()
+    }
 
 
 class ParsedRow(BaseModel):

--- a/backend/tests/unit/onyx/utils/test_csv_utils.py
+++ b/backend/tests/unit/onyx/utils/test_csv_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from onyx.utils.csv_utils import sanitize_csv_cell
+from onyx.utils.csv_utils import sanitize_csv_cell_or_none
 from onyx.utils.csv_utils import sanitize_csv_row
 
 
@@ -29,6 +30,12 @@ from onyx.utils.csv_utils import sanitize_csv_row
 )
 def test_sanitize_csv_cell(value: str, expected: str) -> None:
     assert sanitize_csv_cell(value) == expected
+
+
+def test_sanitize_csv_cell_or_none() -> None:
+    assert sanitize_csv_cell_or_none(None) is None
+    assert sanitize_csv_cell_or_none("=SUM(A1)") == "'=SUM(A1)"
+    assert sanitize_csv_cell_or_none("safe") == "safe"
 
 
 def test_sanitize_csv_row_sanitizes_values_and_preserves_none() -> None:

--- a/backend/tests/unit/onyx/utils/test_csv_utils.py
+++ b/backend/tests/unit/onyx/utils/test_csv_utils.py
@@ -1,0 +1,54 @@
+import pytest
+
+from onyx.utils.csv_utils import sanitize_csv_cell
+from onyx.utils.csv_utils import sanitize_csv_row
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Formula-trigger prefixes get neutralized with a leading quote
+        ("=cmd|' /C calc'!A1", "'=cmd|' /C calc'!A1"),
+        ("=1+1", "'=1+1"),
+        ("+1234", "'+1234"),
+        ("-1234", "'-1234"),
+        ("@SUM(A1)", "'@SUM(A1)"),
+        ("\tleading-tab", "'\tleading-tab"),
+        ("\rleading-cr", "'\rleading-cr"),
+        # Email local parts can legally start with a formula trigger
+        ("=evil@example.com", "'=evil@example.com"),
+        # Normal values pass through untouched
+        ("hello world", "hello world"),
+        ("user@example.com", "user@example.com"),
+        ("1234", "1234"),
+        ("", ""),
+        # Formula chars not in the leading position are fine
+        ("a=b", "a=b"),
+        ("foo + bar", "foo + bar"),
+    ],
+)
+def test_sanitize_csv_cell(value: str, expected: str) -> None:
+    assert sanitize_csv_cell(value) == expected
+
+
+def test_sanitize_csv_row_sanitizes_values_and_preserves_none() -> None:
+    row: dict[str, str | None] = {
+        "user_message": '=HYPERLINK("http://evil.example")',
+        "ai_response": "a normal response",
+        "feedback_text": None,
+        "user_email": "@user@example.com",
+    }
+
+    assert sanitize_csv_row(row) == {
+        "user_message": '\'=HYPERLINK("http://evil.example")',
+        "ai_response": "a normal response",
+        "feedback_text": None,
+        "user_email": "'@user@example.com",
+    }
+
+
+def test_sanitize_csv_row_keys_unchanged() -> None:
+    row: dict[str, str | None] = {"=key": "value"}
+    # Keys come from our own model fields, not user input — only values are
+    # sanitized.
+    assert sanitize_csv_row(row) == {"=key": "value"}


### PR DESCRIPTION
## Description

Fixes Oneleet pentest finding **ON-008 (CSV Injection in Query History Export)** — https://linear.app/onyx-app/issue/ENG-4129

Chat messages exported via the query history CSV were written verbatim, so a message starting with `=`, `+`, `-`, or `@` (e.g. a DDE payload like `=cmd|' /C calc'!A1`) executes as a formula when an admin opens the export in Excel/LibreOffice.

Changes:
- Adds `sanitize_csv_cell` / `sanitize_csv_cell_or_none` / `sanitize_csv_row` to `onyx/utils/csv_utils.py` — values starting with a formula-trigger character (`= + - @`, tab, CR) are prefixed with a single quote, which spreadsheet software renders as text.
- Applies sanitization to all three CSV export write sites:
  - query history export task (`ee/.../query_history/tasks.py`)
  - admin users CSV download (`/manage/users/download`) — email local parts can legally start with a formula trigger
  - usage report chat messages CSV (`ee/.../reporting/usage_export_generation.py`) — `assistant_name` and `user_email` are user-supplied (flagged in review)
- Swept for other CSV producers (`text/csv` / `FileType.CSV` write sites) — no others exist.

## How Has This Been Tested?

- New unit tests: `backend/tests/unit/onyx/utils/test_csv_utils.py` (17 cases — payload escaping, clean values untouched, None preserved, non-leading formula chars untouched). All pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check