### PR TITLE
feat: rate limit chat message feedback endpoints

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -561,8 +561,10 @@ AUTH_RATE_LIMITING_ENABLED = RATE_LIMIT_MAX_REQUESTS and RATE_LIMIT_WINDOW_SECON
 # Rate limiting for the chat message feedback endpoints. Unlike the auth rate
 # limiting above, this is enabled by default — set either value to 0 to
 # disable. Requires the Redis cache backend (no-op under CACHE_BACKEND=postgres).
+# The limit is per user (all sessions/API keys of an account share one bucket),
+# so the default leaves headroom for legitimate bursts while still blocking floods.
 FEEDBACK_RATE_LIMIT_MAX_REQUESTS = int(
-    os.environ.get("FEEDBACK_RATE_LIMIT_MAX_REQUESTS", "30")
+    os.environ.get("FEEDBACK_RATE_LIMIT_MAX_REQUESTS", "100")
 )
 FEEDBACK_RATE_LIMIT_WINDOW_SECONDS = int(
     os.environ.get("FEEDBACK_RATE_LIMIT_WINDOW_SECONDS", "60")

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -557,6 +557,22 @@ if _rate_limit_max_requests_str is not None:
         pass
 
 AUTH_RATE_LIMITING_ENABLED = RATE_LIMIT_MAX_REQUESTS and RATE_LIMIT_WINDOW_SECONDS
+
+# Rate limiting for the chat message feedback endpoints. Unlike the auth rate
+# limiting above, this is enabled by default — set either value to 0 to
+# disable. Requires the Redis cache backend (no-op under CACHE_BACKEND=postgres).
+FEEDBACK_RATE_LIMIT_MAX_REQUESTS = int(
+    os.environ.get("FEEDBACK_RATE_LIMIT_MAX_REQUESTS", "30")
+)
+FEEDBACK_RATE_LIMIT_WINDOW_SECONDS = int(
+    os.environ.get("FEEDBACK_RATE_LIMIT_WINDOW_SECONDS", "60")
+)
+FEEDBACK_RATE_LIMITING_ENABLED = (
+    FEEDBACK_RATE_LIMIT_MAX_REQUESTS > 0
+    and FEEDBACK_RATE_LIMIT_WINDOW_SECONDS > 0
+    and CACHE_BACKEND == CacheBackendType.REDIS
+)
+
 # Used for general redis things
 REDIS_DB_NUMBER = int(os.environ.get("REDIS_DB_NUMBER", 0))
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -36,7 +36,6 @@ from onyx.cache.interface import CacheBackendType
 from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.configs.app_configs import APP_HOST
 from onyx.configs.app_configs import APP_PORT
-from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
@@ -141,6 +140,7 @@ from onyx.server.metrics.prometheus_setup import setup_prometheus_metrics
 from onyx.server.middleware.latency_logging import add_latency_logging_middleware
 from onyx.server.middleware.rate_limiting import close_auth_limiter
 from onyx.server.middleware.rate_limiting import get_auth_rate_limiters
+from onyx.server.middleware.rate_limiting import RATE_LIMITING_ENABLED
 from onyx.server.middleware.rate_limiting import setup_auth_limiter
 from onyx.server.onyx_api.ingestion import router as onyx_api_router
 from onyx.server.pat.api import router as pat_router
@@ -388,7 +388,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
             record_type=RecordType.VERSION, data={"version": __version__}
         )
 
-    if AUTH_RATE_LIMITING_ENABLED:
+    if RATE_LIMITING_ENABLED:
         await setup_auth_limiter()
 
     if DISABLE_VECTOR_DB:
@@ -423,7 +423,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     except Exception:
         logger.exception("Failed to dispose readonly SQLAlchemy engine on shutdown")
 
-    if AUTH_RATE_LIMITING_ENABLED:
+    if RATE_LIMITING_ENABLED:
         await close_auth_limiter()
 
 

--- a/backend/onyx/server/middleware/rate_limiting.py
+++ b/backend/onyx/server/middleware/rate_limiting.py
@@ -1,25 +1,26 @@
-import hashlib
-from collections.abc import Callable
-from typing import List
-
 from fastapi import Depends
 from fastapi import params
 from fastapi import Request
