### PR TITLE
fix(craft): gate external-app domains by credential, not stored policy rows

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5457,7 +5457,7 @@ class BuildMessage(Base):
 class ActionApproval(Base):
     """One agent-initiated gated request and its decision.
 
-    ``actions`` is a non-empty JSONB list of :class:`ActionMatch`-shaped
+    ``actions`` is a non-empty JSONB list of :class:`MatchedAction`-shaped
     dicts, sorted strictest-policy-first; ``actions[0]`` drove the gating
     decision. ``decision IS NULL`` is pending (or a proxy-crash orphan).
     """

--- a/backend/onyx/external_apps/credentials.py
+++ b/backend/onyx/external_apps/credentials.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.external_app import get_external_app_by_id
 from onyx.db.external_app import get_external_app_user_credential
+from onyx.db.models import ExternalApp
 
 
 def build_auth_headers(
@@ -60,3 +61,21 @@ def resolve_injection_headers(
         credentials.update(user_cred.user_credentials.get_value(apply_mask=False))
 
     return build_auth_headers(app.auth_template, credentials)
+
+
+def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bool:
+    """Whether the gate should act on ``app`` for ``user_id`` — i.e. it's active
+    and we have everything needed to serve the request.
+
+    Distinguishes "no credential required" from "required credential unavailable":
+    an enabled app with an empty ``auth_template`` (an allowlist-only app that
+    injects nothing) is available; an app whose template can't be filled is not.
+    A disabled skill (the proxy's kill switch) is never available. Injection
+    re-resolves later with an OAuth refresh, so this verdict-time render is the
+    cheap presence check, not the final one.
+    """
+    if not app.skill.enabled:
+        return False
+    if not app.auth_template:
+        return True
+    return bool(resolve_injection_headers(db_session, app.id, user_id))

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -17,11 +17,15 @@ from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.external_apps.matching.rules import rule_matches
+from onyx.external_apps.providers.registry import effective_policy
 from onyx.external_apps.providers.registry import get_endpoint_catalog
 from onyx.external_apps.providers.registry import get_provider_for_app
 
+# action_type for a domain-matched request that hit no catalog action.
+WHOLE_DOMAIN_ACTION_TYPE = "unspecified"
 
-class ActionMatch(BaseModel):
+
+class MatchedAction(BaseModel):
     """One catalog action a request invoked, with the display strings the
     FE renders. Carried verbatim from matcher through DB JSONB to API."""
 
@@ -33,82 +37,115 @@ class ActionMatch(BaseModel):
     policy: EndpointPolicy
 
 
-class RequestMatch(BaseModel):
+class AllMatchedActions(BaseModel):
     """Every catalog action the request matched within the resolved app.
 
-    ``actions`` is sorted strictest-policy-first; ``decisive`` returns the
+    ``actions`` is sorted strictest-policy-first; ``governing_action`` returns the
     head, whose policy drives the gate's verdict. A batched GraphQL POST is
     the canonical multi-action case.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    actions: tuple[ActionMatch, ...]
+    actions: tuple[MatchedAction, ...]
     app_name: str
     external_app_id: int
     payload: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def _non_empty(self) -> "RequestMatch":
+    def _non_empty(self) -> "AllMatchedActions":
         if not self.actions:
-            raise ValueError("RequestMatch.actions must be non-empty")
+            raise ValueError("AllMatchedActions.actions must be non-empty")
         return self
 
     @property
-    def decisive(self) -> ActionMatch:
+    def governing_action(self) -> MatchedAction:
         """The action whose policy drove the verdict (head of the sorted list)."""
         return self.actions[0]
 
 
-def match_action(
+def _app_name(app: ExternalApp) -> str:
+    provider = get_provider_for_app(app)
+    if provider is not None:
+        return provider.spec.app_name
+    # CUSTOM apps have no provider; their human name lives on the linked skill.
+    if app.app_type == ExternalAppType.CUSTOM:
+        return app.skill.name
+    return app.app_type.value
+
+
+def recognize_actions(
     db_session: Session,
     app: ExternalApp,
     request: ProxiedRequest,
-) -> RequestMatch | None:
-    """Resolve every catalog action ``request`` invoked within ``app``.
+) -> AllMatchedActions | None:
+    """Which catalog action(s) ``request`` invokes within ``app`` — pure
+    recognition, no credential knowledge.
 
-    Stored policy rows are the source of truth: a catalog action without a
-    row is un-gated. ``actions`` is sorted strictest-first so callers can
-    treat ``decisive`` as the verdict-driving action. Body decoding is the
-    caller's job — ``payload`` is empty here; refill via ``model_copy``.
+    Returns an ``AllMatchedActions`` over every catalog action whose rules fire (each
+    carrying its ``effective_policy`` — stored override else catalog default),
+    sorted strictest-first so ``actions[0]`` is the verdict, or ``None`` when no
+    catalog action matches. The credential gate and the whole-domain fallback are
+    the caller's job (see ``apply_credential_gate``). ``payload`` is left empty here; refill
+    it via ``model_copy``.
     """
-    # Custom apps are routed to ask for now.
-    if app.app_type == ExternalAppType.CUSTOM:
-        return RequestMatch(
-            actions=(
-                ActionMatch(
-                    action_type="custom_request",
-                    display_name=f"{request.method} {request.path}",
-                    description="Custom external app request",
-                    policy=EndpointPolicy.ASK,
-                ),
-            ),
-            app_name=app.skill.name,
-            external_app_id=app.id,
-        )
-
     context = MatchContext(request)
     stored = get_policies(db_session, app.id)
     catalog = get_endpoint_catalog(app.app_type)
     matched = [
-        ActionMatch(
+        MatchedAction(
             action_type=endpoint.id,
             display_name=endpoint.normalised_name,
             description=endpoint.description,
-            policy=stored[endpoint.id],
+            policy=effective_policy(endpoint, stored),
         )
         for endpoint in catalog
-        if endpoint.id in stored
-        and any(rule_matches(rule, context) for rule in endpoint.matches)
+        if any(rule_matches(rule, context) for rule in endpoint.matches)
     ]
     if not matched:
         return None
     matched.sort(key=lambda a: POLICY_SEVERITY[a.policy], reverse=True)
-
-    provider = get_provider_for_app(app)
-    app_name = provider.spec.app_name if provider is not None else app.app_type.value
-    return RequestMatch(
+    return AllMatchedActions(
         actions=tuple(matched),
-        app_name=app_name,
+        app_name=_app_name(app),
+        external_app_id=app.id,
+    )
+
+
+def apply_credential_gate(
+    app: ExternalApp,
+    request: ProxiedRequest,
+    matched_actions: AllMatchedActions | None,
+    *,
+    is_available: bool,
+) -> AllMatchedActions | None:
+    """Apply the credential gate to a pure ``recognize_actions`` result, given
+    whether the app ``is_available`` (is active and injectable — the caller resolves
+    that). Pure: no DB or credential access.
+
+    - ``is_available`` + a catalog action matched → those actions, unchanged.
+    - ``is_available`` + nothing matched → gate the whole domain under a default ``ASK``.
+    - not ``is_available`` → keep only a recorded ``DENY`` (an explicit block fires with
+      or without a credential), else ``None`` (forward the request bare, no prompt).
+    """
+    if not is_available:
+        if matched_actions is None:
+            return None
+        deny = tuple(
+            a for a in matched_actions.actions if a.policy is EndpointPolicy.DENY
+        )
+        return matched_actions.model_copy(update={"actions": deny}) if deny else None
+    if matched_actions is not None:
+        return matched_actions
+    return AllMatchedActions(
+        actions=(
+            MatchedAction(
+                action_type=WHOLE_DOMAIN_ACTION_TYPE,
+                display_name=f"Access {_app_name(app)}",
+                description=f"{request.method} {request.path}",
+                policy=EndpointPolicy.ASK,
+            ),
+        ),
+        app_name=_app_name(app),
         external_app_id=app.id,
     )

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -141,7 +141,7 @@ def apply_credential_gate(
         actions=(
             MatchedAction(
                 action_type=WHOLE_DOMAIN_ACTION_TYPE,
-                display_name=f"Access {_app_name(app)}",
+                display_name="Perform action",
                 description=f"{request.method} {request.path}",
                 policy=EndpointPolicy.ASK,
             ),

--- a/backend/onyx/external_apps/providers/registry.py
+++ b/backend/onyx/external_apps/providers/registry.py
@@ -107,6 +107,17 @@ def get_endpoint_catalog(app_type: ExternalAppType) -> list[EndpointSpec]:
     return list(provider.spec.endpoint_catalog) if provider is not None else []
 
 
+def effective_policy(
+    endpoint: EndpointSpec,
+    stored: dict[str, EndpointPolicy],
+) -> EndpointPolicy:
+    """Policy in force for ``endpoint``: the admin's stored override, else the
+    catalog's curated default. Shared by the runtime gate (``recognize_actions``) and
+    the FE view (``action_policy_views``) so they never diverge — notably during
+    catalog drift, when a newly-shipped endpoint has no stored row yet."""
+    return stored.get(endpoint.id, endpoint.default_policy)
+
+
 def validate_action_policies(
     app_type: ExternalAppType,
     policies: dict[str, EndpointPolicy],
@@ -129,8 +140,9 @@ def build_action_policies(
     requested: dict[str, EndpointPolicy] | None,
     existing: dict[str, EndpointPolicy],
 ) -> dict[str, EndpointPolicy]:
-    """The complete policy set to persist for a built-in app: one entry per
-    catalog action, so the stored rows are the full source of truth.
+    """The complete policy set to persist for a built-in app: one row per catalog
+    action (a missing row still resolves to ``default_policy`` at read time via
+    ``effective_policy``).
 
     Each action resolves to the admin's validated override if supplied, else the
     value already stored, else the action's ``default_policy`` (``ASK`` unless the
@@ -160,7 +172,7 @@ def action_policy_views(
             action_id=endpoint.id,
             normalised_name=endpoint.normalised_name,
             description=endpoint.description,
-            state=stored.get(endpoint.id, endpoint.default_policy),
+            state=effective_policy(endpoint, stored),
         )
         for endpoint in get_endpoint_catalog(app_type)
     ]

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -1,7 +1,7 @@
 """Gate addon: enforces approval policy on identified sandbox egress.
 
 Fail-closed: identity, body-size cap, and unidentified-sandbox checks.
-Fail-open: `ActionMatcher` exceptions and non-matching action types.
+Fail-open: `RequestEvaluator` exceptions and non-matching action types.
 """
 
 import asyncio
@@ -29,15 +29,15 @@ from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
 from onyx.db.scheduled_task import get_live_scheduled_run_grants
 from onyx.db.scheduled_task import ScheduledRunGrants
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy import approval_cache
-from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
+from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from onyx.server.features.build.db import action_approval
 from onyx.utils.logger import setup_logger
@@ -122,7 +122,7 @@ class GateAddon:
     def __init__(
         self,
         identity: _IdentityResolver,
-        action_matcher: ActionMatcher,
+        request_evaluator: RequestEvaluator,
         cache_factory: CacheFactory,
         proxy_instance_id: str,
         credential_dispatcher: CredentialInjectionDispatcher,
@@ -130,7 +130,7 @@ class GateAddon:
         stream_responses: bool = True,
     ) -> None:
         self._identity = identity
-        self._action_matcher = action_matcher
+        self._request_evaluator = request_evaluator
         self._cache_factory = cache_factory
         self._proxy_instance_id = proxy_instance_id
         self._credential_dispatcher = credential_dispatcher
@@ -255,20 +255,22 @@ class GateAddon:
         flow.request.headers.pop("Proxy-Authorization", None)
         if gate_target is None:
             return
-        ctx, match = gate_target
+        ctx, matched_actions = gate_target
 
         # Auto-approval short-circuit: a grant source (today: a RUNNING
         # scheduled run pre-approving this app) skips the park. Off-thread to
         # keep sync DB work off the event loop; failure falls through to park.
         try:
-            auto_approved = await asyncio.to_thread(self._try_auto_approve, ctx, match)
+            auto_approved = await asyncio.to_thread(
+                self._try_auto_approve, ctx, matched_actions
+            )
         except Exception:
             logger.exception(
                 "gate.auto_approval_check_error session_id=%s tenant_id=%s "
                 "action_type=%s",
                 ctx.session_id,
                 ctx.tenant_id,
-                match.decisive.action_type,
+                matched_actions.governing_action.action_type,
             )
             auto_approved = False
         if auto_approved:
@@ -279,7 +281,7 @@ class GateAddon:
                     self._dispatch_injection_or_block,
                     flow,
                     sandbox=ctx.without_session(),
-                    match=match,
+                    matched_actions=matched_actions,
                 )
             except Exception:
                 logger.exception(
@@ -287,7 +289,7 @@ class GateAddon:
                     "action_type=%s",
                     ctx.session_id,
                     ctx.tenant_id,
-                    match.decisive.action_type,
+                    matched_actions.governing_action.action_type,
                 )
                 flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             return
@@ -296,8 +298,8 @@ class GateAddon:
         # exceptions, silently bypassing the gate. Fail closed instead.
         approval_id: UUID | None = None
         try:
-            approval_id = self._persist_approval_row(ctx, match)
-            decision = await self._await_decision(approval_id, ctx, match)
+            approval_id = self._persist_approval_row(ctx, matched_actions)
+            decision = await self._await_decision(approval_id, ctx, matched_actions)
             self._write_response_for_decision(flow, decision)
             if decision == ApprovalDecision.APPROVED:
                 # Off-thread: the external-app resolver may refresh an expiring
@@ -308,7 +310,7 @@ class GateAddon:
                     self._dispatch_injection_or_block,
                     flow,
                     sandbox=ctx.without_session(),
-                    match=match,
+                    matched_actions=matched_actions,
                 )
         except Exception:
             logger.exception(
@@ -317,7 +319,7 @@ class GateAddon:
                 ctx.session_id,
                 ctx.tenant_id,
                 approval_id,
-                match.decisive.action_type,
+                matched_actions.governing_action.action_type,
             )
             flow.response = http_403(SandboxProxyError.INTERNAL_ERROR)
             if approval_id is not None:
@@ -329,10 +331,10 @@ class GateAddon:
 
     async def _resolve_and_match(
         self, flow: http.HTTPFlow
-    ) -> tuple[SessionContext, RequestMatch] | None:
+    ) -> tuple[SessionContext, AllMatchedActions] | None:
         """Identity → matcher → (only if gated) in-band session resolution.
 
-        Returns `(ctx, match)` to proceed, or `None` two ways:
+        Returns `(ctx, matched_actions)` to proceed, or `None` two ways:
         * fail-closed — sets a 403 `flow.response` first (unidentified
           sandbox, oversize body, unattributable gated request).
         * fail-open — leaves the response untouched so mitmproxy forwards
@@ -369,7 +371,9 @@ class GateAddon:
             return None
 
         try:
-            match = self._action_matcher.match(flow.request, sandbox.tenant_id)
+            matched_actions = self._request_evaluator.evaluate(
+                flow.request, sandbox.tenant_id, sandbox.user_id
+            )
         except Exception as e:
             # Matcher crash falls through as off-catalog: host-only resolvers
             # still get a chance to inject so the request doesn't forward with
@@ -379,7 +383,7 @@ class GateAddon:
                 flow.request.host,
                 str(e),
             )
-            match = None
+            matched_actions = None
 
         # Audit every evaluated request. session_id is the unvalidated claimed
         # tag (the ASK path validates it below); off_catalog = nothing matched.
@@ -390,25 +394,34 @@ class GateAddon:
             sandbox.sandbox_id,
             self._extract_session_tag(flow),
             flow.request.host,
-            match.decisive.action_type if match is not None else "-",
-            match.decisive.policy.value if match is not None else "off_catalog",
+            matched_actions.governing_action.action_type
+            if matched_actions is not None
+            else "-",
+            matched_actions.governing_action.policy.value
+            if matched_actions is not None
+            else "off_catalog",
         )
 
         # ALWAYS / DENY / off-catalog terminate here; ASK falls through to the
         # approval pipeline in `request()`.
-        if match is None:
-            self._dispatch_injection_or_block(flow, sandbox=sandbox, match=None)
+        if matched_actions is None:
+            self._dispatch_injection_or_block(
+                flow, sandbox=sandbox, matched_actions=None
+            )
             return None
 
-        if match.decisive.policy is EndpointPolicy.DENY:
+        if matched_actions.governing_action.policy is EndpointPolicy.DENY:
             flow.response = http_403(SandboxProxyError.POLICY_DENIED)
             return None
 
-        if match.decisive.policy is EndpointPolicy.ALWAYS:
+        if matched_actions.governing_action.policy is EndpointPolicy.ALWAYS:
             # Off-thread: see the ASK path in `request` — the resolver may refresh
             # an expiring OAuth token before injecting on this auto-approved call.
             await asyncio.to_thread(
-                self._dispatch_injection_or_block, flow, sandbox=sandbox, match=match
+                self._dispatch_injection_or_block,
+                flow,
+                sandbox=sandbox,
+                matched_actions=matched_actions,
             )
             return None
 
@@ -432,7 +445,7 @@ class GateAddon:
                 sandbox.sandbox_id,
                 sandbox.user_id,
                 sandbox.tenant_id,
-                match.decisive.action_type,
+                matched_actions.governing_action.action_type,
                 flow.request.host,
             )
             flow.response = http_403(SandboxProxyError.NO_ACTIVE_SESSION)
@@ -445,19 +458,19 @@ class GateAddon:
             ctx.session_id,
             ctx.tenant_id,
             ctx.sandbox_id,
-            match.decisive.action_type,
+            matched_actions.governing_action.action_type,
             flow.request.host,
         )
-        return ctx, match
+        return ctx, matched_actions
 
     def _resolve_auto_approval(
-        self, db: Session, ctx: SessionContext, match: RequestMatch
+        self, db: Session, ctx: SessionContext, matched_actions: AllMatchedActions
     ) -> _AutoApproval | None:
         """Resolve a gated request to an auto-approval, or ``None`` to park."""
         # Scheduled-task grants are the only auto-approval type today. As other
         # types appear (session-scoped, per-action), each becomes a source
         # resolved here — first hit wins.
-        return self._scheduled_task_grant(db, ctx, match)
+        return self._scheduled_task_grant(db, ctx, matched_actions)
 
     @cachedmethod(
         operator.attrgetter("_grant_cache"),
@@ -468,7 +481,7 @@ class GateAddon:
         return get_live_scheduled_run_grants(db_session=db, session_id=session_id)
 
     def _scheduled_task_grant(
-        self, db: Session, ctx: SessionContext, match: RequestMatch
+        self, db: Session, ctx: SessionContext, matched_actions: AllMatchedActions
     ) -> _AutoApproval | None:
         """Grant source: a RUNNING scheduled run whose task pre-approves the
         matched app."""
@@ -476,19 +489,21 @@ class GateAddon:
         if grants is None:
             return None
         run_id, granted_app_ids = grants
-        if match.external_app_id not in granted_app_ids:
+        if matched_actions.external_app_id not in granted_app_ids:
             return None
         return _AutoApproval(
             decided_via=ApprovalDecidedVia.PRE_APPROVAL,
             notif_type=NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION,
-            notification_title=f"Scheduled task used {match.app_name} (pre-approved)",
+            notification_title=f"Scheduled task used {matched_actions.app_name} (pre-approved)",
             notification_data={
                 "run_id": str(run_id),
-                "external_app_id": match.external_app_id,
+                "external_app_id": matched_actions.external_app_id,
             },
         )
 
-    def _try_auto_approve(self, ctx: SessionContext, match: RequestMatch) -> bool:
+    def _try_auto_approve(
+        self, ctx: SessionContext, matched_actions: AllMatchedActions
+    ) -> bool:
         """Mint a pre-decided APPROVED row if a grant source covers this
         request; False otherwise (falls through to the park). Source-agnostic.
 
@@ -496,16 +511,16 @@ class GateAddon:
         on a pre-decided row.
         """
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
-            approval = self._resolve_auto_approval(db, ctx, match)
+            approval = self._resolve_auto_approval(db, ctx, matched_actions)
             if approval is None:
                 return False
             row = action_approval.insert_action_approval(
                 db,
                 session_id=ctx.session_id,
-                actions=[a.model_dump(mode="json") for a in match.actions],
-                app_name=match.app_name,
-                payload=match.payload,
-                external_app_id=match.external_app_id,
+                actions=[a.model_dump(mode="json") for a in matched_actions.actions],
+                app_name=matched_actions.app_name,
+                payload=matched_actions.payload,
+                external_app_id=matched_actions.external_app_id,
                 decision=ApprovalDecision.APPROVED,
                 decided_via=approval.decided_via,
             )
@@ -519,8 +534,8 @@ class GateAddon:
             ctx.session_id,
             ctx.tenant_id,
             approval.decided_via,
-            match.external_app_id,
-            match.decisive.action_type,
+            matched_actions.external_app_id,
+            matched_actions.governing_action.action_type,
         )
         try:
             self._notify_auto_approved(ctx, approval)
@@ -532,21 +547,23 @@ class GateAddon:
             )
         return True
 
-    def _persist_approval_row(self, ctx: SessionContext, match: RequestMatch) -> UUID:
+    def _persist_approval_row(
+        self, ctx: SessionContext, matched_actions: AllMatchedActions
+    ) -> UUID:
         """Commit the row, register it for the drain, announce to the chat.
 
         Announce is best-effort: a miss degrades to the FE surfacing the
         card on the next `/live` refetch, so we don't fail the request.
         """
-        actions_payload = [a.model_dump(mode="json") for a in match.actions]
+        actions_payload = [a.model_dump(mode="json") for a in matched_actions.actions]
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             row = action_approval.insert_action_approval(
                 db,
                 session_id=ctx.session_id,
                 actions=actions_payload,
-                app_name=match.app_name,
-                payload=match.payload,
-                external_app_id=match.external_app_id,
+                app_name=matched_actions.app_name,
+                payload=matched_actions.payload,
+                external_app_id=matched_actions.external_app_id,
             )
             approval_id = row.approval_id
             db.commit()
@@ -573,12 +590,12 @@ class GateAddon:
             ctx.tenant_id,
             ctx.sandbox_id,
             self._proxy_instance_id,
-            match.decisive.action_type,
-            len(match.actions),
+            matched_actions.governing_action.action_type,
+            len(matched_actions.actions),
         )
 
         try:
-            self._notify_approval_requested(approval_id, ctx, match)
+            self._notify_approval_requested(approval_id, ctx, matched_actions)
         except Exception as e:
             logger.warning(
                 "approval.notify_failed approval_id=%s error=%s",
@@ -592,7 +609,7 @@ class GateAddon:
         self,
         approval_id: UUID,
         ctx: SessionContext,
-        match: RequestMatch,
+        matched_actions: AllMatchedActions,
     ) -> ApprovalDecision:
         """Park on the wake channel; claim EXPIRED on timeout / cancel.
 
@@ -619,7 +636,7 @@ class GateAddon:
                 approval_id,
                 ctx.session_id,
                 ctx.tenant_id,
-                match.decisive.action_type,
+                matched_actions.governing_action.action_type,
             )
             resolved = self._claim_expired_or_read_winner(approval_id, ctx.tenant_id)
             if resolved == ApprovalDecision.EXPIRED:
@@ -682,14 +699,14 @@ class GateAddon:
         flow: http.HTTPFlow,
         *,
         sandbox: ResolvedSandbox,
-        match: RequestMatch | None,
+        matched_actions: AllMatchedActions | None,
     ) -> None:
         """Run the credential dispatcher; fail closed with a 403 on BLOCKED."""
         self._credential_dispatcher.apply_or_block(
             flow,
             InjectionContext(
                 sandbox=sandbox,
-                match=match,
+                matched_actions=matched_actions,
             ),
         )
 
