### PR TITLE
feat(craft): dedicated sandbox-controller SA (scope sandbox RBAC) [draft]

### DIFF
--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -42,7 +42,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (eq (include "onyx.craftEnabled" .) "true") .Values.craft.dedicatedControllerServiceAccount }}
+      serviceAccountName: {{ include "onyx.fullname" . }}-sandbox-controller
+      {{- else }}
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       {{- with .Values.api.nodeSelector }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -38,7 +38,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (eq (include "onyx.craftEnabled" .) "true") .Values.craft.dedicatedControllerServiceAccount }}
+      serviceAccountName: {{ include "onyx.fullname" . }}-sandbox-controller
+      {{- else }}
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       {{- with .Values.celery_worker_heavy.nodeSelector }}

--- a/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks.yaml
@@ -38,7 +38,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if and (eq (include "onyx.craftEnabled" .) "true") .Values.craft.dedicatedControllerServiceAccount }}
+      serviceAccountName: {{ include "onyx.fullname" . }}-sandbox-controller
+      {{- else }}
       serviceAccountName: {{ include "onyx.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.celery_shared.podSecurityContext | nindent 8 }}
       {{- with .Values.celery_worker_scheduled_tasks.nodeSelector }}

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -6,7 +6,15 @@
 {{- if not $roleArn }}
 {{- fail "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=true (IRSA role ARN for the sandbox-file-sync ServiceAccount — output of the craft_sandbox terraform module)." }}
 {{- end }}
+{{- $controllerName := printf "%s-sandbox-controller" (include "onyx.fullname" .) }}
+{{- $dedicated := .Values.craft.dedicatedControllerServiceAccount | default false }}
 {{- $boundSAs := prepend (.Values.craft.extraBoundServiceAccounts | default list) (include "onyx.serviceAccountName" .) }}
+{{- if $dedicated }}
+{{- $boundSAs = prepend (.Values.craft.extraBoundServiceAccounts | default list) $controllerName }}
+{{- if not (.Values.craft.sandboxControllerRoleArn | default "") }}
+{{- fail "craft.sandboxControllerRoleArn is required when craft.dedicatedControllerServiceAccount=true (workload IRSA role ARN; its trust policy must also list this SA's OIDC subject via the terraform irsa_additional_service_accounts var)." }}
+{{- end }}
+{{- end }}
 # skip-containers keeps the IRSA creds in the file-sync sidecar, out of the agent container.
 apiVersion: v1
 kind: ServiceAccount
@@ -21,6 +29,22 @@ metadata:
     eks.amazonaws.com/skip-containers: "sandbox"
 automountServiceAccountToken: true
 ---
+{{- if $dedicated }}
+# Dedicated SA for the only workloads that touch the sandbox k8s API (api, heavy,
+# scheduled-tasks); carries the workload IRSA role so they keep S3 + RDS.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $controllerName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-controller
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.craft.sandboxControllerRoleArn | quote }}
+automountServiceAccountToken: true
+---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-rbac.yaml
@@ -1,0 +1,101 @@
+{{- if eq (include "onyx.craftEnabled" .) "true" }}
+{{- $sandboxNs := .Values.configMap.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $saName := (index .Values.configMap "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox-file-sync" }}
+{{- $proxyNs := (index .Values.configMap "SANDBOX_PROXY_NAMESPACE") | default .Release.Namespace }}
+{{- $roleArn := .Values.craft.sandboxFileSyncRoleArn | default "" }}
+{{- if not $roleArn }}
+{{- fail "craft.sandboxFileSyncRoleArn is required when configMap.ENABLE_CRAFT=true (IRSA role ARN for the sandbox-file-sync ServiceAccount — output of the craft_sandbox terraform module)." }}
+{{- end }}
+{{- $boundSAs := prepend (.Values.craft.extraBoundServiceAccounts | default list) (include "onyx.serviceAccountName" .) }}
+# skip-containers keeps the IRSA creds in the file-sync sidecar, out of the agent container.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-file-sync
+  annotations:
+    eks.amazonaws.com/role-arn: {{ $roleArn | quote }}
+    eks.amazonaws.com/skip-containers: "sandbox"
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+rules:
+  # watch is required: _wait_for_pod_ready streams pod events during provision.
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+subjects:
+  {{- range $boundSAs }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "onyx.fullname" . }}-sandbox-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+# api_server resolves SANDBOX_PROXY_HOST's ClusterIP for the sandbox pod's /etc/hosts alias.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  namespace: {{ $proxyNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  namespace: {{ $proxyNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-manager
+subjects:
+  {{- range $boundSAs }}
+  - kind: ServiceAccount
+    name: {{ . }}
+    namespace: {{ $.Release.Namespace }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ include "onyx.fullname" . }}-proxy-resolve
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1466,6 +1466,13 @@ configMap:
   SANDBOX_PROXY_CA_SECRET: "sandbox-proxy-ca"
   SANDBOX_PROXY_CA_CONFIGMAP: "sandbox-proxy-ca-bundle"
 
