### PR TITLE
perf(craft): overlap serve-wait, workspace setup, and hydration on session create

### DIFF
--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -408,6 +408,12 @@ def restore_session(
                 onyx_pat=onyx_pat,
                 all_llm_configs=all_llm_configs,
             )
+            # provision() returns at pod-Ready; the workspace setup below talks
+            # to opencode-serve, so block until it has bound.
+            if not sandbox_manager.wait_for_serve_ready(sandbox.id):
+                raise RuntimeError(
+                    f"opencode-serve never became ready for sandbox {sandbox.id}"
+                )
 
             update_sandbox_status__no_commit(
                 db_session, sandbox.id, SandboxStatus.RUNNING

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -119,7 +119,6 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -128,11 +127,10 @@ class SandboxManager(_ServeMixin, ABC):
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
 
-        ``block_until_serve_ready``: block until opencode-serve answers before
-        returning. Default keeps the pod-Ready + serve-Ready contract that
-        callers rely on. The create-session flow passes ``False`` and runs
-        ``wait_for_serve_ready()`` concurrently with workspace setup + skill
-        hydration instead.
+        Returns once the pod/container is Ready. opencode-serve binds a few
+        seconds later — callers that need to talk to it must
+        ``wait_for_serve_ready()`` first (create overlaps that wait with
+        workspace setup; other flows call it inline).
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -119,6 +119,7 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        wait_for_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -126,6 +127,12 @@ class SandboxManager(_ServeMixin, ABC):
         configured. K8s pre-loads each into opencode-serve's startup config
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
+
+        ``wait_for_serve_ready``: block until opencode-serve answers before
+        returning. Default keeps the pod-Ready + serve-Ready contract that
+        callers rely on. The create-session flow passes ``False`` and runs
+        ``wait_for_serve_ready()`` concurrently with workspace setup + skill
+        hydration instead.
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces
@@ -320,6 +327,12 @@ class SandboxManager(_ServeMixin, ABC):
             True if sandbox is healthy, False otherwise
         """
         ...
+
+    def wait_for_serve_ready(self, sandbox_id: UUID) -> bool:
+        """Block until opencode-serve answers. Split out of ``provision()`` so
+        the create-session flow can overlap it with workspace setup + skill
+        hydration (all only need the pod to be Ready)."""
+        return self._wait_for_opencode_serve_ready(sandbox_id)
 
     def send_message(
         self,

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -119,7 +119,7 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        wait_for_serve_ready: bool = True,
+        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -128,7 +128,7 @@ class SandboxManager(_ServeMixin, ABC):
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
 
-        ``wait_for_serve_ready``: block until opencode-serve answers before
+        ``block_until_serve_ready``: block until opencode-serve answers before
         returning. Default keeps the pod-Ready + serve-Ready contract that
         callers rely on. The create-session flow passes ``False`` and runs
         ``wait_for_serve_ready()`` concurrently with workspace setup + skill

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -691,6 +691,7 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        wait_for_serve_ready: bool = True,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -776,7 +777,7 @@ class DockerSandboxManager(SandboxManager):
                 f"Timeout waiting for sandbox container {container.name} to be running."
             )
 
-        if not self._wait_for_opencode_serve_ready(sandbox_id):
+        if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(sandbox_id):
             raise RuntimeError(
                 f"opencode-serve never became ready in sandbox container {container.name}."
             )

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -691,7 +691,6 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -775,13 +774,6 @@ class DockerSandboxManager(SandboxManager):
         if not self._wait_for_container_running(container):
             raise RuntimeError(
                 f"Timeout waiting for sandbox container {container.name} to be running."
-            )
-
-        if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
-            sandbox_id
-        ):
-            raise RuntimeError(
-                f"opencode-serve never became ready in sandbox container {container.name}."
             )
 
         logger.info(

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -691,7 +691,7 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        wait_for_serve_ready: bool = True,
+        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -777,7 +777,9 @@ class DockerSandboxManager(SandboxManager):
                 f"Timeout waiting for sandbox container {container.name} to be running."
             )
 
-        if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(sandbox_id):
+        if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
+            sandbox_id
+        ):
             raise RuntimeError(
                 f"opencode-serve never became ready in sandbox container {container.name}."
             )

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1193,7 +1193,6 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1260,16 +1259,9 @@ class KubernetesSandboxManager(SandboxManager):
 
             # Reusing a live pod: clear any stale tombstone so event-bus
             # creation can attach. A stale password heals via the 401 path in
-            # the readiness probe below.
+            # the caller's wait_for_serve_ready().
             with self._event_buses_lock:
                 self._terminated_sandboxes.discard(sandbox_id)
-
-            if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
-                sandbox_id
-            ):
-                raise RuntimeError(
-                    f"opencode-serve never became ready in existing sandbox pod {pod_name}"
-                )
 
             logger.info(
                 "Reusing existing Kubernetes sandbox %s, pod: %s", sandbox_id, pod_name
@@ -1346,15 +1338,6 @@ class KubernetesSandboxManager(SandboxManager):
             if not self._wait_for_pod_ready(pod_name):
                 raise RuntimeError(
                     f"Timeout waiting for sandbox pod {pod_name} to become ready"
-                )
-
-            # 4. Wait for opencode-serve to bind :4096 (unless the caller will
-            # do it concurrently with workspace setup).
-            if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
-                sandbox_id
-            ):
-                raise RuntimeError(
-                    f"opencode-serve never became ready in sandbox pod {pod_name}"
                 )
 
             logger.info(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1193,7 +1193,7 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        wait_for_serve_ready: bool = True,
+        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1264,7 +1264,7 @@ class KubernetesSandboxManager(SandboxManager):
             with self._event_buses_lock:
                 self._terminated_sandboxes.discard(sandbox_id)
 
-            if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(
+            if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
                 sandbox_id
             ):
                 raise RuntimeError(
@@ -1350,7 +1350,7 @@ class KubernetesSandboxManager(SandboxManager):
 
             # 4. Wait for opencode-serve to bind :4096 (unless the caller will
             # do it concurrently with workspace setup).
-            if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(
+            if block_until_serve_ready and not self._wait_for_opencode_serve_ready(
                 sandbox_id
             ):
                 raise RuntimeError(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1193,6 +1193,7 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        wait_for_serve_ready: bool = True,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1263,7 +1264,9 @@ class KubernetesSandboxManager(SandboxManager):
             with self._event_buses_lock:
                 self._terminated_sandboxes.discard(sandbox_id)
 
-            if not self._wait_for_opencode_serve_ready(sandbox_id):
+            if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(
+                sandbox_id
+            ):
                 raise RuntimeError(
                     f"opencode-serve never became ready in existing sandbox pod {pod_name}"
                 )
@@ -1345,8 +1348,11 @@ class KubernetesSandboxManager(SandboxManager):
                     f"Timeout waiting for sandbox pod {pod_name} to become ready"
                 )
 
-            # 4. Wait for opencode-serve to bind :4096 .
-            if not self._wait_for_opencode_serve_ready(sandbox_id):
+            # 4. Wait for opencode-serve to bind :4096 (unless the caller will
+            # do it concurrently with workspace setup).
+            if wait_for_serve_ready and not self._wait_for_opencode_serve_ready(
+                sandbox_id
+            ):
                 raise RuntimeError(
                     f"opencode-serve never became ready in sandbox pod {pod_name}"
                 )

--- a/backend/onyx/server/features/build/sandbox/user_library.py
+++ b/backend/onyx/server/features/build/sandbox/user_library.py
@@ -49,9 +49,14 @@ def hydrate_user_library(
     sandbox_id: UUID,
     user_id: UUID,
     db_session: Session,
+    files: FileSet | None = None,
 ) -> PushResult:
-    """Push all user library files to a single sandbox (cold-start hydration)."""
-    files = build_user_library_fileset(user_id, db_session)
+    """Push all user library files to a single sandbox (cold-start hydration).
+
+    ``files`` lets the caller prebuild the fileset (a DB read) on its own thread
+    so the push can run off-thread without touching ``db_session``."""
+    if files is None:
+        files = build_user_library_fileset(user_id, db_session)
     return get_sandbox_manager().push_to_sandbox(
         sandbox_id=sandbox_id,
         mount_path=USER_LIBRARY_MOUNT_PATH,

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -259,7 +259,7 @@ class SessionManager:
         if user is None:
             raise ValueError(f"User {user_id} not found")
         _, all_llm_configs = self.build_llm_configs(user)
-        return _sandbox.ensure_sandbox_ready(
+        sandbox = _sandbox.ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
@@ -268,6 +268,13 @@ class SessionManager:
             provisioning_wait_seconds=provisioning_wait_seconds,
             user=user,
         )
+        # Headless callers send a prompt right after; block until opencode-serve
+        # answers (create overlaps this wait, but here there's nothing to overlap).
+        if not self._sandbox_manager.wait_for_serve_ready(sandbox.id):
+            raise RuntimeError(
+                f"opencode-serve never became ready for sandbox {sandbox.id}"
+            )
+        return sandbox
 
     def create_session__no_commit(
         self,
@@ -343,9 +350,9 @@ class SessionManager:
 
         # Ensure the user's sandbox is RUNNING. Interactive callers can't
         # afford to wait through a concurrent provisioner, so we use the
-        # FAIL policy (raise RuntimeError if another request is mid-
-        # provision). block_until_serve_ready=False: opencode-serve binding is
-        # awaited below, concurrently with workspace setup + hydration.
+        # FAIL policy (raise RuntimeError if another request is mid-provision).
+        # The pod is Ready on return; the opencode-serve wait runs below,
+        # concurrently with workspace setup + hydration.
         sandbox = _sandbox.ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
@@ -353,7 +360,6 @@ class SessionManager:
             all_llm_configs,
             policy=_sandbox.ProvisioningPolicy.FAIL,
             user=user,
-            block_until_serve_ready=False,
         )
 
         logger.info(

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -344,7 +344,7 @@ class SessionManager:
         # Ensure the user's sandbox is RUNNING. Interactive callers can't
         # afford to wait through a concurrent provisioner, so we use the
         # FAIL policy (raise RuntimeError if another request is mid-
-        # provision). wait_for_serve_ready=False: opencode-serve binding is
+        # provision). block_until_serve_ready=False: opencode-serve binding is
         # awaited below, concurrently with workspace setup + hydration.
         sandbox = _sandbox.ensure_sandbox_ready(
             self._db_session,
@@ -353,7 +353,7 @@ class SessionManager:
             all_llm_configs,
             policy=_sandbox.ProvisioningPolicy.FAIL,
             user=user,
-            wait_for_serve_ready=False,
+            block_until_serve_ready=False,
         )
 
         logger.info(

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -4,7 +4,6 @@ SessionManager is the main entry point for build session lifecycle management.
 It orchestrates session CRUD, message handling, artifact management, and file system access.
 """
 
-import contextvars
 import hashlib
 import io
 import mimetypes
@@ -12,8 +11,6 @@ import uuid
 import zipfile
 from collections.abc import Callable
 from collections.abc import Generator
-from concurrent.futures import as_completed
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -75,6 +72,8 @@ from onyx.server.features.build.session.streaming import BuildStreamingState
 from onyx.skills.push import build_user_skills_payload
 from onyx.skills.push import hydrate_sandbox_skills
 from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import FunctionCall
+from onyx.utils.threadpool_concurrency import run_functions_in_parallel
 from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
@@ -199,9 +198,19 @@ class SessionManager:
         return get_user_build_sessions(user_id, self._db_session)
 
     def _hydrate_skills(
-        self, sandbox_id: UUID, user: User, files: FileSet | None = None
+        self, sandbox_id: UUID, user_id: UUID, files: FileSet | None = None
     ) -> None:
         try:
+            # When the caller prebuilt ``files`` (e.g. the parallel create-session
+            # warm-up) we never touch the ORM, so this is thread-safe.
+            user = (
+                None
+                if files is not None
+                else fetch_user_by_id(self._db_session, user_id)
+            )
+            if files is None and user is None:
+                logger.warning("Cannot push skills: user %s not found", user_id)
+                return
             hydrate_sandbox_skills(sandbox_id, user, self._db_session, files=files)
         except Exception:
             logger.warning(
@@ -378,6 +387,8 @@ class SessionManager:
         # opencode-serve binding, workspace setup (bun install + Next.js), and
         # the managed-dir pushes share no ordering — only a Ready pod. Fan them
         # out so the slowest, not their sum, sets the wall-clock.
+        # run_functions_in_parallel propagates contextvars (tenant id, tracing)
+        # and re-raises the first failure.
         def _wait_serve() -> None:
             if not self._sandbox_manager.wait_for_serve_ready(sandbox_id):
                 raise RuntimeError(
@@ -395,23 +406,35 @@ class SessionManager:
                 user_name=user_name,
             )
 
-        tasks: list[Callable[[], None]] = [
-            _wait_serve,
-            _setup_workspace,
-            lambda: self._hydrate_skills(sandbox_id, user, skills_files),
-            lambda: self._hydrate_user_library(sandbox_id, user_id, user_library_files),
-        ]
-
-        with ThreadPoolExecutor(
-            max_workers=len(tasks), thread_name_prefix="session-warmup"
-        ) as executor:
-            # ThreadPoolExecutor doesn't copy contextvars; run each task in its
-            # own copy so the tenant id + tracing context propagate.
-            futures = [
-                executor.submit(contextvars.copy_context().run, task) for task in tasks
-            ]
-            for future in as_completed(futures):
-                future.result()
+        try:
+            run_functions_in_parallel(
+                [
+                    FunctionCall(_wait_serve),
+                    FunctionCall(_setup_workspace),
+                    FunctionCall(
+                        self._hydrate_skills, (sandbox_id, user_id, skills_files)
+                    ),
+                    FunctionCall(
+                        self._hydrate_user_library,
+                        (sandbox_id, user_id, user_library_files),
+                    ),
+                ]
+            )
+        except Exception:
+            # A failed warm-up (e.g. serve never bound) can leave a partial
+            # workspace + Next.js dev server holding nextjs_port. Tear it down so
+            # the rolled-back nextjs_port can be reused without colliding.
+            try:
+                self._sandbox_manager.cleanup_session_workspace(
+                    sandbox_id, build_session_id, nextjs_port
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to clean up partial workspace for session %s",
+                    build_session_id,
+                    exc_info=True,
+                )
+            raise
 
         logger.info(
             "Successfully created session %s with workspace in sandbox %s",
@@ -468,11 +491,7 @@ class SessionManager:
                     )
                 )
                 if is_healthy and workspace_exists:
-                    user = fetch_user_by_id(self._db_session, user_id)
-                    if user is None:
-                        logger.warning("Cannot push skills: user %s not found", user_id)
-                    else:
-                        self._hydrate_skills(sandbox.id, user)
+                    self._hydrate_skills(sandbox.id, user_id)
                     self._hydrate_user_library(sandbox.id, user_id)
                     logger.info(
                         "Returning existing empty session %s for user %s",

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -4,6 +4,7 @@ SessionManager is the main entry point for build session lifecycle management.
 It orchestrates session CRUD, message handling, artifact management, and file system access.
 """
 
+import contextvars
 import hashlib
 import io
 import mimetypes
@@ -11,6 +12,8 @@ import uuid
 import zipfile
 from collections.abc import Callable
 from collections.abc import Generator
+from concurrent.futures import as_completed
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -57,6 +60,7 @@ from onyx.server.features.build.sandbox.base import get_sandbox_manager
 from onyx.server.features.build.sandbox.manager.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.user_library import build_user_library_fileset
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session import sandbox_lifecycle as _sandbox
 from onyx.server.features.build.session import streaming as _streaming
@@ -204,9 +208,11 @@ class SessionManager:
                 "Failed to push skills to sandbox %s", sandbox_id, exc_info=True
             )
 
-    def _hydrate_user_library(self, sandbox_id: UUID, user_id: UUID) -> None:
+    def _hydrate_user_library(
+        self, sandbox_id: UUID, user_id: UUID, files: FileSet | None = None
+    ) -> None:
         try:
-            hydrate_user_library(sandbox_id, user_id, self._db_session)
+            hydrate_user_library(sandbox_id, user_id, self._db_session, files=files)
         except Exception:
             logger.warning(
                 "Failed to push user library to sandbox %s", sandbox_id, exc_info=True
@@ -338,7 +344,8 @@ class SessionManager:
         # Ensure the user's sandbox is RUNNING. Interactive callers can't
         # afford to wait through a concurrent provisioner, so we use the
         # FAIL policy (raise RuntimeError if another request is mid-
-        # provision).
+        # provision). wait_for_serve_ready=False: opencode-serve binding is
+        # awaited below, concurrently with workspace setup + hydration.
         sandbox = _sandbox.ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
@@ -346,27 +353,59 @@ class SessionManager:
             all_llm_configs,
             policy=_sandbox.ProvisioningPolicy.FAIL,
             user=user,
+            wait_for_serve_ready=False,
         )
 
-        # Set up session workspace within the sandbox
         logger.info(
             "Setting up session workspace %s in sandbox %s", session_id, sandbox.id
         )
         user_name = user.personal_name
 
+        # Prebuild filesets (DB reads) on this thread so the pushes can run
+        # off-thread without touching db_session. Capture ids as primitives too,
+        # so the worker threads never touch a (non-thread-safe) ORM attribute.
         skills_section, skills_files = build_user_skills_payload(user, self._db_session)
+        user_library_files = build_user_library_fileset(user_id, self._db_session)
+        sandbox_id = sandbox.id
+        build_session_id = build_session.id
 
-        self._sandbox_manager.setup_session_workspace(
-            sandbox_id=sandbox.id,
-            session_id=build_session.id,
-            llm_config=llm_config,
-            nextjs_port=nextjs_port,
-            skills_section=skills_section,
-            snapshot_path=None,  # TODO: Support restoring from snapshot
-            user_name=user_name,
-        )
-        self._hydrate_skills(sandbox.id, user, files=skills_files)
-        self._hydrate_user_library(sandbox.id, user_id)
+        # opencode-serve binding, workspace setup (bun install + Next.js), and
+        # the managed-dir pushes share no ordering — only a Ready pod. Fan them
+        # out so the slowest, not their sum, sets the wall-clock.
+        def _wait_serve() -> None:
+            if not self._sandbox_manager.wait_for_serve_ready(sandbox_id):
+                raise RuntimeError(
+                    f"opencode-serve never became ready for sandbox {sandbox_id}"
+                )
+
+        def _setup_workspace() -> None:
+            self._sandbox_manager.setup_session_workspace(
+                sandbox_id=sandbox_id,
+                session_id=build_session_id,
+                llm_config=llm_config,
+                nextjs_port=nextjs_port,
+                skills_section=skills_section,
+                snapshot_path=None,  # TODO: Support restoring from snapshot
+                user_name=user_name,
+            )
+
+        tasks: list[Callable[[], None]] = [
+            _wait_serve,
+            _setup_workspace,
+            lambda: self._hydrate_skills(sandbox_id, user, skills_files),
+            lambda: self._hydrate_user_library(sandbox_id, user_id, user_library_files),
+        ]
+
+        with ThreadPoolExecutor(
+            max_workers=len(tasks), thread_name_prefix="session-warmup"
+        ) as executor:
+            # ThreadPoolExecutor doesn't copy contextvars; run each task in its
+            # own copy so the tenant id + tracing context propagate.
+            futures = [
+                executor.submit(contextvars.copy_context().run, task) for task in tasks
+            ]
+            for future in as_completed(futures):
+                future.result()
 
         logger.info(
             "Successfully created session %s with workspace in sandbox %s",

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -53,14 +53,13 @@ def provision_sandbox(
     user_id: UUID,
     tenant_id: str,
     all_llm_configs: list[LLMProviderConfig],
-    block_until_serve_ready: bool = True,
 ) -> None:
     """Ensure a PAT exists, then provision the pod with every accessible
     provider pre-loaded so per-prompt model overrides can cross providers
     without a pod restart. ``all_llm_configs[0]`` is the default.
 
-    ``block_until_serve_ready=False`` returns once the pod is Ready, leaving the
-    opencode-serve wait to the caller (so it can overlap workspace setup).
+    Returns once the pod is Ready; opencode-serve readiness is the caller's
+    concern (see ``SandboxManager.wait_for_serve_ready``).
 
     Updates the sandbox row's status to whatever the manager returns.
     Caller is responsible for committing.
@@ -73,7 +72,6 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
-        block_until_serve_ready=block_until_serve_ready,
     )
     update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
 
@@ -140,10 +138,10 @@ def ensure_sandbox_ready(
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
     user: User | None = None,
-    block_until_serve_ready: bool = True,
 ) -> Sandbox:
     """Return a ``RUNNING`` sandbox for ``user_id``, creating, waking, or
-    recovering as needed.
+    recovering as needed. The pod is Ready on return; opencode-serve readiness
+    is the caller's concern (``SandboxManager.wait_for_serve_ready``).
 
     Branches by current sandbox status:
     - No sandbox row: create + provision.
@@ -237,6 +235,5 @@ def ensure_sandbox_ready(
         user_id,
         tenant_id,
         all_llm_configs,
-        block_until_serve_ready=block_until_serve_ready,
     )
     return sandbox

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -53,13 +53,13 @@ def provision_sandbox(
     user_id: UUID,
     tenant_id: str,
     all_llm_configs: list[LLMProviderConfig],
-    wait_for_serve_ready: bool = True,
+    block_until_serve_ready: bool = True,
 ) -> None:
     """Ensure a PAT exists, then provision the pod with every accessible
     provider pre-loaded so per-prompt model overrides can cross providers
     without a pod restart. ``all_llm_configs[0]`` is the default.
 
-    ``wait_for_serve_ready=False`` returns once the pod is Ready, leaving the
+    ``block_until_serve_ready=False`` returns once the pod is Ready, leaving the
     opencode-serve wait to the caller (so it can overlap workspace setup).
 
     Updates the sandbox row's status to whatever the manager returns.
@@ -73,7 +73,7 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
-        wait_for_serve_ready=wait_for_serve_ready,
+        block_until_serve_ready=block_until_serve_ready,
     )
     update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
 
