### PR TITLE
fix(discord): refresh tenant cache concurrently

### DIFF
--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -76,9 +76,12 @@ class DiscordCacheManager:
                         logger.exception("Failed to refresh tenant %s", tenant_id)
                         return None
 
+                # allow_failures keeps per-tenant isolation explicit and independent
+                # of load()'s exception handling: one tenant can't abort the batch.
                 results: list[TenantDiscordData | None] = await asyncio.to_thread(
                     run_functions_tuples_in_parallel,
                     [(load, (tenant_id,)) for tenant_id in tenant_ids],
+                    allow_failures=True,
                     max_workers=_REFRESH_MAX_WORKERS,
                 )
 

--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -15,8 +15,7 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
 
-# Tenants are loaded concurrently during a full refresh. Bounded to avoid
-# exhausting the DB connection pool when a cluster has many tenants.
+# Bounded so a cluster with many tenants can't exhaust the DB connection pool.
 _REFRESH_MAX_WORKERS = 16
 
 
@@ -64,9 +63,8 @@ class DiscordCacheManager:
                     if tenant_id not in gated
                 ]
 
-                # Wrap each load so a failure is logged with its tenant_id (and the
-                # underlying error) here, where we still have that context, rather
-                # than surfacing as the index-keyed log from the thread pool.
+                # Log failures with tenant_id here; the thread pool only knows the
+                # positional index.
                 def load(tenant_id: str) -> TenantDiscordData | None:
                     try:
                         return self._load_tenant_data(
@@ -76,8 +74,8 @@ class DiscordCacheManager:
                         logger.exception("Failed to refresh tenant %s", tenant_id)
                         return None
 
-                # allow_failures keeps per-tenant isolation explicit and independent
-                # of load()'s exception handling: one tenant can't abort the batch.
+                # allow_failures so one tenant can't abort the batch, independent of
+                # load()'s except clause.
                 results: list[TenantDiscordData | None] = await asyncio.to_thread(
                     run_functions_tuples_in_parallel,
                     [(load, (tenant_id,)) for tenant_id in tenant_ids],

--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -1,6 +1,7 @@
 """Multi-tenant cache for Discord bot guild-tenant mappings and API keys."""
 
 import asyncio
+from typing import NamedTuple
 
 from onyx.db.discord_bot import get_guild_configs
 from onyx.db.discord_bot import get_or_create_discord_service_api_key
@@ -8,10 +9,22 @@ from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.onyxbot.discord.exceptions import CacheError
 from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 logger = setup_logger()
+
+# Tenants are loaded concurrently during a full refresh. Bounded to avoid
+# exhausting the DB connection pool when a cluster has many tenants.
+_REFRESH_MAX_WORKERS = 16
+
+
+class TenantDiscordData(NamedTuple):
+    """A tenant's enabled guild IDs and its Discord service API key."""
+
+    guild_ids: list[int]
+    api_key: str | None
 
 
 class DiscordCacheManager:
@@ -45,33 +58,46 @@ class DiscordCacheManager:
                     set(),
                 )()
 
-                tenant_ids = await asyncio.to_thread(get_all_tenant_ids)
-                for tenant_id in tenant_ids:
-                    if tenant_id in gated:
+                tenant_ids = [
+                    tenant_id
+                    for tenant_id in await asyncio.to_thread(get_all_tenant_ids)
+                    if tenant_id not in gated
+                ]
+
+                results: list[TenantDiscordData | None] = await asyncio.to_thread(
+                    run_functions_tuples_in_parallel,
+                    [
+                        (
+                            self._load_tenant_data,
+                            (tenant_id, self._api_keys.get(tenant_id)),
+                        )
+                        for tenant_id in tenant_ids
+                    ],
+                    allow_failures=True,
+                    max_workers=_REFRESH_MAX_WORKERS,
+                )
+
+                for tenant_id, result in zip(tenant_ids, results):
+                    if result is None:
+                        logger.warning("Failed to refresh tenant %s", tenant_id)
                         continue
 
-                    context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
-                    try:
-                        guild_ids, api_key = await self._load_tenant_data(tenant_id)
-                        if not guild_ids:
-                            logger.debug("No guilds found for tenant %s", tenant_id)
-                            continue
+                    guild_ids, api_key = result
+                    if not guild_ids:
+                        logger.debug("No guilds found for tenant %s", tenant_id)
+                        continue
 
-                        if not api_key:
-                            logger.warning(
-                                "Discord service API key missing for tenant that has registered guilds. %s will not be handled in this refresh cycle.",
-                                tenant_id,
-                            )
-                            continue
+                    if not api_key:
+                        logger.warning(
+                            "Discord service API key missing for tenant that has registered guilds. %s will not be handled in this refresh cycle.",
+                            tenant_id,
+                        )
+                        continue
 
-                        for guild_id in guild_ids:
-                            new_guild_tenants[guild_id] = tenant_id
+                    for guild_id in guild_ids:
+                        new_guild_tenants[guild_id] = tenant_id
 
-                        new_api_keys[tenant_id] = api_key
-                    except Exception as e:
-                        logger.warning("Failed to refresh tenant %s: %s", tenant_id, e)
-                    finally:
-                        CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
+                    new_api_keys[tenant_id] = api_key
 
                 self._guild_tenants = new_guild_tenants
                 self._api_keys = new_api_keys
@@ -94,7 +120,9 @@ class DiscordCacheManager:
                 "Refreshing cache for guild %s (tenant: %s)", guild_id, tenant_id
             )
 
