### PR TITLE
fix(craft): Persist thinking as collapsed rows

### DIFF
--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -431,6 +431,8 @@ def translate_opencode_event(
         msg_id = props.get("messageID")
         if not isinstance(delta, str) or not isinstance(part_id, str):
             return
+        if not delta:
+            return
         # Assistant-only filter. Deltas race ~300ms ahead of message.updated;
         # _is_assistant_message hydrates via REST when the role is unknown.
         if not _is_assistant_message(state, msg_id, fetch_message):

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -23,7 +23,7 @@ def _model_options(provider: str, model_name: str) -> dict[str, Any]:
         if model_name in _ADAPTIVE_THINKING_MODELS or model_name.startswith(
             tuple(f"{m}-" for m in _ADAPTIVE_THINKING_MODELS)
         ):
-            return {"thinking": {"type": "adaptive"}}
+            return {"thinking": {"type": "adaptive", "display": "summarized"}}
         return {"thinking": {"type": "enabled", "budgetTokens": 16000}}
     if provider == "google":
         return {"thinking_budget": 16000, "thinking_level": "high"}

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -143,10 +143,10 @@ class BuildStreamingState:
         """Build a synthetic packet with accumulated thought text.
 
         ``routing_meta`` (when set) is merged into the packet's ACP ``_meta``
-        field.
+        field so a persisted subagent follow-up reloads under its subagent.
 
         Returns:
-            A synthetic agent_thought packet or None if no chunks accumulated
+            A synthetic agent_thought packet or None if no chunks accumulated.
         """
         if not self.thought_chunks:
             return None
@@ -316,7 +316,7 @@ def _save_pending_chunks(
     state: BuildStreamingState,
     routing_meta: dict[str, Any] | None = None,
 ) -> None:
-    """Flush any pending accumulated message/thought chunks to the DB.
+    """Flush pending message/thought chunks to the DB.
 
     Called when the next sandbox event is of a different type than the chunks
     currently being accumulated, and once more at end of stream.
@@ -506,8 +506,10 @@ def persist_sandbox_event(
 
     Behavior matches the pre-refactor interactive path exactly:
     - SSEKeepalive: no-op (handled by callers).
-    - agent_message_chunk / agent_thought_chunk: accumulated; flushed
-      when a non-chunk event arrives or at end of stream.
+    - agent_message_chunk: accumulated; flushed when a non-chunk event arrives
+      or at end of stream.
+    - agent_thought_chunk: accumulated; flushed when a non-chunk event arrives
+      or at end of stream.
     - tool_call_start: no-op (only completed tool calls persist).
     - tool_call_progress: TodoWrite saves every progress update; other
       tools save only on `status == "completed"`. Completed Task

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -205,7 +205,7 @@ class TestStreamingPersistence:
         assert messages[3].type == MessageType.ASSISTANT
         assert messages[3].message_metadata["content"]["text"] == "Done with tool."
 
-    def test_agent_thought_chunks_persist_as_single_thought_row(
+    def test_agent_thought_chunks_persist_as_single_collapsed_row(
         self,
         db_session: Session,
         test_user: User,
@@ -215,7 +215,7 @@ class TestStreamingPersistence:
         stub_sandbox_manager: StubSandboxManager,
         tenant_context: None,  # noqa: ARG002
     ) -> None:
-        """3 thought chunks → 1 ``agent_thought`` row with concatenated text."""
+        """3 thought chunks stream live, then persist as one ``agent_thought`` row."""
         sandbox(user=test_user)
         stub_sandbox_manager.send_message_events = [
             _thought_chunk("Hmm, "),

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -41,9 +41,23 @@ def test_single_provider_renders_all_required_fields() -> None:
     assert config["enabled_providers"] == ["anthropic"]
     assert config["provider"]["anthropic"]["options"]["apiKey"] == "sk-test"
     # opus-4-7 is in _ADAPTIVE_THINKING_MODELS, so adaptive thinking.
+    # Anthropic defaults adaptive thinking display to "omitted"; explicit
+    # summarized display is required for Craft to receive readable thought text.
     assert config["provider"]["anthropic"]["models"]["claude-opus-4-7"]["options"][
         "thinking"
-    ] == {"type": "adaptive"}
+    ] == {"type": "adaptive", "display": "summarized"}
+
+
+def test_adaptive_anthropic_models_request_readable_thinking_summaries() -> None:
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-8")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-8",
+    )
+
+    assert config["provider"]["anthropic"]["models"]["claude-opus-4-8"]["options"][
+        "thinking"
+    ] == {"type": "adaptive", "display": "summarized"}
 
 
 def test_multi_provider_each_gets_its_own_block() -> None:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
@@ -139,6 +139,32 @@ def test_reasoning_delta_yields_agent_thought_chunk() -> None:
     assert isinstance(out[0], AgentThoughtChunk)
 
 
+def test_empty_reasoning_delta_is_ignored() -> None:
+    """Anthropic can emit an empty reasoning delta when adaptive thinking
+    display is omitted. Empty thought packets should not be surfaced to Craft."""
+    s = _assistant_state()
+    s.part_types["p1"] = "reasoning"
+
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": SESS,
+                    "messageID": "msg_assistant",
+                    "partID": "p1",
+                    "field": "text",
+                    "delta": "",
+                },
+            },
+            s,
+        )
+    )
+
+    assert out == []
+    assert "p1" not in s.local_text
+
+
 def test_reasoning_part_type_recorded_from_part_updated() -> None:
     """A ``message.part.updated`` with ``type=reasoning`` should register
     the part's type so subsequent deltas route to AgentThoughtChunk."""