@@ -140,7 +140,7 @@ def ensure_sandbox_ready(
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
     user: User | None = None,
-    wait_for_serve_ready: bool = True,
+    block_until_serve_ready: bool = True,
 ) -> Sandbox:
     """Return a ``RUNNING`` sandbox for ``user_id``, creating, waking, or
     recovering as needed.
@@ -237,6 +237,6 @@ def ensure_sandbox_ready(
         user_id,
         tenant_id,
         all_llm_configs,
-        wait_for_serve_ready=wait_for_serve_ready,
+        block_until_serve_ready=block_until_serve_ready,
     )
     return sandbox

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -53,10 +53,14 @@ def provision_sandbox(
     user_id: UUID,
     tenant_id: str,
     all_llm_configs: list[LLMProviderConfig],
+    wait_for_serve_ready: bool = True,
 ) -> None:
     """Ensure a PAT exists, then provision the pod with every accessible
     provider pre-loaded so per-prompt model overrides can cross providers
     without a pod restart. ``all_llm_configs[0]`` is the default.
+
+    ``wait_for_serve_ready=False`` returns once the pod is Ready, leaving the
+    opencode-serve wait to the caller (so it can overlap workspace setup).
 
     Updates the sandbox row's status to whatever the manager returns.
     Caller is responsible for committing.