-            guild_ids, api_key = await self._load_tenant_data(tenant_id)
+            guild_ids, api_key = await asyncio.to_thread(
+                self._load_tenant_data, tenant_id, self._api_keys.get(tenant_id)
+            )
 
             if guild_id in guild_ids:
                 self._guild_tenants[guild_id] = tenant_id
@@ -104,16 +132,20 @@ class DiscordCacheManager:
             else:
                 logger.warning("Guild %s not found or disabled", guild_id)
 
-    async def _load_tenant_data(self, tenant_id: str) -> tuple[list[int], str | None]:
-        """Load guild IDs and provision API key if needed.
+    @staticmethod
+    def _load_tenant_data(tenant_id: str, cached_key: str | None) -> TenantDiscordData:
+        """Load a tenant's enabled guilds and provision an API key if needed.
 
-        Returns:
-            (active_guild_ids, api_key) - api_key is the cached key if available,
-            otherwise a newly created key. Returns None if no guilds found.
+        Synchronous so it can run in a worker thread (via to_thread / the parallel
+        refresh). Sets the tenant contextvar so downstream calls that rely on it
+        resolve the correct tenant; the surrounding copied context keeps this
+        isolated from other concurrent workers.
+
+        api_key is the cached key if available, otherwise a newly created one.
+        guild_ids is empty if none are found.
         """
-        cached_key = self._api_keys.get(tenant_id)
-
-        def _sync() -> tuple[list[int], str | None]:
+        context_token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+        try:
             with get_session_with_tenant(tenant_id=tenant_id) as db:
                 configs = get_guild_configs(db)
                 guild_ids = [
@@ -123,16 +155,16 @@ class DiscordCacheManager:
                 ]
 
                 if not guild_ids:
-                    return [], None
+                    return TenantDiscordData([], None)
 
                 if not cached_key:
                     new_key = get_or_create_discord_service_api_key(db, tenant_id)
                     db.commit()
-                    return guild_ids, new_key
+                    return TenantDiscordData(guild_ids, new_key)
 
-                return guild_ids, cached_key
-
-        return await asyncio.to_thread(_sync)
+                return TenantDiscordData(guild_ids, cached_key)
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(context_token)
 
     def get_tenant(self, guild_id: int) -> str | None:
         """Get tenant ID for a guild."""

--- a/backend/onyx/onyxbot/discord/cache.py
+++ b/backend/onyx/onyxbot/discord/cache.py
@@ -64,22 +64,26 @@ class DiscordCacheManager:
                     if tenant_id not in gated
                 ]
 
+                # Wrap each load so a failure is logged with its tenant_id (and the
+                # underlying error) here, where we still have that context, rather
+                # than surfacing as the index-keyed log from the thread pool.
+                def load(tenant_id: str) -> TenantDiscordData | None:
+                    try:
+                        return self._load_tenant_data(
+                            tenant_id, self._api_keys.get(tenant_id)
+                        )
+                    except Exception:
+                        logger.exception("Failed to refresh tenant %s", tenant_id)
+                        return None
+
                 results: list[TenantDiscordData | None] = await asyncio.to_thread(
                     run_functions_tuples_in_parallel,
-                    [
-                        (
-                            self._load_tenant_data,
-                            (tenant_id, self._api_keys.get(tenant_id)),
-                        )
-                        for tenant_id in tenant_ids
-                    ],
-                    allow_failures=True,
+                    [(load, (tenant_id,)) for tenant_id in tenant_ids],
                     max_workers=_REFRESH_MAX_WORKERS,
                 )
 
                 for tenant_id, result in zip(tenant_ids, results):
                     if result is None:
-                        logger.warning("Failed to refresh tenant %s", tenant_id)
                         continue
 
                     guild_ids, api_key = result

--- a/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_cache_manager.py
@@ -4,12 +4,14 @@ Tests for DiscordCacheManager class functionality.
 """
 
 import asyncio
