### PR TITLE
chore(craft): bump sandbox default image to v0.1.52

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -51,7 +51,7 @@ ATTACHMENTS_DIRECTORY = "attachments"
 SANDBOX_NAMESPACE = os.environ.get("SANDBOX_NAMESPACE", "onyx-sandboxes")
 
 SANDBOX_CONTAINER_IMAGE = os.environ.get(
-    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.51"
+    "SANDBOX_CONTAINER_IMAGE", "onyxdotapp/sandbox:v0.1.52"
 )
 
 # Path structure: s3://{bucket}/{tenant_id}/snapshots/{session_id}/{snapshot_id}.tar.gz

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -171,7 +171,7 @@ SANDBOX_SERVICE_ACCOUNT_NAME=sandbox-file-sync  # Has S3 access via IRSA for sna
 
 ```bash
 # Container image (defaults to a pinned tag in docker-compose.yml)
-SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.51
+SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.52
 
 # Public URL the sandbox agent uses to reach Onyx (HTTPS, externally resolvable —
 # compose hostnames like http://api_server:8080 will not resolve from inside the

--- a/deployment/docker_compose/docker-compose.craft.yml
+++ b/deployment/docker_compose/docker-compose.craft.yml
@@ -11,7 +11,7 @@ services:
       # Public Onyx URL; Internal compose hostnames don't resolve from the
       # sandbox bridge.
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.51}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.52}
       # Pinned: Must match the compose `networks:` block + install.sh literal.
       # An env_file leak would point Python at a non-existent network.
       - SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
@@ -45,7 +45,7 @@ services:
       # backend to snapshot + terminate sandboxes.
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-docker}
       - SANDBOX_API_SERVER_URL=${SANDBOX_API_SERVER_URL:-}
-      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.51}
+      - SANDBOX_CONTAINER_IMAGE=${SANDBOX_CONTAINER_IMAGE:-onyxdotapp/sandbox:v0.1.52}
       # See api_server above re: Pinned env_file-override vars.
       - SANDBOX_DOCKER_NETWORK=onyx_craft_sandbox
       - SANDBOX_DOCKER_MEMORY_LIMIT=${SANDBOX_DOCKER_MEMORY_LIMIT:-2g}

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -28,7 +28,7 @@ IMAGE_TAG=latest
 # SANDBOX_API_SERVER_URL=https://onyx.your-org.example
 #
 ## Sandbox container image. Pinned by default for reproducibility.
-# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.51
+# SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:v0.1.52
 #
 ## Sandbox bridge network. Created by install.sh (or manually:
 ##   docker network create onyx_craft_sandbox


### PR DESCRIPTION
## Description

Bumps the pinned Craft sandbox image from `v0.1.51` → `v0.1.52` (built from the build-context refactor in #11748 — relocation to `sandbox/image/` plus skills moved to `onyx/skills/builtin`). Updates every pinned reference:

- `backend/onyx/server/features/build/configs.py` — default pin
- `deployment/docker_compose/docker-compose.craft.yml` — api_server + background
- `deployment/docker_compose/env.template` — commented example
- `backend/onyx/server/features/build/sandbox/README.md` — doc example

Cloud values bumped in companion PR onyx-dot-app/cloud-deployment-yamls#435.

## How Has This Been Tested?

Config-only change. Verified `grep -rn v0.1.51` returns no remaining references after the bump. The `v0.1.52` image is being built by the `experimental-cc4a` tag deploy workflow.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check