+# -- Craft sandbox identity/RBAC (rendered when configMap.ENABLE_CRAFT=true).
+craft:
+  # Required when ENABLE_CRAFT=true. The craft_sandbox terraform module's role_arn output.
+  sandboxFileSyncRoleArn: ""
+  # Extra SAs (release ns) to also grant sandbox RBAC, e.g. a separate worker SA.
+  extraBoundServiceAccounts: []
+
 # -- Sandbox egress proxy.
 sandboxProxy:
   replicaCount: 2

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1472,6 +1472,18 @@ craft:
   sandboxFileSyncRoleArn: ""
   # Extra SAs (release ns) to also grant sandbox RBAC, e.g. a separate worker SA.
   extraBoundServiceAccounts: []
+  # When true, create a dedicated `<release>-sandbox-controller` SA, bind the
+  # sandbox RBAC to ONLY it (not the shared workload SA), and run the three
+  # workloads that touch the sandbox k8s API under it: api_server, the heavy
+  # worker (cleanup_idle_sandboxes), and the scheduled-tasks worker
+  # (run_scheduled_task). Shrinks "who can exec into sandboxes" from every
+  # workload to just those three. Requires sandboxControllerRoleArn AND the
+  # workload IRSA role's trust policy to list this SA's OIDC subject.
+  dedicatedControllerServiceAccount: false
+  # Workload IRSA role ARN (eks module output `workload_irsa_role_arn`) annotated
+  # onto the controller SA so api_server/celery keep S3 + RDS. Required when
+  # dedicatedControllerServiceAccount=true.
+  sandboxControllerRoleArn: ""
 
 # -- Sandbox egress proxy.
 sandboxProxy:

--- a/deployment/terraform/modules/aws/craft_sandbox/main.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/main.tf
@@ -1,0 +1,90 @@
+# Craft sandbox cloud prereqs: encrypted S3 snapshot bucket + IRSA role for the
+# sandbox file-sync SA. Outputs role_arn + bucket_name for Helm.
+
+locals {
+  # OIDC passed as inputs (not a data source) so this works in the same apply that
+  # creates the cluster, and on destroy after it's gone.
+  oidc_url = var.oidc_provider
+  oidc_arn = var.oidc_provider_arn
+  sa_sub   = "system:serviceaccount:${var.sandbox_namespace}:${var.service_account_name}"
+}
+
+resource "aws_s3_bucket" "sandbox" {
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "sandbox" {
+  bucket                  = aws_s3_bucket.sandbox.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "sandbox" {
+  bucket = aws_s3_bucket.sandbox.id
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+    filter {} # applies to all objects (required by the provider)
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+}
+
+resource "aws_iam_policy" "sandbox_s3" {
+  name        = "${var.cluster_name}-sandbox-s3-policy"
+  description = "Sandbox file-sync S3 access for ${var.cluster_name}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:AbortMultipartUpload"]
+        Resource = "${aws_s3_bucket.sandbox.arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = aws_s3_bucket.sandbox.arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "sandbox_file_sync" {
+  name = "SandboxFileSyncRole-${var.cluster_name}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Federated = local.oidc_arn }
+        Action    = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oidc_url}:sub" = local.sa_sub
+            "${local.oidc_url}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "sandbox_s3" {
+  role       = aws_iam_role.sandbox_file_sync.name
+  policy_arn = aws_iam_policy.sandbox_s3.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/outputs.tf
@@ -1,0 +1,13 @@
+output "role_arn" {
+  description = "IRSA role ARN to annotate the sandbox-file-sync ServiceAccount with."
+  value       = aws_iam_role.sandbox_file_sync.arn
+}
+
+output "bucket_name" {
+  description = "Sandbox S3 bucket name (set as SANDBOX_S3_BUCKET)."
+  value       = aws_s3_bucket.sandbox.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.sandbox.arn
+}

--- a/deployment/terraform/modules/aws/craft_sandbox/variables.tf
+++ b/deployment/terraform/modules/aws/craft_sandbox/variables.tf
@@ -1,0 +1,37 @@
+variable "cluster_name" {
+  type        = string
+  description = "EKS cluster name (used to name resources)."
+}
+
+variable "oidc_provider_arn" {
+  type        = string
+  description = "EKS OIDC provider ARN (from the eks module output) for the IRSA trust policy."
+}
+
+variable "oidc_provider" {
+  type        = string
+  description = "EKS OIDC issuer host/path without https:// (from the eks module output) for the sub/aud condition keys."
+}
+
+variable "bucket_name" {
+  type        = string
+  description = "S3 bucket name for sandbox snapshots / file-sync."
+}
+
+variable "sandbox_namespace" {
+  type        = string
+  description = "Kubernetes namespace the sandbox file-sync ServiceAccount lives in."
+  default     = "onyx-sandboxes"
+}
+
+variable "service_account_name" {
+  type        = string
+  description = "Name of the sandbox file-sync ServiceAccount the IRSA role trusts."
+  default     = "sandbox-file-sync"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to created resources."
+  default     = {}
+}

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -3,6 +3,42 @@ locals {
     bucket_arn     = "arn:aws:s3:::${name}"
     bucket_objects = "arn:aws:s3:::${name}/*"
   }]
