### PR TITLE
fix(opal): fix `InputTypeIn` height to 36px

### DIFF
--- a/web/lib/opal/src/components/inputs/shared.css
+++ b/web/lib/opal/src/components/inputs/shared.css
@@ -16,7 +16,7 @@
 
 .opal-input {
   /* `--interactive-duration` (150ms) felt too laggy, so we're using 100ms instead. */
-  @apply flex flex-row items-center justify-between flex-1 h-fit p-1.5 rounded-08 relative w-full transition-all duration-100 ease-(--interactive-easing);
+  @apply flex flex-row items-center justify-between flex-1 h-fit p-[5px] rounded-08 relative w-full transition-all duration-100 ease-(--interactive-easing);
 }
 
 .opal-input[data-variant="primary"] {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,7 +2,6 @@ import "./globals.css";
 
 import { GTM_ENABLED, MODAL_ROOT_ID } from "@/lib/constants";
 import { Metadata } from "next";
-
 import AppProvider from "@/providers/AppProvider";
 import DynamicMetadata from "@/providers/DynamicMetadata";
 import { PHProvider } from "./providers";


### PR DESCRIPTION
## Description

`InputTypeIn` was rendering at 38px instead of the required 36px. All five variants already carry a 1px border (transparent for `internal`/`disabled`, visible for `primary`/`error`/`readOnly`), so the height formula was:

```
1px border + 6px padding (p-1.5) + 24px inner input (h-6) + 6px padding + 1px border = 38px
```

Fix: reduce uniform padding from `p-1.5` (6px) to `p-[5px]` (5px) in the shared `.opal-input` base class:

```
1px + 5px + 24px + 5px + 1px = 36px ✓
```

No variant-specific overrides needed — the transparent-border approach (already used by `internal` and `disabled`) keeps the layout model uniform across all variants.

Also includes a minor cosmetic cleanup to `web/src/app/layout.tsx` (removes a spurious blank line).

## How Has This Been Tested?

Verified by inspecting the height arithmetic across all five variants (`primary`, `internal`, `error`, `disabled`, `readOnly`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check