### PR TITLE
fix(craft): set install.sh SANDBOX_BACKEND by image tag

### DIFF
--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -12,21 +12,14 @@
 ## docker-compose.craft.yml overlay together.
 IMAGE_TAG=latest
 
-## Onyx Craft Configuration
-## Craft enables AI-powered web app building within Onyx (disabled by default).
-## To enable Craft, re-run install.sh with --include-craft. Setting these
-## variables by hand without the craft compose overlay (which only the
-## installer writes) leaves api_server with SANDBOX_BACKEND=docker but no
-## Docker socket mount — sandboxes will fail to provision.
+## Onyx Craft Configuration (off by default).
+## Enable with install.sh --include-craft — it also writes the craft compose
+## overlay; setting these by hand won't mount the Docker socket craft needs.
 # ENABLE_CRAFT=true
 #
-## --- Craft sandbox backend (docker-compose only) ---
-## docker-compose defaults SANDBOX_BACKEND to "docker" so api_server drives
-## sandbox containers directly via the host Docker Engine. This requires
-## mounting /var/run/docker.sock into api_server and background — anything
-## that can talk to the Docker socket is effectively root on the host, so
-## only enable Craft on hosts you fully control. Override to "local" only
-## for development against a single backend process (no isolation).
+## docker backend drives sandboxes via the host Docker socket (root-equivalent;
+## trusted hosts only) and needs v4.0.6+ images. install.sh picks docker vs
+## kubernetes by image tag.
 # SANDBOX_BACKEND=docker
 #
 ## SANDBOX_API_SERVER_URL must be a *public* HTTPS URL the sandbox can reach

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -195,6 +195,32 @@ fetch_latest_release_tag() {
     return 0
 }
 
+# Craft sandbox backend for an image tag. The docker backend exists only in
+# v4.0.6+; older pinned tags get "kubernetes" (rolling tags track newest).
+sandbox_backend_for_tag() {
+    local ver="${1#craft-}"; ver="${ver#v}"; ver="${ver%%-*}"
+    printf '%s' "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' || { echo docker; return; }
+    local major="${ver%%.*}" rest="${ver#*.}"
+    local minor="${rest%%.*}" patch="${rest#*.}"
+    if [ "$major" -gt 4 ] ||
+        { [ "$major" -eq 4 ] && [ "$minor" -gt 0 ]; } ||
+        { [ "$major" -eq 4 ] && [ "$minor" -eq 0 ] && [ "$patch" -ge 6 ]; }; then
+        echo docker
+    else
+        echo kubernetes
+    fi
+}
+
+# Write SANDBOX_BACKEND to .env for image tag $1; sets SANDBOX_BACKEND_VALUE.
+set_sandbox_backend_for_tag() {
+    SANDBOX_BACKEND_VALUE="$(sandbox_backend_for_tag "$1")"
+    if grep -q "^#* *SANDBOX_BACKEND=" "$ENV_FILE"; then
+        sed -i.bak "s/^#* *SANDBOX_BACKEND=.*/SANDBOX_BACKEND=$SANDBOX_BACKEND_VALUE/" "$ENV_FILE"
+    else
+        echo "SANDBOX_BACKEND=$SANDBOX_BACKEND_VALUE" >> "$ENV_FILE"
+    fi
+}
+
 # --- Docker Compose detection ---
 # Sets COMPOSE_CMD to "docker compose" (plugin) or "docker-compose" (standalone).
 # Returns 0 if either is available, 1 otherwise. Safe to re-run after installing
@@ -1005,6 +1031,14 @@ if [ -f "$ENV_FILE" ]; then
         print_success "Will restart with current settings"
     fi
 
+    # Keep SANDBOX_BACKEND aligned with the effective image tag (the one just
+    # chosen, or the pinned IMAGE_TAG already in .env on a plain restart).
+    if [ "$INCLUDE_CRAFT" = true ]; then
+        EFFECTIVE_TAG="${VERSION:-$(grep -E '^IMAGE_TAG=' "$ENV_FILE" | head -1 | cut -d= -f2-)}"
+        set_sandbox_backend_for_tag "$EFFECTIVE_TAG"
+        print_success "Craft sandbox backend set to $SANDBOX_BACKEND_VALUE (image tag: ${EFFECTIVE_TAG})"
+    fi
+
     # Ensure COMPOSE_PROFILES is cleared when running in lite mode on an
     # existing .env (the template ships with s3-filestore enabled).
     if [[ "$LITE_MODE" = true ]] && grep -q "^COMPOSE_PROFILES=.*s3-filestore" "$ENV_FILE" 2>/dev/null; then