+from fastapi import Response
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 
+from onyx.auth.users import current_chat_accessible_user
 from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import FEEDBACK_RATE_LIMIT_MAX_REQUESTS
 from onyx.configs.app_configs import FEEDBACK_RATE_LIMIT_WINDOW_SECONDS
 from onyx.configs.app_configs import FEEDBACK_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import RATE_LIMIT_MAX_REQUESTS
 from onyx.configs.app_configs import RATE_LIMIT_WINDOW_SECONDS
-from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
+from onyx.db.enums import AccountType
+from onyx.db.models import User
 from onyx.redis.redis_pool import get_async_redis_connection
 
 RATE_LIMITING_ENABLED = (
     bool(AUTH_RATE_LIMITING_ENABLED) or FEEDBACK_RATE_LIMITING_ENABLED
 )
+
+_RATE_LIMIT_USER_ID_STATE_KEY = "rate_limit_user_id"
 
 
 async def setup_auth_limiter() -> None:
@@ -42,27 +43,17 @@ async def rate_limit_key(request: Request) -> str:
     return f"{ip_part}-{ua_part}"
 
 
-async def user_rate_limit_key(request: Request) -> str:
-    """Rate-limit key for authenticated endpoints.
-
-    Keys on the caller's credential rather than resolving the user from the
-    DB (which would add a query to every request): the session cookie when
-    present, else the Authorization header (API keys), else IP + User-Agent.
-    Values are hashed so raw session tokens / API keys never appear in Redis
-    keys.
-    """
-    session_cookie = request.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME)
-    if session_cookie:
-        return "sess-" + hashlib.sha256(session_cookie.encode("utf-8")).hexdigest()
-
-    auth_header = request.headers.get("authorization")
-    if auth_header:
-        return "auth-" + hashlib.sha256(auth_header.encode("utf-8")).hexdigest()
-
+async def user_scoped_rate_limit_key(request: Request) -> str:
+    """Key on the authenticated user id stashed on request.state by the
+    user-scoped limiter dependency; falls back to IP + User-Agent when no
+    user id was stashed (anonymous access)."""
+    user_id: str | None = getattr(request.state, _RATE_LIMIT_USER_ID_STATE_KEY, None)
+    if user_id is not None:
+        return f"user-{user_id}"
     return await rate_limit_key(request)
 
 
-def get_auth_rate_limiters() -> List[Callable]:
+def get_auth_rate_limiters() -> list[params.Depends]:
     if not AUTH_RATE_LIMITING_ENABLED:
         return []
 
@@ -79,18 +70,40 @@ def get_auth_rate_limiters() -> List[Callable]:
 
 
 def get_feedback_rate_limiters() -> list[params.Depends]:
-    """Per-credential rate limiters for the chat message feedback endpoints
+    """Per-user rate limiters for the chat message feedback endpoints
     (ON-009). Enabled by default; disabled via FEEDBACK_RATE_LIMIT_* env vars
-    or automatically when running without Redis."""
+    or automatically when running without Redis.
+
+    The limiter dependency resolves the authenticated user first, so:
+    - unauthenticated floods are rejected with 401 before touching limiter
+      state, and callers can't mint rate-limit buckets by rotating cookie or
+      Authorization header values,
+    - limits are per user id, so they can't be multiplied by creating extra
+      sessions or varying credential formatting for the same account.
+
+    The shared anonymous user (when anonymous access is enabled) is keyed by
+    IP + User-Agent instead, so one anonymous abuser can't exhaust every
+    anonymous caller's budget.
+    """
     if not FEEDBACK_RATE_LIMITING_ENABLED:
         return []
 
