### PR TITLE
feat(craft): Decode gmail payloads on approval

### DIFF
--- a/backend/onyx/external_apps/presentation/decode.py
+++ b/backend/onyx/external_apps/presentation/decode.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from onyx.db.models import ExternalApp
+from onyx.external_apps.providers.registry import get_provider_for_app
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def decode_action_payload(
+    app: ExternalApp, action_type: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """Human-readable view of ``payload`` for ``action_type``.
+
+    Resolves the provider's decoder and applies it. Fails open to the original
+    ``payload`` (no decoder, or a decoder that raises) so the gate is never
+    blanked or broken.
+    """
+    provider = get_provider_for_app(app)
+    if provider is None:
+        return payload
+    decoder = provider.payload_decoder(action_type)
+    if decoder is None:
+        return payload
+    try:
+        return decoder.decode(payload)
+    except Exception:
+        logger.exception(
+            "payload_decode_failed app_type=%s action_type=%s",
+            app.app_type,
+            action_type,
+        )
+        return payload

--- a/backend/onyx/external_apps/presentation/decode.py
+++ b/backend/onyx/external_apps/presentation/decode.py
@@ -1,33 +1,30 @@
 from typing import Any
 
-from onyx.db.models import ExternalApp
-from onyx.external_apps.providers.registry import get_provider_for_app
+from onyx.external_apps.presentation.payload_decoders import PayloadDecoder
+from onyx.external_apps.providers.registry import PROVIDERS
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# action_type namespaces its provider, so entries can't collide.
+_DECODERS: dict[str, PayloadDecoder] = {
+    action_type: decoder
+    for provider in PROVIDERS.values()
+    for action_type, decoder in provider.payload_decoders().items()
+}
 
-def decode_action_payload(
-    app: ExternalApp, action_type: str, payload: dict[str, Any]
-) -> dict[str, Any]:
+
+def decode_payload(action_type: str, payload: dict[str, Any]) -> dict[str, Any]:
     """Human-readable view of ``payload`` for ``action_type``.
 
-    Resolves the provider's decoder and applies it. Fails open to the original
-    ``payload`` (no decoder, or a decoder that raises) so the gate is never
-    blanked or broken.
+    Fails open to ``payload`` (no decoder, or a decoder that raises) so the
+    approval is never blanked or broken.
     """
-    provider = get_provider_for_app(app)
-    if provider is None:
-        return payload
-    decoder = provider.payload_decoder(action_type)
+    decoder = _DECODERS.get(action_type)
     if decoder is None:
         return payload
     try:
         return decoder.decode(payload)
     except Exception:
-        logger.exception(
-            "payload_decode_failed app_type=%s action_type=%s",
-            app.app_type,
-            action_type,
-        )
+        logger.exception("payload_decode_failed action_type=%s", action_type)
         return payload

--- a/backend/onyx/external_apps/presentation/payload_decoders.py
+++ b/backend/onyx/external_apps/presentation/payload_decoders.py
@@ -20,7 +20,7 @@ class PayloadDecoder(Protocol):
         ...
 
 
-class GmailRawMimeDecoder:
+class GmailRawMimeDecoder(PayloadDecoder):
     """Decode the base64url RFC-822 message in a Gmail body into reviewable fields.
 
     ``messages.send`` carries it directly (``{"raw": …}``); draft create/update
@@ -72,12 +72,17 @@ def _b64url_decode(data: str) -> bytes:
     return base64.urlsafe_b64decode(data + padding)
 
 
+# Recipient headers surfaced on the card; the lower-cased name is the payload
+# key ("To" -> "to").
+_RECIPIENT_HEADERS = ("To", "Cc", "Bcc")
+
+
 def _summarize_message(message: EmailMessage) -> dict[str, Any]:
     """The reviewable fields of a parsed message; absent fields are omitted."""
     summary: dict[str, Any] = {}
-    for field, header in (("to", "To"), ("cc", "Cc"), ("bcc", "Bcc")):
+    for header in _RECIPIENT_HEADERS:
         if recipients := _addresses(message.get_all(header)):
-            summary[field] = recipients
+            summary[header.lower()] = recipients
     if subject := message["Subject"]:
         summary["subject"] = str(subject)
     if body := _plain_body(message):

--- a/backend/onyx/external_apps/presentation/payload_decoders.py
+++ b/backend/onyx/external_apps/presentation/payload_decoders.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import base64
+import binascii
+from email import message_from_bytes
+from email import policy
+from email.message import EmailMessage
+from email.utils import formataddr
+from email.utils import getaddresses
+from typing import Any
+from typing import Protocol
+
+
+class PayloadDecoder(Protocol):
+    """A single (provider, action) body-decoding strategy."""
+
+    def decode(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Human-readable view of ``payload``. MUST fail open — return ``payload``
+        unchanged rather than raise — so an unparseable body still surfaces."""
+        ...
+
+
+class GmailRawMimeDecoder:
+    """Decode a base64url RFC-822 message at ``raw_path`` into reviewable fields.
+
+    ``messages.send`` holds it top-level (``{"raw": …}``); draft create/update
+    nest it (``{"message": {"raw": …}}``). Surfaces all recipients and attachment
+    metadata (never contents), replacing the blob in place. Falls back to the raw
+    payload if the field is absent or unparseable.
+    """
+
+    def __init__(self, raw_path: tuple[str, ...]) -> None:
+        self._raw_path = raw_path
+
+    def decode(self, payload: dict[str, Any]) -> dict[str, Any]:
+        raw = _dig(payload, self._raw_path)
+        if not isinstance(raw, str):
+            return payload
+        try:
+            message = message_from_bytes(_b64url_decode(raw), policy=policy.default)
+        except (binascii.Error, ValueError):
+            return payload
+        return _replace_raw(payload, self._raw_path, _summarize_message(message))
+
+
+def _dig(payload: dict[str, Any], path: tuple[str, ...]) -> Any:
+    """The value at ``path`` within nested dicts, or ``None`` if absent."""
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _replace_raw(
+    payload: dict[str, Any], path: tuple[str, ...], summary: dict[str, Any]
+) -> dict[str, Any]:
+    """``payload`` with the ``raw`` key at ``path`` swapped for ``summary``; all
+    other keys kept."""
+    head, *tail = path
+    if not tail:
+        return {**{k: v for k, v in payload.items() if k != head}, **summary}
+    nested = payload.get(head)
+    if not isinstance(nested, dict):
+        return payload
+    return {**payload, head: _replace_raw(nested, tuple(tail), summary)}
+
+
+def _b64url_decode(data: str) -> bytes:
+    """base64url-decode, restoring the padding Gmail's encoder strips."""
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def _summarize_message(message: EmailMessage) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    for field, header in (("to", "To"), ("cc", "Cc"), ("bcc", "Bcc")):
+        recipients = _addresses(message.get_all(header))
+        if recipients:
+            summary[field] = recipients
+    subject = message["Subject"]
+    if subject:
+        summary["subject"] = str(subject)
+    body = _plain_body(message)
+    if body:
+        summary["body"] = body
+    attachments = _attachments(message)
+    if attachments:
+        summary["attachments"] = attachments
+    return summary
+
+
+def _addresses(values: list[Any] | None) -> list[str]:
+    """Flatten one or more address headers to ``Name <addr>`` / ``addr`` strings."""
+    if not values:
+        return []
+    return [
+        formataddr((name, addr)) if name else addr
+        for name, addr in getaddresses([str(value) for value in values])
+        if addr
+    ]
+
+
+def _plain_body(message: EmailMessage) -> str:
+    """The message's text body, preferring plaintext over HTML."""
+    body_part = message.get_body(preferencelist=("plain", "html"))
+    if body_part is None:
+        return ""
+    try:
+        content = body_part.get_content()
+    except (LookupError, ValueError):
+        return ""
+    return content.strip() if isinstance(content, str) else ""
+
+
+def _attachments(message: EmailMessage) -> list[dict[str, Any]]:
+    """Attachment metadata only — filename, type, and byte size; never content."""
+    attachments: list[dict[str, Any]] = []
+    for part in message.iter_attachments():
+        content = part.get_payload(decode=True)
+        attachments.append(
+            {
+                "filename": part.get_filename() or "(unnamed)",
+                "type": part.get_content_type(),
+                "size": len(content) if isinstance(content, bytes) else 0,
+            }
+        )
+    return attachments

--- a/backend/onyx/external_apps/presentation/payload_decoders.py
+++ b/backend/onyx/external_apps/presentation/payload_decoders.py
@@ -21,50 +21,49 @@ class PayloadDecoder(Protocol):
 
 
 class GmailRawMimeDecoder:
-    """Decode a base64url RFC-822 message at ``raw_path`` into reviewable fields.
+    """Decode the base64url RFC-822 message in a Gmail body into reviewable fields.
 
-    ``messages.send`` holds it top-level (``{"raw": …}``); draft create/update
-    nest it (``{"message": {"raw": …}}``). Surfaces all recipients and attachment
-    metadata (never contents), replacing the blob in place. Falls back to the raw
-    payload if the field is absent or unparseable.
+    ``messages.send`` carries it directly (``{"raw": …}``); draft create/update
+    wrap it under ``message`` (``{"message": {"raw": …}}``). ``wrapper_key`` names
+    that wrapper, or ``None`` when ``raw`` is top-level.
+
+    The opaque blob is replaced in place with To/Cc/Bcc/Subject/Body and
+    attachment metadata (never attachment contents); all other keys are kept.
+    Falls back to the raw payload if ``raw`` is missing or won't parse.
     """
 
-    def __init__(self, raw_path: tuple[str, ...]) -> None:
-        self._raw_path = raw_path
+    def __init__(self, wrapper_key: str | None = None) -> None:
+        self._wrapper_key = wrapper_key
 
     def decode(self, payload: dict[str, Any]) -> dict[str, Any]:
-        raw = _dig(payload, self._raw_path)
-        if not isinstance(raw, str):
+        container = self._container(payload)
+        if container is None or not isinstance(container.get("raw"), str):
             return payload
-        try:
-            message = message_from_bytes(_b64url_decode(raw), policy=policy.default)
-        except (binascii.Error, ValueError):
+        message = _parse_mime(container["raw"])
+        if message is None:
             return payload
-        return _replace_raw(payload, self._raw_path, _summarize_message(message))
+
+        decoded = {key: value for key, value in container.items() if key != "raw"}
+        decoded.update(_summarize_message(message))
+        if self._wrapper_key is None:
+            return decoded
+        return {**payload, self._wrapper_key: decoded}
+
+    def _container(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        """The dict that directly holds ``raw`` — ``payload`` itself, or its
+        ``wrapper_key`` sub-dict — or ``None`` when that isn't a dict."""
+        if self._wrapper_key is None:
+            return payload
+        nested = payload.get(self._wrapper_key)
+        return nested if isinstance(nested, dict) else None
 
 
-def _dig(payload: dict[str, Any], path: tuple[str, ...]) -> Any:
-    """The value at ``path`` within nested dicts, or ``None`` if absent."""
-    current: Any = payload
-    for key in path:
-        if not isinstance(current, dict):
-            return None
-        current = current.get(key)
-    return current
-
-
-def _replace_raw(
-    payload: dict[str, Any], path: tuple[str, ...], summary: dict[str, Any]
-) -> dict[str, Any]:
-    """``payload`` with the ``raw`` key at ``path`` swapped for ``summary``; all
-    other keys kept."""
-    head, *tail = path
-    if not tail:
-        return {**{k: v for k, v in payload.items() if k != head}, **summary}
-    nested = payload.get(head)
-    if not isinstance(nested, dict):
-        return payload
-    return {**payload, head: _replace_raw(nested, tuple(tail), summary)}
+def _parse_mime(raw_b64: str) -> EmailMessage | None:
+    """Parse a base64url-encoded RFC-822 message, or ``None`` if it won't decode."""
+    try:
+        return message_from_bytes(_b64url_decode(raw_b64), policy=policy.default)
+    except (binascii.Error, ValueError):
+        return None
 
 
 def _b64url_decode(data: str) -> bytes:
@@ -74,19 +73,16 @@ def _b64url_decode(data: str) -> bytes:
 
 
 def _summarize_message(message: EmailMessage) -> dict[str, Any]:
+    """The reviewable fields of a parsed message; absent fields are omitted."""
     summary: dict[str, Any] = {}
     for field, header in (("to", "To"), ("cc", "Cc"), ("bcc", "Bcc")):
-        recipients = _addresses(message.get_all(header))
-        if recipients:
+        if recipients := _addresses(message.get_all(header)):
             summary[field] = recipients
-    subject = message["Subject"]
-    if subject:
+    if subject := message["Subject"]:
         summary["subject"] = str(subject)
-    body = _plain_body(message)
-    if body:
+    if body := _plain_body(message):
         summary["body"] = body
-    attachments = _attachments(message)
-    if attachments:
+    if attachments := _attachments(message):
         summary["attachments"] = attachments
     return summary
 

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 
 from onyx.db.enums import ExternalAppType
+from onyx.external_apps.presentation.payload_decoders import PayloadDecoder
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.utils.logger import setup_logger
 
@@ -144,6 +145,11 @@ class ExternalAppProvider(ABC):
                 f"{cls.__name__} must define `spec` as a "
                 f"{cls._spec_type.__name__} instance."
             )
