### PR TITLE
feat: context-window usage gauge in the chat input

### DIFF
--- a/backend/alembic/versions/c3d9f17a4e2b_add_chat_message_prompt_tokens.py
+++ b/backend/alembic/versions/c3d9f17a4e2b_add_chat_message_prompt_tokens.py
@@ -1,0 +1,34 @@
+"""add chat_message.prompt_tokens
+
+Revision ID: c3d9f17a4e2b
+Revises: f3a9c1d4b7e2
+Create Date: 2026-06-04 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "c3d9f17a4e2b"
+down_revision = "f3a9c1d4b7e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_message",
+        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+    )
+    # The producing model's context window, stored per turn so a reload after a
+    # mid-chat model switch keeps the original gauge denominator.
+    op.add_column(
+        "chat_message",
+        sa.Column("max_input_tokens", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_message", "max_input_tokens")
+    op.drop_column("chat_message", "prompt_tokens")

--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -49,6 +49,8 @@ class ChatStateContainer:
         self.reasoning_tokens: str | None = None
         # This is accumulated during the streaming of the answer
         self.answer_tokens: str | None = None
+        # Provider-reported prompt_tokens for this turn (real context-window usage)
+        self.prompt_tokens: int | None = None
         # Store citation mapping for building citation_docs_info during partial saves
         self.citation_to_doc: CitationMapping = {}
         # True if this turn is a clarification question (deep research flow)
@@ -75,6 +77,11 @@ class ChatStateContainer:
         """Set the answer tokens from the final answer generation."""
         with self._lock:
             self.answer_tokens = answer
+
+    def set_prompt_tokens(self, prompt_tokens: int) -> None:
+        """Set the provider-reported prompt_tokens for this turn."""
+        with self._lock:
+            self.prompt_tokens = prompt_tokens
 
     def set_citation_mapping(self, citation_to_doc: CitationMapping) -> None:
         """Set the citation mapping from citation processor."""
@@ -110,6 +117,11 @@ class ChatStateContainer:
         """Thread-safe getter for is_clarification."""
         with self._lock:
             return self.is_clarification
+
+    def get_prompt_tokens(self) -> int | None:
+        """Thread-safe getter for the provider-reported prompt_tokens."""
+        with self._lock:
+            return self.prompt_tokens
 
     def set_pre_answer_processing_time(self, duration: float | None) -> None:
         """Set the pre-answer processing time (time before answer starts)."""

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -1286,6 +1286,11 @@ def run_llm_step_pkt_generator(
                     "cache_read_input_tokens": usage.cache_read_input_tokens,
                     "cache_creation_input_tokens": usage.cache_creation_input_tokens,
                 }
+                # A real turn always has a non-zero prompt; 0 means the provider
+                # reported usage without input tokens (e.g. some local models) —
+                # skip it so the gauge keeps its baseline instead of reading ~0%.
+                if state_container and usage.prompt_tokens:
+                    state_container.set_prompt_tokens(usage.prompt_tokens)
                 # Note: LLM cost tracking is now handled in multi_llm.py
             finish_reason = packet.choice.finish_reason
             if finish_reason:

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -117,6 +117,7 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import AgentResponseDelta
 from onyx.server.query_and_chat.streaming_models import AgentResponseStart
 from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.server.query_and_chat.streaming_models import ContextUsagePacket
 from onyx.server.query_and_chat.streaming_models import heartbeat_packet
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
@@ -1127,8 +1128,12 @@ def _run_models(
         context: _PersistContext,
         *,
         stop_button: bool = False,
-    ) -> None:
+    ) -> int | None:
         """Persist one model's outcome exactly once, from any thread.
+
+        Returns the turn's prompt (context) token count when this call did the
+        completion, else None (already persisted, errored, or skipped) — the
+        caller uses it to emit the context-window gauge from a safe thread.
 
         The LLM loops never observe the stop signal, so a worker that returns
         non-errored always holds a complete answer. Partial content exists only