-    return [
-        Depends(
-            RateLimiter(
-                times=FEEDBACK_RATE_LIMIT_MAX_REQUESTS,
-                seconds=FEEDBACK_RATE_LIMIT_WINDOW_SECONDS,
-                identifier=user_rate_limit_key,
-            )
+    limiter = RateLimiter(
+        times=FEEDBACK_RATE_LIMIT_MAX_REQUESTS,
+        seconds=FEEDBACK_RATE_LIMIT_WINDOW_SECONDS,
+        identifier=user_scoped_rate_limit_key,
+    )
+
+    async def user_scoped_feedback_limiter(
+        request: Request,
+        response: Response,
+        user: User = Depends(current_chat_accessible_user),
+    ) -> None:
+        # FastAPI caches the user dependency per-request, so the endpoint's
+        # own auth dependency does not run a second time.
+        request.state.rate_limit_user_id = (
+            str(user.id) if user.account_type != AccountType.ANONYMOUS else None
         )
-    ]
+        await limiter(request, response)
+
+    return [Depends(user_scoped_feedback_limiter)]

--- a/backend/onyx/server/middleware/rate_limiting.py
+++ b/backend/onyx/server/middleware/rate_limiting.py
@@ -1,15 +1,25 @@
+import hashlib
 from collections.abc import Callable
 from typing import List
 
 from fastapi import Depends
+from fastapi import params
 from fastapi import Request
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 
 from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
+from onyx.configs.app_configs import FEEDBACK_RATE_LIMIT_MAX_REQUESTS
+from onyx.configs.app_configs import FEEDBACK_RATE_LIMIT_WINDOW_SECONDS
+from onyx.configs.app_configs import FEEDBACK_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import RATE_LIMIT_MAX_REQUESTS
 from onyx.configs.app_configs import RATE_LIMIT_WINDOW_SECONDS
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.redis.redis_pool import get_async_redis_connection
+
+RATE_LIMITING_ENABLED = (
+    bool(AUTH_RATE_LIMITING_ENABLED) or FEEDBACK_RATE_LIMITING_ENABLED
+)
 
 
 async def setup_auth_limiter() -> None:
@@ -32,6 +42,26 @@ async def rate_limit_key(request: Request) -> str:
     return f"{ip_part}-{ua_part}"
 
 
+async def user_rate_limit_key(request: Request) -> str:
+    """Rate-limit key for authenticated endpoints.
+
+    Keys on the caller's credential rather than resolving the user from the
+    DB (which would add a query to every request): the session cookie when
+    present, else the Authorization header (API keys), else IP + User-Agent.
+    Values are hashed so raw session tokens / API keys never appear in Redis
+    keys.
+    """
+    session_cookie = request.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME)
+    if session_cookie:
+        return "sess-" + hashlib.sha256(session_cookie.encode("utf-8")).hexdigest()
+
+    auth_header = request.headers.get("authorization")
+    if auth_header:
+        return "auth-" + hashlib.sha256(auth_header.encode("utf-8")).hexdigest()
+
+    return await rate_limit_key(request)
+
+
 def get_auth_rate_limiters() -> List[Callable]:
     if not AUTH_RATE_LIMITING_ENABLED:
         return []
@@ -43,6 +73,24 @@ def get_auth_rate_limiters() -> List[Callable]:
                 seconds=RATE_LIMIT_WINDOW_SECONDS or 60,
                 # Use the custom key function to distinguish users
                 identifier=rate_limit_key,
+            )
+        )
+    ]
+
+
+def get_feedback_rate_limiters() -> list[params.Depends]:
+    """Per-credential rate limiters for the chat message feedback endpoints
+    (ON-009). Enabled by default; disabled via FEEDBACK_RATE_LIMIT_* env vars
+    or automatically when running without Redis."""
+    if not FEEDBACK_RATE_LIMITING_ENABLED:
+        return []
+
+    return [
+        Depends(
+            RateLimiter(
+                times=FEEDBACK_RATE_LIMIT_MAX_REQUESTS,
+                seconds=FEEDBACK_RATE_LIMIT_WINDOW_SECONDS,
+                identifier=user_rate_limit_key,
             )
         )
     ]

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -73,6 +73,7 @@ from onyx.llm.factory import get_llm_for_persona
 from onyx.llm.factory import get_llm_token_counter
 from onyx.secondary_llm_flows.chat_session_naming import generate_chat_session_name
 from onyx.server.api_key_usage import check_api_key_usage
+from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
 from onyx.server.query_and_chat.models import ChatFeedbackRequest
 from onyx.server.query_and_chat.models import ChatMessageIdentifier
 from onyx.server.query_and_chat.models import ChatRenameRequest
