### PR TITLE
fix(craft): Custom apps use glob for upstream url instead of regex

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5946,7 +5946,7 @@ class ExternalApp(Base):
         default=ExternalAppType.CUSTOM,
         server_default=ExternalAppType.CUSTOM.value,
     )
-    # CUSTOM apps store URL globs here (translated to regexes at match time
+    # CUSTOM apps store URL globs here (translated to regexes at match time).
     upstream_url_patterns: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -103,6 +103,7 @@ from onyx.db.enums import UserFileStatus
 from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.pydantic_type import PydanticListType
 from onyx.db.pydantic_type import PydanticType
+from onyx.external_apps.url_glob import UrlGlob
 from onyx.file_store.models import FileDescriptor
 from onyx.kg.models import KGEntityTypeAttributes
 from onyx.kg.models import KGStage
@@ -5945,6 +5946,7 @@ class ExternalApp(Base):
         default=ExternalAppType.CUSTOM,
         server_default=ExternalAppType.CUSTOM.value,
     )
+    # CUSTOM apps store URL globs here (translated to regexes at match time
     upstream_url_patterns: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
     )
@@ -5982,6 +5984,17 @@ class ExternalApp(Base):
         back_populates="external_app",
         cascade="all, delete-orphan",
     )
+
+    @property
+    def upstream_url_regexes(self) -> list[str]:
+        """``upstream_url_patterns`` as match-ready regexes: CUSTOM apps author
+        globs (translated here), built-in providers author regexes used as-is."""
+        if self.app_type == ExternalAppType.CUSTOM:
+            return [
+                UrlGlob(value=pattern).to_regex()
+                for pattern in self.upstream_url_patterns
+            ]
+        return list(self.upstream_url_patterns)
 
 
 class ExternalAppUserCredential(Base):

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -80,7 +80,7 @@ def match_action(
                     action_type="custom_request",
                     display_name=f"{request.method} {request.path}",
                     description="Custom external app request",
-                    policy=EndpointPolicy.ASK,
+                    policy=EndpointPolicy.ALWAYS,
                 ),
             ),
             app_name=app.skill.name,

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -10,6 +10,7 @@ from pydantic import model_validator
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
 from onyx.db.enums import POLICY_SEVERITY
 from onyx.db.external_app import get_policies
 from onyx.db.models import ExternalApp
