### PR TITLE
fix(security): require auth for /metrics and docs endpoints (ENG-4131)

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1232,6 +1232,11 @@ EXPECTED_API_KEY = os.environ.get(
     "EXPECTED_API_KEY", ""
 )  # Additional security check for the control plane API
 
+# Optional Bearer token required to scrape the Prometheus /metrics endpoint.
+# When unset (default), /metrics is served without auth for backwards
+# compatibility. When set, callers must send "Authorization: Bearer <token>".
+METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN") or ""
+
 # API configuration
 CONTROL_PLANE_API_BASE_URL = os.environ.get(
     "CONTROL_PLANE_API_BASE_URL", "http://localhost:8082"

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -66,6 +66,7 @@ from onyx.db.engine.sql_engine import SqlEngine
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.file_store.file_store import get_default_file_store
 from onyx.hooks.registry import validate_registry
+from onyx.server.api_docs import add_authenticated_docs_routes
 from onyx.server.api_key.api import router as api_key_router
 from onyx.server.auth.captcha_api import CaptchaCookieMiddleware
 from onyx.server.auth.captcha_api import LoginCaptchaMiddleware
@@ -458,6 +459,12 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
             {"url": f"{WEB_DOMAIN.rstrip('/')}/api", "description": "Onyx API Server"}
         ],
         lifespan=lifespan_override or lifespan,
+        # Disable the built-in (unauthenticated) docs routes. They are
+        # re-registered behind admin auth via add_authenticated_docs_routes()
+        # below so the API surface isn't disclosed to anonymous clients.
+        openapi_url=None,
+        docs_url=None,
+        redoc_url=None,
     )
     if SENTRY_DSN:
         from onyx.configs.sentry import _add_instance_tags
@@ -714,6 +721,10 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     # counter). Must be called here — before the app starts — because the
     # instrumentator adds middleware via app.add_middleware().
     setup_prometheus_metrics(application)
+
+    # Re-register the documentation routes (/openapi.json, /docs, /redoc) behind
+    # admin auth. The built-in versions were disabled in the FastAPI(...) ctor.
+    add_authenticated_docs_routes(application)
 
     # Ensure all routes have auth enabled or are explicitly marked as public
     check_router_auth(application)

