### PR TITLE
feat: show connectors page lite mode

### DIFF
--- a/web/src/layouts/admin/ClientLayout.tsx
+++ b/web/src/layouts/admin/ClientLayout.tsx
@@ -9,6 +9,8 @@ import { markdown } from "@opal/utils";
 import useScreenSize from "@/hooks/useScreenSize";
 import { SvgSidebar } from "@opal/icons";
 import { useSidebarState } from "@/layouts/sidebar-layouts";
+import { isVectorDbRequiredRoute } from "@/lib/admin-routes";
+import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
 export interface ClientLayoutProps {
   children: React.ReactNode;
@@ -23,6 +25,15 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
   // Certain admin panels have their own custom sidebar.
   // For those pages, we skip rendering the default `AdminSidebar` and let those individual pages render their own.
   const hasCustomSidebar = pathname.startsWith("/admin/connectors");
+
+  // Lite mode (no vector DB): connector/indexing pages can't run, show a notice.
+  const vectorDbEnabled = settings.settings.vector_db_enabled !== false;
+  const content =
+    !vectorDbEnabled && isVectorDbRequiredRoute(pathname) ? (
+      <LiteModeIndexingNotice />
+    ) : (
+      children
+    );
 
   return (
     <div className="h-screen w-screen flex overflow-hidden">
@@ -43,7 +54,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
       )}
 
       {hasCustomSidebar ? (
-        <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">{children}</div>
+        <div className="flex-1 min-w-0 min-h-0 overflow-y-auto">{content}</div>
       ) : (
         <>
           <AdminSidebar />
@@ -60,7 +71,7 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
                 />
               </div>
             )}
-            {children}
+            {content}
           </div>
         </>
       )}