+
+    def payload_decoder(self, action_type: str) -> PayloadDecoder | None:
+        """Display decoder for ``action_type``'s request body, or ``None`` if it
+        needs none. Override per provider."""
+        ...
 
 
 class OnyxManagedExtApp(ExternalAppProvider, abstract=True):

--- a/backend/onyx/external_apps/providers/base.py
+++ b/backend/onyx/external_apps/providers/base.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from abc import abstractmethod
+from collections.abc import Mapping
 from typing import Any
 from typing import ClassVar
 
@@ -146,10 +147,10 @@ class ExternalAppProvider(ABC):
                 f"{cls._spec_type.__name__} instance."
             )
 
-    def payload_decoder(self, action_type: str) -> PayloadDecoder | None:
-        """Display decoder for ``action_type``'s request body, or ``None`` if it
-        needs none. Override per provider."""
-        ...
+    def payload_decoders(self) -> Mapping[str, PayloadDecoder]:
+        """Display decoders for this provider's request bodies, keyed by
+        ``action_type``. Empty by default; override to register decoders."""
+        return {}
 
 
 class OnyxManagedExtApp(ExternalAppProvider, abstract=True):

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from onyx.configs.app_configs import EXT_APP_GMAIL_CLIENT_ID
 from onyx.configs.app_configs import EXT_APP_GMAIL_CLIENT_SECRET
 from onyx.db.enums import EndpointPolicy
