### PR TITLE
feat: per-user usage + cost tracking — schema + models (1/4)

### DIFF
--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -64,10 +64,10 @@ def upgrade() -> None:
         # Empty string (not NULL) for "no provider" so the dedup unique index
         # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
         sa.Column("provider", sa.String(), nullable=False, server_default=""),
-        sa.Column("input_tokens", sa.Integer(), nullable=False),
-        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column("input_tokens", sa.BigInteger(), nullable=False),
+        sa.Column("output_tokens", sa.BigInteger(), nullable=False),
         sa.Column(
-            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+            "cache_read_tokens", sa.BigInteger(), nullable=False, server_default="0"
         ),
         sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
         sa.Column(
@@ -107,11 +107,11 @@ def downgrade() -> None:
     op.drop_constraint(
         "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
     )
-    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
-    # the alter can't fail on NULLs.
-    op.execute(
-        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
-    )
+    # Delete cost-only rows before restoring NOT NULL. Zero-filling them would
+    # leave token_budget=0 rows that older enforcement reads as "block at 0
+    # tokens" (rejecting every request); a cost-only limit can't function once
+    # cost_budget_cents is dropped below anyway.
+    op.execute("DELETE FROM token_rate_limit WHERE token_budget IS NULL")
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -1,0 +1,114 @@
+"""add usage + cost tracking schema
+
+Creates the per-user usage rollup table and the per-model cost-override table,
+and adds a cost budget to token rate limits (token budget becomes nullable so a
+limit can be token-only, cost-only, or both).
+
+Revision ID: 8c1d4f6a2e9b
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-05 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import fastapi_users_db_sqlalchemy
+
+# revision identifiers, used by Alembic.
+revision = "8c1d4f6a2e9b"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "model_cost_override",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
+        sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
+        # null cache rate bills cache reads at the input rate (litellm default).
+        sa.Column("cache_read_cost_per_mtok", sa.Float(), nullable=True),
+        # The model's onupdate=func.now() is ORM-side only (not DDL), so
+        # updated_at auto-bumps on ORM writes but not on raw-SQL UPDATEs.
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+    )
+
+    op.create_table(
+        "user_usage",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "user_id",
+            fastapi_users_db_sqlalchemy.generics.GUID(),
+            nullable=False,
+        ),
+        sa.Column(
+            "window_start", sa.DateTime(timezone=True), nullable=False, index=True
+        ),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("flow", sa.String(), nullable=False),
+        # Empty string (not NULL) for "no provider" so the dedup unique index
+        # works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
+        sa.Column("input_tokens", sa.Integer(), nullable=False),
+        sa.Column("output_tokens", sa.Integer(), nullable=False),
+        sa.Column(
+            "cache_read_tokens", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("cost_cents", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # Upsert key. provider is non-null ('' when absent), so a plain unique index
+    # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
+    op.create_index(
+        "uq_user_usage_dims",
+        "user_usage",
+        ["user_id", "window_start", "model", "flow", "provider"],
+        unique=True,
+    )
+
+    op.add_column(
+        "token_rate_limit",
+        sa.Column("cost_budget_cents", sa.Float(), nullable=True),
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=True)
+    # A limit must carry a token budget, a cost budget, or both — never neither.
+    op.create_check_constraint(
+        "ck_token_rate_limit_budget_set",
+        "token_rate_limit",
+        "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_token_rate_limit_budget_set", "token_rate_limit", type_="check"
+    )
+    # token_budget goes back to NOT NULL; back-fill any cost-only rows first so
+    # the alter can't fail on NULLs.
+    op.execute(
+        "UPDATE token_rate_limit SET token_budget = 0 WHERE token_budget IS NULL"
+    )
+    op.alter_column("token_rate_limit", "token_budget", nullable=False)
+    op.drop_column("token_rate_limit", "cost_budget_cents")
+    op.drop_index("uq_user_usage_dims", table_name="user_usage")
+    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
+    op.drop_index("ix_user_usage_window_start", table_name="user_usage")
+    op.drop_table("user_usage")
+    op.drop_table("model_cost_override")

--- a/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
+++ b/backend/alembic/versions/8c1d4f6a2e9b_add_usage_cost_tracking.py
@@ -26,6 +26,9 @@ def upgrade() -> None:
         "model_cost_override",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("model", sa.String(), nullable=False),
+        # Empty string (not NULL) for a provider-agnostic override, so the unique
+        # key works on every Postgres version (NULLS NOT DISTINCT is PG15+ only).
+        sa.Column("provider", sa.String(), nullable=False, server_default=""),
         sa.Column("input_cost_per_mtok", sa.Float(), nullable=False),
         sa.Column("output_cost_per_mtok", sa.Float(), nullable=False),
         # null cache rate bills cache reads at the input rate (litellm default).
@@ -39,7 +42,10 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("model", name="uq_model_cost_override_model"),
+        # provider+model so the same model can be priced per provider.
+        sa.UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
     op.create_table(
@@ -73,7 +79,8 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
     )
-    op.create_index("ix_user_usage_user_id", "user_usage", ["user_id"], unique=False)
+    # No standalone user_id index: uq_user_usage_dims leads with user_id, so
+    # Postgres uses it for user-only lookups.
     # Upsert key. provider is non-null ('' when absent), so a plain unique index
     # dedups correctly on every Postgres version (no PG15-only NULLS NOT DISTINCT).
     op.create_index(
@@ -108,7 +115,6 @@ def downgrade() -> None:
     op.alter_column("token_rate_limit", "token_budget", nullable=False)
     op.drop_column("token_rate_limit", "cost_budget_cents")
     op.drop_index("uq_user_usage_dims", table_name="user_usage")
-    op.drop_index("ix_user_usage_user_id", table_name="user_usage")
     op.drop_index("ix_user_usage_window_start", table_name="user_usage")
     op.drop_table("user_usage")
     op.drop_table("model_cost_override")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5375,8 +5375,10 @@ class UserUsage(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
+    # No index=True: uq_user_usage_dims leads with user_id, so Postgres uses it
+    # for user-only lookups.
     user_id: Mapped[UUID] = mapped_column(
-        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False
     )
 
     window_start: Mapped[datetime.datetime] = mapped_column(
@@ -5427,8 +5429,13 @@ class ModelCostOverride(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 
-    # litellm-style model name (e.g. "gpt-4o"); one override per model.
-    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    # litellm-style model name (e.g. "gpt-4o").
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for a provider-agnostic override, so the unique key
+    # below works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
 
     # Rates in USD per million tokens.
     input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
@@ -5438,6 +5445,13 @@ class ModelCostOverride(Base):
 
     updated_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # provider+model so the same model can be priced per provider.
+        UniqueConstraint(
+            "provider", "model", name="uq_model_cost_override_provider_model"
+        ),
     )
 
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5393,9 +5393,11 @@ class UserUsage(Base):
         String, nullable=False, default="", server_default=""
     )
 
-    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
-    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    input_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
     cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
 
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4594,13 +4594,24 @@ class TokenRateLimit(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
-    token_budget: Mapped[int] = mapped_column(Integer, nullable=False)
+    # A row carries a token budget, a cost budget, or both; a null side is exempt
+    # from that gate. At least one must be set — enforced by the check constraint
+    # below, so a backfill / direct write can't create an unenforceable row.
+    token_budget: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_budget_cents: Mapped[float | None] = mapped_column(Float, nullable=True)
     period_hours: Mapped[int] = mapped_column(Integer, nullable=False)
     scope: Mapped[TokenRateLimitScope] = mapped_column(
         Enum(TokenRateLimitScope, native_enum=False)
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "token_budget IS NOT NULL OR cost_budget_cents IS NOT NULL",
+            name="ck_token_rate_limit_budget_set",
+        ),
     )
 
 
@@ -5345,6 +5356,88 @@ class TenantUsage(Base):
     __table_args__ = (
         # Ensure only one row per window start (tenant_id is in the schema name)
         UniqueConstraint("window_start", name="uq_tenant_usage_window"),
+    )
+
+
+class UserUsage(Base):
+    """
+    Per-user LLM usage rollup within a time window — the source of truth for
+    per-user cost/token attribution and budget checks. Mirrors TenantUsage's
+    window-rollup model (one accumulating row per window+dims, not a per-call
+    ledger).
+
+    One row per (user, window, model, flow, provider), accumulated in place;
+    windows match the tenant-usage alignment so per-user and per-tenant totals
+    reconcile.
+    """
+
+    __tablename__ = "user_usage"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("user.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+
+    window_start: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    flow: Mapped[str] = mapped_column(String, nullable=False)
+    # Empty string (not NULL) for "no provider" so the dedup unique index below
+    # works on every Postgres version without NULLS NOT DISTINCT (PG15+).
+    provider: Mapped[str] = mapped_column(
+        String, nullable=False, default="", server_default=""
+    )
+
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False)
+    cache_read_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cost_cents: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        # Upsert key: accumulate into one row per dimension tuple per window.
+        # provider is non-null ('' when absent), so a plain unique index dedups
+        # correctly on every Postgres version (no NULLS NOT DISTINCT needed).
+        Index(
+            "uq_user_usage_dims",
+            "user_id",
+            "window_start",
+            "model",
+            "flow",
+            "provider",
+            unique=True,
+        ),
+    )
+
+
+class ModelCostOverride(Base):
+    """Admin-set per-model rates that supersede litellm pricing.
+
+    Negotiated enterprise rates win over litellm's published numbers, so cost
+    computation consults this table before falling back to litellm.
+    """
+
+    __tablename__ = "model_cost_override"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+
+    # litellm-style model name (e.g. "gpt-4o"); one override per model.
+    model: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+
+    # Rates in USD per million tokens.
+    input_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    output_cost_per_mtok: Mapped[float] = mapped_column(Float, nullable=False)
+    # Cache-read rate; null bills cache reads at the input rate (litellm default).
+    cache_read_cost_per_mtok: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
 
 


### PR DESCRIPTION
**Part 1 of 4** — splitting the per-user usage + cost tracking work (originally #11732) into smaller, reviewable, stacked PRs per maintainer feedback. This first PR is **schema only** — no logic.

### Adds
- **`user_usage`** — per-user usage rollup, one row per (user × model × window-day): input/output/cache tokens + cost.
- **`model_cost_override`** — admin-set per-model negotiated rates (input / output / optional cache-read).
- **`token_rate_limit.cost_budget_cents`** (+ `token_budget` becomes nullable) so a limit can be token-only, cost-only, or both.
- One consolidated additive migration (single head).

### The stack (each builds on the previous, opened as the prior merges)
1. **Schema + models** ← this PR
2. Per-user usage + cost accounting (recording processor, `GET /user/usage`, cost resolution, admin cost-overrides + export)
3. Cost budgets on token rate limits — CE/global enforcement + structured 429
4. Frontend (Usage tab, cost-overrides panel, rate-limit cost-budget field, 429 banner)

The per-user/group budget **enforcement** and the admin per-user usage **report** live under `ee/` and are being implemented separately by the Onyx team.

Supersedes #11732.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add schema and models for per-user usage and cost tracking, plus optional cost budgets on token rate limits. Schema-only; one additive migration with a safe downgrade.

- **New Features**
  - user_usage: per-user × model × flow × provider × window rollup with input/output/cache tokens and cost_cents; unique on (user_id, window_start, model, flow, provider); provider defaults to '' for cross-PG support.
  - model_cost_override: admin-set USD/mtok rates (input/output, optional cache-read) per provider+model (unique); provider defaults to '' for provider-agnostic overrides; used before `litellm` defaults; includes updated_at.
  - token_rate_limit: adds cost_budget_cents; token_budget is nullable; DB check constraint requires at least one of token or cost budget.

- **Migration**
  - On downgrade, delete cost-only token limits before restoring NOT NULL to avoid token_budget=0 rows that block all requests.
  - Dropped redundant user_usage user_id index; the unique dims index covers it.

<sup>Written for commit dc6de975544b67812e77ae21f9ba67a87210b4be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

