### PR TITLE
fix(craft): keep Craft preview URLs contained and copyable

### DIFF
--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@tests/setup/test-utils";
+import UrlBar from "./UrlBar";
+
+describe("UrlBar", () => {
+  test("contains long preview URLs inside the URL bar", () => {
+    const longPreviewUrl =
+      "https://craft-preview.onyx.app/sessions/session-with-a-very-long-id/apps/generated-webapp/routes/deeply/nested/path/with/an-unbroken-segment-that-would-otherwise-overflow-the-url-bar?query=another-unbroken-value-that-keeps-going";
+
+    render(
+      <UrlBar
+        displayUrl={longPreviewUrl}
+        previewUrl={longPreviewUrl}
+        showNavigation
+        canGoBack
+        canGoForward
+        onBack={jest.fn()}
+        onForward={jest.fn()}
+        onRefresh={jest.fn()}
+        sessionId="session-with-a-very-long-id"
+      />
+    );
+
+    const urlText = screen.getByText(longPreviewUrl);
+    const textWrapper = urlText.parentElement;
+    const urlPill = textWrapper?.parentElement;
+
+    expect(urlText.tagName).toBe("P");
+    expect(urlText).toHaveClass("truncate");
+    expect(textWrapper).toHaveClass("min-w-0", "flex-1", "overflow-hidden");
+    expect(urlPill).toHaveClass("min-w-0", "flex-1");
+    expect(
+      screen.getByRole("button", { name: "Share webapp" })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -27,6 +27,7 @@ describe("UrlBar", () => {
 
     expect(urlText.tagName).toBe("P");
     expect(urlText).toHaveClass("truncate");
+    expect(urlText).toHaveAttribute("title", longPreviewUrl);
     expect(textWrapper).toHaveClass("min-w-0", "flex-1", "overflow-hidden");
     expect(urlPill).toHaveClass("min-w-0", "flex-1");
     expect(

--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -1,9 +1,23 @@
 import React from "react";
-import { render, screen } from "@tests/setup/test-utils";
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import { copyText } from "@opal/utils";
 import UrlBar from "./UrlBar";
 
+jest.mock("@opal/utils", () => {
+  const actual = jest.requireActual("@opal/utils");
+  return {
+    ...actual,
+    copyText: jest.fn(),
+  };
+});
+
 describe("UrlBar", () => {
-  test("contains long preview URLs inside the URL bar", () => {
+  beforeEach(() => {
+    (copyText as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  test("contains long preview URLs inside the URL bar and copies them", async () => {
+    const user = setupUser();
     const longPreviewUrl =
       "https://craft-preview.onyx.app/sessions/session-with-a-very-long-id/apps/generated-webapp/routes/deeply/nested/path/with/an-unbroken-segment-that-would-otherwise-overflow-the-url-bar?query=another-unbroken-value-that-keeps-going";
 
@@ -22,16 +36,35 @@ describe("UrlBar", () => {
     );
 
     const urlText = screen.getByText(longPreviewUrl);
+    const copyButton = screen.getByRole("button", {
+      name: `Copy URL: ${longPreviewUrl}`,
+    });
     const textWrapper = urlText.parentElement;
-    const urlPill = textWrapper?.parentElement;
+    const urlPill = textWrapper?.parentElement?.parentElement;
 
     expect(urlText.tagName).toBe("P");
     expect(urlText).toHaveClass("truncate");
-    expect(urlText).toHaveAttribute("title", longPreviewUrl);
-    expect(textWrapper).toHaveClass("min-w-0", "flex-1", "overflow-hidden");
+    expect(copyButton).toHaveClass("cursor-pointer");
+    expect(textWrapper).toHaveClass("block", "w-full", "min-w-0");
+    expect(textWrapper?.parentElement).toHaveClass(
+      "min-w-0",
+      "flex-1",
+      "overflow-hidden"
+    );
     expect(urlPill).toHaveClass("min-w-0", "flex-1");
     expect(
       screen.getByRole("button", { name: "Share webapp" })
+    ).toBeInTheDocument();
+
+    await user.hover(copyButton);
+    await waitFor(() => {
+      expect(screen.getAllByText(longPreviewUrl).length).toBeGreaterThan(1);
+    });
+
+    await user.click(copyButton);
+    expect(copyText).toHaveBeenCalledWith(longPreviewUrl);
+    expect(
+      screen.getByRole("button", { name: "Copied URL; open in a new tab" })
     ).toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@opal/utils", () => {
 
 describe("UrlBar", () => {
   beforeEach(() => {
+    (copyText as jest.Mock).mockReset();
     (copyText as jest.Mock).mockResolvedValue(undefined);
   });
 
@@ -39,19 +40,23 @@ describe("UrlBar", () => {
     const copyButton = screen.getByRole("button", {
       name: `Copy URL: ${longPreviewUrl}`,
     });
-    const textWrapper = urlText.parentElement;
-    const urlPill = textWrapper?.parentElement?.parentElement;
+    const textWrapper = screen.getByTestId("url-text-wrapper");
+    const urlPill = screen.getByTestId("url-bar-pill");
+    const openButton = screen.getByRole("button", {
+      name: "open in a new tab",
+    });
 
     expect(urlText.tagName).toBe("P");
     expect(urlText).toHaveClass("truncate");
-    expect(copyButton).toHaveClass("cursor-pointer");
-    expect(textWrapper).toHaveClass("block", "w-full", "min-w-0");
-    expect(textWrapper?.parentElement).toHaveClass(
+    expect(copyButton).toHaveClass(
+      "block",
+      "w-full",
       "min-w-0",
-      "flex-1",
-      "overflow-hidden"
+      "cursor-pointer"
     );
+    expect(textWrapper).toHaveClass("min-w-0", "flex-1", "overflow-hidden");
     expect(urlPill).toHaveClass("min-w-0", "flex-1");
+    expect(openButton).toHaveAttribute("data-copy-state", "idle");
     expect(
       screen.getByRole("button", { name: "Share webapp" })
     ).toBeInTheDocument();
@@ -63,8 +68,54 @@ describe("UrlBar", () => {
 
     await user.click(copyButton);
     expect(copyText).toHaveBeenCalledWith(longPreviewUrl);
+    await waitFor(() => {
+      expect(openButton).toHaveAttribute("data-copy-state", "copied");
+    });
     expect(
-      screen.getByRole("button", { name: "Copied URL; open in a new tab" })
+      screen.getByRole("button", { name: "open in a new tab" })
+    ).toBeInTheDocument();
+
+    await user.hover(openButton);
+    await waitFor(() => {
+      expect(screen.getAllByText("open in a new tab").length).toBeGreaterThan(
+        0
+      );
+    });
+    expect(screen.queryByText("Copied URL")).not.toBeInTheDocument();
+  });
+
+  test("resets copy feedback when the displayed URL changes", async () => {
+    const user = setupUser();
+    const firstPreviewUrl = "https://craft-preview.onyx.app/sessions/first";
+    const secondPreviewUrl = "https://craft-preview.onyx.app/sessions/second";
+    const { rerender } = render(
+      <UrlBar displayUrl={firstPreviewUrl} previewUrl={firstPreviewUrl} />
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `Copy URL: ${firstPreviewUrl}`,
+      })
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "open in a new tab" })
+      ).toHaveAttribute("data-copy-state", "copied");
+    });
+
+    rerender(
+      <UrlBar displayUrl={secondPreviewUrl} previewUrl={secondPreviewUrl} />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "open in a new tab" })
+      ).toHaveAttribute("data-copy-state", "idle");
+    });
+    expect(
+      screen.getByRole("button", {
+        name: `Copy URL: ${secondPreviewUrl}`,
+      })
     ).toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { fireEvent } from "@testing-library/react";
 import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
 import { copyText } from "@opal/utils";
 import UrlBar from "./UrlBar";
@@ -71,6 +72,12 @@ describe("UrlBar", () => {
     await waitFor(() => {
       expect(openButton).toHaveAttribute("data-copy-state", "copied");
     });
+    const copiedIcon = openButton.querySelector("svg");
+    expect(copiedIcon).toBeInTheDocument();
+    fireEvent.animationEnd(copiedIcon!);
+    await waitFor(() => {
+      expect(openButton).toHaveAttribute("data-copy-state", "idle");
+    });
     expect(
       screen.getByRole("button", { name: "open in a new tab" })
     ).toBeInTheDocument();
@@ -118,4 +125,17 @@ describe("UrlBar", () => {
       })
     ).toBeInTheDocument();
   });
+
+  test.each(["no-sandbox://", "artifacts://"])(
+    "does not copy internal display URL %s",
+    async (internalUrl) => {
+      render(<UrlBar displayUrl={internalUrl} />);
+
+      expect(screen.getByText(internalUrl)).toHaveClass("truncate");
+      expect(
+        screen.queryByRole("button", { name: `Copy URL: ${internalUrl}` })
+      ).not.toBeInTheDocument();
+      expect(copyText).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -147,7 +147,13 @@ export default function UrlBar({
             </Tooltip>
           )}
           <div className="min-w-0 flex-1 overflow-hidden">
-            <Text as="p" font="secondary-body" color="text-03" maxLines={1}>
+            <Text
+              as="p"
+              font="secondary-body"
+              color="text-03"
+              maxLines={1}
+              title={displayUrl}
+            >
               {displayUrl}
             </Text>
           </div>

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { cn } from "@opal/utils";
+import { cn, copyText } from "@opal/utils";
 import { Text, Button } from "@opal/components";
 import {
   SvgDownloadCloud,
@@ -10,6 +10,7 @@ import {
   SvgArrowRight,
   SvgExternalLink,
   SvgRevert,
+  SvgCheck,
 } from "@opal/icons";
 import { IconProps } from "@opal/types";
 import { Tooltip } from "@opal/components";
@@ -71,9 +72,40 @@ export default function UrlBar({
   sharingScope = "private",
   onScopeChange,
 }: UrlBarProps) {
+  const [copyState, setCopyState] = React.useState<"idle" | "copied">("idle");
+  const copyResetTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const isUrlCopied = copyState === "copied";
+
+  React.useEffect(() => {
+    return () => {
+      if (copyResetTimeoutRef.current) {
+        clearTimeout(copyResetTimeoutRef.current);
+      }
+    };
+  }, []);
+
   const handleOpenInNewTab = () => {
     if (previewUrl) {
       window.open(previewUrl, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const handleCopyUrl = async () => {
+    if (copyResetTimeoutRef.current) {
+      clearTimeout(copyResetTimeoutRef.current);
+    }
+
+    try {
+      await copyText(displayUrl);
+      setCopyState("copied");
+      copyResetTimeoutRef.current = setTimeout(() => {
+        setCopyState("idle");
+      }, 1500);
+    } catch (err) {
+      console.error("Failed to copy URL:", err);
+      setCopyState("idle");
     }
   };
 
@@ -136,26 +168,48 @@ export default function UrlBar({
           )}
           {/* Open in new tab button - only shown for Preview tab with valid URL */}
           {previewUrl && (
-            <Tooltip tooltip="open in a new tab" delayDuration={200}>
+            <Tooltip
+              tooltip={isUrlCopied ? "Copied URL" : "open in a new tab"}
+              delayDuration={200}
+            >
               <button
                 onClick={handleOpenInNewTab}
                 className="shrink-0 p-0.5 rounded-sm transition-colors hover:bg-background-tint-03 text-text-03"
-                aria-label="open in a new tab"
+                aria-label={
+                  isUrlCopied
+                    ? "Copied URL; open in a new tab"
+                    : "open in a new tab"
+                }
               >
-                <SvgExternalLink size={14} />
+                {isUrlCopied ? (
+                  <SvgCheck
+                    key="copied"
+                    size={14}
+                    className="animate-in fade-in-0 zoom-in-95 duration-200 stroke-status-success-05"
+                  />
+                ) : (
+                  <SvgExternalLink
+                    key="open"
+                    size={14}
+                    className="transition-transform duration-200"
+                  />
+                )}
               </button>
             </Tooltip>
           )}
           <div className="min-w-0 flex-1 overflow-hidden">
-            <Text
-              as="p"
-              font="secondary-body"
-              color="text-03"
-              maxLines={1}
-              title={displayUrl}
-            >
-              {displayUrl}
-            </Text>
+            <Tooltip tooltip={displayUrl} side="bottom" delayDuration={200}>
+              <button
+                type="button"
+                onClick={handleCopyUrl}
+                className="block w-full min-w-0 cursor-pointer text-left focus:outline-hidden"
+                aria-label={`Copy URL: ${displayUrl}`}
+              >
+                <Text as="p" font="secondary-body" color="text-03" maxLines={1}>
+                  {displayUrl}
+                </Text>
+              </button>
+            </Tooltip>
           </div>
         </div>
         {/* Export button — shown for downloadable file previews (e.g. markdown → docx) */}

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -72,26 +72,20 @@ export default function UrlBar({
   sharingScope = "private",
   onScopeChange,
 }: UrlBarProps) {
-  const [copyState, setCopyState] = React.useState<"idle" | "copied">("idle");
-  const copyResetTimeoutRef = React.useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const isUrlCopied = copyState === "copied";
-
-  React.useEffect(() => {
-    return () => {
-      if (copyResetTimeoutRef.current) {
-        clearTimeout(copyResetTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (copyResetTimeoutRef.current) {
-      clearTimeout(copyResetTimeoutRef.current);
-      copyResetTimeoutRef.current = null;
+  const [copiedUrl, setCopiedUrl] = React.useState<string | null>(null);
+  const [copyFeedbackKey, setCopyFeedbackKey] = React.useState(0);
+  const isDisplayUrlCopyable = React.useMemo(() => {
+    try {
+      const { protocol } = new URL(displayUrl);
+      return protocol === "http:" || protocol === "https:";
+    } catch {
+      return false;
     }
-    setCopyState("idle");
+  }, [displayUrl]);
+  const isUrlCopied = copiedUrl === displayUrl;
+
+  React.useEffect(() => {
+    setCopiedUrl(null);
   }, [displayUrl]);
 
   const handleOpenInNewTab = () => {
@@ -101,23 +95,25 @@ export default function UrlBar({
   };
 
   const handleCopyUrl = async () => {
-    if (copyResetTimeoutRef.current) {
-      clearTimeout(copyResetTimeoutRef.current);
-      copyResetTimeoutRef.current = null;
+    if (!isDisplayUrlCopyable) {
+      return;
     }
 
     try {
       await copyText(displayUrl);
-      setCopyState("copied");
-      copyResetTimeoutRef.current = setTimeout(() => {
-        setCopyState("idle");
-        copyResetTimeoutRef.current = null;
-      }, 1500);
+      setCopiedUrl(displayUrl);
+      setCopyFeedbackKey((key) => key + 1);
     } catch (err) {
       console.error("Failed to copy URL:", err);
-      setCopyState("idle");
+      setCopiedUrl(null);
     }
   };
+
+  const urlText = (
+    <Text as="p" font="secondary-body" color="text-03" maxLines={1}>
+      {displayUrl}
+    </Text>
+  );
 
   return (
     <div className="px-3 pb-2">
@@ -186,13 +182,20 @@ export default function UrlBar({
                 onClick={handleOpenInNewTab}
                 className="shrink-0 p-0.5 rounded-sm transition-colors hover:bg-background-tint-03 text-text-03"
                 aria-label="open in a new tab"
-                data-copy-state={copyState}
+                data-copy-state={isUrlCopied ? "copied" : "idle"}
               >
                 {isUrlCopied ? (
                   <SvgCheck
-                    key="copied"
+                    key={`copied-${copyFeedbackKey}`}
                     size={14}
-                    className="animate-in fade-in-0 zoom-in-95 duration-200 stroke-status-success-05"
+                    className="animate-in fade-in-0 zoom-in-95 duration-500 stroke-status-success-05"
+                    onAnimationEnd={() => {
+                      setCopiedUrl((currentCopiedUrl) =>
+                        currentCopiedUrl === displayUrl
+                          ? null
+                          : currentCopiedUrl
+                      );
+                    }}
                   />
                 ) : (
                   <SvgExternalLink
@@ -209,16 +212,18 @@ export default function UrlBar({
             className="min-w-0 flex-1 overflow-hidden"
           >
             <Tooltip tooltip={displayUrl} side="bottom" delayDuration={200}>
-              <button
-                type="button"
-                onClick={handleCopyUrl}
-                className="block w-full min-w-0 cursor-pointer text-left focus:outline-hidden"
-                aria-label={`Copy URL: ${displayUrl}`}
-              >
-                <Text as="p" font="secondary-body" color="text-03" maxLines={1}>
-                  {displayUrl}
-                </Text>
-              </button>
+              {isDisplayUrlCopyable ? (
+                <button
+                  type="button"
+                  onClick={handleCopyUrl}
+                  className="block w-full min-w-0 cursor-pointer text-left focus:outline-hidden"
+                  aria-label={`Copy URL: ${displayUrl}`}
+                >
+                  {urlText}
+                </button>
+              ) : (
+                <div className="block w-full min-w-0 text-left">{urlText}</div>
+              )}
             </Tooltip>
           </div>
         </div>

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -86,6 +86,14 @@ export default function UrlBar({
     };
   }, []);
 
+  React.useEffect(() => {
+    if (copyResetTimeoutRef.current) {
+      clearTimeout(copyResetTimeoutRef.current);
+      copyResetTimeoutRef.current = null;
+    }
+    setCopyState("idle");
+  }, [displayUrl]);
+
   const handleOpenInNewTab = () => {
     if (previewUrl) {
       window.open(previewUrl, "_blank", "noopener,noreferrer");
@@ -95,6 +103,7 @@ export default function UrlBar({
   const handleCopyUrl = async () => {
     if (copyResetTimeoutRef.current) {
       clearTimeout(copyResetTimeoutRef.current);
+      copyResetTimeoutRef.current = null;
     }
 
     try {
@@ -102,6 +111,7 @@ export default function UrlBar({
       setCopyState("copied");
       copyResetTimeoutRef.current = setTimeout(() => {
         setCopyState("idle");
+        copyResetTimeoutRef.current = null;
       }, 1500);
     } catch (err) {
       console.error("Failed to copy URL:", err);
@@ -153,7 +163,10 @@ export default function UrlBar({
           </div>
         )}
         {/* URL display */}
-        <div className="flex-1 min-w-0 flex items-center px-3 py-1.5 bg-background-tint-02 rounded-full gap-2 min-h-9">
+        <div
+          data-testid="url-bar-pill"
+          className="flex-1 min-w-0 flex items-center px-3 py-1.5 bg-background-tint-02 rounded-full gap-2 min-h-9"
+        >
           {/* Download raw file button */}
           {onDownloadRaw && (
             <Tooltip tooltip={downloadRawTooltip} delayDuration={200}>
@@ -168,18 +181,12 @@ export default function UrlBar({
           )}
           {/* Open in new tab button - only shown for Preview tab with valid URL */}
           {previewUrl && (
-            <Tooltip
-              tooltip={isUrlCopied ? "Copied URL" : "open in a new tab"}
-              delayDuration={200}
-            >
+            <Tooltip tooltip="open in a new tab" delayDuration={200}>
               <button
                 onClick={handleOpenInNewTab}
                 className="shrink-0 p-0.5 rounded-sm transition-colors hover:bg-background-tint-03 text-text-03"
-                aria-label={
-                  isUrlCopied
-                    ? "Copied URL; open in a new tab"
-                    : "open in a new tab"
-                }
+                aria-label="open in a new tab"
+                data-copy-state={copyState}
               >
                 {isUrlCopied ? (
                   <SvgCheck
@@ -197,7 +204,10 @@ export default function UrlBar({
               </button>
             </Tooltip>
           )}
-          <div className="min-w-0 flex-1 overflow-hidden">
+          <div
+            data-testid="url-text-wrapper"
+            className="min-w-0 flex-1 overflow-hidden"
+          >
             <Tooltip tooltip={displayUrl} side="bottom" delayDuration={200}>
               <button
                 type="button"

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -146,8 +146,8 @@ export default function UrlBar({
               </button>
             </Tooltip>
           )}
-          <div className="min-w-0 flex-1">
-            <Text font="secondary-body" color="text-03" maxLines={1}>
+          <div className="min-w-0 flex-1 overflow-hidden">
+            <Text as="p" font="secondary-body" color="text-03" maxLines={1}>
               {displayUrl}
             </Text>
           </div>


### PR DESCRIPTION
## Description

Fixes the Craft preview URL bar so long URLs remain contained, while still keeping the full URL accessible.

- Long preview URLs are clipped/ellipsized inside the URL pill.
- Hovering the clipped URL uses the standard Opal tooltip to show the full URL.
- Clicking the URL text copies the full URL to the clipboard for real web URLs only (`http:` / `https:`).
- Internal display values such as `no-sandbox://` and `artifacts://` remain display-only and are not copyable.
- After copy, the existing open-in-new-tab icon briefly changes to a success check with a light animation.
- Copy feedback no longer uses timeout/ref orchestration; it is tied to the copied URL and clears on the check animation end.
- The open-in-new-tab tooltip remains `open in a new tab`; the check icon carries the transient copy feedback.
- The URL text uses the normal pointer cursor; no `cursor-copy` override.
- No Opal tooltip sizing/behavior override is included.
- The URL bar regression test targets explicit URL pill/wrapper test IDs instead of fragile parent traversal.

Screenshot:

<img width="590" height="127" alt="Screenshot 2026-06-06 at 16 55 24" src="https://github.com/user-attachments/assets/40032ae7-377a-49f5-a623-ee0fb5f61802" />

## How Has This Been Tested?

- `bunx jest src/app/craft/components/output-panel/UrlBar.test.tsx --runInBand`
- `bun run types:check`
- `bun run lint`
- `bun run format:check`
- Repo pre-commit hooks during commit: `oxfmt`, `oxlint`, and TypeScript type check passed.
- Browser layout verification against this worktree on `localhost:3101`: long URL intrinsic text width was larger than the URL pill, while the rendered URL remained clipped inside the bar with ellipsis.

Test cases covered:

- Render a long unbroken preview URL with navigation, refresh, open-in-new-tab, and share controls present.
- Assert URL text remains a block truncation target inside a shrinkable overflow-hidden flex wrapper.
- Assert hover displays the full URL through the app tooltip.
- Assert clicking an `http:` / `https:` URL copies the full URL.
- Assert copy feedback changes the open-in-new-tab button to the copied/check state.
- Assert the copied/check state clears when its animation ends.
- Assert the open-in-new-tab tooltip still reads `open in a new tab` after copy feedback.
- Assert copy feedback resets immediately when `displayUrl` changes mid-animation.
- Assert internal display values (`no-sandbox://`, `artifacts://`) are not copyable.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
