### PR TITLE
feat(craft): drive model picker from shared recommended-models config

### DIFF
--- a/backend/onyx/llm/well_known_providers/auto_update_models.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_models.py
@@ -37,13 +37,21 @@ class LLMRecommendations(BaseModel):
     providers: dict[str, LLMProviderRecommendation]
 
     def get_visible_models(self, provider_name: str) -> list[SimpleKnownModel]:
-        """Get the set of models that should be visible by default for a provider."""
-        if provider_name in self.providers:
-            provider_config = self.providers[provider_name]
-            return [provider_config.default_model] + list(
-                provider_config.additional_visible_models
-            )
-        return []
+        """Default model first, then additional models, deduped by name. The
+        default is often repeated in additional_visible_models (where it carries
+        a display name), so keep the entry that has one."""
+        provider_config = self.providers.get(provider_name)
+        if provider_config is None:
+            return []
+        by_name: dict[str, SimpleKnownModel] = {}
+        for model in [
+            provider_config.default_model,
+            *provider_config.additional_visible_models,
+        ]:
+            existing = by_name.get(model.name)
+            if existing is None or (model.display_name and not existing.display_name):
+                by_name[model.name] = model
+        return list(by_name.values())
 
     def get_default_model(self, provider_name: str) -> SimpleKnownModel | None:
         """Get the default model for a provider."""

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -252,6 +252,11 @@ def model_configurations_for_provider(
 ) -> list[ModelConfigurationView]:
     recommended_visible_models = llm_recommendations.get_visible_models(provider_name)
     recommended_visible_models_names = [m.name for m in recommended_visible_models]
+    display_name_by_name = {
+        m.name: m.display_name for m in recommended_visible_models if m.display_name
+    }
+    default_model = llm_recommendations.get_default_model(provider_name)
+    default_model_name = default_model.name if default_model else None
 
     # Preserve provider-defined ordering while de-duplicating.
     model_names: list[str] = []
