### PR TITLE
feat: add Jira Service Management connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -220,6 +220,7 @@ class DocumentSource(str, Enum):
     OUTLINE = "outline"
     CONFLUENCE = "confluence"
     JIRA = "jira"
+    JIRA_SERVICE_MANAGEMENT = "jira_service_management"
     SLAB = "slab"
     PRODUCTBOARD = "productboard"
     FILE = "file"
@@ -699,6 +700,7 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.OUTLINE: "Documentation and knowledge base pages",
     DocumentSource.CONFLUENCE: "Wiki pages, spaces, and documentation",
     DocumentSource.JIRA: "Issues, tickets, and project tracking",
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: "Service management tickets and requests",
     DocumentSource.SLAB: "Documentation and knowledge base pages",
     DocumentSource.PRODUCTBOARD: "Product management boards and insights",
     DocumentSource.FILE: "Uploaded files",

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -389,6 +389,7 @@ def process_jira_issue(
     comment_email_blacklist: tuple[str, ...] = (),
     labels_to_skip: set[str] | None = None,
     parent_hierarchy_raw_node_id: str | None = None,
+    source: DocumentSource = DocumentSource.JIRA,
 ) -> Document | None:
     if labels_to_skip:
         if any(label in issue.fields.labels for label in labels_to_skip):
