### PR TITLE
chore(gha): git actions-checkout read permissions

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,6 +9,8 @@ on:
 # Set restrictive default permissions for all jobs. Jobs that need more permissions
 # should explicitly declare them.
 permissions:
+  # Required to checkout the repo on private repos (no-op on public)
+  contents: read
   # Required for OIDC authentication with AWS
   id-token: write # zizmor: ignore[excessive-permissions]
 
@@ -1568,6 +1570,7 @@ jobs:
       - run-id=${{ github.run_id }}-trivy-scan-${{ matrix.component }}
       - extras=ecr-cache
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       security-events: write # needed for SARIF uploads
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/pr-golang-tests.yml
+++ b/.github/workflows/pr-golang-tests.yml
@@ -13,7 +13,8 @@ on:
     tags:
       - "v*.*.*"
 
-permissions: {}
+permissions:
+  contents: read # needed to checkout the repo on private repos (no-op on public)
 
 env:
   GO_VERSION: "1.26"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,6 +11,7 @@ jobs:
     environment:
       name: release-cli
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 10
     steps:
@@ -38,6 +39,7 @@ jobs:
       - run-id=${{ github.run_id }}-cli-amd64
     environment: deploy
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 30
     outputs:
@@ -93,6 +95,7 @@ jobs:
       - run-id=${{ github.run_id }}-cli-arm64
     environment: deploy
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 30
     outputs:

--- a/.github/workflows/release-devcontainer.yml
+++ b/.github/workflows/release-devcontainer.yml
@@ -19,6 +19,7 @@ jobs:
       - run-id=${{ github.run_id }}-devcontainer-amd64
     environment: deploy
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 60
     outputs:
@@ -79,6 +80,7 @@ jobs:
       - run-id=${{ github.run_id }}-devcontainer-arm64
     environment: deploy
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 60
     outputs:

--- a/.github/workflows/release-devtools.yml
+++ b/.github/workflows/release-devtools.yml
@@ -11,6 +11,7 @@ jobs:
     environment:
       name: release-devtools
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       id-token: write
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-slim
     timeout-minutes: 45
     permissions:
+      contents: read # needed to checkout the repo on private repos (no-op on public)
       security-events: write # needed for SARIF uploads
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Similar to https://github.com/onyx-dot-app/onyx/pull/11771, but for the `actions-checkout` step

## How Has This Been Tested?

Captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant minimal `contents: read` permissions to GHA jobs so `actions/checkout` works on private repos, while keeping least-privilege defaults. No functional changes to builds or releases.

- **Bug Fixes**
  - Added `permissions.contents: read` to jobs using `actions/checkout` in deployment, PR tests, CLI release, devcontainer release, devtools release, and zizmor workflows.
  - No-op on public repos; other permissions unchanged.

<sup>Written for commit 7d01889588c3051c455a19ca9c98be21e8c8714d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

