### PR TITLE
chore(mcp): add Linear MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "agent-wiki": {
       "type": "http",
       "url": "https://dev-wiki.onyx.app/api/mcp"
+    },
+    "linear": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
     }
   }
 }


### PR DESCRIPTION
## What

Adds [Linear's hosted MCP server](https://linear.app/docs/mcp) to `.mcp.json`.

```json
"linear": {
  "type": "http",
  "url": "https://mcp.linear.app/mcp"
}
```

## Notes

- Uses Claude Code's **native HTTP transport** (`"type": "http"`) pointing at Linear's streamable HTTP endpoint, rather than the `npx mcp-remote` subprocess wrapper shown in some docs.
- Linear's server uses **OAuth 2.1**, so the first connection prompts for browser auth. Restart Claude Code (or run `/mcp`) to pick up the new server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Linear’s hosted MCP server to `.mcp.json` using native HTTP transport to enable Linear actions. Uses `https://mcp.linear.app/mcp`; first run triggers OAuth 2.1 login.

- **Migration**
  - Restart Claude Code or run `/mcp` to load the new server.
  - Sign in to Linear in the browser when prompted (OAuth 2.1).

<sup>Written for commit 617024599224a838420ad370504d60f6a4fa8f67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