@@ -485,7 +486,7 @@ def process_jira_issue(
     return Document(
         id=page_url,
         sections=[TextSection(link=page_url, text=ticket_content)],
-        source=DocumentSource.JIRA,
+        source=source,
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
@@ -511,6 +512,8 @@ class JiraConnector(
     CheckpointedConnectorWithPermSync[JiraConnectorCheckpoint],
     SlimConnectorWithPermSync,
 ):
+    document_source: DocumentSource = DocumentSource.JIRA
+
     def __init__(
         self,
         jira_base_url: str,
@@ -834,6 +837,7 @@ class JiraConnector(
                     comment_email_blacklist=self.comment_email_blacklist,
                     labels_to_skip=self.labels_to_skip,
                     parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+                    source=self.document_source,
                 ):
                     # Add permission information to the document if requested
                     if include_permissions:

--- a/backend/onyx/connectors/jira_service_management/__init__.py
+++ b/backend/onyx/connectors/jira_service_management/__init__.py
@@ -1,0 +1,3 @@
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)

--- a/backend/onyx/connectors/jira_service_management/connector.py
+++ b/backend/onyx/connectors/jira_service_management/connector.py
@@ -1,0 +1,6 @@
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira.connector import JiraConnector
+
+
+class JiraServiceManagementConnector(JiraConnector):
+    document_source = DocumentSource.JIRA_SERVICE_MANAGEMENT

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -60,6 +60,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.jira.connector",
         class_name="JiraConnector",
     ),
+    DocumentSource.JIRA_SERVICE_MANAGEMENT: ConnectorMapping(
+        module_path="onyx.connectors.jira_service_management.connector",
+        class_name="JiraServiceManagementConnector",
+    ),
     DocumentSource.PRODUCTBOARD: ConnectorMapping(
         module_path="onyx.connectors.productboard.connector",
         class_name="ProductboardConnector",

--- a/backend/onyx/kg/setup/kg_default_entity_definitions.py
+++ b/backend/onyx/kg/setup/kg_default_entity_definitions.py
@@ -90,6 +90,45 @@ def get_default_entity_types(vendor_name: str) -> dict[str, KGEntityTypeDefiniti
             grounding=KGGroundingType.GROUNDED,
             grounded_source_name=DocumentSource.JIRA,
         ),
+        "JIRA_SERVICE_MANAGEMENT": KGEntityTypeDefinition(
+            description=(
+                "A formal Jira Service Management ticket about a customer issue or request."
+            ),
+            attributes=KGEntityTypeAttributes(
+                metadata_attribute_conversion={
+                    "issuetype": KGAttributeProperty(name="subtype", keep=True),
+                    "status": KGAttributeProperty(name="status", keep=True),
+                    "priority": KGAttributeProperty(name="priority", keep=True),
+                    "project_name": KGAttributeProperty(name="project", keep=True),
+                    "created": KGAttributeProperty(name="created_at", keep=True),
+                    "updated": KGAttributeProperty(name="updated_at", keep=True),
+                    "resolution_date": KGAttributeProperty(
+                        name="completed_at", keep=True
+                    ),
+                    "duedate": KGAttributeProperty(name="due_date", keep=True),
+                    "reporter_email": KGAttributeProperty(
+                        name="creator",
+                        keep=False,
+                        implication_property=KGAttributeImplicationProperty(
+                            implied_entity_type=KGAttributeEntityOption.FROM_EMAIL,
+                            implied_relationship_name="is_creator_of",
+                        ),
+                    ),
+                    "assignee_email": KGAttributeProperty(
+                        name="assignee",
+                        keep=False,
+                        implication_property=KGAttributeImplicationProperty(
+                            implied_entity_type=KGAttributeEntityOption.FROM_EMAIL,
+                            implied_relationship_name="is_assignee_of",
+                        ),
+                    ),
+                    "key": KGAttributeProperty(name="key", keep=True),
+                    "parent": KGAttributeProperty(name="parent", keep=True),
+                },
+            ),
+            grounding=KGGroundingType.GROUNDED,
+            grounded_source_name=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+        ),
         "GITHUB_PR": KGEntityTypeDefinition(
             description="A formal engineering request to merge proposed changes into the codebase.",
             attributes=KGEntityTypeAttributes(

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -23,6 +23,8 @@ def source_to_github_img_link(source: DocumentSource) -> str | None:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Confluence.png"
     if source == DocumentSource.JIRA.value:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Jira.png"
+    if source == DocumentSource.JIRA_SERVICE_MANAGEMENT.value:
+        return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/backend/slackbot_images/Jira.png"
     if source == DocumentSource.NOTION.value:
         return "https://raw.githubusercontent.com/onyx-dot-app/onyx/main/web/public/Notion.png"
     if source == DocumentSource.ZENDESK.value:

--- a/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def jira_base_url() -> str:
+    return "https://jira.example.com"

--- a/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py
@@ -1,0 +1,84 @@
+import time
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from jira import JIRA
+from jira.resources import Issue
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.jira_service_management.connector import (
+    JiraServiceManagementConnector,
+)
+from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
+from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
+
+
+def _build_mock_issue() -> MagicMock:
+    issue = MagicMock(spec=Issue)
+    issue.key = "JSM-1"
+    issue.fields = MagicMock()
+    issue.fields.summary = "Customer request"
+    issue.fields.updated = "2025-06-06T00:00:00.000+0000"
+    issue.fields.description = "Help me please"
+    issue.fields.labels = []
+    issue.fields.reporter = None
+    issue.fields.assignee = None
+    issue.fields.priority = None
+    issue.fields.status = None
+    issue.fields.resolution = None
+    issue.fields.project = MagicMock()
+    issue.fields.project.key = "JSM"
+    issue.fields.project.name = "Jira Service Management"
+    issue.fields.issuetype = MagicMock()
+    issue.fields.issuetype.name = "Task"
+    issue.fields.parent = None
+    issue.raw = {"fields": {"description": issue.fields.description}}
+    return issue
+
+
+def test_jira_service_management_connector_uses_distinct_source(
+    jira_base_url: str,
+) -> None:
+    connector = JiraServiceManagementConnector(
+        jira_base_url=jira_base_url,
+        project_key="JSM",
+    )
+
+    mock_client = MagicMock(spec=JIRA)
+    mock_client._options = {"rest_api_version": "2"}
+    mock_client.search_issues.side_effect = [[_build_mock_issue()], []]
+    connector._jira_client = mock_client
+
+    with patch(
+        "onyx.connectors.jira.connector.process_jira_issue"
+    ) as mock_process:
+        mock_process.return_value = Document(
+            id="https://jira.example.com/browse/JSM-1",
+            sections=[
+                TextSection(
+                    link="https://jira.example.com/browse/JSM-1",
+                    text="Help me please",
+                )
+            ],
+            source=DocumentSource.JIRA_SERVICE_MANAGEMENT,
+            semantic_identifier="JSM-1: Customer request",
+            metadata={},
+        )
+
+        outputs = load_everything_from_checkpoint_connector(
+            connector,
+            0,
+            time.time(),
+        )
+        docs = [
+            item
+            for batch in outputs
+            for item in batch.items
+            if isinstance(item, Document)
+        ]
+
+    assert docs
+    assert docs[0].source == DocumentSource.JIRA_SERVICE_MANAGEMENT
+    assert mock_process.call_count == 1
+    assert mock_process.call_args.kwargs["source"] == DocumentSource.JIRA_SERVICE_MANAGEMENT

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
@@ -134,6 +134,23 @@ def test_jira_normalization(url: str, expected: str) -> None:
     "url,expected",
     [
         (
+            "https://example.atlassian.net/jira/browse/PROJ-123?query=param#section",
+            "https://example.atlassian.net/jira/browse/PROJ-123",
+        ),
+    ],
+)
+def test_jira_service_management_normalization(url: str, expected: str) -> None:
+    """Test Jira Service Management URL normalization (uses default normalizer)."""
+    assert (
+        normalize_url(url, source_type=DocumentSource.JIRA_SERVICE_MANAGEMENT)
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
             "https://github.com/owner/repo/blob/main/file.py?query=param#section",
             "https://github.com/owner/repo/blob/main/file.py",
         ),

--- a/web/src/components/admin/connectors/ConnectorTitle.tsx
+++ b/web/src/components/admin/connectors/ConnectorTitle.tsx
@@ -71,6 +71,12 @@ export const ConnectorTitle = ({
       "Jira Project URL",
       typedConnector.connector_specific_config.jira_project_url
     );
+  } else if (connector.source === "jira_service_management") {
+    const typedConnector = connector as Connector<JiraConfig>;
+    additionalMetadata.set(
+      "JSM Project URL",
+      typedConnector.connector_specific_config.jira_project_url
+    );
   } else if (connector.source === "slack") {
     const typedConnector = connector as Connector<SlackConfig>;
     if (

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -754,6 +754,91 @@ export const connectorConfigs: Record<
     ],
     advanced_values: [],
   },
+  jira_service_management: {
+    description: "Configure Jira Service Management connector",
+    subtext: `Configure which Jira Service Management content to index. You can index everything or specify a particular project.`,
+    values: [
+      {
+        type: "text",
+        query: "Enter the Jira base URL:",
+        label: "Jira Base URL",
+        name: "jira_base_url",
+        optional: false,
+        description:
+          "The base URL of your Jira instance (e.g., https://your-domain.atlassian.net)",
+      },
+      {
+        type: "checkbox",
+        query: "Using scoped token?",
+        label: "Using scoped token",
+        name: "scoped_token",
+        optional: true,
+        default: false,
+      },
+      {
+        type: "tab",
+        name: "indexing_scope",
+        label: "How Should We Index Your JSM?",
+        optional: true,
+        tabs: [
+          {
+            value: "everything",
+            label: "Everything",
+            fields: [
+              {
+                type: "string_tab",
+                label: "Everything",
+                name: "everything",
+                description:
+                  "This connector will index all issues the provided credentials have access to!",
+              },
+            ],
+          },
+          {
+            value: "project",
+            label: "Project",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the project key:",
+                label: "Project Key",
+                name: "project_key",
+                description:
+                  "The key of a specific project to index (e.g., 'PROJ').",
+              },
+            ],
+          },
+          {
+            value: "jql",
+            label: "JQL Query",
+            fields: [
+              {
+                type: "text",
+                query: "Enter the JQL query:",
+                label: "JQL Query",
+                name: "jql_query",
+                description:
+                  "A custom JQL query to filter Jira issues." +
+                  "\n\nIMPORTANT: Do not include any time-based filters in the JQL query as that will conflict with the connector's logic. Additionally, do not include ORDER BY clauses." +
+                  "\n\nSee Atlassian's [JQL documentation](https://support.atlassian.com/jira-software-cloud/docs/advanced-search-reference-jql-fields/) for more details on syntax.",
+              },
+            ],
+          },
+        ],
+        defaultTab: "everything",
+      },
+      {
+        type: "list",
+        query: "Enter email addresses to blacklist from comments:",
+        label: "Comment Email Blacklist",
+        name: "comment_email_blacklist",
+        description:
+          "This is generally useful to ignore certain bots. Add user emails which comments should NOT be indexed.",
+        optional: true,
+      },
+    ],
+    advanced_values: [],
+  },
   salesforce: {
     description: "Configure Salesforce connector",
     values: [

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -309,6 +309,10 @@ export const credentialTemplates: Record<ValidSources, any> = {
     jira_user_email: null,
     jira_api_token: "",
   } as JiraCredentialJson,
+  jira_service_management: {
+    jira_user_email: null,
+    jira_api_token: "",
+  } as JiraCredentialJson,
   productboard: { productboard_access_token: "" } as ProductboardCredentialJson,
   slab: { slab_bot_token: "" } as SlabCredentialJson,
   coda: { coda_bearer_token: "" } as CodaCredentialJson,

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -239,6 +239,12 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
     isPopular: true,
   },
+  jira_service_management: {
+    icon: SvgJira,
+    displayName: "Jira Service Management",
+    category: SourceCategory.TicketingAndTaskManagement,
+    docs: `${DOCS_ADMINS_PATH}/connectors/official/jira`,
+  },
   zendesk: {
     icon: SvgZendesk,
     displayName: "Zendesk",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,7 @@ export enum ValidSources {
   Outline = "outline",
   Confluence = "confluence",
   Jira = "jira",
+  JiraServiceManagement = "jira_service_management",
   Productboard = "productboard",
   Slab = "slab",
   Coda = "coda",
@@ -614,6 +615,7 @@ export const federatedSourceToRegularSource = (
 export const validAutoSyncSources = [
   ValidSources.Confluence,
   ValidSources.Jira,
+  ValidSources.JiraServiceManagement,
   ValidSources.GoogleDrive,
   ValidSources.Gmail,
   ValidSources.Slack,


### PR DESCRIPTION
## Summary

Adds a Jira Service Management connector by reusing the existing Jira indexing flow with a new `jira_service_management` source, connector registration, source metadata, and frontend form wiring.

## Testing

- `python3 -m py_compile backend/onyx/configs/constants.py backend/onyx/connectors/jira/connector.py backend/onyx/connectors/registry.py backend/onyx/kg/setup/kg_default_entity_definitions.py backend/onyx/onyxbot/slack/icons.py backend/onyx/connectors/jira_service_management/__init__.py backend/onyx/connectors/jira_service_management/connector.py backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py backend/tests/unit/onyx/connectors/jira_service_management/test_connector.py`
- `git diff --check`

Closes #2281.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Jira Service Management connector that reuses the Jira indexing flow, introducing a distinct `jira_service_management` source with backend, KG, tests, and admin UI support. Closes #2281.

- **New Features**
  - Added `DocumentSource.JIRA_SERVICE_MANAGEMENT` with description and a grounded KG entity type.
  - Introduced `JiraServiceManagementConnector` (extends `JiraConnector`) and registry mapping; Jira issue processing now accepts a `source` to tag docs correctly.
  - Added admin UI and credentials for `jira_service_management` (base URL, scoped token, project/JQL options, blacklist); included in `validAutoSyncSources` and source metadata.
  - Mapped Slack icon; added URL normalization, a pytest fixture, and unit tests verifying the distinct source behavior.

<sup>Written for commit 825c71c9932f1108e2b95e0d6cfcdbc8765421b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