--- a/web/src/layouts/admin/ClientLayout.tsx
+++ b/web/src/layouts/admin/ClientLayout.tsx
@@ -7,8 +7,9 @@ import { ApplicationStatus } from "@/interfaces/settings";
 import { Button, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
 import useScreenSize from "@/hooks/useScreenSize";
-import { SvgSidebar } from "@opal/icons";
+import { SvgSidebar, SvgSimpleLoader } from "@opal/icons";
 import { useSidebarState } from "@/layouts/sidebar-layouts";
+import { Section } from "@/layouts/general-layouts";
 import { isVectorDbRequiredRoute } from "@/lib/admin-routes";
 import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
@@ -28,12 +29,18 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
 
   // Lite mode (no vector DB): connector/indexing pages can't run, show a notice.
   const vectorDbEnabled = settings.settings.vector_db_enabled !== false;
-  const content =
-    !vectorDbEnabled && isVectorDbRequiredRoute(pathname) ? (
-      <LiteModeIndexingNotice />
-    ) : (
-      children
-    );
+  let content = children;
+  if (isVectorDbRequiredRoute(pathname)) {
+    if (settings.settingsLoading) {
+      content = (
+        <Section padding={2}>
+          <SvgSimpleLoader className="h-6 w-6" />
+        </Section>
+      );
+    } else if (!vectorDbEnabled) {
+      content = <LiteModeIndexingNotice />;
+    }
+  }
 
   return (
     <div className="h-screen w-screen flex overflow-hidden">

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -270,7 +270,8 @@ export function sidebarItem(route: AdminRouteEntry) {
 export const VECTOR_DB_REQUIRED_ROUTE_PREFIXES: readonly string[] = [
   ADMIN_ROUTES.INDEXING_STATUS.path,
   ADMIN_ROUTES.ADD_CONNECTOR.path,
-  ADMIN_ROUTES.DOCUMENT_SETS.path,
+  // Covers /sets, /explorer, and /feedback — all require a vector DB.
+  ADMIN_ROUTES.DOCUMENTS.path,
   ADMIN_ROUTES.INDEX_SETTINGS.path,
   "/admin/connector",
   "/admin/federated",

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -262,3 +262,22 @@ export const ADMIN_ROUTES = {
 export function sidebarItem(route: AdminRouteEntry) {
   return { name: route.sidebarLabel, icon: route.icon, link: route.path };
 }
+
+/**
+ * Connector/indexing admin route prefixes that need a vector DB. In Lite mode
+ * these render an informational notice instead of their normal content.
+ */
+export const VECTOR_DB_REQUIRED_ROUTE_PREFIXES: readonly string[] = [
+  ADMIN_ROUTES.INDEXING_STATUS.path,
+  ADMIN_ROUTES.ADD_CONNECTOR.path,
+  ADMIN_ROUTES.DOCUMENT_SETS.path,
+  ADMIN_ROUTES.INDEX_SETTINGS.path,
+  "/admin/connector",
+  "/admin/federated",
+];
+
+export function isVectorDbRequiredRoute(pathname: string): boolean {
+  return VECTOR_DB_REQUIRED_ROUTE_PREFIXES.some((prefix) =>
+    pathname.startsWith(prefix)
+  );
+}

--- a/web/src/sections/admin/LiteModeIndexingNotice.tsx
+++ b/web/src/sections/admin/LiteModeIndexingNotice.tsx
@@ -1,0 +1,25 @@
+import { IllustrationContent } from "@opal/layouts";
+import { Section } from "@/layouts/general-layouts";
+import SvgUnPlugged from "@opal/illustrations/un-plugged";
+import { markdown } from "@opal/utils";
+import { DOCS_BASE_URL } from "@/lib/constants";
+
+const DEPLOYMENT_DOCS_URL = `${DOCS_BASE_URL}/deployment/getting_started/quickstart`;
+
+/**
+ * Replaces connector/indexing admin pages in Lite mode (no vector DB), where
+ * indexing can't run — points users at a Standard-mode deployment instead.
+ */
+export default function LiteModeIndexingNotice() {
+  return (
+    <Section padding={2}>
+      <IllustrationContent
+        illustration={SvgUnPlugged}
+        title="Indexing is unavailable in Lite mode"
+        description={markdown(
+          `This deployment runs Onyx Lite, which has no vector database — connectors and document indexing are disabled, and nothing is indexed. To connect data sources and index documents, deploy Onyx in **Standard mode**. See the [deployment guide](${DEPLOYMENT_DOCS_URL}) to get started.`
+        )}
+      />
+    </Section>
+  );
+}

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -55,7 +55,6 @@ function buildItems(
   hasSubscription: boolean,
   hooksEnabled: boolean
 ): SidebarItemEntry[] {
-  const vectorDbEnabled = settings?.settings.vector_db_enabled !== false;
   const items: SidebarItemEntry[] = [];
 
   const add = (section: string, route: Parameters<typeof sidebarItem>[0]) => {
@@ -99,17 +98,16 @@ function buildItems(
   add(SECTIONS.AGENTS_AND_ACTIONS, ADMIN_ROUTES.OPENAPI_ACTIONS);
 
   // 3. Documents & Knowledge
-  if (vectorDbEnabled) {
-    add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.INDEXING_STATUS);
-    add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.ADD_CONNECTOR);
-    add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.DOCUMENT_SETS);
-    if (!isCurator) {
-      items.push({
-        ...sidebarItem(ADMIN_ROUTES.INDEX_SETTINGS),
-        section: SECTIONS.DOCUMENTS_AND_KNOWLEDGE,
-        error: settings?.settings.needs_reindexing,
-      });
-    }
+  // Shown even in Lite mode; the pages themselves render a no-indexing notice.
+  add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.INDEXING_STATUS);
+  add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.ADD_CONNECTOR);
+  add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.DOCUMENT_SETS);
+  if (!isCurator) {
+    items.push({
+      ...sidebarItem(ADMIN_ROUTES.INDEX_SETTINGS),
+      section: SECTIONS.DOCUMENTS_AND_KNOWLEDGE,
+      error: settings?.settings.needs_reindexing,
+    });
   }
 
   // 4. Integrations (admin only)


### PR DESCRIPTION
## Description

Show a simple connectors page in lite mode that makes it clear that standard mode has indexing
<img width="1571" height="873" alt="Screenshot 2026-06-04 at 4 02 16 PM" src="https://github.com/user-attachments/assets/b3732b92-5d61-4602-93a6-0485ed10b34e" />


## How Has This Been Tested?

tested manually

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Lite-mode view for connectors and indexing. These routes now show a clear notice that Standard mode is required, keep sidebar items visible, and display a loader while settings load.

- **New Features**
  - Added `LiteModeIndexingNotice` with a link to deployment docs.
  - Added `VECTOR_DB_REQUIRED_ROUTE_PREFIXES` and `isVectorDbRequiredRoute`; `ClientLayout` swaps page content with the notice (or a loader when `settingsLoading` is true) when `vector_db_enabled` is false.
  - Updated admin sidebar to always show Documents & Knowledge; in Lite mode, those pages render the notice.

<sup>Written for commit 2323208c8a7b1ff9cc0c680035e16f4abde6eabe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

