### PR TITLE
fix(craft): report sandbox ready on restore without waiting for Next.js

### DIFF
--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -1,7 +1,4 @@
-import {
-  useBuildSessionStore,
-  waitForWebappReady,
-} from "@/app/craft/hooks/useBuildSessionStore";
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 import * as api from "@/app/craft/services/apiServices";
 
 jest.mock("@/app/craft/services/apiServices");
@@ -43,10 +40,6 @@ describe("loadSession restore status", () => {
     } as never);
     mockedApi.fetchMessages.mockResolvedValue([] as never);
     mockedApi.fetchArtifacts.mockResolvedValue([] as never);
-    // Default: webapp already serving, so the readiness gate is a no-op.
-    mockedApi.fetchWebappInfo.mockResolvedValue(
-      webappInfo(true, true) as never
-    );
   });
 
   it("keeps the sandbox running when the post-restore artifact fetch fails", async () => {
@@ -72,64 +65,19 @@ describe("loadSession restore status", () => {
     expect(session?.sandbox?.status).toBe("failed");
   });
 
-  it("waits for the webapp before flipping to running, then shows running", async () => {
+  it("reports the sandbox running immediately without waiting on the webapp", async () => {
     mockedApi.fetchSession.mockResolvedValue(sleepingSession() as never);
     mockedApi.restoreSession.mockResolvedValue(runningSession() as never);
-    // Webapp not ready on the first poll, ready on the second.
-    mockedApi.fetchWebappInfo
-      .mockResolvedValueOnce(webappInfo(true, false) as never)
-      .mockResolvedValue(webappInfo(true, true) as never);
-
-    await useBuildSessionStore.getState().loadSession(SESSION_ID);
-
-    // It consulted webapp readiness, and the final state is running.
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalled();
-    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
-    expect(session?.sandbox?.status).toBe("running");
-  });
-});
-
-describe("waitForWebappReady", () => {
-  afterEach(() => jest.clearAllMocks());
-
-  it("returns immediately when the session has no webapp", async () => {
-    mockedApi.fetchWebappInfo.mockResolvedValue(
-      webappInfo(false, false) as never
-    );
-    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns immediately when the webapp is already ready", async () => {
-    mockedApi.fetchWebappInfo.mockResolvedValue(
-      webappInfo(true, true) as never
-    );
-    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(1);
-  });
-
-  it("polls until the webapp reports ready", async () => {
-    mockedApi.fetchWebappInfo
-      .mockResolvedValueOnce(webappInfo(true, false) as never)
-      .mockResolvedValueOnce(webappInfo(true, false) as never)
-      .mockResolvedValue(webappInfo(true, true) as never);
-    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(3);
-  });
-
-  it("gives up after maxAttempts when the webapp never comes up", async () => {
+    // Even if the Next.js dev server never reports ready, the status chip
+    // must not block on it — the preview polls webapp-info on its own.
     mockedApi.fetchWebappInfo.mockResolvedValue(
       webappInfo(true, false) as never
     );
-    await waitForWebappReady(SESSION_ID, { intervalMs: 0, maxAttempts: 3 });
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(3);
-  });
 
-  it("keeps polling through transient fetch errors", async () => {
-    mockedApi.fetchWebappInfo
-      .mockRejectedValueOnce(new Error("sandbox not reachable"))
-      .mockResolvedValue(webappInfo(true, true) as never);
-    await waitForWebappReady(SESSION_ID, { intervalMs: 0 });
-    expect(mockedApi.fetchWebappInfo).toHaveBeenCalledTimes(2);
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    expect(mockedApi.fetchWebappInfo).not.toHaveBeenCalled();
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.sandbox?.status).toBe("running");
   });
 });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -41,7 +41,6 @@ import {
   deleteSession as apiDeleteSession,
   fetchMessages,
   fetchArtifacts,
-  fetchWebappInfo,
   restoreSession,
 } from "@/app/craft/services/apiServices";
 
@@ -753,30 +752,6 @@ const createInitialSessionData = (
 // =============================================================================
 // Store
 // =============================================================================
-
-// The dev server is started fire-and-forget, so the backend reports RUNNING
-// before the webapp serves. Poll webapp-info until ready (bounded by maxAttempts).
-export async function waitForWebappReady(
-  sessionId: string,
-  { intervalMs = 1500, maxAttempts = 20 }: WaitForWebappReadyOptions = {}
-): Promise<void> {
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    let info: Awaited<ReturnType<typeof fetchWebappInfo>> | null = null;
-    try {
-      info = await fetchWebappInfo(sessionId);
-    } catch {
-      // keep polling
-    }
-    // Done on a definitive answer (no webapp or serving); errors keep polling.
-    if (info && (!info.has_webapp || info.ready)) return;
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-  }
-}
-
-interface WaitForWebappReadyOptions {
-  intervalMs?: number;
-  maxAttempts?: number;
-}
 
 export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
   currentSessionId: null,
@@ -1581,19 +1556,15 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           return;
         }
 
