### PR TITLE
fix(discord): grant LIMITED service-account keys chat scope

### DIFF
--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -16,6 +16,7 @@ from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import UNNAMED_KEY_PLACEHOLDER
 from onyx.db.enums import AccountType
+from onyx.db.enums import Permission
 from onyx.db.models import ApiKey
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
@@ -118,6 +119,11 @@ def insert_api_key(
             api_key_user_row,
             is_admin=(api_key_args.role == UserRole.ADMIN),
         )
+    elif api_key_args.role == UserRole.LIMITED:
+        # LIMITED keys join no group, so they get no group-derived permissions.
+        # Grant chat scope directly to preserve their chat-only capability
+        # (WRITE_CHAT implies READ_CHAT).
+        api_key_user_row.effective_permissions = [Permission.WRITE_CHAT.value]
 
     db_session.commit()
 

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -177,9 +177,12 @@ def update_api_key(
                 api_key_user,
                 is_admin=(api_key_args.role == UserRole.ADMIN),
             )
+        elif api_key_args.role == UserRole.LIMITED:
+            # LIMITED keys join no group; grant chat scope directly to match
+            # insert_api_key (WRITE_CHAT implies READ_CHAT).
+            api_key_user.effective_permissions = [Permission.WRITE_CHAT.value]
         else:
-            # No group assigned for LIMITED, but we still need to recompute
-            # since we just removed the old default-group membership above.
+            # Recompute since we just removed the old default-group membership.
             recompute_user_permissions__no_commit(api_key_user.id, db_session)
 
     db_session.commit()

--- a/backend/onyx/db/discord_bot.py
+++ b/backend/onyx/db/discord_bot.py
@@ -15,6 +15,7 @@ from onyx.auth.api_key import hash_api_key
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DISCORD_SERVICE_API_KEY_NAME
 from onyx.db.api_key import insert_api_key
+from onyx.db.enums import Permission
 from onyx.db.models import ApiKey
 from onyx.db.models import DiscordBotConfig
 from onyx.db.models import DiscordChannelConfig