@@ -800,7 +817,7 @@ class GateAddon:
             )
 
     def _notify_approval_requested(
-        self, approval_id: UUID, ctx: SessionContext, match: RequestMatch
+        self, approval_id: UUID, ctx: SessionContext, matched_actions: AllMatchedActions
     ) -> None:
         """Best-effort APPROVAL_REQUESTED notification dispatch.
 
@@ -816,9 +833,9 @@ class GateAddon:
                 additional_data={
                     "approval_id": str(approval_id),
                     "session_id": str(ctx.session_id),
-                    "action_type": match.decisive.action_type,
-                    "action_count": len(match.actions),
-                    "app_name": match.app_name,
+                    "action_type": matched_actions.governing_action.action_type,
+                    "action_count": len(matched_actions.actions),
+                    "app_name": matched_actions.app_name,
                     "link": _CRAFT_SESSION_LINK_TEMPLATE.format(
                         session_id=ctx.session_id
                     ),

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -18,7 +18,7 @@ from typing import Protocol
 
 from mitmproxy import http
 
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.errors import http_403
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
@@ -35,13 +35,13 @@ class CredentialUnavailableError(Exception):
 class InjectionContext:
     """Per-request inputs every resolver receives.
 
-    `match` is the request-level match (carrying `external_app_id`), or
-    `None` on off-catalog forwards. `sandbox.tenant_id` is what resolvers
-    key their per-tenant lookups by.
+    `matched_actions` is the actions matched for this request (carrying
+    `external_app_id`), or `None` on off-catalog forwards. `sandbox.tenant_id` is
+    what resolvers key their per-tenant lookups by.
     """
 
     sandbox: ResolvedSandbox
-    match: RequestMatch | None
+    matched_actions: AllMatchedActions | None
 
 
 class CredentialResolver(Protocol):
@@ -50,7 +50,7 @@ class CredentialResolver(Protocol):
     def claims(self, request: http.Request, ctx: InjectionContext) -> bool:
         """Cheap predicate: does this resolver own this request?
 
