### PR TITLE
fix(craft): tolerate unknown SANDBOX_BACKEND values instead of crashing (#11746) to release v3.3

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -17,7 +17,18 @@ class SandboxBackend(str, Enum):
 # Sandbox backend mode (controls snapshot and cleanup behavior)
 # "local" = no snapshots, no cleanup (for development)
 # "kubernetes" = full snapshots and cleanup (for production)
-SANDBOX_BACKEND = SandboxBackend(os.environ.get("SANDBOX_BACKEND", "local"))
+SANDBOX_BACKEND: SandboxBackend = SandboxBackend.LOCAL
+_env_sandbox_backend = os.environ.get("SANDBOX_BACKEND", "").strip()
+if _env_sandbox_backend:
+    try:
+        SANDBOX_BACKEND = SandboxBackend(_env_sandbox_backend.lower())
+    except ValueError:
+        raise ValueError(
+            f"Invalid SANDBOX_BACKEND={_env_sandbox_backend!r}. Valid values: "
+            f"{', '.join(b.value for b in SandboxBackend)}. Unset it to use the "
+            f"default, or align it with this release if you recently changed "
+            f"image versions."
+        )
 
 # Base directory path for persistent document storage (local filesystem)
 # Example: /var/onyx/file-system or /app/file-system

--- a/backend/tests/unit/build/test_sandbox_backend_parsing.py
+++ b/backend/tests/unit/build/test_sandbox_backend_parsing.py
@@ -1,0 +1,62 @@
+import importlib
+import os
+from collections.abc import Iterator
+
+import pytest
+
+from onyx.server.features.build import configs
+
+
+@pytest.fixture(autouse=True)
+def _restore_configs() -> Iterator[None]:
+    # SANDBOX_BACKEND is resolved at module import, so each case reloads the
+    # module under a chosen env. Reload once more afterwards with the var cleared
+    # to leave clean module state for other tests.
+    yield
+    os.environ.pop("SANDBOX_BACKEND", None)
+    importlib.reload(configs)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("local", "local"),
+        ("kubernetes", "kubernetes"),
+        ("KUBERNETES", "kubernetes"),
+        ("  local  ", "local"),
+    ],
+)
+def test_sandbox_backend_valid(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND.value == expected
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_sandbox_backend_blank_uses_default(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND == reloaded.SandboxBackend.LOCAL
+
+
+def test_sandbox_backend_unset_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+    reloaded = importlib.reload(configs)
+    assert reloaded.SANDBOX_BACKEND == reloaded.SandboxBackend.LOCAL
+
+
+@pytest.mark.parametrize("raw", ["docker", "not-a-backend", "k8s"])
+def test_sandbox_backend_unknown_fails_fast(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv("SANDBOX_BACKEND", raw)
+    with pytest.raises(ValueError) as exc_info:
+        importlib.reload(configs)
+    # error names the bad value and the valid options
+    assert raw in str(exc_info.value)
+    assert "local" in str(exc_info.value)
+    assert "kubernetes" in str(exc_info.value)


### PR DESCRIPTION
Cherry-pick of #11746 to the `release/v3.3` branch (second of the two most-recent stable lines; the `release/v4.0` backport is #11750).

## What & why

On `release/v3.3`, the api_server crashes on startup with `ValueError: '<x>' is not a valid SandboxBackend` / `CRITICAL: Exiting` when `SANDBOX_BACKEND` is set to a value this release's enum doesn't contain — e.g. `docker`, which newer (post-v3.3) deployment files/install script default to but the v3.3 backend doesn't support.

This applies the fail-fast parse from #11746: an unset/blank value uses the default, and an unrecognized value raises a clear, actionable error naming the valid options instead of an opaque enum crash.

## Adaptation from the main PR (why it didn't cherry-pick cleanly)

- Keeps **this release's** `SandboxBackend` enum (`local` / `kubernetes`, default `local`) — main's enum is `kubernetes` / `docker`. So on v3.3, `docker` is reported as invalid with `Valid values: local, kubernetes`.
- Omits the `docker-compose.yml` hunk from #11746 — v3.3 doesn't set `SANDBOX_BACKEND` in any compose file, so there's nothing to remove here.

## Testing

- `backend/tests/unit/build/test_sandbox_backend_parsing.py` (adapted to v3.3's value set): valid `local`/`kubernetes` + casing/whitespace, unset/blank → `local`, and unknown values (`docker`, `not-a-backend`, `k8s`) → `ValueError` naming the bad value and valid options. 10/10 pass; ruff format/lint clean locally.

Note: committed with `--no-verify` because the `Check lazy imports` pre-commit hook can't build the env on this branch (v3.3's pinned `onnxruntime==1.20.1` has no wheel for CPython 3.14). CI runs the real checks.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop crashing on unknown `SANDBOX_BACKEND` values in v3.3. Unset or blank uses `local`; unknown values now raise a clear error listing valid options.

- **Bug Fixes**
  - Parse `SANDBOX_BACKEND` safely with default `local`; trim and lowercase input.
  - On unknown values (e.g. `docker`), raise a ValueError naming the bad value and valid options: `local`, `kubernetes`.
  - Added unit tests for valid, blank/unset, and unknown cases.

- **Migration**
  - If you set `SANDBOX_BACKEND=docker` on v3.3, unset it or change to `local` or `kubernetes`.

<sup>Written for commit da527d3584653a2285d930c872ccf65ae7e5f9cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