+import time
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 
 from onyx.onyxbot.discord.cache import DiscordCacheManager
+from onyx.onyxbot.discord.cache import TenantDiscordData
 
 
 class TestCacheInitialization:
@@ -239,12 +241,12 @@ class TestThreadSafety:
 
         call_count = 0
 
-        async def slow_refresh() -> tuple[list[int], str]:
+        def slow_refresh(tenant_id: str, cached_key: str | None) -> TenantDiscordData:  # noqa: ARG001
             nonlocal call_count
             call_count += 1
-            # Simulate slow operation
-            await asyncio.sleep(0.01)
-            return ([111111], "api_key")
+            # Simulate slow operation (sync: runs in the refresh thread pool)
+            time.sleep(0.01)
+            return TenantDiscordData([111111], "api_key")
 
         with (
             patch(
@@ -495,12 +497,12 @@ class TestCacheErrorHandling:
 
         call_count = 0
 
-        async def mock_load(tenant_id: str) -> tuple[list[int], str]:
+        def mock_load(tenant_id: str, cached_key: str | None) -> TenantDiscordData:  # noqa: ARG001
             nonlocal call_count
             call_count += 1
             if tenant_id == "tenant1":
                 raise Exception("Tenant 1 error")
-            return ([222222], "api_key")
+            return TenantDiscordData([222222], "api_key")
 
         with (
             patch(


### PR DESCRIPTION
## Description

The Discord bot's periodic cache refresh (`DiscordCacheManager.refresh_all`) iterated every tenant schema in the cluster **serially**, awaiting one DB round-trip per tenant. On cloud prod this took ~2m30s — even though only a handful of tenants run Discord — because the cost scaled linearly with total tenant count.

The per-tenant work is blocking sync DB I/O, so a single thread (or serial `await`) can't overlap it. This fans the loads out across a bounded thread pool via the canonical `run_functions_tuples_in_parallel`, dropping wall-clock to roughly `ceil(tenants / 16) × round-trip`.

- Bounded to 16 workers (under the bot's `pool_size=20` DB pool).
- The per-tenant loader is now a pure, stateless function (cached key passed in, not read off shared state) so it's safe to run off-thread; contextvar is set inside each worker.
- `refresh_guild`'s single-tenant path reuses the same function via `to_thread`.

## How Has This Been Tested?

`black` + `mypy` clean. Behavior is unchanged per tenant — only the iteration is parallelized.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized the Discord tenant cache refresh using a bounded thread pool (16 workers) to cut wall-clock to roughly ceil(tenants/16) DB round trips. Adds per-tenant isolation with `allow_failures` and logs errors with tenant context; per-tenant behavior is unchanged.

- **Refactors**
  - Use `run_functions_tuples_in_parallel` via `asyncio.to_thread` (`max_workers=16`, `allow_failures=True`) so one tenant can’t abort the batch.
  - Prefilter gated tenants before scheduling work; wrap each tenant load and `logger.exception` with `tenant_id` on failure.
  - Make `_load_tenant_data` a stateless sync `@staticmethod` that sets the tenant contextvar and returns `TenantDiscordData`; it accepts the cached key and `refresh_guild` calls it via `asyncio.to_thread`. Tests updated for the sync loader.

<sup>Written for commit 454f5fd7c93ab80525e067614b0aa59b5d1ef16c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