@@ -168,11 +170,11 @@ class GmailProvider(GoogleOAuthProvider, OnyxManagedExtApp):
 
     # base64url MIME bodies decoded for the approval card. `messages.send` holds
     # `raw` top-level; draft create/update nest it under `message`.
-    _PAYLOAD_DECODERS: dict[str, PayloadDecoder] = {
+    _PAYLOAD_DECODERS: Mapping[str, PayloadDecoder] = {
         GmailAction.MESSAGES_SEND: GmailRawMimeDecoder(("raw",)),
         GmailAction.DRAFTS_CREATE: GmailRawMimeDecoder(("message", "raw")),
         GmailAction.DRAFTS_UPDATE: GmailRawMimeDecoder(("message", "raw")),
     }
 
-    def payload_decoder(self, action_type: str) -> PayloadDecoder | None:
-        return self._PAYLOAD_DECODERS.get(action_type)
+    def payload_decoders(self) -> Mapping[str, PayloadDecoder]:
+        return self._PAYLOAD_DECODERS

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -171,9 +171,9 @@ class GmailProvider(GoogleOAuthProvider, OnyxManagedExtApp):
     # base64url MIME bodies decoded for the approval card. `messages.send` holds
     # `raw` top-level; draft create/update nest it under `message`.
     _PAYLOAD_DECODERS: Mapping[str, PayloadDecoder] = {
-        GmailAction.MESSAGES_SEND: GmailRawMimeDecoder(("raw",)),
-        GmailAction.DRAFTS_CREATE: GmailRawMimeDecoder(("message", "raw")),
-        GmailAction.DRAFTS_UPDATE: GmailRawMimeDecoder(("message", "raw")),
+        GmailAction.MESSAGES_SEND: GmailRawMimeDecoder(),
+        GmailAction.DRAFTS_CREATE: GmailRawMimeDecoder(wrapper_key="message"),
+        GmailAction.DRAFTS_UPDATE: GmailRawMimeDecoder(wrapper_key="message"),
     }
 
     def payload_decoders(self) -> Mapping[str, PayloadDecoder]:

--- a/backend/onyx/external_apps/providers/gmail.py
+++ b/backend/onyx/external_apps/providers/gmail.py
@@ -2,6 +2,8 @@ from onyx.configs.app_configs import EXT_APP_GMAIL_CLIENT_ID
 from onyx.configs.app_configs import EXT_APP_GMAIL_CLIENT_SECRET
 from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
+from onyx.external_apps.presentation.payload_decoders import GmailRawMimeDecoder
+from onyx.external_apps.presentation.payload_decoders import PayloadDecoder
 from onyx.external_apps.providers.actions import EndpointSpec
 from onyx.external_apps.providers.actions import ExternalAppAction
 from onyx.external_apps.providers.actions import RestRoute
@@ -163,3 +165,14 @@ class GmailProvider(GoogleOAuthProvider, OnyxManagedExtApp):
         "client_id": EXT_APP_GMAIL_CLIENT_ID,
         "client_secret": EXT_APP_GMAIL_CLIENT_SECRET,
     }
