### PR TITLE
fix(slack-skill): form-encode Slack API args so query params aren't dropped

### DIFF
--- a/backend/onyx/skills/builtin/slack/slack_api.py
+++ b/backend/onyx/skills/builtin/slack/slack_api.py
@@ -56,7 +56,7 @@ def _call(method: str, body: dict[str, Any], as_json: bool = False) -> dict[str,
         content_type = "application/json; charset=utf-8"
     else:
         data = urllib.parse.urlencode(
-            {k: _form_value(v) for k, v in body.items()}
+            {k: _form_value(v) for k, v in body.items() if v is not None}
         ).encode("utf-8")
         content_type = "application/x-www-form-urlencoded; charset=utf-8"
     req = urllib.request.Request(  # noqa: S310 — fixed https base url

--- a/backend/onyx/skills/builtin/slack/slack_api.py
+++ b/backend/onyx/skills/builtin/slack/slack_api.py
@@ -10,6 +10,7 @@ import json
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any
 
@@ -31,14 +32,38 @@ def _prune(value: Any) -> Any:
     return value
 
 
-def _call(method: str, body: dict[str, Any]) -> dict[str, Any]:
+def _form_value(value: Any) -> str:
+    """Coerce a param value for x-www-form-urlencoded Slack requests.
+    Booleans become "true"/"false"; nested values are JSON-encoded
+    (Slack reads complex args like blocks as JSON strings)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    return str(value)
+
+
+def _call(method: str, body: dict[str, Any], as_json: bool = False) -> dict[str, Any]:
     """POST to a Slack method; return the parsed JSON. Raises on
-    transport failure (handled by the caller)."""
+    transport failure (handled by the caller).
+
+    Args are form-encoded by default, not JSON: Slack's web/query methods
+    (conversations.list, users.list, etc.) read params from the
+    form-encoded body and silently ignore a JSON body. Set as_json=True
+    for the few methods that require an application/json body."""
+    if as_json:
+        data = json.dumps(body).encode("utf-8")
+        content_type = "application/json; charset=utf-8"
+    else:
+        data = urllib.parse.urlencode(
+            {k: _form_value(v) for k, v in body.items()}
+        ).encode("utf-8")
+        content_type = "application/x-www-form-urlencoded; charset=utf-8"
     req = urllib.request.Request(  # noqa: S310 — fixed https base url
         _BASE + method,
-        data=json.dumps(body).encode("utf-8"),
+        data=data,
         method="POST",
-        headers={"Content-Type": "application/json; charset=utf-8"},
+        headers={"Content-Type": content_type},
     )
     with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT_SECONDS) as resp:  # noqa: S310
         return json.loads(resp.read().decode("utf-8"))
@@ -110,7 +135,27 @@ def _build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("call", help="raw Slack method")
     sp.add_argument("method")
     sp.add_argument("json_args", nargs="?")
+    sp.add_argument(
+        "--json",
+        dest="as_json",
+        action="store_true",
+        help="send args as a JSON body (for JSON-only methods)",
+    )
     return p
+
+
+def _raw_call(method: str, json_args: str | None, as_json: bool) -> dict[str, Any]:
+    """`call` escape hatch: invoke an arbitrary Slack method with a
+    JSON object of args."""
+    if not _METHOD_RE.match(method):
+        return {"ok": False, "error": "invalid_method_name"}
+    args: dict[str, Any] = {}
+    if json_args:
+        parsed = json.loads(json_args)
+        if not isinstance(parsed, dict):
+            return {"ok": False, "error": "json_args_not_object"}
+        args = parsed
+    return _call(method, args, as_json=as_json)
 
 
 def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
@@ -147,16 +192,8 @@ def _dispatch(a: argparse.Namespace) -> dict[str, Any]:
     if a.cmd == "post":
         return _call("chat.postMessage", {"channel": a.channel, "text": a.text})
 
-    # `call` raw escape hatch
-    if not _METHOD_RE.match(a.method):
-        return {"ok": False, "error": "invalid_method_name"}
-    args: dict[str, Any] = {}
-    if a.json_args:
-        parsed = json.loads(a.json_args)
-        if not isinstance(parsed, dict):
-            return {"ok": False, "error": "json_args_not_object"}
-        args = parsed
-    return _call(a.method, args)
+    # `call` is the only remaining subcommand (subparser is required).
+    return _raw_call(a.method, a.json_args, a.as_json)
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
## Description

The Slack skill's `_call()` sent args as a JSON body. Slack's web/query methods (`conversations.list`, `conversations.history`, `users.list`, etc.) read params from a form-encoded body and silently ignore JSON — so filters like `types`, `exclude_archived`, `limit`, and `cursor` were dropped (e.g. `channels` never returned private channels), with `ok: true` and no error.

Fix: form-encode args by default (`application/x-www-form-urlencoded`), coercing bools to `true`/`false` and nested values to JSON strings. Added a `--json` opt-in on the `call` escape hatch for the few JSON-only methods.

Fixes: https://linear.app/onyx-app/issue/ENG-4136/craft-polish-slack-external-app-needs-dm-access

## How Has This Been Tested?

`ruff check`, `ruff format`, and `mypy` clean; parser/helper behavior exercised locally. Live verification (private channels appear with `is_private=true`) must run in the sandbox, which injects the Slack token.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Form-encode Slack API request args by default to fix dropped params in web/query methods. Filters like `types`, `exclude_archived`, `limit`, and `cursor` now work (e.g., private channels appear as expected).

- **Bug Fixes**
  - Send `application/x-www-form-urlencoded` bodies by default so Slack reads params.
  - Omit `None`-valued params from the form body.
  - Coerce bools to "true"/"false"; JSON-stringify dict/list values.
  - Update `_call(method, body, as_json=False)` to support both encodings; add `_form_value`.
  - Add `--json` flag to the `call` subcommand (via `_raw_call`) for JSON-only methods.

<sup>Written for commit 84db0644097709561b5d58a9be409919c49f0822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