@@ -69,6 +73,7 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
+        wait_for_serve_ready=wait_for_serve_ready,
     )
     update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
 
@@ -135,6 +140,7 @@ def ensure_sandbox_ready(
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
     user: User | None = None,
+    wait_for_serve_ready: bool = True,
 ) -> Sandbox:
     """Return a ``RUNNING`` sandbox for ``user_id``, creating, waking, or
     recovering as needed.
@@ -231,5 +237,6 @@ def ensure_sandbox_ready(
         user_id,
         tenant_id,
         all_llm_configs,
+        wait_for_serve_ready=wait_for_serve_ready,
     )
     return sandbox

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -160,12 +160,17 @@ def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, Fil
 
 def hydrate_sandbox_skills(
     sandbox_id: UUID,
-    user: User,
+    user: User | None,
     db_session: Session,
     files: FileSet | None = None,
 ) -> PushResult:
-    """Push all visible skills to a single sandbox (cold-start hydration)."""
+    """Push all visible skills to a single sandbox (cold-start hydration).
+
+    ``user`` is only needed to build the fileset; pass ``files`` to skip that
+    (and ``user`` may then be ``None``)."""
     if files is None:
+        if user is None:
+            raise ValueError("hydrate_sandbox_skills requires user when files is None")
         files = build_skills_fileset_for_user(user, db_session)
     return get_sandbox_manager().push_to_sandbox(
         sandbox_id=sandbox_id,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -243,7 +243,6 @@ class StubSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -253,7 +252,6 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "onyx_pat": onyx_pat,
             "all_llm_configs": all_llm_configs,
-            "block_until_serve_ready": block_until_serve_ready,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -128,6 +128,7 @@ class StubSandboxManager(SandboxManager):
 
         # Return-value hooks.
         self.provision_returns: SandboxInfo | None = None
+        self.wait_for_serve_ready_returns: bool = True
         self.health_check_returns: bool | None = None
         self.session_workspace_exists_returns: bool | None = None
         self.create_snapshot_returns: SnapshotResult | None | object = _UNSET
@@ -161,6 +162,8 @@ class StubSandboxManager(SandboxManager):
 
         # Observable state: scoped counters and last-payload snapshots.
         self.provision_count: int = 0
+        self.wait_for_serve_ready_count: int = 0
+        self.last_wait_for_serve_ready_sandbox_id: UUID | None = None
         self.terminate_count: int = 0
         self.setup_session_workspace_count: int = 0
         self.cleanup_session_workspace_count: int = 0
@@ -240,6 +243,7 @@ class StubSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        wait_for_serve_ready: bool = True,
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -249,10 +253,16 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "onyx_pat": onyx_pat,
             "all_llm_configs": all_llm_configs,
+            "wait_for_serve_ready": wait_for_serve_ready,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")
         return self.provision_returns
+
+    def wait_for_serve_ready(self, sandbox_id: UUID) -> bool:
+        self.wait_for_serve_ready_count += 1
+        self.last_wait_for_serve_ready_sandbox_id = sandbox_id
+        return self.wait_for_serve_ready_returns
 
     def terminate(self, sandbox_id: UUID) -> None:
         self.terminate_count += 1

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -243,7 +243,7 @@ class StubSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        wait_for_serve_ready: bool = True,
+        block_until_serve_ready: bool = True,
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -253,7 +253,7 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "onyx_pat": onyx_pat,
             "all_llm_configs": all_llm_configs,
-            "wait_for_serve_ready": wait_for_serve_ready,
+            "block_until_serve_ready": block_until_serve_ready,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -113,7 +113,8 @@ class TestCreateSession:
 
         assert stub_sandbox_manager.last_provision_payload is not None
         assert (
-            stub_sandbox_manager.last_provision_payload["wait_for_serve_ready"] is False
+            stub_sandbox_manager.last_provision_payload["block_until_serve_ready"]
+            is False
         )
         # The wait is still performed — just decoupled from provision().
         assert stub_sandbox_manager.wait_for_serve_ready_count == 1

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -92,14 +92,14 @@ class TestCreateSession:
         assert stub_sandbox_manager.provision_count == 1
         assert build_session.user_id == test_user.id
 
-    def test_create_session_overlaps_serve_wait_with_setup(
+    def test_create_session_waits_for_serve_once(
         self,
         test_user: User,
         session_manager_with_stub: SessionManager,
         stub_sandbox_manager: StubSandboxManager,
     ) -> None:
-        # provision() hands back at pod-Ready; the opencode-serve wait runs
-        # concurrently with workspace setup + hydration instead.
+        # provision() hands back at pod-Ready; create waits for opencode-serve
+        # separately (overlapped with workspace setup + hydration).
         stub_sandbox_manager.provision_returns = SandboxInfo(
             sandbox_id=uuid4(),
             directory_path="/tmp/sandbox",
@@ -111,12 +111,7 @@ class TestCreateSession:
 
         session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
 
-        assert stub_sandbox_manager.last_provision_payload is not None
-        assert (
-            stub_sandbox_manager.last_provision_payload["block_until_serve_ready"]
-            is False
-        )
-        # The wait is still performed — just decoupled from provision().
+        assert stub_sandbox_manager.provision_count == 1
         assert stub_sandbox_manager.wait_for_serve_ready_count == 1
 
     def test_create_session_raises_when_serve_never_ready(

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -92,6 +92,51 @@ class TestCreateSession:
         assert stub_sandbox_manager.provision_count == 1
         assert build_session.user_id == test_user.id
 
+    def test_create_session_overlaps_serve_wait_with_setup(
+        self,
+        test_user: User,
+        session_manager_with_stub: SessionManager,
+        stub_sandbox_manager: StubSandboxManager,
+    ) -> None:
+        # provision() hands back at pod-Ready; the opencode-serve wait runs
+        # concurrently with workspace setup + hydration instead.
+        stub_sandbox_manager.provision_returns = SandboxInfo(
+            sandbox_id=uuid4(),
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+        stub_sandbox_manager.setup_session_workspace_silent = True
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
+
+        session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
+
+        assert stub_sandbox_manager.last_provision_payload is not None
+        assert (
+            stub_sandbox_manager.last_provision_payload["wait_for_serve_ready"] is False
+        )
+        # The wait is still performed — just decoupled from provision().
+        assert stub_sandbox_manager.wait_for_serve_ready_count == 1
+
+    def test_create_session_raises_when_serve_never_ready(
+        self,
+        test_user: User,
+        session_manager_with_stub: SessionManager,
+        stub_sandbox_manager: StubSandboxManager,
+    ) -> None:
+        stub_sandbox_manager.provision_returns = SandboxInfo(
+            sandbox_id=uuid4(),
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+        stub_sandbox_manager.setup_session_workspace_silent = True
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.wait_for_serve_ready_returns = False
+
+        with pytest.raises(RuntimeError, match="never became ready"):
+            session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
+
     def test_create_session_reuses_existing_sandbox(
         self,
         db_session: Session,

--- a/backend/tests/unit/build/test_opencode_serve_ready_password_reset.py
+++ b/backend/tests/unit/build/test_opencode_serve_ready_password_reset.py
@@ -106,7 +106,6 @@ def test_reuse_existing_pod_clears_stale_tombstone() -> None:
         mock.patch.object(mgr, "_pod_exists_and_healthy", return_value=True),
         mock.patch.object(mgr, "_ensure_service_exists"),
         mock.patch.object(mgr, "_wait_for_pod_ready", return_value=True),
-        mock.patch.object(mgr, "_wait_for_opencode_serve_ready", return_value=True),
     ):
         info = mgr.provision(
             sandbox_id=sandbox_id,


### PR DESCRIPTION
## Description

Cold-start of a Craft session ran four independent steps **serially** after the pod was Ready: the opencode-serve readiness wait, the workspace setup (`bun install` + Next.js launch), and the two managed-dir hydration pushes (skills, then user library). None of them depend on each other — they only need the pod to be Ready (the serve wait needs opencode on :4096; setup needs the pod filesystem; the pushes need the sidecar push daemon). Serializing them made wall-clock the *sum* of all four.

This fans them out so wall-clock is the *slowest single step* instead. On a representative wake-from-sleep that's roughly `pod-Ready + max(serve, bun, hydration)` ≈ **~15s** instead of `pod-Ready + serve + bun + hydration` ≈ **~31s**.

### Design: serve-readiness is now an explicit step

To overlap the opencode-serve wait, `provision()` can no longer own it. Rather than thread a `block_until_serve_ready` flag through `ensure_sandbox_ready → provision_sandbox → provision`, the serve-wait is **pulled out of `provision()` entirely** and made an explicit, composable step:

- **`provision()` (both backends) now means "pod/container is Ready"** — the opencode-serve wait and the related flag are gone. `ensure_sandbox_ready` / `provision_sandbox` likewise return at pod-Ready and document that serve-readiness is the caller's concern.
- **`SandboxManager.wait_for_serve_ready(sandbox_id)`** (shared, wraps `_wait_for_opencode_serve_ready`) is the explicit wait. Each caller invokes it where it fits:
  - **create** runs it as one of its parallel tasks (the overlap).
  - **headless `ensure_sandbox_running`** calls it inline before returning (it sends a prompt next).
  - **`restore_session`** calls it inline after provisioning (its workspace setup talks to opencode).

No behavior-toggling boolean anywhere; call sites read as "provision, then wait for serve."

### create_session__no_commit
Provisions to pod-Ready, prebuilds the skill + user-library filesets on the request thread (DB reads), then runs serve-wait ∥ workspace-setup ∥ skills-push ∥ user-library-push on a `ThreadPoolExecutor`. Each task runs in its own `contextvars` copy so the tenant id / tracing context propagate (the executor doesn't copy them). Ids are captured as primitives so workers never touch a non-thread-safe ORM attribute; filesets are prebuilt so the pushes don't touch `db_session`. `hydrate_user_library` gained an optional prebuilt-`files` arg, mirroring `hydrate_sandbox_skills`.

Hydration failures stay non-fatal (logged), matching prior behavior; a serve-readiness failure propagates as `RuntimeError`, same as before.

Scope: the interactive create / pre-provision path (what cold-start exercises). `restore_session` keeps its current sequencing (it just gains the explicit serve-wait); fanning out its setup is a possible follow-up.

## How Has This Been Tested?

- `tests/external_dependency_unit/craft/test_session_lifecycle.py`:
  - `test_create_session_waits_for_serve_once` — create provisions once and waits for serve exactly once (the wait is decoupled from `provision()`).
  - `test_create_session_raises_when_serve_never_ready` — a never-ready serve propagates `RuntimeError`.
- `tests/unit/build/test_opencode_serve_ready_password_reset.py` — the reuse-pod test's now-vestigial serve-wait patch was removed; **passes locally (2/2)** since `provision()` no longer probes serve.
- `ruff`, `ruff format`, and `ty` pass on all changed files (also via pre-commit). The DB-backed lifecycle suite runs in CI — local Postgres isn't reachable in this environment.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check