+
+    # base64url MIME bodies decoded for the approval card. `messages.send` holds
+    # `raw` top-level; draft create/update nest it under `message`.
+    _PAYLOAD_DECODERS: dict[str, PayloadDecoder] = {
+        GmailAction.MESSAGES_SEND: GmailRawMimeDecoder(("raw",)),
+        GmailAction.DRAFTS_CREATE: GmailRawMimeDecoder(("message", "raw")),
+        GmailAction.DRAFTS_UPDATE: GmailRawMimeDecoder(("message", "raw")),
+    }
+
+    def payload_decoder(self, action_type: str) -> PayloadDecoder | None:
+        return self._PAYLOAD_DECODERS.get(action_type)

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -20,7 +20,6 @@ from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.external_apps.matching.request import ProxiedRequest
-from onyx.external_apps.presentation.decode import decode_action_payload
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -87,12 +86,7 @@ class ExternalAppActionMatcher(ActionMatcher):
             request.raw_content or b"",
             (request.headers.get("content-type") or "").lower(),
         )
-        # Overwrite with a human-readable form for the approval card. Display-only:
-        # the forwarded request is untouched; fails open to the raw payload.
-        display_payload = decode_action_payload(
-            app, matched.decisive.action_type, payload or {}
-        )
-        return matched.model_copy(update={"payload": display_payload})
+        return matched.model_copy(update={"payload": payload or {}})
 
 
 def _decode_body(body: bytes, content_type: str) -> dict[str, Any] | None:

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -20,6 +20,7 @@ from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import match_action
 from onyx.external_apps.matching.engine import RequestMatch
 from onyx.external_apps.matching.request import ProxiedRequest
+from onyx.external_apps.presentation.decode import decode_action_payload
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -86,7 +87,12 @@ class ExternalAppActionMatcher(ActionMatcher):
             request.raw_content or b"",
             (request.headers.get("content-type") or "").lower(),
         )
-        return matched.model_copy(update={"payload": payload or {}})
+        # Overwrite with a human-readable form for the approval card. Display-only:
+        # the forwarded request is untouched; fails open to the raw payload.
+        display_payload = decode_action_payload(
+            app, matched.decisive.action_type, payload or {}
+        )
+        return matched.model_copy(update={"payload": display_payload})
 
 
 def _decode_body(body: bytes, content_type: str) -> dict[str, Any] | None:

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -63,7 +63,7 @@ class ApprovalView(BaseModel):
     decision: ApprovalDecision | None
     decided_at: datetime | None
 
