### PR TITLE
fix(craft): keep file-sync IRSA out of the untrusted sandbox container

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -147,6 +147,7 @@ _PROXY_CA_SOURCE_VOLUME = "sandbox-ca-source"
 # Pinned to the proxy IP via pod hostAliases — the iptables lockdown
 # blocks DNS, so the sandbox can't resolve it on its own.
 _PROXY_ALIAS = "sandbox-proxy"
+_SANDBOX_CONTAINER_NAME = "sandbox"
 
 # Per-session egress tagging plugin, baked into the sandbox image (see
 # docker/Dockerfile). Path must match the COPY destination there.
@@ -582,7 +583,7 @@ class KubernetesSandboxManager(SandboxManager):
             )
 
         sandbox_container = client.V1Container(
-            name="sandbox",
+            name=_SANDBOX_CONTAINER_NAME,
             image=self._image,
             image_pull_policy="IfNotPresent",
             command=["/workspace/entrypoint.sh"],
@@ -803,7 +804,9 @@ class KubernetesSandboxManager(SandboxManager):
                 namespace=self._namespace,
                 # The pod-identity webhook reads skip-containers from the POD, not the
                 # SA — keep the IRSA token out of the untrusted agent container.
-                annotations={"eks.amazonaws.com/skip-containers": "sandbox"},
+                annotations={
+                    "eks.amazonaws.com/skip-containers": _SANDBOX_CONTAINER_NAME
+                },
                 labels={
                     LABEL_K8S_COMPONENT: LABEL_K8S_COMPONENT_SANDBOX,
                     LABEL_K8S_MANAGED_BY: LABEL_K8S_MANAGED_BY_ONYX,
@@ -932,7 +935,7 @@ class KubernetesSandboxManager(SandboxManager):
         self,
         sandbox_id: UUID,
         *,
-        container: str = "sandbox",
+        container: str = _SANDBOX_CONTAINER_NAME,
         tail_lines: int = 200,
     ) -> Iterator[str]:
         """Yield log lines from a sandbox pod's container as they arrive.
@@ -1649,7 +1652,7 @@ echo "Session workspace setup complete"
                 name=pod_name,
                 namespace=self._namespace,
                 command=["/bin/sh", "-c", setup_script],
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 stderr=True,
                 stdin=False,
                 stdout=True,
@@ -1718,7 +1721,7 @@ echo "Session cleanup complete"
                 name=pod_name,
                 namespace=self._namespace,
                 command=["/bin/sh", "-c", cleanup_script],
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 stderr=True,
                 stdin=False,
                 stdout=True,
@@ -1823,7 +1826,7 @@ echo "Session cleanup complete"
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stderr=True,
                 stdin=False,
@@ -1866,7 +1869,7 @@ echo "Session cleanup complete"
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stderr=True,
                 stdin=False,
@@ -1968,7 +1971,7 @@ echo "Session cleanup complete"
                     self._stream_core_api.connect_get_namespaced_pod_exec,
                     name=pod_name,
                     namespace=self._namespace,
-                    container="sandbox",
+                    container=_SANDBOX_CONTAINER_NAME,
                     command=["/bin/sh", "-c", start_script],
                     stderr=True,
                     stdin=False,
@@ -2023,7 +2026,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
             self._stream_core_api.connect_get_namespaced_pod_exec,
             name=pod_name,
             namespace=self._namespace,
-            container="sandbox",
+            container=_SANDBOX_CONTAINER_NAME,
             command=["/bin/sh", "-c", config_script],
             stderr=True,
             stdin=False,
@@ -2113,7 +2116,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stderr=True,
                 stdin=False,
@@ -2243,7 +2246,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stderr=True,
                 stdin=False,
@@ -2321,7 +2324,7 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stderr=True,
                 stdin=False,
@@ -2409,7 +2412,7 @@ fi
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=["/bin/sh", "-c", script],
                 stderr=True,
                 stdin=False,
@@ -2507,7 +2510,7 @@ echo "$base"
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=["/bin/sh", "-c", script],
                 stdin=True,
                 stdout=True,
@@ -2612,7 +2615,7 @@ echo "$base"
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stdin=False,
                 stdout=True,
@@ -2660,7 +2663,7 @@ echo WRITE_OK"""
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=["/bin/sh", "-c", script],
                 stdin=False,
                 stdout=True,
@@ -2712,7 +2715,7 @@ fi
                 self._stream_core_api.connect_get_namespaced_pod_exec,
                 name=pod_name,
                 namespace=self._namespace,
-                container="sandbox",
+                container=_SANDBOX_CONTAINER_NAME,
                 command=exec_command,
                 stdin=False,
                 stdout=True,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -570,8 +570,9 @@ class KubernetesSandboxManager(SandboxManager):
         """
         pod_name = self._get_pod_name(sandbox_id)
 
-        # Sandbox container — runs the agent. No IRSA (skip-containers annotation
-        # on the SA strips AWS env vars and the projected token from this container).
+        # Sandbox container — runs the agent. No IRSA: the pod's skip-containers
+        # annotation (set on the pod metadata, where the webhook reads it) keeps the
+        # AWS env vars and projected token out of this container.
         sandbox_ports = [
             client.V1ContainerPort(name="opencode", container_port=OPENCODE_SERVE_PORT),
         ]
@@ -800,6 +801,9 @@ class KubernetesSandboxManager(SandboxManager):
             metadata=client.V1ObjectMeta(
                 name=pod_name,
                 namespace=self._namespace,
+                # The pod-identity webhook reads skip-containers from the POD, not the
+                # SA — keep the IRSA token out of the untrusted agent container.
+                annotations={"eks.amazonaws.com/skip-containers": "sandbox"},
                 labels={
                     LABEL_K8S_COMPONENT: LABEL_K8S_COMPONENT_SANDBOX,
                     LABEL_K8S_MANAGED_BY: LABEL_K8S_MANAGED_BY_ONYX,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -101,6 +101,16 @@ def test_pod_has_sandbox_and_sidecar_with_distinct_entrypoints(
     assert by_name["sidecar"].command == ["/workspace/sidecar-entrypoint.sh"]
 
 
+def test_irsa_skip_containers_annotation_targets_sandbox_container(
+    pod: client.V1Pod,
+) -> None:
+    annotations = pod.metadata.annotations or {}
+    assert (
+        annotations["eks.amazonaws.com/skip-containers"]
+        == _container(pod, "sandbox").name
+    )
+
+
 # ---------------------------------------------------------------------------
 # Push daemon / snapshot API placement (sidecar only)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**Security fix:** keep the file-sync IRSA credential out of the untrusted Craft sandbox (agent) container.

The `sandbox-file-sync` ServiceAccount carries `eks.amazonaws.com/skip-containers: sandbox` so the IRSA token is injected only into the trusted file-sync `sidecar`, never the `sandbox` container that runs agent/user code. But the `amazon-eks-pod-identity-webhook` reads `skip-containers` from the **pod** annotation, while it reads `role-arn` from the **ServiceAccount**. The annotation was only on the SA, so the webhook ignored it and injected `AWS_ROLE_ARN` + the projected token into **both** containers — letting agent code assume `SandboxFileSyncRole` and read/write/delete the sandbox snapshot S3 bucket.

This sets the annotation on the sandbox **pod** (`V1ObjectMeta`) in `kubernetes_sandbox_manager.py`, where the webhook actually reads it, and corrects the now-inaccurate comment. The SA-level annotation is harmless and left untouched.

## How Has This Been Tested?

Verified the mechanism on EKS with a controlled 2-container pod using the `sandbox-file-sync` SA: with `skip-containers` on the **pod**, the named container received no `AWS_ROLE_ARN` and no projected-token mount, while the other container did — whereas SA-level placement leaves both containers with the credential (the bug). `py_compile` passes on the changed module.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security fix: keep the file-sync IRSA out of the untrusted sandbox (agent) container by setting `eks.amazonaws.com/skip-containers: sandbox` on pod metadata that `amazon-eks-pod-identity-webhook` actually reads. Also centralizes the sandbox container name so the annotation and exec/log calls stay in sync.

- **Bug Fixes**
  - Applied the annotation on the pod (`V1ObjectMeta`); SA annotation left as-is but ignored by the webhook.
  - Centralized the sandbox container name in `_SANDBOX_CONTAINER_NAME` and updated all exec/log call sites; the pod annotation references this constant to prevent drift.
  - Verified on EKS: sandbox container gets no `AWS_ROLE_ARN` or projected token; sidecar still gets them. Added a unit test to assert the annotation targets the sandbox container.

<sup>Written for commit 054cb28d0a014e289f16e6ec2ba1571fcabc2b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

