### PR TITLE
feat(craft): codify Onyx Craft EKS infra (terraform + helm)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.19
+version: 0.5.20
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,10 +17,10 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: added
-      description: '`configMap.ENABLE_PUBLIC_DOCS` flag (default off) gating the
-        interactive API docs and schema. When unset, /openapi.json, /docs, and
-        /redoc are not registered (404); set to "true" to expose them publicly
-        with no authentication.'
+      description: Add Craft sandbox RBAC and the `sandbox-file-sync`
+        ServiceAccount, configured through `craft.sandboxFileSyncRoleArn`
+        and `craft.extraBoundServiceAccounts`, so EKS installs can bind
+        sandbox snapshot access to a Terraform-managed IRSA role.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -8,6 +8,13 @@
 {{- fail "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=true (IRSA role ARN for the sandbox-file-sync ServiceAccount — output of the craft_sandbox terraform module)." }}
 {{- end }}
 {{- $boundSAs := prepend ((index $craft "extraBoundServiceAccounts") | default (list)) (include "onyx.serviceAccountName" .) }}
+{{- $rbacNameBase := printf "%s-%s" (include "onyx.fullname" .) .Release.Namespace }}
+{{- $rbacNamePrefix := $rbacNameBase }}
+{{- if gt (len $rbacNameBase) 47 }}
+{{- $rbacNamePrefix = printf "%s-%s" ($rbacNameBase | trunc 38 | trimSuffix "-") (sha256sum $rbacNameBase | trunc 8) }}
+{{- end }}
+{{- $sandboxManagerName := printf "%s-sandbox-manager" $rbacNamePrefix }}
+{{- $proxyResolveName := printf "%s-proxy-resolve" $rbacNamePrefix }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -23,7 +30,7 @@ automountServiceAccountToken: true
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  name: {{ $sandboxManagerName }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -49,7 +56,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  name: {{ $sandboxManagerName }}
   namespace: {{ $sandboxNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -62,14 +69,14 @@ subjects:
   {{- end }}
 roleRef:
   kind: Role
-  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  name: {{ $sandboxManagerName }}
   apiGroup: rbac.authorization.k8s.io
 ---
 # api_server resolves SANDBOX_PROXY_HOST's ClusterIP for the sandbox pod's /etc/hosts alias.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  name: {{ $proxyResolveName }}
   namespace: {{ $proxyNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -82,7 +89,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  name: {{ $proxyResolveName }}
   namespace: {{ $proxyNs }}
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
@@ -95,6 +102,6 @@ subjects:
   {{- end }}
 roleRef:
   kind: Role
-  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  name: {{ $proxyResolveName }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -1,0 +1,101 @@
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $saName := (index .Values.configMap "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox-file-sync" }}
+{{- $proxyNs := (index .Values.configMap "SANDBOX_PROXY_NAMESPACE") | default .Release.Namespace }}
+{{- $roleArn := .Values.craft.sandboxFileSyncRoleArn | default "" }}
+{{- if not $roleArn }}
+{{- fail "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=true (IRSA role ARN for the sandbox-file-sync ServiceAccount — output of the craft_sandbox terraform module)." }}
+{{- end }}
+{{- $boundSAs := prepend (.Values.craft.extraBoundServiceAccounts | default list) (include "onyx.serviceAccountName" .) }}
+# skip-containers keeps the IRSA creds in the file-sync sidecar, out of the agent container.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-file-sync
+  annotations:
+    eks.amazonaws.com/role-arn: {{ $roleArn | quote }}
+    eks.amazonaws.com/skip-containers: "sandbox"
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+rules:
+  # watch is required: _wait_for_pod_ready streams pod events during provision.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+subjects:
+  {{- range $boundSAs }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# api_server resolves SANDBOX_PROXY_HOST's ClusterIP for the sandbox pod's /etc/hosts alias.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  namespace: {{ $proxyNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  namespace: {{ $proxyNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+subjects:
+  {{- range $boundSAs }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -1,13 +1,13 @@
 {{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{- $craft := .Values.craft | default dict }}
 {{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 {{- $saName := (index .Values.configMap "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox-file-sync" }}
 {{- $proxyNs := (index .Values.configMap "SANDBOX_PROXY_NAMESPACE") | default .Release.Namespace }}
-{{- $roleArn := .Values.craft.sandboxFileSyncRoleArn | default "" }}
+{{- $roleArn := (index $craft "sandboxFileSyncRoleArn") | default "" }}
 {{- if not $roleArn }}
 {{- fail "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=true (IRSA role ARN for the sandbox-file-sync ServiceAccount — output of the craft_sandbox terraform module)." }}
 {{- end }}
-{{- $boundSAs := prepend (.Values.craft.extraBoundServiceAccounts | default list) (include "onyx.serviceAccountName" .) }}
-# skip-containers keeps the IRSA creds in the file-sync sidecar, out of the agent container.
+{{- $boundSAs := prepend ((index $craft "extraBoundServiceAccounts") | default (list)) (include "onyx.serviceAccountName" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -18,7 +18,6 @@ metadata:
     app.kubernetes.io/component: sandbox-file-sync
   annotations:
     eks.amazonaws.com/role-arn: {{ $roleArn | quote }}
-    eks.amazonaws.com/skip-containers: "sandbox"
 automountServiceAccountToken: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -18,6 +18,11 @@ configMap:
   SANDBOX_S3_BUCKET: "onyx-sandbox-snapshots-ci"
   AWS_ENDPOINT_URL: "http://minio.onyx-sandboxes.svc.cluster.local:9000"
 
+craft:
+  # CI-only placeholder. Kind tests use MinIO credentials from auth.objectstorage,
+  # but the chart requires an IRSA role ARN whenever ENABLE_CRAFT=true.
+  sandboxFileSyncRoleArn: "arn:aws:iam::000000000000:role/ci-sandbox-file-sync"
+
 # Placeholder secret values so auth-secrets.yaml renders without erroring.
 # Postgres/Redis/MinIO actually run in docker-compose alongside the kind
 # cluster in this lane (see pr-craft-k8s-tests.yml), so the in-chart values

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1496,6 +1496,13 @@ configMap:
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
 
+# -- Craft sandbox identity/RBAC (rendered when configMap.ENABLE_CRAFT=true).
+craft:
+  # Required when ENABLE_CRAFT=true. The craft_sandbox terraform module's role_arn output.
+  sandboxFileSyncRoleArn: ""
+  # Extra SAs (release ns) to also grant sandbox RBAC, e.g. a separate worker SA.
+  extraBoundServiceAccounts: []
+
 # -- Sandbox egress proxy.
 sandboxProxy:
   replicaCount: 2

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1493,6 +1493,7 @@ configMap:
   # Sandbox config — always "kubernetes" for Helm deployments
   SANDBOX_BACKEND: "kubernetes"
   SANDBOX_NAMESPACE: "onyx-sandboxes"
+  SANDBOX_SERVICE_ACCOUNT_NAME: "sandbox-file-sync"
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
 

--- a/deployment/terraform/modules/aws/craft_sandbox/main.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/main.tf
@@ -1,0 +1,90 @@
+# Craft sandbox cloud prereqs: encrypted S3 snapshot bucket + IRSA role for the
+# sandbox file-sync SA. Outputs role_arn + bucket_name for Helm.
+
+locals {
+  # OIDC passed as inputs (not a data source) so this works in the same apply that
+  # creates the cluster, and on destroy after it's gone.
+  oidc_url = var.oidc_provider
+  oidc_arn = var.oidc_provider_arn
+  sa_sub   = "system:serviceaccount:${var.sandbox_namespace}:${var.service_account_name}"
+}
+
+resource "aws_s3_bucket" "sandbox" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "sandbox" {
+  bucket                  = aws_s3_bucket.sandbox.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+    filter {} # applies to all objects (required by the provider)
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_iam_policy" "sandbox_s3" {
+  name        = "${var.cluster_name}-sandbox-s3-policy"
+  description = "Sandbox file-sync S3 access for ${var.cluster_name}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
+        Resource = "${aws_s3_bucket.sandbox.arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.sandbox.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "sandbox_file_sync" {
+  name = "SandboxFileSyncRole-${var.cluster_name}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Federated = local.oidc_arn }
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oidc_url}:sub" = local.sa_sub
+            "${local.oidc_url}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sandbox_s3" {
+  role       = aws_iam_role.sandbox_file_sync.name
+  policy_arn = aws_iam_policy.sandbox_s3.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/main.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/main.tf
@@ -4,18 +4,22 @@
 locals {
   # OIDC passed as inputs (not a data source) so this works in the same apply that
   # creates the cluster, and on destroy after it's gone.
-  oidc_url = var.oidc_provider
-  oidc_arn = var.oidc_provider_arn
-  sa_sub   = "system:serviceaccount:${var.sandbox_namespace}:${var.service_account_name}"
+  oidc_url                = var.oidc_provider
+  oidc_arn                = var.oidc_provider_arn
+  sa_sub                  = "system:serviceaccount:${var.sandbox_namespace}:${var.service_account_name}"
+  bucket_arn              = "arn:aws:s3:::${var.bucket_name}"
+  cluster_name_iam_suffix = length(var.cluster_name) <= 44 ? var.cluster_name : "${substr(var.cluster_name, 0, 35)}-${substr(sha1(var.cluster_name), 0, 8)}"
 }
 
 resource "aws_s3_bucket" "sandbox" {
+  count  = var.create_bucket ? 1 : 0
   bucket = var.bucket_name
   tags   = var.tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
-  bucket = aws_s3_bucket.sandbox.id
+  count  = var.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.sandbox[0].id
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
@@ -24,7 +28,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
 }
 
 resource "aws_s3_bucket_public_access_block" "sandbox" {
-  bucket                  = aws_s3_bucket.sandbox.id
+  count                   = var.create_bucket ? 1 : 0
+  bucket                  = aws_s3_bucket.sandbox[0].id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -32,7 +37,8 @@ resource "aws_s3_bucket_public_access_block" "sandbox" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "sandbox" {
-  bucket = aws_s3_bucket.sandbox.id
+  count  = var.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.sandbox[0].id
   rule {
     id     = "abort-incomplete-multipart"
     status = "Enabled"
@@ -52,19 +58,19 @@ resource "aws_iam_policy" "sandbox_s3" {
       {
         Effect   = "Allow"
         Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
-        Resource = "${aws_s3_bucket.sandbox.arn}/*"
+        Resource = "${local.bucket_arn}/*"
       },
       {
         Effect   = "Allow"
         Action   = ["s3:ListBucket"]
-        Resource = aws_s3_bucket.sandbox.arn
+        Resource = local.bucket_arn
       }
     ]
   })
 }
 
 resource "aws_iam_role" "sandbox_file_sync" {
-  name = "SandboxFileSyncRole-${var.cluster_name}"
+  name = "SandboxFileSyncRole-${local.cluster_name_iam_suffix}"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
@@ -5,9 +5,10 @@ output "role_arn" {
 
 output "bucket_name" {
   description = "Sandbox S3 bucket name (set as SANDBOX_S3_BUCKET)."
-  value       = aws_s3_bucket.sandbox.id
+  value       = var.bucket_name
 }
 
 output "bucket_arn" {
-  value = aws_s3_bucket.sandbox.arn
+  description = "Sandbox S3 bucket ARN."
+  value       = local.bucket_arn
 }

--- a/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
@@ -1,0 +1,13 @@
+output "role_arn" {
+  description = "IRSA role ARN to annotate the sandbox-file-sync ServiceAccount with."
+  value       = aws_iam_role.sandbox_file_sync.arn
+}
+
+output "bucket_name" {
+  description = "Sandbox S3 bucket name (set as SANDBOX_S3_BUCKET)."
+  value       = aws_s3_bucket.sandbox.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.sandbox.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/variables.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/variables.tf
@@ -18,6 +18,12 @@ variable "bucket_name" {
   description = "S3 bucket name for sandbox snapshots / file-sync."
 }
 
+variable "create_bucket" {
+  type        = bool
+  description = "Whether to create and manage the sandbox S3 bucket. Set false to reuse an existing bucket named by bucket_name."
+  default     = true
+}
+
 variable "sandbox_namespace" {
   type        = string
   description = "Kubernetes namespace the sandbox file-sync ServiceAccount lives in."

--- a/deployment/terraform/modules/aws/craft_sandbox/variables.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/variables.tf
@@ -1,0 +1,37 @@
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name (used to name resources)."
+}
+
+variable "oidc_provider_arn" {
+  type        = string
+  description = "EKS OIDC provider ARN (from the eks module output) for the IRSA trust policy."
+}
+
+variable "oidc_provider" {
+  type        = string
+  description = "EKS OIDC issuer host/path without https:// (from the eks module output) for the sub/aud condition keys."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "S3 bucket name for sandbox snapshots / file-sync."
+}
+
+variable "sandbox_namespace" {
+  type        = string
+  description = "Kubernetes namespace the sandbox file-sync ServiceAccount lives in."
+  default     = "onyx-sandboxes"
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "Name of the sandbox file-sync ServiceAccount the IRSA role trusts."
+  default     = "sandbox-file-sync"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to created resources."
+  default     = {}
+}

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -3,6 +3,42 @@ locals {
     bucket_arn     = "arn:aws:s3:::${name}"
     bucket_objects = "arn:aws:s3:::${name}/*"
   }]
+
+  # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
+  # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
+  craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
+    sandbox = {
+      name           = "sandbox-node-group"
+      instance_types = var.craft_sandbox_node_instance_types
+      min_size       = var.craft_sandbox_node_min_size
+      max_size       = var.craft_sandbox_node_max_size
+      desired_size   = var.craft_sandbox_node_desired_size
+      labels = {
+        "onyx.app/workload" = "sandbox"
+      }
+      taints = [{
+        key    = "workload"
+        value  = "sandbox"
+        effect = "NO_SCHEDULE"
+      }]
+      metadata_options = {
+        http_endpoint               = "enabled"
+        http_tokens                 = "required"
+        http_put_response_hop_limit = 1
+      }
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 50
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+    }
+  } : {}
 }
 
 module "eks" {
@@ -27,7 +63,7 @@ module "eks" {
     ami_type = "AL2023_x86_64_STANDARD"
   }
 
-  eks_managed_node_groups = {
+  eks_managed_node_groups = merge({
     for k, v in var.eks_managed_node_groups : k => merge(v,
       {
         instance_types = v.instance_types != null ? v.instance_types : (
@@ -45,7 +81,7 @@ module "eks" {
         subnet_ids = var.main_node_subnet_ids
       } : {}
     )
-  }
+  }, local.craft_sandbox_node_groups)
 
   tags = var.tags
 }

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -13,10 +13,10 @@ locals {
       min_size       = var.craft_sandbox_node_min_size
       max_size       = var.craft_sandbox_node_max_size
       desired_size   = var.craft_sandbox_node_desired_size
-      # The upstream EKS module always adds the shared node security group.
-      # Attach the EKS primary cluster SG too so sandbox nodes match normal
-      # managed node group connectivity assumptions.
-      attach_cluster_primary_security_group = true
+      # Keep the sandbox nodes on the upstream shared node security group only.
+      # Attaching the EKS primary cluster SG as well puts two
+      # kubernetes.io/cluster/<name>-tagged SGs on the same nodes, which breaks
+      # tag-based discovery in controllers such as AWS Load Balancer Controller.
       labels = {
         "onyx.app/workload" = "sandbox"
       }

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -7,8 +7,8 @@ locals {
   # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
   craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
-    craft_sandbox = {
-      name           = "craft-sandbox-node-group"
+    sandbox = {
+      name           = "sandbox-node-group"
       instance_types = var.craft_sandbox_node_instance_types
       min_size       = var.craft_sandbox_node_min_size
       max_size       = var.craft_sandbox_node_max_size

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -13,6 +13,10 @@ locals {
       min_size       = var.craft_sandbox_node_min_size
       max_size       = var.craft_sandbox_node_max_size
       desired_size   = var.craft_sandbox_node_desired_size
+      # The upstream EKS module always adds the shared node security group.
+      # Attach the EKS primary cluster SG too so sandbox nodes match normal
+      # managed node group connectivity assumptions.
+      attach_cluster_primary_security_group = true
       labels = {
         "onyx.app/workload" = "sandbox"
       }

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -7,8 +7,8 @@ locals {
   # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
   # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
   craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
-    sandbox = {
-      name           = "sandbox-node-group"
+    craft_sandbox = {
+      name           = "craft-sandbox-node-group"
       instance_types = var.craft_sandbox_node_instance_types
       min_size       = var.craft_sandbox_node_min_size
       max_size       = var.craft_sandbox_node_max_size

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -15,3 +15,15 @@ output "workload_irsa_role_arn" {
   description = "ARN of the IAM role for workloads (S3 + optional RDS)"
   value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
 }
+
+# Re-exported from the upstream eks module so the craft_sandbox module can
+# trust-scope its IRSA role to the cluster's OIDC provider.
+output "oidc_provider_arn" {
+  description = "EKS OIDC provider ARN (for IRSA roles)"
+  value       = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider" {
+  description = "EKS OIDC issuer host/path (no https://)"
+  value       = module.eks.oidc_provider
+}

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -126,6 +126,36 @@ variable "tags" {
   default     = {}
 }
 
+variable "enable_craft_sandbox_node_group" {
+  type        = bool
+  description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1)."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m5.large"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type        = number
+  description = "Min size of the Craft sandbox node group."
+  default     = 0
+}
+
+variable "craft_sandbox_node_max_size" {
+  type        = number
+  description = "Max size of the Craft sandbox node group (concurrency: each sandbox needs ~1 vCPU/2Gi)."
+  default     = 4
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type        = number
+  description = "Desired size of the Craft sandbox node group."
+  default     = 1
+}
+
 variable "create_gp3_storage_class" {
   type        = bool
   description = "Whether to create the gp3 storage class. The gp3 storage class will be patched to make it default and allow volume expansion."

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -74,6 +74,12 @@ module "eks" {
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
 
+  enable_craft_sandbox_node_group   = var.enable_craft_sandbox_node_group
+  craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
+  craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
+  craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
+  craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
+
   main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
     var.main_node_private_subnets_only ? local.private_subnets : []
   )

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -7,6 +7,14 @@ output "cluster_name" {
   value = module.eks.cluster_name
 }
 
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider" {
+  value = module.eks.oidc_provider
+}
+
 output "postgres_endpoint" {
   description = "RDS endpoint hostname"
   value       = module.postgres.endpoint

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -110,6 +110,34 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
+# Craft sandbox node group knobs, forwarded to the eks module (default off).
+variable "enable_craft_sandbox_node_group" {
+  type        = bool
+  description = "Create a dedicated, IMDSv2-hardened Craft sandbox node group (labeled/tainted for sandbox pods)."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m5.large"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type    = number
+  default = 0
+}
+
+variable "craft_sandbox_node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type    = number
+  default = 1
+}
+
 variable "enable_iam_auth" {
   type        = bool
   description = "Enable AWS IAM authentication for the RDS Postgres instance and wire IRSA policies"

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -124,18 +124,21 @@ variable "craft_sandbox_node_instance_types" {
 }
 
 variable "craft_sandbox_node_min_size" {
-  type    = number
-  default = 0
+  type        = number
+  description = "Min size of the Craft sandbox node group."
+  default     = 0
 }
 
 variable "craft_sandbox_node_max_size" {
-  type    = number
-  default = 4
+  type        = number
+  description = "Max size of the Craft sandbox node group."
+  default     = 4
 }
 
 variable "craft_sandbox_node_desired_size" {
-  type    = number
-  default = 1
+  type        = number
+  description = "Desired size of the Craft sandbox node group."
+  default     = 1
 }
 
 variable "enable_iam_auth" {

--- a/docs/craft/infra/sidecar-reimplementation.md
+++ b/docs/craft/infra/sidecar-reimplementation.md
@@ -14,7 +14,7 @@ The single-container sandbox puts credentials and control-plane processes in the
 ## Important Notes
 
 - Both containers use the same `onyxdotapp/sandbox` image with different `command` overrides.
-- `eks.amazonaws.com/skip-containers: "sandbox"` on the service account skips IRSA injection into the `sandbox` container.
+- `eks.amazonaws.com/skip-containers: "sandbox"` on the pod metadata skips IRSA injection into the `sandbox` container.
 - Snapshot endpoints are Ed25519-signed.
 - `GET /health` is the only unsigned endpoint.
 - `shareProcessNamespace` is set to `false`.
@@ -57,7 +57,8 @@ The single-container sandbox puts credentials and control-plane processes in the
 ```
 ┌───────────────────────────────────────────────────────────────┐
 │ Pod: sandbox-{id}                                             │
-│ SA: sandbox-file-sync, skip-containers: "sandbox"             │
+│ SA: sandbox-file-sync                                         │
+│ Pod annotation: skip-containers: "sandbox"                    │
 │ shareProcessNamespace: false                                  │
 │                                                               │
 │ ┌───────────────────────────┐ ┌─────────────────────────────┐ │
@@ -117,12 +118,12 @@ Mounts:
 
 ### Phase 2: IRSA Isolation
 
-Add `skip-containers` to the `sandbox-file-sync` service account:
+Add `skip-containers` to the sandbox pod metadata in `_create_sandbox_pod()`:
 
-```yaml
-annotations:
-  eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT:role/sandbox-s3-role
-  eks.amazonaws.com/skip-containers: "sandbox"
+```python
+metadata=client.V1ObjectMeta(
+    annotations={"eks.amazonaws.com/skip-containers": "sandbox"},
+)
 ```
 
 ### Phase 3: Sidecar Entrypoint and Server
@@ -262,11 +263,11 @@ All other methods continue to exec into the `sandbox` container.
 
 #### 6a. Helm Chart (`deployment/helm/charts/onyx/`)
 
-No changes needed.
+`templates/sandbox-rbac.yaml` creates the `sandbox-file-sync` ServiceAccount with the IRSA role annotation, plus the sandbox-manager Role/RoleBinding.
 
-#### 6b. Production (internal deployment repo)
+#### 6b. Legacy manifests
 
-**`serviceaccount/sandbox-file-sync-sa.yaml`** — add `skip-containers`:
+If a deployment repo still owns the ServiceAccount outside Helm, keep only the IRSA role annotation there:
 
 ```yaml
 apiVersion: v1
@@ -281,20 +282,18 @@ metadata:
     app.kubernetes.io/managed-by: ArgoCD
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::<AWS_ACCOUNT_ID>:role/<SANDBOX_FILE_SYNC_ROLE>
-    eks.amazonaws.com/skip-containers: "sandbox"
 automountServiceAccountToken: true
 ```
 
+#### 6c. Dev
 
-#### 6c. Dev (internal deployment repo)
-
-The `sandbox-file-sync` SA for craft-dev needs the same `skip-containers: "sandbox"` annotation.
+Dev uses the same split: the ServiceAccount carries `role-arn`, and the pod spec carries `skip-containers`.
 
 #### Deployment Order
 
 1. Build and push the new sandbox image (snapshot endpoints in daemon, new entrypoints)
 2. Merge backend code changes (sidecar in pod spec, snapshot methods call sidecar HTTP API)
-3. Deploy SA annotation + backend atomically
+3. Deploy the role-annotated SA + backend pod annotation before enabling production traffic
 4. Verify on a new pod:
    - `kubectl exec -c sandbox` → `AWS_ROLE_ARN` is unset
    - `kubectl exec -c sandbox` → `/var/run/secrets/eks.amazonaws.com/` does not exist

--- a/docs/craft/infra/todos.md
+++ b/docs/craft/infra/todos.md
@@ -8,7 +8,7 @@ Status in PR 11787:
 |---|---|---|
 | 1. Helm sandbox RBAC + ServiceAccount | Covered | `templates/sandbox-namespace.yaml` renders the sandbox namespace, and `templates/sandbox-rbac.yaml` renders the `sandbox-file-sync` ServiceAccount, sandbox manager Role/RoleBinding, proxy service lookup Role/RoleBinding, and fails fast when the EKS IRSA role ARN is missing. |
 | 2. Terraform sandbox object store + workload identity | Covered | `modules/aws/craft_sandbox` creates or references the snapshot bucket, creates the S3 policy, creates the sandbox file-sync IRSA role, and outputs the role ARN/bucket name for Helm. |
-| 3. Node-group security-group composition | Covered | The sandbox managed node group uses the upstream shared node SG and explicitly sets `attach_cluster_primary_security_group=true`, so the launch template carries both the shared node SG and EKS primary cluster SG. |
+| 3. Node-group security-group composition | Covered | The sandbox managed node group uses the upstream shared node SG, matching regular managed node groups without also attaching the EKS primary cluster SG and creating duplicate `kubernetes.io/cluster/<name>`-tagged SGs on the same nodes. |
 | 4. Node-group metadata-service hardening | Covered | The sandbox managed node group sets IMDSv2 required and hop-limit 1. |
 | 5. Network firewall | Not codified in this PR | Still valid and still independent. The runbook calls this out as remaining defense-in-depth work because it needs regional firewall subnets, route-table changes, and firewall rule deployment beyond this Terraform/Helm slice. |
 
@@ -39,9 +39,9 @@ For migrations with an existing bucket, set `create_bucket=false` and pass the e
 
 ## 3. Node-group security-group composition
 
-A dedicated sandbox node group must carry the same set of security groups that the cluster's regular managed node groups carry — typically the EKS cluster SG **plus** the shared node SG. If the launch template only attaches the cluster SG, pods on sandbox nodes can't reach pods on the regular node group (DNS, in-cluster service calls, etc.) because the shared node SG's ingress is self-referential.
+A dedicated sandbox node group must use the same shared node security group shape as the cluster's regular managed node groups. Do not attach both the upstream shared node SG and the EKS primary cluster SG to the same nodes: both SGs are tagged with `kubernetes.io/cluster/<name>`, and AWS Load Balancer Controller expects exactly one matching SG on nodes.
 
-**Acceptance:** the Terraform launch template for the sandbox node group attaches both SGs by default, matching how EKS managed node groups normally provision.
+**Acceptance:** the Terraform launch template for the sandbox node group attaches the upstream shared node SG and no second `kubernetes.io/cluster/<name>`-tagged SG.
 
 ## 4. Node-group metadata-service hardening
 

--- a/docs/craft/infra/todos.md
+++ b/docs/craft/infra/todos.md
@@ -6,24 +6,26 @@ Things to codify so enabling Craft on a new cluster becomes "set `ENABLE_CRAFT=t
 
 Render everything in the sandbox namespace required for Craft via the Helm chart when `ENABLE_CRAFT=true`:
 
-- The sandbox ServiceAccount, with workload-identity annotations and the `eks.amazonaws.com/skip-containers=sandbox` annotation so only the sidecar container receives cloud credentials.
-- The sandbox-namespace Role granting `pods`, `pods/exec`, `services` verbs.
+- The sandbox ServiceAccount, with the workload-identity role annotation.
+- The sandbox-namespace Role granting `pods`, `pods/exec`, `pods/log`, `services`, and `secrets` verbs used by the sandbox manager.
 - RoleBinding(s) attaching that Role to whichever workload ServiceAccount(s) call the K8s API to manage sandbox pods (typically the api-server SA and the relevant Celery worker SAs).
 
 Source identifiers (IAM role ARN, bound SA names) from a configurable values block and mark them required so a misconfigured deploy fails fast.
 
-This removes the need for manual `kubectl annotate` and `kubectl create rolebinding` steps when onboarding a new cluster. Existing clusters whose Role is currently shipped via raw manifests / external GitOps need a one-time cleanup so the chart becomes the single source of truth.
+The `eks.amazonaws.com/skip-containers=sandbox` credential-isolation annotation belongs on each sandbox pod's metadata, not on this ServiceAccount. `KubernetesSandboxManager` owns that runtime pod annotation.
+
+This removes the need for manual `kubectl create serviceaccount`, `kubectl annotate`, and `kubectl create rolebinding` steps when onboarding a new cluster. Existing clusters whose Role is currently shipped via raw manifests / external GitOps need a one-time cleanup so the chart becomes the single source of truth.
 
 ## 2. Terraform module: sandbox object store + workload-identity role
 
 A shared Terraform module that provisions the cloud-side prerequisites for Craft on a given cluster:
 
-- Object-storage bucket for snapshots (with encryption + public-access block)
+- Optional object-storage bucket for snapshots (with encryption + public-access block)
 - IAM policy granting the SA read/write/delete/list on that bucket
 - IAM role with a trust policy scoped to the sandbox namespace + SA via the cluster's OIDC provider
 - Outputs (`role_arn`, `bucket_name`) to wire into the cluster's Helm values
 
-Existing buckets/roles on already-deployed clusters need to be imported into module state, not recreated.
+For migrations with an existing bucket, set `create_bucket=false` and pass the existing bucket name. Terraform will still create the IAM role and policy for that bucket, but it will not create or manage the bucket itself. Existing roles that should become module-managed still need Terraform import.
 
 ## 3. Node-group security-group composition
 
@@ -54,8 +56,8 @@ Replicate the production network-firewall setup in every region that runs Craft.
 
 Onboarding a new Craft cluster becomes:
 
-1. `terraform apply` against the cluster (provisions bucket + role, sets metadata hop-limit).
+1. `terraform apply` against the cluster (provisions or references the bucket, creates the role, sets metadata hop-limit).
 2. Copy `role_arn` and `bucket_name` from terraform outputs into the cluster's Helm values alongside `ENABLE_CRAFT: "true"`.
-3. `helm upgrade` (creates namespace, SA, network policy).
+3. `helm upgrade` (creates namespace, SA, and sandbox RBAC).
 
 Item 5 is independent and bolts on to any cluster after the rest is in place.

--- a/docs/craft/infra/todos.md
+++ b/docs/craft/infra/todos.md
@@ -2,6 +2,16 @@
 
 Things to codify so enabling Craft on a new cluster becomes "set `ENABLE_CRAFT=true` in values.yaml" instead of following a manual setup guide. Each item is independent — ship in any order.
 
+Status in PR 11787:
+
+| Item | Status | Notes |
+|---|---|---|
+| 1. Helm sandbox RBAC + ServiceAccount | Covered | `templates/sandbox-namespace.yaml` renders the sandbox namespace, and `templates/sandbox-rbac.yaml` renders the `sandbox-file-sync` ServiceAccount, sandbox manager Role/RoleBinding, proxy service lookup Role/RoleBinding, and fails fast when the EKS IRSA role ARN is missing. |
+| 2. Terraform sandbox object store + workload identity | Covered | `modules/aws/craft_sandbox` creates or references the snapshot bucket, creates the S3 policy, creates the sandbox file-sync IRSA role, and outputs the role ARN/bucket name for Helm. |
+| 3. Node-group security-group composition | Covered | The sandbox managed node group uses the upstream shared node SG and explicitly sets `attach_cluster_primary_security_group=true`, so the launch template carries both the shared node SG and EKS primary cluster SG. |
+| 4. Node-group metadata-service hardening | Covered | The sandbox managed node group sets IMDSv2 required and hop-limit 1. |
+| 5. Network firewall | Not codified in this PR | Still valid and still independent. The runbook calls this out as remaining defense-in-depth work because it needs regional firewall subnets, route-table changes, and firewall rule deployment beyond this Terraform/Helm slice. |
+
 ## 1. Helm template: sandbox namespace RBAC + ServiceAccount
 
 Render everything in the sandbox namespace required for Craft via the Helm chart when `ENABLE_CRAFT=true`:

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -21,7 +21,7 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 
 **Helm** (`deployment/helm/charts/onyx`) creates ONLY Kubernetes objects:
 - All in-cluster workloads (api, web, nginx, celery, model servers, code-interpreter, **sandbox-proxy**).
-- The **`onyx-sandboxes`** namespace (`templates/sandbox-namespace.yaml`) + **`sandbox-file-sync` SA** + sandbox RBAC (`onyx-sandbox-manager`, `onyx-proxy-resolve`) (`templates/sandbox-rbac.yaml`).
+- The **`onyx-sandboxes`** namespace (`templates/sandbox-namespace.yaml`) + **`sandbox-file-sync` SA** + sandbox RBAC (`<release>-<release-namespace>-sandbox-manager`, `<release>-<release-namespace>-proxy-resolve`) (`templates/sandbox-rbac.yaml`).
 - `configMap` + secrets that **point the app at the terraform-created endpoints** (POSTGRES_HOST, REDIS_HOST, OpenSearch host, S3 buckets) and carry the IRSA role ARNs.
 
 **Neither crosses over:** Terraform never deploys app workloads or app RBAC; Helm never creates AWS resources — it only *references* them via values you pass from terraform outputs.
@@ -82,10 +82,10 @@ opencode auth/config.
 |---|---|---:|---|
 | `Namespace/onyx-sandboxes` | cluster | Yes | Keeps runtime sandbox pods/services/secrets separate from app workloads. |
 | `ServiceAccount/sandbox-file-sync` | `onyx-sandboxes` | Yes on EKS | Annotated with `craft.sandboxFileSyncRoleArn`; used by sandbox pods for sidecar S3 access. |
-| `Role/onyx-sandbox-manager` | `onyx-sandboxes` | Yes | Allows the Onyx workload SA to manage sandbox pods, services, secrets, exec, and logs. |
-| `RoleBinding/onyx-sandbox-manager` | `onyx-sandboxes` | Yes | Binds sandbox-management permissions to `onyx.serviceAccountName` and `craft.extraBoundServiceAccounts`. |
-| `Role/onyx-proxy-resolve` | proxy namespace | Yes | Allows service lookup for resolving `SANDBOX_PROXY_HOST` to a ClusterIP. |
-| `RoleBinding/onyx-proxy-resolve` | proxy namespace | Yes | Binds proxy service lookup to the same workload SAs. |
+| `Role/<release>-<release-namespace>-sandbox-manager` | `onyx-sandboxes` | Yes | Allows the Onyx workload SA to manage sandbox pods, services, secrets, exec, and logs. |
+| `RoleBinding/<release>-<release-namespace>-sandbox-manager` | `onyx-sandboxes` | Yes | Binds sandbox-management permissions to `onyx.serviceAccountName` and `craft.extraBoundServiceAccounts`. |
+| `Role/<release>-<release-namespace>-proxy-resolve` | proxy namespace | Yes | Allows service lookup for resolving `SANDBOX_PROXY_HOST` to a ClusterIP. |
+| `RoleBinding/<release>-<release-namespace>-proxy-resolve` | proxy namespace | Yes | Binds proxy service lookup to the same workload SAs. |
 | `Deployment/onyx-sandbox-proxy` | release namespace | Yes for proxied egress | Runs the egress proxy/gate. |
 | `Service/onyx-sandbox-proxy` | release namespace | Yes for proxied egress | Stable in-cluster address for sandbox traffic. |
 | `ServiceAccount/onyx-sandbox-proxy` | release namespace | Yes for proxy | Identity used by the proxy deployment. |
@@ -303,10 +303,10 @@ The chart now owns these Kubernetes objects when `ENABLE_CRAFT=true`:
 
 - `namespace/onyx-sandboxes`;
 - `serviceaccount/sandbox-file-sync`;
-- `role/onyx-sandbox-manager`;
-- `rolebinding/onyx-sandbox-manager`;
-- `role/onyx-proxy-resolve`;
-- `rolebinding/onyx-proxy-resolve`;
+- `role/<release>-<release-namespace>-sandbox-manager`;
+- `rolebinding/<release>-<release-namespace>-sandbox-manager`;
+- `role/<release>-<release-namespace>-proxy-resolve`;
+- `rolebinding/<release>-<release-namespace>-proxy-resolve`;
 - sandbox proxy ServiceAccount, Roles, RoleBindings, Deployment, Service, PDB,
   and NetworkPolicy;
 - sandbox push/proxy NetworkPolicies.
@@ -317,13 +317,17 @@ running, then replace the manual objects with chart-managed ones:
 
 ```bash
 kubectl -n onyx-sandboxes get pods,svc,secret
-kubectl -n onyx-sandboxes delete role onyx-sandbox-manager --ignore-not-found
-kubectl -n onyx-sandboxes delete rolebinding onyx-sandbox-manager --ignore-not-found
+kubectl -n onyx-sandboxes delete role onyx-sandbox-manager onyx-onyx-sandbox-manager --ignore-not-found
+kubectl -n onyx-sandboxes delete rolebinding onyx-sandbox-manager onyx-onyx-sandbox-manager --ignore-not-found
 kubectl -n onyx-sandboxes delete serviceaccount sandbox-file-sync --ignore-not-found
-kubectl -n onyx delete role onyx-proxy-resolve --ignore-not-found
-kubectl -n onyx delete rolebinding onyx-proxy-resolve --ignore-not-found
+kubectl -n onyx delete role onyx-proxy-resolve onyx-onyx-proxy-resolve --ignore-not-found
+kubectl -n onyx delete rolebinding onyx-proxy-resolve onyx-onyx-proxy-resolve --ignore-not-found
 helm upgrade --install onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml ...
 ```
+
+The example commands include legacy unqualified names and assume release `onyx`
+in namespace `onyx`. For other release namespaces, use the rendered
+Role/RoleBinding names from `helm template`.
 
 If you cannot delete the objects, you can adopt them into Helm by adding the
 standard Helm ownership labels/annotations, but deletion and recreation is
@@ -476,5 +480,5 @@ sandbox provisions on the tainted sandbox node group → snapshot + restore, zer
 Also verified: direct IMDS from a sandbox pod is blocked (`hop_limit=1`); `sandbox-proxy` reaches RDS
 (authenticated query) and gates egress (DB-resolved per request); the file-sync `sidecar` IRSA reads/writes
 the bucket via `s5cmd`; **celery** runs the real `cleanup_idle_sandboxes_task` end-to-end — the worker SA
-(`onyx-workload-access`, bound to `onyx-sandbox-manager`) execs into `onyx-sandboxes`, snapshots to S3, and
+(`onyx-workload-access`, bound to `onyx-onyx-sandbox-manager`) execs into `onyx-sandboxes`, snapshots to S3, and
 sleeps the sandbox, then the API restore re-provisions and pulls that celery-made snapshot back.

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -74,7 +74,7 @@ opencode auth/config.
 | `SandboxFileSyncRole-*` IAM role | Yes | Lets the sandbox file-sync ServiceAccount access the snapshot bucket without static AWS keys. |
 | S3 IAM policy | Yes | Grants `GetObject`, `PutObject`, `DeleteObject`, `AbortMultipartUpload`, and `ListBucket` on the snapshot bucket. |
 | EKS OIDC outputs | Yes | Let the `craft_sandbox` module build IRSA trust without an EKS data source, so fresh apply and destroy both work. |
-| Optional Craft sandbox node group | Strongly recommended | Gives sandbox pods dedicated, tainted, IMDS-hardened nodes. Existing labeled/tainted nodes can satisfy the same scheduling contract. The Terraform node group attaches both the shared node SG and EKS primary cluster SG. |
+| Optional Craft sandbox node group | Strongly recommended | Gives sandbox pods dedicated, tainted, IMDS-hardened nodes. Existing labeled/tainted nodes can satisfy the same scheduling contract. The Terraform node group uses the upstream shared node SG and intentionally does not also attach the EKS primary cluster SG. |
 
 ### Helm/Kubernetes additions
 
@@ -155,11 +155,11 @@ sidecar S3 permissions; IRSA does that. It is defense-in-depth so untrusted code
 cannot easily reach node metadata credentials.
 
 Security-group composition matters too. Regular managed node groups get the
-shared node security group from the upstream EKS module. The sandbox node group
-also sets `attach_cluster_primary_security_group=true`, so its launch template
-gets both the shared node SG and the EKS primary cluster SG. That keeps sandbox
-nodes on the same in-cluster connectivity footing as the regular node groups
-while still separating scheduling with labels/taints.
+shared node security group from the upstream EKS module, and the sandbox node
+group follows that shape. Do not also attach the EKS primary cluster SG: the
+upstream module tags the shared node SG and EKS tags the primary cluster SG with
+`kubernetes.io/cluster/<name>`, so attaching both to the same nodes breaks
+controllers that expect exactly one cluster-tagged node security group.
 
 ## 3. Deploy on a fresh cluster
 
@@ -285,8 +285,8 @@ If the existing node group already has:
 - label `onyx.app/workload=sandbox`;
 - taint `workload=sandbox:NoSchedule`;
 - acceptable IMDS hardening;
-- the same security-group shape as regular managed node groups: shared node SG
-  plus EKS primary cluster SG;
+- the same security-group shape as regular managed node groups: the shared node
+  SG, without also attaching another `kubernetes.io/cluster/<name>`-tagged SG;
 
 then leave `enable_craft_sandbox_node_group=false` and keep using those nodes.
 If you want Terraform to own the node group, either import the existing node
@@ -403,7 +403,7 @@ The lead infra TODO list in `docs/craft/infra/todos.md` is accounted for as:
 |---|---|---|
 | Helm sandbox namespace RBAC + ServiceAccount | Covered | Helm owns `onyx-sandboxes` via `sandbox-namespace.yaml`, then owns `sandbox-file-sync`, sandbox manager RBAC, and proxy service lookup RBAC via `sandbox-rbac.yaml` when Craft is enabled. |
 | Terraform sandbox object store + workload identity | Covered | `craft_sandbox` creates/references the snapshot bucket and creates the sandbox file-sync IRSA role/policy. Existing buckets use `create_bucket=false`. |
-| Node-group security-group composition | Covered | The Terraform sandbox node group carries both the shared node SG and EKS primary cluster SG. Migrated manual node groups should be checked for the same SG shape. |
+| Node-group security-group composition | Covered | The Terraform sandbox node group uses the upstream shared node SG, matching regular managed node groups while avoiding duplicate `kubernetes.io/cluster/<name>`-tagged SGs on the same nodes. Migrated manual node groups should be checked for the same invariant. |
 | Node-group metadata-service hardening | Covered | The Terraform sandbox node group enforces IMDSv2 and hop-limit 1. Migrated manual node groups should match before relying on them. |
 | Network firewall defense-in-depth | Not codified here | Still valid. This requires regional network-firewall resources, dedicated firewall subnets, sandbox-subnet route-table updates, RFC1918/metadata denies, and managed threat-intel rules. Track and land independently. |
 

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -1,7 +1,8 @@
-# Onyx Craft on a fresh EKS cluster
+# Onyx Craft on EKS: infrastructure and migration runbook
 
-How to stand up Onyx + Craft on a brand-new EKS cluster (single-tenant model: managed RDS +
-ElastiCache + OpenSearch + S3), and the chart/terraform changes that make it work out of the box.
+How to stand up Onyx + Craft on a brand-new EKS cluster, and how to migrate existing
+manual Craft/EKS setups onto the codified Terraform + Helm path. This assumes a
+single-tenant model with managed RDS, ElastiCache, OpenSearch, and S3.
 
 Validated end-to-end on `roshan-craft-test` (us-west-2): `terraform apply` + `helm install` →
 Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node steps.
@@ -35,39 +36,124 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 | workload role ARN | `serviceAccount.annotations` (recommended) |
 
 > ⚠️ The one currently-blurred boundary: today the **eks module also creates the `onyx` namespace + the
-> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §3) is to move
+> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §5) is to move
 > both to Helm (`--create-namespace` + `serviceAccount.create`/`annotations`), leaving terraform with AWS only.
 
-## 1. Changes to ship (product repo)
+## 1. What Craft adds
 
-All backward-compatible — every new variable defaults to the prior behavior; existing consumers
-(st-dev, customers) are unaffected.
+Craft needs infrastructure that a normal Onyx deployment does not need because it
+runs untrusted code in short-lived Kubernetes pods and persists their workspace
+state through snapshots.
 
-### Terraform modules (`deployment/terraform/modules/aws/`)
+### Runtime model
 
-| File | Change | Why |
-|---|---|---|
-| `vpc/{main,variables}.tf` | `azs = slice(names, 0, min(3, len))`; add `single_nat_gateway` var | `slice(…,0,3)` crashed in 2-AZ regions; per-AZ NAT (3 EIPs) can exhaust the EIP quota |
-| `eks/outputs.tf` | Re-export `node_security_group_id`, `cluster_security_group_id` | `enable_opensearch=true` referenced them but they weren't exported (OpenSearch was broken) |
-| `eks/main.tf` | Create `kubernetes_namespace` for the IRSA SA before the SA | Fresh cluster has no `onyx` ns yet → SA create failed |
-| `eks/{main,variables}.tf` | `main_node_{min,max,desired}_size` vars (desired default 2) | One node doesn't fit the workload; autoscaler isn't relied on for initial size |
-| `eks/{main,variables}.tf` | `enable_craft_sandbox_node_group` (+ instance/min/max/desired) → node group labeled `onyx.app/workload=sandbox`, tainted `workload=sandbox:NoSchedule`, IMDSv2 `http_put_response_hop_limit=1` | Sandbox pods have a hardcoded `nodeSelector: onyx.app/workload=sandbox`; IMDS hardening keeps untrusted code off node creds |
-| `postgres/{main,variables}.tf` | `deletion_protection` + `skip_final_snapshot` vars | Were hardcoded → dev/throwaway teardown impossible |
-| `onyx/{main,variables}.tf` | Forward all of the above + `redis_instance_type`, `postgres_instance_type`, `opensearch_{zone_awareness_enabled,availability_zone_count,auto_tune_enabled}`, `cluster_endpoint_public_access_cidrs` already exposed | The product `onyx` module lagged the cloud module; couldn't run lean or single-node OpenSearch |
-| **NEW `craft_sandbox/`** | Optional S3 bucket creation (SSE, public-access-block, abort-incomplete-MPU) + IAM policy + IRSA role trust-scoped to `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`; outputs `role_arn`, `bucket_name` | Cloud-side prereqs for sandbox snapshot S3 access (was a manual console runbook). Set `create_bucket=false` to reuse an existing bucket. |
+When a Craft sandbox starts, the application code creates a sandbox pod in
+`onyx-sandboxes`. That pod has:
 
-### Helm chart (`deployment/helm/charts/onyx/`)
+- a `sandbox` container, which runs the user-facing agent/code environment;
+- a `sidecar` container, which runs the push daemon and snapshot API;
+- a shared `emptyDir` workspace mounted at `/workspace/sessions`;
+- a ConfigMap-backed proxy CA bundle;
+- a pod-level `eks.amazonaws.com/skip-containers: sandbox` annotation so IRSA
+  credentials are injected into the sidecar but not the untrusted sandbox container;
+- `nodeSelector: onyx.app/workload=sandbox`;
+- a matching `workload=sandbox:NoSchedule` toleration.
 
-| File | Change |
-|---|---|
-| **NEW `templates/sandbox-rbac.yaml`** | Gated on `ENABLE_CRAFT=true`, renders: `sandbox-file-sync` SA (IRSA `role-arn`); `onyx-sandbox-manager` Role+RoleBinding in the sandbox ns (pods, pods/exec, pods/log, services, secrets); `onyx-proxy-resolve` Role+RoleBinding in the proxy ns (services read, for SANDBOX_PROXY_HOST ClusterIP resolution). Bound to `onyx.serviceAccountName` + `craft.extraBoundServiceAccounts`. Fails fast if `craft.sandboxFileSyncRoleArn` is unset. |
-| `values.yaml` | `craft.sandboxFileSyncRoleArn` (required when Craft on) + `craft.extraBoundServiceAccounts` |
+The sandbox manager also creates a per-sandbox ClusterIP Service for opencode,
+the push daemon, and Next.js dev-server ports, plus a per-sandbox Secret for
+opencode auth/config.
 
-> These two close `docs/craft/infra/todos.md` items #1 (chart SA/RBAC) and #2 (craft_sandbox terraform).
+### AWS/Terraform additions
 
----
+| Resource | Required? | Purpose |
+|---|---:|---|
+| `modules/aws/craft_sandbox` | Yes for EKS snapshot support | Creates or references the sandbox snapshot bucket, creates the S3 IAM policy, and creates the IRSA role trusted by `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`. |
+| Sandbox snapshot S3 bucket | Yes, but may already exist | Stores workspace snapshots. Use `create_bucket=false` when migrating an existing bucket. |
+| S3 bucket hardening | Only when Terraform creates the bucket | Enables SSE, blocks public access, and aborts incomplete multipart uploads after 7 days. Existing buckets are not modified when `create_bucket=false`. |
+| `SandboxFileSyncRole-*` IAM role | Yes | Lets the sandbox file-sync ServiceAccount access the snapshot bucket without static AWS keys. |
+| S3 IAM policy | Yes | Grants `GetObject`, `PutObject`, `DeleteObject`, `AbortMultipartUpload`, and `ListBucket` on the snapshot bucket. |
+| EKS OIDC outputs | Yes | Let the `craft_sandbox` module build IRSA trust without an EKS data source, so fresh apply and destroy both work. |
+| Optional Craft sandbox node group | Strongly recommended | Gives sandbox pods dedicated, tainted, IMDS-hardened nodes. Existing labeled/tainted nodes can satisfy the same scheduling contract. |
 
-## 2. Deploy on a fresh cluster
+### Helm/Kubernetes additions
+
+| Object | Namespace | Required? | Purpose |
+|---|---|---:|---|
+| `Namespace/onyx-sandboxes` | cluster | Yes | Keeps runtime sandbox pods/services/secrets separate from app workloads. |
+| `ServiceAccount/sandbox-file-sync` | `onyx-sandboxes` | Yes on EKS | Annotated with `craft.sandboxFileSyncRoleArn`; used by sandbox pods for sidecar S3 access. |
+| `Role/onyx-sandbox-manager` | `onyx-sandboxes` | Yes | Allows the Onyx workload SA to manage sandbox pods, services, secrets, exec, and logs. |
+| `RoleBinding/onyx-sandbox-manager` | `onyx-sandboxes` | Yes | Binds sandbox-management permissions to `onyx.serviceAccountName` and `craft.extraBoundServiceAccounts`. |
+| `Role/onyx-proxy-resolve` | proxy namespace | Yes | Allows service lookup for resolving `SANDBOX_PROXY_HOST` to a ClusterIP. |
+| `RoleBinding/onyx-proxy-resolve` | proxy namespace | Yes | Binds proxy service lookup to the same workload SAs. |
+| `Deployment/onyx-sandbox-proxy` | release namespace | Yes for proxied egress | Runs the egress proxy/gate. |
+| `Service/onyx-sandbox-proxy` | release namespace | Yes for proxied egress | Stable in-cluster address for sandbox traffic. |
+| `ServiceAccount/onyx-sandbox-proxy` | release namespace | Yes for proxy | Identity used by the proxy deployment. |
+| Proxy CA `Role`/`RoleBinding` | release namespace | Yes for proxy CA | Lets the proxy read/create its CA Secret. |
+| Proxy sandbox `Role`/`RoleBinding` | `onyx-sandboxes` | Yes for proxy | Lets the proxy watch sandbox pods and write the CA ConfigMap. |
+| `NetworkPolicy/onyx-sandbox-proxy` | release namespace | Strongly recommended | Allows only the sandbox namespace to reach the proxy port. |
+| `NetworkPolicy/onyx-sandbox-push` | `onyx-sandboxes` | Strongly recommended | Allows only API server and scheduled-task worker pods to reach sandbox push/opencode/Next.js ports. |
+| `PodDisruptionBudget/onyx-sandbox-proxy` | release namespace | Availability only | Keeps multi-replica proxy deployments from voluntary disruption all at once. |
+
+### Helm values added by this PR
+
+| Value | Required? | Meaning |
+|---|---:|---|
+| `craft.sandboxFileSyncRoleArn` | Yes when `ENABLE_CRAFT=true` on EKS | The `craft_sandbox.role_arn` Terraform output; annotated onto `sandbox-file-sync`. |
+| `craft.extraBoundServiceAccounts` | Only for additional managers | Extra release-namespace ServiceAccounts that should manage sandboxes. |
+| `sandboxProxy.*` | Existing Craft proxy config | Controls sandbox proxy replicas, ports, resources, CA names, scheduling, and security context. |
+
+## 2. How the sandbox node group works
+
+The sandbox node group is an optional EKS managed node group dedicated to Craft
+sandbox pods. It is enabled with:
+
+```hcl
+enable_craft_sandbox_node_group = true
+```
+
+Terraform creates a node group with:
+
+```yaml
+labels:
+  onyx.app/workload: sandbox
+taints:
+  - key: workload
+    value: sandbox
+    effect: NO_SCHEDULE
+```
+
+The sandbox manager creates every sandbox pod with:
+
+```yaml
+nodeSelector:
+  onyx.app/workload: sandbox
+tolerations:
+  - key: workload
+    operator: Equal
+    value: sandbox
+    effect: NoSchedule
+```
+
+That means:
+
+- sandbox pods can only schedule onto nodes labeled `onyx.app/workload=sandbox`;
+- normal Onyx pods cannot schedule onto the sandbox nodes because they do not
+  tolerate `workload=sandbox:NoSchedule`;
+- existing manually created nodes can work if they have the same label and taint;
+- the Terraform node group is the repeatable/codified version of that manual setup.
+
+The node group also sets:
+
+```hcl
+http_tokens                 = "required"
+http_put_response_hop_limit = 1
+```
+
+This hardens access to EC2 Instance Metadata Service. It is not what gives the
+sidecar S3 permissions; IRSA does that. It is defense-in-depth so untrusted code
+cannot easily reach node metadata credentials.
+
+## 3. Deploy on a fresh cluster
 
 Prereqs: `terraform` (HashiCorp tap), `kubectl`, `helm`, `aws`. AWS auth via SSO — before every
 terraform/aws command (SSO static-key shadow + ~daily token expiry):
@@ -97,9 +183,29 @@ helm upgrade --install onyx . -n onyx -f <values> \
 # 5. kubectl port-forward -n onyx svc/onyx-nginx-controller 8080:80  → http://localhost:8080
 ```
 
-For a migration that already has a sandbox snapshot bucket, pass that bucket name to
-`craft_sandbox.bucket_name` and set `craft_sandbox.create_bucket=false`. The module will still
-create the file-sync IAM role and policy for that bucket; it will not create or manage the bucket.
+Example root-module shape for the Craft-specific Terraform:
+
+```hcl
+module "craft_sandbox" {
+  source = "../modules/aws/craft_sandbox"
+
+  cluster_name      = module.onyx.cluster_name
+  oidc_provider_arn = module.onyx.oidc_provider_arn
+  oidc_provider     = module.onyx.oidc_provider
+
+  bucket_name   = "<sandbox-snapshot-bucket>"
+  create_bucket = true
+  tags          = local.merged_tags
+}
+
+output "sandbox_file_sync_role_arn" {
+  value = module.craft_sandbox.role_arn
+}
+
+output "sandbox_snapshot_bucket_name" {
+  value = module.craft_sandbox.bucket_name
+}
+```
 
 ### Required managed-service wiring (chart `configMap`)
 Point at the terraform endpoints; disable in-cluster deps:
@@ -116,7 +222,166 @@ Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default 
 
 ---
 
-## 3. Remaining work (not codified)
+## 4. Migrating an existing manual Craft/EKS setup
+
+Existing setups usually already have some combination of: a snapshot bucket, an
+IAM role, a manually annotated ServiceAccount, sandbox RBAC, and manually
+labeled/tainted sandbox nodes. The migration is to make Terraform own AWS/IAM
+and Helm own Kubernetes objects without changing the runtime contract.
+
+### Existing snapshot bucket
+
+Do not recreate the bucket. Configure:
+
+```hcl
+module "craft_sandbox" {
+  source = "../modules/aws/craft_sandbox"
+
+  cluster_name      = module.onyx.cluster_name
+  oidc_provider_arn = module.onyx.oidc_provider_arn
+  oidc_provider     = module.onyx.oidc_provider
+
+  bucket_name   = "<existing-bucket>"
+  create_bucket = false
+  tags          = local.merged_tags
+}
+```
+
+With `create_bucket=false`, Terraform does not create or modify the bucket. It
+still creates the IAM policy and IRSA role that allow `sandbox-file-sync` to use
+that bucket. Then pass both pieces to Helm:
+
+```bash
+helm upgrade --install onyx deployment/helm/charts/onyx \
+  -n onyx \
+  -f your-values.yaml \
+  --set craft.sandboxFileSyncRoleArn="$(terraform output -raw sandbox_file_sync_role_arn)" \
+  --set configMap.SANDBOX_S3_BUCKET="<existing-bucket>"
+```
+
+Until these chart changes are released, deploy from the local chart path
+(`deployment/helm/charts/onyx`). Do not edit chart templates manually; set values.
+
+### Existing manual sandbox node group
+
+Craft does not require the Terraform-created node group specifically. It requires
+nodes that satisfy the sandbox pod scheduling contract:
+
+```bash
+kubectl get nodes -l onyx.app/workload=sandbox
+kubectl describe node <sandbox-node> | rg 'Taints|workload=sandbox'
+```
+
+If the existing node group already has:
+
+- label `onyx.app/workload=sandbox`;
+- taint `workload=sandbox:NoSchedule`;
+- acceptable IMDS hardening;
+
+then leave `enable_craft_sandbox_node_group=false` and keep using those nodes.
+If you want Terraform to own the node group, either import the existing node
+group into Terraform state or create a Terraform-managed node group with a
+non-conflicting name and drain/remove the manual one after sandboxes move.
+
+Do not enable the Terraform node group with the same name as an existing manual
+node group unless you are intentionally importing that resource. Otherwise the
+apply can fail or create duplicate capacity.
+
+### Existing manual Kubernetes objects
+
+The chart now owns these Kubernetes objects when `ENABLE_CRAFT=true`:
+
+- `namespace/onyx-sandboxes`;
+- `serviceaccount/sandbox-file-sync`;
+- `role/onyx-sandbox-manager`;
+- `rolebinding/onyx-sandbox-manager`;
+- `role/onyx-proxy-resolve`;
+- `rolebinding/onyx-proxy-resolve`;
+- sandbox proxy ServiceAccount, Roles, RoleBindings, Deployment, Service, PDB,
+  and NetworkPolicy;
+- sandbox push/proxy NetworkPolicies.
+
+If those objects were created manually, Helm may refuse to install because they
+lack Helm ownership metadata. Prefer a maintenance window where no sandboxes are
+running, then replace the manual objects with chart-managed ones:
+
+```bash
+kubectl -n onyx-sandboxes get pods,svc,secret
+kubectl -n onyx-sandboxes delete role onyx-sandbox-manager --ignore-not-found
+kubectl -n onyx-sandboxes delete rolebinding onyx-sandbox-manager --ignore-not-found
+kubectl -n onyx-sandboxes delete serviceaccount sandbox-file-sync --ignore-not-found
+kubectl -n onyx delete role onyx-proxy-resolve --ignore-not-found
+kubectl -n onyx delete rolebinding onyx-proxy-resolve --ignore-not-found
+helm upgrade --install onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml ...
+```
+
+If you cannot delete the objects, you can adopt them into Helm by adding the
+standard Helm ownership labels/annotations, but deletion and recreation is
+usually simpler for RBAC/ServiceAccount objects. Do not delete active sandbox
+pods or their Services in the middle of a user turn.
+
+### Existing manually annotated `sandbox-file-sync` ServiceAccount
+
+The chart recreates/updates `sandbox-file-sync` with:
+
+```yaml
+annotations:
+  eks.amazonaws.com/role-arn: <craft.sandboxFileSyncRoleArn>
+```
+
+The `skip-containers` annotation belongs on the sandbox pod, not the
+ServiceAccount. The runtime pod metadata sets:
+
+```yaml
+eks.amazonaws.com/skip-containers: sandbox
+```
+
+so the sidecar receives IRSA credentials and the untrusted sandbox container does
+not.
+
+### Existing published-chart install
+
+If the published `onyx/onyx` Helm chart does not yet include this PR, install or
+upgrade from the local chart in this branch:
+
+```bash
+helm dependency build deployment/helm/charts/onyx
+helm upgrade --install onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml ...
+```
+
+This is a chart-source change, not a values-only change against the old
+published chart. Setting `craft.sandboxFileSyncRoleArn` against a chart version
+that does not contain `templates/sandbox-rbac.yaml` will not create the missing
+RBAC/ServiceAccount objects.
+
+### Post-migration checks
+
+```bash
+# Terraform outputs exist.
+terraform output sandbox_file_sync_role_arn
+terraform output sandbox_snapshot_bucket_name
+
+# Helm renders the Craft objects.
+helm template onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml \
+  --set craft.sandboxFileSyncRoleArn="$(terraform output -raw sandbox_file_sync_role_arn)" \
+  --show-only templates/sandbox-rbac.yaml
+
+# Workload SA can manage sandboxes.
+kubectl auth can-i create pods -n onyx-sandboxes \
+  --as system:serviceaccount:onyx:onyx-workload-access
+kubectl auth can-i create pods/exec -n onyx-sandboxes \
+  --as system:serviceaccount:onyx:onyx-workload-access
+kubectl auth can-i get services -n onyx \
+  --as system:serviceaccount:onyx:onyx-workload-access
+
+# Sandbox nodes exist if using dedicated scheduling.
+kubectl get nodes -l onyx.app/workload=sandbox
+
+# The sandbox file-sync SA has the IRSA role annotation.
+kubectl -n onyx-sandboxes get sa sandbox-file-sync -o yaml | rg 'eks.amazonaws.com/role-arn'
+```
+
+## 5. Remaining work (not codified)
 
 - **cluster-autoscaler** doesn't scale managed node groups: node groups lack the discovery tags
   (`k8s.io/cluster-autoscaler/enabled`, `…/<cluster>`) and the addon (eks-blueprints 1.16.3) ClusterRole
@@ -150,7 +415,7 @@ Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default 
 
 ---
 
-## 4. Notes / gotchas (condensed)
+## 6. Notes / gotchas (condensed)
 
 - us-west-1 has only 2 AZs (→ the slice fix). Shared account near the EIP quota → use `single_nat_gateway=true`.
 - The `vespa` node group is vestigial in v4.0 (OpenSearch replaced Vespa) — size it small or make it optional.
@@ -169,7 +434,7 @@ Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default 
 
 ---
 
-## 5. Test harness (this validation — not for the PR)
+## 7. Test harness (this validation — not for the PR)
 
 `deployment/terraform/craft-test/` (root module + `secrets.auto.tfvars`, gitignored) and
 `deployment/helm/values-craft-test.yaml` are the throwaway test instance used to validate the above.

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -21,7 +21,7 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 
 **Helm** (`deployment/helm/charts/onyx`) creates ONLY Kubernetes objects:
 - All in-cluster workloads (api, web, nginx, celery, model servers, code-interpreter, **sandbox-proxy**).
-- The **`onyx-sandboxes`** namespace + **`sandbox-file-sync` SA** + sandbox RBAC (`onyx-sandbox-manager`, `onyx-proxy-resolve`) — `templates/sandbox-rbac.yaml`.
+- The **`onyx-sandboxes`** namespace (`templates/sandbox-namespace.yaml`) + **`sandbox-file-sync` SA** + sandbox RBAC (`onyx-sandbox-manager`, `onyx-proxy-resolve`) (`templates/sandbox-rbac.yaml`).
 - `configMap` + secrets that **point the app at the terraform-created endpoints** (POSTGRES_HOST, REDIS_HOST, OpenSearch host, S3 buckets) and carry the IRSA role ARNs.
 
 **Neither crosses over:** Terraform never deploys app workloads or app RBAC; Helm never creates AWS resources — it only *references* them via values you pass from terraform outputs.
@@ -36,8 +36,9 @@ Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node 
 | workload role ARN | `serviceAccount.annotations` (recommended) |
 
 > ⚠️ The one currently-blurred boundary: today the **eks module also creates the `onyx` namespace + the
-> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §5) is to move
+> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §6) is to move
 > both to Helm (`--create-namespace` + `serviceAccount.create`/`annotations`), leaving terraform with AWS only.
+> This is tracked under the remaining-work section.
 
 ## 1. What Craft adds
 
@@ -73,7 +74,7 @@ opencode auth/config.
 | `SandboxFileSyncRole-*` IAM role | Yes | Lets the sandbox file-sync ServiceAccount access the snapshot bucket without static AWS keys. |
 | S3 IAM policy | Yes | Grants `GetObject`, `PutObject`, `DeleteObject`, `AbortMultipartUpload`, and `ListBucket` on the snapshot bucket. |
 | EKS OIDC outputs | Yes | Let the `craft_sandbox` module build IRSA trust without an EKS data source, so fresh apply and destroy both work. |
-| Optional Craft sandbox node group | Strongly recommended | Gives sandbox pods dedicated, tainted, IMDS-hardened nodes. Existing labeled/tainted nodes can satisfy the same scheduling contract. |
+| Optional Craft sandbox node group | Strongly recommended | Gives sandbox pods dedicated, tainted, IMDS-hardened nodes. Existing labeled/tainted nodes can satisfy the same scheduling contract. The Terraform node group attaches both the shared node SG and EKS primary cluster SG. |
 
 ### Helm/Kubernetes additions
 
@@ -152,6 +153,13 @@ http_put_response_hop_limit = 1
 This hardens access to EC2 Instance Metadata Service. It is not what gives the
 sidecar S3 permissions; IRSA does that. It is defense-in-depth so untrusted code
 cannot easily reach node metadata credentials.
+
+Security-group composition matters too. Regular managed node groups get the
+shared node security group from the upstream EKS module. The sandbox node group
+also sets `attach_cluster_primary_security_group=true`, so its launch template
+gets both the shared node SG and the EKS primary cluster SG. That keeps sandbox
+nodes on the same in-cluster connectivity footing as the regular node groups
+while still separating scheduling with labels/taints.
 
 ## 3. Deploy on a fresh cluster
 
@@ -277,6 +285,8 @@ If the existing node group already has:
 - label `onyx.app/workload=sandbox`;
 - taint `workload=sandbox:NoSchedule`;
 - acceptable IMDS hardening;
+- the same security-group shape as regular managed node groups: shared node SG
+  plus EKS primary cluster SG;
 
 then leave `enable_craft_sandbox_node_group=false` and keep using those nodes.
 If you want Terraform to own the node group, either import the existing node
@@ -351,7 +361,8 @@ helm upgrade --install onyx deployment/helm/charts/onyx -n onyx -f your-values.y
 
 This is a chart-source change, not a values-only change against the old
 published chart. Setting `craft.sandboxFileSyncRoleArn` against a chart version
-that does not contain `templates/sandbox-rbac.yaml` will not create the missing
+that does not contain `templates/sandbox-namespace.yaml` and
+`templates/sandbox-rbac.yaml` will not create the missing namespace,
 RBAC/ServiceAccount objects.
 
 ### Post-migration checks
@@ -362,6 +373,9 @@ terraform output sandbox_file_sync_role_arn
 terraform output sandbox_snapshot_bucket_name
 
 # Helm renders the Craft objects.
+helm template onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml \
+  --set craft.sandboxFileSyncRoleArn="$(terraform output -raw sandbox_file_sync_role_arn)" \
+  --show-only templates/sandbox-namespace.yaml
 helm template onyx deployment/helm/charts/onyx -n onyx -f your-values.yaml \
   --set craft.sandboxFileSyncRoleArn="$(terraform output -raw sandbox_file_sync_role_arn)" \
   --show-only templates/sandbox-rbac.yaml
@@ -381,7 +395,19 @@ kubectl get nodes -l onyx.app/workload=sandbox
 kubectl -n onyx-sandboxes get sa sandbox-file-sync -o yaml | rg 'eks.amazonaws.com/role-arn'
 ```
 
-## 5. Remaining work (not codified)
+## 5. Lead infra TODO coverage
+
+The lead infra TODO list in `docs/craft/infra/todos.md` is accounted for as:
+
+| TODO | Status in this PR | Operational note |
+|---|---|---|
+| Helm sandbox namespace RBAC + ServiceAccount | Covered | Helm owns `onyx-sandboxes` via `sandbox-namespace.yaml`, then owns `sandbox-file-sync`, sandbox manager RBAC, and proxy service lookup RBAC via `sandbox-rbac.yaml` when Craft is enabled. |
+| Terraform sandbox object store + workload identity | Covered | `craft_sandbox` creates/references the snapshot bucket and creates the sandbox file-sync IRSA role/policy. Existing buckets use `create_bucket=false`. |
+| Node-group security-group composition | Covered | The Terraform sandbox node group carries both the shared node SG and EKS primary cluster SG. Migrated manual node groups should be checked for the same SG shape. |
+| Node-group metadata-service hardening | Covered | The Terraform sandbox node group enforces IMDSv2 and hop-limit 1. Migrated manual node groups should match before relying on them. |
+| Network firewall defense-in-depth | Not codified here | Still valid. This requires regional network-firewall resources, dedicated firewall subnets, sandbox-subnet route-table updates, RFC1918/metadata denies, and managed threat-intel rules. Track and land independently. |
+
+## 6. Remaining work (not codified)
 
 - **cluster-autoscaler** doesn't scale managed node groups: node groups lack the discovery tags
   (`k8s.io/cluster-autoscaler/enabled`, `…/<cluster>`) and the addon (eks-blueprints 1.16.3) ClusterRole
@@ -415,7 +441,7 @@ kubectl -n onyx-sandboxes get sa sandbox-file-sync -o yaml | rg 'eks.amazonaws.c
 
 ---
 
-## 6. Notes / gotchas (condensed)
+## 7. Notes / gotchas (condensed)
 
 - us-west-1 has only 2 AZs (→ the slice fix). Shared account near the EIP quota → use `single_nat_gateway=true`.
 - The `vespa` node group is vestigial in v4.0 (OpenSearch replaced Vespa) — size it small or make it optional.
@@ -434,7 +460,7 @@ kubectl -n onyx-sandboxes get sa sandbox-file-sync -o yaml | rg 'eks.amazonaws.c
 
 ---
 
-## 7. Test harness (this validation — not for the PR)
+## 8. Test harness (this validation — not for the PR)
 
 `deployment/terraform/craft-test/` (root module + `secrets.auto.tfvars`, gitignored) and
 `deployment/helm/values-craft-test.yaml` are the throwaway test instance used to validate the above.

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -1,0 +1,201 @@
+# Onyx Craft on a fresh EKS cluster
+
+How to stand up Onyx + Craft on a brand-new EKS cluster (single-tenant model: managed RDS +
+ElastiCache + OpenSearch + S3), and the chart/terraform changes that make it work out of the box.
+
+Validated end-to-end on `roshan-craft-test` (us-west-2): `terraform apply` + `helm install` →
+Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node steps.
+
+---
+
+## 0. Terraform vs Helm — who creates what
+
+**Clean seam: Terraform = AWS infrastructure; Helm = everything inside Kubernetes. Terraform's outputs are Helm's inputs.**
+
+**Terraform** (`deployment/terraform/…`) creates ONLY AWS resources:
+- VPC / subnets / NAT; EKS **cluster** + **node groups** (main, vespa, **sandbox** — labeled/tainted/IMDSv2) + the **OIDC provider**; EKS add-ons + gp3 storage class.
+- Managed data stores: **RDS** (Postgres), **ElastiCache** (Redis), **OpenSearch** domain; **S3** buckets (file-store + sandbox snapshots); **WAF**.
+- IAM/IRSA **roles**: the workload role (S3/RDS) + `SandboxFileSyncRole` (`craft_sandbox` module).
+- **Outputs** (the only thing Helm consumes): cluster name, RDS/Redis/OpenSearch endpoints, S3 bucket names, the IRSA **role ARNs**, the OIDC provider ARN/URL.
+
+**Helm** (`deployment/helm/charts/onyx`) creates ONLY Kubernetes objects:
+- All in-cluster workloads (api, web, nginx, celery, model servers, code-interpreter, **sandbox-proxy**).
+- The **`onyx-sandboxes`** namespace + **`sandbox-file-sync` SA** + sandbox RBAC (`onyx-sandbox-manager`, `onyx-proxy-resolve`) — `templates/sandbox-rbac.yaml`.
+- `configMap` + secrets that **point the app at the terraform-created endpoints** (POSTGRES_HOST, REDIS_HOST, OpenSearch host, S3 buckets) and carry the IRSA role ARNs.
+
+**Neither crosses over:** Terraform never deploys app workloads or app RBAC; Helm never creates AWS resources — it only *references* them via values you pass from terraform outputs.
+
+**The handoff (terraform output → helm value):**
+| terraform output | helm value / use |
+|---|---|
+| `cluster_name` | `aws eks update-kubeconfig` (then helm targets the cluster) |
+| `postgres_endpoint` / redis / `opensearch_endpoint` | `configMap.POSTGRES_HOST` / `REDIS_HOST` / `OPENSEARCH_HOST` |
+| file-store + sandbox bucket names | `configMap.S3_FILE_STORE_BUCKET_NAME` / `SANDBOX_S3_BUCKET` |
+| `sandbox_file_sync_role_arn` (craft_sandbox) | `craft.sandboxFileSyncRoleArn` → sandbox SA annotation |
+| workload role ARN | `serviceAccount.annotations` (recommended) |
+
+> ⚠️ The one currently-blurred boundary: today the **eks module also creates the `onyx` namespace + the
+> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §3) is to move
+> both to Helm (`--create-namespace` + `serviceAccount.create`/`annotations`), leaving terraform with AWS only.
+
+## 1. Changes to ship (product repo)
+
+All backward-compatible — every new variable defaults to the prior behavior; existing consumers
+(st-dev, customers) are unaffected.
+
+### Terraform modules (`deployment/terraform/modules/aws/`)
+
+| File | Change | Why |
+|---|---|---|
+| `vpc/{main,variables}.tf` | `azs = slice(names, 0, min(3, len))`; add `single_nat_gateway` var | `slice(…,0,3)` crashed in 2-AZ regions; per-AZ NAT (3 EIPs) can exhaust the EIP quota |
+| `eks/outputs.tf` | Re-export `node_security_group_id`, `cluster_security_group_id` | `enable_opensearch=true` referenced them but they weren't exported (OpenSearch was broken) |
+| `eks/main.tf` | Create `kubernetes_namespace` for the IRSA SA before the SA | Fresh cluster has no `onyx` ns yet → SA create failed |
+| `eks/{main,variables}.tf` | `main_node_{min,max,desired}_size` vars (desired default 2) | One node doesn't fit the workload; autoscaler isn't relied on for initial size |
+| `eks/{main,variables}.tf` | `enable_craft_sandbox_node_group` (+ instance/min/max/desired) → node group labeled `onyx.app/workload=sandbox`, tainted `workload=sandbox:NoSchedule`, IMDSv2 `http_put_response_hop_limit=1` | Sandbox pods have a hardcoded `nodeSelector: onyx.app/workload=sandbox`; IMDS hardening keeps untrusted code off node creds |
+| `postgres/{main,variables}.tf` | `deletion_protection` + `skip_final_snapshot` vars | Were hardcoded → dev/throwaway teardown impossible |
+| `onyx/{main,variables}.tf` | Forward all of the above + `redis_instance_type`, `postgres_instance_type`, `opensearch_{zone_awareness_enabled,availability_zone_count,auto_tune_enabled}`, `cluster_endpoint_public_access_cidrs` already exposed | The product `onyx` module lagged the cloud module; couldn't run lean or single-node OpenSearch |
+| **NEW `craft_sandbox/`** | S3 bucket (SSE, public-access-block, abort-incomplete-MPU) + IAM policy + IRSA role trust-scoped to `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`; outputs `role_arn`, `bucket_name` | Cloud-side prereqs for sandbox snapshot S3 access (was a manual console runbook) |
+
+### Helm chart (`deployment/helm/charts/onyx/`)
+
+| File | Change |
+|---|---|
+| **NEW `templates/sandbox-rbac.yaml`** | Gated on `ENABLE_CRAFT=true`, renders: `sandbox-file-sync` SA (IRSA `role-arn` + `skip-containers=sandbox`); `onyx-sandbox-manager` Role+RoleBinding in the sandbox ns (pods/exec/attach/portforward/log, services, configmaps, secrets, pvc); `onyx-proxy-resolve` Role+RoleBinding in the proxy ns (services/endpoints read, for SANDBOX_PROXY_HOST ClusterIP resolution). Bound to `onyx.serviceAccountName` + `craft.extraBoundServiceAccounts`. Fails fast if `craft.sandboxFileSyncRoleArn` is unset. |
+| `values.yaml` | `craft.sandboxFileSyncRoleArn` (required when Craft on) + `craft.extraBoundServiceAccounts` |
+
+> These two close `docs/craft/infra/todos.md` items #1 (chart SA/RBAC) and #2 (craft_sandbox terraform).
+
+---
+
+## 2. Deploy on a fresh cluster
+
+Prereqs: `terraform` (HashiCorp tap), `kubectl`, `helm`, `aws`. AWS auth via SSO — before every
+terraform/aws command (SSO static-key shadow + ~daily token expiry):
+```bash
+aws login   # or: aws sso login --sso-session <session>
+eval "$(aws configure export-credentials --profile <profile> --format env)"; unset AWS_PROFILE
+```
+
+```bash
+# 1. Infra (root module instantiates modules/aws/onyx + modules/aws/craft_sandbox)
+cd deployment/terraform/<root>
+terraform init && terraform apply           # ~25-35 min (RDS + OpenSearch are the long poles)
+
+# 2. kubeconfig
+aws eks update-kubeconfig --name $(terraform output -raw cluster_name) --region <region>
+
+# 3. App (point chart configMap at the managed-service endpoints from terraform outputs)
+cd ../../helm/charts/onyx && helm dependency build
+helm upgrade --install onyx . -n onyx -f <values> \
+  --set craft.sandboxFileSyncRoleArn="$(terraform -chdir=<root> output -raw sandbox_file_sync_role_arn)" \
+  --set auth.postgresql.values.password=<rds pw> \
+  --set auth.userauth.values.user_auth_secret="$(openssl rand -hex 32)" \
+  --set configMap.OPENSEARCH_ADMIN_PASSWORD=<opensearch pw> \
+  --set auth.sandboxPushSecret.values.private_key="$(<gen ed25519, see values.yaml comment>)"
+
+# 4. Runtime app config (UI): register first user (becomes admin), add an LLM provider.
+# 5. kubectl port-forward -n onyx svc/onyx-nginx-controller 8080:80  → http://localhost:8080
+```
+
+### Required managed-service wiring (chart `configMap`)
+Point at the terraform endpoints; disable in-cluster deps:
+- `postgresql.enabled/redis.enabled/opensearch.enabled/minio.enabled: false`; `serviceAccount.name: onyx-workload-access` (IRSA), `auth.objectstorage.enabled: false`.
+- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
+- OpenSearch (v4.0 search backend): `ONYX_DISABLE_VESPA=true`, `ENABLE_OPENSEARCH_INDEXING/RETRIEVAL_FOR_ONYX=true`, `USING_AWS_MANAGED_OPENSEARCH=true`, `OPENSEARCH_REST_API_PORT=443`, `OPENSEARCH_USE_SSL=true`, `OPENSEARCH_ADMIN_USERNAME=admin`.
+- S3: `S3_FILE_STORE_BUCKET_NAME`, `S3_ENDPOINT_URL=""`, `AWS_REGION_NAME`.
+- Craft: `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080`, `SANDBOX_S3_BUCKET`, `auth.sandboxPushSecret.enabled=true`. (`SANDBOX_SERVICE_ACCOUNT_NAME`/`SANDBOX_CONTAINER_IMAGE` default correctly.)
+
+### Images
+`global.version: craft-edge` (backend/web/model-server — the moving Craft build; stable v4.0.x has no
+Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default tracks the current
+`onyxdotapp/sandbox:vX.Y.Z`.
+
+---
+
+## 3. Remaining work (not codified)
+
+- **cluster-autoscaler** doesn't scale managed node groups: node groups lack the discovery tags
+  (`k8s.io/cluster-autoscaler/enabled`, `…/<cluster>`) and the addon (eks-blueprints 1.16.3) ClusterRole
+  lacks `volumeattachments` on k8s 1.33. Workaround = pre-sized node groups (`desired`). Real fix = add
+  discovery tags + bump the autoscaler chart.
+- **Workload IRSA SA → chart-owned (refactor).** The `eks` module creates the `onyx-workload-access`
+  SA (and its namespace) directly, which couples terraform to the app namespace and forces a
+  `helm uninstall` before `terraform destroy` (else the namespace deletion hangs on helm finalizers).
+  Cleaner: terraform outputs only the workload role ARN; Helm owns the SA + namespace via
+  `serviceAccount.create=true` + `serviceAccount.annotations.{eks.amazonaws.com/role-arn}` +
+  `--create-namespace` (the chart already supports all three). This mirrors how the sandbox SA already
+  works (`craft.sandboxFileSyncRoleArn`) and removes the terraform namespace/SA creation entirely.
+- **`craft_sandbox` module** should keep taking OIDC (`oidc_provider_arn`/`oidc_provider`) as inputs,
+  NOT via `data.aws_eks_cluster` — the data-source form breaks both fresh apply (cluster not created yet)
+  and destroy (cluster gone). (Already fixed; noted so it isn't reverted.)
+- **SECURITY — `skip-containers` on the SA is silently ignored; the untrusted sandbox container holds the
+  file-sync IRSA.** `sandbox-rbac.yaml` puts `eks.amazonaws.com/skip-containers: sandbox` on the
+  `sandbox-file-sync` **ServiceAccount** to keep AWS creds out of the agent (`sandbox`) container. But the
+  `amazon-eks-pod-identity-webhook` reads `skip-containers` from the **pod annotation**, NOT the SA — while
+  it reads `role-arn` from the SA (which is why injection happened). The sandbox manager builds the pod with
+  no annotations, so `skip-containers` never reaches the webhook → `AWS_ROLE_ARN` + the projected token land
+  in **both** containers. Confirmed by a controlled 2-container pod: with `skip-containers` on the *pod*, the
+  listed container got no creds and the other did. Net: agent code in the sandbox can assume
+  `SandboxFileSyncRole` and read/write/delete the whole snapshot bucket. **Fix:** set the annotation on the
+  POD in `kubernetes_sandbox_manager.py` (`V1ObjectMeta`, ~L800): `annotations={"eks.amazonaws.com/
+  skip-containers": "sandbox"}`. (The SA-level annotation is dead weight for this — keep or drop.)
+  Defense-in-depth (per-tenant prefix-scoped IAM) was weighed and **deferred as overkill**: once the token
+  no longer reaches the untrusted container, the bucket-wide policy is only exploitable by compromising the
+  trusted sidecar itself. Scoping per-identity isn't a policy edit anyway — all sandboxes share one role, so
+  it needs per-tenant roles or EKS Pod Identity + ABAC. Revisit for **MT cloud** if cross-tenant isolation
+  guarantees are required.
+- **SECURITY — egress proxy is allow-all without a catalog, and forwards link-local IMDS.** The
+  `sandbox-proxy` gate logs every request as `policy=off_catalog` and forwards it (verified: `example.com`
+  returned the real page; `registry.npmjs.org`/`api.openai.com` → 200). It also forwards `169.254.169.254`
+  (IMDS) and `sts.us-west-2.amazonaws.com`. The node-level IMDSv2 `hop_limit=1` blocks *direct* IMDS from a
+  sandbox pod (verified: direct `curl` times out, exit 7), but the proxy runs on main nodes (`hop_limit=2`)
+  and is an alternate path to node metadata. Hardening: (1) hard-deny link-local/metadata (`169.254.0.0/16`,
+  `fd00:ec2::254`) at the proxy regardless of catalog; (2) configure the egress catalog so off-catalog
+  defaults to **deny** in prod (today an unconfigured catalog = allow-all monitor mode).
+- **BUG — idle-cleanup reaps a sandbox mid-turn → wedged session.** `cleanup_idle_sandboxes` sleeps a
+  sandbox judged idle (heartbeat-only) even with a turn in flight → deletes its Service → api-server
+  `event_bus` loops on `Name or service not known` (UI freeze), AND the in-flight turn's Redis lock
+  `buildpromptslot_{sandbox}_{session}` is left held → after revive, new turns are refused
+  (`prompt_slot: concurrent turn in flight`) until the 900s TTL. Fixes: (1) exclude sandboxes holding a
+  buildpromptslot lock from idle reaping; (2) release the lock on sleep; (3) make the event_bus
+  sleep-aware (stop/auto-revive instead of infinite DNS retry); (4) heartbeat for the duration of a turn.
+
+---
+
+## 4. Notes / gotchas (condensed)
+
+- us-west-1 has only 2 AZs (→ the slice fix). Shared account near the EIP quota → use `single_nat_gateway=true`.
+- The `vespa` node group is vestigial in v4.0 (OpenSearch replaced Vespa) — size it small or make it optional.
+- `cluster_endpoint_public_access_cidrs=[]` causes a perpetual no-op diff AWS rejects — set explicitly (e.g. `["0.0.0.0/0"]`).
+- Codified chart/terraform changes live in the **local** chart, not the published `onyx/onyx` — install from `.` until released.
+- LLM provider: configure via admin UI (encrypted in DB) — never `GEN_AI_API_KEY` in a ConfigMap.
+- S3 buckets deliberately have no `force_destroy` (so `terraform destroy` can never wipe real snapshot/
+  file-store data). To tear down an *ephemeral* cluster, `aws s3 rm` the buckets first, then destroy.
+- `sandbox-proxy` is a DB/Redis client, not just a forward proxy: its `gate.py` resolves tenant / sandbox /
+  egress-policy from **RDS** (and uses **Redis**) on every request, so it needs the same managed-service
+  wiring + network reachability as the app pods. Verified: proxy node SG → RDS:5432 path open and an
+  authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved per request.
+- Teardown order/gotchas: `helm uninstall` before `terraform destroy` (else the `onyx` namespace hangs on
+  finalizers). The VPC CNI can leave orphaned `available` `aws-K8S-*` ENIs that pin the node SG/subnets →
+  `destroy` hangs ~15 min then fails on `DependencyViolation`; delete those ENIs, then re-run destroy.
+
+---
+
+## 5. Test harness (this validation — not for the PR)
+
+`deployment/terraform/craft-test/` (root module + `secrets.auto.tfvars`, gitignored) and
+`deployment/helm/values-craft-test.yaml` are the throwaway test instance used to validate the above.
+Lean sizing: `cache.t4g.micro` Redis, `db.t4g.small` Postgres, `m7i.xlarge` main (desired 3),
+single-node `t3.medium.search` OpenSearch, `m5.large` sandbox node, single NAT gateway.
+
+**Validated:** snapshot create → S3 (`{tenant}/snapshots/{session}/{id}.tar.gz`, source only — node_modules
+regenerated on revive) and restore-on-revive, both via the `sandbox-file-sync` IRSA against the
+`craft_sandbox` bucket; cross-replica opencode-serve session reuse (3 api replicas); chart-rendered RBAC +
+terraform sandbox node group replacing all manual steps (Validation A); full from-scratch apply+install
+(Validation B: `terraform apply` 121 resources → `helm install` from local chart → register user + LLM →
+sandbox provisions on the tainted sandbox node group → snapshot + restore, zero manual kubectl/RBAC/node).
+Also verified: direct IMDS from a sandbox pod is blocked (`hop_limit=1`); `sandbox-proxy` reaches RDS
+(authenticated query) and gates egress (DB-resolved per request); the file-sync `sidecar` IRSA reads/writes
+the bucket via `s5cmd`; **celery** runs the real `cleanup_idle_sandboxes_task` end-to-end — the worker SA
+(`onyx-workload-access`, bound to `onyx-sandbox-manager`) execs into `onyx-sandboxes`, snapshots to S3, and
+sleeps the sandbox, then the API restore re-provisions and pulls that celery-made snapshot back.

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -54,13 +54,13 @@ All backward-compatible — every new variable defaults to the prior behavior; e
 | `eks/{main,variables}.tf` | `enable_craft_sandbox_node_group` (+ instance/min/max/desired) → node group labeled `onyx.app/workload=sandbox`, tainted `workload=sandbox:NoSchedule`, IMDSv2 `http_put_response_hop_limit=1` | Sandbox pods have a hardcoded `nodeSelector: onyx.app/workload=sandbox`; IMDS hardening keeps untrusted code off node creds |
 | `postgres/{main,variables}.tf` | `deletion_protection` + `skip_final_snapshot` vars | Were hardcoded → dev/throwaway teardown impossible |
 | `onyx/{main,variables}.tf` | Forward all of the above + `redis_instance_type`, `postgres_instance_type`, `opensearch_{zone_awareness_enabled,availability_zone_count,auto_tune_enabled}`, `cluster_endpoint_public_access_cidrs` already exposed | The product `onyx` module lagged the cloud module; couldn't run lean or single-node OpenSearch |
-| **NEW `craft_sandbox/`** | S3 bucket (SSE, public-access-block, abort-incomplete-MPU) + IAM policy + IRSA role trust-scoped to `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`; outputs `role_arn`, `bucket_name` | Cloud-side prereqs for sandbox snapshot S3 access (was a manual console runbook) |
+| **NEW `craft_sandbox/`** | Optional S3 bucket creation (SSE, public-access-block, abort-incomplete-MPU) + IAM policy + IRSA role trust-scoped to `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`; outputs `role_arn`, `bucket_name` | Cloud-side prereqs for sandbox snapshot S3 access (was a manual console runbook). Set `create_bucket=false` to reuse an existing bucket. |
 
 ### Helm chart (`deployment/helm/charts/onyx/`)
 
 | File | Change |
 |---|---|
-| **NEW `templates/sandbox-rbac.yaml`** | Gated on `ENABLE_CRAFT=true`, renders: `sandbox-file-sync` SA (IRSA `role-arn` + `skip-containers=sandbox`); `onyx-sandbox-manager` Role+RoleBinding in the sandbox ns (pods/exec/attach/portforward/log, services, configmaps, secrets, pvc); `onyx-proxy-resolve` Role+RoleBinding in the proxy ns (services/endpoints read, for SANDBOX_PROXY_HOST ClusterIP resolution). Bound to `onyx.serviceAccountName` + `craft.extraBoundServiceAccounts`. Fails fast if `craft.sandboxFileSyncRoleArn` is unset. |
+| **NEW `templates/sandbox-rbac.yaml`** | Gated on `ENABLE_CRAFT=true`, renders: `sandbox-file-sync` SA (IRSA `role-arn`); `onyx-sandbox-manager` Role+RoleBinding in the sandbox ns (pods, pods/exec, pods/log, services, secrets); `onyx-proxy-resolve` Role+RoleBinding in the proxy ns (services read, for SANDBOX_PROXY_HOST ClusterIP resolution). Bound to `onyx.serviceAccountName` + `craft.extraBoundServiceAccounts`. Fails fast if `craft.sandboxFileSyncRoleArn` is unset. |
 | `values.yaml` | `craft.sandboxFileSyncRoleArn` (required when Craft on) + `craft.extraBoundServiceAccounts` |
 
 > These two close `docs/craft/infra/todos.md` items #1 (chart SA/RBAC) and #2 (craft_sandbox terraform).
@@ -97,6 +97,10 @@ helm upgrade --install onyx . -n onyx -f <values> \
 # 5. kubectl port-forward -n onyx svc/onyx-nginx-controller 8080:80  → http://localhost:8080
 ```
 
+For a migration that already has a sandbox snapshot bucket, pass that bucket name to
+`craft_sandbox.bucket_name` and set `craft_sandbox.create_bucket=false`. The module will still
+create the file-sync IAM role and policy for that bucket; it will not create or manage the bucket.
+
 ### Required managed-service wiring (chart `configMap`)
 Point at the terraform endpoints; disable in-cluster deps:
 - `postgresql.enabled/redis.enabled/opensearch.enabled/minio.enabled: false`; `serviceAccount.name: onyx-workload-access` (IRSA), `auth.objectstorage.enabled: false`.
@@ -128,22 +132,6 @@ Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default 
 - **`craft_sandbox` module** should keep taking OIDC (`oidc_provider_arn`/`oidc_provider`) as inputs,
   NOT via `data.aws_eks_cluster` — the data-source form breaks both fresh apply (cluster not created yet)
   and destroy (cluster gone). (Already fixed; noted so it isn't reverted.)
-- **SECURITY — `skip-containers` on the SA is silently ignored; the untrusted sandbox container holds the
-  file-sync IRSA.** `sandbox-rbac.yaml` puts `eks.amazonaws.com/skip-containers: sandbox` on the
-  `sandbox-file-sync` **ServiceAccount** to keep AWS creds out of the agent (`sandbox`) container. But the
-  `amazon-eks-pod-identity-webhook` reads `skip-containers` from the **pod annotation**, NOT the SA — while
-  it reads `role-arn` from the SA (which is why injection happened). The sandbox manager builds the pod with
-  no annotations, so `skip-containers` never reaches the webhook → `AWS_ROLE_ARN` + the projected token land
-  in **both** containers. Confirmed by a controlled 2-container pod: with `skip-containers` on the *pod*, the
-  listed container got no creds and the other did. Net: agent code in the sandbox can assume
-  `SandboxFileSyncRole` and read/write/delete the whole snapshot bucket. **Fix:** set the annotation on the
-  POD in `kubernetes_sandbox_manager.py` (`V1ObjectMeta`, ~L800): `annotations={"eks.amazonaws.com/
-  skip-containers": "sandbox"}`. (The SA-level annotation is dead weight for this — keep or drop.)
-  Defense-in-depth (per-tenant prefix-scoped IAM) was weighed and **deferred as overkill**: once the token
-  no longer reaches the untrusted container, the bucket-wide policy is only exploitable by compromising the
-  trusted sidecar itself. Scoping per-identity isn't a policy edit anyway — all sandboxes share one role, so
-  it needs per-tenant roles or EKS Pod Identity + ABAC. Revisit for **MT cloud** if cross-tenant isolation
-  guarantees are required.
 - **SECURITY — egress proxy is allow-all without a catalog, and forwards link-local IMDS.** The
   `sandbox-proxy` gate logs every request as `policy=off_catalog` and forwards it (verified: `example.com`
   returned the real page; `registry.npmjs.org`/`api.openai.com` → 200). It also forwards `169.254.169.254`


### PR DESCRIPTION
## Description

Codifies the infrastructure required to run **Onyx Craft** on EKS so a fresh cluster works out of the box instead of relying on manual `kubectl`/AWS console steps. The key boundary is: Terraform creates AWS resources and outputs identifiers; Helm creates Kubernetes objects and consumes those Terraform outputs as values.

All changes are gated/defaulted: no behavior change when Craft is off, and the dedicated sandbox node group is off unless `enable_craft_sandbox_node_group=true`.

## What This Adds

**Terraform / AWS**
- **New `modules/aws/craft_sandbox`**: creates or references the sandbox snapshot S3 bucket, creates the S3 IAM policy, and creates the IRSA role trusted by `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`.
- **Optional S3 bucket management**: `create_bucket=true` creates the bucket with SSE, public-access block, and abort-incomplete-multipart lifecycle. `create_bucket=false` reuses an existing bucket and creates only IAM/IRSA for it.
- **EKS OIDC outputs**: re-exported so `craft_sandbox` can build IRSA trust without a data source, which works on fresh apply and destroy.
- **Optional Craft sandbox node group**: labeled `onyx.app/workload=sandbox`, tainted `workload=sandbox:NoSchedule`, encrypted gp3 root volume, IMDSv2 required, metadata hop limit 1, and uses the upstream shared node SG without also attaching the EKS primary cluster SG.
- **`modules/aws/onyx` forwarding**: forwards the sandbox-node-group knobs and re-exports OIDC values for root-module wiring.

**Helm / Kubernetes**
- **`templates/sandbox-namespace.yaml`**: when `ENABLE_CRAFT=true`, creates the `onyx-sandboxes` namespace.
- **`templates/sandbox-rbac.yaml`**: when `ENABLE_CRAFT=true`, creates `sandbox-file-sync`, `onyx-sandbox-manager`, and `onyx-proxy-resolve` objects.
- **`sandbox-file-sync` ServiceAccount**: annotated with `craft.sandboxFileSyncRoleArn`; this is the identity used by sandbox pods for sidecar S3 snapshot access.
- **Sandbox manager RBAC**: grants the Onyx workload ServiceAccount permission in `onyx-sandboxes` to manage pods, services, secrets, pod exec, and pod logs.
- **Proxy resolve RBAC**: grants service lookup in the proxy namespace so the API can resolve `SANDBOX_PROXY_HOST` to a ClusterIP.
- **New values**: `craft.sandboxFileSyncRoleArn` and `craft.extraBoundServiceAccounts`.

The actual sandbox pods/services/secrets are still created dynamically by the application at runtime. Each sandbox pod has a `sandbox` container and a `sidecar`; the pod-level `eks.amazonaws.com/skip-containers: sandbox` annotation from latest `main` keeps IRSA credentials out of the untrusted sandbox container while still allowing the sidecar to snapshot to S3.

## Lead Infra TODO Coverage

The checklist in `docs/craft/infra/todos.md` is accounted for as follows:

| TODO | Status | Notes |
|---|---|---|
| Helm sandbox namespace RBAC + ServiceAccount | Covered | Helm owns `onyx-sandboxes` via `sandbox-namespace.yaml`, then owns `sandbox-file-sync`, sandbox manager RBAC, and proxy service lookup RBAC via `sandbox-rbac.yaml`. |
| Terraform sandbox object store + workload identity | Covered | `craft_sandbox` creates/references the snapshot bucket and creates the sandbox file-sync IRSA role/policy. Existing buckets use `create_bucket=false`. |
| Node-group security-group composition | Covered | The sandbox managed node group uses the upstream shared node SG, matching regular managed node groups while avoiding duplicate `kubernetes.io/cluster/<name>`-tagged SGs on the same nodes. Migrated manual node groups should be checked for the same invariant. |
| Node-group metadata-service hardening | Covered | The Terraform sandbox node group enforces IMDSv2 and hop-limit 1. Migrated manual node groups should match before relying on them. |
| Network firewall defense-in-depth | Not codified in this PR | Still valid and independent. It needs regional network-firewall resources, dedicated firewall subnets, sandbox-subnet route-table updates, RFC1918/metadata denies, and managed threat-intel rules. |

## How The Sandbox Node Group Works

The Terraform-managed sandbox node group is a codified version of the manual node setup Craft already needed:

- Nodes are labeled `onyx.app/workload=sandbox`.
- Nodes are tainted `workload=sandbox:NoSchedule`.
- Sandbox pods use `nodeSelector: onyx.app/workload=sandbox`.
- Sandbox pods tolerate `workload=sandbox:NoSchedule`.
- The launch template uses the upstream shared node SG and intentionally does not also attach the EKS primary cluster SG.

That means sandbox pods land only on sandbox nodes, normal Onyx workloads do not land there, and sandbox nodes keep the same shared-node-SG connectivity shape as the regular managed node groups. The node group is optional because existing manually created nodes can satisfy the same contract if they have the same label/taint, SG invariant, and acceptable IMDS hardening.

## Fresh Install Path

For a new EKS install:

1. Apply the root Terraform module that creates the normal `onyx` infra and instantiates `craft_sandbox`.
2. Enable the sandbox node group if you want Terraform-managed sandbox capacity: `enable_craft_sandbox_node_group=true`.
3. Deploy from the local chart in this branch until the published chart includes these templates.
4. Pass the Terraform role output into Helm:

```bash
helm upgrade --install onyx deployment/helm/charts/onyx \
  -n onyx \
  -f your-values.yaml \
  --set craft.sandboxFileSyncRoleArn="$(terraform output -raw sandbox_file_sync_role_arn)" \
  --set configMap.SANDBOX_S3_BUCKET="$(terraform output -raw sandbox_snapshot_bucket_name)"
```

Also set the normal managed-service values for RDS, Redis, OpenSearch, file-store S3, `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL`, and `auth.sandboxPushSecret`.

## Migration Path For Existing Setups

**Existing snapshot bucket**
- Set `craft_sandbox.bucket_name = "<existing-bucket>"`.
- Set `craft_sandbox.create_bucket = false`.
- Terraform will not create or modify the bucket; it will create the S3 policy and IRSA role for that bucket.
- Pass `craft.sandboxFileSyncRoleArn=<role_arn>` and `configMap.SANDBOX_S3_BUCKET=<existing-bucket>` to Helm.

**Existing manual sandbox node group**
- If the existing nodes already have label `onyx.app/workload=sandbox`, taint `workload=sandbox:NoSchedule`, acceptable IMDS hardening, and the same shared-node-SG invariant as regular managed node groups, Craft can keep using them.
- Leave `enable_craft_sandbox_node_group=false` unless you want Terraform to create/manage sandbox capacity.
- If you want Terraform ownership of an existing node group, import it or create a non-conflicting Terraform-managed node group and drain/remove the manual one later.

**Existing manual Kubernetes RBAC/ServiceAccount objects**
- The chart now owns `onyx-sandboxes`, `sandbox-file-sync`, `onyx-sandbox-manager`, `onyx-proxy-resolve`, and the sandbox proxy/push NetworkPolicy path.
- If those objects were manually created, Helm may refuse to install until they are deleted/recreated or adopted with Helm ownership metadata.
- Prefer a maintenance window with no active sandbox turns, then replace the manual RBAC/ServiceAccount objects with chart-managed ones.

**Published chart caveat**
- This is not values-only against the old published chart. Until this chart version is released, use `deployment/helm/charts/onyx` from this branch. Do not manually edit chart templates; set values and run `helm upgrade --install` against the local chart.

## Docs

Adds and expands `docs/craft/kubernetes/craft-eks-runbook.md` with:
- Terraform-vs-Helm responsibility split.
- Complete inventory of net-new AWS/Kubernetes objects.
- Lead infra TODO coverage.
- Sandbox node group explanation, including SG composition and IMDS hardening.
- Fresh cluster install path.
- Existing bucket, existing node group, and existing manual RBAC migration paths.
- Post-migration validation commands.
- Remaining gotchas/security notes from validation.

## How Has This Been Tested?

Previously validated from scratch on a real EKS cluster (us-west-2, single-tenant model: managed RDS + ElastiCache + OpenSearch + S3): `terraform apply` -> `helm install` from this chart -> register user + LLM -> Craft provisions a sandbox on the dedicated tainted node group -> snapshot + restore round-trip via the `sandbox-file-sync` IRSA against the `craft_sandbox` bucket, including the snapshot path through the real Celery `cleanup_idle_sandboxes_task`, all with zero manual kubectl/RBAC/node steps.

Latest-head validation after rebasing on current `origin/main`:
- Repaired the private/gitignored `deployment/terraform/craft-test` harness locally so it could plan/apply against the current module interface. Those harness changes are local-only and are not part of this PR.
- `terraform init` succeeded in `deployment/terraform/craft-test`.
- `terraform apply` on the `roshan-craft-test` cluster completed with `Resources: 0 added, 2 changed, 0 destroyed`.
- Post-apply `terraform plan -detailed-exitcode` reported no changes.
- Earlier live validation verified the sandbox launch template `lt-0d686236052bb4edb` version 2 had IMDSv2 required and metadata hop limit 1. A later review found attaching both the shared node SG and EKS primary cluster SG creates duplicate `kubernetes.io/cluster/<name>`-tagged SGs on sandbox nodes, so this PR now keeps sandbox nodes on the upstream shared node SG only.
- `helm dependency build deployment/helm/charts/onyx` succeeded.
- `helm upgrade --install onyx deployment/helm/charts/onyx -n onyx -f deployment/helm/values-craft-test.yaml ...` completed successfully and advanced the release to revision 4.
- `helm status onyx -n onyx` reported `deployed`.
- `kubectl rollout status` succeeded for all Onyx deployments in the test cluster, including API, web, all Celery workers, model servers, code interpreter, nginx, and sandbox proxy.
- Verified `onyx-sandboxes/sandbox-file-sync` is annotated with the Terraform output IRSA role ARN.
- Verified `onyx-sandboxes` sandbox manager RBAC and `onyx` proxy-resolve RBAC exist.
- Verified the Onyx workload service account can create sandbox pods, create pod exec sessions, and read proxy services via `kubectl auth can-i`.

Static/render validation:
- `terraform fmt -check deployment/terraform/modules/aws/eks/main.tf deployment/terraform/modules/aws/onyx/variables.tf deployment/terraform/modules/aws/craft_sandbox/main.tf deployment/terraform/modules/aws/craft_sandbox/outputs.tf`
- `git diff --check`
- `helm template` of the Craft sandbox namespace/RBAC/proxy templates with Craft enabled and dummy required secrets from `values-ci.yaml`.

Remaining validation gap: this latest pass used the private/gitignored `craft-test` harness shim for the test cluster. Fresh-cluster apply without that local shim was covered by the earlier full-flow validation, but not repeated after the final SG/node-group-key cleanup or after removing `attach_cluster_primary_security_group=true` from the sandbox node group. Standalone `terraform validate` for the EKS module is currently blocked by Helm provider v3 schema errors in downloaded `eks_blueprints_addons` module blocks (`set`, `set_sensitive`, `postrender`), which is unrelated to this sandbox SG change.


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codifies EKS infrastructure for Onyx Craft so a fresh cluster works out of the box and migrations are clean. Adds Terraform for the snapshot bucket + IRSA, an optional sandbox node group, and Helm-managed sandbox RBAC with namespace-safe names, all gated and defaulting to prior behavior.

- New Features
  - Terraform: new `modules/aws/craft_sandbox` creates or reuses the snapshot S3 bucket (`create_bucket=false` to reuse), adds the S3 policy, and creates the IRSA role for `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`. Outputs: `role_arn`, `bucket_name`, `bucket_arn`.
  - Terraform: `modules/aws/eks` adds an optional sandbox managed node group (label/taint `workload=sandbox`, IMDSv2 required, hop-limit 1, 50GiB gp3) using only the shared node SG to avoid duplicate cluster-tagged SGs.
  - Terraform: `modules/aws/onyx` forwards the sandbox node-group knobs and the OIDC outputs.
  - Helm: new `templates/sandbox-rbac.yaml` (gated by `ENABLE_CRAFT`) creates the `sandbox-file-sync` ServiceAccount (annotated with `craft.sandboxFileSyncRoleArn`) and sandbox-manager/proxy-resolve RBAC; fails fast if the role ARN is unset; names include the release namespace and are hash-truncated to avoid cross-release collisions. New values: `craft.sandboxFileSyncRoleArn`, `craft.extraBoundServiceAccounts`, and `configMap.SANDBOX_SERVICE_ACCOUNT_NAME` (default `sandbox-file-sync`).
  - Helm: bump chart to `0.5.20` with ArtifactHub notes for the new Craft sandbox RBAC. CI overlay adds a dummy `craft.sandboxFileSyncRoleArn` so kind renders pass.
  - Docs: add an EKS runbook and align infra notes; clarify `skip-containers` is a pod-level annotation.

- Migration
  - No action if Craft is off.
  - To enable: apply the `craft_sandbox` module (use `create_bucket=false` to reuse an existing bucket), pass its `role_arn` to Helm as `craft.sandboxFileSyncRoleArn`, and set `SANDBOX_S3_BUCKET`.
  - Optional: enable the dedicated sandbox node group with `enable_craft_sandbox_node_group=true`; existing labeled/tainted nodes can keep being used.
  - Replace any manually created sandbox ServiceAccount/RBAC with the chart-managed objects.

<sup>Written for commit 2300a2ed4873425c9a7274f7039846d57f74e431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