-    @computed_field  # type: ignore[prop-decorator]
+    @computed_field
     @property
     def display_payload(self) -> dict[str, Any]:
         """`payload` decoded for the reviewer (e.g. Gmail base64url MIME →
@@ -71,7 +71,7 @@ class ApprovalView(BaseModel):
         action_type = self.actions[0].action_type if self.actions else ""
         return decode_payload(action_type, self.payload)
 
-    @computed_field  # type: ignore[prop-decorator]
+    @computed_field
     @property
     def is_live(self) -> bool:
         if self.decision is not None:

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -31,6 +31,7 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.presentation.decode import decode_payload
 from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build.db import action_approval
 from onyx.server.features.build.db.build_session import get_build_session
@@ -61,6 +62,14 @@ class ApprovalView(BaseModel):
     created_at: datetime
     decision: ApprovalDecision | None
     decided_at: datetime | None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def display_payload(self) -> dict[str, Any]:
+        """`payload` decoded for the reviewer (e.g. Gmail base64url MIME →
+        To/Subject/Body), or `payload` itself when nothing decodes it."""
+        action_type = self.actions[0].action_type if self.actions else ""
+        return decode_payload(action_type, self.payload)
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -63,12 +63,12 @@ class BuiltInSkillDefinition(BaseModel):
     is_available: Callable[[Session], bool] = _always_available
     unavailable_reason: str | None = None
 
-    @computed_field  # type: ignore[prop-decorator]
+    @computed_field
     @property
     def source_dir(self) -> Path:
         return Path(SKILLS_TEMPLATE_PATH) / self.built_in_skill_id
 
-    @computed_field  # type: ignore[prop-decorator]
+    @computed_field
     @property
     def has_template(self) -> bool:
         # Disk-derived so it can't drift from the actual source layout.

--- a/backend/tests/unit/build/test_approval_display_payload.py
+++ b/backend/tests/unit/build/test_approval_display_payload.py
@@ -1,0 +1,58 @@
+import base64
+import datetime
+from email.message import EmailMessage
+from typing import Any
+from uuid import uuid4
+
+from onyx.db.enums import EndpointPolicy
+from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.providers.gmail import GmailAction
+from onyx.server.features.build.approvals.api import ApprovalView
+
+
+def _send_payload() -> dict[str, Any]:
+    message = EmailMessage()
+    message["To"] = "alice@example.com"
+    message["Subject"] = "Hi"
+    message.set_content("Body text")
+    raw = base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+    return {"raw": raw}
+
+
+def _view(action_type: str, payload: dict[str, Any]) -> ApprovalView:
+    return ApprovalView(
+        approval_id=uuid4(),
+        session_id=uuid4(),
+        actions=[
+            ActionMatch(
+                action_type=action_type,
+                display_name="x",
+                description="x",
+                policy=EndpointPolicy.ASK,
+            )
+        ],
+        app_name="Gmail",
+        payload=payload,
+        created_at=datetime.datetime.now(datetime.timezone.utc),
+        decision=None,
+        decided_at=None,
+    )
+
+
+def test_display_payload_decodes_by_decisive_action() -> None:
+    payload = _send_payload()
+
+    view = _view(GmailAction.MESSAGES_SEND, payload)
+
+    assert view.payload == payload  # raw preserved
+    assert view.display_payload["to"] == ["alice@example.com"]
+    assert view.display_payload["subject"] == "Hi"
+    assert "raw" not in view.display_payload
+
+
+def test_display_payload_passthrough_when_no_decoder() -> None:
+    payload = {"addLabelIds": ["INBOX"]}
+
+    view = _view(GmailAction.MESSAGES_MODIFY, payload)
+
+    assert view.display_payload == payload

--- a/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
+++ b/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
@@ -4,9 +4,7 @@ import base64
 from email.message import EmailMessage
 from typing import Any
 
-from onyx.db.enums import ExternalAppType
-from onyx.db.models import ExternalApp
-from onyx.external_apps.presentation.decode import decode_action_payload
+from onyx.external_apps.presentation.decode import decode_payload
 from onyx.external_apps.presentation.payload_decoders import GmailRawMimeDecoder
 from onyx.external_apps.providers.gmail import GmailAction
 from onyx.external_apps.providers.gmail import GmailProvider
@@ -133,54 +131,40 @@ def test_nested_decoder_fails_open_when_message_absent() -> None:
     assert GmailRawMimeDecoder(("message", "raw")).decode(payload) == payload
 
 
-def test_provider_factory_resolves_encoded_body_actions() -> None:
-    provider = GmailProvider()
-    assert isinstance(
-        provider.payload_decoder(GmailAction.MESSAGES_SEND), GmailRawMimeDecoder
-    )
-    assert isinstance(
-        provider.payload_decoder(GmailAction.DRAFTS_CREATE), GmailRawMimeDecoder
-    )
-    assert isinstance(
-        provider.payload_decoder(GmailAction.DRAFTS_UPDATE), GmailRawMimeDecoder
-    )
-    assert provider.payload_decoder(GmailAction.MESSAGES_READ) is None
-    assert provider.payload_decoder("nonexistent.action") is None
+def test_provider_registers_encoded_body_decoders() -> None:
+    decoders = GmailProvider().payload_decoders()
+    assert set(decoders) == {
+        GmailAction.MESSAGES_SEND,
+        GmailAction.DRAFTS_CREATE,
+        GmailAction.DRAFTS_UPDATE,
+    }
+    assert all(isinstance(d, GmailRawMimeDecoder) for d in decoders.values())
 
 
-def _gmail_app() -> ExternalApp:
-    # Transient model is enough — get_provider_for_app reads only app_type.
-    return ExternalApp(app_type=ExternalAppType.GMAIL)
-
-
-def test_orchestrator_decodes_gmail_send() -> None:
+def test_decode_payload_decodes_gmail_send() -> None:
     payload = _raw(_message(to="alice@example.com", subject="Hi", body="Body"))
 
-    decoded = decode_action_payload(_gmail_app(), GmailAction.MESSAGES_SEND, payload)
+    decoded = decode_payload(GmailAction.MESSAGES_SEND, payload)
 
     assert decoded["to"] == ["alice@example.com"]
     assert decoded["subject"] == "Hi"
     assert "raw" not in decoded
 
 
-def test_orchestrator_decodes_draft_create() -> None:
+def test_decode_payload_decodes_draft_create() -> None:
     payload = {"message": _raw(_message(to="alice@example.com", subject="Draft"))}
 
-    decoded = decode_action_payload(_gmail_app(), GmailAction.DRAFTS_CREATE, payload)
+    decoded = decode_payload(GmailAction.DRAFTS_CREATE, payload)
 
     assert decoded["message"]["to"] == ["alice@example.com"]
     assert "raw" not in decoded["message"]
 
 
-def test_orchestrator_passthrough_for_undecoded_action() -> None:
+def test_decode_payload_passthrough_for_undecoded_action() -> None:
     payload = {"addLabelIds": ["INBOX"]}
-    result = decode_action_payload(_gmail_app(), GmailAction.MESSAGES_MODIFY, payload)
-    assert result == payload
+    assert decode_payload(GmailAction.MESSAGES_MODIFY, payload) == payload
 
 
-def test_orchestrator_passthrough_for_unregistered_app() -> None:
+def test_decode_payload_passthrough_for_unknown_action() -> None:
     payload = {"raw": "anything"}
-    result = decode_action_payload(
-        ExternalApp(app_type=ExternalAppType.CUSTOM), "custom.action", payload
-    )
-    assert result == payload
+    assert decode_payload("custom.action", payload) == payload

--- a/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
+++ b/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import base64
+from email.message import EmailMessage
+from typing import Any
+
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.external_apps.presentation.decode import decode_action_payload
+from onyx.external_apps.presentation.payload_decoders import GmailRawMimeDecoder
+from onyx.external_apps.providers.gmail import GmailAction
+from onyx.external_apps.providers.gmail import GmailProvider
+
+# The `messages.send` decoder; draft create/update use the nested `message.raw`.
+_SEND_DECODER = GmailRawMimeDecoder(("raw",))
+
+
+def _b64(message: EmailMessage) -> str:
+    return base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
+
+
+def _raw(message: EmailMessage) -> dict[str, Any]:
+    """The Gmail send body for ``message`` — base64url of the MIME bytes."""
+    return {"raw": _b64(message)}
+
+
+def _message(
+    *,
+    to: str = "alice@example.com",
+    subject: str = "Hello",
+    body: str = "Hi there",
+    cc: str | None = None,
+    bcc: str | None = None,
+) -> EmailMessage:
+    message = EmailMessage()
+    message["To"] = to
+    message["Subject"] = subject
+    if cc:
+        message["Cc"] = cc
+    if bcc:
+        message["Bcc"] = bcc
+    message.set_content(body)
+    return message
+
+
+def test_decodes_recipients_subject_and_body() -> None:
+    payload = _raw(
+        _message(
+            to="alice@example.com, Bob <bob@example.com>",
+            cc="carol@example.com",
+            bcc="dave@example.com",
+            subject="Q2 numbers",
+            body="Here are the numbers.",
+        )
+    )
+
+    decoded = _SEND_DECODER.decode(payload)
+
+    assert decoded["to"] == ["alice@example.com", "Bob <bob@example.com>"]
+    assert decoded["cc"] == ["carol@example.com"]
+    assert decoded["bcc"] == ["dave@example.com"]  # Bcc surfaced, not hidden
+    assert decoded["subject"] == "Q2 numbers"
+    assert decoded["body"] == "Here are the numbers."
+    assert "raw" not in decoded
+
+
+def test_html_only_body_is_extracted() -> None:
+    message = EmailMessage()
+    message["To"] = "alice@example.com"
+    message["Subject"] = "HTML"
+    message.set_content("<p>Hello</p>", subtype="html")
+
+    decoded = _SEND_DECODER.decode(_raw(message))
+
+    assert "Hello" in decoded["body"]
+
+
+def test_attachment_surfaced_as_metadata_only() -> None:
+    message = _message(body="see attached")
+    message.add_attachment(
+        b"%PDF-1.4 fake",
+        maintype="application",
+        subtype="pdf",
+        filename="report.pdf",
+    )
+
+    decoded = _SEND_DECODER.decode(_raw(message))
+
+    assert decoded["attachments"] == [
+        {
+            "filename": "report.pdf",
+            "type": "application/pdf",
+            "size": len(b"%PDF-1.4 fake"),
+        }
+    ]
+    # Metadata only — the bytes themselves are never carried.
+    assert "%PDF" not in str(decoded)
+
+
+def test_sibling_keys_preserved() -> None:
+    payload = _raw(_message())
+    payload["threadId"] = "abc123"
+
+    decoded = _SEND_DECODER.decode(payload)
+
+    assert decoded["threadId"] == "abc123"
+
+
+def test_missing_raw_returns_payload_unchanged() -> None:
+    payload = {"not_raw": "x"}
+    assert _SEND_DECODER.decode(payload) == payload
+
+
+def test_malformed_base64_fails_open_to_raw() -> None:
+    payload = {"raw": "!!!! not base64 !!!!"}
+    # No exception, original payload returned so the reviewer still sees a body.
+    assert _SEND_DECODER.decode(payload) == payload
+
+
+def test_decodes_nested_draft_message() -> None:
+    # Draft create/update nest the MIME under `message`.
+    payload = {"message": _raw(_message(to="alice@example.com", subject="Draft"))}
+
+    decoded = GmailRawMimeDecoder(("message", "raw")).decode(payload)
+
+    assert decoded["message"]["to"] == ["alice@example.com"]
+    assert decoded["message"]["subject"] == "Draft"
+    assert "raw" not in decoded["message"]
+
+
+def test_nested_decoder_fails_open_when_message_absent() -> None:
+    payload = {"id": "draft-123"}  # e.g. a body without the nested message
+    assert GmailRawMimeDecoder(("message", "raw")).decode(payload) == payload
+
+
+def test_provider_factory_resolves_encoded_body_actions() -> None:
+    provider = GmailProvider()
+    assert isinstance(
+        provider.payload_decoder(GmailAction.MESSAGES_SEND), GmailRawMimeDecoder
+    )
+    assert isinstance(
+        provider.payload_decoder(GmailAction.DRAFTS_CREATE), GmailRawMimeDecoder
+    )
+    assert isinstance(
+        provider.payload_decoder(GmailAction.DRAFTS_UPDATE), GmailRawMimeDecoder
+    )
+    assert provider.payload_decoder(GmailAction.MESSAGES_READ) is None
+    assert provider.payload_decoder("nonexistent.action") is None
+
+
+def _gmail_app() -> ExternalApp:
+    # Transient model is enough — get_provider_for_app reads only app_type.
+    return ExternalApp(app_type=ExternalAppType.GMAIL)
+
+
+def test_orchestrator_decodes_gmail_send() -> None:
+    payload = _raw(_message(to="alice@example.com", subject="Hi", body="Body"))
+
+    decoded = decode_action_payload(_gmail_app(), GmailAction.MESSAGES_SEND, payload)
+
+    assert decoded["to"] == ["alice@example.com"]
+    assert decoded["subject"] == "Hi"
+    assert "raw" not in decoded
+
+
+def test_orchestrator_decodes_draft_create() -> None:
+    payload = {"message": _raw(_message(to="alice@example.com", subject="Draft"))}
+
+    decoded = decode_action_payload(_gmail_app(), GmailAction.DRAFTS_CREATE, payload)
+
+    assert decoded["message"]["to"] == ["alice@example.com"]
+    assert "raw" not in decoded["message"]
+
+
+def test_orchestrator_passthrough_for_undecoded_action() -> None:
+    payload = {"addLabelIds": ["INBOX"]}
+    result = decode_action_payload(_gmail_app(), GmailAction.MESSAGES_MODIFY, payload)
+    assert result == payload
+
+
+def test_orchestrator_passthrough_for_unregistered_app() -> None:
+    payload = {"raw": "anything"}
+    result = decode_action_payload(
+        ExternalApp(app_type=ExternalAppType.CUSTOM), "custom.action", payload
+    )
+    assert result == payload

--- a/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
+++ b/backend/tests/unit/external_apps/presentation/test_payload_decoders.py
@@ -9,8 +9,8 @@ from onyx.external_apps.presentation.payload_decoders import GmailRawMimeDecoder
 from onyx.external_apps.providers.gmail import GmailAction
 from onyx.external_apps.providers.gmail import GmailProvider
 
-# The `messages.send` decoder; draft create/update use the nested `message.raw`.
-_SEND_DECODER = GmailRawMimeDecoder(("raw",))
+# The `messages.send` decoder; draft create/update wrap the MIME under `message`.
+_SEND_DECODER = GmailRawMimeDecoder()
 
 
 def _b64(message: EmailMessage) -> str:
@@ -116,10 +116,10 @@ def test_malformed_base64_fails_open_to_raw() -> None:
 
 
 def test_decodes_nested_draft_message() -> None:
-    # Draft create/update nest the MIME under `message`.
+    # Draft create/update wrap the MIME under `message`.
     payload = {"message": _raw(_message(to="alice@example.com", subject="Draft"))}
 
-    decoded = GmailRawMimeDecoder(("message", "raw")).decode(payload)
+    decoded = GmailRawMimeDecoder(wrapper_key="message").decode(payload)
 
     assert decoded["message"]["to"] == ["alice@example.com"]
     assert decoded["message"]["subject"] == "Draft"
@@ -128,7 +128,7 @@ def test_decodes_nested_draft_message() -> None:
 
 def test_nested_decoder_fails_open_when_message_absent() -> None:
     payload = {"id": "draft-123"}  # e.g. a body without the nested message
-    assert GmailRawMimeDecoder(("message", "raw")).decode(payload) == payload
+    assert GmailRawMimeDecoder(wrapper_key="message").decode(payload) == payload
 
 
 def test_provider_registers_encoded_body_decoders() -> None:

--- a/web/src/app/craft/components/CometEdge.stories.tsx
+++ b/web/src/app/craft/components/CometEdge.stories.tsx
@@ -71,6 +71,10 @@ const SLACK_APPROVAL: ApprovalView = {
     channel: "#sales-ops",
     text: "Heads up — 3 enterprise deals slipped to Q4 on procurement review. Recovery playbook in thread. 🧵",
   },
+  display_payload: {
+    channel: "#sales-ops",
+    text: "Heads up — 3 enterprise deals slipped to Q4 on procurement review. Recovery playbook in thread. 🧵",
+  },
   created_at: "2026-05-28T15:42:11Z",
   decision: null,
   decided_at: null,

--- a/web/src/app/craft/components/approvals/ApprovalCard.stories.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.stories.tsx
@@ -40,7 +40,7 @@ const LINEAR_ISSUE_CREATE: ApprovalAction = {
 };
 
 function approval(overrides: Partial<ApprovalView>): ApprovalView {
-  return {
+  const merged = {
     approval_id: "appr-01HX3K9M4Q7W2",
     session_id: "sess-01HX3K9M4Q7W2",
     actions: [SLACK_POST_MESSAGE],
@@ -52,6 +52,8 @@ function approval(overrides: Partial<ApprovalView>): ApprovalView {
     is_live: true,
     ...overrides,
   };
+  // The card renders display_payload; mirror payload unless overridden.
+  return { display_payload: merged.payload, ...merged };
 }
 
 export const Collapsed: Story = {

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -232,7 +232,7 @@ export default function ApprovalCard({
           <CollapsibleContent>
             <div className="p-2 flex flex-col gap-3">
               <ActionList actions={approval.actions} />
-              <PayloadView payload={approval.payload} />
+              <PayloadView payload={approval.display_payload} />
               {errorMessage && (
                 <div className="text-status-error-05">
                   <Text font="secondary-body" color="inherit">

--- a/web/src/app/craft/types/approvals.ts
+++ b/web/src/app/craft/types/approvals.ts
@@ -23,6 +23,7 @@ export interface ApprovalView {
   actions: ApprovalAction[];
   app_name: string;
   payload: Record<string, unknown>;
+  display_payload: Record<string, unknown>;
   created_at: string;
   decision: ApprovalDecision | null;
   decided_at: string | null;


### PR DESCRIPTION
## Description
Gmail has a weird quirk where you send encoded json in the body. This means that when displayed on the approval, you just get meaningless raw base64 encoded data.

This PR implements a decoding strategy so that the body's of payloads can be formatted nicely.

Before:
<img width="761" height="615" alt="Screenshot 2026-06-03 at 10 43 22 AM" src="https://github.com/user-attachments/assets/25e62db7-6957-44d3-8ad5-06c57d91b271" />


After
<img width="806" height="525" alt="Screenshot 2026-06-04 at 1 53 08 PM" src="https://github.com/user-attachments/assets/5948956f-dd03-4abd-82a4-7e62c76b8cf8" />


## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decode Gmail base64url MIME bodies on approval cards so reviewers see To/Subject/Body and attachment metadata instead of raw base64. Adds a provider-driven, fail-open decoding registry and updates the UI to render the decoded `display_payload`.

- **New Features**
  - Provider-based decoding registry keyed by `action_type`.
  - Gmail decoders for `messages.send`, `drafts.create`, and `drafts.update` (handles nested `message`) to surface recipients, subject, body, and attachment metadata (no file contents).
  - Computed `ApprovalView.display_payload` that decodes or falls back to `payload`; `ApprovalCard` renders `display_payload` and stories/types updated.

<sup>Written for commit d0ca33ee6ab51cd9b854e72661ec2b348622003d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