@@ -743,7 +744,10 @@ def set_preferred_response_endpoint(
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
 
 
-@router.post("/create-chat-message-feedback")
+@router.post(
+    "/create-chat-message-feedback",
+    dependencies=get_feedback_rate_limiters(),
+)
 def create_chat_feedback(
     feedback: ChatFeedbackRequest,
     user: User = Depends(current_chat_accessible_user),
@@ -761,7 +765,10 @@ def create_chat_feedback(
     )
 
 
-@router.delete("/remove-chat-message-feedback")
+@router.delete(
+    "/remove-chat-message-feedback",
+    dependencies=get_feedback_rate_limiters(),
+)
 def remove_chat_feedback(
     chat_message_id: int,
     user: User = Depends(current_chat_accessible_user),

--- a/backend/tests/external_dependency_unit/server/test_feedback_rate_limiting.py
+++ b/backend/tests/external_dependency_unit/server/test_feedback_rate_limiting.py
@@ -1,23 +1,26 @@
-"""Tests for the per-credential rate limiting applied to the chat message
-feedback endpoints (ON-009). Uses a real Redis connection via the centralized
-pool — only the FastAPI app is a minimal stand-in for the real router."""
+"""Tests for the per-user rate limiting applied to the chat message feedback
+endpoints (ON-009). Uses a real Redis connection via the centralized pool —
+the FastAPI app is a minimal stand-in for the real router, with auth
+dependency-overridden to control the resolved user."""
 
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
-from fastapi import Depends
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from fastapi_limiter import FastAPILimiter
-from fastapi_limiter.depends import RateLimiter
 
-from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
+from onyx.auth.users import current_chat_accessible_user
+from onyx.configs.app_configs import FEEDBACK_RATE_LIMIT_MAX_REQUESTS
+from onyx.db.enums import AccountType
 from onyx.redis.redis_pool import get_async_redis_connection
-from onyx.server.middleware.rate_limiting import user_rate_limit_key
+from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
 
-_LIMIT_TIMES = 3
-_LIMIT_WINDOW_SECONDS = 60
+
+def _fake_user(account_type: AccountType = AccountType.STANDARD) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid.uuid4(), account_type=account_type)
 
 
 def _build_app() -> FastAPI:
@@ -30,53 +33,64 @@ def _build_app() -> FastAPI:
 
     app = FastAPI(lifespan=lifespan)
 
-    # Same shape as get_feedback_rate_limiters(), but with a small limit so
-    # the test doesn't need to fire 30 requests.
-    @app.post(
-        "/feedback",
-        dependencies=[
-            Depends(
-                RateLimiter(
-                    times=_LIMIT_TIMES,
-                    seconds=_LIMIT_WINDOW_SECONDS,
-                    identifier=user_rate_limit_key,
-                )
-            )
-        ],
-    )
+    # The real dependency list used by the feedback endpoints
+    @app.post("/feedback", dependencies=get_feedback_rate_limiters())
     def feedback() -> dict[str, str]:
         return {"status": "ok"}
 
     return app
 
 
-def _session_cookie() -> dict[str, str]:
-    # Unique per call so test runs never collide with a stale window
-    return {FASTAPI_USERS_AUTH_COOKIE_NAME: f"test-session-{uuid.uuid4()}"}
-
-
-def test_feedback_rate_limit_blocks_flood_for_same_session() -> None:
+def test_feedback_rate_limit_blocks_flood_for_same_user() -> None:
     app = _build_app()
-    cookies = _session_cookie()
+    user = _fake_user()
+    app.dependency_overrides[current_chat_accessible_user] = lambda: user
 
     with TestClient(app) as client:
-        for _ in range(_LIMIT_TIMES):
-            response = client.post("/feedback", cookies=cookies)
+        for _ in range(FEEDBACK_RATE_LIMIT_MAX_REQUESTS):
+            response = client.post("/feedback")
             assert response.status_code == 200
 
-        response = client.post("/feedback", cookies=cookies)
+        response = client.post("/feedback")
         assert response.status_code == 429
 
 
-def test_feedback_rate_limit_separate_sessions_have_separate_buckets() -> None:
+def test_feedback_rate_limit_separate_users_have_separate_buckets() -> None:
     app = _build_app()
-    first_session = _session_cookie()
-    second_session = _session_cookie()
+    first_user = _fake_user()
+    second_user = _fake_user()
 
     with TestClient(app) as client:
-        for _ in range(_LIMIT_TIMES):
-            assert client.post("/feedback", cookies=first_session).status_code == 200
-        assert client.post("/feedback", cookies=first_session).status_code == 429
+        app.dependency_overrides[current_chat_accessible_user] = lambda: first_user
+        for _ in range(FEEDBACK_RATE_LIMIT_MAX_REQUESTS):
+            assert client.post("/feedback").status_code == 200
+        assert client.post("/feedback").status_code == 429
 
-        # A different session is not affected by the first session's flood
-        assert client.post("/feedback", cookies=second_session).status_code == 200
+        # A different user is not affected by the first user's flood
+        app.dependency_overrides[current_chat_accessible_user] = lambda: second_user
+        assert client.post("/feedback").status_code == 200
+
+
+def test_feedback_rate_limit_same_user_cannot_reset_via_new_session() -> None:
+    """Keying is on the user id, not the session credential — re-logging-in
+    (new cookie) must not grant a fresh budget."""
+    app = _build_app()
+    user = _fake_user()
+    app.dependency_overrides[current_chat_accessible_user] = lambda: user
+
+    with TestClient(app) as client:
+        for _ in range(FEEDBACK_RATE_LIMIT_MAX_REQUESTS):
+            assert (
+                client.post(
+                    "/feedback", cookies={"fastapiusersauth": str(uuid.uuid4())}
+                ).status_code
+                == 200
+            )
+
+        # Fresh cookie value, same user -> still over the limit
+        assert (
+            client.post(
+                "/feedback", cookies={"fastapiusersauth": str(uuid.uuid4())}
+            ).status_code
+            == 429
+        )

--- a/backend/tests/external_dependency_unit/server/test_feedback_rate_limiting.py
+++ b/backend/tests/external_dependency_unit/server/test_feedback_rate_limiting.py
@@ -1,0 +1,82 @@
+"""Tests for the per-credential rate limiting applied to the chat message
+feedback endpoints (ON-009). Uses a real Redis connection via the centralized
+pool — only the FastAPI app is a minimal stand-in for the real router."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import Depends
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from fastapi_limiter import FastAPILimiter
+from fastapi_limiter.depends import RateLimiter
+
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
+from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.server.middleware.rate_limiting import user_rate_limit_key
+
+_LIMIT_TIMES = 3
+_LIMIT_WINDOW_SECONDS = 60
+
+
+def _build_app() -> FastAPI:
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
+        redis = await get_async_redis_connection()
+        await FastAPILimiter.init(redis)
+        yield
+        await FastAPILimiter.close()
+
+    app = FastAPI(lifespan=lifespan)
+
+    # Same shape as get_feedback_rate_limiters(), but with a small limit so
+    # the test doesn't need to fire 30 requests.
+    @app.post(
+        "/feedback",
+        dependencies=[
+            Depends(
+                RateLimiter(
+                    times=_LIMIT_TIMES,
+                    seconds=_LIMIT_WINDOW_SECONDS,
+                    identifier=user_rate_limit_key,
+                )
+            )
+        ],
+    )
+    def feedback() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+def _session_cookie() -> dict[str, str]:
+    # Unique per call so test runs never collide with a stale window
+    return {FASTAPI_USERS_AUTH_COOKIE_NAME: f"test-session-{uuid.uuid4()}"}
+
+
+def test_feedback_rate_limit_blocks_flood_for_same_session() -> None:
+    app = _build_app()
+    cookies = _session_cookie()
+
+    with TestClient(app) as client:
+        for _ in range(_LIMIT_TIMES):
+            response = client.post("/feedback", cookies=cookies)
+            assert response.status_code == 200
+
+        response = client.post("/feedback", cookies=cookies)
+        assert response.status_code == 429
+
+
+def test_feedback_rate_limit_separate_sessions_have_separate_buckets() -> None:
+    app = _build_app()
+    first_session = _session_cookie()
+    second_session = _session_cookie()
+
+    with TestClient(app) as client:
+        for _ in range(_LIMIT_TIMES):
+            assert client.post("/feedback", cookies=first_session).status_code == 200
+        assert client.post("/feedback", cookies=first_session).status_code == 429
+
+        # A different session is not affected by the first session's flood
+        assert client.post("/feedback", cookies=second_session).status_code == 200

--- a/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
+++ b/backend/tests/unit/onyx/db/engine/test_engine_disposal.py
@@ -142,9 +142,7 @@ async def test_lifespan_shutdown_disposes_all_three_engines() -> None:
         stack.enter_context(patch.object(onyx_main, "get_or_generate_uuid"))
         stack.enter_context(patch.object(onyx_main, "optional_telemetry"))
         stack.enter_context(patch.object(onyx_main, "MULTI_TENANT", False))
-        stack.enter_context(
-            patch.object(onyx_main, "AUTH_RATE_LIMITING_ENABLED", False)
-        )
+        stack.enter_context(patch.object(onyx_main, "RATE_LIMITING_ENABLED", False))
         stack.enter_context(patch.object(onyx_main, "DISABLE_VECTOR_DB", False))
         stack.enter_context(patch.object(onyx_main, "OAUTH_CLIENT_ID", ""))
         stack.enter_context(patch.object(onyx_main, "OAUTH_CLIENT_SECRET", ""))


### PR DESCRIPTION
## Description

Fixes Oneleet pentest finding **ON-009 (Lack of Rate Limiting on Chat Message Feedback Endpoint)** — https://linear.app/onyx-app/issue/ENG-4130

The feedback endpoints accepted unlimited submissions (Burp Intruder flood returned 200s indefinitely). This adds per-credential rate limiting to `POST /chat/create-chat-message-feedback` and `DELETE /chat/remove-chat-message-feedback` using the existing fastapi-limiter + Redis infrastructure.

Design notes:
- **Default-on**: 100 requests / 60s per user, configurable via `FEEDBACK_RATE_LIMIT_MAX_REQUESTS` / `FEEDBACK_RATE_LIMIT_WINDOW_SECONDS` (set either to 0 to disable). The existing auth rate limiting stays opt-in; the `FastAPILimiter` lifespan init now runs when either is enabled.
- **Keying**: hashed session cookie → hashed `Authorization` header (API keys) → IP+UA fallback. No DB lookup per request; no raw tokens in Redis keys. Caveat: limits are per-session rather than per-user, so minting new sessions multiplies the budget — acceptable since login itself is the expensive/limitable step.
- **Redis-less mode**: automatically disabled under `CACHE_BACKEND=postgres` so onyx-lite deployments are unaffected.
- Existing usage is far below the limit (integration utils submit feedback 2×; e2e specs a handful), so no CI/test impact.
- 429 `Too Many Requests` is returned by fastapi-limiter's default callback, same as the existing auth limiters.

## How Has This Been Tested?

- New external-dependency-unit tests (`backend/tests/external_dependency_unit/server/test_feedback_rate_limiting.py`) against real Redis: flood blocked with 429 after the limit; separate sessions get separate buckets. Both pass.
- Verified both routes carry the `RateLimiter` dependency and config defaults resolve to enabled by importing the router with the dev env.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-user rate limiting to chat message feedback endpoints to block floods; returns 429 after the limit. Defaults to 100 requests per 60s; addresses Linear ENG-4130 (ON-009).

- **Bug Fixes**
  - Applied `fastapi-limiter` to `POST /chat/create-chat-message-feedback` and `DELETE /chat/remove-chat-message-feedback`.
  - Default 100 requests/60s per user; configurable via `FEEDBACK_RATE_LIMIT_MAX_REQUESTS` and `FEEDBACK_RATE_LIMIT_WINDOW_SECONDS` (set either to 0 to disable). Auto-disabled when `CACHE_BACKEND=postgres`.
  - Keys on resolved user ID; anonymous requests key by IP+UA. Unauthenticated floods 401 before limiter state. Rotating sessions/API keys doesn’t mint new buckets. No raw tokens in `Redis`; no extra DB lookups.
  - App lifespan initializes the limiter when any rate limiting is enabled. Tests cover 429 after the limit, separate user buckets, and that new sessions don’t reset limits.

<sup>Written for commit b6a31ea4a1bebe58f7d54842a4557895fd6bc926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


