### PR TITLE
chore(mcp): add agent-wiki MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "playwright": {
       "command": "npx",
       "args": ["@playwright/mcp@0.0.75", "--headless", "--isolated"]
+    },
+    "agent-wiki": {
+      "type": "http",
+      "url": "https://dev-wiki.onyx.app/api/mcp"
     }
   }
 }


### PR DESCRIPTION
## What

Adds the [agent-wiki](https://dev-wiki.onyx.app) hosted MCP server to \`.mcp.json\`.

```
"agent-wiki": {
  "type": "http",
  "url": "https://dev-wiki.onyx.app/api/mcp"
}
```

## Notes

- Uses Claude Code's **native HTTP transport** (\`"type": "http"\`) pointing at the agent-wiki streamable HTTP endpoint.
- Restart Claude Code (or run \`/mcp\`) to pick up the new server.

Follows the same pattern as #11786.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `agent-wiki` MCP server to `.mcp.json` to enable Claude Code to connect to the Agent Wiki via HTTP.

- **New Features**
  - Configures `agent-wiki` as an HTTP server at https://dev-wiki.onyx.app/api/mcp

- **Migration**
  - Restart Claude Code or run `/mcp` to load the new server.

<sup>Written for commit 295bcafa15b92925ae471edce87ebcbed76d3132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

