### PR TITLE
chore: centralize retry-after parsing

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -26,6 +26,7 @@ from onyx.connectors.sharepoint.connector import GRAPH_API_RETRYABLE_STATUSES
 from onyx.connectors.sharepoint.connector import SHARED_DOCUMENTS_MAP_REVERSE
 from onyx.connectors.sharepoint.connector import sleep_and_retry
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -71,7 +72,15 @@ def _graph_api_get(
                 resp.status_code in GRAPH_API_RETRYABLE_STATUSES
                 and attempt < GRAPH_API_MAX_RETRIES
             ):
-                wait = min(int(resp.headers.get("Retry-After", str(2**attempt))), 60)
+                parsed_retry_after = parse_retry_after_seconds(
+                    resp.headers.get("Retry-After")
+                )
+                wait = min(
+                    parsed_retry_after
+                    if parsed_retry_after is not None
+                    else float(2**attempt),
+                    60,
+                )
                 logger.warning(
                     "Graph API %s on attempt %s, retrying in %ss: %s",
                     resp.status_code,

--- a/backend/onyx/connectors/bitbucket/utils.py
+++ b/backend/onyx/connectors/bitbucket/utils.py
@@ -22,6 +22,10 @@ from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
 
+# Upper bound on how long we'll honor a server-provided Retry-After before
+# sleeping. Bitbucket's rate-limit window is per-minute.
+_MAX_RETRY_AFTER_SLEEP_SECONDS = 60
+
 # Fields requested from Bitbucket PR list endpoint to ensure rich PR data
 PR_LIST_RESPONSE_FIELDS: str = ",".join(
     [
@@ -118,7 +122,7 @@ def bitbucket_get(
                 else None
             )
             if retry_after is not None:
-                time.sleep(retry_after)
+                time.sleep(min(retry_after, _MAX_RETRY_AFTER_SLEEP_SECONDS))
             raise BitbucketRetriableError("Bitbucket rate limit exceeded (429)") from e
         if status is not None and 500 <= status < 600:
             raise BitbucketRetriableError(f"Bitbucket server error: {status}") from e

--- a/backend/onyx/connectors/bitbucket/utils.py
+++ b/backend/onyx/connectors/bitbucket/utils.py
@@ -17,6 +17,7 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
@@ -111,12 +112,13 @@ def bitbucket_get(
     except httpx.HTTPStatusError as e:
         status = e.response.status_code if e.response is not None else None
         if status == 429:
-            retry_after = e.response.headers.get("Retry-After") if e.response else None
+            retry_after = (
+                parse_retry_after_seconds(e.response.headers.get("Retry-After"))
+                if e.response
+                else None
+            )
             if retry_after is not None:
-                try:
-                    time.sleep(int(retry_after))
-                except (TypeError, ValueError):
-                    pass
+                time.sleep(retry_after)
             raise BitbucketRetriableError("Bitbucket rate limit exceeded (429)") from e
         if status is not None and 500 <= status < 600:
             raise BitbucketRetriableError(f"Bitbucket server error: {status}") from e

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -30,6 +30,7 @@ from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 if TYPE_CHECKING:
     from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
@@ -443,23 +444,17 @@ def _handle_http_error(e: requests.HTTPError, attempt: int, max_retries: int) ->
     ):
         raise e
 
-    retry_after = None
-
-    retry_after_header = e.response.headers.get("Retry-After")
-    if retry_after_header is not None:
-        try:
-            retry_after = int(retry_after_header)
-            if retry_after > MAX_DELAY:
-                logger.warning(
-                    "Clamping retry_after from %s to %s seconds...",
-                    retry_after,
-                    MAX_DELAY,
-                )
-                retry_after = MAX_DELAY
-            if retry_after < MIN_DELAY:
-                retry_after = MIN_DELAY
-        except ValueError:
-            pass
+    retry_after = parse_retry_after_seconds(e.response.headers.get("Retry-After"))
+    if retry_after is not None:
+        if retry_after > MAX_DELAY:
+            logger.warning(
+                "Clamping retry_after from %s to %s seconds...",
+                retry_after,
+                MAX_DELAY,
+            )
+            retry_after = MAX_DELAY
+        if retry_after < MIN_DELAY:
+            retry_after = MIN_DELAY
 
     if retry_after is not None:
         logger.warning(

--- a/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
+++ b/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
@@ -8,6 +8,7 @@ from typing import TypeVar
 import requests
 
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -102,12 +103,8 @@ def wrap_request_to_handle_ratelimiting(
         for _ in range(max_waits):
             response = request_fn(*args, **kwargs)
             if response.status_code == 429:
-                try:
-                    wait_time = int(
-                        response.headers.get("Retry-After", default_wait_time_sec)
-                    )
-                except ValueError:
-                    wait_time = default_wait_time_sec
+                parsed = parse_retry_after_seconds(response.headers.get("Retry-After"))
+                wait_time = parsed if parsed is not None else default_wait_time_sec
 
                 time.sleep(wait_time)
                 continue

--- a/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
+++ b/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
@@ -97,7 +97,10 @@ R = TypeVar("R", bound=Callable[..., requests.Response])
 
 
 def wrap_request_to_handle_ratelimiting(
-    request_fn: R, default_wait_time_sec: int = 30, max_waits: int = 30
+    request_fn: R,
+    default_wait_time_sec: int = 30,
+    max_waits: int = 30,
+    max_wait_time_sec: int = 300,
 ) -> R:
     def wrapped_request(*args: list, **kwargs: dict[str, Any]) -> requests.Response:
         for _ in range(max_waits):
@@ -105,6 +108,8 @@ def wrap_request_to_handle_ratelimiting(
             if response.status_code == 429:
                 parsed = parse_retry_after_seconds(response.headers.get("Retry-After"))
                 wait_time = parsed if parsed is not None else default_wait_time_sec
+                # Cap so an absurd Retry-After can't stall the caller indefinitely.
+                wait_time = min(wait_time, max_wait_time_sec)
 
                 time.sleep(wait_time)
                 continue

--- a/backend/onyx/connectors/google_utils/google_utils.py
+++ b/backend/onyx/connectors/google_utils/google_utils.py
@@ -12,6 +12,7 @@ from googleapiclient.errors import HttpError
 
 from onyx.connectors.google_drive.models import GoogleDriveFileType
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.retry_wrapper import retry_builder
 
 logger = setup_logger()
@@ -75,9 +76,9 @@ def _execute_with_retry(request: Any) -> Any:
 
             if _is_rate_limit_error(error):
                 # Attempt to get 'Retry-After' from headers
-                retry_after = error.resp.get("Retry-After")
-                if retry_after:
-                    sleep_time = int(retry_after)
+                retry_after = parse_retry_after_seconds(error.resp.get("Retry-After"))
+                if retry_after is not None:
+                    sleep_time = retry_after
                 else:
                     # Extract 'Retry after' timestamp from error message
                     match = re.search(

--- a/backend/onyx/connectors/hubspot/rate_limit.py
+++ b/backend/onyx/connectors/hubspot/rate_limit.py
@@ -10,6 +10,7 @@ from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
     RateLimitTriedTooManyTimesError,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -67,14 +68,9 @@ def is_rate_limit_error(exception: Exception) -> bool:
 def get_rate_limit_retry_delay_seconds(exception: Exception) -> float:
     headers = getattr(exception, "headers", None)
 
-    retry_after = _extract_header(headers, "Retry-After")
-    if retry_after:
-        try:
-            return float(retry_after) + _SLEEP_PADDING_SECONDS
-        except ValueError:
-            logger.debug(
-                "Failed to parse Retry-After header '%s' as float", retry_after
-            )
+    retry_after = parse_retry_after_seconds(_extract_header(headers, "Retry-After"))
+    if retry_after is not None:
+        return retry_after + _SLEEP_PADDING_SECONDS
 
     interval_ms = _extract_header(headers, "x-hubspot-ratelimit-interval-milliseconds")
     if interval_ms:

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -83,6 +83,7 @@ from onyx.file_processing.image_utils import make_image_callback
 from onyx.file_processing.image_utils import store_image_and_create_section
 from onyx.file_store.staging import RawFileCallback
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 from onyx.utils.url import SSRFException
 from onyx.utils.url import validate_outbound_http_url
@@ -313,23 +314,19 @@ def _graph_error_code(response: requests.Response | None) -> str:
 
 
 def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
-    """Honor a numeric Retry-After header when the server provides one,
-    otherwise fall back to capped exponential backoff with equal jitter.
+    """Honor a server-provided Retry-After header (numeric seconds or HTTP-date)
+    when present, otherwise fall back to capped exponential backoff with equal
+    jitter.
 
     Base sequence is 5s, 10s, 20s, capped at 30s. The actual sleep is drawn
     from ``[base/2, base]`` so that many documents failing at the same instant
     (e.g. during a Graph throttling window) don't all retry on the same tick
     and re-create the thundering herd. Server-provided Retry-After values are
     used verbatim — those are an explicit instruction, not a guess.
-
-    The HTTP-date form of Retry-After is rare from SharePoint / Graph in
-    practice and falls through to the jittered exponential backoff.
     """
-    if retry_after:
-        try:
-            return float(retry_after)
-        except ValueError:
-            pass
+    parsed = parse_retry_after_seconds(retry_after)
+    if parsed is not None:
+        return parsed
     base = min(30, (2**attempt) * 5)
     return base / 2 + random.uniform(0, base / 2)
 
@@ -1874,8 +1871,13 @@ class SharepointConnector(
                 )
                 if response.status_code in GRAPH_API_RETRYABLE_STATUSES:
                     if attempt < GRAPH_API_MAX_RETRIES:
-                        retry_after = int(
-                            response.headers.get("Retry-After", str(2**attempt))
+                        parsed_retry_after = parse_retry_after_seconds(
+                            response.headers.get("Retry-After")
+                        )
+                        retry_after = (
+                            parsed_retry_after
+                            if parsed_retry_after is not None
+                            else float(2**attempt)
                         )
                         wait = min(retry_after, 60)
                         logger.warning(

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -70,6 +70,7 @@ from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -1429,7 +1430,10 @@ class SlackConnector(
             slack_error = e.response.get("error", "")
             if slack_error == "ratelimited":
                 # Handle rate limiting specifically
-                retry_after = int(e.response.headers.get("Retry-After", 1))
+                retry_after = (
+                    parse_retry_after_seconds(e.response.headers.get("Retry-After"))
+                    or 1
+                )
                 logger.warning(
                     "Slack API rate limited during validation. Retry suggested after %s seconds. Proceeding with validation, but be aware that connector operations might be throttled.",
                     retry_after,

--- a/backend/onyx/connectors/slack/onyx_retry_handler.py
+++ b/backend/onyx/connectors/slack/onyx_retry_handler.py
@@ -8,6 +8,7 @@ from slack_sdk.http_retry.state import RetryState
 
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -115,11 +116,14 @@ class OnyxRedisSlackRetryHandler(RetryHandler):
                 else retry_after_header_value
             )
 
-            retry_after_value_int = int(
-                retry_after_value
-            )  # will raise ValueError if somehow we can't convert to int
-            jitter = retry_after_value_int * 0.25 * random.random()
-            duration_s = retry_after_value_int + jitter
+            parsed_retry_after = parse_retry_after_seconds(retry_after_value)
+            if parsed_retry_after is None:
+                raise ValueError(
+                    "OnyxRedisSlackRetryHandler.prepare_for_next_attempt: "
+                    "could not parse retry-after value"
+                )
+            jitter = parsed_retry_after * 0.25 * random.random()
+            duration_s = parsed_retry_after + jitter
         except ValueError:
             duration_s += random.random()
 

--- a/backend/onyx/connectors/teams/utils.py
+++ b/backend/onyx/connectors/teams/utils.py
@@ -16,6 +16,7 @@ from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.teams.models import Message
 from onyx.utils.logger import setup_logger
+from onyx.utils.retry_after import parse_retry_after_seconds
 
 logger = setup_logger()
 
@@ -32,17 +33,16 @@ GRAPH_API_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 50
 
 
 def _backoff_seconds(attempt: int, retry_after: str | None) -> float:
-    """Honor a numeric ``Retry-After`` header when the server provides one,
-    otherwise capped exponential backoff (5s, 10s, 20s, capped at 30s) with
-    equal jitter so many concurrent failures don't all retry on the same tick.
+    """Honor a server-provided ``Retry-After`` header (numeric seconds or
+    HTTP-date) when present, otherwise capped exponential backoff (5s, 10s,
+    20s, capped at 30s) with equal jitter so many concurrent failures don't all
+    retry on the same tick.
 
     ``attempt`` is 0-indexed (0 for the first retry).
     """
-    if retry_after:
-        try:
-            return float(retry_after)
-        except ValueError:
-            pass
+    parsed = parse_retry_after_seconds(retry_after)
+    if parsed is not None:
+        return parsed
     base = min(30, (2**attempt) * 5)
     return base / 2 + random.uniform(0, base / 2)
 

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -33,6 +33,7 @@ from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.file_processing.html_utils import parse_html_page_basic
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.retry_wrapper import retry_builder
 
 MAX_PAGE_SIZE = 30  # Zendesk API maximum
@@ -78,10 +79,10 @@ def request_with_rate_limit(
         )
 
         if response.status_code == 429:
-            retry_after = response.headers.get("Retry-After")
+            retry_after = parse_retry_after_seconds(response.headers.get("Retry-After"))
             if retry_after is not None:
                 # Sleep for the duration indicated by the Retry-After header
-                time.sleep(int(retry_after))
+                time.sleep(retry_after)
 
         elif (
             response.status_code == 403

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -39,6 +39,8 @@ from onyx.utils.retry_wrapper import retry_builder
 MAX_PAGE_SIZE = 30  # Zendesk API maximum
 MAX_AUTHOR_MAP_SIZE = 50_000  # Reset author map cache if it gets too large
 _SLIM_BATCH_SIZE = 1000
+# Upper bound on how long we'll honor a server-provided Retry-After.
+_MAX_RETRY_AFTER_SLEEP_SECONDS = 60
 
 
 class ZendeskCredentialsNotSetUpError(PermissionError):
@@ -82,7 +84,7 @@ def request_with_rate_limit(
             retry_after = parse_retry_after_seconds(response.headers.get("Retry-After"))
             if retry_after is not None:
                 # Sleep for the duration indicated by the Retry-After header
-                time.sleep(retry_after)
+                time.sleep(min(retry_after, _MAX_RETRY_AFTER_SLEEP_SECONDS))
 
         elif (
             response.status_code == 403

--- a/backend/onyx/utils/retry_after.py
+++ b/backend/onyx/utils/retry_after.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from datetime import timezone
+from email.utils import parsedate_to_datetime
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+def parse_retry_after_seconds(value: str | None) -> float | None:
+    """Parse an HTTP ``Retry-After`` header value into seconds to wait.
+
+    RFC 9110 allows two forms:
+    - delay-seconds: a non-negative number of seconds (e.g. ``"120"``).
+    - HTTP-date: an absolute instant (e.g. ``"Wed, 21 Oct 2015 07:28:00 GMT"``),
+      converted to seconds from now and floored at 0 for already-elapsed dates.
+
+    Returns ``None`` when the value is missing or unparseable, so callers can
+    fall back to their own backoff strategy.
+    """
+    if value is None:
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    # delay-seconds form. The spec says integer, but some servers send floats;
+    # accept both and floor at 0 since a negative wait is meaningless.
+    try:
+        return max(float(text), 0.0)
+    except ValueError:
+        pass
+
+    # HTTP-date form.
+    try:
+        retry_at = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        logger.debug("Failed to parse Retry-After header '%s'", text)
+        return None
+
+    if retry_at is None:
+        logger.debug("Failed to parse Retry-After header '%s'", text)
+        return None
+
+    # parsedate_to_datetime returns a naive datetime when the date carries no
+    # timezone; RFC dates are GMT, so treat that as UTC.
+    if retry_at.tzinfo is None:
+        retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+    delta_seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
+    return max(delta_seconds, 0.0)

--- a/backend/onyx/utils/retry_after.py
+++ b/backend/onyx/utils/retry_after.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime
 from datetime import timezone
 from email.utils import parsedate_to_datetime
@@ -25,12 +26,13 @@ def parse_retry_after_seconds(value: str | None) -> float | None:
     if not text:
         return None
 
-    # delay-seconds form. The spec says integer, but some servers send floats;
-    # accept both and floor at 0 since a negative wait is meaningless.
+    # The spec says integer, but some servers send floats. Reject nan/inf
     try:
-        return max(float(text), 0.0)
+        seconds = float(text)
     except ValueError:
-        pass
+        seconds = None
+    if seconds is not None:
+        return max(seconds, 0.0) if math.isfinite(seconds) else None
 
     # HTTP-date form.
     try:

--- a/backend/tests/unit/onyx/connectors/cross_connector_utils/test_rate_limit.py
+++ b/backend/tests/unit/onyx/connectors/cross_connector_utils/test_rate_limit.py
@@ -1,6 +1,14 @@
 import time
+from typing import Any
+from typing import cast
+
+import pytest
+import requests
 
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import rate_limit_builder
+from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
+    wrap_request_to_handle_ratelimiting,
+)
 
 
 def test_rate_limit_basic() -> None:
@@ -25,3 +33,35 @@ def test_rate_limit_basic() -> None:
     assert call_cnt == 3
     assert time_to_finish_non_ratelimited < 1
     assert time_to_finish_ratelimited > 5
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, retry_after: str | None = None) -> None:
+        self.status_code = status_code
+        self.headers: dict[str, str] = {}
+        if retry_after is not None:
+            self.headers["Retry-After"] = retry_after
+
+
+def test_wrap_request_caps_absurd_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A finite-but-huge Retry-After would make `time.sleep` raise OverflowError;
+    # the wrapper must cap it so the request can still recover.
+    responses = iter([_FakeResponse(429, retry_after="1e300"), _FakeResponse(200)])
+    slept: list[float] = []
+
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+    def _request_fn(*args: Any, **kwargs: Any) -> requests.Response:  # noqa: ARG001
+        return cast(requests.Response, next(responses))
+
+    wrapped = wrap_request_to_handle_ratelimiting(
+        _request_fn,
+        max_wait_time_sec=300,
+    )
+
+    result = wrapped()
+
+    assert result.status_code == 200
+    assert slept == [300]

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
@@ -232,13 +232,19 @@ def test_backoff_seconds_respects_retry_after_header_verbatim() -> None:
             assert sp_connector._backoff_seconds(0, retry_after=raw) == float(raw)
 
 
+def test_backoff_seconds_honors_http_date_retry_after() -> None:
+    """An already-elapsed HTTP-date Retry-After is honored verbatim (0s wait)."""
+    assert (
+        sp_connector._backoff_seconds(0, retry_after="Wed, 21 Oct 2015 07:28:00 GMT")
+        == 0
+    )
+
+
 def test_backoff_seconds_falls_back_when_retry_after_unparseable() -> None:
-    """Non-numeric Retry-After (HTTP-date) falls through to jittered backoff."""
+    """Genuinely unparseable Retry-After values fall through to jittered backoff."""
     base = 5  # attempt=0
     for _ in range(20):
-        s = sp_connector._backoff_seconds(
-            0, retry_after="Wed, 21 Oct 2026 07:28:00 GMT"
-        )
+        s = sp_connector._backoff_seconds(0, retry_after="not-a-date")
         assert base / 2 <= s <= base
 
 

--- a/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
@@ -121,7 +121,13 @@ def test_backoff_falls_back_to_capped_jittered_exponential() -> None:
         assert base / 2 <= delay <= base
 
 
-def test_backoff_ignores_non_numeric_retry_after() -> None:
-    # HTTP-date Retry-After values fall through to jittered exponential backoff.
-    delay = _backoff_seconds(attempt=0, retry_after="Wed, 21 Oct 2026 07:28:00 GMT")
+def test_backoff_honors_http_date_retry_after() -> None:
+    # An already-elapsed HTTP-date Retry-After is honored verbatim (0s wait),
+    # not treated as unparseable.
+    assert _backoff_seconds(attempt=0, retry_after="Wed, 21 Oct 2015 07:28:00 GMT") == 0
+
+
+def test_backoff_ignores_unparseable_retry_after() -> None:
+    # Genuinely unparseable values fall through to jittered exponential backoff.
+    delay = _backoff_seconds(attempt=0, retry_after="not-a-date")
     assert 2.5 <= delay <= 5

--- a/backend/tests/unit/onyx/utils/test_retry_after.py
+++ b/backend/tests/unit/onyx/utils/test_retry_after.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from email.utils import format_datetime
+
+import pytest
+
+from onyx.utils.retry_after import parse_retry_after_seconds
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("0", 0.0),
+        ("1", 1.0),
+        ("120", 120.0),
+        ("12.5", 12.5),
+        ("  30  ", 30.0),
+        # Negative seconds are nonsensical; floor at 0.
+        ("-5", 0.0),
+    ],
+)
+def test_parses_delay_seconds(value: str, expected: float) -> None:
+    assert parse_retry_after_seconds(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", "not-a-date", "soon"])
+def test_returns_none_for_missing_or_unparseable(value: str | None) -> None:
+    assert parse_retry_after_seconds(value) is None
+
+
+def test_parses_future_http_date() -> None:
+    future = datetime.now(timezone.utc) + timedelta(seconds=120)
+    parsed = parse_retry_after_seconds(format_datetime(future, usegmt=True))
+    assert parsed is not None
+    # Allow a little slack for clock drift / execution time.
+    assert 110 <= parsed <= 121
+
+
+def test_past_http_date_floors_at_zero() -> None:
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    assert parse_retry_after_seconds(format_datetime(past, usegmt=True)) == 0.0
+
+
+def test_parses_literal_http_date_string() -> None:
+    # A date far in the past must floor at 0 regardless of formatting details.
+    assert parse_retry_after_seconds("Wed, 21 Oct 2015 07:28:00 GMT") == 0.0

--- a/backend/tests/unit/onyx/utils/test_retry_after.py
+++ b/backend/tests/unit/onyx/utils/test_retry_after.py
@@ -29,6 +29,15 @@ def test_returns_none_for_missing_or_unparseable(value: str | None) -> None:
     assert parse_retry_after_seconds(value) is None
 
 
+@pytest.mark.parametrize(
+    "value", ["nan", "inf", "-inf", "infinity", "Inf", "NaN", "1e400"]
+)
+def test_rejects_non_finite_numbers(value: str) -> None:
+    # These parse as floats but are not valid delays; they must not produce an
+    # undefined or unbounded sleep.
+    assert parse_retry_after_seconds(value) is None
+
+
 def test_parses_future_http_date() -> None:
     future = datetime.now(timezone.utc) + timedelta(seconds=120)
     parsed = parse_retry_after_seconds(format_datetime(future, usegmt=True))


### PR DESCRIPTION
## Description

Centralize retry-after header parsing to also account for datetime responses

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized Retry-After parsing into `onyx.utils.retry_after.parse_retry_after_seconds` and switched all connectors and the rate-limit wrapper to use it. We now honor seconds and HTTP-date forms, ignore invalid values, and cap extreme sleeps to avoid stalls.

- **Refactors**
  - Added `onyx.utils.retry_after.parse_retry_after_seconds` to parse numeric seconds (including floats) or HTTP-date into non-negative seconds, rejecting non-finite values; past dates floor to 0; returns `None` when unparseable.
  - Replaced ad hoc parsing across SharePoint (connector + permissions), Teams, Slack, Confluence, Bitbucket, Zendesk, HubSpot, Google, and the cross-connector wrapper; added sleep caps (Bitbucket/Zendesk 60s, wrapper 300s), Slack retry handler now jitters parsed values. Tests updated/added for HTTP-date handling, non-finite numbers, and capping huge Retry-After values.

<sup>Written for commit 3e69936d50d3f78b5b23343d121dc0cadb13b9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