--- a/backend/onyx/server/api_docs.py
+++ b/backend/onyx/server/api_docs.py
@@ -1,0 +1,87 @@
+"""Authenticated replacements for FastAPI's built-in documentation routes.
+
+FastAPI normally serves ``/openapi.json``, ``/docs``, ``/redoc`` and
+``/docs/oauth2-redirect`` to anyone. That discloses the full API surface to
+unauthenticated clients (Oneleet pentest finding ON-010 / ENG-4131). We disable
+the built-in routes (by passing ``openapi_url=None`` etc. to ``FastAPI(...)``)
+and re-register them here behind ``current_curator_or_admin_user`` so only
+logged-in admins/curators can reach them.
+
+The offline schema generator (``backend/scripts/onyx_openapi_schema.py``) reads
+the app object directly and does not hit these routes, so it is unaffected.
+"""
+
+from fastapi import Depends
+from fastapi import FastAPI
+from fastapi.openapi.docs import get_redoc_html
+from fastapi.openapi.docs import get_swagger_ui_html
+from fastapi.openapi.docs import get_swagger_ui_oauth2_redirect_html
+from fastapi.responses import HTMLResponse
+from fastapi.responses import JSONResponse
+
+from onyx.auth.users import current_curator_or_admin_user
+
+# Keep these identical to FastAPI's defaults so existing nginx rules and any
+# bookmarks/browser flows continue to resolve to the same paths.
+OPENAPI_URL = "/openapi.json"
+DOCS_URL = "/docs"
+REDOC_URL = "/redoc"
+OAUTH2_REDIRECT_URL = "/docs/oauth2-redirect"
+
+
+def add_authenticated_docs_routes(application: FastAPI) -> None:
+    """Register admin-gated ``/openapi.json``, ``/docs``, ``/redoc`` routes.
+
+    Must be called with ``FastAPI(openapi_url=None, docs_url=None,
+    redoc_url=None)`` so these custom routes are the only ones serving docs.
+    """
+
+    admin_only = [Depends(current_curator_or_admin_user)]
+
+    def openapi() -> JSONResponse:
+        return JSONResponse(application.openapi())
+
+    def swagger_ui_html() -> HTMLResponse:
+        return get_swagger_ui_html(
+            openapi_url=OPENAPI_URL,
+            title=f"{application.title} - Swagger UI",
+            oauth2_redirect_url=OAUTH2_REDIRECT_URL,
+        )
+
+    def swagger_ui_redirect() -> HTMLResponse:
+        return get_swagger_ui_oauth2_redirect_html()
+
+    def redoc_html() -> HTMLResponse:
+        return get_redoc_html(
+            openapi_url=OPENAPI_URL,
+            title=f"{application.title} - ReDoc",
+        )
+
+    application.add_api_route(
+        OPENAPI_URL,
+        openapi,
+        methods=["GET"],
+        include_in_schema=False,
+        dependencies=admin_only,
+    )
+    application.add_api_route(
+        DOCS_URL,
+        swagger_ui_html,
+        methods=["GET"],
+        include_in_schema=False,
+        dependencies=admin_only,
+    )
+    application.add_api_route(
+        OAUTH2_REDIRECT_URL,
+        swagger_ui_redirect,
+        methods=["GET"],
+        include_in_schema=False,
+        dependencies=admin_only,
+    )
+    application.add_api_route(
+        REDOC_URL,
+        redoc_html,
+        methods=["GET"],
+        include_in_schema=False,
+        dependencies=admin_only,
+    )

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -14,11 +14,10 @@ from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 PUBLIC_ENDPOINT_SPECS = [
-    # built-in documentation functions
-    ("/openapi.json", {"GET", "HEAD"}),
-    ("/docs", {"GET", "HEAD"}),
-    ("/docs/oauth2-redirect", {"GET", "HEAD"}),
-    ("/redoc", {"GET", "HEAD"}),
+    # NOTE: the documentation routes (/openapi.json, /docs, /redoc,
+    # /docs/oauth2-redirect) are intentionally NOT public. They are registered
+    # behind current_curator_or_admin_user in onyx.server.api_docs so the API
+    # surface is not disclosed to anonymous clients (ON-010 / ENG-4131).
     # should always be callable, will just return 401 if not authenticated
     ("/me", {"GET"}),
     # just returns 200 to validate that the server is up
@@ -61,7 +60,10 @@ PUBLIC_ENDPOINT_SPECS = [
     ("/auth/saml/logout", {"POST"}),
     # anonymous user on cloud
     ("/tenants/anonymous-user", {"POST"}),
-    ("/metrics", {"GET"}),  # added by prometheus_fastapi_instrumentator
+    # Added by prometheus_fastapi_instrumentator. Access is gated by
+    # verify_metrics_token (a Bearer-token check) when METRICS_AUTH_TOKEN is set;
+    # that token gate is not user auth, so the route stays whitelisted here.
+    ("/metrics", {"GET"}),
     # craft webapp proxy — access enforced per-session via sharing_scope in handler
     ("/build/sessions/{session_id}/webapp", {"GET"}),
     ("/build/sessions/{session_id}/webapp/{path:path}", {"GET"}),

--- a/backend/onyx/server/metrics/auth.py
+++ b/backend/onyx/server/metrics/auth.py
@@ -1,0 +1,35 @@
+"""Auth for the Prometheus ``/metrics`` endpoint.
+
+The endpoint is scraped by machines (e.g. a Prometheus ServiceMonitor) that
+cannot present a session cookie, so it is protected with a static Bearer token
+rather than user auth. When ``METRICS_AUTH_TOKEN`` is unset the endpoint is open
+(backwards-compatible default); when set, callers must send
+``Authorization: Bearer <token>`` (Oneleet pentest finding ON-010 / ENG-4131).
+"""
+
+import secrets
+
+from fastapi import Header
+
+from onyx.auth.constants import BEARER_PREFIX
+from onyx.configs.app_configs import METRICS_AUTH_TOKEN
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+async def verify_metrics_token(
+    authorization: str | None = Header(default=None),
+) -> None:
+    """Reject /metrics requests that don't carry the configured Bearer token.
+
+    No-op when ``METRICS_AUTH_TOKEN`` is unset.
+    """
+    if not METRICS_AUTH_TOKEN:
+        return
+
+    if not authorization or not authorization.startswith(BEARER_PREFIX):
+        raise OnyxError(OnyxErrorCode.UNAUTHENTICATED)
+
+    token = authorization[len(BEARER_PREFIX) :].strip()
+    if not secrets.compare_digest(token, METRICS_AUTH_TOKEN):
+        raise OnyxError(OnyxErrorCode.UNAUTHENTICATED)

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -10,11 +10,13 @@ SQLAlchemy connection pool metrics are registered separately via
 (after engines are created).
 """
 
+from fastapi import Depends
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import default as default_metrics
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from starlette.applications import Starlette
 
+from onyx.server.metrics.auth import verify_metrics_token
 from onyx.server.metrics.per_tenant import per_tenant_request_callback
 from onyx.server.metrics.postgres_connection_pool import pool_timeout_handler
 from onyx.server.metrics.slow_requests import slow_request_callback
@@ -72,4 +74,8 @@ def setup_prometheus_metrics(app: Starlette) -> None:
     instrumentator.add(slow_request_callback)
     instrumentator.add(per_tenant_request_callback)
 
-    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(app)
+    # ``dependencies`` is forwarded to ``app.get(...)`` by ``expose()`` — this
+    # gates /metrics behind the Bearer token when METRICS_AUTH_TOKEN is set.
+    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(
+        app, dependencies=[Depends(verify_metrics_token)]
+    )

--- a/backend/tests/integration/tests/auth/test_docs_auth.py
+++ b/backend/tests/integration/tests/auth/test_docs_auth.py
@@ -1,0 +1,28 @@
+"""Docs endpoints must require admin auth (Oneleet pentest finding ON-010).
+
+`/openapi.json`, `/docs` and `/redoc` used to be served to anyone, disclosing
+the full API surface. They are now registered behind
+``current_curator_or_admin_user`` (see ``onyx.server.api_docs``).
+"""
+
+import pytest
+
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+DOCS_PATHS = ["/openapi.json", "/docs", "/redoc"]
+
+
+@pytest.mark.parametrize("path", DOCS_PATHS)
+def test_docs_endpoints_reject_anonymous(path: str) -> None:
+    """Without credentials the docs routes must not be readable."""
+    response = client.get(f"{API_SERVER_URL}{path}")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.parametrize("path", DOCS_PATHS)
+def test_docs_endpoints_allow_admin(path: str, admin_user: DATestUser) -> None:
+    """A logged-in admin can still reach the docs."""
+    response = client.get(f"{API_SERVER_URL}{path}", headers=admin_user.headers)
+    assert response.status_code == 200

--- a/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
+++ b/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
@@ -5,11 +5,15 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from prometheus_client import CollectorRegistry
 from prometheus_client import Gauge
 
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.metrics.auth import verify_metrics_token
 from onyx.server.metrics.per_tenant import per_tenant_request_callback
 from onyx.server.metrics.prometheus_setup import setup_prometheus_metrics
 from onyx.server.metrics.slow_requests import slow_request_callback
@@ -98,7 +102,50 @@ def test_setup_attaches_instrumentator_to_app() -> None:
                 10.0,
             ),
         )
-        mock_instance.expose.assert_called_once_with(app)
+        # /metrics is exposed with the Bearer-token dependency attached.
+        mock_instance.expose.assert_called_once()
+        expose_args, expose_kwargs = mock_instance.expose.call_args
+        assert expose_args == (app,)
+        dependencies = expose_kwargs["dependencies"]
+        assert len(dependencies) == 1
+        assert dependencies[0].dependency is verify_metrics_token
+
+
+@pytest.mark.asyncio
+async def test_verify_metrics_token_noop_when_unset() -> None:
+    """With no token configured, /metrics stays open (backwards-compatible)."""
+    with patch("onyx.server.metrics.auth.METRICS_AUTH_TOKEN", ""):
+        # Must not raise regardless of what (if anything) the caller sends.
+        await verify_metrics_token(authorization=None)
+        await verify_metrics_token(authorization="Bearer whatever")
+
+
+@pytest.mark.asyncio
+async def test_verify_metrics_token_accepts_valid_bearer() -> None:
+    with patch("onyx.server.metrics.auth.METRICS_AUTH_TOKEN", "s3cret"):
+        await verify_metrics_token(authorization="Bearer s3cret")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    [
+        None,  # missing header
+        "",  # empty header
+        "s3cret",  # missing Bearer scheme
+        "Basic s3cret",  # wrong scheme
+        "Bearer wrong",  # wrong token
+        "Bearer ",  # empty token
+    ],
+)
+async def test_verify_metrics_token_rejects_bad_auth(
+    authorization: str | None,
+) -> None:
+    with patch("onyx.server.metrics.auth.METRICS_AUTH_TOKEN", "s3cret"):
+        with pytest.raises(OnyxError) as exc_info:
+            await verify_metrics_token(authorization=authorization)
+        assert exc_info.value.error_code == OnyxErrorCode.UNAUTHENTICATED
+        assert exc_info.value.status_code == 401
 
 
 def test_per_tenant_callback_increments_with_tenant_id() -> None:

--- a/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
+++ b/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
@@ -20,4 +20,11 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+      {{- if and .Values.auth.metricsToken (ne (toString .Values.auth.metricsToken.enabled) "false") }}
+      authorization:
+        type: Bearer
+        credentials:
+          name: {{ include "onyx.secretName" .Values.auth.metricsToken }}
+          key: {{ default "metrics_auth_token" .Values.auth.metricsToken.secretKeys.METRICS_AUTH_TOKEN }}
+      {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1342,6 +1342,24 @@ auth:
     # If not set, helm install/upgrade will fail when auth.userauth.enabled=true.
     values:
       user_auth_secret: ""
+  metricsToken:
+    # -- Bearer token required to scrape the API server's Prometheus /metrics
+    # endpoint. Disabled by default to preserve upgrade compatibility (when
+    # disabled, /metrics is served without auth, matching prior behavior). When
+    # enabled, the token is injected into the API pod as METRICS_AUTH_TOKEN and
+    # the API ServiceMonitor is configured to send it as a Bearer token.
+    enabled: false
+    # -- Overwrite the default secret name, ignored if existingSecret is defined
+    secretName: 'onyx-metrics-token'
+    # -- Use a secret specified elsewhere
+    existingSecret: ""
+    # -- This defines the env var to secret map
+    secretKeys:
+      METRICS_AUTH_TOKEN: metrics_auth_token
+    # -- Secret value. Required when this secret is enabled - generate with: openssl rand -hex 32
+    # If not set, helm install/upgrade will fail when auth.metricsToken.enabled=true.
+    values:
+      metrics_auth_token: ""
   # Ed25519 private key for sandbox push auth (only the public key reaches sandbox pods).
   # Generate with: python3 -c "import base64; from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey as K; from cryptography.hazmat.primitives.serialization import *; print(base64.b64encode(K.generate().private_bytes(Encoding.Raw,PrivateFormat.Raw,NoEncryption())).decode())"
   sandboxPushSecret:


### PR DESCRIPTION
## Description

Oneleet pentest finding **ON-010 / ENG-4131**: `/openapi.json`, `/docs`, `/redoc` and `/metrics` were served to anonymous clients (HTTP 200, no session cookie), disclosing the full API surface (367 paths) and operational metrics.

This locks them down while keeping them usable for who legitimately needs them:

**Docs → admin auth.** Disabled FastAPI's built-in auto-docs (`openapi_url=None, docs_url=None, redoc_url=None`) and re-registered `/openapi.json`, `/docs`, `/redoc`, `/docs/oauth2-redirect` behind `current_curator_or_admin_user` in the new `onyx/server/api_docs.py`. Dropped them from `PUBLIC_ENDPOINT_SPECS` so the startup `check_router_auth` now *enforces* the dependency (regression guard). Logged-in admins keep access via session cookie; anonymous gets 401.

**`/metrics` → optional Bearer token.** Added `METRICS_AUTH_TOKEN`; the new `verify_metrics_token` dependency (attached via `Instrumentator.expose(..., dependencies=[...])`) requires `Authorization: Bearer <token>` when the env var is set, and is a **no-op when unset** (backwards-compatible). Since `/metrics` is scraped in-cluster by a Prometheus ServiceMonitor that can't send a cookie, a token is the right mechanism.

**Deployment (helm).** Added an `auth.metricsToken` secret block (modeled on `auth.userauth`, `enabled: false` by default for upgrade compatibility) — the existing secret machinery auto-injects `METRICS_AUTH_TOKEN` into the API pod — and a conditional `authorization: {type: Bearer, ...}` block on the API `ServiceMonitor` so in-cluster Prometheus keeps scraping when enabled.

### Notes
- Offline schema generation / client codegen are unaffected — `scripts/onyx_openapi_schema.py` reads the app object, not the live route. No frontend code consumes `/openapi.json` at runtime.
- EE inherits the change via the shared base `get_application` + `PUBLIC_ENDPOINT_SPECS` (verified the EE app builds and its auth check passes).
- **Out of scope:** the Celery workers' separate `prometheus_client` `/metrics` servers (internal-only ports, not the FastAPI app) are unchanged.

## How Has This Been Tested?

- **Unit** (`backend/tests/unit/onyx/server/test_prometheus_instrumentation.py`): `verify_metrics_token` cases (unset / valid / missing / wrong-scheme / wrong-token / empty) + updated the `expose()` wiring assertion. 16 passed.
- **Integration** (`backend/tests/integration/tests/auth/test_docs_auth.py`): anonymous → 401/403, admin → 200 on the docs routes.
- Verified the full app (EE variant) builds and `check_router_auth` passes with all routes registered; isolated TestClient smoke test confirmed docs gating (admin 200 / denied 401) and the metrics token (401 missing/bad, 200 valid, open when unset).
- pre-commit (`ty`, `ruff`, `ruff format`, `Check YAML`, `ripsecrets`) all green.

> Live curl + the integration test against the running stack, and `helm template --set auth.metricsToken.enabled=true`, should be run in CI / a full environment (services weren't running in my dev snapshot).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down `/openapi.json`, `/docs`, `/redoc`, and `/metrics` to stop anonymous access and API surface exposure. Resolves ENG-4131 (Oneleet ON-010). Docs now require an admin session; `/metrics` uses an optional Bearer token via `METRICS_AUTH_TOKEN`.

- **Bug Fixes**
  - Disabled `FastAPI` auto-docs; re-registered `/openapi.json`, `/docs`, `/redoc`, `/docs/oauth2-redirect` behind `current_curator_or_admin_user`.
  - Added `verify_metrics_token` on `/metrics`; requires `Authorization: Bearer <token>` when `METRICS_AUTH_TOKEN` is set (no-op when unset).
  - Updated `PUBLIC_ENDPOINT_SPECS` and Helm: new `auth.metricsToken` secret; `ServiceMonitor` sends Bearer credentials when enabled.

- **Migration**
  - Backwards-compatible by default: keep `/metrics` open with `auth.metricsToken.enabled=false`.
  - To secure `/metrics`: set `auth.metricsToken.enabled=true`, provide the secret value (e.g., `openssl rand -hex 32`), and the `ServiceMonitor` will send the Bearer token.
  - Docs now require an authenticated admin session; no further changes needed.

<sup>Written for commit 3b490247f8593a3368194314a91b04e64d27d5a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