@@ -71,6 +72,21 @@ def match_action(
     treat ``decisive`` as the verdict-driving action. Body decoding is the
     caller's job — ``payload`` is empty here; refill via ``model_copy``.
     """
+    # Custom apps are routed to ask for now.
+    if app.app_type == ExternalAppType.CUSTOM:
+        return RequestMatch(
+            actions=(
+                ActionMatch(
+                    action_type="custom_request",
+                    display_name=f"{request.method} {request.path}",
+                    description="Custom external app request",
+                    policy=EndpointPolicy.ASK,
+                ),
+            ),
+            app_name=app.skill.name,
+            external_app_id=app.id,
+        )
+
     context = MatchContext(request)
     stored = get_policies(db_session, app.id)
     catalog = get_endpoint_catalog(app.app_type)

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -80,7 +80,7 @@ def match_action(
                     action_type="custom_request",
                     display_name=f"{request.method} {request.path}",
                     description="Custom external app request",
-                    policy=EndpointPolicy.ALWAYS,
+                    policy=EndpointPolicy.ASK,
                 ),
             ),
             app_name=app.skill.name,

--- a/backend/onyx/external_apps/url_glob.py
+++ b/backend/onyx/external_apps/url_glob.py
@@ -52,6 +52,7 @@ class UrlGlob(BaseModel):
 
     @classmethod
     def parse(cls, value: str) -> "UrlGlob":
+        value = value.strip()
         _validate(value)
         return cls(value=value)
 

--- a/backend/onyx/external_apps/url_glob.py
+++ b/backend/onyx/external_apps/url_glob.py
@@ -1,0 +1,60 @@
+import re
+from functools import lru_cache
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+
+
+@lru_cache(maxsize=1024)
+def _to_regex(glob: str) -> str:
+    return ".*".join(re.escape(span) for span in glob.split("*"))
+
+
+def _validate(glob: str) -> None:
+    stripped = glob.strip()
+    if not stripped:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "URL pattern must not be empty.")
+
+    scheme = _SCHEME_RE.match(stripped)
+    if scheme is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"URL pattern must start with http:// or https://: {glob!r}",
+        )
+
+    # The host (up to the first path separator) is the credential-injection
+    # boundary, so it must be literal.
+    host = stripped[scheme.end() :].split("/", 1)[0]
+    if not host:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT, f"URL pattern must include a host: {glob!r}"
+        )
+    if "*" in host:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"URL pattern host must be literal (no wildcards): {glob!r}",
+        )
+
+
+class UrlGlob(BaseModel):
+    """A URL glob. Construct via ``parse`` at trust boundaries (it validates);
+    the plain constructor trusts its input (used when rendering
+    already-validated values loaded from the database)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    value: str
+
+    @classmethod
+    def parse(cls, value: str) -> "UrlGlob":
+        _validate(value)
+        return cls(value=value)
+
+    def to_regex(self) -> str:
+        """The anchored-by-``re.fullmatch`` regex this glob matches as."""
+        return _to_regex(self.value)

--- a/backend/onyx/sandbox_proxy/action_matcher.py
+++ b/backend/onyx/sandbox_proxy/action_matcher.py
@@ -37,20 +37,19 @@ def resolve_app_for_url(
     ``url``, or ``None`` if no connected app claims it.
 
     ``apps`` is expected id-ordered (as ``get_external_apps`` returns it), so the
-    lowest-id app wins when patterns overlap. A malformed stored pattern is
-    skipped rather than failing the whole resolution — egress for other apps must
-    not hinge on one bad regex.
+    lowest-id app wins when patterns overlap. A malformed built-in regex is
+    skipped rather than failing resolution for every other app.
     """
     for app in apps:
-        for pattern in app.upstream_url_patterns:
+        for regex in app.upstream_url_regexes:
             try:
-                if re.fullmatch(pattern, url):
+                if re.fullmatch(regex, url):
                     return app
             except re.error:
                 logger.warning(
                     "skipping malformed upstream_url_pattern app_id=%s pattern=%r",
                     app.id,
-                    pattern,
+                    regex,
                 )
     return None
 

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -33,6 +33,7 @@ from onyx.external_apps.providers.registry import build_action_policies
 from onyx.external_apps.providers.registry import fetch_available_built_in_apps
 from onyx.external_apps.providers.registry import fetch_built_in_app
 from onyx.external_apps.providers.registry import get_onyx_managed_provider
+from onyx.external_apps.url_glob import UrlGlob
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.api.models import BuiltInExternalAppDescriptor
 from onyx.server.features.build.api.models import CreateBuiltInExternalAppRequest
@@ -186,6 +187,16 @@ def update_external_app_admin(
     app = _get_app_or_404(db_session, external_app_id)
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
 
+    # Custom apps author URL patterns as globs; validate them (built-ins author
+    # regexes, which the matcher uses as-is).
+    if (
+        not managed
+        and app.app_type == ExternalAppType.CUSTOM
+        and request.upstream_url_patterns is not None
+    ):
+        for pattern in request.upstream_url_patterns:
+            UrlGlob.parse(pattern)
+
     # Full policy set; None map leaves stored policies untouched.
     action_policies = build_action_policies(
         app.app_type,
@@ -254,6 +265,10 @@ def create_custom_external_app(
             OnyxErrorCode.INVALID_INPUT,
             "upstream_url_patterns must not contain empty entries.",
         )
+    # Custom app globs; validate before ingesting the bundle so a bad
+    # pattern fails fast.
+    for pattern in parsed_patterns:
+        UrlGlob.parse(pattern)
     validate_auth_template(parsed_auth_template, parsed_org_credentials)
 
     if bundle is None:

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -115,6 +115,58 @@ def test_create_persists_skill_and_app(
     db_session.commit()
 
 
+def test_custom_app_glob_matches_deep_path(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom apps store their URL patterns as authored globs; the matcher
+    translates them to regexes that cover deep paths (the Discord 401
+    regression — ``/api/*`` must match ``/api/v10/...``)."""
+    from onyx.sandbox_proxy.action_matcher import resolve_app_for_url
+
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    resp = _create(db_session, test_user, slug)
+    # The glob is stored and round-tripped verbatim — no regex stored at rest.
+    assert resp.upstream_url_patterns == _UPSTREAM
+
+    app = db_session.scalar(select(ExternalApp).where(ExternalApp.id == resp.id))
+    assert app is not None
+    assert list(app.upstream_url_patterns) == _UPSTREAM
+    # The matcher translates the glob, resolving a realistic deep path here.
+    assert resolve_app_for_url("https://api.example.com/v10/users/@me", [app]) is app
+    assert resolve_app_for_url("https://other.example.com/x", [app]) is None
+
+    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.commit()
+
+
+def test_create_rejects_wildcard_host_glob(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    slug = f"custom-test-{uuid4().hex[:8]}"
+
+    with pytest.raises(OnyxError):
+        api.create_custom_external_app(
+            name="Wildcard Host",
+            description="",
+            upstream_url_patterns=json.dumps(["https://*.example.com/*"]),
+            auth_template=json.dumps(_AUTH_TEMPLATE),
+            organization_credentials=json.dumps({"api_key": "sk-test"}),
+            enabled=True,
+            bundle=_upload(f"{slug}.zip"),
+            _=test_user,
+            db_session=db_session,
+        )
+    # Rejected before persistence — no skill row created.
+    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is None
+
+
 def test_create_with_no_credentials(
     db_session: Session,
     test_user: User,

--- a/backend/tests/integration/tests/external_apps/test_external_apps.py
+++ b/backend/tests/integration/tests/external_apps/test_external_apps.py
@@ -43,7 +43,7 @@ def _create_test_app(
     defaults: dict[str, Any] = {
         "name": "Test App",
         "description": "An app for testing",
-        "upstream_url_patterns": [r"^https://api\.example\.com/.*$"],
+        "upstream_url_patterns": ["https://api.example.com/*"],
         "auth_template": dict(_AUTH_TEMPLATE),
         "organization_credentials": dict(_ORG_CREDENTIALS),
         "enabled": True,
@@ -104,7 +104,7 @@ def test_admin_creates_app_user_configures_credentials(
     assert admin_app.name == "Test App"
     assert admin_app.description == "An app for testing"
     assert admin_app.enabled is True
-    assert admin_app.upstream_url_patterns == [r"^https://api\.example\.com/.*$"]
+    assert admin_app.upstream_url_patterns == ["https://api.example.com/*"]
     assert admin_app.auth_template == _AUTH_TEMPLATE
     # Org credentials are masked in the admin response so secrets are never
     # returned to the client.
@@ -431,7 +431,7 @@ def test_update_or_delete_nonexistent_app_returns_404(
             app_id=missing_id,
             name="x",
             description="x",
-            upstream_url_patterns=[r"^https://api\.example\.com/.*$"],
+            upstream_url_patterns=["https://api.example.com/*"],
             auth_template={},
             organization_credentials={},
         )

--- a/backend/tests/unit/onyx/external_apps/test_url_glob.py
+++ b/backend/tests/unit/onyx/external_apps/test_url_glob.py
@@ -1,0 +1,70 @@
+import re
+
+import pytest
+
+from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.url_glob import UrlGlob
+
+
+def _matches(glob: str, url: str) -> bool:
+    return re.fullmatch(UrlGlob(value=glob).to_regex(), url) is not None
+
+
+def test_dot_is_literal_not_wildcard() -> None:
+    # The dot in the host must not match arbitrary characters.
+    assert _matches("https://discord.com/api/v10", "https://discord.com/api/v10")
+    assert not _matches("https://discord.com/api/v10", "https://discordxcom/api/v10")
+
+
+def test_star_matches_full_path_including_slashes() -> None:
+    # Regression: `/api/*` must cover deep paths, not just one segment — this is
+    # the bug that caused Discord 401s when the glob was matched as a raw regex.
+    assert _matches(
+        "https://discord.com/api/*", "https://discord.com/api/v10/users/@me"
+    )
+    assert _matches("https://discord.com/api/*", "https://discord.com/api/")
+    # The literal prefix is still required.
+    assert not _matches("https://discord.com/api/*", "https://discord.com/apiv2/users")
+
+
+def test_star_in_middle() -> None:
+    glob = "https://api.github.com/repos/*/issues"
+    assert _matches(glob, "https://api.github.com/repos/onyx/issues")
+    assert not _matches(glob, "https://api.github.com/repos/onyx/pulls")
+
+
+def test_exact_pattern_matches_only_itself() -> None:
+    glob = "https://api.example.com/health"
+    assert _matches(glob, "https://api.example.com/health")
+    assert not _matches(glob, "https://api.example.com/health/sub")
+
+
+def test_query_string_metachars_are_literal() -> None:
+    glob = "https://api.example.com/search?q=*"
+    assert _matches(glob, "https://api.example.com/search?q=anything")
+    # `?` is literal, so a URL without it doesn't match.
+    assert not _matches(glob, "https://api.example.com/searchXq=anything")
+
+
+@pytest.mark.parametrize(
+    "bad_glob",
+    [
+        "",
+        "   ",
+        "discord.com/api/*",  # no scheme
+        "ftp://discord.com/*",  # wrong scheme
+        "https://*.example.com/*",  # wildcard host
+        "https://*/api",  # wildcard host
+        "https:///api",  # missing host
+    ],
+)
+def test_parse_rejects_unsafe_globs(bad_glob: str) -> None:
+    with pytest.raises(OnyxError):
+        UrlGlob.parse(bad_glob)
+
+
+def test_parse_accepts_literal_host_globs() -> None:
+    assert (
+        UrlGlob.parse("https://api.example.com/*").value == "https://api.example.com/*"
+    )
+    UrlGlob.parse("http://localhost:8080/v1/*")

--- a/backend/tests/unit/sandbox_proxy/test_action_matcher.py
+++ b/backend/tests/unit/sandbox_proxy/test_action_matcher.py
@@ -1,9 +1,9 @@
 """Unit tests for the proxy's URL → ExternalApp resolution.
 
-``resolve_app_for_url`` is the proxy-side glue that binds a request to a
-connected app before deferring to ``external_apps.matching.match_action``.
-Transient (un-flushed) ``ExternalApp`` objects suffice — it only reads
-``upstream_url_patterns`` (and ``id`` for a warning log), never the DB.
+``resolve_app_for_url`` binds a request to a connected app before deferring to
+``external_apps.matching.match_action``. Transient (un-flushed) ``ExternalApp``
+objects suffice — it only reads ``upstream_url_patterns``, never the DB. CUSTOM
+apps author globs; built-in providers author regexes.
 """
 
 from __future__ import annotations
@@ -20,21 +20,24 @@ def _app(
     return ExternalApp(app_type=app_type, upstream_url_patterns=patterns)
 
 
-def test_matches_the_app_whose_pattern_fires() -> None:
-    slack = _app(["https://slack\\.com/api/.*"], ExternalAppType.SLACK)
-    gcal = _app(
-        ["https://www\\.googleapis\\.com/calendar/.*"],
-        ExternalAppType.GOOGLE_CALENDAR,
-    )
-    apps = [slack, gcal]
+def test_custom_glob_matches_deep_path() -> None:
+    # `/api/*` must cover deep paths (the Discord 401 regression).
+    app = _app(["https://discord.com/api/*"])
+    assert resolve_app_for_url("https://discord.com/api/v10/users/@me", [app]) is app
+    # The dot is literal, so a look-alike host must not match.
+    assert resolve_app_for_url("https://discordxcom/api/x", [app]) is None
 
-    assert resolve_app_for_url("https://slack.com/api/chat.postMessage", apps) is slack
-    assert resolve_app_for_url("https://www.googleapis.com/calendar/v3/x", apps) is gcal
+
+def test_builtin_regex_used_as_is() -> None:
+    slack = _app(["https://slack\\.com/api/.*"], ExternalAppType.SLACK)
+    assert (
+        resolve_app_for_url("https://slack.com/api/chat.postMessage", [slack]) is slack
+    )
 
 
 def test_no_pattern_matches_returns_none() -> None:
-    slack = _app(["https://slack\\.com/api/.*"])
-    assert resolve_app_for_url("https://example.com/", [slack]) is None
+    app = _app(["https://slack.com/api/*"])
+    assert resolve_app_for_url("https://example.com/", [app]) is None
 
 
 def test_empty_patterns_never_match() -> None:
@@ -42,14 +45,13 @@ def test_empty_patterns_never_match() -> None:
 
 
 def test_first_app_in_order_wins_on_overlap() -> None:
-    broad = _app(["https://slack\\.com/.*"])
-    narrow = _app(["https://slack\\.com/api/.*"])
+    broad = _app(["https://slack.com/*"])
+    narrow = _app(["https://slack.com/api/*"])
     # Caller passes apps id-ordered; the earlier one wins.
     assert resolve_app_for_url("https://slack.com/api/x", [broad, narrow]) is broad
 
 
-def test_malformed_pattern_is_skipped_not_fatal() -> None:
-    bad = _app(["("])  # invalid regex
-    good = _app(["https://slack\\.com/api/.*"])
-    # The bad pattern is skipped; resolution continues to the good app.
+def test_malformed_builtin_regex_is_skipped_not_fatal() -> None:
+    bad = _app(["("], ExternalAppType.SLACK)  # invalid regex
+    good = _app(["https://slack\\.com/api/.*"], ExternalAppType.SLACK)
     assert resolve_app_for_url("https://slack.com/api/x", [bad, good]) is good

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -181,8 +181,9 @@ export default function CreateCustomAppModal({
             <div className="flex flex-col gap-1">
               <Text font="main-ui-action">Upstream URL patterns</Text>
               <Text font="secondary-body" color="text-03">
-                Outbound URLs the proxy may inject credentials into. Type a
-                pattern and press Enter.
+                {
+                  "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
+                }
               </Text>
               <ListFieldInput
                 values={upstreamPatterns}


### PR DESCRIPTION
## Description
The user writes custom app urls and globs, but the matcher will parse these as regexes. Also extends the matching engine to always allow custom apps

## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch custom external app URL matching from regex to simple globs. This fixes deep-path matches (e.g. https://discord.com/api/* now matches /api/v10/...) and routes all CUSTOM app requests to a single "custom_request" action with ASK policy.

- **Bug Fixes**
  - Add UrlGlob to validate/convert globs: require http/https, non-empty, literal host; `*` spans slashes; dot is literal.
  - Add ExternalApp.upstream_url_regexes and update resolver to use it; CUSTOM apps translate globs at match time, built-ins keep regex; malformed built-in regexes are skipped.
  - Validate custom patterns on create/update; reject wildcard hosts and empty entries.
  - Tests cover deep-path matches, validation failures, resolver behavior; UI help text explains glob rules and literal-host requirement.

<sup>Written for commit 528dddff88adc91c4d4e6026c8309d7897531ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