--- a/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
@@ -27,8 +27,8 @@ class TestBuildStreamingState:
         # After finalize, chunks should be cleared
         assert len(state.message_chunks) == 0
 
-    def test_thought_chunks_accumulate_separately(self) -> None:
-        """Message and thought chunks tracked independently."""
+    def test_thought_chunks_persist_as_single_assistant_row(self) -> None:
+        """Append two thought chunks -> finalize -> one synthetic packet."""
         state = BuildStreamingState(turn_index=0)
 
         state.add_thought_chunk("Thinking about ")
@@ -39,6 +39,7 @@ class TestBuildStreamingState:
         assert packet is not None
         assert packet["type"] == "agent_thought"
         assert packet["content"]["text"] == "Thinking about the problem..."
+        assert state.thought_chunks == []
 
     def test_type_change_finalizes_previous_type(self) -> None:
         """Driving the state machine through a real chunk → opposing-type packet should

--- a/web/src/app/craft/components/BuildMessageList.test.tsx
+++ b/web/src/app/craft/components/BuildMessageList.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import BuildMessageList from "@/app/craft/components/BuildMessageList";
+import type { BuildMessage } from "@/app/craft/types/streamingTypes";
+import type { StreamItem } from "@/app/craft/types/displayTypes";
+
+jest.mock("@/refresh-components/Logo", () => ({
+  __esModule: true,
+  default: () => <div data-testid="onyx-logo" />,
+}));
+
+jest.mock("@/components/chat/MinimalMarkdown", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+jest.mock("@/app/app/message/BlinkingBar", () => ({
+  BlinkingBar: () => <span data-testid="blinking-bar" />,
+}));
+
+jest.mock("motion/react", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      transition: _transition,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      exit?: unknown;
+      transition?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+function scrollRef() {
+  const el = document.createElement("div");
+  el.scrollTo = jest.fn();
+  return { current: el };
+}
+
+function renderList(props: {
+  messages?: BuildMessage[];
+  streamItems?: StreamItem[];
+  isStreaming?: boolean;
+}) {
+  return render(
+    <BuildMessageList
+      messages={props.messages ?? []}
+      streamItems={props.streamItems ?? []}
+      isStreaming={props.isStreaming}
+      autoScrollEnabled={false}
+      scrollContainerRef={scrollRef()}
+    />
+  );
+}
+
+const savedAssistantMessage: BuildMessage = {
+  id: "assistant-1",
+  type: "assistant",
+  content: "Final answer",
+  timestamp: new Date("2026-01-01T00:00:00Z"),
+  message_metadata: {
+    streamItems: [
+      {
+        type: "thinking",
+        id: "thought-1",
+        content: "Checking the app structure.",
+        isStreaming: false,
+      },
+      {
+        type: "text",
+        id: "text-1",
+        content: "Final answer",
+        isStreaming: false,
+      },
+    ],
+  },
+};
+
+describe("BuildMessageList thinking visibility", () => {
+  it("shows restored thought packets as collapsed thinking rows", () => {
+    renderList({ messages: [savedAssistantMessage] });
+
+    fireEvent.click(screen.getByRole("button", { name: /Thinking/ }));
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(screen.getByText("Checking the app structure.")).toBeInTheDocument();
+    expect(screen.getByText("Final answer")).toBeInTheDocument();
+  });
+
+  it("does not open restored thought packets by default", () => {
+    renderList({ messages: [savedAssistantMessage] });
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Checking the app structure.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Final answer")).toBeInTheDocument();
+  });
+
+  it("keeps completed thought packets collapsed in the active stream", () => {
+    renderList({
+      isStreaming: true,
+      streamItems: [
+        {
+          type: "thinking",
+          id: "settled-thought",
+          content: "Checking the app structure.",
+          isStreaming: false,
+        },
+        {
+          type: "text",
+          id: "stream-text",
+          content: "Final answer",
+          isStreaming: false,
+        },
+      ],
+    });
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Checking the app structure.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Final answer")).toBeInTheDocument();
+  });
+
+  it("shows live thought packets as collapsed progress by default", () => {
+    renderList({
+      isStreaming: true,
+      streamItems: [
+        {
+          type: "thinking",
+          id: "live-thought",
+          content: "Checking the app structure.",
+          isStreaming: true,
+        },
+      ],
+    });
+
+    expect(screen.getByText("Thinking...")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Checking the app structure.")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Thinking/ }));
+
+    expect(screen.getByText("Checking the app structure.")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo } from "react";
 import { cn } from "@opal/utils";
+import { AnimatePresence, motion } from "motion/react";
 import Logo from "@/refresh-components/Logo";
 import TextChunk from "@/app/craft/components/TextChunk";
 import ThinkingCard from "@/app/craft/components/ThinkingCard";
@@ -83,25 +84,24 @@ export default function BuildMessageList({
 
   const renderStreamItems = (
     rawItems: StreamItem[],
-    opts: { isCurrentStream: boolean; extractLatestTodo: boolean }
+    opts: {
+      isCurrentStream: boolean;
+      extractLatestTodo: boolean;
+    }
   ): { nodes: React.ReactNode[]; pinnedTodo: TodoListState | null } => {
     // Render items in stream order (tools, text, thinking interleaved).
     //
     // Filtering rules that apply first:
     // - Only the LATEST todo_list is kept (either pinned via extractLatestTodo
     //   or rendered inline at its original position).
-    // - Thinking is ephemeral: the card shows only while the model is actively
-    //   thinking and disappears once that block settles.
+    // - Thinking remains as a collapsed transcript row so users have a durable
+    //   signal that the model spent time reasoning without opening by default.
     let latestTodoIdx = -1;
     rawItems.forEach((it, idx) => {
       if (it.type === "todo_list") latestTodoIdx = idx;
     });
 
     const items = rawItems.filter((it, idx) => {
-      // Drop settled thinking entirely — it's only shown live, in progress.
-      if (it.type === "thinking" && !it.isStreaming) {
-        return false;
-      }
       // Collapse to one todo_list per turn.
       if (it.type === "todo_list" && idx !== latestTodoIdx) {
         return false;
@@ -179,12 +179,21 @@ export default function BuildMessageList({
           );
         case "thinking":
           return (
-            <div key={item.id} className={cn(topMargin)}>
+            <motion.div
+              key={item.id}
+              className={cn(topMargin)}
+              initial={
+                opts.isCurrentStream ? { opacity: 0, y: -4, height: 0 } : false
+              }
+              animate={{ opacity: 1, y: 0, height: "auto" }}
+              exit={{ opacity: 0, y: -6, height: 0, marginTop: 0 }}
+              transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+            >
               <ThinkingCard
                 content={item.content}
                 isStreaming={item.isStreaming}
               />
-            </div>
+            </motion.div>
           );
         case "todo_list":
           return (
@@ -217,6 +226,10 @@ export default function BuildMessageList({
             extractLatestTodo: true,
           })
         : null;
+    const visibleSavedRender =
+      savedRender && (savedRender.pinnedTodo || savedRender.nodes.length > 0)
+        ? savedRender
+        : null;
 
     return (
       <div key={message.id} className="flex items-start gap-3 py-4">
@@ -224,17 +237,17 @@ export default function BuildMessageList({
           <Logo onyxBranded folded size={24} />
         </div>
         <div className="flex-1 flex flex-col gap-2 min-w-0">
-          {savedRender ? (
+          {visibleSavedRender ? (
             <>
-              {savedRender.pinnedTodo && (
+              {visibleSavedRender.pinnedTodo && (
                 <div>
                   <TodoListCard
-                    todoList={savedRender.pinnedTodo}
-                    defaultOpen={savedRender.pinnedTodo.isOpen}
+                    todoList={visibleSavedRender.pinnedTodo}
+                    defaultOpen={visibleSavedRender.pinnedTodo.isOpen}
                   />
                 </div>
               )}
-              {savedRender.nodes}
+              {visibleSavedRender.nodes}
             </>
           ) : (
             <TextChunk content={message.content} />
@@ -303,7 +316,9 @@ export default function BuildMessageList({
                   <BlinkingBar />
                 </div>
               ) : (
-                streamRender?.nodes
+                <AnimatePresence initial={false}>
+                  {streamRender?.nodes}
+                </AnimatePresence>
               )}
               {trailingAssistantSlot}
             </div>

--- a/web/src/app/craft/components/ThinkingCard.stories.tsx
+++ b/web/src/app/craft/components/ThinkingCard.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ThinkingCard from "@/app/craft/components/ThinkingCard";
+
+const THINKING_CONTENT = `Inspecting the current Craft session state and tracing the packet flow.
+
+The stream contains a thought chunk before the final answer, so the UI keeps a quiet row in the transcript.
+
+Next step: preserve the row as collapsed context while letting the user expand it if they want the details.`;
+
+const meta: Meta<typeof ThinkingCard> = {
+  title: "Apps/Craft/Messages/Thinking Card",
+  component: ThinkingCard,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-[640px]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    content: THINKING_CONTENT,
+    defaultOpen: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThinkingCard>;
+
+export const LiveCollapsed: Story = {
+  args: {
+    isStreaming: true,
+  },
+};
+
+export const LiveExpanded: Story = {
+  args: {
+    isStreaming: true,
+    defaultOpen: true,
+  },
+};
+
+export const CompletedCollapsed: Story = {
+  args: {
+    isStreaming: false,
+  },
+};
+
+export const CompletedExpanded: Story = {
+  args: {
+    isStreaming: false,
+    defaultOpen: true,
+  },
+};

--- a/web/src/app/craft/components/ThinkingCard.stories.tsx
+++ b/web/src/app/craft/components/ThinkingCard.stories.tsx
@@ -11,6 +11,14 @@ const meta: Meta<typeof ThinkingCard> = {
   title: "Apps/Craft/Messages/Thinking Card",
   component: ThinkingCard,
   tags: ["autodocs"],
+  render: (args) => (
+    <ThinkingCard
+      key={`${args.isStreaming ? "live" : "complete"}-${
+        args.defaultOpen ? "open" : "closed"
+      }`}
+      {...args}
+    />
+  ),
   decorators: [
     (Story) => (
       <div className="w-[640px]">

--- a/web/src/app/craft/components/ThinkingCard.test.tsx
+++ b/web/src/app/craft/components/ThinkingCard.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ThinkingCard from "@/app/craft/components/ThinkingCard";
+
+jest.mock("@/components/chat/MinimalMarkdown", () => ({
+  __esModule: true,
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+describe("ThinkingCard", () => {
+  it("does not reset a manual disclosure choice when defaultOpen changes", () => {
+    const { rerender } = render(
+      <ThinkingCard
+        content="Inspecting the stream."
+        isStreaming={false}
+        defaultOpen
+      />
+    );
+
+    expect(screen.getByText("Inspecting the stream.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Thinking/ }));
+    expect(
+      screen.queryByText("Inspecting the stream.")
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <ThinkingCard
+        content="Inspecting the stream."
+        isStreaming={false}
+        defaultOpen={false}
+      />
+    );
+    rerender(
+      <ThinkingCard
+        content="Inspecting the stream."
+        isStreaming={false}
+        defaultOpen
+      />
+    );
+
+    expect(
+      screen.queryByText("Inspecting the stream.")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ReactNode } from "react";
 import { cn } from "@opal/utils";
 import { Text } from "@opal/components";
@@ -93,10 +93,6 @@ export default function ThinkingCard({
   defaultOpen = false,
 }: ThinkingCardProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
-
-  useEffect(() => {
-    setIsOpen(defaultOpen);
-  }, [defaultOpen]);
 
   if (!content) return null;
 

--- a/web/src/app/craft/components/ThinkingCard.tsx
+++ b/web/src/app/craft/components/ThinkingCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { cn } from "@opal/utils";
-import { Tag, Text } from "@opal/components";
+import { Text } from "@opal/components";
 import { SvgBubbleText, SvgChevronDown } from "@opal/icons";
 import {
   Collapsible,
@@ -68,22 +68,35 @@ const THINKING_MARKDOWN_OVERRIDES = {
 interface ThinkingCardProps {
   content: string;
   isStreaming: boolean;
+  defaultOpen?: boolean;
 }
 
-function formatTokenCount(chars: number): string {
-  // ~4 chars per token; coarse but consistent with Claude/OpenAI's "Thought for Ns"
-  // approximations when wall-clock timing isn't tracked.
-  const tokens = Math.round(chars / 4);
-  if (tokens < 1000) return `${tokens} tokens`;
-  return `${(tokens / 1000).toFixed(1)}k tokens`;
+function ThinkingActivityIcon({ isStreaming }: { isStreaming: boolean }) {
+  if (!isStreaming) {
+    return <SvgBubbleText className="size-4 shrink-0 stroke-text-03" />;
+  }
+
+  return (
+    <span
+      aria-hidden
+      className="relative flex size-4 shrink-0 items-center justify-center"
+    >
+      <span className="absolute size-3 rounded-full bg-status-info-03 opacity-35 motion-safe:animate-ping motion-reduce:hidden" />
+      <span className="size-1.5 rounded-full bg-status-info-05" />
+    </span>
+  );
 }
 
 export default function ThinkingCard({
   content,
   isStreaming,
+  defaultOpen = false,
 }: ThinkingCardProps) {
-  const [isOpen, setIsOpen] = useState(false);
-  const chip = useMemo(() => formatTokenCount(content.length), [content]);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  useEffect(() => {
+    setIsOpen(defaultOpen);
+  }, [defaultOpen]);
 
   if (!content) return null;
 
@@ -92,23 +105,18 @@ export default function ThinkingCard({
       <CollapsibleTrigger asChild>
         <button
           className={cn(
-            "group w-full text-left px-3 py-2 rounded-md transition-colors",
-            "hover:bg-background-tint-02"
+            "group w-full text-left px-3 py-1.5 rounded-md transition-colors duration-200",
+            "hover:bg-background-tint-02 motion-reduce:transition-none"
           )}
         >
           <div className="flex items-center gap-2 min-w-0 w-full">
-            <SvgBubbleText className="size-4 shrink-0 stroke-text-03" />
+            <ThinkingActivityIcon isStreaming={isStreaming} />
             <Text font="main-ui-muted" color="text-04" nowrap>
-              {isStreaming ? "Thinking" : "Thought"}
+              {isStreaming ? "Thinking..." : "Thinking"}
             </Text>
-            {!isStreaming && (
-              <span className="shrink-0">
-                <Tag title={chip} size="sm" color="gray" />
-              </span>
-            )}
             <SvgChevronDown
               className={cn(
-                "size-4 stroke-text-03 transition-all duration-150 shrink-0 ml-auto",
+                "size-4 stroke-text-03 transition-all duration-150 shrink-0 ml-auto motion-reduce:transition-none",
                 "group-hover:stroke-text-05",
                 !isOpen && "-rotate-90"
               )}

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -87,6 +87,65 @@ describe("loadSession restore status", () => {
     const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
     expect(session?.sandbox?.status).toBe("running");
   });
+
+  it("restores persisted agent thought packets as collapsed transcript stream items", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+    mockedApi.fetchMessages.mockResolvedValue([
+      {
+        id: "user-1",
+        type: "user",
+        content: "Build a dashboard",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "user_message",
+          content: { type: "text", text: "Build a dashboard" },
+        },
+      },
+      {
+        id: "thought-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_thought",
+          content: { type: "text", text: "Inspecting available files." },
+        },
+      },
+      {
+        id: "answer-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_message",
+          content: { type: "text", text: "Created the dashboard." },
+        },
+      },
+    ] as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    const assistant = session?.messages.find((message) => {
+      return message.type === "assistant";
+    });
+    const streamItems = assistant?.message_metadata?.streamItems;
+
+    expect(streamItems).toEqual([
+      {
+        type: "thinking",
+        id: "thought-1",
+        content: "Inspecting available files.",
+        isStreaming: false,
+      },
+      {
+        type: "text",
+        id: "answer-1",
+        content: "Created the dashboard.",
+        isStreaming: false,
+      },
+    ]);
+  });
 });
 
 describe("waitForWebappReady", () => {

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -60,7 +60,7 @@ import {
  * The backend stores messages with these packet types in message_metadata:
  * - user_message: {type: "user_message", content: {type: "text", text: "..."}}
  * - agent_message: {type: "agent_message", content: {type: "text", text: "..."}}
- * - agent_thought: {type: "agent_thought", content: {type: "text", text: "..."}}
+ * - agent_thought: DB-stored thinking rows restored as collapsed stream items
  * - tool_call_progress: Full tool call data with status="completed"
  * - agent_plan_update: Plan entries (not rendered as stream items)
  *

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -1,0 +1,141 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+import { useBuildStreaming } from "@/app/craft/hooks/useBuildStreaming";
+import type { StreamItem } from "@/app/craft/types/displayTypes";
+import {
+  processSSEStream,
+  sendMessageStream,
+} from "@/app/craft/services/apiServices";
+
+jest.mock("swr", () => ({
+  useSWRConfig: () => ({ mutate: jest.fn() }),
+}));
+
+jest.mock("@/app/craft/services/apiServices", () => ({
+  RateLimitError: class RateLimitError extends Error {},
+  fetchScheduledRunEventStream: jest.fn(),
+  fetchSession: jest.fn(),
+  interruptMessageStream: jest.fn(),
+  processSSEStream: jest.fn(),
+  sendMessageStream: jest.fn(),
+}));
+
+const sessionId = "session-thinking";
+
+describe("useBuildStreaming thinking packets", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    useBuildSessionStore.setState({
+      currentSessionId: null,
+      sessions: new Map(),
+    } as never);
+    useBuildSessionStore.getState().createSession(sessionId, {
+      status: "active",
+      isLoaded: true,
+    });
+
+    jest.mocked(sendMessageStream).mockResolvedValue({} as Response);
+    jest
+      .mocked(processSSEStream)
+      .mockImplementation(async (_response, onPacket) => {
+        onPacket({
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Inspecting the app state." },
+          timestamp: "2026-01-01T00:00:00Z",
+        } as never);
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "tool-read",
+          kind: "read",
+          title: "Read file",
+          content: null,
+          locations: null,
+          raw_input: null,
+          raw_output: null,
+          status: "pending",
+          timestamp: "2026-01-01T00:00:01Z",
+        });
+      });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("settles a thought when the next packet arrives while keeping the row visible", async () => {
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const streamItems =
+      useBuildSessionStore.getState().sessions.get(sessionId)?.streamItems ??
+      [];
+
+    expect(streamItems).toHaveLength(2);
+    expect(streamItems[0]).toMatchObject({
+      type: "thinking",
+      content: "Inspecting the app state.",
+      isStreaming: false,
+    });
+    expect(streamItems[1]).toMatchObject({
+      type: "tool_call",
+      id: "tool-read",
+    });
+  });
+
+  it("saves thought stream items into assistant metadata on prompt_response", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Inspecting the app state." },
+          timestamp: "2026-01-01T00:00:00Z",
+        } as never);
+        onPacket({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Built the app." },
+          timestamp: "2026-01-01T00:00:01Z",
+        } as never);
+        onPacket({
+          type: "prompt_response",
+          timestamp: "2026-01-01T00:00:02Z",
+        });
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    const assistantMessage = session?.messages.find(
+      (message) => message.type === "assistant"
+    );
+    const metadata = assistantMessage?.message_metadata as
+      | { streamItems?: StreamItem[] }
+      | undefined;
+
+    expect(session?.streamItems).toEqual([]);
+    expect(assistantMessage?.content).toBe("Built the app.");
+    expect(metadata?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "thinking",
+        content: "Inspecting the app state.",
+        isStreaming: false,
+      }),
+      expect.objectContaining({
+        type: "text",
+        content: "Built the app.",
+        isStreaming: false,
+      }),
+    ]);
+  });
+});

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -384,17 +384,15 @@ export function useBuildStreaming() {
                 .map((item) => item.content)
                 .join("");
 
-              if (savedStreamItems.length > 0 || textContent) {
-                appendMessageToSession(sessionId, {
-                  id: genId("agent-msg"),
-                  type: "assistant",
-                  content: textContent,
-                  timestamp: new Date(),
-                  message_metadata: {
-                    streamItems: savedStreamItems,
-                  },
-                });
-              }
+              appendMessageToSession(sessionId, {
+                id: genId("agent-msg"),
+                type: "assistant",
+                content: textContent,
+                timestamp: new Date(),
+                message_metadata: {
+                  streamItems: savedStreamItems,
+                },
+              });
             }
 
             updateSessionData(sessionId, {

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -373,25 +373,28 @@ export function useBuildStreaming() {
               .sessions.get(sessionId);
 
             if (session && session.streamItems.length > 0) {
+              const savedStreamItems = session.streamItems.map((item) => ({
+                ...item,
+                ...(item.type === "text" || item.type === "thinking"
+                  ? { isStreaming: false }
+                  : {}),
+              }));
               const textContent = session.streamItems
                 .filter((item) => item.type === "text")
                 .map((item) => item.content)
                 .join("");
 
-              appendMessageToSession(sessionId, {
-                id: genId("agent-msg"),
-                type: "assistant",
-                content: textContent,
-                timestamp: new Date(),
-                message_metadata: {
-                  streamItems: session.streamItems.map((item) => ({
-                    ...item,
-                    ...(item.type === "text" || item.type === "thinking"
-                      ? { isStreaming: false }
-                      : {}),
-                  })),
-                },
-              });
+              if (savedStreamItems.length > 0 || textContent) {
+                appendMessageToSession(sessionId, {
+                  id: genId("agent-msg"),
+                  type: "assistant",
+                  content: textContent,
+                  timestamp: new Date(),
+                  message_metadata: {
+                    streamItems: savedStreamItems,
+                  },
+                });
+              }
             }
 
             updateSessionData(sessionId, {

--- a/web/src/app/craft/utils/parsePacket.test.ts
+++ b/web/src/app/craft/utils/parsePacket.test.ts
@@ -1,0 +1,27 @@
+import { parsePacket } from "@/app/craft/utils/parsePacket";
+
+describe("parsePacket", () => {
+  it("parses raw opencode thought chunks that carry the event type in sessionUpdate", () => {
+    expect(
+      parsePacket({
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text: "Inspecting the app state." },
+      })
+    ).toEqual({
+      type: "thinking_chunk",
+      text: "Inspecting the app state.",
+    });
+  });
+
+  it("parses persisted agent thought packets as thinking chunks", () => {
+    expect(
+      parsePacket({
+        type: "agent_thought",
+        content: { type: "text", text: "Inspecting saved context." },
+      })
+    ).toEqual({
+      type: "thinking_chunk",
+      text: "Inspecting saved context.",
+    });
+  });
+});

--- a/web/src/app/craft/utils/parsePacket.ts
+++ b/web/src/app/craft/utils/parsePacket.ts
@@ -25,7 +25,10 @@ import type { TodoItem, TodoStatus } from "../types/displayTypes";
 export function parsePacket(raw: unknown): ParsedPacket {
   if (!raw || typeof raw !== "object") return { type: "unknown" };
   const p = raw as Record<string, unknown>;
-  const packetType = p.type as string | undefined;
+  const packetType =
+    (p.type as string | undefined) ??
+    (p.sessionUpdate as string | undefined) ??
+    (p.session_update as string | undefined);
 
   switch (packetType) {
     case "agent_message_chunk": // Live SSE


### PR DESCRIPTION
## Description

Persists Craft thinking as a quiet, collapsed transcript row instead of removing it after the model finishes thinking.

The row now behaves like the requested indicator:

- live thinking appears as a compact `Thinking...` line with the existing activity icon
- thinking content does not auto-open by default
- users can click the row to expand and read the thinking content
- completed/restored thinking persists as a collapsed `Thinking` row
- the thinking row no longer shows a token count chip

The implementation keeps the diff small by reusing the existing Craft primitives: `agent_thought_chunk` still becomes a `thinking` `StreamItem`, `ThinkingCard` remains the display component, `Collapsible` remains the disclosure UI, `parsePacket` remains the only packet classifier, and session restore continues through `convertMessagesToStreamItems`. Backend chunk finalization now writes accumulated thought chunks as one synthetic `agent_thought` packet so restored sessions can show the same collapsed row.

This also keeps the earlier packet fixes in place: raw opencode thought events can use `sessionUpdate`/`session_update`, empty reasoning deltas are ignored, and adaptive Claude models request readable summarized thinking.

Storybook now includes `Apps/Craft/Messages/Thinking Card` with live/completed collapsed and expanded states. `ThinkingCard.defaultOpen` defaults to `false` so the app keeps the requested collapsed-by-default behavior while Storybook can render expanded states directly.

Collapsed by default:

![Collapsed persistent Craft thinking](https://github.com/onyx-dot-app/onyx/releases/download/pr-11779-craft-thinking-screenshots/craft-thinking-collapsed-persistent.png)

Expanded on click:

![Expanded persistent Craft thinking](https://github.com/onyx-dot-app/onyx/releases/download/pr-11779-craft-thinking-screenshots/craft-thinking-expanded-persistent.png)

Covered behavior:

- `BuildMessageList` renders restored thought packets as collapsed thinking rows.
- Restored thought rows do not open by default.
- Completed thought rows remain visible in the active stream instead of being filtered out.
- Live thought rows show `Thinking...` but keep their content collapsed until clicked.
- Thinking rows do not render a token count chip.
- `ThinkingCard` treats `defaultOpen` as an initial value and does not reset a user's manual disclosure choice when props change.
- Storybook remounts keyed `ThinkingCard` examples when controls intentionally switch the initial open state.
- `useBuildStreaming` settles a thought row immediately when the next packet arrives without removing it.
- `prompt_response` saves thinking stream items into assistant metadata with `isStreaming: false`.
- `parsePacket` handles both live `agent_thought_chunk` and persisted `agent_thought` packets.
- `loadSession` restores persisted `agent_thought` packets through the existing parser/converter path.
- `BuildStreamingState.finalize_thought_chunks()` returns one persisted `agent_thought` packet instead of discarding accumulated thought text.
- DB-bound streaming persistence expectation changed from “no `agent_thought` row” to “one collapsed `agent_thought` row”.
- Storybook covers the `ThinkingCard` live/completed and collapsed/expanded visual states.

## How Has This Been Tested?

- `bun run storybook:build` — passed.
- `bun run test -- --runTestsByPath src/app/craft/components/ThinkingCard.test.tsx src/app/craft/components/BuildMessageList.test.tsx src/app/craft/hooks/useBuildStreaming.test.tsx --runInBand` — 7 passed.
- `bun run test -- --runTestsByPath src/app/craft/components/BuildMessageList.test.tsx src/app/craft/hooks/useBuildStreaming.test.tsx src/app/craft/utils/parsePacket.test.ts src/app/craft/hooks/loadSessionRestore.test.ts --runInBand` — 17 passed.
- `source .venv/bin/activate && pytest -q backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py` — 6 passed.
- `source .venv/bin/activate && pytest -q backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py` — 91 passed.
- `bun run types:check` — passed.
- `bun run lint -- src/app/craft/components/ThinkingCard.tsx src/app/craft/components/ThinkingCard.stories.tsx src/app/craft/components/ThinkingCard.test.tsx src/app/craft/hooks/useBuildStreaming.ts src/app/craft/hooks/useBuildStreaming.test.tsx` — passed across the review-fix files.
- `bun run lint -- src/app/craft/components/ThinkingCard.tsx src/app/craft/components/ThinkingCard.stories.tsx src/app/craft/components/BuildMessageList.tsx src/app/craft/hooks/useBuildStreaming.ts src/app/craft/hooks/useBuildSessionStore.ts src/app/craft/utils/parsePacket.ts src/app/craft/components/BuildMessageList.test.tsx src/app/craft/hooks/useBuildStreaming.test.tsx src/app/craft/hooks/loadSessionRestore.test.ts src/app/craft/utils/parsePacket.test.ts` — passed across the changed Craft files/stories.
- `source .venv/bin/activate && python -m ruff check backend/onyx/server/features/build/session/streaming.py backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py backend/tests/external_dependency_unit/craft/test_streaming_persistence.py` — passed.
- `git diff --check` — passed.
- Commit hooks passed on `5d7cee8b5e` and `9e09ec3f35`, including applicable ty, ruff, ruff format, oxfmt, oxlint, TypeScript type check, and ripsecrets.
- Branch hygiene check: `.impeccable.md` is absent from the PR diff and branch history against `main`.
- Browser inspection on `http://localhost:3000/craft/v1` as `roshan@onyx.app`: sent two prompts in session `7684fd58-ab44-47db-8735-642a7b631229`; both SSE bodies contained only `agent_message_chunk` and `prompt_response`, with no `agent_thought_chunk` to render. This confirms the observed localhost issue is upstream of rendering for that live sandbox/session.
- Screenshots above were captured from a temporary local preview route rendering the real `ThinkingCard` component in collapsed and expanded states; the route was deleted before commit.

Not tested:

- `source .venv/bin/activate && python -m dotenv -f .vscode/.env run -- pytest -q backend/tests/external_dependency_unit/craft/test_streaming_persistence.py::TestStreamingPersistence::test_agent_thought_chunks_persist_as_single_collapsed_row` could not start because Postgres on `127.0.0.1:5432` refused connections.
- Full `backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py` run in this local environment; the event bus tried to resolve/connect to an opencode event-stream host before consuming dispatched mock events.
- Live full-app visual of an actual `agent_thought_chunk`, because the running localhost sandbox did not emit one. Existing sandbox/opencode serve processes likely need restart/reprovision to pick up the adaptive-thinking config change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