-        Implementations should key off `request.host` (and `ctx.match` /
+        Implementations should key off `request.host` (and `ctx.matched_actions` /
         `ctx.sandbox.tenant_id` for per-context routing); they MUST NOT open
         a DB session — that's `resolve()`'s job.
         """

--- a/backend/onyx/sandbox_proxy/request_evaluator.py
+++ b/backend/onyx/sandbox_proxy/request_evaluator.py
@@ -11,22 +11,27 @@ from collections.abc import Iterable
 from typing import Any
 from typing import Protocol
 from urllib.parse import parse_qs
+from uuid import UUID
 
 from mitmproxy import http
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.external_app import get_external_apps
 from onyx.db.models import ExternalApp
-from onyx.external_apps.matching.engine import match_action
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.credentials import app_is_available
+from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.external_apps.matching.engine import apply_credential_gate
+from onyx.external_apps.matching.engine import recognize_actions
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
-class ActionMatcher(Protocol):
-    def match(self, request: http.Request, tenant_id: str) -> RequestMatch | None: ...
+class RequestEvaluator(Protocol):
+    def evaluate(
+        self, request: http.Request, tenant_id: str, user_id: UUID
+    ) -> AllMatchedActions | None: ...
 
 
 def resolve_app_for_url(
@@ -54,15 +59,18 @@ def resolve_app_for_url(
     return None
 
 
-class ExternalAppActionMatcher(ActionMatcher):
+class ExternalAppRequestEvaluator(RequestEvaluator):
     """Matches a request against the tenant's connected external apps.
 
     Opens its own short tenant-scoped DB session (mirrors ``IdentityResolver``):
-    load the tenant's apps, resolve the one owning the request URL, then defer to
-    the pre-written ``match_action`` for the policy verdict.
+    load the tenant's apps, resolve the one owning the request URL, recognise the
+    catalog action(s) via ``recognize_actions``, then apply the credential gate via
+    ``apply_credential_gate`` to produce the verdict.
     """
 
-    def match(self, request: http.Request, tenant_id: str) -> RequestMatch | None:
+    def evaluate(
+        self, request: http.Request, tenant_id: str, user_id: UUID
+    ) -> AllMatchedActions | None:
         with get_session_with_tenant(tenant_id=tenant_id) as db:
             apps = get_external_apps(db)
             app = resolve_app_for_url(request.url, apps)
@@ -76,8 +84,13 @@ class ExternalAppActionMatcher(ActionMatcher):
                 path=(request.path or "").split("?", 1)[0],
                 body=request.raw_content,
             )
-            matched = match_action(db, app, proxied)
-            if matched is None:
+            matched_actions = apply_credential_gate(
+                app,
+                proxied,
+                recognize_actions(db, app, proxied),
+                is_available=app_is_available(db, app, user_id),
+            )
+            if matched_actions is None:
                 return None
 
         # Engine leaves `payload` empty — we own the raw content + content-type.
@@ -85,7 +98,7 @@ class ExternalAppActionMatcher(ActionMatcher):
             request.raw_content or b"",
             (request.headers.get("content-type") or "").lower(),
         )
-        return matched.model_copy(update={"payload": payload or {}})
+        return matched_actions.model_copy(update={"payload": payload or {}})
 
 
 def _decode_body(body: bytes, content_type: str) -> dict[str, Any] | None:

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -1,7 +1,7 @@
 """External-app credential resolver.
 
 Claims a request iff the matcher has attributed it to a connected `ExternalApp`
-(`ctx.match is not None`) and renders the app's `auth_template` from the org +
+(`ctx.matched_actions is not None`) and renders the app's `auth_template` from the org +
 per-user credentials via `resolve_injection_headers`. Per-header fail-open
 behaviour for missing placeholders lives in `build_auth_headers`.
 """
@@ -30,11 +30,11 @@ class ExternalAppResolver(CredentialResolver):
         ctx: InjectionContext,
     ) -> bool:
         # The matcher has already proven URL→app attribution; host is unused.
-        return ctx.match is not None
+        return ctx.matched_actions is not None
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
-        match = ctx.match
-        if match is None:
+        matched_actions = ctx.matched_actions
+        if matched_actions is None:
             # `claims` guarantees this is unreachable; explicit raise so a
             # broken Protocol contract surfaces as a 403, not a NoneType crash.
             raise CredentialUnavailableError(
@@ -48,13 +48,13 @@ class ExternalAppResolver(CredentialResolver):
         # clears the credential, which renders as empty headers below).
         ensure_fresh_credentials(
             ctx.sandbox.tenant_id,
-            match.external_app_id,
+            matched_actions.external_app_id,
             ctx.sandbox.user_id,
         )
 
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             headers = resolve_injection_headers(
-                db, match.external_app_id, ctx.sandbox.user_id
+                db, matched_actions.external_app_id, ctx.sandbox.user_id
             )
 
         # Per-app audit line so `external_app_id` survives in logs even when
@@ -63,7 +63,7 @@ class ExternalAppResolver(CredentialResolver):
         # the request still forwards (upstream 401 surfaces to the user).
         logger.info(
             "external_app_resolver.resolved external_app_id=%s host=%s headers=%s",
-            match.external_app_id,
+            matched_actions.external_app_id,
             request.host,
             sorted(headers),
         )

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -16,7 +16,6 @@ from mitmproxy.tools.dump import DumpMaster
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CacheBackend
 from onyx.db.engine.sql_engine import SqlEngine
-from onyx.sandbox_proxy.action_matcher import ExternalAppActionMatcher
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.backend import build_ca_store
 from onyx.sandbox_proxy.backend import build_ip_lookup
@@ -26,6 +25,7 @@ from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatche
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.identity import IdentityResolver
 from onyx.sandbox_proxy.identity import SandboxIPLookup
+from onyx.sandbox_proxy.request_evaluator import ExternalAppRequestEvaluator
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
 from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
 from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
@@ -245,7 +245,7 @@ def main() -> int:
         )
         gate = GateAddon(
             identity=identity,
-            action_matcher=ExternalAppActionMatcher(),
+            request_evaluator=ExternalAppRequestEvaluator(),
             cache_factory=_build_cache_factory(),
             proxy_instance_id=proxy_instance_id,
             credential_dispatcher=CredentialInjectionDispatcher(resolvers),

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -30,7 +30,7 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.external_apps.presentation.decode import decode_payload
 from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build.db import action_approval
@@ -56,7 +56,7 @@ class ApprovalView(BaseModel):
     approval_id: UUID
     session_id: UUID
     # Non-empty by construction; sorted strictest-policy-first.
-    actions: list[ActionMatch]
+    actions: list[MatchedAction]
     app_name: str
     payload: dict[str, Any]
     created_at: datetime

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -35,7 +35,7 @@ def insert_action_approval(
     decided_via: ApprovalDecidedVia | None = None,
 ) -> ActionApproval:
     """Commit an approval row. ``actions`` is the JSONB list of
-    ``ActionMatch``-shaped dicts; must be non-empty. Re-sorted
+    ``MatchedAction``-shaped dicts; must be non-empty. Re-sorted
     strictest-policy-first so every reader can rely on ``actions[0]``.
 
     Defaults to a pending row (``decision IS NULL``). Passing ``decision``

--- a/backend/tests/external_dependency_unit/craft/_test_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/_test_helpers.py
@@ -47,7 +47,7 @@ from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
 from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.models import UserRole
-from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 
 
@@ -360,9 +360,9 @@ def action_entry(
     policy: EndpointPolicy = EndpointPolicy.ASK,
 ) -> dict[str, Any]:
     """JSONB-shape dict for one `ActionApproval.actions` entry. Routes
-    through `ActionMatch` so the shape can't drift from the production
+    through `MatchedAction` so the shape can't drift from the production
     model."""
-    return ActionMatch(
+    return MatchedAction(
         action_type=action_type,
         display_name=display_name,
         description=description,

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -1,6 +1,18 @@
 """Outbound-request → policy-verdict matching for connected external apps.
 
 Exercises the real provider catalogs + a real DB (no structural mocking).
+
+Three layers are tested here:
+- ``recognize_actions`` — pure recognition: which catalog action(s) a request invokes,
+  each carrying its ``effective_policy`` (stored override else catalog default).
+- ``app_is_available`` — the credential predicate: active + injectable (a
+  credentialless allowlist-only app can be served; a missing required credential
+  cannot).
+- ``ExternalAppRequestEvaluator.evaluate`` — the end-to-end result: recognition +
+  availability + the ``apply_credential_gate`` fork (synthesize / DENY-only / bare).
+
+The pure ``apply_credential_gate`` fork itself is unit-tested in
+``tests/unit/external_apps/matching/test_engine.py``.
 """
 
 from __future__ import annotations
@@ -19,24 +31,39 @@ from onyx.db.enums import EndpointPolicy
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.db.models import ExternalAppPolicy
+from onyx.db.models import User
+from onyx.external_apps.credentials import app_is_available
 from onyx.external_apps.matching import engine as matching_engine
-from onyx.external_apps.matching.engine import ActionMatch
-from onyx.external_apps.matching.engine import match_action
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.external_apps.matching.engine import MatchedAction
+from onyx.external_apps.matching.engine import recognize_actions
+from onyx.external_apps.matching.engine import WHOLE_DOMAIN_ACTION_TYPE
 from onyx.external_apps.matching.request import ProxiedRequest
-from onyx.sandbox_proxy import action_matcher as action_matcher_mod
-from onyx.sandbox_proxy.action_matcher import ExternalAppActionMatcher
+from onyx.sandbox_proxy import request_evaluator as request_evaluator_mod
+from onyx.sandbox_proxy.request_evaluator import ExternalAppRequestEvaluator
 from tests.external_dependency_unit.craft._test_helpers import make_external_app
 from tests.external_dependency_unit.craft._test_helpers import make_skill
 
 
-def _connect_app(db_session: Session, app_type: ExternalAppType) -> ExternalApp:
+def _connect_app(
+    db_session: Session,
+    app_type: ExternalAppType,
+    *,
+    with_credential: bool = True,
+    upstream_url_patterns: list[str] | None = None,
+) -> ExternalApp:
+    """A connected app whose ``auth_template`` is fillable (``with_credential``)
+    or not (org credentials empty → ``resolve_injection_headers`` returns {})."""
     skill = make_skill(db_session)
     return make_external_app(
         db_session,
         skill=skill,
         auth_template={"Authorization": "Bearer {access_token}"},
+        organization_credentials=(
+            {"access_token": "test-token"} if with_credential else None
+        ),
         app_type=app_type,
+        upstream_url_patterns=upstream_url_patterns,
     )
 
 
@@ -56,20 +83,20 @@ def _set_policy(
     db_session.flush()
 
 
-# ── match_action: per-provider recognition ────────────────────────
+# ── recognize_actions: pure recognition (no credentials) ────────────────
 
 
-def test_match_slack_rest_uses_stored_override(
+def test_match_stored_override_wins(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001 — for tenant context
 ) -> None:
     app = _connect_app(db_session, ExternalAppType.SLACK)
     _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.ALWAYS)
 
     request = ProxiedRequest(method="POST", path="/api/chat.postMessage")
-    assert match_action(db_session, app, request) == RequestMatch(
+    assert recognize_actions(db_session, app, request) == AllMatchedActions(
         actions=(
-            ActionMatch(
+            MatchedAction(
                 action_type="slack.messages.write",
                 display_name="Post a message",
                 description="Post a message to a channel or conversation.",
@@ -81,45 +108,56 @@ def test_match_slack_rest_uses_stored_override(
     )
 
 
-def test_match_slack_rest_unset_returns_none(
+def test_unset_read_action_uses_catalog_default_always(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001 — for tenant context
 ) -> None:
-    # Real catalog action with no stored policy row → un-gated, since the
-    # stored rows are the source of truth for what's gated.
+    # Slack is all-POST, so the catalog default (not HTTP method) classifies reads.
     app = _connect_app(db_session, ExternalAppType.SLACK)
     request = ProxiedRequest(method="POST", path="/api/conversations.list")
-    assert match_action(db_session, app, request) is None
+    matched_actions = recognize_actions(db_session, app, request)
+    assert matched_actions is not None
+    assert [a.action_type for a in matched_actions.actions] == ["slack.channels.read"]
+    assert matched_actions.actions[0].policy == EndpointPolicy.ALWAYS
 
 
-def test_match_google_calendar_method_and_path(
+def test_unset_write_action_uses_catalog_default_ask(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001 — for tenant context
+) -> None:
+    app = _connect_app(db_session, ExternalAppType.SLACK)
+    request = ProxiedRequest(method="POST", path="/api/chat.postMessage")
+    matched_actions = recognize_actions(db_session, app, request)
+    assert matched_actions is not None
+    assert [a.action_type for a in matched_actions.actions] == ["slack.messages.write"]
+    assert matched_actions.actions[0].policy == EndpointPolicy.ASK
+
+
+def test_match_google_calendar_method_distinguishes_actions(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001 — for tenant context
 ) -> None:
     app = _connect_app(db_session, ExternalAppType.GOOGLE_CALENDAR)
     _set_policy(db_session, app, "gcal.events.delete", EndpointPolicy.DENY)
+    item_path = "/calendar/v3/calendars/primary/events/evt123"
 
-    delete_req = ProxiedRequest(
-        method="DELETE",
-        path="/calendar/v3/calendars/primary/events/evt123",
-    )
-    matched = match_action(db_session, app, delete_req)
-    assert matched is not None
-    assert matched.app_name == "Google Calendar"
-    assert [a.action_type for a in matched.actions] == ["gcal.events.delete"]
-    assert matched.actions[0].policy == EndpointPolicy.DENY
+    delete_req = ProxiedRequest(method="DELETE", path=item_path)
+    matched_actions = recognize_actions(db_session, app, delete_req)
+    assert matched_actions is not None
+    assert [a.action_type for a in matched_actions.actions] == ["gcal.events.delete"]
+    assert matched_actions.actions[0].policy == EndpointPolicy.DENY
 
-    # Same path, read method → different action with no stored row → None.
-    read_req = ProxiedRequest(
-        method="GET",
-        path="/calendar/v3/calendars/primary/events/evt123",
-    )
-    assert match_action(db_session, app, read_req) is None
+    # Same path, GET → the read action; no stored row → catalog default ALWAYS.
+    read_req = ProxiedRequest(method="GET", path=item_path)
+    read_matched_actions = recognize_actions(db_session, app, read_req)
+    assert read_matched_actions is not None
+    assert [a.action_type for a in read_matched_actions.actions] == ["gcal.events.read"]
+    assert read_matched_actions.actions[0].policy == EndpointPolicy.ALWAYS
 
 
 def test_match_linear_graphql_body(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001 — for tenant context
 ) -> None:
     app = _connect_app(db_session, ExternalAppType.LINEAR)
     _set_policy(db_session, app, "linear.issues.create", EndpointPolicy.DENY)
@@ -127,50 +165,22 @@ def test_match_linear_graphql_body(
     body = json.dumps(
         {"query": "mutation { issueCreate(input: $i) { issue { id } } }"}
     ).encode()
-    matched = match_action(
+    matched_actions = recognize_actions(
         db_session, app, ProxiedRequest(method="POST", path="/graphql", body=body)
     )
-    assert matched is not None
-    assert matched.app_name == "Linear"
-    assert [a.action_type for a in matched.actions] == ["linear.issues.create"]
-    assert matched.actions[0].policy == EndpointPolicy.DENY
-
-
-def test_off_catalog_request_returns_none(
-    db_session: Session,
-    test_user: object,  # noqa: ARG001
-) -> None:
-    app = _connect_app(db_session, ExternalAppType.SLACK)
-    request = ProxiedRequest(method="POST", path="/api/some.unknownMethod")
-    assert match_action(db_session, app, request) is None
-
-
-def test_match_action_app_name_falls_back_when_provider_unregistered(
-    db_session: Session,
-    monkeypatch: pytest.MonkeyPatch,
-    test_user: object,  # noqa: ARG001
-) -> None:
-    """A connected app whose provider isn't registered (catalog drift) still
-    yields a match; ``app_name`` falls back to the raw enum value rather
-    than crashing the gate."""
-    app = _connect_app(db_session, ExternalAppType.SLACK)
-    _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.ASK)
-    monkeypatch.setattr(matching_engine, "get_provider_for_app", lambda _app: None)
-
-    matched = match_action(
-        db_session, app, ProxiedRequest(method="POST", path="/api/chat.postMessage")
-    )
-    assert matched is not None
-    assert matched.app_name == ExternalAppType.SLACK.value
+    assert matched_actions is not None
+    assert matched_actions.app_name == "Linear"
+    assert [a.action_type for a in matched_actions.actions] == ["linear.issues.create"]
+    assert matched_actions.actions[0].policy == EndpointPolicy.DENY
 
 
 def test_graphql_batched_sorts_strictest_first(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,  # noqa: ARG001 — for tenant context
 ) -> None:
-    """A batched request matching two actions (ALWAYS + DENY) returns both
-    on ``RequestMatch.actions``, sorted strictest-first so ``actions[0]``
-    drives the gate's verdict regardless of catalog order."""
+    """A batched request matching two actions (ALWAYS + DENY) returns both on
+    ``AllMatchedActions.actions``, sorted strictest-first so ``actions[0]`` drives
+    the verdict regardless of catalog order."""
     app = _connect_app(db_session, ExternalAppType.LINEAR)
     _set_policy(db_session, app, "linear.viewer.read", EndpointPolicy.ALWAYS)
     _set_policy(db_session, app, "linear.issues.create", EndpointPolicy.DENY)
@@ -181,22 +191,85 @@ def test_graphql_batched_sorts_strictest_first(
             {"query": "mutation { issueCreate(input: $i) { issue { id } } }"},
         ]
     ).encode()
-    matched = match_action(
+    matched_actions = recognize_actions(
         db_session, app, ProxiedRequest(method="POST", path="/graphql", body=body)
     )
-    assert matched is not None
-    assert matched.app_name == "Linear"
-    assert [a.action_type for a in matched.actions] == [
+    assert matched_actions is not None
+    assert [a.action_type for a in matched_actions.actions] == [
         "linear.issues.create",
         "linear.viewer.read",
     ]
-    assert [a.policy for a in matched.actions] == [
+    assert [a.policy for a in matched_actions.actions] == [
         EndpointPolicy.DENY,
         EndpointPolicy.ALWAYS,
     ]
 
 
-# ── ExternalAppActionMatcher: full proxy-request → verdict bridge ───
+def test_match_action_off_catalog_returns_none(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001 — for tenant context
+) -> None:
+    # Pure recognition: a request matching no catalog action returns None. The
+    # whole-domain synthesize is the caller's job (apply_credential_gate), tested separately.
+    app = _connect_app(db_session, ExternalAppType.SLACK)
+    request = ProxiedRequest(method="POST", path="/api/some.unknownMethod")
+    assert recognize_actions(db_session, app, request) is None
+
+
+def test_match_action_app_name_falls_back_when_provider_unregistered(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    test_user: User,  # noqa: ARG001 — for tenant context
+) -> None:
+    """A connected app whose provider isn't registered (catalog drift) still
+    yields a matched_actions; ``app_name`` falls back to the raw enum value rather than
+    crashing the gate."""
+    app = _connect_app(db_session, ExternalAppType.SLACK)
+    _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.ASK)
+    monkeypatch.setattr(matching_engine, "get_provider_for_app", lambda _app: None)
+
+    matched_actions = recognize_actions(
+        db_session, app, ProxiedRequest(method="POST", path="/api/chat.postMessage")
+    )
+    assert matched_actions is not None
+    assert matched_actions.app_name == ExternalAppType.SLACK.value
+
+
+# ── app_is_available: the credential predicate ─────────────────────
+
+
+def test_available_credentialless_app(db_session: Session, test_user: User) -> None:
+    # Empty auth_template = "no credential required" → available (still gated).
+    skill = make_skill(db_session)
+    app = make_external_app(
+        db_session, skill=skill, auth_template={}, app_type=ExternalAppType.CUSTOM
+    )
+    assert app_is_available(db_session, app, test_user.id) is True
+
+
+def test_available_with_fillable_credential(
+    db_session: Session, test_user: User
+) -> None:
+    app = _connect_app(db_session, ExternalAppType.SLACK, with_credential=True)
+    assert app_is_available(db_session, app, test_user.id) is True
+
+
+def test_not_available_required_credential_missing(
+    db_session: Session, test_user: User
+) -> None:
+    app = _connect_app(db_session, ExternalAppType.SLACK, with_credential=False)
+    assert app_is_available(db_session, app, test_user.id) is False
+
+
+def test_not_available_when_disabled(db_session: Session, test_user: User) -> None:
+    skill = make_skill(db_session, enabled=False)
+    app = make_external_app(
+        db_session, skill=skill, auth_template={}, app_type=ExternalAppType.CUSTOM
+    )
+    assert app_is_available(db_session, app, test_user.id) is False
+
+
+# ── ExternalAppRequestEvaluator: full proxy-request → verdict bridge ───
 
 
 def _session_factory(
@@ -224,63 +297,114 @@ def _slack_request(
 
 def test_external_app_matcher_resolves_app_and_verdict(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    skill = make_skill(db_session)
-    app = make_external_app(
+    app = _connect_app(
         db_session,
-        skill=skill,
-        auth_template={"Authorization": "Bearer {access_token}"},
-        app_type=ExternalAppType.SLACK,
+        ExternalAppType.SLACK,
         upstream_url_patterns=["https://slack\\.com/api/.*"],
     )
     _set_policy(db_session, app, "slack.messages.write", EndpointPolicy.DENY)
 
     monkeypatch.setattr(
-        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+        request_evaluator_mod, "get_session_with_tenant", _session_factory(db_session)
     )
-    matcher = ExternalAppActionMatcher()
-    matched = matcher.match(_slack_request(), "public")
+    matcher = ExternalAppRequestEvaluator()
+    matched_actions = matcher.evaluate(_slack_request(), "public", test_user.id)
 
-    assert matched is not None
-    assert [a.action_type for a in matched.actions] == ["slack.messages.write"]
-    assert matched.actions[0].policy == EndpointPolicy.DENY
-    assert matched.app_name == "Slack"
-    assert matched.external_app_id == app.id
-    assert matched.payload == {"channel": "C1", "text": "hi"}
+    assert matched_actions is not None
+    assert [a.action_type for a in matched_actions.actions] == ["slack.messages.write"]
+    assert matched_actions.actions[0].policy == EndpointPolicy.DENY
+    assert matched_actions.app_name == "Slack"
+    assert matched_actions.external_app_id == app.id
+    assert matched_actions.payload == {"channel": "C1", "text": "hi"}
 
 
 def test_external_app_matcher_unconnected_host_returns_none(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+        request_evaluator_mod, "get_session_with_tenant", _session_factory(db_session)
     )
-    matcher = ExternalAppActionMatcher()
+    matcher = ExternalAppRequestEvaluator()
     request = http.Request.make("GET", "https://example.com/", headers={})
-    assert matcher.match(request, "public") is None
+    assert matcher.evaluate(request, "public", test_user.id) is None
 
 
-def test_external_app_matcher_off_catalog_on_connected_host_returns_none(
+def test_external_app_matcher_no_credential_forwards_bare(
     db_session: Session,
-    test_user: object,  # noqa: ARG001
+    test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    skill = make_skill(db_session)
-    make_external_app(
+    _connect_app(
         db_session,
-        skill=skill,
-        auth_template={"Authorization": "Bearer {access_token}"},
-        app_type=ExternalAppType.SLACK,
+        ExternalAppType.SLACK,
+        with_credential=False,
+        upstream_url_patterns=["https://slack\\.com/api/.*"],
+    )
+    monkeypatch.setattr(
+        request_evaluator_mod, "get_session_with_tenant", _session_factory(db_session)
+    )
+    matcher = ExternalAppRequestEvaluator()
+    # conversations.list is a read (catalog default ALWAYS), but with no usable
+    # credential the request forwards bare instead of being gated.
+    request = _slack_request(url="https://slack.com/api/conversations.list")
+    assert matcher.evaluate(request, "public", test_user.id) is None
+
+
+def test_external_app_matcher_off_catalog_synthesizes_whole_domain(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _connect_app(
+        db_session,
+        ExternalAppType.SLACK,
         upstream_url_patterns=["https://slack\\.com/api/.*"],
     )
 
     monkeypatch.setattr(
-        action_matcher_mod, "get_session_with_tenant", _session_factory(db_session)
+        request_evaluator_mod, "get_session_with_tenant", _session_factory(db_session)
     )
-    matcher = ExternalAppActionMatcher()
+    matcher = ExternalAppRequestEvaluator()
     request = _slack_request(url="https://slack.com/api/some.unknownMethod")
-    assert matcher.match(request, "public") is None
+    matched_actions = matcher.evaluate(request, "public", test_user.id)
+
+    assert matched_actions is not None
+    assert matched_actions.actions[0].action_type == WHOLE_DOMAIN_ACTION_TYPE
+    assert matched_actions.actions[0].policy == EndpointPolicy.ASK
+    assert matched_actions.external_app_id == app.id
+
+
+def test_external_app_matcher_credentialless_app_is_gated(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression guard: an enabled allowlist-only app (empty auth_template) is
+    # available and so its whole domain is gated under a synthesized ASK.
+    # CUSTOM apps author URL *globs* (``*`` wildcard), not regexes.
+    skill = make_skill(db_session)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        auth_template={},
+        app_type=ExternalAppType.CUSTOM,
+        upstream_url_patterns=["https://example.com/*"],
+    )
+    monkeypatch.setattr(
+        request_evaluator_mod, "get_session_with_tenant", _session_factory(db_session)
+    )
+    matcher = ExternalAppRequestEvaluator()
+    request = http.Request.make("POST", "https://example.com/anything", headers={})
+    matched_actions = matcher.evaluate(request, "public", test_user.id)
+
+    assert matched_actions is not None
+    assert matched_actions.actions[0].action_type == WHOLE_DOMAIN_ACTION_TYPE
+    assert matched_actions.actions[0].policy == EndpointPolicy.ASK
+    assert matched_actions.external_app_id == app.id
+    # CUSTOM apps have no provider; the name comes from the linked skill.
+    assert matched_actions.app_name == skill.name

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -20,7 +20,7 @@ from onyx.db.models import ActionApproval
 from onyx.db.models import BuildSession
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build.approvals.api import DecisionBody
 from onyx.server.features.build.approvals.api import list_live_approvals
@@ -601,13 +601,13 @@ def test_list_live_approvals_returns_multi_action_view(
 
     # Strictest-first ordering is the API contract surface; ASK > ALWAYS.
     expected_actions = [
-        ActionMatch(
+        MatchedAction(
             action_type="linear.issues.create",
             display_name="Create an issue",
             description="Create a new issue.",
             policy=EndpointPolicy.ASK,
         ),
-        ActionMatch(
+        MatchedAction(
             action_type="linear.viewer.read",
             display_name="Read the connected user",
             description="Read the authenticated user's profile (viewer).",

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -123,7 +123,7 @@ def test_custom_app_glob_matches_deep_path(
     """Custom apps store their URL patterns as authored globs; the matcher
     translates them to regexes that cover deep paths (the Discord 401
     regression — ``/api/*`` must match ``/api/v10/...``)."""
-    from onyx.sandbox_proxy.action_matcher import resolve_app_for_url
+    from onyx.sandbox_proxy.request_evaluator import resolve_app_for_url
 
     monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
     slug = f"custom-test-{uuid4().hex[:8]}"

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -18,11 +18,11 @@ from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.models import ActionApproval
 from onyx.db.models import BuildSession
-from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.craft._test_helpers import action_entry
@@ -85,9 +85,9 @@ class _UnusedResolver(_IdentityResolver):
         raise AssertionError("identity.resolve_session_by_id unexpectedly used")
 
 
-class _UnusedMatcher(ActionMatcher):
-    def match(self, request: Any, tenant_id: str) -> Any:  # noqa: ARG002
-        raise AssertionError("action_matcher.match unexpectedly used")
+class _UnusedMatcher(RequestEvaluator):
+    def evaluate(self, request: Any, tenant_id: str, user_id: UUID) -> Any:  # noqa: ARG002
+        raise AssertionError("request_evaluator.evaluate unexpectedly used")
 
 
 def _build_addon() -> GateAddon:
@@ -100,7 +100,7 @@ def _build_addon() -> GateAddon:
 
     return GateAddon(
         identity=_UnusedResolver(),
-        action_matcher=_UnusedMatcher(),
+        request_evaluator=_UnusedMatcher(),
         cache_factory=_factory_raises,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher([]),

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -47,7 +47,7 @@ def test_claims_then_resolve_round_trips_encrypted_key(
             sandbox_name="sandbox-test",
             sandbox_ip="127.0.0.1",
         ),
-        match=None,
+        matched_actions=None,
     )
 
     try:

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -45,7 +45,7 @@ def test_claims_then_resolve_round_trips_minted_pat(
             sandbox_name="sandbox-test",
             sandbox_ip="127.0.0.1",
         ),
-        match=None,
+        matched_actions=None,
     )
 
     monkeypatch.setattr(onyx_pat_mod, "SANDBOX_API_SERVER_URL", f"https://{_API_HOST}")

--- a/backend/tests/unit/build/test_approval_display_payload.py
+++ b/backend/tests/unit/build/test_approval_display_payload.py
@@ -5,7 +5,7 @@ from typing import Any
 from uuid import uuid4
 
 from onyx.db.enums import EndpointPolicy
-from onyx.external_apps.matching.engine import ActionMatch
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.external_apps.providers.gmail import GmailAction
 from onyx.server.features.build.approvals.api import ApprovalView
 
@@ -24,7 +24,7 @@ def _view(action_type: str, payload: dict[str, Any]) -> ApprovalView:
         approval_id=uuid4(),
         session_id=uuid4(),
         actions=[
-            ActionMatch(
+            MatchedAction(
                 action_type=action_type,
                 display_name="x",
                 description="x",

--- a/backend/tests/unit/external_apps/matching/test_engine.py
+++ b/backend/tests/unit/external_apps/matching/test_engine.py
@@ -1,4 +1,4 @@
-"""Pure unit tests for the matching engine. The DB-driven ``match_action``
+"""Pure unit tests for the matching engine. The DB-driven ``recognize_actions``
 path is covered in ``external_dependency_unit/craft/test_action_matching.py``."""
 
 from __future__ import annotations
@@ -6,11 +6,82 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.db.enums import EndpointPolicy
+from onyx.db.enums import ExternalAppType
+from onyx.db.models import ExternalApp
+from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.external_apps.matching.engine import apply_credential_gate
+from onyx.external_apps.matching.engine import MatchedAction
+from onyx.external_apps.matching.engine import WHOLE_DOMAIN_ACTION_TYPE
+from onyx.external_apps.matching.request import ProxiedRequest
 
 
-def test_request_match_rejects_empty_actions() -> None:
-    """A RequestMatch with no actions is a programmer error — every gate
+def test_rejects_empty_actions() -> None:
+    """An AllMatchedActions with no actions is a programmer error — every gate
     consumer reads ``actions[0]``."""
     with pytest.raises(ValidationError, match="actions must be non-empty"):
-        RequestMatch(actions=(), app_name="X", external_app_id=1)
+        AllMatchedActions(actions=(), app_name="X", external_app_id=1)
+
+
+# ── apply_credential_gate: the pure credential/synthesize fork ─────────
+
+
+def _app(app_type: ExternalAppType = ExternalAppType.SLACK) -> ExternalApp:
+    app = ExternalApp(app_type=app_type)
+    app.id = 1
+    return app
+
+
+def _request() -> ProxiedRequest:
+    return ProxiedRequest(method="POST", path="/api/x")
+
+
+def _matched_actions(*policies: EndpointPolicy) -> AllMatchedActions:
+    return AllMatchedActions(
+        actions=tuple(
+            MatchedAction(
+                action_type=f"a{i}", display_name="A", description="d", policy=p
+            )
+            for i, p in enumerate(policies)
+        ),
+        app_name="Slack",
+        external_app_id=1,
+    )
+
+
+def test_apply_gate_serveable_passes_recognition_through() -> None:
+    matched_actions = _matched_actions(EndpointPolicy.ALWAYS)
+    assert (
+        apply_credential_gate(_app(), _request(), matched_actions, is_available=True)
+        is matched_actions
+    )
+
+
+def test_apply_gate_serveable_no_catalog_synthesizes_whole_domain_ask() -> None:
+    matched_actions = apply_credential_gate(_app(), _request(), None, is_available=True)
+    assert matched_actions is not None
+    assert matched_actions.governing_action.action_type == WHOLE_DOMAIN_ACTION_TYPE
+    assert matched_actions.governing_action.policy == EndpointPolicy.ASK
+    assert matched_actions.app_name == "Slack"
+    assert matched_actions.external_app_id == 1
+
+
+def test_apply_gate_not_serveable_no_catalog_forwards_bare() -> None:
+    assert apply_credential_gate(_app(), _request(), None, is_available=False) is None
+
+
+def test_apply_gate_not_serveable_without_deny_forwards_bare() -> None:
+    matched_actions = _matched_actions(EndpointPolicy.ALWAYS, EndpointPolicy.ASK)
+    assert (
+        apply_credential_gate(_app(), _request(), matched_actions, is_available=False)
+        is None
+    )
+
+
+def test_apply_gate_not_serveable_keeps_only_deny() -> None:
+    matched_actions = _matched_actions(EndpointPolicy.DENY, EndpointPolicy.ASK)
+    gated = apply_credential_gate(
+        _app(), _request(), matched_actions, is_available=False
+    )
+    assert gated is not None
+    assert [a.policy for a in gated.actions] == [EndpointPolicy.DENY]

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -1,7 +1,7 @@
 """Shared stubs and factories for sandbox_proxy unit tests.
 
 - `StaticLookup` — `SandboxIPLookup` stub keyed by source IP.
-- `make_resolved_sandbox` / `make_flow` / `make_request_match` — value
+- `make_resolved_sandbox` / `make_flow` / `make_matched_actions` — value
   + mitmproxy-flow factories.
 - `StubResolver` — identity resolver stub (sandbox + session) for the gate.
 - `RecordingCredentialResolver` — `CredentialResolver` stub recording the
@@ -18,8 +18,8 @@ from uuid import uuid4
 from mitmproxy import http
 
 from onyx.db.enums import EndpointPolicy
-from onyx.external_apps.matching.engine import ActionMatch
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import InjectionContext
@@ -199,7 +199,7 @@ class RecordingCredentialResolver(CredentialResolver):
         return dict(self._headers)
 
 
-def make_request_match(
+def make_matched_actions(
     *,
     action_type: str = "slack.messages.write",
     display_name: str = "Post a message",
@@ -208,11 +208,11 @@ def make_request_match(
     policy: EndpointPolicy = EndpointPolicy.ASK,
     external_app_id: int = 42,
     app_name: str = "Slack",
-) -> RequestMatch:
-    """Factory for single-action `RequestMatch` test rows."""
-    return RequestMatch(
+) -> AllMatchedActions:
+    """Factory for single-action `AllMatchedActions` test rows."""
+    return AllMatchedActions(
         actions=(
-            ActionMatch(
+            MatchedAction(
                 action_type=action_type,
                 display_name=display_name,
                 description=description,

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock
 
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
@@ -17,13 +17,13 @@ from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.credential_injection import InjectionOutcome
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
-from tests.unit.sandbox_proxy.conftest import make_request_match
+from tests.unit.sandbox_proxy.conftest import make_matched_actions
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 
 
-def _ctx(*, match: RequestMatch | None = None) -> InjectionContext:
-    return InjectionContext(sandbox=_sandbox(), match=match)
+def _ctx(*, matched_actions: AllMatchedActions | None = None) -> InjectionContext:
+    return InjectionContext(sandbox=_sandbox(), matched_actions=matched_actions)
 
 
 def test_no_resolver_claims_returns_pass_through() -> None:
@@ -165,10 +165,10 @@ def test_resolver_receives_request_and_full_context() -> None:
     """Sanity: `claims` and `resolve` both see the same request + ctx the
     dispatcher was handed, unchanged."""
     sandbox = _sandbox(tenant_id="tenant-xyz")
-    match = make_request_match()
+    matched_actions = make_matched_actions()
     resolver = RecordingCredentialResolver(claims_result=True)
     flow = _flow(host="api.anthropic.com")
-    ctx = InjectionContext(sandbox=sandbox, match=match)
+    ctx = InjectionContext(sandbox=sandbox, matched_actions=matched_actions)
 
     CredentialInjectionDispatcher([resolver]).apply(flow, ctx)
 

--- a/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_external_app_resolver.py
@@ -15,13 +15,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from onyx.external_apps.matching.engine import RequestMatch
+from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.resolvers import external_app as external_app_mod
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
-from tests.unit.sandbox_proxy.conftest import make_request_match
+from tests.unit.sandbox_proxy.conftest import make_matched_actions
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 
 
@@ -44,16 +44,18 @@ def _recorder_db_factory(ops: list[str]) -> Any:
     return factory
 
 
-def _ctx(*, match: RequestMatch | None = None) -> InjectionContext:
-    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=match)
+def _ctx(*, matched_actions: AllMatchedActions | None = None) -> InjectionContext:
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=matched_actions
+    )
 
 
 def test_claims_true_iff_match_present() -> None:
     """Host is irrelevant — the matcher has already attributed the request."""
     resolver = ExternalAppResolver()
     req = _flow(host="api.slack.com").request
-    assert resolver.claims(req, _ctx(match=make_request_match())) is True
-    assert resolver.claims(req, _ctx(match=None)) is False
+    assert resolver.claims(req, _ctx(matched_actions=make_matched_actions())) is True
+    assert resolver.claims(req, _ctx(matched_actions=None)) is False
 
 
 def test_resolve_forwards_external_app_id_user_id_and_tenant(
@@ -75,8 +77,8 @@ def test_resolve_forwards_external_app_id_user_id_and_tenant(
         external_app_mod, "get_session_with_tenant", _recorder_db_factory(ops)
     )
 
-    match = make_request_match(external_app_id=99)
-    ctx = _ctx(match=match)
+    matched_actions = make_matched_actions(external_app_id=99)
+    ctx = _ctx(matched_actions=matched_actions)
 
     headers = ExternalAppResolver().resolve(_flow().request, ctx)
 
@@ -108,8 +110,8 @@ def test_resolve_refreshes_token_before_rendering(
         external_app_mod, "get_session_with_tenant", _recorder_db_factory([])
     )
 
-    match = make_request_match(external_app_id=99)
-    ctx = _ctx(match=match)
+    matched_actions = make_matched_actions(external_app_id=99)
+    ctx = _ctx(matched_actions=matched_actions)
 
     headers = ExternalAppResolver().resolve(_flow().request, ctx)
 
@@ -118,8 +120,8 @@ def test_resolve_refreshes_token_before_rendering(
 
 
 def test_resolve_raises_when_match_is_none() -> None:
-    """Contract violation safety net: `claims` guarantees `match` is set, but
+    """Contract violation safety net: `claims` guarantees `matched_actions` is set, but
     a Protocol bug must surface as a 403, not a NoneType crash inside SQL code."""
     resolver = ExternalAppResolver()
     with pytest.raises(CredentialUnavailableError):
-        resolver.resolve(_flow().request, _ctx(match=None))
+        resolver.resolve(_flow().request, _ctx(matched_actions=None))

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1,6 +1,6 @@
 """Unit tests for the GateAddon mitmproxy addon.
 
-External dependencies (`_IdentityResolver`, `ActionMatcher`, `CacheFactory`)
+External dependencies (`_IdentityResolver`, `RequestEvaluator`, `CacheFactory`)
 are stubbed via small Protocol implementations; `get_session_with_tenant` is
 patched per test.
 
@@ -29,8 +29,7 @@ from redis.exceptions import RedisError
 from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
-from onyx.external_apps.matching.engine import RequestMatch
-from onyx.sandbox_proxy.action_matcher import ActionMatcher
+from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
@@ -41,9 +40,10 @@ from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.identity import SessionContext
+from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
 from tests.unit.sandbox_proxy.conftest import make_flow as _flow
-from tests.unit.sandbox_proxy.conftest import make_request_match
+from tests.unit.sandbox_proxy.conftest import make_matched_actions
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 from tests.unit.sandbox_proxy.conftest import RecordingCredentialResolver
 from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
@@ -53,22 +53,23 @@ from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
 # ---------------------------------------------------------------------------
 
 
-class _StubMatcher(ActionMatcher):
+class _StubMatcher(RequestEvaluator):
     def __init__(
         self,
         *,
-        result: RequestMatch | None = None,
+        result: AllMatchedActions | None = None,
         exc: Exception | None = None,
     ) -> None:
         self._result = result
         self._exc = exc
         self.calls = 0
 
-    def match(
+    def evaluate(
         self,
         request: http.Request,  # noqa: ARG002
         tenant_id: str,  # noqa: ARG002
-    ) -> RequestMatch | None:
+        user_id: UUID,  # noqa: ARG002
+    ) -> AllMatchedActions | None:
         self.calls += 1
         if self._exc is not None:
             raise self._exc
@@ -112,7 +113,7 @@ def _build(
 ) -> GateAddon:
     return GateAddon(
         identity=resolver,
-        action_matcher=matcher,
+        request_evaluator=matcher,
         cache_factory=cache_factory,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher(
@@ -131,11 +132,11 @@ def _assert_403(flow: http.HTTPFlow, expected_code: SandboxProxyError) -> None:
     assert body["message"]
 
 
-_MATCH = make_request_match(payload={"text": "hi"})
-_MATCH_ALWAYS = make_request_match(
+_MATCH = make_matched_actions(payload={"text": "hi"})
+_MATCH_ALWAYS = make_matched_actions(
     action_type="slack.channels.read", policy=EndpointPolicy.ALWAYS
 )
-_MATCH_DENY = make_request_match(payload={"text": "hi"}, policy=EndpointPolicy.DENY)
+_MATCH_DENY = make_matched_actions(payload={"text": "hi"}, policy=EndpointPolicy.DENY)
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +241,7 @@ async def test_resolve_and_match_no_tag_fails_closed() -> None:
 @pytest.mark.asyncio
 async def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     """Non-gated traffic: matcher returns None → forwarded; the off-catalog
-    dispatcher invocation runs with `match=None` so host-only resolvers can
+    dispatcher invocation runs with `matched_actions=None` so host-only resolvers can
     still claim by host."""
     sandbox = _sandbox()
     resolver = _StubResolver(sandbox=sandbox)
@@ -254,10 +255,10 @@ async def test_resolve_and_match_matcher_returns_none_fails_open() -> None:
     assert result is None
     assert flow.response is None  # forwarded
     assert resolver.resolve_session_by_id_calls == []
-    # The off-catalog dispatch IS wired — the resolver was probed with match=None.
+    # The off-catalog dispatch IS wired — the resolver was probed with matched_actions=None.
     assert len(spy.claims_calls) == 1
     _request, ctx = spy.claims_calls[0]
-    assert ctx.match is None
+    assert ctx.matched_actions is None
     assert ctx.sandbox is sandbox
 
 
@@ -277,9 +278,9 @@ async def test_resolve_and_match_matcher_raises_falls_through_as_off_catalog() -
     assert result is None
     assert flow.response is None  # forwarded
     assert resolver.resolve_session_by_id_calls == []
-    # Dispatcher was invoked with match=None (same as a real off-catalog).
+    # Dispatcher was invoked with matched_actions=None (same as a real off-catalog).
     assert len(spy.claims_calls) == 1
-    assert spy.claims_calls[0][1].match is None
+    assert spy.claims_calls[0][1].matched_actions is None
 
 
 # ---------------------------------------------------------------------------
@@ -342,11 +343,11 @@ async def test_resolve_and_match_deny_blocks_with_403() -> None:
 class _PipelineSpy:
     """Records the approval pipeline + dispatcher so a test can read the path."""
 
-    persisted: list[tuple[SessionContext, RequestMatch]]
-    awaited: list[RequestMatch]
-    # (match, sandbox_user_id, sandbox_tenant_id) — captured off the
+    persisted: list[tuple[SessionContext, AllMatchedActions]]
+    awaited: list[AllMatchedActions]
+    # (matched_actions, sandbox_user_id, sandbox_tenant_id) — captured off the
     # InjectionContext the dispatcher was handed.
-    dispatched: list[tuple[RequestMatch | None, UUID, str]]
+    dispatched: list[tuple[AllMatchedActions | None, UUID, str]]
 
     @property
     def approval_ran(self) -> bool:
@@ -367,23 +368,23 @@ def _spy_pipeline(
     """
     spy = _PipelineSpy(persisted=[], awaited=[], dispatched=[])
 
-    def _persist(ctx: SessionContext, match: RequestMatch) -> UUID:
-        spy.persisted.append((ctx, match))
+    def _persist(ctx: SessionContext, matched_actions: AllMatchedActions) -> UUID:
+        spy.persisted.append((ctx, matched_actions))
         return uuid4()
 
     async def _await(
-        _aid: UUID, _ctx: SessionContext, match: RequestMatch
+        _aid: UUID, _ctx: SessionContext, matched_actions: AllMatchedActions
     ) -> ApprovalDecision | None:
-        spy.awaited.append(match)
+        spy.awaited.append(matched_actions)
         return decision
 
     def _dispatch(
         flow: http.HTTPFlow,  # noqa: ARG001
         *,
         sandbox: ResolvedSandbox,
-        match: RequestMatch | None,
+        matched_actions: AllMatchedActions | None,
     ) -> None:
-        spy.dispatched.append((match, sandbox.user_id, sandbox.tenant_id))
+        spy.dispatched.append((matched_actions, sandbox.user_id, sandbox.tenant_id))
 
     monkeypatch.setattr(addon, "_persist_approval_row", _persist)
     monkeypatch.setattr(addon, "_await_decision", _await)
@@ -482,7 +483,7 @@ async def test_ask_denied_blocks(
 
 
 _RUN_ID = UUID("55555555-5555-5555-5555-555555555555")
-# make_request_match defaults external_app_id=42.
+# make_matched_actions defaults external_app_id=42.
 _GRANTED_APP_ID = 42
 
 
@@ -695,8 +696,8 @@ async def test_resolve_and_match_happy_path_promotes_session() -> None:
     result = await addon._resolve_and_match(flow)
 
     assert result is not None
-    ctx, match = result
-    assert match is _MATCH
+    ctx, matched_actions = result
+    assert matched_actions is _MATCH
     assert ctx.session_id == session_id
     assert ctx.user_id == user_id
     assert ctx.tenant_id == sandbox.tenant_id
@@ -1025,14 +1026,16 @@ def test_dispatch_injection_writes_resolved_headers() -> None:
     flow.request.headers["Authorization"] = "sandbox-placeholder"
     sandbox = _sandbox()
 
-    addon._dispatch_injection_or_block(flow, sandbox=sandbox, match=_MATCH_ALWAYS)
+    addon._dispatch_injection_or_block(
+        flow, sandbox=sandbox, matched_actions=_MATCH_ALWAYS
+    )
 
     assert flow.response is None  # forwarded
     assert flow.request.headers["Authorization"] == "Bearer real-secret"
     assert len(spy.resolve_calls) == 1
     seen = spy.resolve_calls[0]
     assert seen.sandbox is sandbox
-    assert seen.match is _MATCH_ALWAYS
+    assert seen.matched_actions is _MATCH_ALWAYS
 
 
 def test_dispatch_injection_pass_through_forwards_untouched() -> None:
@@ -1045,7 +1048,9 @@ def test_dispatch_injection_pass_through_forwards_untouched() -> None:
     flow = _flow()
     flow.request.headers["X-Pod-Side"] = "preserve"
 
-    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
+    addon._dispatch_injection_or_block(
+        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    )
 
     assert flow.response is None
     assert flow.request.headers["X-Pod-Side"] == "preserve"
@@ -1066,7 +1071,9 @@ def test_dispatch_injection_credential_unavailable_blocks_with_403() -> None:
     )
     flow = _flow()
 
-    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
+    addon._dispatch_injection_or_block(
+        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    )
 
     _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
 
@@ -1082,7 +1089,9 @@ def test_dispatch_injection_resolver_exception_blocks_with_403() -> None:
     )
     flow = _flow()
 
-    addon._dispatch_injection_or_block(flow, sandbox=_sandbox(), match=_MATCH_ALWAYS)
+    addon._dispatch_injection_or_block(
+        flow, sandbox=_sandbox(), matched_actions=_MATCH_ALWAYS
+    )
 
     _assert_403(flow, SandboxProxyError.CREDENTIAL_ERROR)
 
@@ -1318,10 +1327,10 @@ def test_persist_approval_row_announce_failure_is_swallowed(
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
-    notify_calls: list[tuple[UUID, SessionContext, RequestMatch]] = []
+    notify_calls: list[tuple[UUID, SessionContext, AllMatchedActions]] = []
 
     def _fake_notify(
-        _self: Any, aid: UUID, ctx_arg: SessionContext, match_arg: RequestMatch
+        _self: Any, aid: UUID, ctx_arg: SessionContext, match_arg: AllMatchedActions
     ) -> None:
         notify_calls.append((aid, ctx_arg, match_arg))
 

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -47,7 +47,9 @@ def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _ctx() -> InjectionContext:
-    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=None)
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=None
+    )
 
 
 @pytest.fixture

--- a/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_onyx_pat_resolver.py
@@ -62,7 +62,9 @@ def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _ctx() -> InjectionContext:
-    return InjectionContext(sandbox=_sandbox(tenant_id="tenant-7"), match=None)
+    return InjectionContext(
+        sandbox=_sandbox(tenant_id="tenant-7"), matched_actions=None
+    )
 
 
 @pytest.fixture

--- a/backend/tests/unit/sandbox_proxy/test_request_evaluator.py
+++ b/backend/tests/unit/sandbox_proxy/test_request_evaluator.py
@@ -1,16 +1,16 @@
 """Unit tests for the proxy's URL → ExternalApp resolution.
 
 ``resolve_app_for_url`` binds a request to a connected app before deferring to
-``external_apps.matching.match_action``. Transient (un-flushed) ``ExternalApp``
-objects suffice — it only reads ``upstream_url_patterns``, never the DB. CUSTOM
-apps author globs; built-in providers author regexes.
+``external_apps.matching.recognize_actions``. Transient (un-flushed)
+``ExternalApp`` objects suffice — it only reads ``upstream_url_patterns``, never
+the DB. CUSTOM apps author globs; built-in providers author regexes.
 """
 
 from __future__ import annotations
 
 from onyx.db.enums import ExternalAppType
 from onyx.db.models import ExternalApp
-from onyx.sandbox_proxy.action_matcher import resolve_app_for_url
+from onyx.sandbox_proxy.request_evaluator import resolve_app_for_url
 
 
 def _app(

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -32,11 +32,11 @@ from mitmproxy import http as mitm_http
 from mitmproxy.options import Options
 from mitmproxy.tools.dump import DumpMaster
 
-from onyx.sandbox_proxy.action_matcher import ActionMatcher
 from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 
 # Inter-chunk delay on the upstream. The whole stream takes
 # `(_CHUNK_COUNT - 1) * _CHUNK_DELAY_S`, during which a streamed client must
@@ -113,10 +113,15 @@ class _StubResolver(_IdentityResolver):
         return None
 
 
-class _NonGatingMatcher(ActionMatcher):
+class _NonGatingMatcher(RequestEvaluator):
     """Never matches, so every request fails open and is forwarded."""
 
-    def match(self, request: mitm_http.Request, tenant_id: str) -> None:  # noqa: ARG002
+    def evaluate(
+        self,
+        request: mitm_http.Request,  # noqa: ARG002
+        tenant_id: str,  # noqa: ARG002
+        user_id: UUID,  # noqa: ARG002
+    ) -> None:
         return None
 
 
@@ -165,7 +170,7 @@ def _start_proxy(
     """
     gate = GateAddon(
         identity=_StubResolver(),
-        action_matcher=_NonGatingMatcher(),
+        request_evaluator=_NonGatingMatcher(),
         cache_factory=_unused_factory,
         proxy_instance_id="proxy-test",
         credential_dispatcher=CredentialInjectionDispatcher([]),


### PR DESCRIPTION
## Description

A connected external app now gates its **whole upstream domain by credential availability**, rather than requiring a per-action policy row. Previously, an action with no stored `ExternalAppPolicy` row was treated as off-catalog → no credential injected → the upstream returned 401.

`match_action` now resolves each matched catalog action via a shared `effective_policy` helper (stored override → catalog `default_policy`, the same formula the FE view already uses), injects when a usable credential exists, blocks a recorded `DENY` regardless of credential, and gates any uncategorized request to a connected domain under a synthesized `ASK`. A request with no usable credential still forwards bare (no prompt). `user_id` is threaded through the matcher so the credential check runs before any prompt.

Storage semantics are unchanged in this PR (still full materialization); the override-only storage model is a follow-up that stacks on this.

Fixes: https://linear.app/onyx-app/issue/ENG-4141/craft-polish-external-app-policies-should-default-to-pass-through-for
## How Has This Been Tested?

- Rewrote `test_action_matching.py`: catalog-default fallback, synthesized `ASK`, no-credential bare-forward, `DENY`-survives-no-credential, and the `user_id`-threaded matcher.
- 321 unit tests + `ty` pass locally; the external-dependency-unit suite runs in CI (needs Postgres).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates each external app’s whole upstream domain by credential availability instead of stored policy rows. Recognition uses catalog defaults; off-catalog on a connected domain synthesizes an ASK when the app is available, while missing required credentials forwards bare; DENY still blocks.

- **Bug Fixes**
  - Gate by credential presence; empty `auth_template` apps still gate; disabled apps never serve.
  - Share catalog defaults via `effective_policy` (runtime + FE) to avoid drift.
  - Split recognition and gating: `recognize_actions` + `apply_credential_gate`, with availability from `app_is_available`.
  - Off-catalog on a connected domain → synthesized ASK when available; not available → keep explicit DENY only, else forward bare.
  - Resolve `app_name` via provider; for `CUSTOM` use `skill.name`, else fall back to enum for safety during catalog drift.
  - Whole-domain synthesized ASK now shows “Perform action” as the approval label.

- **Migration**
  - Replace `ActionMatcher` with `RequestEvaluator`; new signature `evaluate(request, tenant_id, user_id)`.
  - Type rename: `ActionMatch` → `MatchedAction`, `RequestMatch` → `AllMatchedActions`.
  - Property rename: `decisive` → `governing_action`.
  - `InjectionContext` field rename: `match` → `matched_actions`.
  - Update imports and call sites accordingly.

<sup>Written for commit a1df8f64c8e7b7690d51028d007dbe92df743140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