@@ -1102,24 +1136,22 @@ else
     if [ "$INCLUDE_CRAFT" = true ]; then
         # Set ENABLE_CRAFT=true for runtime configuration (handles commented and uncommented lines)
         sed -i.bak 's/^#* *ENABLE_CRAFT=.*/ENABLE_CRAFT=true/' "$ENV_FILE" 2>/dev/null || true
-        # Ensure SANDBOX_BACKEND=docker is written explicitly (docker-compose
-        # defaults to it already, but a literal entry in .env makes the
-        # selection visible/auditable to operators).
-        if grep -q "^#* *SANDBOX_BACKEND=" "$ENV_FILE"; then
-            sed -i.bak 's/^#* *SANDBOX_BACKEND=.*/SANDBOX_BACKEND=docker/' "$ENV_FILE"
-        else
-            echo "SANDBOX_BACKEND=docker" >> "$ENV_FILE"
-        fi
-        print_success "Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=docker)"
+        # docker backend exists only in v4.0.6+; older tags get kubernetes.
+        set_sandbox_backend_for_tag "$VERSION"
+        print_success "Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=$SANDBOX_BACKEND_VALUE)"
 
-        echo ""
-        print_warning "Craft + docker backend: api_server and background bind-mount"
-        print_warning "/var/run/docker.sock (RW = root on host on compromise);"
-        print_warning "sandbox-proxy bind-mounts it RO (still exposes container env,"
-        print_warning "labels, and the events stream). Only enable on hosts you fully"
-        print_warning "control. On EC2, require IMDSv2 (HttpTokens=required) so"
-        print_warning "sandboxes cannot pull IAM credentials from instance metadata."
-        echo ""
+        if [ "$SANDBOX_BACKEND_VALUE" = "docker" ]; then
+            echo ""
+            print_warning "Craft + docker backend: api_server and background bind-mount"
+            print_warning "/var/run/docker.sock (RW = root on host on compromise);"
+            print_warning "sandbox-proxy bind-mounts it RO (still exposes container env,"
+            print_warning "labels, and the events stream). Only enable on hosts you fully"
+            print_warning "control. On EC2, require IMDSv2 (HttpTokens=required) so"
+            print_warning "sandboxes cannot pull IAM credentials from instance metadata."
+            echo ""
+        else
+            print_info "Image tag ${VERSION} predates the docker sandbox backend (v4.0.6+); using SANDBOX_BACKEND=${SANDBOX_BACKEND_VALUE}."
+        fi
     else
         print_info "Onyx Craft disabled (use --include-craft to enable)"
     fi


### PR DESCRIPTION
## Description

Follow-up to #11746 that closes the skew at the source. `install.sh --include-craft` hardcoded `SANDBOX_BACKEND=docker` into `.env`, so pinning an image that doesn't support the docker sandbox backend produced a `.env` the image won't run correctly.

This derives the value from the selected image tag instead, via a `sandbox_backend_for_tag()` helper:

- **`docker`** for **v4.0.6+** (where the docker backend exists) and for rolling tags that track the newest build (`edge`, `craft-edge`, `latest`, `craft-latest`, `beta`, `nightly`).
- **`kubernetes`** for **v4.0.5 and older** pinned tags.

It also only prints the docker-socket trust-boundary warning when `docker` is actually selected.

Resolved cases:

| tag | backend |
|---|---|
| `v4.0.5`, `v4.0.0`, `v3.3.10`, `v4.0.5-cloud.3` | `kubernetes` |
| `v4.0.6`, `v4.0.7`, `v4.0.6-beta.0`, `v4.1.0`, `v5.0.0` | `docker` |
| `edge`, `craft-edge`, `latest`, `craft-latest`, `beta`, `nightly` | `docker` |

## How Has This Been Tested?

- Exercised `sandbox_backend_for_tag()` against the tag matrix above (incl. `craft-`/`v` prefixes and `-beta`/`-cloud` suffixes) — all resolve as expected.
- `bash -n` syntax check passes; shellcheck pre-commit hook passes.

No backport needed: `release/v4.0` and `release/v3.3` `install.sh` don't write `SANDBOX_BACKEND`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check