-        // Hold the chip on "restoring" (and refresh the preview) until the
-        // webapp actually serves, then flip to the real status below.
+        // Restore finished: report the sandbox ready right away. The preview
+        // polls webapp-info on its own (webappNeedsRefresh), so the status
+        // chip doesn't wait on the Next.js dev server coming up.
         updateSessionData(sessionId, {
           status: sessionData.status === "active" ? "active" : "idle",
-          sandbox: sessionData.sandbox
-            ? { ...sessionData.sandbox, status: "restoring" }
-            : sessionData.sandbox,
+          sandbox: sessionData.sandbox,
           webappNeedsRefresh:
             (get().sessions.get(sessionId)?.webappNeedsRefresh || 0) + 1,
         });
-
-        await waitForWebappReady(sessionId);
-        updateSessionData(sessionId, { sandbox: sessionData.sandbox });
 
         // An artifact-fetch failure must NOT flip the sandbox to "failed".
         try {

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -1556,9 +1556,6 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           return;
         }
 
-        // Restore finished: report the sandbox ready right away. The preview
-        // polls webapp-info on its own (webappNeedsRefresh), so the status
-        // chip doesn't wait on the Next.js dev server coming up.
         updateSessionData(sessionId, {
           status: sessionData.status === "active" ? "active" : "idle",
           sandbox: sessionData.sandbox,


### PR DESCRIPTION
## Description

When reopening an existing sleeping session, the frontend re-provisions the sandbox and then held the status chip on **"Restoring sandbox…"** until `waitForWebappReady` polled `/webapp-info` to success (up to ~30s) before flipping it to **"Sandbox running"**.

The Next.js dev server is started fire-and-forget (`nohup bun run dev &`), so the backend never blocks on it — but this frontend gate added the dev server's cold-compile time onto the chip's "restoring" state. The preview iframe already polls `/webapp-info` independently (via `webappNeedsRefresh`) to know when to render, so gating the *status chip* on webserver readiness was redundant.

This change reports the sandbox's real status as soon as `restoreSession` returns, instead of waiting for the webserver. The preview readiness is unaffected — `OutputPanel` continues to poll and refresh on its own.

- Drops the `await waitForWebappReady(sessionId)` gate in `loadSession`'s restore branch and flips the chip to its backend status immediately.
- Removes the now-unused `waitForWebappReady` helper, its options interface, and the dangling `fetchWebappInfo` import.

This only affects the wake/restore path (reopening a sleeping session). The create-new-session path was never gated on the webserver on either the frontend or backend.

## How Has This Been Tested?

`bunx jest src/app/craft/hooks/loadSessionRestore.test.ts` — updated the restore-status suite:
- replaced "waits for the webapp before flipping to running" with "reports the sandbox running immediately without waiting on the webapp" (asserts `fetchWebappInfo` is never called and the chip is `running` even when the webapp never reports ready);
- removed the standalone `waitForWebappReady` suite.

All 3 tests pass; `tsc --noEmit` and pre-commit (oxfmt/oxlint/TypeScript) are clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report sandbox as running immediately after restore, without waiting for the Next.js dev server. Reopening sleeping sessions is faster; the preview still polls `/webapp-info` independently.

- **Bug Fixes**
  - Removed the webapp readiness gate on restore, so the status chip reflects the backend sandbox status right away.
  - Only affects wake/restore; new-session flow is unchanged.

- **Refactors**
  - Deleted `waitForWebappReady` and its options; removed the `fetchWebappInfo` import from the store.
  - Updated restore tests to assert no webapp wait and removed the `waitForWebappReady` test suite.

<sup>Written for commit 52236bf674b05d1a9554a39d4828613279347fbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