@@ -273,8 +278,10 @@ def model_configurations_for_provider(
         ModelConfigurationView(
             name=model_name,
             is_visible=model_name in recommended_visible_models_names,
+            is_recommended_default=model_name == default_model_name,
             max_input_tokens=get_max_input_tokens(model_name, provider_name),
             supports_image_input=model_supports_image_input(model_name, provider_name),
+            display_name=display_name_by_name.get(model_name),
         )
         for model_name in model_names
     ]

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.3",
-  "updated_at": "2026-04-28T00:00:00Z",
+  "version": "1.4",
+  "updated_at": "2026-06-04T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": "gpt-5.5",
@@ -11,8 +11,12 @@
       ]
     },
     "anthropic": {
-      "default_model": "claude-opus-4-7",
+      "default_model": "claude-opus-4-8",
       "additional_visible_models": [
+        {
+          "name": "claude-opus-4-8",
+          "display_name": "Claude Opus 4.8"
+        },
         {
           "name": "claude-opus-4-7",
           "display_name": "Claude Opus 4.7"

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -66,15 +66,10 @@ SANDBOX_SERVICE_ACCOUNT_NAME = os.environ.get(
 
 ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 
-# Keep in sync with BUILD_MODE_PROVIDERS in
-# web/src/app/craft/onboarding/constants.ts; enforced by
-# test_build_mode_provider_types_sync.py.
+
+# Provider types Craft supports. The recommended models per type come from the
+# shared recommended-models config (served via /build/recommended-models).
 BUILD_MODE_ALLOWED_PROVIDER_TYPES = ["anthropic", "openai", "openrouter"]
-BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE = {
-    "anthropic": "claude-opus-4-8",
-    "openai": "gpt-5.5",
-    "openrouter": "minimax/minimax-m3",
-}
 
 # Dev/debug-only: exposes an SSE endpoint that tails the sandbox pod's
 # opencode-serve container logs. Never enable in prod — the logs include LLM I/O

--- a/backend/onyx/server/features/build/session/llm_config.py
+++ b/backend/onyx/server/features/build/session/llm_config.py
@@ -8,8 +8,10 @@ restart.
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.well_known_providers.llm_provider_options import (
+    fetch_default_model_for_provider,
+)
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
-from onyx.server.features.build.configs import BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.utils.logger import setup_logger
@@ -18,15 +20,12 @@ logger = setup_logger()
 
 
 def _recommended_model(provider: LLMProviderView) -> str | None:
-    """The Craft-recommended model for ``provider``: the type's recommended
-    model if defined, else the first visible model. ``None`` if the provider
-    has no usable (visible) model."""
+    """Recommended model for ``provider``: the type's default from the shared
+    config, else the first visible model. ``None`` if no visible model."""
     visible_models = [m for m in provider.model_configurations if m.is_visible]
     if not visible_models:
         return None
-    return BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE.get(
-        provider.provider, visible_models[0].name
-    )
+    return fetch_default_model_for_provider(provider.provider) or visible_models[0].name
 
 
 def _config_from_provider(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -73,21 +73,31 @@ class LLMProviderDescriptor(BaseModel):
         llm_provider_model: "LLMProviderModel",
     ) -> "LLMProviderDescriptor":
         from onyx.llm.well_known_providers.llm_provider_options import (
+            fetch_default_model_for_provider,
+        )
+        from onyx.llm.well_known_providers.llm_provider_options import (
             get_provider_display_name,
         )
 
         provider = llm_provider_model.provider
+
+        model_configurations = filter_model_configurations(
+            llm_provider_model.model_configurations,
+            provider,
+            use_stored_display_name=llm_provider_model.custom_config is not None,
+        )
+        default_model = fetch_default_model_for_provider(provider)
+        for model_configuration in model_configurations:
+            model_configuration.is_recommended_default = (
+                model_configuration.name == default_model
+            )
 
         return cls(
             id=llm_provider_model.id,
             name=llm_provider_model.name,
             provider=provider,
             provider_display_name=get_provider_display_name(provider),
-            model_configurations=filter_model_configurations(
-                llm_provider_model.model_configurations,
-                provider,
-                use_stored_display_name=llm_provider_model.custom_config is not None,
-            ),
+            model_configurations=model_configurations,
         )
 
 
@@ -204,6 +214,8 @@ class ModelConfigurationView(BaseModel):
     max_input_tokens: int | None = None
     supports_image_input: bool
     supports_reasoning: bool = False
+    # True when this is the provider's recommended default model.
+    is_recommended_default: bool = False
     display_name: str | None = None
     custom_display_name: str | None = None
     provider_display_name: str | None = None

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -9,6 +9,9 @@ from onyx.llm.model_name_parser import parse_litellm_model_name
 from onyx.llm.utils import get_max_input_tokens
 from onyx.llm.utils import litellm_thinks_model_supports_image_input
 from onyx.llm.utils import model_is_reasoning_model
+from onyx.llm.well_known_providers.llm_provider_options import (
+    fetch_default_model_for_provider,
+)
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
@@ -70,6 +73,8 @@ def assert_response_is_equivalent(
                 req.name, provider_name
             ),
             "supports_reasoning": model_is_reasoning_model(req.name, provider_name),
+            "is_recommended_default": req.name
+            == fetch_default_model_for_provider(provider_name),
             "display_name": display_name,
             "provider_display_name": parsed.provider_display_name,
             "vendor": parsed.vendor,

--- a/backend/tests/unit/onyx/llm/test_llm_provider_options.py
+++ b/backend/tests/unit/onyx/llm/test_llm_provider_options.py
@@ -13,6 +13,35 @@ from onyx.llm.well_known_providers.llm_provider_options import (
 from onyx.llm.well_known_providers.models import SimpleKnownModel
 
 
+def test_get_visible_models_dedupes_default_and_prefers_display_name() -> None:
+    # The default is repeated in additional_visible_models (where it carries a
+    # display name); get_visible_models must return it once, with the name.
+    recommendations = LLMRecommendations(
+        version="test",
+        updated_at=datetime.now(timezone.utc),
+        providers={
+            "anthropic": LLMProviderRecommendation(
+                default_model=SimpleKnownModel(name="claude-opus-4-8"),
+                additional_visible_models=[
+                    SimpleKnownModel(
+                        name="claude-opus-4-8", display_name="Claude Opus 4.8"
+                    ),
+                    SimpleKnownModel(
+                        name="claude-sonnet-4-6", display_name="Claude Sonnet 4.6"
+                    ),
+                ],
+            )
+        },
+    )
+
+    visible = recommendations.get_visible_models("anthropic")
+
+    assert [(m.name, m.display_name) for m in visible] == [
+        ("claude-opus-4-8", "Claude Opus 4.8"),
+        ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+    ]
+
+
 def _build_recommendations(
     provider_name: str, visible_model_names: list[str]
 ) -> LLMRecommendations:
@@ -67,6 +96,58 @@ def test_model_configurations_vertex_are_sorted_by_name(
         True,
         False,
     ]
+
+
+def test_model_configurations_carry_display_name_and_dedupe_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The default is repeated in additional_visible_models (where it carries a
+    # display name); the result must be deduped and carry that display name.
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.fetch_models_for_provider",
+        lambda _provider_name: [],
+    )
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.get_max_input_tokens",
+        lambda _model_name, _provider_name: None,
+    )
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.model_supports_image_input",
+        lambda _model_name, _provider_name: False,
+    )
+
+    recommendations = LLMRecommendations(
+        version="test",
+        updated_at=datetime.now(timezone.utc),
+        providers={
+            "anthropic": LLMProviderRecommendation(
+                default_model=SimpleKnownModel(name="claude-opus-4-8"),
+                additional_visible_models=[
+                    SimpleKnownModel(
+                        name="claude-opus-4-8", display_name="Claude Opus 4.8"
+                    ),
+                    SimpleKnownModel(
+                        name="claude-sonnet-4-6", display_name="Claude Sonnet 4.6"
+                    ),
+                ],
+            )
+        },
+    )
+
+    model_configurations = model_configurations_for_provider(
+        "anthropic", recommendations
+    )
+
+    assert [m.name for m in model_configurations] == [
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+    ]
+    by_name = {m.name: m for m in model_configurations}
+    assert by_name["claude-opus-4-8"].display_name == "Claude Opus 4.8"
+    assert all(m.is_visible for m in model_configurations)
+    # Only the config's default model is flagged as the recommended default.
+    assert by_name["claude-opus-4-8"].is_recommended_default is True
+    assert by_name["claude-sonnet-4-6"].is_recommended_default is False
 
 
 def test_model_configurations_non_vertex_preserve_provider_order(

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -9,6 +9,7 @@ pre-registered when the pod was created.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from datetime import datetime
 from typing import cast
@@ -16,6 +17,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import SandboxStatus
@@ -28,6 +30,25 @@ from onyx.server.features.build.session.llm_config import get_all_build_mode_llm
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.manage.llm.models import ModelConfigurationView
+
+# The recommended default model per provider type is sourced from the shared
+# recommended-models config (GitHub-or-bundled) at runtime. Stub it here so
+# these unit tests are deterministic and don't hit the network.
+_TEST_RECOMMENDED_BY_TYPE = {
+    "anthropic": "claude-opus-4-8",
+    "openai": "gpt-5.5",
+    "openrouter": "minimax/minimax-m3",
+}
+
+
+@pytest.fixture(autouse=True)
+def _stub_recommended_default() -> Iterator[None]:
+    with patch(
+        "onyx.server.features.build.session.llm_config."
+        "fetch_default_model_for_provider",
+        side_effect=lambda provider_name: _TEST_RECOMMENDED_BY_TYPE.get(provider_name),
+    ):
+        yield
 
 
 def _model(name: str, is_visible: bool = True) -> ModelConfigurationView:

--- a/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
+++ b/backend/tests/unit/onyx/server/features/build/test_build_mode_provider_types_sync.py
@@ -1,52 +1,40 @@
-"""Guards that the backend Craft-allowed provider types stay in sync with the
-frontend source of truth (``BUILD_MODE_PROVIDERS`` keys in
-``web/src/app/craft/onboarding/constants.ts``). Drift (e.g. adding a type on one
-side only) fails CI instead of silently mismatching onboarding vs. provisioning."""
+"""Guards for the Craft-supported provider list, which is maintained in two
+runtimes: BUILD_MODE_ALLOWED_PROVIDER_TYPES (backend, used for provisioning /
+DB filtering) and CRAFT_PROVIDERS (frontend, used for the model picker). These
+tests fail loudly if they drift, or if the shared recommended-models config is
+missing a default for a supported type."""
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
 
+from onyx.llm.well_known_providers.llm_provider_options import (
+    _load_bundled_recommendations,
+)
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
-from onyx.server.features.build.configs import BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE
 
 
-def _build_mode_providers_block() -> str:
+def _frontend_craft_provider_keys() -> list[str]:
     rel = Path("web/src/app/craft/onboarding/constants.ts")
     for parent in Path(__file__).resolve().parents:
         candidate = parent / rel
         if candidate.exists():
             text = candidate.read_text()
-            start = text.index("export const BUILD_MODE_PROVIDERS")
-            return text[start : text.index("\n];", start)]
+            start = text.index("export const CRAFT_PROVIDERS")
+            block = text[start : text.index("\n];", start)]
+            return re.findall(r'key:\s*"([^"]+)"', block)
     raise FileNotFoundError(f"Could not locate {rel} above {__file__}")
 
 
-def _frontend_provider_keys() -> list[str]:
-    # Within BUILD_MODE_PROVIDERS only provider objects carry a `key:` field
-    # (models use `name:`), so this captures provider types in order.
-    return re.findall(r'key:\s*"([^"]+)"', _build_mode_providers_block())
+def test_frontend_and_backend_craft_provider_types_match() -> None:
+    assert _frontend_craft_provider_keys() == BUILD_MODE_ALLOWED_PROVIDER_TYPES
 
 
-def _frontend_recommended_by_type() -> dict[str, str]:
-    block = _build_mode_providers_block()
-    result: dict[str, str] = {}
-    # Split into per-provider chunks on `key: "..."`, then within each find the
-    # model object flagged `recommended: true`.
-    for m in re.finditer(r'key:\s*"([^"]+)".*?models:\s*\[(.*?)\]', block, re.DOTALL):
-        key, models_blob = m.group(1), m.group(2)
-        rec = re.search(
-            r'name:\s*"([^"]+)"[^}]*?recommended:\s*true', models_blob, re.DOTALL
+def test_recommended_config_covers_allowed_provider_types() -> None:
+    recommendations = _load_bundled_recommendations()
+    for provider_type in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
+        assert recommendations.get_default_model(provider_type) is not None, (
+            f"recommended-models.json has no default_model for Craft provider "
+            f"type {provider_type!r}"
         )
-        if rec:
-            result[key] = rec.group(1)
-    return result
-
-
-def test_backend_provider_types_match_frontend() -> None:
-    assert _frontend_provider_keys() == BUILD_MODE_ALLOWED_PROVIDER_TYPES
-
-
-def test_backend_recommended_models_match_frontend() -> None:
-    assert _frontend_recommended_by_type() == BUILD_MODE_RECOMMENDED_MODEL_BY_TYPE

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from onyx.db.enums import LLMModelFlowType
+from onyx.server.manage.llm.models import LLMProviderDescriptor
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationView
 
@@ -191,6 +192,72 @@ class TestModelConfigurationUpsertRequestFromModel:
         req = ModelConfigurationUpsertRequest.from_model(mc)
 
         assert req.supports_reasoning is False
+
+
+# LLMProviderDescriptor.from_model — is_recommended_default marking
+#
+# This flag is the only signal the (non-admin) Craft model picker uses to badge
+# and default-select the provider's recommended model on /llm/provider, so it
+# must be set on exactly the recommended-default model.
+
+
+class TestLLMProviderDescriptorRecommendedDefault:
+    @staticmethod
+    def _provider_model(provider: str = "anthropic") -> MagicMock:
+        m = MagicMock()
+        m.id = 1
+        m.name = provider.title()
+        m.provider = provider
+        m.custom_config = None
+        return m
+
+    @staticmethod
+    def _view(name: str) -> ModelConfigurationView:
+        return ModelConfigurationView(
+            name=name, is_visible=True, supports_image_input=False
+        )
+
+    def _from_model(
+        self,
+        provider_model: MagicMock,
+        views: list[ModelConfigurationView],
+        default: str,
+    ) -> LLMProviderDescriptor:
+        with (
+            patch(
+                "onyx.server.manage.llm.models.filter_model_configurations",
+                return_value=views,
+            ),
+            patch(
+                "onyx.llm.well_known_providers.llm_provider_options."
+                "fetch_default_model_for_provider",
+                return_value=default,
+            ),
+        ):
+            return LLMProviderDescriptor.from_model(provider_model)
+
+    def test_marks_only_the_recommended_default_model(self) -> None:
+        descriptor = self._from_model(
+            self._provider_model(),
+            [self._view("claude-opus-4-8"), self._view("claude-sonnet-4-6")],
+            default="claude-opus-4-8",
+        )
+        flags = {
+            m.name: m.is_recommended_default for m in descriptor.model_configurations
+        }
+        assert flags == {"claude-opus-4-8": True, "claude-sonnet-4-6": False}
+
+    def test_nothing_flagged_when_default_not_among_configured_models(self) -> None:
+        # The recommended default isn't configured → no model flagged (the picker
+        # falls back to the first visible model).
+        descriptor = self._from_model(
+            self._provider_model(),
+            [self._view("claude-sonnet-4-6")],
+            default="claude-opus-4-8",
+        )
+        assert all(
+            not m.is_recommended_default for m in descriptor.model_configurations
+        )
 
 
 def _make_model_config(

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -12,11 +12,11 @@ import { Switch } from "@opal/components";
 import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
   BuildLlmSelection,
-  BUILD_MODE_PROVIDERS,
-  isRecommendedModel,
+  CRAFT_PROVIDERS,
 } from "@/app/craft/onboarding/constants";
+import { useLLMProviderOptions } from "@/lib/hooks/useLLMProviderOptions";
 import { ToggleWarningModal } from "./ToggleWarningModal";
-import { getModelIcon } from "@/lib/languageModels";
+import { getModelIcon, getProvider } from "@/lib/languageModels";
 import { Section } from "@/layouts/general-layouts";
 import {
   Accordion,
@@ -52,20 +52,15 @@ export function BuildLLMPopover({
   children,
   disabled = false,
 }: BuildLLMPopoverProps) {
+  // Well-known options expose unconfigured providers (admin-only; non-admins
+  // get nothing here and just see their configured providers).
+  const { llmProviderOptions } = useLLMProviderOptions();
   const [showRecommendedOnly, setShowRecommendedOnly] = useState(true);
   const [showToggleWarning, setShowToggleWarning] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const isClosingModalRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
-
-  // Check which providers are configured (exact match on provider field)
-  const isProviderConfigured = useCallback(
-    (providerKey: string) => {
-      return llmProviders?.some((p) => p.provider === providerKey);
-    },
-    [llmProviders]
-  );
 
   // Get the actual provider descriptor for a configured provider
   const getProviderDescriptor = useCallback(
@@ -75,31 +70,44 @@ export function BuildLLMPopover({
     [llmProviders]
   );
 
+  // Label of the top craft provider's recommended model, for the toggle warning.
+  const recommendedModelLabel = useMemo(() => {
+    for (const { key } of CRAFT_PROVIDERS) {
+      const models =
+        llmProviders?.find((p) => p.provider === key)?.model_configurations ??
+        llmProviderOptions?.find((o) => o.name === key)?.known_models;
+      const rec = models?.find((m) => m.is_recommended_default);
+      if (rec) return rec.display_name || rec.name;
+    }
+    return "the recommended model";
+  }, [llmProviders, llmProviderOptions]);
+
   // Build model options based on mode
   const modelOptions = useMemo((): ModelOption[] => {
     const options: ModelOption[] = [];
 
     if (showRecommendedOnly) {
-      // Show curated list from BUILD_MODE_PROVIDERS
-      BUILD_MODE_PROVIDERS.forEach((provider) => {
-        const isConfigured = isProviderConfigured(provider.providerName);
-        const descriptor = getProviderDescriptor(provider.providerName);
-        const modelsToShow = provider.models.filter((m) => m.recommended);
+      // One recommended model per craft provider type (configured first; for
+      // admins, unconfigured providers come from the well-known options).
+      CRAFT_PROVIDERS.forEach(({ key }) => {
+        const descriptor = getProviderDescriptor(key);
+        const models =
+          descriptor?.model_configurations ??
+          llmProviderOptions?.find((o) => o.name === key)?.known_models;
+        const recModel =
+          models?.find((m) => m.is_recommended_default) ??
+          models?.find((m) => m.is_visible);
+        if (!recModel) return;
 
-        modelsToShow.forEach((model) => {
-          // Get display name from backend if available
-          const backendConfig = descriptor?.model_configurations.find(
-            (mc) => mc.name === model.name
-          );
-          options.push({
-            providerKey: provider.providerName,
-            providerName: descriptor?.name || provider.label,
-            providerDisplayName: provider.label,
-            modelName: model.name,
-            displayName: backendConfig?.display_name || model.label,
-            isRecommended: true,
-            isConfigured: isConfigured ?? false,
-          });
+        const label = getProvider(key).companyName;
+        options.push({
+          providerKey: key,
+          providerName: descriptor?.name || label,
+          providerDisplayName: label,
+          modelName: recModel.name,
+          displayName: recModel.display_name || recModel.name,
+          isRecommended: true,
+          isConfigured: !!descriptor,
         });
       });
     } else {
@@ -117,7 +125,7 @@ export function BuildLLMPopover({
               provider.provider_display_name || provider.provider,
             modelName: model.name,
             displayName: model.display_name || model.name,
-            isRecommended: isRecommendedModel(model.name),
+            isRecommended: model.is_recommended_default ?? false,
             isConfigured: true,
           });
         });
@@ -128,7 +136,7 @@ export function BuildLLMPopover({
   }, [
     showRecommendedOnly,
     llmProviders,
-    isProviderConfigured,
+    llmProviderOptions,
     getProviderDescriptor,
   ]);
 
@@ -441,6 +449,7 @@ export function BuildLLMPopover({
       {/* Warning modal when turning OFF "Recommended Models Only" */}
       <ToggleWarningModal
         open={showToggleWarning}
+        recommendedModelLabel={recommendedModelLabel}
         onConfirm={() => {
           setShowRecommendedOnly(false);
           isClosingModalRef.current = true;

--- a/web/src/app/craft/components/ModelPickerButton.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.tsx
@@ -8,7 +8,6 @@ import { useLLMProviders } from "@/hooks/useLanguageModels";
 import { getModelIcon } from "@/lib/languageModels";
 import {
   BuildLlmSelection,
-  BUILD_MODE_PROVIDERS,
   getDefaultLlmSelection,
 } from "@/app/craft/onboarding/constants";
 
@@ -35,17 +34,11 @@ export default function ModelPickerButton({
 
   const displayName = useMemo(() => {
     if (!effective) return "Select model";
-    if (llmProviders) {
-      for (const provider of llmProviders) {
-        const config = provider.model_configurations.find(
-          (m) => m.name === effective.modelName
-        );
-        if (config) return config.display_name || config.name;
-      }
-    }
-    for (const provider of BUILD_MODE_PROVIDERS) {
-      const model = provider.models.find((m) => m.name === effective.modelName);
-      if (model) return model.label;
+    for (const provider of llmProviders ?? []) {
+      const config = provider.model_configurations.find(
+        (m) => m.name === effective.modelName
+      );
+      if (config) return config.display_name || config.name;
     }
     return effective.modelName;
   }, [effective, llmProviders]);

--- a/web/src/app/craft/components/ToggleWarningModal.tsx
+++ b/web/src/app/craft/components/ToggleWarningModal.tsx
@@ -2,16 +2,17 @@
 
 import { Text } from "@opal/components";
 import { markdown } from "@opal/utils";
-import { RECOMMENDED_CRAFT_MODEL_LABEL } from "@/app/craft/onboarding/constants";
 
 interface ToggleWarningModalProps {
   open: boolean;
+  recommendedModelLabel: string;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 export function ToggleWarningModal({
   open,
+  recommendedModelLabel,
   onConfirm,
   onCancel,
 }: ToggleWarningModalProps) {
@@ -42,7 +43,7 @@ export function ToggleWarningModal({
           <div className="flex justify-center text-center">
             <Text font="main-ui-body" color="text-04">
               {markdown(
-                `We recommend using **${RECOMMENDED_CRAFT_MODEL_LABEL}** for Crafting.\nOther models may have reduced capabilities for code creation,\ndata analysis, and artifact creation.`
+                `We recommend using **${recommendedModelLabel}** for Crafting.\nOther models may have reduced capabilities for code creation,\ndata analysis, and artifact creation.`
               )}
             </Text>
           </div>

--- a/web/src/app/craft/onboarding/__tests__/constants.test.ts
+++ b/web/src/app/craft/onboarding/__tests__/constants.test.ts
@@ -1,0 +1,96 @@
+import {
+  craftModelName,
+  getDefaultLlmSelection,
+  hasSupportedCraftProvider,
+  isSupportedProviderType,
+} from "@/app/craft/onboarding/constants";
+import { ModelConfiguration } from "@/lib/languageModels/types";
+
+function model(
+  name: string,
+  opts: { visible?: boolean; craft?: boolean } = {}
+): ModelConfiguration {
+  return {
+    name,
+    is_visible: opts.visible ?? true,
+    is_recommended_default: opts.craft ?? false,
+    max_input_tokens: null,
+    supports_image_input: false,
+    supports_reasoning: false,
+  };
+}
+
+function provider(providerType: string, models: ModelConfiguration[]) {
+  return {
+    name: providerType,
+    provider: providerType,
+    model_configurations: models,
+  };
+}
+
+describe("isSupportedProviderType", () => {
+  it("recognizes craft provider types", () => {
+    expect(isSupportedProviderType("anthropic")).toBe(true);
+    expect(isSupportedProviderType("openai")).toBe(true);
+    expect(isSupportedProviderType("openrouter")).toBe(true);
+    expect(isSupportedProviderType("azure")).toBe(false);
+  });
+});
+
+describe("hasSupportedCraftProvider", () => {
+  it("is true when a configured provider is a craft type", () => {
+    expect(hasSupportedCraftProvider([{ provider: "anthropic" }])).toBe(true);
+  });
+
+  it("is false for unsupported-only or empty/undefined", () => {
+    expect(hasSupportedCraftProvider([{ provider: "azure" }])).toBe(false);
+    expect(hasSupportedCraftProvider([])).toBe(false);
+    expect(hasSupportedCraftProvider(undefined)).toBe(false);
+  });
+});
+
+describe("craftModelName", () => {
+  it("prefers the is_recommended_default model", () => {
+    expect(craftModelName([model("a"), model("b", { craft: true })])).toBe("b");
+  });
+
+  it("falls back to the first visible model", () => {
+    expect(
+      craftModelName([model("hidden", { visible: false }), model("v")])
+    ).toBe("v");
+  });
+
+  it("returns null when nothing is visible or recommended", () => {
+    expect(craftModelName([model("hidden", { visible: false })])).toBeNull();
+    expect(craftModelName([])).toBeNull();
+  });
+});
+
+describe("getDefaultLlmSelection", () => {
+  it("picks the highest-priority craft provider (anthropic) with its recommended model", () => {
+    const result = getDefaultLlmSelection([
+      provider("openai", [model("gpt-5.5", { craft: true })]),
+      provider("anthropic", [
+        model("claude-opus-4-8", { craft: true }),
+        model("claude-sonnet-4-6"),
+      ]),
+    ]);
+    expect(result).toEqual({
+      providerName: "anthropic",
+      provider: "anthropic",
+      modelName: "claude-opus-4-8",
+    });
+  });
+
+  it("falls back to first visible model when no is_recommended_default flag", () => {
+    const result = getDefaultLlmSelection([
+      provider("openai", [model("gpt-5.5")]),
+    ]);
+    expect(result?.modelName).toBe("gpt-5.5");
+  });
+
+  it("returns null with no providers", () => {
+    expect(getDefaultLlmSelection([])).toBeNull();
+    expect(getDefaultLlmSelection(undefined)).toBeNull();
+  });
+});

--- a/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
+++ b/web/src/app/craft/onboarding/components/BuildOnboardingModal.tsx
@@ -18,9 +18,11 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { testApiKeyHelper } from "@/sections/modals/languageModels/svc";
 import OnboardingInfoPages from "@/app/craft/onboarding/components/OnboardingInfoPages";
 import OnboardingLlmSetup, {
-  PROVIDERS,
   type ProviderKey,
 } from "@/app/craft/onboarding/components/OnboardingLlmSetup";
+import { craftModelName } from "@/app/craft/onboarding/constants";
+import { useLLMProviderOptions } from "@/lib/hooks/useLLMProviderOptions";
+import { getProvider } from "@/lib/languageModels";
 
 interface BuildOnboardingModalProps {
   mode: OnboardingModalMode;
@@ -92,42 +94,50 @@ export default function BuildOnboardingModal({
   // Determine initial provider for add-llm mode
   const initialProvider = mode.type === "add-llm" ? mode.provider : undefined;
 
+  const { llmProviderOptions } = useLLMProviderOptions();
+
+  const knownModelsFor = (providerType: string) =>
+    llmProviderOptions?.find((o) => o.name === providerType)?.known_models ??
+    [];
+
   // LLM setup state
   const [selectedProvider, setSelectedProvider] = useState<ProviderKey>(
     (initialProvider as ProviderKey) || "anthropic"
   );
-  const [selectedModel, setSelectedModel] = useState<string>(
-    PROVIDERS.find((p) => p.key === (initialProvider || "anthropic"))?.models[0]
-      ?.name || ""
-  );
+  const [selectedModel, setSelectedModel] = useState<string>("");
   const [apiKey, setApiKey] = useState("");
   const [connectionStatus, setConnectionStatus] = useState<
     "idle" | "testing" | "success" | "error"
   >("idle");
   const [errorMessage, setErrorMessage] = useState("");
 
-  // Reset LLM state when mode changes to add-llm with a specific provider
+  // Seed the default model once options load; skip if the user chose one.
+  useEffect(() => {
+    if (selectedModel) return;
+    const def = craftModelName(knownModelsFor(selectedProvider));
+    if (def) setSelectedModel(def);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [llmProviderOptions, selectedProvider, selectedModel]);
+
+  // Reset LLM state on add-llm mode change; the seed effect above fills the
+  // model for the new provider (clearing it triggers that effect).
   useEffect(() => {
     if (mode.type === "add-llm" && mode.provider) {
-      const providerConfig = PROVIDERS.find(
-        (p) => p.key === (mode.provider as ProviderKey)
-      );
-      if (providerConfig) {
-        setSelectedProvider(providerConfig.key);
-        setSelectedModel(providerConfig.models[0]?.name || "");
-        setApiKey("");
-        setConnectionStatus("idle");
-        setErrorMessage("");
-      }
+      setSelectedProvider(mode.provider as ProviderKey);
+      setSelectedModel("");
+      setApiKey("");
+      setConnectionStatus("idle");
+      setErrorMessage("");
     }
   }, [mode]);
 
   // Submission state
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const currentProviderConfig = PROVIDERS.find(
-    (p) => p.key === selectedProvider
-  )!;
+  const currentProviderLabel = getProvider(selectedProvider).companyName;
+  const currentProviderModels = knownModelsFor(selectedProvider).filter(
+    (m) => m.is_visible
+  );
   const isLlmValid = apiKey.trim() && selectedModel;
 
   // Calculate step navigation
@@ -156,13 +166,13 @@ export default function BuildOnboardingModal({
     setConnectionStatus("testing");
     setErrorMessage("");
 
-    const providerName = currentProviderConfig.label;
+    const providerName = currentProviderLabel;
     const payload = {
       name: providerName,
-      provider: currentProviderConfig.providerName,
+      provider: selectedProvider,
       api_key: apiKey,
       default_model_name: selectedModel,
-      model_configurations: currentProviderConfig.models.map((m) => ({
+      model_configurations: currentProviderModels.map((m) => ({
         name: m.name,
         is_visible: true,
         max_input_tokens: null,
@@ -171,7 +181,7 @@ export default function BuildOnboardingModal({
     };
 
     const testResult = await testApiKeyHelper(
-      currentProviderConfig.providerName,
+      selectedProvider,
       payload,
       apiKey,
       selectedModel
@@ -226,7 +236,7 @@ export default function BuildOnboardingModal({
       }
 
       track(AnalyticsEvent.CONFIGURED_LLM_PROVIDER, {
-        provider: currentProviderConfig.providerName,
+        provider: selectedProvider,
         is_creation: true,
         source: LLMProviderConfiguredSource.CRAFT_ONBOARDING,
       });

--- a/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
+++ b/web/src/app/craft/onboarding/components/OnboardingLlmSetup.tsx
@@ -6,11 +6,13 @@ import { Disabled } from "@opal/core";
 import { Text, Tooltip } from "@opal/components";
 import { LLMProviderDescriptor } from "@/lib/languageModels/types";
 import {
-  BUILD_MODE_PROVIDERS as PROVIDERS,
+  CRAFT_PROVIDERS,
+  craftModelName,
   type ProviderKey,
 } from "@/app/craft/onboarding/constants";
+import { useLLMProviderOptions } from "@/lib/hooks/useLLMProviderOptions";
+import { getProvider } from "@/lib/languageModels";
 
-export { PROVIDERS };
 export type { ProviderKey };
 
 interface SelectableButtonProps {
@@ -136,21 +138,29 @@ export default function OnboardingLlmSetup({
   onConnectionStatusChange,
   onErrorMessageChange,
 }: OnboardingLlmSetupProps) {
-  const currentProviderConfig = PROVIDERS.find(
-    (p) => p.key === selectedProvider
-  )!;
+  const { llmProviderOptions } = useLLMProviderOptions();
 
-  const isProviderConfigured = (providerName: string) => {
-    return llmProviders?.some((p) => p.provider === providerName) ?? false;
+  const knownModelsFor = (providerType: string) =>
+    llmProviderOptions?.find((o) => o.name === providerType)?.known_models ??
+    [];
+  // Recommended default first; stable sort keeps the rest in provider order.
+  const currentModels = knownModelsFor(selectedProvider)
+    .filter((m) => m.is_visible)
+    .sort(
+      (a, b) =>
+        Number(b.is_recommended_default) - Number(a.is_recommended_default)
+    );
+
+  const isProviderConfigured = (providerType: string) => {
+    return llmProviders?.some((p) => p.provider === providerType) ?? false;
   };
 
   const handleProviderChange = (provider: ProviderKey) => {
-    const providerConfig = PROVIDERS.find((p) => p.key === provider)!;
     // Don't allow selecting already-configured providers
-    if (isProviderConfigured(providerConfig.providerName)) return;
+    if (isProviderConfigured(provider)) return;
 
     onProviderChange(provider);
-    onModelChange(providerConfig.models[0]?.name || "");
+    onModelChange(craftModelName(knownModelsFor(provider)) ?? "");
     onConnectionStatusChange("idle");
     onErrorMessageChange("");
   };
@@ -182,17 +192,17 @@ export default function OnboardingLlmSetup({
           Provider
         </Text>
         <div className="flex justify-center gap-3 w-full max-w-md">
-          {PROVIDERS.map((provider) => {
-            const isConfigured = isProviderConfigured(provider.providerName);
+          {CRAFT_PROVIDERS.map(({ key, recommended }) => {
+            const isConfigured = isProviderConfigured(key);
             return (
-              <div key={provider.key} className="flex-1">
+              <div key={key} className="flex-1">
                 <SelectableButton
-                  selected={selectedProvider === provider.key}
-                  onClick={() => handleProviderChange(provider.key)}
+                  selected={selectedProvider === key}
+                  onClick={() => handleProviderChange(key)}
                   subtext={
                     isConfigured
                       ? "Already configured"
-                      : provider.recommended
+                      : recommended
                         ? "Recommended"
                         : undefined
                   }
@@ -203,7 +213,7 @@ export default function OnboardingLlmSetup({
                       : undefined
                   }
                 >
-                  {provider.label}
+                  {getProvider(key).companyName}
                 </SelectableButton>
               </div>
             );
@@ -217,13 +227,13 @@ export default function OnboardingLlmSetup({
           Default Model
         </Text>
         <div className="flex justify-center gap-3 flex-wrap w-full max-w-md">
-          {currentProviderConfig.models.map((model) => (
+          {currentModels.map((model) => (
             <div key={model.name} className="flex-1 min-w-0">
               <ModelSelectButton
                 selected={selectedModel === model.name}
                 onClick={() => handleModelChange(model.name)}
-                label={model.label}
-                recommended={model.recommended}
+                label={model.display_name || model.name}
+                recommended={model.is_recommended_default}
                 disabled={connectionStatus === "testing"}
               />
             </div>
@@ -242,7 +252,10 @@ export default function OnboardingLlmSetup({
               type="password"
               value={apiKey}
               onChange={(e) => handleApiKeyChange(e.target.value)}
-              placeholder={currentProviderConfig.apiKeyPlaceholder}
+              placeholder={
+                CRAFT_PROVIDERS.find((p) => p.key === selectedProvider)
+                  ?.apiKeyPlaceholder
+              }
               disabled={connectionStatus === "testing"}
               className="w-full px-3 py-2 rounded-08 input-normal text-text-04 placeholder:text-text-02 focus:outline-hidden"
             />

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -2,6 +2,8 @@
 // LLM Selection Types and Utilities
 // =============================================================================
 
+import { ModelConfiguration } from "@/lib/languageModels/types";
+
 export interface BuildLlmSelection {
   providerName: string; // LLMProviderDescriptor.name (any configured provider)
   provider: string; // e.g., "anthropic"
@@ -10,137 +12,63 @@ export interface BuildLlmSelection {
 
 export type ProviderKey = "anthropic" | "openai" | "openrouter";
 
-// Single source of truth for Craft providers/models; everything below derives
-// from it (allowed types, recommended flags, default selection).
-export interface BuildModeModel {
-  name: string;
-  label: string;
-  recommended?: boolean;
-}
-
-export interface BuildModeProvider {
+// Craft-supported provider types (mirrors backend BUILD_MODE_ALLOWED_PROVIDER_TYPES)
+// in priority order, plus the api-key placeholder for onboarding. Which model is
+// recommended comes from the backend `is_recommended_default` flag on each model.
+export const CRAFT_PROVIDERS: {
   key: ProviderKey;
-  label: string;
-  providerName: string;
+  apiKeyPlaceholder: string;
   recommended?: boolean;
-  models: BuildModeModel[];
-  // API-related fields (optional, only needed for onboarding modal)
-  apiKeyPlaceholder?: string;
-  apiKeyUrl?: string;
-  apiKeyLabel?: string;
-}
-
-export const BUILD_MODE_PROVIDERS: BuildModeProvider[] = [
-  {
-    key: "anthropic",
-    label: "Anthropic",
-    providerName: "anthropic",
-    recommended: true,
-    models: [
-      { name: "claude-opus-4-8", label: "Claude Opus 4.8", recommended: true },
-      { name: "claude-opus-4-7", label: "Claude Opus 4.7" },
-      { name: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-    ],
-    apiKeyPlaceholder: "sk-ant-...",
-    apiKeyUrl: "https://console.anthropic.com/dashboard",
-    apiKeyLabel: "Anthropic Console",
-  },
-  {
-    key: "openai",
-    label: "OpenAI",
-    providerName: "openai",
-    models: [
-      { name: "gpt-5.5", label: "GPT-5.5", recommended: true },
-      { name: "gpt-5.4", label: "GPT-5.4" },
-      { name: "gpt-5.3", label: "GPT-5.3" },
-    ],
-    apiKeyPlaceholder: "sk-...",
-    apiKeyUrl: "https://platform.openai.com/api-keys",
-    apiKeyLabel: "OpenAI Dashboard",
-  },
-  {
-    key: "openrouter",
-    label: "OpenRouter",
-    providerName: "openrouter",
-    models: [
-      {
-        name: "minimax/minimax-m3",
-        label: "MiniMax M3",
-        recommended: true,
-      },
-      {
-        name: "moonshotai/kimi-k2.6",
-        label: "Kimi K2.6",
-      },
-    ],
-    apiKeyPlaceholder: "sk-or-...",
-    apiKeyUrl: "https://openrouter.ai/keys",
-    apiKeyLabel: "OpenRouter Dashboard",
-  },
+}[] = [
+  { key: "anthropic", apiKeyPlaceholder: "sk-ant-...", recommended: true },
+  { key: "openai", apiKeyPlaceholder: "sk-..." },
+  { key: "openrouter", apiKeyPlaceholder: "sk-or-..." },
 ];
 
-// Allowed provider types are just the curated providers' keys. Keep
-// BUILD_MODE_PROVIDERS in sync with the backend BUILD_MODE_ALLOWED_PROVIDER_TYPES
-// (enforced by test_build_mode_provider_types_sync.py).
-const ALLOWED_PROVIDER_TYPES = new Set<string>(
-  BUILD_MODE_PROVIDERS.map((p) => p.key)
-);
-const RECOMMENDED_MODEL_NAMES = new Set(
-  BUILD_MODE_PROVIDERS.flatMap((p) =>
-    p.models.filter((m) => m.recommended).map((m) => m.name)
-  )
-);
-
-// Top recommended Craft model's label, derived so UI copy isn't hardcoded.
-export const RECOMMENDED_CRAFT_MODEL_LABEL: string = (() => {
-  const provider =
-    BUILD_MODE_PROVIDERS.find((p) => p.recommended) ?? BUILD_MODE_PROVIDERS[0]!;
-  const model =
-    provider.models.find((m) => m.recommended) ?? provider.models[0]!;
-  return model.label;
-})();
+const CRAFT_PROVIDER_KEYS = new Set<string>(CRAFT_PROVIDERS.map((p) => p.key));
 
 interface MinimalLlmProvider {
   name: string | null;
   provider: string;
+  model_configurations: ModelConfiguration[];
 }
 
 export function isSupportedProviderType(provider: string): boolean {
-  return ALLOWED_PROVIDER_TYPES.has(provider);
+  return CRAFT_PROVIDER_KEYS.has(provider);
 }
 
-// True when at least one configured provider is a supported Craft type
-// (anthropic/openai/openrouter). The gate for both onboarding LLM setup and
-// pre-provisioning — an unsupported-only setup (e.g. Azure) can't craft.
 export function hasSupportedCraftProvider(
   llmProviders: { provider: string }[] | undefined
 ): boolean {
   return !!llmProviders?.some((p) => isSupportedProviderType(p.provider));
 }
 
-export function isRecommendedModel(modelName: string): boolean {
-  return RECOMMENDED_MODEL_NAMES.has(modelName);
+// The Craft-recommended model name for a provider's model list (the one the
+// backend flagged), falling back to the first visible model.
+export function craftModelName(models: ModelConfiguration[]): string | null {
+  return (
+    models.find((m) => m.is_recommended_default)?.name ??
+    models.find((m) => m.is_visible)?.name ??
+    null
+  );
 }
 
-function defaultModelForType(key: ProviderKey): string {
-  const p = BUILD_MODE_PROVIDERS.find((x) => x.key === key)!;
-  return (p.models.find((m) => m.recommended) ?? p.models[0]!).name;
-}
-
-// Highest-priority configured provider of a supported type, with that type's
-// recommended model. Access control is enforced server-side at session create.
+// Highest-priority configured craft provider, with its recommended model.
+// Access control is enforced server-side at session create.
 export function getDefaultLlmSelection(
   llmProviders: MinimalLlmProvider[] | undefined
 ): BuildLlmSelection | null {
-  if (!llmProviders || llmProviders.length === 0) return null;
+  if (!llmProviders) return null;
 
-  for (const p of BUILD_MODE_PROVIDERS) {
-    const match = llmProviders.find((lp) => lp.provider === p.key);
+  for (const { key } of CRAFT_PROVIDERS) {
+    const match = llmProviders.find((p) => p.provider === key);
     if (match) {
+      const modelName = craftModelName(match.model_configurations);
+      if (!modelName) continue;
       return {
         providerName: match.name ?? "",
         provider: match.provider,
-        modelName: defaultModelForType(p.key),
+        modelName,
       };
     }
   }

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -7,6 +7,8 @@ export interface ModelConfiguration {
   max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
+  /** True when this is the provider's recommended default model. */
+  is_recommended_default?: boolean;
   display_name?: string;
   /** Admin-set override that takes precedence over display_name everywhere in the UI. */
   custom_display_name?: string;


### PR DESCRIPTION
## Description

Onyx Craft's model picker was a hardcoded frontend list (`BUILD_MODE_PROVIDERS`) separate from the shared `recommended-models.json`, which is why **Opus 4.8 wasn't surfacing**. This makes the shared config the single source of truth and **reuses the existing provider APIs** instead of a bespoke Craft endpoint.

### Backend
- `recommended-models.json`: `claude-opus-4-8` is the Anthropic default.
- New `ModelConfigurationView.is_recommended_default` flag = "the provider's recommended default model," computed from the existing `get_default_model` / `fetch_default_model_for_provider`. Populated in `model_configurations_for_provider` (well-known options) and `LLMProviderDescriptor.from_model` (the non-admin `/llm/provider` path). `model_configurations_for_provider` also now propagates the config's `display_name` onto `known_models`.
- **No Craft-specific endpoint/hook/default-helper** — there is one notion of "recommended default," shared by the picker and by `_recommended_model` (sandbox provisioning).

### Frontend
- Deleted the hardcoded `BUILD_MODE_PROVIDERS` and `useCraftRecommendedModels`. The picker + gates reuse the existing `useLLMProviders()`; onboarding reuses `useLLMProviderOptions()` (admin).
- `constants.ts` is now `CRAFT_PROVIDERS` (types + api-key placeholder, mirrors backend `BUILD_MODE_ALLOWED_PROVIDER_TYPES`) + small helpers that read `is_recommended_default`.
- Behavior change: the picker no longer lists *unconfigured* providers to non-admins (they can't connect anyway); admins still see them via the options hook.

## How Has This Been Tested?

Targeted unit tests for the linchpin (the `is_recommended_default` flag the picker depends on) plus the existing suites:
- `test_model_configuration.py::TestLLMProviderDescriptorRecommendedDefault` — `/llm/provider`'s `from_model` flags exactly the recommended-default model, and flags nothing when that model isn't configured (picker falls back to first visible).
- `test_llm_provider_options.py` — `model_configurations_for_provider` flags only the config default, dedupes, and carries display names.
- `test_build_mode_provider_types_sync.py` — guardrail that the frontend `CRAFT_PROVIDERS` list and backend `BUILD_MODE_ALLOWED_PROVIDER_TYPES` can't silently drift, + the bundled config covers every Craft type.
- `constants.test.ts` (frontend) — `getDefaultLlmSelection` priority/fallback, `hasSupportedCraftProvider`, `craftModelName`, `isSupportedProviderType`.
- 351 backend unit tests + frontend tests pass; `ruff`, `ty`, `oxlint`, `tsc` clean via pre-commit. Pre-existing `sandbox/` failures are unrelated network/timing flakes.

<img width="655" height="674" alt="Screenshot 2026-06-06 at 16 36 24" src="https://github.com/user-attachments/assets/db3da94c-3a1e-4ea9-836c-d7232952379d" />


> Note: `get_recommendations()` prefers the `main`-branch copy of `recommended-models.json` (`AUTO_LLM_CONFIG_URL`), so the Opus 4.8 default takes effect once this merges; the deploy follows the merge, so there's no dark window.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check