### PR TITLE
feat(input): expand paste tiles back into the input bar

### DIFF
--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -44,6 +44,8 @@ export interface UseContentEditableReturn {
   /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
   insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
+  /** Clear double-paste tracking for paste events not routed through pasteText. */
+  resetPasteTracking: () => void;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   setCursorToEnd: () => void;
@@ -354,6 +356,13 @@ export function useContentEditable({
     [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor, expandTile]
   );
 
+  // Hosts call this for paste events handled without reaching pasteText (file
+  // pastes, intercepted `/skill` pastes); since Ctrl/Cmd+V is exempted from the
+  // keydown reset, the tracker would otherwise stay armed across them.
+  const resetPasteTracking = useCallback(() => {
+    lastPasteTileRef.current = null;
+  }, []);
+
   const handleTileMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       clearTileSelection();
@@ -647,6 +656,7 @@ export function useContentEditable({
     expandTile,
     insertSkillTile,
     pasteText,
+    resetPasteTracking,
     handleCopy,
     handleCut,
     setCursorToEnd,

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -76,7 +76,6 @@ export function useContentEditable({
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
-  // Set by a Ctrl/Cmd+Shift+V keydown so the imminent paste stays plain text.
   const plainPasteRef = useRef(false);
   const [tilePopover, setTilePopover] = useState<PasteTileData | null>(null);
   const [pasteExpandHintVisible, setPasteExpandHintVisible] = useState(false);
@@ -167,9 +166,8 @@ export function useContentEditable({
     const text = getTextContent(el);
     messageRef.current = text;
     setMessageState(text);
-    // The "paste again to expand" hint lives as long as a paste tile does.
     setPasteExpandHintVisible(
-      !!el.querySelector('[data-rich-tile]:not([data-tile-type="skill"])')
+      !!el.querySelector('[data-rich-tile][data-tile-type="paste"]')
     );
     onContentChangeRef.current?.(text);
     return text;
@@ -207,6 +205,7 @@ export function useContentEditable({
 
   const handleCompositionEnd = useCallback(() => {
     isComposingRef.current = false;
+    plainPasteRef.current = false;
     syncFromDOM();
     resize();
   }, [syncFromDOM, resize]);
@@ -336,7 +335,6 @@ export function useContentEditable({
     [syncFromDOM, resize]
   );
 
-  // The existing paste tile whose content equals `text`, if any (skill tiles excluded).
   const findMatchingPasteTile = useCallback(
     (text: string): HTMLElement | null => {
       const el = ref.current;
@@ -360,7 +358,6 @@ export function useContentEditable({
       plainPasteRef.current = false;
 
       if (pasteTilesEnabled && !plainPaste && shouldCreatePasteTile(text)) {
-        // Same clipboard as an existing tile → expand it instead of duplicating.
         const existing = findMatchingPasteTile(text);
         if (existing) {
           expandTile(existing);
@@ -492,8 +489,7 @@ export function useContentEditable({
       const isPasteShortcut =
         (event.ctrlKey || event.metaKey) &&
         (event.key === "v" || event.key === "V");
-      // A Ctrl/Cmd+Shift+V arms a plain paste; any other (non-modifier) key
-      // disarms it so a stale flag can't hijack a later normal paste.
+      // Arm plain paste on Ctrl/Cmd+Shift+V; any other key disarms a stale flag.
       if (isPasteShortcut) {
         plainPasteRef.current = event.shiftKey;
       } else if (!isModifier) {
@@ -650,6 +646,7 @@ export function useContentEditable({
       event.clipboardData.setData("text/plain", getTextContent(temp));
 
       range.deleteContents();
+      selectedTileRef.current = null;
       syncFromDOM();
       resize();
     },

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -19,6 +19,8 @@ import {
   SKILL_TILE_TYPE,
 } from "@/lib/richInputTile";
 
+type PasteTileData = { text: string; tile: HTMLElement };
+
 export interface UseContentEditableOptions {
   initialContent?: string;
   wrapperRef: React.RefObject<HTMLDivElement | null>;
@@ -43,7 +45,7 @@ export interface UseContentEditableReturn {
   /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
   insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
-  resetPasteTracking: () => void;
+  armPasteExpansion: () => void;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   setCursorToEnd: () => void;
@@ -51,7 +53,7 @@ export interface UseContentEditableReturn {
   handleTileMouseDown: (event: React.MouseEvent<HTMLDivElement>) => void;
   handleTileClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   handleTileKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => boolean;
-  tilePopover: { text: string; tile: HTMLElement } | null;
+  tilePopover: PasteTileData | null;
   dismissTilePopover: () => void;
   updateTileText: (newText: string) => void;
 }
@@ -73,13 +75,9 @@ export function useContentEditable({
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
-  const lastPasteTileRef = useRef<{ text: string; tile: HTMLElement } | null>(
-    null
-  );
-  const [tilePopover, setTilePopover] = useState<{
-    text: string;
-    tile: HTMLElement;
-  } | null>(null);
+  const lastPasteTileRef = useRef<PasteTileData | null>(null);
+  const pendingExpansionRef = useRef<PasteTileData | null>(null);
+  const [tilePopover, setTilePopover] = useState<PasteTileData | null>(null);
 
   useEffect(() => {
     onContentChangeRef.current = onContentChange;
@@ -335,23 +333,28 @@ export function useContentEditable({
 
   const pasteText = useCallback(
     (text: string) => {
+      const pendingExpansion = pendingExpansionRef.current;
+      pendingExpansionRef.current = null;
       if (pasteTilesEnabled && shouldCreatePasteTile(text)) {
-        const last = lastPasteTileRef.current;
-        if (last && last.text === text && ref.current?.contains(last.tile)) {
-          expandTile(last.tile);
+        if (
+          pendingExpansion &&
+          pendingExpansion.text === text &&
+          ref.current?.contains(pendingExpansion.tile)
+        ) {
+          expandTile(pendingExpansion.tile);
           return;
         }
         const tile = insertTileAtCursor(text);
         lastPasteTileRef.current = tile ? { text, tile } : null;
       } else {
         insertTextAtCursor(text);
-        lastPasteTileRef.current = null;
       }
     },
     [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor, expandTile]
   );
 
-  const resetPasteTracking = useCallback(() => {
+  const armPasteExpansion = useCallback(() => {
+    pendingExpansionRef.current = lastPasteTileRef.current;
     lastPasteTileRef.current = null;
   }, []);
 
@@ -646,7 +649,7 @@ export function useContentEditable({
     expandTile,
     insertSkillTile,
     pasteText,
-    resetPasteTracking,
+    armPasteExpansion,
     handleCopy,
     handleCut,
     setCursorToEnd,

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -45,7 +45,8 @@ export interface UseContentEditableReturn {
   /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
   insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
-  armPasteExpansion: () => void;
+  /** Whether to show the "paste again to expand" hint — true while a paste tile exists. */
+  pasteExpandHintVisible: boolean;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   setCursorToEnd: () => void;
@@ -75,9 +76,10 @@ export function useContentEditable({
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
-  const lastPasteTileRef = useRef<PasteTileData | null>(null);
-  const pendingExpansionRef = useRef<PasteTileData | null>(null);
+  // Set by a Ctrl/Cmd+Shift+V keydown so the imminent paste stays plain text.
+  const plainPasteRef = useRef(false);
   const [tilePopover, setTilePopover] = useState<PasteTileData | null>(null);
+  const [pasteExpandHintVisible, setPasteExpandHintVisible] = useState(false);
 
   useEffect(() => {
     onContentChangeRef.current = onContentChange;
@@ -165,6 +167,10 @@ export function useContentEditable({
     const text = getTextContent(el);
     messageRef.current = text;
     setMessageState(text);
+    // The "paste again to expand" hint lives as long as a paste tile does.
+    setPasteExpandHintVisible(
+      !!el.querySelector('[data-rich-tile]:not([data-tile-type="skill"])')
+    );
     onContentChangeRef.current?.(text);
     return text;
   }, []);
@@ -216,7 +222,7 @@ export function useContentEditable({
 
       clearTileSelection();
       setTilePopover(null);
-      lastPasteTileRef.current = null;
+      setPasteExpandHintVisible(false);
 
       ref.current.textContent = text;
       messageRef.current = text;
@@ -245,7 +251,7 @@ export function useContentEditable({
 
     clearTileSelection();
     setTilePopover(null);
-    lastPasteTileRef.current = null;
+    setPasteExpandHintVisible(false);
 
     ref.current.innerHTML = "";
     messageRef.current = "";
@@ -294,7 +300,6 @@ export function useContentEditable({
       tile.replaceWith(textNode);
 
       if (selectedTileRef.current === tile) selectedTileRef.current = null;
-      lastPasteTileRef.current = null;
       setTilePopover(null);
 
       el.focus();
@@ -331,37 +336,53 @@ export function useContentEditable({
     [syncFromDOM, resize]
   );
 
+  // The existing paste tile whose content equals `text`, if any (skill tiles excluded).
+  const findMatchingPasteTile = useCallback(
+    (text: string): HTMLElement | null => {
+      const el = ref.current;
+      if (!el) return null;
+      const tiles = Array.from(
+        el.querySelectorAll<HTMLElement>("[data-rich-tile]")
+      );
+      return (
+        tiles.find(
+          (tile) =>
+            !isSkillTile(tile) && tile.getAttribute("data-text") === text
+        ) ?? null
+      );
+    },
+    []
+  );
+
   const pasteText = useCallback(
     (text: string) => {
-      const pendingExpansion = pendingExpansionRef.current;
-      pendingExpansionRef.current = null;
-      if (pasteTilesEnabled && shouldCreatePasteTile(text)) {
-        if (
-          pendingExpansion &&
-          pendingExpansion.text === text &&
-          ref.current?.contains(pendingExpansion.tile)
-        ) {
-          expandTile(pendingExpansion.tile);
+      const plainPaste = plainPasteRef.current;
+      plainPasteRef.current = false;
+
+      if (pasteTilesEnabled && !plainPaste && shouldCreatePasteTile(text)) {
+        // Same clipboard as an existing tile → expand it instead of duplicating.
+        const existing = findMatchingPasteTile(text);
+        if (existing) {
+          expandTile(existing);
           return;
         }
-        const tile = insertTileAtCursor(text);
-        lastPasteTileRef.current = tile ? { text, tile } : null;
+        insertTileAtCursor(text);
       } else {
         insertTextAtCursor(text);
       }
     },
-    [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor, expandTile]
+    [
+      pasteTilesEnabled,
+      insertTileAtCursor,
+      insertTextAtCursor,
+      expandTile,
+      findMatchingPasteTile,
+    ]
   );
-
-  const armPasteExpansion = useCallback(() => {
-    pendingExpansionRef.current = lastPasteTileRef.current;
-    lastPasteTileRef.current = null;
-  }, []);
 
   const handleTileMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       clearTileSelection();
-      lastPasteTileRef.current = null;
       if (disabledRef.current) return;
 
       const target = event.target as HTMLElement;
@@ -471,8 +492,12 @@ export function useContentEditable({
       const isPasteShortcut =
         (event.ctrlKey || event.metaKey) &&
         (event.key === "v" || event.key === "V");
-      if (!isModifier && !isPasteShortcut) {
-        lastPasteTileRef.current = null;
+      // A Ctrl/Cmd+Shift+V arms a plain paste; any other (non-modifier) key
+      // disarms it so a stale flag can't hijack a later normal paste.
+      if (isPasteShortcut) {
+        plainPasteRef.current = event.shiftKey;
+      } else if (!isModifier) {
+        plainPasteRef.current = false;
       }
 
       const isNav = event.key === "ArrowLeft" || event.key === "ArrowRight";
@@ -649,7 +674,7 @@ export function useContentEditable({
     expandTile,
     insertSkillTile,
     pasteText,
-    armPasteExpansion,
+    pasteExpandHintVisible,
     handleCopy,
     handleCut,
     setCursorToEnd,

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -38,7 +38,9 @@ export interface UseContentEditableReturn {
   handleCompositionStart: () => void;
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
-  insertTileAtCursor: (text: string) => void;
+  insertTileAtCursor: (text: string) => HTMLElement | null;
+  /** Replace a paste tile with its full text inline at its position. */
+  expandTile: (tile: HTMLElement) => void;
   /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
   insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
@@ -71,6 +73,12 @@ export function useContentEditable({
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
+  // Most recent paste's tile, so a second back-to-back paste of the same text
+  // expands it inline instead of stacking a duplicate. Cleared by any
+  // intervening keystroke or click (see handleTileKeyDown).
+  const lastPasteTileRef = useRef<{ text: string; tile: HTMLElement } | null>(
+    null
+  );
   const [tilePopover, setTilePopover] = useState<{
     text: string;
     tile: HTMLElement;
@@ -213,6 +221,7 @@ export function useContentEditable({
 
       clearTileSelection();
       setTilePopover(null);
+      lastPasteTileRef.current = null;
 
       ref.current.textContent = text;
       messageRef.current = text;
@@ -241,6 +250,7 @@ export function useContentEditable({
 
     clearTileSelection();
     setTilePopover(null);
+    lastPasteTileRef.current = null;
 
     ref.current.innerHTML = "";
     messageRef.current = "";
@@ -260,8 +270,8 @@ export function useContentEditable({
   );
 
   const insertTileAtCursor = useCallback(
-    (text: string) => {
-      if (!ref.current) return;
+    (text: string): HTMLElement | null => {
+      if (!ref.current) return null;
       const tile = createRichInputTileNode({
         type: "paste",
         text,
@@ -270,6 +280,31 @@ export function useContentEditable({
       });
       insertNodeAtCursorUtil(ref.current, tile);
       setCursorAfterNode(tile);
+
+      syncFromDOM();
+      resize();
+      return tile;
+    },
+    [syncFromDOM, resize]
+  );
+
+  const expandTile = useCallback(
+    (tile: HTMLElement) => {
+      const el = ref.current;
+      if (!el || !el.contains(tile)) return;
+
+      const textNode = document.createTextNode(
+        tile.getAttribute("data-text") ?? ""
+      );
+      tile.replaceWith(textNode);
+
+      if (selectedTileRef.current === tile) selectedTileRef.current = null;
+      lastPasteTileRef.current = null;
+      setTilePopover(null);
+
+      el.focus();
+      setCursorAfterNode(textNode);
+      el.normalize();
 
       syncFromDOM();
       resize();
@@ -304,17 +339,25 @@ export function useContentEditable({
   const pasteText = useCallback(
     (text: string) => {
       if (pasteTilesEnabled && shouldCreatePasteTile(text)) {
-        insertTileAtCursor(text);
+        const last = lastPasteTileRef.current;
+        if (last && last.text === text && ref.current?.contains(last.tile)) {
+          expandTile(last.tile);
+          return;
+        }
+        const tile = insertTileAtCursor(text);
+        lastPasteTileRef.current = tile ? { text, tile } : null;
       } else {
         insertTextAtCursor(text);
+        lastPasteTileRef.current = null;
       }
     },
-    [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor]
+    [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor, expandTile]
   );
 
   const handleTileMouseDown = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       clearTileSelection();
+      lastPasteTileRef.current = null;
       if (disabledRef.current) return;
 
       const target = event.target as HTMLElement;
@@ -416,6 +459,20 @@ export function useContentEditable({
 
   const handleTileKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
+      // A keystroke between two pastes breaks the back-to-back expand, but
+      // modifier holds and Ctrl/Cmd+V itself are part of pasting.
+      const isModifier =
+        event.key === "Control" ||
+        event.key === "Meta" ||
+        event.key === "Shift" ||
+        event.key === "Alt";
+      const isPasteShortcut =
+        (event.ctrlKey || event.metaKey) &&
+        (event.key === "v" || event.key === "V");
+      if (!isModifier && !isPasteShortcut) {
+        lastPasteTileRef.current = null;
+      }
+
       const isNav = event.key === "ArrowLeft" || event.key === "ArrowRight";
       const isDelete = event.key === "Backspace" || event.key === "Delete";
 
@@ -587,6 +644,7 @@ export function useContentEditable({
     handleCompositionEnd,
     insertTextAtCursor,
     insertTileAtCursor,
+    expandTile,
     insertSkillTile,
     pasteText,
     handleCopy,

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -293,6 +293,10 @@ export function useContentEditable({
       const el = ref.current;
       if (!el || !el.contains(tile)) return;
 
+      const sel = window.getSelection();
+      const caret =
+        sel && sel.rangeCount > 0 ? sel.getRangeAt(0).cloneRange() : null;
+
       const textNode = document.createTextNode(
         tile.getAttribute("data-text") ?? ""
       );
@@ -302,8 +306,19 @@ export function useContentEditable({
       setTilePopover(null);
 
       el.focus();
-      setCursorAfterNode(textNode);
-      el.normalize();
+      // Restore the caret if it's still in the input; a caret on the now-detached
+      // tile (or in the popover) fails this and falls back to the text end.
+      if (
+        caret &&
+        el.contains(caret.startContainer) &&
+        el.contains(caret.endContainer)
+      ) {
+        sel!.removeAllRanges();
+        sel!.addRange(caret);
+      } else {
+        setCursorAfterNode(textNode);
+        el.normalize();
+      }
 
       syncFromDOM();
       resize();

--- a/web/src/hooks/useContentEditable.ts
+++ b/web/src/hooks/useContentEditable.ts
@@ -39,12 +39,10 @@ export interface UseContentEditableReturn {
   handleCompositionEnd: () => void;
   insertTextAtCursor: (text: string) => void;
   insertTileAtCursor: (text: string) => HTMLElement | null;
-  /** Replace a paste tile with its full text inline at its position. */
   expandTile: (tile: HTMLElement) => void;
   /** Insert a skill tile, replacing `beforeToken` (the `/<query>` before the caret). */
   insertSkillTile: (slug: string, name: string, beforeToken: string) => boolean;
   pasteText: (text: string) => void;
-  /** Clear double-paste tracking for paste events not routed through pasteText. */
   resetPasteTracking: () => void;
   handleCopy: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   handleCut: (event: React.ClipboardEvent<HTMLDivElement>) => void;
@@ -75,9 +73,6 @@ export function useContentEditable({
   const rafRef = useRef<number | null>(null);
   const wrapperPaddingYRef = useRef(0);
   const selectedTileRef = useRef<HTMLElement | null>(null);
-  // Most recent paste's tile, so a second back-to-back paste of the same text
-  // expands it inline instead of stacking a duplicate. Cleared by any
-  // intervening keystroke or click (see handleTileKeyDown).
   const lastPasteTileRef = useRef<{ text: string; tile: HTMLElement } | null>(
     null
   );
@@ -356,9 +351,6 @@ export function useContentEditable({
     [pasteTilesEnabled, insertTileAtCursor, insertTextAtCursor, expandTile]
   );
 
-  // Hosts call this for paste events handled without reaching pasteText (file
-  // pastes, intercepted `/skill` pastes); since Ctrl/Cmd+V is exempted from the
-  // keydown reset, the tracker would otherwise stay armed across them.
   const resetPasteTracking = useCallback(() => {
     lastPasteTileRef.current = null;
   }, []);
@@ -468,8 +460,6 @@ export function useContentEditable({
 
   const handleTileKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
-      // A keystroke between two pastes breaks the back-to-back expand, but
-      // modifier holds and Ctrl/Cmd+V itself are part of pasting.
       const isModifier =
         event.key === "Control" ||
         event.key === "Meta" ||

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -155,7 +155,6 @@ const AppInputBar = React.memo(
       handleCompositionStart,
       handleCompositionEnd,
       pasteText,
-      armPasteExpansion,
       handleCopy,
       handleCut,
       setCursorToEnd,
@@ -371,7 +370,6 @@ const AppInputBar = React.memo(
 
     function handlePaste(event: React.ClipboardEvent) {
       if (disabled) return;
-      armPasteExpansion();
       const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
       if (pastedFiles.length > 0) {
         event.preventDefault();

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -155,6 +155,7 @@ const AppInputBar = React.memo(
       handleCompositionStart,
       handleCompositionEnd,
       pasteText,
+      resetPasteTracking,
       handleCopy,
       handleCut,
       setCursorToEnd,
@@ -373,13 +374,17 @@ const AppInputBar = React.memo(
       const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
       if (pastedFiles.length > 0) {
         event.preventDefault();
+        resetPasteTracking();
         handleFileUpload(pastedFiles);
         return;
       }
 
       event.preventDefault();
       const text = event.clipboardData.getData("text/plain");
-      if (!text) return;
+      if (!text) {
+        resetPasteTracking();
+        return;
+      }
 
       pasteText(text);
     }

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -164,6 +164,7 @@ const AppInputBar = React.memo(
       tilePopover,
       dismissTilePopover,
       updateTileText,
+      expandTile,
     } = useContentEditable({
       initialContent: initialMessage,
       wrapperRef: inputWrapperRef,
@@ -994,6 +995,7 @@ const AppInputBar = React.memo(
                 tileElement={tilePopover.tile}
                 onDismiss={dismissTilePopover}
                 onTextChange={updateTileText}
+                onExpand={() => expandTile(tilePopover.tile)}
               />
             )}
           </div>

--- a/web/src/sections/input/AppInputBar.tsx
+++ b/web/src/sections/input/AppInputBar.tsx
@@ -155,7 +155,7 @@ const AppInputBar = React.memo(
       handleCompositionStart,
       handleCompositionEnd,
       pasteText,
-      resetPasteTracking,
+      armPasteExpansion,
       handleCopy,
       handleCut,
       setCursorToEnd,
@@ -371,20 +371,17 @@ const AppInputBar = React.memo(
 
     function handlePaste(event: React.ClipboardEvent) {
       if (disabled) return;
+      armPasteExpansion();
       const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
       if (pastedFiles.length > 0) {
         event.preventDefault();
-        resetPasteTracking();
         handleFileUpload(pastedFiles);
         return;
       }
 
       event.preventDefault();
       const text = event.clipboardData.getData("text/plain");
-      if (!text) {
-        resetPasteTracking();
-        return;
-      }
+      if (!text) return;
 
       pasteText(text);
     }

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -113,7 +113,7 @@ const BaseInputBar = memo(
         handleCompositionStart,
         handleCompositionEnd,
         pasteText,
-        armPasteExpansion,
+        pasteExpandHintVisible,
         handleCopy,
         handleCut,
         setCursorToEnd,
@@ -187,7 +187,6 @@ const BaseInputBar = memo(
       const handlePaste = useCallback(
         (event: ClipboardEvent) => {
           if (disabled) return;
-          armPasteExpansion();
           const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
           if (pastedFiles.length > 0) {
             event.preventDefault();
@@ -200,7 +199,7 @@ const BaseInputBar = memo(
           if (onPasteText?.(text)) return;
           pasteText(text);
         },
-        [disabled, onPasteFiles, onPasteText, pasteText, armPasteExpansion]
+        [disabled, onPasteFiles, onPasteText, pasteText]
       );
 
       const handleSubmit = useCallback(() => {
@@ -331,13 +330,23 @@ const BaseInputBar = memo(
             <div className="flex justify-between items-center w-full p-1 min-h-[40px]">
               <div className="flex flex-row items-center gap-2">
                 {bottomLeftSlot}
-                {!message && queueEnabled && queue.length > 0 && (
+                {pasteExpandHintVisible ? (
                   <div className="flex items-center gap-1 select-none">
-                    <Keycap>↑</Keycap>
                     <Text font="secondary-body" color="text-02">
-                      to edit queued messages
+                      Paste again to expand
                     </Text>
                   </div>
+                ) : (
+                  !message &&
+                  queueEnabled &&
+                  queue.length > 0 && (
+                    <div className="flex items-center gap-1 select-none">
+                      <Keycap>↑</Keycap>
+                      <Text font="secondary-body" color="text-02">
+                        to edit queued messages
+                      </Text>
+                    </div>
+                  )
                 )}
               </div>
               <div className="flex flex-row items-center gap-1">

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -113,7 +113,7 @@ const BaseInputBar = memo(
         handleCompositionStart,
         handleCompositionEnd,
         pasteText,
-        resetPasteTracking,
+        armPasteExpansion,
         handleCopy,
         handleCut,
         setCursorToEnd,
@@ -187,26 +187,20 @@ const BaseInputBar = memo(
       const handlePaste = useCallback(
         (event: ClipboardEvent) => {
           if (disabled) return;
+          armPasteExpansion();
           const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
           if (pastedFiles.length > 0) {
             event.preventDefault();
-            resetPasteTracking();
             onPasteFiles?.(pastedFiles);
             return;
           }
           event.preventDefault();
           const text = event.clipboardData.getData("text/plain");
-          if (!text) {
-            resetPasteTracking();
-            return;
-          }
-          if (onPasteText?.(text)) {
-            resetPasteTracking();
-            return;
-          }
+          if (!text) return;
+          if (onPasteText?.(text)) return;
           pasteText(text);
         },
-        [disabled, onPasteFiles, onPasteText, pasteText, resetPasteTracking]
+        [disabled, onPasteFiles, onPasteText, pasteText, armPasteExpansion]
       );
 
       const handleSubmit = useCallback(() => {

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -122,6 +122,7 @@ const BaseInputBar = memo(
         tilePopover,
         dismissTilePopover,
         updateTileText,
+        expandTile,
       } = useContentEditable({
         wrapperRef: inputWrapperRef,
         pasteTilesEnabled,
@@ -387,6 +388,7 @@ const BaseInputBar = memo(
               tileElement={tilePopover.tile}
               onDismiss={dismissTilePopover}
               onTextChange={updateTileText}
+              onExpand={() => expandTile(tilePopover.tile)}
             />
           )}
         </Disabled>

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -113,6 +113,7 @@ const BaseInputBar = memo(
         handleCompositionStart,
         handleCompositionEnd,
         pasteText,
+        resetPasteTracking,
         handleCopy,
         handleCut,
         setCursorToEnd,
@@ -189,16 +190,23 @@ const BaseInputBar = memo(
           const pastedFiles = getPastedFilesIfNoText(event.clipboardData);
           if (pastedFiles.length > 0) {
             event.preventDefault();
+            resetPasteTracking();
             onPasteFiles?.(pastedFiles);
             return;
           }
           event.preventDefault();
           const text = event.clipboardData.getData("text/plain");
-          if (!text) return;
-          if (onPasteText?.(text)) return;
+          if (!text) {
+            resetPasteTracking();
+            return;
+          }
+          if (onPasteText?.(text)) {
+            resetPasteTracking();
+            return;
+          }
           pasteText(text);
         },
-        [disabled, onPasteFiles, onPasteText, pasteText]
+        [disabled, onPasteFiles, onPasteText, pasteText, resetPasteTracking]
       );
 
       const handleSubmit = useCallback(() => {

--- a/web/src/sections/input/PasteTilePopover.tsx
+++ b/web/src/sections/input/PasteTilePopover.tsx
@@ -2,12 +2,15 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { Button } from "@opal/components";
+import { SvgArrowRight } from "@opal/icons";
 
 interface PasteTilePopoverProps {
   text: string;
   tileElement: HTMLElement;
   onDismiss: () => void;
   onTextChange: (newText: string) => void;
+  onExpand: () => void;
 }
 
 // Popover anchored to a paste tile that lets the user view/edit the full
@@ -19,6 +22,7 @@ function PasteTilePopover({
   tileElement,
   onDismiss,
   onTextChange,
+  onExpand,
 }: PasteTilePopoverProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [rect, setRect] = useState(() => tileElement.getBoundingClientRect());
@@ -97,6 +101,18 @@ function PasteTilePopover({
             fieldSizing: "content",
           }}
         />
+        <div className="flex justify-end border-t border-border-01 px-1 pt-1">
+          <Button
+            variant="default"
+            prominence="tertiary"
+            size="xs"
+            rightIcon={SvgArrowRight}
+            onClick={onExpand}
+            tooltip="Replace this tile with its full text inline"
+          >
+            Expand into input bar
+          </Button>
+        </div>
       </div>
     </>,
     document.body

--- a/web/tests/e2e/chat/InputBar.ts
+++ b/web/tests/e2e/chat/InputBar.ts
@@ -33,6 +33,7 @@ export class InputBar {
   readonly tilePopover: Locator;
   readonly tilePopoverTextarea: Locator;
   readonly tilePopoverBackdrop: Locator;
+  readonly tilePopoverExpandButton: Locator;
   readonly tilePreview: Locator;
   readonly tileMeta: Locator;
 
@@ -49,6 +50,9 @@ export class InputBar {
     );
     this.tilePopoverTextarea = this.tilePopover.locator("textarea");
     this.tilePopoverBackdrop = page.getByTestId("paste-tile-backdrop");
+    this.tilePopoverExpandButton = this.tilePopover.getByRole("button", {
+      name: "Expand into input bar",
+    });
     this.tilePreview = page.locator(".rich-input-tile-preview");
     this.tileMeta = page.locator(".rich-input-tile-meta");
   }
@@ -142,6 +146,10 @@ export class InputBar {
 
   async editTileText(newText: string): Promise<void> {
     await this.tilePopoverTextarea.fill(newText);
+  }
+
+  async expandTileViaPopover(): Promise<void> {
+    await this.tilePopoverExpandButton.click();
   }
 
   async dismissPopoverViaEscape(): Promise<void> {

--- a/web/tests/e2e/chat/InputBar.ts
+++ b/web/tests/e2e/chat/InputBar.ts
@@ -100,7 +100,6 @@ export class InputBar {
     }, text);
   }
 
-  /** Paste preceded by a Ctrl+Shift+V keydown (plain paste — never tiles). */
   async pastePlain(text: string): Promise<void> {
     await this.page.evaluate((t) => {
       const el = document.getElementById("onyx-chat-input-textbox")!;
@@ -127,7 +126,6 @@ export class InputBar {
     }, text);
   }
 
-  /** Dispatch a Ctrl+Shift+V keydown only (arms plain paste, no paste follows). */
   async armPlainPaste(): Promise<void> {
     await this.page.evaluate(() => {
       const el = document.getElementById("onyx-chat-input-textbox")!;

--- a/web/tests/e2e/chat/InputBar.ts
+++ b/web/tests/e2e/chat/InputBar.ts
@@ -100,13 +100,44 @@ export class InputBar {
     }, text);
   }
 
-  async pasteEmpty(): Promise<void> {
+  /** Paste preceded by a Ctrl+Shift+V keydown (plain paste — never tiles). */
+  async pastePlain(text: string): Promise<void> {
+    await this.page.evaluate((t) => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "V",
+          code: "KeyV",
+          ctrlKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      const dt = new DataTransfer();
+      dt.setData("text/plain", t);
+      el.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: dt,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    }, text);
+  }
+
+  /** Dispatch a Ctrl+Shift+V keydown only (arms plain paste, no paste follows). */
+  async armPlainPaste(): Promise<void> {
     await this.page.evaluate(() => {
       const el = document.getElementById("onyx-chat-input-textbox")!;
       el.focus();
       el.dispatchEvent(
-        new ClipboardEvent("paste", {
-          clipboardData: new DataTransfer(),
+        new KeyboardEvent("keydown", {
+          key: "V",
+          code: "KeyV",
+          ctrlKey: true,
+          shiftKey: true,
           bubbles: true,
           cancelable: true,
         })

--- a/web/tests/e2e/chat/InputBar.ts
+++ b/web/tests/e2e/chat/InputBar.ts
@@ -100,6 +100,22 @@ export class InputBar {
     }, text);
   }
 
+  // Dispatches a paste with neither text nor files — exercises the paste-handler
+  // path that returns before pasteText (like a file or `/skill` paste).
+  async pasteEmpty(): Promise<void> {
+    await this.page.evaluate(() => {
+      const el = document.getElementById("onyx-chat-input-textbox")!;
+      el.focus();
+      el.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: new DataTransfer(),
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    });
+  }
+
   async pasteHtml(html: string, plainText: string): Promise<void> {
     await this.page.evaluate(
       ({ html, plain }) => {

--- a/web/tests/e2e/chat/InputBar.ts
+++ b/web/tests/e2e/chat/InputBar.ts
@@ -100,8 +100,6 @@ export class InputBar {
     }, text);
   }
 
-  // Dispatches a paste with neither text nor files — exercises the paste-handler
-  // path that returns before pasteText (like a file or `/skill` paste).
   async pasteEmpty(): Promise<void> {
     await this.page.evaluate(() => {
       const el = document.getElementById("onyx-chat-input-textbox")!;

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -542,6 +542,7 @@ test.describe("Paste Tiles", () => {
 
   test("multiple tiles can coexist", async ({ chatPage }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
+    // Breaks the back-to-back sequence; without it the second paste expands.
     await chatPage.page.keyboard.press("End");
     await chatPage.inputBar.paste(LARGE_TEXT);
     await chatPage.inputBar.expectTileCount(2);
@@ -599,6 +600,50 @@ test.describe("Paste Tiles", () => {
     await chatPage.inputBar.clickTile();
     await chatPage.inputBar.expectPopoverVisible();
     await chatPage.inputBar.dismissPopoverViaBackdrop();
+  });
+
+  test("popover Expand button replaces the tile with inline text", async ({
+    chatPage,
+  }) => {
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.clickTile();
+    await chatPage.inputBar.expandTileViaPopover();
+    await chatPage.inputBar.expectTileCount(0);
+    await chatPage.inputBar.expectPopoverHidden();
+    await chatPage.inputBar.expectText("line 1");
+    await chatPage.inputBar.expectText("line 4");
+  });
+
+  test("Expand keeps edits made in the popover", async ({ chatPage }) => {
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.clickTile();
+    await chatPage.inputBar.editTileText("edited\nline 2\nline 3\nline 4");
+    await chatPage.inputBar.expandTileViaPopover();
+    await chatPage.inputBar.expectTileCount(0);
+    await chatPage.inputBar.expectText("edited");
+  });
+
+  test("Expanded text is sent as the message body", async ({ chatPage }) => {
+    await chatPage.inputBar.typeText("Context: ");
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.clickTile();
+    await chatPage.inputBar.expandTileViaPopover();
+    await chatPage.inputBar.send();
+    const msg = chatPage.humanMessage();
+    await expect(msg).toContainText("Context:");
+    await expect(msg).toContainText("line 1");
+    await expect(msg).toContainText("line 4");
+  });
+
+  test("second back-to-back paste expands the tile into inline text", async ({
+    chatPage,
+  }) => {
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.expectTileCount(1);
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.expectTileCount(0);
+    await chatPage.inputBar.expectText("line 1");
+    await chatPage.inputBar.expectText("line 4");
   });
 });
 

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -7,6 +7,7 @@ import {
 import { expectElementScreenshot } from "@tests/e2e/utils/visualRegression";
 
 const LARGE_TEXT = "line 1\nline 2\nline 3\nline 4";
+const LARGE_TEXT_B = "alpha\nbeta\ngamma\ndelta";
 
 test.describe("Core Text Input & Submission", () => {
   test.beforeEach(async ({ chatPage }) => {
@@ -540,10 +541,12 @@ test.describe("Paste Tiles", () => {
     await chatPage.inputBar.expectEmpty();
   });
 
-  test("multiple tiles can coexist", async ({ chatPage }) => {
+  test("pasting different large text creates a second tile", async ({
+    chatPage,
+  }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
     await chatPage.page.keyboard.press("End");
-    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.paste(LARGE_TEXT_B);
     await chatPage.inputBar.expectTileCount(2);
   });
 
@@ -634,7 +637,7 @@ test.describe("Paste Tiles", () => {
     await expect(msg).toContainText("line 4");
   });
 
-  test("second back-to-back paste expands the tile into inline text", async ({
+  test("pasting the same clipboard again expands the tile into inline text", async ({
     chatPage,
   }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
@@ -645,13 +648,33 @@ test.describe("Paste Tiles", () => {
     await chatPage.inputBar.expectText("line 4");
   });
 
-  test("an intervening empty paste prevents the back-to-back expand", async ({
+  test("pasting matching text expands the existing tile even after typing", async ({
     chatPage,
   }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
-    await chatPage.inputBar.pasteEmpty();
+    await chatPage.inputBar.expectTileCount(1);
+    await chatPage.inputBar.typeText(" middle ");
     await chatPage.inputBar.paste(LARGE_TEXT);
-    await chatPage.inputBar.expectTileCount(2);
+    await chatPage.inputBar.expectTileCount(0);
+    await chatPage.inputBar.expectText("line 1");
+  });
+
+  test("Ctrl+Shift+V pastes plain text without creating a tile", async ({
+    chatPage,
+  }) => {
+    await chatPage.inputBar.pastePlain(LARGE_TEXT);
+    await chatPage.inputBar.expectTileCount(0);
+    await chatPage.inputBar.expectText("line 1");
+    await chatPage.inputBar.expectText("line 4");
+  });
+
+  test("a keystroke disarms a pending Ctrl+Shift+V so the next paste tiles", async ({
+    chatPage,
+  }) => {
+    await chatPage.inputBar.armPlainPaste();
+    await chatPage.inputBar.typeText("x");
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.expectTileCount(1);
   });
 });
 

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -542,7 +542,6 @@ test.describe("Paste Tiles", () => {
 
   test("multiple tiles can coexist", async ({ chatPage }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
-    // Breaks the back-to-back sequence; without it the second paste expands.
     await chatPage.page.keyboard.press("End");
     await chatPage.inputBar.paste(LARGE_TEXT);
     await chatPage.inputBar.expectTileCount(2);
@@ -650,8 +649,6 @@ test.describe("Paste Tiles", () => {
     chatPage,
   }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);
-    // Stands in for a file/`/skill` paste: returns before pasteText, so the
-    // next identical text paste must create a new tile, not expand the first.
     await chatPage.inputBar.pasteEmpty();
     await chatPage.inputBar.paste(LARGE_TEXT);
     await chatPage.inputBar.expectTileCount(2);

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -645,6 +645,17 @@ test.describe("Paste Tiles", () => {
     await chatPage.inputBar.expectText("line 1");
     await chatPage.inputBar.expectText("line 4");
   });
+
+  test("a paste handled outside pasteText breaks the back-to-back expand", async ({
+    chatPage,
+  }) => {
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    // Stands in for a file/`/skill` paste: returns before pasteText, so the
+    // next identical text paste must create a new tile, not expand the first.
+    await chatPage.inputBar.pasteEmpty();
+    await chatPage.inputBar.paste(LARGE_TEXT);
+    await chatPage.inputBar.expectTileCount(2);
+  });
 });
 
 test.describe("Paste Tiles — User Setting", () => {

--- a/web/tests/e2e/chat/input_bar_behaviors.spec.ts
+++ b/web/tests/e2e/chat/input_bar_behaviors.spec.ts
@@ -645,7 +645,7 @@ test.describe("Paste Tiles", () => {
     await chatPage.inputBar.expectText("line 4");
   });
 
-  test("a paste handled outside pasteText breaks the back-to-back expand", async ({
+  test("an intervening empty paste prevents the back-to-back expand", async ({
     chatPage,
   }) => {
     await chatPage.inputBar.paste(LARGE_TEXT);


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/c4b57103-9347-4bb5-9be7-d365e5f44d2f



Adds the ability to "expand" a collapsed paste tile back into inline text in the chat input bar, via two methods:

1. **Popover button** — clicking a paste tile opens its edit popover, which now has an **"Expand into input bar →"** button that replaces the tile with its full text inline (preserving any edits made in the popover).
2. **Double paste** — pasting the same large content twice back-to-back (no keystroke/click in between) expands the just-created tile inline instead of stacking a second identical tile.

Implementation lives in `useContentEditable`:
- New `expandTile(tile)` swaps the tile node for a text node at its position and places the caret after it.
- `pasteText` tracks the most recent paste's tile; an immediate second paste of the same text expands it. The tracking is cleared by any intervening keystroke (except modifier holds and `Ctrl/Cmd+V` itself), mouse click, or programmatic message change — so the gesture only fires when the two pastes are truly back-to-back.

Both `BaseInputBar` and `AppInputBar` wire `expandTile` to the popover's new `onExpand`. Serialization is unchanged — expanded text is a normal text node, so the sent message body is identical.

## How Has This Been Tested?

Added Playwright e2e coverage in `web/tests/e2e/chat/input_bar_behaviors.spec.ts`:
- Popover **Expand** button replaces the tile with inline text
- Expand preserves edits made in the popover
- Expanded text is sent as the message body
- Second back-to-back paste expands the tile inline

The existing `"multiple tiles can coexist"` test (paste → `End` → paste → 2 tiles) now also guards that the double-paste expand only triggers without an intervening keystroke.

Also verified locally: `tsgo` type check, `oxlint`, `oxfmt`, and lib unit tests (45/45) all pass.

Fixes: https://linear.app/onyx-app/issue/ENG-4146/craft-polish-ux-to-expand-paste-tiles

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets users expand a collapsed paste tile back into inline text via popover or by pasting the same clipboard again; adds Ctrl/Cmd+Shift+V plain paste and a paste-only “Paste again to expand” hint. Expansion now preserves the caret when possible; message serialization is unchanged.

- **New Features**
  - Popover: Added “Expand into input bar” button that replaces the tile with inline text, preserves edits, and keeps the caret position when possible (otherwise places it after). Wired in `BaseInputBar` and `AppInputBar`; popover uses `@opal/components` and `@opal/icons`.
  - Dedupe on paste: Pasting the same large text again expands the existing tile instead of creating a duplicate (works even after typing or cursor moves).
  - Plain paste: Ctrl/Cmd+Shift+V forces a plain-text paste and never creates a tile; the flag auto‑clears on any non‑modifier key.
  - Hint: Shows a sticky “Paste again to expand” only when a paste tile exists.

- **Bug Fixes**
  - Clear stale selection/plain‑paste refs after IME composition and Cut; hint resets on DOM changes.

<sup>Written for commit 93121129bc58e79455594cf3db40e8e4c1f1af2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