@@ -106,6 +107,12 @@ def get_or_create_discord_service_api_key(
         new_api_key = generate_api_key(tenant_id)
         existing.hashed_api_key = hash_api_key(new_api_key)
         existing.api_key_display = build_displayable_api_key(new_api_key)
+        # Backfill chat scope on keys provisioned before chat APIs were scoped.
+        service_user = db_session.scalar(
+            select(User).where(User.id == existing.user_id)  # ty: ignore[invalid-argument-type]
+        )
+        if service_user is not None:
+            service_user.effective_permissions = [Permission.WRITE_CHAT.value]
         db_session.flush()
         return new_api_key
 
@@ -113,7 +120,7 @@ def get_or_create_discord_service_api_key(
     logger.info("Creating Discord service API key for tenant %s", tenant_id)
     api_key_args = APIKeyArgs(
         name=DISCORD_SERVICE_API_KEY_NAME,
-        role=UserRole.LIMITED,  # Limited role is sufficient for chat requests
+        role=UserRole.LIMITED,  # insert_api_key grants LIMITED keys chat scope
     )
     api_key_descriptor = insert_api_key(
         db_session=db_session,

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
@@ -6,8 +6,10 @@ These tests verify CRUD operations for Discord bot models.
 from collections.abc import Generator
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import get_effective_permissions
 from onyx.db.discord_bot import bulk_create_channel_configs
 from onyx.db.discord_bot import create_discord_bot_config
 from onyx.db.discord_bot import create_guild_config
@@ -24,7 +26,9 @@ from onyx.db.discord_bot import get_or_create_discord_service_api_key
 from onyx.db.discord_bot import sync_channel_configs
 from onyx.db.discord_bot import update_discord_channel_config
 from onyx.db.discord_bot import update_guild_config
+from onyx.db.enums import Permission
 from onyx.db.models import Persona
+from onyx.db.models import User
 from onyx.db.utils import DiscordChannelView
 from onyx.server.manage.discord_bot.utils import generate_discord_registration_key
 
@@ -622,6 +626,59 @@ class TestServiceApiKeyAPI:
         assert stored_key is not None
 
         # Cleanup
+        delete_discord_service_api_key(db_session)
+        db_session.commit()
+
+    def test_service_account_has_chat_scope(self, db_session: Session) -> None:
+        """The Discord service account must hold the scopes the chat surface
+        requires (send-chat-message needs write:chat, which implies read:chat),
+        otherwise require_permission denies the bot."""
+        delete_discord_service_api_key(db_session)
+        db_session.commit()
+
+        get_or_create_discord_service_api_key(db_session, "public")
+        db_session.commit()
+
+        stored_key = get_discord_service_api_key(db_session)
+        assert stored_key is not None
+        service_user = db_session.scalar(
+            select(User).where(User.id == stored_key.user_id)  # ty: ignore[invalid-argument-type]
+        )
+        assert service_user is not None
+        perms = get_effective_permissions(service_user)
+        assert {Permission.READ_CHAT, Permission.WRITE_CHAT} <= perms
+
+        delete_discord_service_api_key(db_session)
+        db_session.commit()
+
+    def test_get_or_create_backfills_legacy_key_scope(
+        self, db_session: Session
+    ) -> None:
+        """A key provisioned before chat APIs were scoped (empty permissions) is
+        repaired with chat scope on the next get_or_create call."""
+        delete_discord_service_api_key(db_session)
+        db_session.commit()
+
+        get_or_create_discord_service_api_key(db_session, "public")
+        db_session.commit()
+
+        # Simulate a legacy key whose backing user has no permissions.
+        stored_key = get_discord_service_api_key(db_session)
+        assert stored_key is not None
+        legacy_user = db_session.scalar(
+            select(User).where(User.id == stored_key.user_id)  # ty: ignore[invalid-argument-type]
+        )
+        assert legacy_user is not None
+        legacy_user.effective_permissions = []
+        db_session.commit()
+
+        get_or_create_discord_service_api_key(db_session, "public")
+        db_session.commit()
+
+        db_session.refresh(legacy_user)
+        perms = get_effective_permissions(legacy_user)
+        assert {Permission.READ_CHAT, Permission.WRITE_CHAT} <= perms
+
         delete_discord_service_api_key(db_session)
         db_session.commit()
 

--- a/backend/tests/integration/tests/permissions/test_basic_access.py
+++ b/backend/tests/integration/tests/permissions/test_basic_access.py
@@ -16,8 +16,9 @@ from tests.integration.common_utils.test_models import DATestUser
 
 # Representative endpoints that use require_permission(Permission.BASIC_ACCESS).
 # One per major router file to cover breadth without redundancy.
+# Chat endpoints are gated by READ_CHAT/WRITE_CHAT (not BASIC_ACCESS) and are
+# covered by test_chat_scopes.py.
 BASIC_ACCESS_ENDPOINTS: list[tuple[str, str]] = [
-    ("GET", "/chat/get-user-chat-sessions"),
     ("GET", "/manage/credential"),
     ("GET", "/manage/connector"),
     ("GET", "/users"),

--- a/backend/tests/integration/tests/permissions/test_chat_scopes.py
+++ b/backend/tests/integration/tests/permissions/test_chat_scopes.py
@@ -5,6 +5,7 @@ import pytest
 from onyx.db.enums import Permission
 from tests.integration.common_utils.http_client import request_status
 from tests.integration.common_utils.managers.pat import PATManager
+from tests.integration.common_utils.test_models import DATestAPIKey
 from tests.integration.common_utils.test_models import DATestUser
 
 _SESSION_ID = "00000000-0000-0000-0000-000000000000"
@@ -71,3 +72,15 @@ def test_non_chat_scope_denied_on_chat_dep_route(
     read_search_headers: dict[str, str],
 ) -> None:
     assert request_status(read_search_headers, CHAT_DEP_ROUTE) == 403
+
+
+def test_limited_service_account_reaches_chat(
+    limited_service_account: DATestAPIKey,
+) -> None:
+    """LIMITED service-account keys (e.g. the Discord bot) hold write:chat
+    (implies read:chat), so they reach the chat surface but not basic-only routes."""
+    headers = limited_service_account.headers
+    assert request_status(headers, READ_CHAT_ROUTE) < 400
+    # bogus id -> 4xx, never 403
+    assert request_status(headers, WRITE_CHAT_ROUTE) != 403
+    assert request_status(headers, BASIC_ONLY_ROUTE) == 403


### PR DESCRIPTION
## Description

#11672 re-guarded the core chat endpoints with `require_permission(READ_CHAT/WRITE_CHAT)`, which checks `User.effective_permissions`. The Discord bot calls `send-chat-message` with a `LIMITED` service-account key, and `LIMITED` keys carry `[]` (only `ADMIN`/`BASIC` keys get group-derived permissions) — so every Discord chat now 403s.

This grants `LIMITED` keys `write:chat` (implies `read:chat`) at creation in `insert_api_key`, and backfills the same on already-provisioned Discord keys in `get_or_create_discord_service_api_key` (applied on the bot's next startup — no migration).

Note: a service account with any permissions is no longer `is_limited_user`, and `read:chat`/`write:chat` also cover list/search/stop — minor, harmless broadenings (the bot only calls `send-chat-message`).

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check