### PR TITLE
chore(dev): don't hot-reload local python on skill bundle edits

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -139,6 +139,8 @@
       "args": [
         "model_server.main:app",
         "--reload",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/skills/builtin",
         "--port",
         "9000"
       ],
@@ -163,6 +165,8 @@
       "args": [
         "onyx.main:app",
         "--reload",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/skills/builtin",
         "--port",
         "8080"
       ],
@@ -189,6 +193,8 @@
       "args": [
         "onyx.main:app",
         "--reload",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/skills/builtin",
         "--port",
         "8080"
       ],
@@ -252,6 +258,8 @@
       "args": [
         "onyx.mcp_server.api:mcp_app",
         "--reload",
+        "--reload-exclude",
+        "${workspaceFolder}/backend/onyx/skills/builtin",
         "--port",
         "8090",
         "--timeout-graceful-shutdown",

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -21,8 +21,18 @@ Example launch.json entry:
 
 import os
 import sys
+from pathlib import Path
 
+from watchfiles import DefaultFilter
 from watchfiles import run_process
+
+# Built-in ext-app + craft skill bundles are content shipped to the sandbox,
+# not imported by the worker, so editing them shouldn't trigger a restart.
+# Mirrors BUILTIN_SKILLS_PATH (onyx/skills/built_in.py); kept inline to avoid
+# importing onyx.db into the reloader supervisor just for a path.
+_SKILLS_BUNDLE_DIR = str(
+    Path(__file__).resolve().parents[1] / "onyx" / "skills" / "builtin"
+)
 
 
 def _run(argv: list[str]) -> None:
@@ -35,4 +45,9 @@ def _run(argv: list[str]) -> None:
 if __name__ == "__main__":
     celery_argv = ["celery", *sys.argv[1:]]
     watch_paths = [p for p in ("./onyx", "./ee") if os.path.isdir(p)]
-    run_process(*watch_paths, target=_run, args=(celery_argv,))
+    run_process(
+        *watch_paths,
+        target=_run,
+        args=(celery_argv,),
+        watch_filter=DefaultFilter(ignore_paths=[_SKILLS_BUNDLE_DIR]),
+    )


### PR DESCRIPTION
## Description

Editing built-in ext-app / craft skill bundles under `backend/onyx/skills/builtin/` no longer restarts local Python processes. Excludes that dir from the Celery watchfiles reloader (`dev_celery_reload.py`) and from the uvicorn `--reload` configs (API, API k8s, MCP, Model Server) in `launch.json`. Top-level `skills/*.py` loader modules and all other code still reload as before.

## How Has This Been Tested?

Smoke-tested the watchfiles filter: skill bundle files (`.py`/`.md`/`.template`) are ignored while `skills/bundle.py` and `onyx/main.py` still trigger reloads. Restart local services to pick up the new watch config.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hot-reloading local Python when editing built-in skill bundles in backend/onyx/skills/builtin. Other code, including loader modules, still reloads as before.

- **Refactors**
  - Added `--reload-exclude ${workspaceFolder}/backend/onyx/skills/builtin` to `uvicorn` configs for API, API k8s, MCP, and Model Server in `.vscode/launch.json`.
  - Updated `backend/scripts/dev_celery_reload.py` to ignore that directory via watchfiles DefaultFilter, preventing `Celery` worker restarts on bundle edits.

- **Migration**
  - Restart local services to apply the new watch config.

<sup>Written for commit da498d8b2f70f8c1ff5e067a88730b86804a5e30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

