### PR TITLE
ci(preview): skip preview deployment when Vercel credentials are unset

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   check-credentials:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       has-credentials: ${{ steps.check.outputs.has-credentials }}
     steps:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,7 +11,6 @@ on:
       - "web/**"
 permissions:
   contents: read
-  pull-requests: write
 jobs:
   check-credentials:
     runs-on: ubuntu-latest
@@ -35,6 +34,9 @@ jobs:
     if: needs.check-credentials.outputs.has-credentials == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,7 +13,26 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
+  check-credentials:
+    runs-on: ubuntu-latest
+    outputs:
+      has-credentials: ${{ steps.check.outputs.has-credentials }}
+    steps:
+      - name: Check Vercel credentials
+        id: check
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ] && [ -n "$VERCEL_TOKEN" ]; then
+            echo "has-credentials=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-credentials=false" >> "$GITHUB_OUTPUT"
+            echo "Vercel credentials not set; skipping preview deployment."
+          fi
+
   Deploy-Preview:
+    needs: check-credentials
+    if: needs.check-credentials.outputs.has-credentials == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## What

Adds a `check-credentials` gate job to `.github/workflows/preview.yml` that verifies the Vercel credentials (`VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `VERCEL_TOKEN`) are present before running `Deploy-Preview`. When any are missing (e.g. on forks or branches without the secrets configured), the deploy job is **skipped** rather than failing.

## Why

The preview deployment fails noisily when Vercel credentials aren't available. Skipping keeps the workflow green in those cases.

## How

GitHub Actions does not expose the `secrets` context to job-level `if:` conditions (only `github`, `needs`, `vars`, `inputs`). So the gate job reads the secret into an `env` var inside a step (where it *is* allowed), emits a boolean output, and `Deploy-Preview` gates on it via `needs` + `if`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Vercel preview deployments when credentials are missing, keeping CI green on forks and branches without secrets. Adds a `check-credentials` gate job in `.github/workflows/preview.yml` to verify `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, and `VERCEL_TOKEN`; `Deploy-Preview` runs only when this is true, and `pull-requests: write` is scoped to that job.

<sup>Written for commit 00ffba904cc5aba5e78e757c2062866247ff5df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

