### PR TITLE
 chore(gha): add read permissions to paths filter

### DIFF
--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -20,10 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed files via the GitHub API
-    # (pulls.listFiles), which private repos gate behind pull-requests:read;
-    # without it the job fails with "Resource not accessible by integration".
-    # Harmless no-op on public repos, which don't enforce the scope.
+    # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-database-tests.yml
+++ b/.github/workflows/pr-database-tests.yml
@@ -20,6 +20,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed files via the GitHub API
+    # (pulls.listFiles), which private repos gate behind pull-requests:read;
+    # without it the job fails with "Resource not accessible by integration".
+    # Harmless no-op on public repos, which don't enforce the scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       db: ${{ steps.filter.outputs.db || 'true' }}
     steps:

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -53,10 +53,7 @@ jobs:
     # everything runs.
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed files via the GitHub API
-    # (pulls.listFiles), which private repos gate behind pull-requests:read;
-    # without it the job fails with "Resource not accessible by integration".
-    # Harmless no-op on public repos, which don't enforce the scope.
+    # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -53,6 +53,13 @@ jobs:
     # everything runs.
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed files via the GitHub API
+    # (pulls.listFiles), which private repos gate behind pull-requests:read;
+    # without it the job fails with "Resource not accessible by integration".
+    # Harmless no-op on public repos, which don't enforce the scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       integration: ${{ steps.filter.outputs.integration || 'true' }}
     steps:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -88,6 +88,13 @@ jobs:
     # `true` so everything runs.
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed files via the GitHub API
+    # (pulls.listFiles), which private repos gate behind pull-requests:read;
+    # without it the job fails with "Resource not accessible by integration".
+    # Harmless no-op on public repos, which don't enforce the scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       playwright: ${{ steps.filter.outputs.playwright || 'true' }}
       # Whether this change touches MCP-OAuth-relevant code. Drives whether a

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -88,10 +88,7 @@ jobs:
     # `true` so everything runs.
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed files via the GitHub API
-    # (pulls.listFiles), which private repos gate behind pull-requests:read;
-    # without it the job fails with "Resource not accessible by integration".
-    # Harmless no-op on public repos, which don't enforce the scope.
+    # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -20,10 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed files via the GitHub API
-    # (pulls.listFiles), which private repos gate behind pull-requests:read;
-    # without it the job fails with "Resource not accessible by integration".
-    # Harmless no-op on public repos, which don't enforce the scope.
+    # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-python-checks.yml
+++ b/.github/workflows/pr-python-checks.yml
@@ -20,6 +20,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed files via the GitHub API
+    # (pulls.listFiles), which private repos gate behind pull-requests:read;
+    # without it the job fails with "Resource not accessible by integration".
+    # Harmless no-op on public repos, which don't enforce the scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -116,6 +116,11 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # dorny/paths-filter (Detect Connector changes) reads the PR's changed
+      # files via the GitHub API (pulls.listFiles), which private repos gate
+      # behind pull-requests:read; without it the step fails with "Resource not
+      # accessible by integration". Harmless no-op on public repos.
+      pull-requests: read
     # See https://runs-on.com/runners/linux/
     runs-on:
       [

--- a/.github/workflows/pr-python-connector-tests.yml
+++ b/.github/workflows/pr-python-connector-tests.yml
@@ -116,10 +116,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      # dorny/paths-filter (Detect Connector changes) reads the PR's changed
-      # files via the GitHub API (pulls.listFiles), which private repos gate
-      # behind pull-requests:read; without it the step fails with "Resource not
-      # accessible by integration". Harmless no-op on public repos.
+      # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
       pull-requests: read
     # See https://runs-on.com/runners/linux/
     runs-on:

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -20,10 +20,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # dorny/paths-filter reads the PR's changed files via the GitHub API
-    # (pulls.listFiles), which private repos gate behind pull-requests:read;
-    # without it the job fails with "Resource not accessible by integration".
-    # Harmless no-op on public repos, which don't enforce the scope.
+    # paths-filter needs pull-requests:read to list PR files on private repos (no-op on public).
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/pr-python-tests.yml
+++ b/.github/workflows/pr-python-tests.yml
@@ -20,6 +20,13 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # dorny/paths-filter reads the PR's changed files via the GitHub API
+    # (pulls.listFiles), which private repos gate behind pull-requests:read;
+    # without it the job fails with "Resource not accessible by integration".
+    # Harmless no-op on public repos, which don't enforce the scope.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       python: ${{ steps.filter.outputs.python || 'true' }}
     steps:


### PR DESCRIPTION
## Description

Required for this action to work in private forks of the Onyx repo

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `pull-requests: read` (and `contents: read` where missing) to PR workflow "changes" jobs so `dorny/paths-filter` can list PR files on private forks. Restores path-based test filtering; no behavior change on public repos.

<sup>Written for commit 6f6efaaeae3bbdca9a44ea61b9221b8d6913ee6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