+
+  # Optional dedicated node group for sandbox pods (nodeSelector/toleration below).
+  # IMDSv2 hop-limit 1 blocks sandboxed containers from the node metadata service.
+  craft_sandbox_node_groups = var.enable_craft_sandbox_node_group ? {
+    sandbox = {
+      name           = "sandbox-node-group"
+      instance_types = var.craft_sandbox_node_instance_types
+      min_size       = var.craft_sandbox_node_min_size
+      max_size       = var.craft_sandbox_node_max_size
+      desired_size   = var.craft_sandbox_node_desired_size
+      labels = {
+        "onyx.app/workload" = "sandbox"
+      }
+      taints = [{
+        key    = "workload"
+        value  = "sandbox"
+        effect = "NO_SCHEDULE"
+      }]
+      metadata_options = {
+        http_endpoint               = "enabled"
+        http_tokens                 = "required"
+        http_put_response_hop_limit = 1
+      }
+      block_device_mappings = {
+        xvda = {
+          device_name = "/dev/xvda"
+          ebs = {
+            volume_size           = 50
+            volume_type           = "gp3"
+            encrypted             = true
+            delete_on_termination = true
+          }
+        }
+      }
+    }
+  } : {}
 }
 
 module "eks" {
@@ -27,7 +63,7 @@ module "eks" {
     ami_type = "AL2023_x86_64_STANDARD"
   }
 
-  eks_managed_node_groups = {
+  eks_managed_node_groups = merge({
     for k, v in var.eks_managed_node_groups : k => merge(v,
       {
         instance_types = v.instance_types != null ? v.instance_types : (
@@ -45,7 +81,7 @@ module "eks" {
         subnet_ids = var.main_node_subnet_ids
       } : {}
     )
-  }
+  }, local.craft_sandbox_node_groups)
 
   tags = var.tags
 }

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -185,11 +185,16 @@ module "irsa-workload-access" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version = "4.7.0"
 
-  create_role                   = true
-  role_name                     = "AmazonEKSTFWorkloadAccessRole-${module.eks.cluster_name}"
-  provider_url                  = module.eks.oidc_provider
-  role_policy_arns              = [aws_iam_policy.s3_access_policy[0].arn]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:${var.irsa_service_account_namespace}:${var.irsa_service_account_name}"]
+  create_role      = true
+  role_name        = "AmazonEKSTFWorkloadAccessRole-${module.eks.cluster_name}"
+  provider_url     = module.eks.oidc_provider
+  role_policy_arns = [aws_iam_policy.s3_access_policy[0].arn]
+  # Trust the default workload SA plus any extras (e.g. the Craft
+  # `<release>-sandbox-controller` SA) so they can assume this same role.
+  oidc_fully_qualified_subjects = concat(
+    ["system:serviceaccount:${var.irsa_service_account_namespace}:${var.irsa_service_account_name}"],
+    [for sa in var.irsa_additional_service_accounts : "system:serviceaccount:${var.irsa_service_account_namespace}:${sa}"]
+  )
 
   depends_on = [module.eks]
 }

--- a/deployment/terraform/modules/aws/eks/outputs.tf
+++ b/deployment/terraform/modules/aws/eks/outputs.tf
@@ -15,3 +15,15 @@ output "workload_irsa_role_arn" {
   description = "ARN of the IAM role for workloads (S3 + optional RDS)"
   value       = length(module.irsa-workload-access) > 0 ? module.irsa-workload-access[0].iam_role_arn : null
 }
+
+# Re-exported from the upstream eks module so the craft_sandbox module can
+# trust-scope its IRSA role to the cluster's OIDC provider.
+output "oidc_provider_arn" {
+  description = "EKS OIDC provider ARN (for IRSA roles)"
+  value       = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider" {
+  description = "EKS OIDC issuer host/path (no https://)"
+  value       = module.eks.oidc_provider
+}

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -180,6 +180,12 @@ variable "irsa_service_account_name" {
   default     = "onyx-workload-access"
 }
 
+variable "irsa_additional_service_accounts" {
+  type        = list(string)
+  description = "Extra SA names (in irsa_service_account_namespace) to add to the workload IRSA role's trust policy — e.g. the Craft `<release>-sandbox-controller` SA so it can assume the same role."
+  default     = []
+}
+
 variable "enable_rds_iam_for_service_account" {
   type        = bool
   description = "Whether to create a dedicated RDS IRSA role and service account (grants rds-db:connect)"

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -126,6 +126,36 @@ variable "tags" {
   default     = {}
 }
 
+variable "enable_craft_sandbox_node_group" {
+  type        = bool
+  description = "Create a dedicated Craft sandbox node group (labeled onyx.app/workload=sandbox, tainted workload=sandbox:NoSchedule, IMDSv2 hop-limit 1)."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m5.large"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type        = number
+  description = "Min size of the Craft sandbox node group."
+  default     = 0
+}
+
+variable "craft_sandbox_node_max_size" {
+  type        = number
+  description = "Max size of the Craft sandbox node group (concurrency: each sandbox needs ~1 vCPU/2Gi)."
+  default     = 4
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type        = number
+  description = "Desired size of the Craft sandbox node group."
+  default     = 1
+}
+
 variable "create_gp3_storage_class" {
   type        = bool
   description = "Whether to create the gp3 storage class. The gp3 storage class will be patched to make it default and allow volume expansion."

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -80,6 +80,8 @@ module "eks" {
   craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
   craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
 
+  irsa_additional_service_accounts = var.irsa_additional_service_accounts
+
   main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
     var.main_node_private_subnets_only ? local.private_subnets : []
   )

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -74,6 +74,12 @@ module "eks" {
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
 
+  enable_craft_sandbox_node_group   = var.enable_craft_sandbox_node_group
+  craft_sandbox_node_instance_types = var.craft_sandbox_node_instance_types
+  craft_sandbox_node_min_size       = var.craft_sandbox_node_min_size
+  craft_sandbox_node_max_size       = var.craft_sandbox_node_max_size
+  craft_sandbox_node_desired_size   = var.craft_sandbox_node_desired_size
+
   main_node_subnet_ids = length(var.main_node_subnet_ids) > 0 ? var.main_node_subnet_ids : (
     var.main_node_private_subnets_only ? local.private_subnets : []
   )

--- a/deployment/terraform/modules/aws/onyx/outputs.tf
+++ b/deployment/terraform/modules/aws/onyx/outputs.tf
@@ -7,6 +7,14 @@ output "cluster_name" {
   value = module.eks.cluster_name
 }
 
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+output "oidc_provider" {
+  value = module.eks.oidc_provider
+}
+
 output "postgres_endpoint" {
   description = "RDS endpoint hostname"
   value       = module.postgres.endpoint

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -110,6 +110,34 @@ variable "redis_auth_token" {
   sensitive   = true
 }
 
+# Craft sandbox node group knobs, forwarded to the eks module (default off).
+variable "enable_craft_sandbox_node_group" {
+  type        = bool
+  description = "Create a dedicated, IMDSv2-hardened Craft sandbox node group (labeled/tainted for sandbox pods)."
+  default     = false
+}
+
+variable "craft_sandbox_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the Craft sandbox node group."
+  default     = ["m5.large"]
+}
+
+variable "craft_sandbox_node_min_size" {
+  type    = number
+  default = 0
+}
+
+variable "craft_sandbox_node_max_size" {
+  type    = number
+  default = 4
+}
+
+variable "craft_sandbox_node_desired_size" {
+  type    = number
+  default = 1
+}
+
 variable "enable_iam_auth" {
   type        = bool
   description = "Enable AWS IAM authentication for the RDS Postgres instance and wire IRSA policies"

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -117,6 +117,12 @@ variable "enable_craft_sandbox_node_group" {
   default     = false
 }
 
+variable "irsa_additional_service_accounts" {
+  type        = list(string)
+  description = "Extra SA names added to the workload IRSA role's trust policy — e.g. the Craft `<release>-sandbox-controller` SA when craft.dedicatedControllerServiceAccount is enabled in Helm."
+  default     = []
+}
+
 variable "craft_sandbox_node_instance_types" {
   type        = list(string)
   description = "Instance types for the Craft sandbox node group."

--- a/docs/craft/kubernetes/craft-eks-runbook.md
+++ b/docs/craft/kubernetes/craft-eks-runbook.md
@@ -1,0 +1,201 @@
+# Onyx Craft on a fresh EKS cluster
+
+How to stand up Onyx + Craft on a brand-new EKS cluster (single-tenant model: managed RDS +
+ElastiCache + OpenSearch + S3), and the chart/terraform changes that make it work out of the box.
+
+Validated end-to-end on `roshan-craft-test` (us-west-2): `terraform apply` + `helm install` →
+Craft provisions a sandbox + snapshot/restore, with no manual kubectl/RBAC/node steps.
+
+---
+
+## 0. Terraform vs Helm — who creates what
+
+**Clean seam: Terraform = AWS infrastructure; Helm = everything inside Kubernetes. Terraform's outputs are Helm's inputs.**
+
+**Terraform** (`deployment/terraform/…`) creates ONLY AWS resources:
+- VPC / subnets / NAT; EKS **cluster** + **node groups** (main, vespa, **sandbox** — labeled/tainted/IMDSv2) + the **OIDC provider**; EKS add-ons + gp3 storage class.
+- Managed data stores: **RDS** (Postgres), **ElastiCache** (Redis), **OpenSearch** domain; **S3** buckets (file-store + sandbox snapshots); **WAF**.
+- IAM/IRSA **roles**: the workload role (S3/RDS) + `SandboxFileSyncRole` (`craft_sandbox` module).
+- **Outputs** (the only thing Helm consumes): cluster name, RDS/Redis/OpenSearch endpoints, S3 bucket names, the IRSA **role ARNs**, the OIDC provider ARN/URL.
+
+**Helm** (`deployment/helm/charts/onyx`) creates ONLY Kubernetes objects:
+- All in-cluster workloads (api, web, nginx, celery, model servers, code-interpreter, **sandbox-proxy**).
+- The **`onyx-sandboxes`** namespace + **`sandbox-file-sync` SA** + sandbox RBAC (`onyx-sandbox-manager`, `onyx-proxy-resolve`) — `templates/sandbox-rbac.yaml`.
+- `configMap` + secrets that **point the app at the terraform-created endpoints** (POSTGRES_HOST, REDIS_HOST, OpenSearch host, S3 buckets) and carry the IRSA role ARNs.
+
+**Neither crosses over:** Terraform never deploys app workloads or app RBAC; Helm never creates AWS resources — it only *references* them via values you pass from terraform outputs.
+
+**The handoff (terraform output → helm value):**
+| terraform output | helm value / use |
+|---|---|
+| `cluster_name` | `aws eks update-kubeconfig` (then helm targets the cluster) |
+| `postgres_endpoint` / redis / `opensearch_endpoint` | `configMap.POSTGRES_HOST` / `REDIS_HOST` / `OPENSEARCH_HOST` |
+| file-store + sandbox bucket names | `configMap.S3_FILE_STORE_BUCKET_NAME` / `SANDBOX_S3_BUCKET` |
+| `sandbox_file_sync_role_arn` (craft_sandbox) | `craft.sandboxFileSyncRoleArn` → sandbox SA annotation |
+| workload role ARN | `serviceAccount.annotations` (recommended) |
+
+> ⚠️ The one currently-blurred boundary: today the **eks module also creates the `onyx` namespace + the
+> `onyx-workload-access` SA** (so terraform reaches into k8s). The recommended end state (see §3) is to move
+> both to Helm (`--create-namespace` + `serviceAccount.create`/`annotations`), leaving terraform with AWS only.
+
+## 1. Changes to ship (product repo)
+
+All backward-compatible — every new variable defaults to the prior behavior; existing consumers
+(st-dev, customers) are unaffected.
+
+### Terraform modules (`deployment/terraform/modules/aws/`)
+
+| File | Change | Why |
+|---|---|---|
+| `vpc/{main,variables}.tf` | `azs = slice(names, 0, min(3, len))`; add `single_nat_gateway` var | `slice(…,0,3)` crashed in 2-AZ regions; per-AZ NAT (3 EIPs) can exhaust the EIP quota |
+| `eks/outputs.tf` | Re-export `node_security_group_id`, `cluster_security_group_id` | `enable_opensearch=true` referenced them but they weren't exported (OpenSearch was broken) |
+| `eks/main.tf` | Create `kubernetes_namespace` for the IRSA SA before the SA | Fresh cluster has no `onyx` ns yet → SA create failed |
+| `eks/{main,variables}.tf` | `main_node_{min,max,desired}_size` vars (desired default 2) | One node doesn't fit the workload; autoscaler isn't relied on for initial size |
+| `eks/{main,variables}.tf` | `enable_craft_sandbox_node_group` (+ instance/min/max/desired) → node group labeled `onyx.app/workload=sandbox`, tainted `workload=sandbox:NoSchedule`, IMDSv2 `http_put_response_hop_limit=1` | Sandbox pods have a hardcoded `nodeSelector: onyx.app/workload=sandbox`; IMDS hardening keeps untrusted code off node creds |
+| `postgres/{main,variables}.tf` | `deletion_protection` + `skip_final_snapshot` vars | Were hardcoded → dev/throwaway teardown impossible |
+| `onyx/{main,variables}.tf` | Forward all of the above + `redis_instance_type`, `postgres_instance_type`, `opensearch_{zone_awareness_enabled,availability_zone_count,auto_tune_enabled}`, `cluster_endpoint_public_access_cidrs` already exposed | The product `onyx` module lagged the cloud module; couldn't run lean or single-node OpenSearch |
+| **NEW `craft_sandbox/`** | S3 bucket (SSE, public-access-block, abort-incomplete-MPU) + IAM policy + IRSA role trust-scoped to `system:serviceaccount:onyx-sandboxes:sandbox-file-sync`; outputs `role_arn`, `bucket_name` | Cloud-side prereqs for sandbox snapshot S3 access (was a manual console runbook) |
+
+### Helm chart (`deployment/helm/charts/onyx/`)
+
+| File | Change |
+|---|---|
+| **NEW `templates/sandbox-rbac.yaml`** | Gated on `ENABLE_CRAFT=true`, renders: `sandbox-file-sync` SA (IRSA `role-arn` + `skip-containers=sandbox`); `onyx-sandbox-manager` Role+RoleBinding in the sandbox ns (pods/exec/attach/portforward/log, services, configmaps, secrets, pvc); `onyx-proxy-resolve` Role+RoleBinding in the proxy ns (services/endpoints read, for SANDBOX_PROXY_HOST ClusterIP resolution). Bound to `onyx.serviceAccountName` + `craft.extraBoundServiceAccounts`. Fails fast if `craft.sandboxFileSyncRoleArn` is unset. |
+| `values.yaml` | `craft.sandboxFileSyncRoleArn` (required when Craft on) + `craft.extraBoundServiceAccounts` |
+
+> These two close `docs/craft/infra/todos.md` items #1 (chart SA/RBAC) and #2 (craft_sandbox terraform).
+
+---
+
+## 2. Deploy on a fresh cluster
+
+Prereqs: `terraform` (HashiCorp tap), `kubectl`, `helm`, `aws`. AWS auth via SSO — before every
+terraform/aws command (SSO static-key shadow + ~daily token expiry):
+```bash
+aws login   # or: aws sso login --sso-session <session>
+eval "$(aws configure export-credentials --profile <profile> --format env)"; unset AWS_PROFILE
+```
+
+```bash
+# 1. Infra (root module instantiates modules/aws/onyx + modules/aws/craft_sandbox)
+cd deployment/terraform/<root>
+terraform init && terraform apply           # ~25-35 min (RDS + OpenSearch are the long poles)
+
+# 2. kubeconfig
+aws eks update-kubeconfig --name $(terraform output -raw cluster_name) --region <region>
+
+# 3. App (point chart configMap at the managed-service endpoints from terraform outputs)
+cd ../../helm/charts/onyx && helm dependency build
+helm upgrade --install onyx . -n onyx -f <values> \
+  --set craft.sandboxFileSyncRoleArn="$(terraform -chdir=<root> output -raw sandbox_file_sync_role_arn)" \
+  --set auth.postgresql.values.password=<rds pw> \
+  --set auth.userauth.values.user_auth_secret="$(openssl rand -hex 32)" \
+  --set configMap.OPENSEARCH_ADMIN_PASSWORD=<opensearch pw> \
+  --set auth.sandboxPushSecret.values.private_key="$(<gen ed25519, see values.yaml comment>)"
+
+# 4. Runtime app config (UI): register first user (becomes admin), add an LLM provider.
+# 5. kubectl port-forward -n onyx svc/onyx-nginx-controller 8080:80  → http://localhost:8080
+```
+
+### Required managed-service wiring (chart `configMap`)
+Point at the terraform endpoints; disable in-cluster deps:
+- `postgresql.enabled/redis.enabled/opensearch.enabled/minio.enabled: false`; `serviceAccount.name: onyx-workload-access` (IRSA), `auth.objectstorage.enabled: false`.
+- RDS: `POSTGRES_HOST`, `PGSSLMODE=require`. ElastiCache: `REDIS_HOST`, `REDIS_SSL=true`, `REDIS_SSL_CERT_REQS=none`, `auth.redis.enabled=false` (no auth token).
+- OpenSearch (v4.0 search backend): `ONYX_DISABLE_VESPA=true`, `ENABLE_OPENSEARCH_INDEXING/RETRIEVAL_FOR_ONYX=true`, `USING_AWS_MANAGED_OPENSEARCH=true`, `OPENSEARCH_REST_API_PORT=443`, `OPENSEARCH_USE_SSL=true`, `OPENSEARCH_ADMIN_USERNAME=admin`.
+- S3: `S3_FILE_STORE_BUCKET_NAME`, `S3_ENDPOINT_URL=""`, `AWS_REGION_NAME`.
+- Craft: `ENABLE_CRAFT=true`, `SANDBOX_API_SERVER_URL=http://onyx-api-service.onyx.svc.cluster.local:8080`, `SANDBOX_S3_BUCKET`, `auth.sandboxPushSecret.enabled=true`. (`SANDBOX_SERVICE_ACCOUNT_NAME`/`SANDBOX_CONTAINER_IMAGE` default correctly.)
+
+### Images
+`global.version: craft-edge` (backend/web/model-server — the moving Craft build; stable v4.0.x has no
+Craft). `code-interpreter`: `latest` (no craft-edge tag). Sandbox image default tracks the current
+`onyxdotapp/sandbox:vX.Y.Z`.
+
+---
+
+## 3. Remaining work (not codified)
+
+- **cluster-autoscaler** doesn't scale managed node groups: node groups lack the discovery tags
+  (`k8s.io/cluster-autoscaler/enabled`, `…/<cluster>`) and the addon (eks-blueprints 1.16.3) ClusterRole
+  lacks `volumeattachments` on k8s 1.33. Workaround = pre-sized node groups (`desired`). Real fix = add
+  discovery tags + bump the autoscaler chart.
+- **Workload IRSA SA → chart-owned (refactor).** The `eks` module creates the `onyx-workload-access`
+  SA (and its namespace) directly, which couples terraform to the app namespace and forces a
+  `helm uninstall` before `terraform destroy` (else the namespace deletion hangs on helm finalizers).
+  Cleaner: terraform outputs only the workload role ARN; Helm owns the SA + namespace via
+  `serviceAccount.create=true` + `serviceAccount.annotations.{eks.amazonaws.com/role-arn}` +
+  `--create-namespace` (the chart already supports all three). This mirrors how the sandbox SA already
+  works (`craft.sandboxFileSyncRoleArn`) and removes the terraform namespace/SA creation entirely.
+- **`craft_sandbox` module** should keep taking OIDC (`oidc_provider_arn`/`oidc_provider`) as inputs,
+  NOT via `data.aws_eks_cluster` — the data-source form breaks both fresh apply (cluster not created yet)
+  and destroy (cluster gone). (Already fixed; noted so it isn't reverted.)
+- **SECURITY — `skip-containers` on the SA is silently ignored; the untrusted sandbox container holds the
+  file-sync IRSA.** `sandbox-rbac.yaml` puts `eks.amazonaws.com/skip-containers: sandbox` on the
+  `sandbox-file-sync` **ServiceAccount** to keep AWS creds out of the agent (`sandbox`) container. But the
+  `amazon-eks-pod-identity-webhook` reads `skip-containers` from the **pod annotation**, NOT the SA — while
+  it reads `role-arn` from the SA (which is why injection happened). The sandbox manager builds the pod with
+  no annotations, so `skip-containers` never reaches the webhook → `AWS_ROLE_ARN` + the projected token land
+  in **both** containers. Confirmed by a controlled 2-container pod: with `skip-containers` on the *pod*, the
+  listed container got no creds and the other did. Net: agent code in the sandbox can assume
+  `SandboxFileSyncRole` and read/write/delete the whole snapshot bucket. **Fix:** set the annotation on the
+  POD in `kubernetes_sandbox_manager.py` (`V1ObjectMeta`, ~L800): `annotations={"eks.amazonaws.com/
+  skip-containers": "sandbox"}`. (The SA-level annotation is dead weight for this — keep or drop.)
+  Defense-in-depth (per-tenant prefix-scoped IAM) was weighed and **deferred as overkill**: once the token
+  no longer reaches the untrusted container, the bucket-wide policy is only exploitable by compromising the
+  trusted sidecar itself. Scoping per-identity isn't a policy edit anyway — all sandboxes share one role, so
+  it needs per-tenant roles or EKS Pod Identity + ABAC. Revisit for **MT cloud** if cross-tenant isolation
+  guarantees are required.
+- **SECURITY — egress proxy is allow-all without a catalog, and forwards link-local IMDS.** The
+  `sandbox-proxy` gate logs every request as `policy=off_catalog` and forwards it (verified: `example.com`
+  returned the real page; `registry.npmjs.org`/`api.openai.com` → 200). It also forwards `169.254.169.254`
+  (IMDS) and `sts.us-west-2.amazonaws.com`. The node-level IMDSv2 `hop_limit=1` blocks *direct* IMDS from a
+  sandbox pod (verified: direct `curl` times out, exit 7), but the proxy runs on main nodes (`hop_limit=2`)
+  and is an alternate path to node metadata. Hardening: (1) hard-deny link-local/metadata (`169.254.0.0/16`,
+  `fd00:ec2::254`) at the proxy regardless of catalog; (2) configure the egress catalog so off-catalog
+  defaults to **deny** in prod (today an unconfigured catalog = allow-all monitor mode).
+- **BUG — idle-cleanup reaps a sandbox mid-turn → wedged session.** `cleanup_idle_sandboxes` sleeps a
+  sandbox judged idle (heartbeat-only) even with a turn in flight → deletes its Service → api-server
+  `event_bus` loops on `Name or service not known` (UI freeze), AND the in-flight turn's Redis lock
+  `buildpromptslot_{sandbox}_{session}` is left held → after revive, new turns are refused
+  (`prompt_slot: concurrent turn in flight`) until the 900s TTL. Fixes: (1) exclude sandboxes holding a
+  buildpromptslot lock from idle reaping; (2) release the lock on sleep; (3) make the event_bus
+  sleep-aware (stop/auto-revive instead of infinite DNS retry); (4) heartbeat for the duration of a turn.
+
+---
+
+## 4. Notes / gotchas (condensed)
+
+- us-west-1 has only 2 AZs (→ the slice fix). Shared account near the EIP quota → use `single_nat_gateway=true`.
+- The `vespa` node group is vestigial in v4.0 (OpenSearch replaced Vespa) — size it small or make it optional.
+- `cluster_endpoint_public_access_cidrs=[]` causes a perpetual no-op diff AWS rejects — set explicitly (e.g. `["0.0.0.0/0"]`).
+- Codified chart/terraform changes live in the **local** chart, not the published `onyx/onyx` — install from `.` until released.
+- LLM provider: configure via admin UI (encrypted in DB) — never `GEN_AI_API_KEY` in a ConfigMap.
+- S3 buckets deliberately have no `force_destroy` (so `terraform destroy` can never wipe real snapshot/
+  file-store data). To tear down an *ephemeral* cluster, `aws s3 rm` the buckets first, then destroy.
+- `sandbox-proxy` is a DB/Redis client, not just a forward proxy: its `gate.py` resolves tenant / sandbox /
+  egress-policy from **RDS** (and uses **Redis**) on every request, so it needs the same managed-service
+  wiring + network reachability as the app pods. Verified: proxy node SG → RDS:5432 path open and an
+  authenticated query succeeds; the gate logs `tenant_id=…/sandbox_id=…` resolved per request.
+- Teardown order/gotchas: `helm uninstall` before `terraform destroy` (else the `onyx` namespace hangs on
+  finalizers). The VPC CNI can leave orphaned `available` `aws-K8S-*` ENIs that pin the node SG/subnets →
+  `destroy` hangs ~15 min then fails on `DependencyViolation`; delete those ENIs, then re-run destroy.
+
+---
+
+## 5. Test harness (this validation — not for the PR)
+
+`deployment/terraform/craft-test/` (root module + `secrets.auto.tfvars`, gitignored) and
+`deployment/helm/values-craft-test.yaml` are the throwaway test instance used to validate the above.
+Lean sizing: `cache.t4g.micro` Redis, `db.t4g.small` Postgres, `m7i.xlarge` main (desired 3),
+single-node `t3.medium.search` OpenSearch, `m5.large` sandbox node, single NAT gateway.
+
+**Validated:** snapshot create → S3 (`{tenant}/snapshots/{session}/{id}.tar.gz`, source only — node_modules
+regenerated on revive) and restore-on-revive, both via the `sandbox-file-sync` IRSA against the
+`craft_sandbox` bucket; cross-replica opencode-serve session reuse (3 api replicas); chart-rendered RBAC +
+terraform sandbox node group replacing all manual steps (Validation A); full from-scratch apply+install
+(Validation B: `terraform apply` 121 resources → `helm install` from local chart → register user + LLM →
+sandbox provisions on the tainted sandbox node group → snapshot + restore, zero manual kubectl/RBAC/node).
+Also verified: direct IMDS from a sandbox pod is blocked (`hop_limit=1`); `sandbox-proxy` reaches RDS
+(authenticated query) and gates egress (DB-resolved per request); the file-sync `sidecar` IRSA reads/writes
+the bucket via `s5cmd`; **celery** runs the real `cleanup_idle_sandboxes_task` end-to-end — the worker SA
+(`onyx-workload-access`, bound to `onyx-sandbox-manager`) execs into `onyx-sandboxes`, snapshots to S3, and
+sleeps the sandbox, then the API restore re-provisions and pulls that celery-made snapshot back.


### PR DESCRIPTION
## Description

**DRAFT for discussion.** Stacked on #11787. Optional hardening so the broad workload ServiceAccount (shared by ~15 pods) no longer carries sandbox `pods/exec` + `delete` RBAC.

Today both sandbox Roles bind to `onyx-workload-access`, which every workload runs under — so web, model servers, slackbot, mcp, and all celery workers *can* exec into / delete sandbox pods even though only **api_server** and the **scheduled-tasks** worker (idle snapshot + sleep) actually do.

This adds an opt-in `craft.dedicatedControllerServiceAccount` (default `false` → no change for existing installs):
- Creates a dedicated `<release>-sandbox-controller` SA, annotated with the workload IRSA role so api/celery keep S3 + RDS.
- Binds `onyx-sandbox-manager` + `onyx-proxy-resolve` to **only** that SA.
- Runs api_server + the scheduled-tasks worker under it; every other workload stays on the shared SA, now **without** sandbox RBAC.
- Terraform: the workload IRSA role's trust policy gains the controller SA's OIDC subject via `irsa_additional_service_accounts`.

## Wiring (operator)
1. terraform: `irsa_additional_service_accounts = ["onyx-sandbox-controller"]` (i.e. `<release>-sandbox-controller`).
2. helm: `craft.dedicatedControllerServiceAccount=true` + `craft.sandboxControllerRoleArn=<workload_irsa_role_arn>`.

## Open questions (discussion)
- **Naming coupling:** the controller SA name must match the terraform `irsa_additional_service_accounts` entry. OK, or derive automatically?
- **Shared AWS role:** the controller reuses the workload IRSA role (only *k8s* RBAC narrows). Worth a distinct, tighter AWS role too?
- **Default:** should this become ON by default for fresh Craft installs once proven?

## How Has This Been Tested?

`helm template` both modes: OFF → no controller SA, bindings target the workload SA (unchanged); ON → controller SA created with the workload role-arn, both Roles bind only to it, and api-server + scheduled-tasks render `serviceAccountName: onyx-sandbox-controller`. `terraform fmt` clean. Not yet applied to a live cluster (draft).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

---

**Stack:**
1. [craft-codify-eks-infra #11787](https://github.com/onyx-dot-app/onyx/pull/11787)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional dedicated `-sandbox-controller` ServiceAccount that scopes sandbox RBAC to `api`, `celery-worker-heavy`, and `celery-worker-scheduled-tasks`. Default behavior is unchanged; when enabled, the shared workload SA no longer has `pods/exec`/`delete` in the sandbox namespace.

- **New Features**
  - Helm: `craft.dedicatedControllerServiceAccount` (default `false`) and `craft.sandboxControllerRoleArn`. Creates `<release>-sandbox-controller`, annotates it with the workload IRSA role, binds sandbox Roles only to it, and sets `serviceAccountName` for `api`, `celery-worker-heavy`, and `celery-worker-scheduled-tasks` when enabled.
  - Terraform: `irsa_additional_service_accounts` to extend the workload IRSA role trust policy to extra SAs (e.g., the controller SA).

- **Migration**
  - Terraform: set `irsa_additional_service_accounts = ["<release>-sandbox-controller"]`.
  - Helm: set `craft.dedicatedControllerServiceAccount=true` and `craft.sandboxControllerRoleArn=<workload_irsa_role_arn>`.

<sup>Written for commit a3c4401ff64c62f91b54da18780052d473b1ff0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