@@ -1155,7 +1160,7 @@ def _run_models(
             return value
 
         try:
-            llm_loop_completion_handle(
+            return llm_loop_completion_handle(
                 state_container=state_containers[model_idx],
                 is_connected=_is_connected,
                 assistant_message=setup.reserved_messages[model_idx],
@@ -1169,6 +1174,7 @@ def _run_models(
                 model_idx,
                 setup.model_display_names[model_idx],
             )
+        return None
 
     def _run_post_steps() -> None:
         with persist_lock:
@@ -1301,7 +1307,24 @@ def _run_models(
             merged_queue.put((model_idx, e))
 
         finally:
-            _persist_model_outcome(model_idx, _PersistContext.WORKER)
+            prompt_tokens = _persist_model_outcome(model_idx, _PersistContext.WORKER)
+            # Route the gauge packet through the queue so the writer (sole owner
+            # of the stream) emits it — never _publish from this worker thread.
+            if prompt_tokens is not None:
+                merged_queue.put(
+                    (
+                        model_idx,
+                        Packet(
+                            placement=Placement(turn_index=0, model_index=model_idx),
+                            obj=ContextUsagePacket(
+                                used_tokens=prompt_tokens,
+                                max_input_tokens=setup.llms[
+                                    model_idx
+                                ].config.max_input_tokens,
+                            ),
+                        ),
+                    )
+                )
             merged_queue.put((model_idx, _MODEL_DONE))
 
     def _save_errored_message(model_idx: int, context: _PersistContext) -> None:
@@ -1376,9 +1399,25 @@ def _run_models(
                         for i in range(n_models):
                             # Snapshot every model now: finished loops save
                             # complete, in-flight ones save partial + stopped.
-                            _persist_model_outcome(
+                            prompt_tokens = _persist_model_outcome(
                                 i, _PersistContext.STOP_BUTTON, stop_button=True
                             )
+                            # Writer thread here — safe to _publish directly so
+                            # the gauge reflects the cancelled turn.
+                            if prompt_tokens is not None:
+                                _publish(
+                                    Packet(
+                                        placement=Placement(
+                                            turn_index=0, model_index=i
+                                        ),
+                                        obj=ContextUsagePacket(
+                                            used_tokens=prompt_tokens,
+                                            max_input_tokens=setup.llms[
+                                                i
+                                            ].config.max_input_tokens,
+                                        ),
+                                    )
+                                )
                         _publish(
                             Packet(
                                 placement=Placement(turn_index=0),
@@ -1829,7 +1868,7 @@ def llm_loop_completion_handle(
     assistant_message: ChatMessage,
     llm: LLM,
     reserved_tokens: int,
-) -> None:
+) -> int | None:
     # Snapshot all state under the container's lock before any DB write.
     # Worker threads may still be running (e.g. user-cancellation path), so
     # direct attribute access is not thread-safe — use the provided getters.
@@ -1841,6 +1880,7 @@ def llm_loop_completion_handle(
     all_search_docs = state_container.get_all_search_docs()
     emitted_citations = state_container.get_emitted_citations()
     pre_answer_processing_time = state_container.get_pre_answer_processing_time()
+    prompt_tokens = state_container.get_prompt_tokens()
 
     completed_normally = is_connected()
     chat_session_id: UUID = assistant_message.chat_session_id
@@ -1883,6 +1923,8 @@ def llm_loop_completion_handle(
             is_clarification=is_clarification,
             emitted_citations=emitted_citations,
             pre_answer_processing_time=pre_answer_processing_time,
+            prompt_tokens=prompt_tokens,
+            max_input_tokens=llm.config.max_input_tokens,
         )
 
         updated_chat_history = create_chat_history_chain(
@@ -1902,6 +1944,8 @@ def llm_loop_completion_handle(
             llm=llm,
             compression_params=compression_params,
         )
+
+    return prompt_tokens
 
 
 _CITATION_LINK_START_PATTERN = re.compile(r"\s*\[\[\d+\]\]\(")

--- a/backend/onyx/chat/save_chat.py
+++ b/backend/onyx/chat/save_chat.py
@@ -177,6 +177,8 @@ def save_chat_turn(
     is_clarification: bool = False,
     emitted_citations: set[int] | None = None,
     pre_answer_processing_time: float | None = None,
+    prompt_tokens: int | None = None,
+    max_input_tokens: int | None = None,
 ) -> None:
     """
     Save a chat turn by populating the assistant_message and creating related entities.
@@ -202,6 +204,7 @@ def save_chat_turn(
         emitted_citations: Set of citation numbers that were actually emitted during streaming.
             If provided, only citations in this set will be saved; others are filtered out.
         pre_answer_processing_time: Duration of processing before answer starts (in seconds)
+        prompt_tokens: Provider-reported prompt tokens for this turn (real context-window usage)
     """
     # 1. Update ChatMessage with message content, reasoning tokens, and token count
     sanitized_message_text = (
@@ -226,6 +229,14 @@ def save_chat_turn(
         )
     else:
         assistant_message.token_count = 0
+
+    # Provider-reported prompt tokens (real context-window usage for this turn)
+    assistant_message.prompt_tokens = prompt_tokens
+    # Pair the denominator with the numerator so reload renders the turn against
+    # its own model's window, not the persona's current one.
+    assistant_message.max_input_tokens = (
+        max_input_tokens if prompt_tokens is not None else None
+    )
 
     # 2. Create DB SearchDoc entries from pre-deduplicated all_search_docs
     search_doc_key_to_id: dict[SearchDocKey, int] = {}

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -956,6 +956,8 @@ def translate_db_message_to_chat_message_detail(
         processing_duration_seconds=chat_message.processing_duration_seconds,
         preferred_response_id=chat_message.preferred_response_id,
         model_display_name=chat_message.model_display_name,
+        prompt_tokens=chat_message.prompt_tokens,
+        max_input_tokens=chat_message.max_input_tokens,
     )
 
     return chat_msg_detail

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2848,6 +2848,12 @@ class ChatMessage(Base):
     reasoning_tokens: Mapped[str | None] = mapped_column(Text, nullable=True)
     message: Mapped[str] = mapped_column(Text)
     token_count: Mapped[int] = mapped_column(Integer)
+    # Provider-reported input-token count for the assistant turn (the real
+    # context size). Nullable: user/root and pre-migration rows have none.
+    prompt_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # The producing model's context window at turn time, persisted so a reload
+    # after a mid-chat model switch keeps the original gauge denominator.
+    max_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     message_type: Mapped[MessageType] = mapped_column(
         Enum(MessageType, native_enum=False)
     )

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -80,6 +80,7 @@ from onyx.llm.factory import get_llm_token_counter
 from onyx.secondary_llm_flows.chat_session_naming import generate_chat_session_name
 from onyx.server.api_key_usage import check_api_key_usage
 from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
+from onyx.server.query_and_chat.context_usage import compute_context_usage
 from onyx.server.query_and_chat.models import ChatFeedbackRequest
 from onyx.server.query_and_chat.models import ChatMessageIdentifier
 from onyx.server.query_and_chat.models import ChatRenameRequest
@@ -367,6 +368,25 @@ def get_chat_session(
             )
             # msg_packet_list.append(Packet(ind=end_step_nr, obj=OverallStop()))
 
+    # Context-window usage for the gauge — only once a turn has reported a real
+    # prompt size (no gauge on a fresh chat). The LLM is resolved lazily so an
+    # empty chat does no extra work; a provider-resolution failure must not break
+    # session load.
+    context_usage = None
+    if chat_session.persona:
+        persona = chat_session.persona
+        try:
+            context_usage = compute_context_usage(
+                chat_message_details,
+                lambda: get_llm_for_persona(
+                    persona=persona, user=user
+                ).config.max_input_tokens,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to compute context usage for session %s", session_id
+            )
+
     return ChatSessionDetailResponse(
         chat_session_id=session_id,
         description=chat_session.description,
@@ -383,6 +403,7 @@ def get_chat_session(
         # Packets are now directly serialized as Packet Pydantic models
         packets=replay_packet_lists,
         current_run=current_run,
+        context_usage=context_usage,
     )
 
 

--- a/backend/onyx/server/query_and_chat/context_usage.py
+++ b/backend/onyx/server/query_and_chat/context_usage.py
@@ -1,0 +1,36 @@
+from collections.abc import Callable
+
+from onyx.configs.constants import MessageType
+from onyx.server.query_and_chat.models import ChatMessageDetail
+from onyx.server.query_and_chat.models import ContextUsage
+
+
+def compute_context_usage(
+    messages: list[ChatMessageDetail],
+    max_input_tokens_fn: Callable[[], int],
+) -> ContextUsage | None:
+    """Most recent assistant turn that reported a real prompt size, or None when
+    none has (so a fresh chat shows no gauge). The denominator persisted with the
+    turn is preferred so a mid-chat model switch doesn't repaint the gauge against
+    the current persona's window; pre-migration rows (no stored window) fall back
+    to the current model's, resolved lazily off the empty-chat path."""
+    last_reported = next(
+        (
+            m
+            for m in reversed(messages)
+            if m.message_type == MessageType.ASSISTANT and m.prompt_tokens is not None
+        ),
+        None,
+    )
+    if last_reported is None:
+        return None
+    used_tokens = last_reported.prompt_tokens
+    if used_tokens is None:
+        return None
+    max_input_tokens = last_reported.max_input_tokens or max_input_tokens_fn()
+    if max_input_tokens <= 0:
+        return None
+    return ContextUsage(
+        used_tokens=used_tokens,
+        max_input_tokens=max_input_tokens,
+    )

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -230,6 +230,8 @@ class ChatMessageDetail(BaseModel):
     processing_duration_seconds: float | None = None
     preferred_response_id: int | None = None
     model_display_name: str | None = None
+    prompt_tokens: int | None = None
+    max_input_tokens: int | None = None
 
     def model_dump(  # ty: ignore[invalid-method-override]
         self, *args: list, **kwargs: dict[str, Any]
@@ -254,6 +256,11 @@ class CurrentRunInfo(BaseModel):
     run_id: int
 
 
+class ContextUsage(BaseModel):
+    used_tokens: int  # provider prompt_tokens of the most recent reporting turn
+    max_input_tokens: int  # the producing model's context window
+
+
 class ChatSessionDetailResponse(BaseModel):
     chat_session_id: UUID
     description: str | None
@@ -271,6 +278,7 @@ class ChatSessionDetailResponse(BaseModel):
     # Set while a run is in flight and resumable: cursor-0 replay+tail is
     # available at /chat-session/{id}/resume-stream.
     current_run: CurrentRunInfo | None = None
+    context_usage: ContextUsage | None = None
 
 
 class AdminSearchRequest(BaseModel):

--- a/backend/onyx/server/query_and_chat/streaming_models.py
+++ b/backend/onyx/server/query_and_chat/streaming_models.py
@@ -45,6 +45,7 @@ class StreamingType(Enum):
     CITATION_INFO = "citation_info"
     TOOL_CALL_DEBUG = "tool_call_debug"
     TOOL_CALL_ARGUMENT_DELTA = "tool_call_argument_delta"
+    CONTEXT_USAGE = "context_usage"
 
     MEMORY_TOOL_START = "memory_tool_start"
     MEMORY_TOOL_DELTA = "memory_tool_delta"
@@ -310,6 +311,15 @@ class ToolCallArgumentDelta(BaseObj):
     argument_deltas: dict[str, Any]
 
 
+# Provider prompt_tokens of the completed turn + the producing model's context window,
+# emitted once at turn end so the frontend can render the context-usage gauge live.
+class ContextUsagePacket(BaseObj):
+    type: Literal["context_usage"] = StreamingType.CONTEXT_USAGE.value
+
+    used_tokens: int
+    max_input_tokens: int
+
+
 ################################################
 # File Reader Packets
 ################################################
@@ -471,6 +481,7 @@ PacketObj = Union[
     CitationInfo,
     ToolCallDebug,
     ToolCallArgumentDelta,
+    ContextUsagePacket,
     # Deep Research Packets
     DeepResearchPlanStart,
     DeepResearchPlanDelta,

--- a/backend/tests/unit/onyx/chat/test_context_usage.py
+++ b/backend/tests/unit/onyx/chat/test_context_usage.py
@@ -1,0 +1,21 @@
+from onyx.chat.chat_state import ChatStateContainer
+
+
+def test_state_container_carries_prompt_tokens() -> None:
+    sc = ChatStateContainer()
+    assert sc.prompt_tokens is None
+    sc.set_prompt_tokens(1234)
+    assert sc.prompt_tokens == 1234
+
+
+def test_prompt_tokens_persists_on_assistant_message() -> None:
+    from onyx.configs.constants import MessageType
+    from onyx.db.models import ChatMessage
+
+    msg = ChatMessage(
+        message="hi",
+        token_count=2,
+        message_type=MessageType.ASSISTANT,
+        prompt_tokens=4096,
+    )
+    assert msg.prompt_tokens == 4096

--- a/backend/tests/unit/onyx/server/query_and_chat/test_session_context_usage.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_session_context_usage.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from datetime import timezone
+
+from onyx.configs.constants import MessageType
+from onyx.server.query_and_chat.context_usage import compute_context_usage
+from onyx.server.query_and_chat.models import ChatMessageDetail
+
+
+def _msg(
+    message_id: int,
+    message_type: MessageType,
+    prompt_tokens: int | None,
+) -> ChatMessageDetail:
+    return ChatMessageDetail(
+        message_id=message_id,
+        message="",
+        message_type=message_type,
+        time_sent=datetime.now(timezone.utc),
+        files=[],
+        prompt_tokens=prompt_tokens,
+    )
+
+
+def test_uses_last_reported_assistant_prompt_tokens() -> None:
+    messages = [
+        _msg(1, MessageType.USER, None),
+        _msg(2, MessageType.ASSISTANT, 5000),
+    ]
+    usage = compute_context_usage(messages, lambda: 128000)
+    assert usage is not None
+    assert usage.used_tokens == 5000
+    assert usage.max_input_tokens == 128000
+
+
+def test_backtracks_to_most_recent_reporting_turn() -> None:
+    # Latest assistant turn has no usage; fall back to the last one that did.
+    messages = [
+        _msg(1, MessageType.ASSISTANT, 4000),
+        _msg(2, MessageType.ASSISTANT, None),
+    ]
+    usage = compute_context_usage(messages, lambda: 128000)
+    assert usage is not None
+    assert usage.used_tokens == 4000
+
+
+def test_none_when_no_reporting_turn() -> None:
+    # user-only history: no assistant message with prompt_tokens -> no gauge.
+    usage = compute_context_usage([_msg(1, MessageType.USER, None)], lambda: 128000)
+    assert usage is None
+
+
+def test_none_for_empty_history() -> None:
+    assert compute_context_usage([], lambda: 128000) is None
+
+
+def test_max_input_tokens_fn_not_resolved_without_a_turn() -> None:
+    # No reporting turn -> the (potentially expensive) LLM resolution is skipped.
+    def _exploding() -> int:
+        raise AssertionError("max_input_tokens_fn must not run without a turn")
+
+    assert compute_context_usage([_msg(1, MessageType.USER, None)], _exploding) is None
+
+
+def test_none_when_max_input_tokens_non_positive() -> None:
+    messages = [_msg(1, MessageType.ASSISTANT, 5000)]
+    assert compute_context_usage(messages, lambda: 0) is None

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -5,6 +5,7 @@ import {
   StreamStopReason,
 } from "@/lib/search/interfaces";
 import { Packet } from "./services/streamingModels";
+import { ContextUsage } from "@/sections/chat/interfaces";
 
 export type FeedbackType = "like" | "dislike";
 
@@ -209,6 +210,9 @@ export interface BackendChatSession {
   packets: Packet[][];
   // Set while a run is in flight and resumable via the resume-stream endpoint
   current_run?: { run_id: number } | null;
+
+  // Session-level context-window usage baseline (gauge fallback when no live turn).
+  context_usage?: ContextUsage | null;
 }
 
 export function toChatSession(backend: BackendChatSession): ChatSession {

--- a/web/src/app/app/services/packetUtils.ts
+++ b/web/src/app/app/services/packetUtils.ts
@@ -1,14 +1,16 @@
 import {
+  ContextUsagePacketObj,
   MessageDelta,
   MessageStart,
   PacketType,
   StreamingCitation,
 } from "./streamingModels";
 import { Packet } from "@/app/app/services/streamingModels";
+import { ContextUsage } from "@/sections/chat/interfaces";
 
 export function isToolPacket(
   packet: Packet,
-  includeSectionEnd: boolean = true
+  includeSectionEnd: boolean = true,
 ) {
   let toolPacketTypes = [
     PacketType.SEARCH_TOOL_START,
@@ -87,7 +89,7 @@ export function isFinalAnswerComing(packets: Packet[]) {
   return packets.some(
     (packet) =>
       packet.obj.type === PacketType.MESSAGE_START ||
-      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START
+      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START,
   );
 }
 
@@ -96,7 +98,7 @@ export function isFinalAnswerComplete(packets: Packet[]) {
   const messageStartPacket = packets.find(
     (packet) =>
       packet.obj.type === PacketType.MESSAGE_START ||
-      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START
+      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START,
   );
 
   if (!messageStartPacket) {
@@ -108,12 +110,12 @@ export function isFinalAnswerComplete(packets: Packet[]) {
     (packet) =>
       (packet.obj.type === PacketType.SECTION_END ||
         packet.obj.type === PacketType.ERROR) &&
-      packet.placement.turn_index === messageStartPacket.placement.turn_index
+      packet.placement.turn_index === messageStartPacket.placement.turn_index,
   );
 }
 
 export function groupPacketsByTurnIndex(
-  packets: Packet[]
+  packets: Packet[],
 ): { turn_index: number; tab_index: number; packets: Packet[] }[] {
   /*
   Group packets by (turn_index, tab_index). 
@@ -127,7 +129,7 @@ export function groupPacketsByTurnIndex(
         string,
         { turn_index: number; tab_index: number; packets: Packet[] }
       >,
-      packet
+      packet,
     ) => {
       const turn_index = packet.placement.turn_index;
       const tab_index = packet.placement.tab_index ?? 0;
@@ -138,7 +140,7 @@ export function groupPacketsByTurnIndex(
       acc.get(key)!.packets.push(packet);
       return acc;
     },
-    new Map()
+    new Map(),
   );
 
   // Convert to array and sort by turn_index first, then tab_index
@@ -186,4 +188,20 @@ export function getCitations(packets: Packet[]): StreamingCitation[] {
   });
 
   return citations;
+}
+
+// Latest context_usage packet wins: in multi-model comparison each model emits
+// one, and taking the last is acceptable for v1.
+export function getContextUsage(packets: Packet[]): ContextUsage | null {
+  for (let i = packets.length - 1; i >= 0; i--) {
+    const packet = packets[i];
+    if (packet && packet.obj.type === PacketType.CONTEXT_USAGE) {
+      const o = packet.obj as ContextUsagePacketObj;
+      return {
+        used_tokens: o.used_tokens,
+        max_input_tokens: o.max_input_tokens,
+      };
+    }
+  }
+  return null;
 }

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -71,6 +71,9 @@ export enum PacketType {
   // Bash Tool packets
   BASH_TOOL_START = "bash_tool_start",
   BASH_TOOL_DELTA = "bash_tool_delta",
+
+  // Context-window usage (emitted at the end of each assistant turn)
+  CONTEXT_USAGE = "context_usage",
 }
 
 export const CODE_INTERPRETER_TOOL_TYPES = {
@@ -346,6 +349,13 @@ export interface BashToolDelta extends BaseObj {
   timed_out: boolean;
 }
 
+// Context-Window Usage Packet (one per assistant turn)
+export interface ContextUsagePacketObj extends BaseObj {
+  type: "context_usage";
+  used_tokens: number;
+  max_input_tokens: number;
+}
+
 export type ChatObj = MessageStart | MessageDelta | MessageEnd;
 
 export type StopObj = Stop;
@@ -462,7 +472,8 @@ export type ObjTypes =
   | ResearchAgentObj
   | CodingAgentObj
   | PacketErrorObj
-  | CitationObj;
+  | CitationObj
+  | ContextUsagePacketObj;
 
 // Placement interface for packet positioning
 export interface Placement {

--- a/web/src/app/app/stores/useChatSessionStore.ts
+++ b/web/src/app/app/stores/useChatSessionStore.ts
@@ -8,6 +8,7 @@ import {
   FeedbackType,
   QueuedMessage,
 } from "../interfaces";
+import { ContextUsage } from "@/sections/chat/interfaces";
 import {
   getLatestMessageChain,
   getMessageByMessageId,
@@ -41,6 +42,10 @@ interface ChatSessionData {
   isLoaded: boolean;
   description?: string;
   personaId?: number;
+
+  // Session-level context-window usage baseline from the session-detail API.
+  // Gauge fallback when the current turn has no live context_usage packet yet.
+  contextUsage?: ContextUsage | null;
 
   // Streaming duration tracking
   streamingStartTime?: number;
@@ -613,6 +618,7 @@ export const useChatSessionStore = create<ChatSessionStore>()((set, get) => ({
       isLoaded: true,
       description: backendSession?.description,
       personaId: backendSession?.persona_id,
+      contextUsage: backendSession?.context_usage ?? null,
     };
 
     const existingSession = get().sessions.get(sessionId);
@@ -741,6 +747,15 @@ export const useStreamingStartTime = () =>
       ? sessions.get(currentSessionId)
       : null;
     return currentSession?.streamingStartTime;
+  });
+
+export const useCurrentSessionContextUsage = () =>
+  useChatSessionStore((state) => {
+    const { currentSessionId, sessions } = state;
+    const currentSession = currentSessionId
+      ? sessions.get(currentSessionId)
+      : null;
+    return currentSession?.contextUsage ?? null;
   });
 
 const EMPTY_QUEUED_MESSAGES: QueuedMessage[] = [];

--- a/web/src/refresh-components/ContextRing.tsx
+++ b/web/src/refresh-components/ContextRing.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@opal/utils";
+import { forwardRef, type HTMLAttributes } from "react";
+
+export type ContextRingTone = "normal" | "warning" | "critical";
+
+// Fill + track colors come from the Opal CSS-var palette (see web/CLAUDE.md
+// §Colors) so dark mode and theming are handled automatically.
+const TONE_FILL: Record<ContextRingTone, string> = {
+  normal: "var(--theme-primary-05)",
+  warning: "var(--status-warning-05)",
+  critical: "var(--status-error-05)",
+};
+const TRACK_COLOR = "var(--background-neutral-03)";
+
+export interface ContextRingProps extends HTMLAttributes<HTMLDivElement> {
+  /** Filled portion of the ring, 0..1. */
+  fraction: number;
+  tone: ContextRingTone;
+  ariaLabel: string;
+  className?: string;
+}
+
+/** A small conic-gradient ring (donut) rendering a filled fraction. */
+const ContextRing = forwardRef<HTMLDivElement, ContextRingProps>(
+  function ContextRing({ fraction, tone, ariaLabel, className, ...rest }, ref) {
+    const degrees = Math.min(1, Math.max(0, fraction)) * 360;
+    return (
+      <div
+        ref={ref}
+        role="img"
+        aria-label={ariaLabel}
+        // Focusable, and forwards ref + props so the wrapping Radix tooltip
+        // (asChild) can attach its hover/focus handlers — without this the
+        // tooltip never triggers.
+        tabIndex={0}
+        className={cn("size-4 shrink-0 rounded-full", className)}
+        style={{
+          background: `conic-gradient(${TONE_FILL[tone]} ${degrees}deg, ${TRACK_COLOR} 0deg)`,
+          // Punch out the center so it reads as a ring (donut), not a filled pie.
+          WebkitMask: "radial-gradient(closest-side, transparent 58%, #000 60%)",
+          mask: "radial-gradient(closest-side, transparent 58%, #000 60%)",
+        }}
+        {...rest}
+      />
+    );
+  },
+);
+
+export default ContextRing;

--- a/web/src/sections/chat/ContextGauge.stories.tsx
+++ b/web/src/sections/chat/ContextGauge.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ContextGauge from "@/sections/chat/ContextGauge";
+
+const meta: Meta<typeof ContextGauge> = {
+  title: "Chat/Context Gauge",
+  component: ContextGauge,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+};
+
+export default meta;
+type Story = StoryObj<typeof ContextGauge>;
+
+// Fill color crosses from theme-primary -> warning (>=70%) -> error (>=90%).
+export const Low: Story = {
+  args: {
+    usage: { used_tokens: 38_400, max_input_tokens: 128_000 },
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    usage: { used_tokens: 96_000, max_input_tokens: 128_000 },
+  },
+};
+
+export const Critical: Story = {
+  args: {
+    usage: { used_tokens: 122_000, max_input_tokens: 128_000 },
+  },
+};
+
+// No usable ratio -> renders nothing.
+export const Hidden: Story = {
+  args: { usage: null },
+};

--- a/web/src/sections/chat/ContextGauge.tsx
+++ b/web/src/sections/chat/ContextGauge.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { Tooltip } from "@opal/components";
+import ContextRing, { ContextRingTone } from "@/refresh-components/ContextRing";
+import { ContextUsage } from "@/sections/chat/interfaces";
+
+interface ContextGaugeProps {
+  usage: ContextUsage | null;
+}
+
+function tone(pct: number): ContextRingTone {
+  if (pct >= 0.9) return "critical";
+  if (pct >= 0.7) return "warning";
+  return "normal";
+}
+
+// 12_400 -> "12.4k". Sub-1k values keep their digits ("840").
+function formatTokens(n: number): string {
+  if (n < 1000) return `${Math.round(n)}`;
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
+/**
+ * A small ring gauge showing how much of the chat's context window is used.
+ * Returns null when there's no usable ratio (no data or non-positive max).
+ */
+function ContextGauge({ usage }: ContextGaugeProps) {
+  if (usage == null || usage.max_input_tokens <= 0) return null;
+
+  const pct = Math.min(1, usage.used_tokens / usage.max_input_tokens);
+  const pctLabel = Math.round(pct * 100);
+
+  // Pass a plain string so Opal's Tooltip wraps it in <Text color="inherit"> —
+  // i.e. the readable inverted color for the dark tooltip surface. Passing a
+  // custom <Content> here applied light-background text colors (unreadable).
+  const tooltip = `${formatTokens(usage.used_tokens)} / ${formatTokens(
+    usage.max_input_tokens,
+  )} (${pctLabel}%) — older messages are trimmed to fit when the window is full.`;
+
+  return (
+    <Tooltip tooltip={tooltip} side="top">
+      <ContextRing
+        fraction={pct}
+        tone={tone(pct)}
+        ariaLabel={`Context window ${pctLabel}% used`}
+      />
+    </Tooltip>
+  );
+}
+
+export default ContextGauge;

--- a/web/src/sections/chat/interfaces.ts
+++ b/web/src/sections/chat/interfaces.ts
@@ -1,0 +1,6 @@
+// Context-window gauge data, derived from the backend's context_usage stream
+// packet or the session-detail API's session-level context_usage object.
+export interface ContextUsage {
+  used_tokens: number;
+  max_input_tokens: number;
+}

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -63,6 +63,8 @@ import {
 } from "@/app/app/stores/useChatSessionStore";
 import QueuedMessageBar from "@/sections/input/QueuedMessageBar";
 import { handleInputNavKeys } from "@/sections/input/inputBarKeys";
+import ContextGauge from "@/sections/chat/ContextGauge";
+import { ContextUsage } from "@/sections/chat/interfaces";
 
 export interface AppInputBarHandle {
   reset: () => void;
@@ -77,6 +79,9 @@ export interface AppInputBarProps {
   chatState: ChatState;
   currentSessionFileTokenCount: number;
   availableContextTokens: number;
+
+  // Context-window usage for the gauge (live turn value, else session baseline).
+  contextUsage?: ContextUsage | null;
 
   // agents
   selectedAgent: MinimalAgent | undefined;
@@ -105,6 +110,7 @@ const AppInputBar = React.memo(
     chatState,
     currentSessionFileTokenCount,
     availableContextTokens,
+    contextUsage,
     selectedAgent,
 
     handleFileUpload,
@@ -674,6 +680,7 @@ const AppInputBar = React.memo(
 
         {/* Bottom right controls */}
         <div className="flex flex-row items-center gap-1">
+          <ContextGauge usage={contextUsage ?? null} />
           {showMicButton &&
             (sttEnabled ? (
               <MicrophoneButton

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -42,7 +42,9 @@ import {
   useChatSessionStore,
   useCurrentMessageHistory,
   useCurrentMessageTree,
+  useCurrentSessionContextUsage,
 } from "@/app/app/stores/useChatSessionStore";
+import { getContextUsage } from "@/app/app/services/packetUtils";
 import {
   useCurrentChatState,
   useIsReady,
@@ -359,6 +361,27 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   );
   const messageHistory = useCurrentMessageHistory();
   const messageTree = useCurrentMessageTree();
+
+  // Context-window gauge: prefer the live value from the most recent assistant
+  // turn that reported usage, else the value loaded from session-detail.
+  const sessionContextUsage = useCurrentSessionContextUsage();
+  const liveContextUsage = useMemo(() => {
+    // Backtrack past assistant turns that reported no usage (matching the backend).
+    for (let i = messageHistory.length - 1; i >= 0; i--) {
+      const message = messageHistory[i];
+      if (message?.type !== "assistant") continue;
+      // The in-flight turn emits its usage packet only at turn end; skip its
+      // still-growing packet list each delta (avoids an O(n^2) rescan) — the
+      // prior turn's gauge stays shown until this turn completes.
+      if (i === messageHistory.length - 1 && currentChatState === "streaming") {
+        continue;
+      }
+      const usage = getContextUsage(message.packets);
+      if (usage) return usage;
+    }
+    return null;
+  }, [messageHistory, currentChatState]);
+  const contextUsage = liveContextUsage ?? sessionContextUsage ?? null;
 
   // Block input when the last turn is multi-model and the user hasn't
   // selected a preferred response yet. Without a selection, it's ambiguous
@@ -1009,6 +1032,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                             : projectContextTokenCount
                         }
                         availableContextTokens={availableContextTokens}
+                        contextUsage={contextUsage}
                         selectedAgent={selectedAgent || liveAgent}
                         handleFileUpload={handleMessageSpecificFileUpload}
                         setPresentingDocument={setPresentingDocument}

--- a/web/tests/e2e/chat/ChatPage.ts
+++ b/web/tests/e2e/chat/ChatPage.ts
@@ -86,4 +86,25 @@ export class ChatPage {
   async expectNoHumanMessages(): Promise<void> {
     await expect(this.humanMessages).toHaveCount(0);
   }
+
+  // ---------------------------------------------------------------------------
+  // Context-window gauge
+  // ---------------------------------------------------------------------------
+
+  /** The gauge, matched by its accessible label. Omit `pctUsed` to match any %. */
+  contextGauge(pctUsed?: number): Locator {
+    const label =
+      pctUsed === undefined
+        ? /Context window \d+% used/
+        : new RegExp(`Context window ${pctUsed}% used`);
+    return this.page.getByLabel(label);
+  }
+
+  async expectContextGauge(pctUsed: number): Promise<void> {
+    await expect(this.contextGauge(pctUsed)).toBeVisible({ timeout: 15_000 });
+  }
+
+  async expectNoContextGauge(): Promise<void> {
+    await expect(this.contextGauge()).toHaveCount(0);
+  }
 }

--- a/web/tests/e2e/chat/context_gauge.spec.ts
+++ b/web/tests/e2e/chat/context_gauge.spec.ts
@@ -1,0 +1,40 @@
+import { test } from "@tests/e2e/chat/fixtures";
+import {
+  buildMockStream,
+  buildMockStreamWithContextUsage,
+  mockChatEndpoint,
+} from "@tests/e2e/utils/chatMock";
+
+test.describe("Context-window gauge", () => {
+  test("renders usage from the context_usage packet after a turn", async ({
+    chatPage,
+  }) => {
+    await chatPage.goto();
+
+    // 64k of a 128k window -> the gauge should report 50% used.
+    await mockChatEndpoint(
+      chatPage.page,
+      buildMockStreamWithContextUsage("Mock response", 64_000, 128_000)
+    );
+
+    await chatPage.inputBar.fill("hello");
+    await chatPage.inputBar.send();
+    await chatPage.expectHumanMessage("hello");
+
+    await chatPage.expectContextGauge(50);
+  });
+
+  test("stays hidden when a turn streams no context_usage packet", async ({
+    chatPage,
+  }) => {
+    await chatPage.goto();
+    // Models/paths that don't report usage emit no context_usage packet -> no gauge.
+    await mockChatEndpoint(chatPage.page, buildMockStream("Mock response"));
+
+    await chatPage.inputBar.fill("hello");
+    await chatPage.inputBar.send();
+    await chatPage.expectHumanMessage("hello");
+
+    await chatPage.expectNoContextGauge();
+  });
+});

--- a/web/tests/e2e/utils/chatMock.ts
+++ b/web/tests/e2e/utils/chatMock.ts
@@ -63,6 +63,51 @@ export function buildMockStream(content: string): string {
   return serializePackets(packets);
 }
 
+/** Like buildMockStream but emits a context_usage packet before stop, so the
+ *  context-window gauge has a value to render. */
+export function buildMockStreamWithContextUsage(
+  content: string,
+  usedTokens: number,
+  maxInputTokens: number
+): string {
+  const { userMessageId, agentMessageId } = nextMessageIds();
+
+  const packets = [
+    {
+      user_message_id: userMessageId,
+      reserved_assistant_message_id: agentMessageId,
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "message_start",
+        id: `mock-${agentMessageId}`,
+        content,
+        final_documents: null,
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: {
+        type: "context_usage",
+        used_tokens: usedTokens,
+        max_input_tokens: maxInputTokens,
+      },
+    },
+    {
+      placement: { turn_index: 0, tab_index: 0 },
+      obj: { type: "stop", stop_reason: "finished" },
+    },
+    {
+      message_id: agentMessageId,
+      citations: {},
+      files: [],
+    },
+  ];
+
+  return serializePackets(packets);
+}
+
 export interface ImageGenStreamOptions {
   fileId: string;
   revisedPrompt: string;


### PR DESCRIPTION
Adds a small ring gauge near the chat input showing how full the model's context window is for the current conversation — `used / max`, 1:1 with the actual prompt the model received.

### Why
There's no visibility into context-window usage today, and Onyx already silently trims older history when the window fills (`convert_chat_history_basic`). This surfaces the real usage and explains the trimming.

### How
- **1:1 real usage** — captures the provider-reported `usage.prompt_tokens` of the last assistant turn (exactly what the model counted: system + persona + tools + history + any RAG), already read in `llm_step`. It's carried back via the existing `ChatStateContainer`, persisted on a new nullable `chat_message.prompt_tokens` column, streamed live as a `context_usage` packet at turn end, and exposed on the chat session-detail API so it survives reload.
- **Empty chats** — a computed baseline (system + persona + tool-definition tokens) so a heavy persona shows a non-zero floor. The baseline tokenization runs **only** for empty chats; the common (non-empty) path reads `max_input_tokens` from the model config without tokenizing.
- **Frontend** — a `ContextGauge` ring in the input row, fed by the live packet (preferred) or the session-loaded value. Color shifts as it fills (green → amber → red); the tooltip shows `used / max (NN%)` plus a note that older messages get trimmed when full. The gauge hides itself when the model's context size is unknown.

### Scope
- **Chat only** — Onyx Craft / Build-Mode is intentionally out of scope.
- Additive only: one migration (`chat_message.prompt_tokens`, nullable), one streaming packet, one session-detail field, one FE component. No breaking changes.

### Testing
- Backend unit: the state-container carry, `prompt_tokens` persistence, and the session-detail `context_usage` (last-turn vs. lazily-computed baseline).
- Frontend: typecheck + lint; a Playwright e2e (a mock `context_usage` packet drives the gauge to the expected percent; its absence keeps the gauge hidden).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small ring gauge next to the chat input that shows how much of the model’s context window is used. It updates at turn end (including cancel), ignores zero-token reports, backtracks to the last turn that reported usage, and hides on fresh chats or when the size is unknown; the gauge uses the producing model’s window per turn so a later model switch doesn’t change the denominator.

- **New Features**
  - Backend: capture provider `usage.prompt_tokens` (ignore `0`), persist to `chat_message.prompt_tokens` and `chat_message.max_input_tokens`, and stream a `context_usage` packet (`used_tokens`, `max_input_tokens`) at turn end and on stop. Session detail exposes `context_usage` after an assistant turn reports `prompt_tokens`, preferring the turn’s stored `max_input_tokens` and lazily falling back to the current model; resolution failures are swallowed (gauge hides).
  - Frontend: Context gauge in the input bar prefers the live `context_usage` packet, backtracks past assistant turns without a packet (skips the in-flight turn), and falls back to session `context_usage`. Uses a `ContextRing` component; color shifts (green→amber ≥70%→red ≥90%); tooltip shows used/max and percent and notes older messages are trimmed; hidden when no usable value.

- **Migration**
  - Add nullable columns `chat_message.prompt_tokens` and `chat_message.max_input_tokens` via Alembic. Run migrations; no breaking changes.

<sup>Written for commit cdff4278e6e683d93ee7fa0f6383a4c566965f30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

