### PR TITLE
fix(docker): restore psql in api pods after perl-base autoremove

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -105,7 +105,6 @@ RUN apt-get update && \
         procps \
         libjemalloc2 \
         libxmlsec1-openssl \
-        postgresql-client \
         && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
@@ -156,6 +155,9 @@ RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     apt-get remove -y --allow-remove-essential perl-base && \
     apt-get autoremove -y && \
     playwright install-deps chromium && \
+    # Re-install after autoremove: perl-base removal cascades through postgresql-client's
+    # perl dependency, sweeping it up. Install it here (post-autoremove) so it survives.
+    apt-get install -y postgresql-client && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
## Description

`postgresql-client` (psql) was silently disappearing from API pods since PR #11565 (builder/runtime Dockerfile split).

Root cause: `postgresql-client` depends on `perl`. The split moved its install into the main runtime apt block — before the `perl-base` removal and `apt-get autoremove` step. Removing `perl-base` cascades through psql's perl dependency, and `autoremove` sweeps it up. The pre-#11565 Dockerfile handled this correctly: it installed `postgresql-client` *after* `autoremove` with an explicit comment — "Install here to avoid some packages being cleaned up above." That invariant was lost in the refactor.

Fix: remove `postgresql-client` from the main runtime apt block and re-install it after `apt-get autoremove`, restoring the original ordering.

## How Has This Been Tested?

Build the backend Docker image and verify `psql --version` works inside the container.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `psql` in API pods by reinstalling `postgresql-client` after `perl-base` removal and `apt-get autoremove`. Fixes the regression from the builder/runtime Dockerfile split where `psql` was being removed.

- **Bug Fixes**
  - Move `postgresql-client` out of the main apt block; install it after `apt-get autoremove` so it survives the `perl-base` removal.
  - Prevents `psql` from disappearing in API pods. Verified with `psql --version` in the built image.

<sup>Written for commit 827a27e9b60519267a7749992a99f1c2f32439b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

