### PR TITLE
feat(craft): Add more actions to Slack, GDrive, and Linear External Apps 

### DIFF
--- a/backend/onyx/external_apps/providers/google_drive.py
+++ b/backend/onyx/external_apps/providers/google_drive.py
@@ -11,8 +11,10 @@ from onyx.external_apps.providers.google_base import GoogleOAuthProvider
 
 # Google Drive API v3. Reads (GET) live under `/drive/v3/...`; content uploads
 # use the separate `/upload/drive/v3/...` host path, so both prefixes appear in
-# the upstream patterns and the catalog. Reads default to ALWAYS; every mutation
-# defaults to ASK so the egress approval gate prompts the user before it runs.
+# the upstream patterns and the catalog. The Google Docs API is a separate host
+# (`docs.googleapis.com/v1/documents/...`) authorized by the same `auth/drive`
+# scope. Reads default to ALWAYS; every mutation defaults to ASK so the egress
+# approval gate prompts the user before it runs.
 class GoogleDriveAction(ExternalAppAction):
     """Strongly-typed catalog ids for the Google Drive provider."""
 
@@ -22,12 +24,17 @@ class GoogleDriveAction(ExternalAppAction):
     FILES_CREATE = "gdrive.files.create"
     FILES_UPDATE = "gdrive.files.update"
     FILES_DELETE = "gdrive.files.delete"
+    DOCS_READ = "gdrive.docs.read"
+    DOCS_CREATE = "gdrive.docs.create"
+    DOCS_UPDATE = "gdrive.docs.update"
 
 
 _FILES = "/drive/v3/files"
 _FILE_ITEM = f"{_FILES}/{{fileId}}"
 _UPLOAD_FILES = "/upload/drive/v3/files"
 _UPLOAD_ITEM = f"{_UPLOAD_FILES}/{{fileId}}"
+_DOCS = "/v1/documents"
+_DOC_ITEM = f"{_DOCS}/{{documentId}}"
 _ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         id=GoogleDriveAction.FILES_READ,
@@ -89,6 +96,28 @@ _ENDPOINTS: list[EndpointSpec] = [
         description="Trash or permanently delete a file.",
         matches=(RestRoute(method="DELETE", path=_FILE_ITEM),),
     ),
+    EndpointSpec(
+        id=GoogleDriveAction.DOCS_READ,
+        normalised_name="Read a document",
+        description=(
+            "Read a Google Doc's structured contents (text, formatting, and "
+            "layout) via the Docs API."
+        ),
+        matches=(RestRoute(method="GET", path=_DOC_ITEM),),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.DOCS_CREATE,
+        normalised_name="Create a document",
+        description="Create a new, empty Google Doc via the Docs API.",
+        matches=(RestRoute(method="POST", path=_DOCS),),
+    ),
+    EndpointSpec(
+        id=GoogleDriveAction.DOCS_UPDATE,
+        normalised_name="Edit a document",
+        description="Apply edits to a Google Doc's contents via the Docs API.",
+        matches=(RestRoute(method="POST", path=_DOC_ITEM),),
+    ),
 ]
 
 
@@ -103,12 +132,14 @@ class GoogleDriveProvider(GoogleOAuthProvider, OnyxManagedExtApp):
             "https://www\\.googleapis\\.com/drive/.*",
             # Content uploads use the separate /upload host path.
             "https://www\\.googleapis\\.com/upload/drive/.*",
+            # The Docs API lives on its own host.
+            "https://docs\\.googleapis\\.com/.*",
         ],
         description=(
-            "Search, read, create, and edit files in your Google Drive inside "
-            "Onyx Craft."
+            "Search, read, create, and edit files and Google Docs in your "
+            "Google Drive inside Onyx Craft."
         ),
-        google_api_name="Google Drive API",
+        google_api_name="Google Drive API and Google Docs API",
         endpoint_catalog=_ENDPOINTS,
     )
 

--- a/backend/onyx/external_apps/providers/linear.py
+++ b/backend/onyx/external_apps/providers/linear.py
@@ -26,6 +26,8 @@ class LinearAction(ExternalAppAction):
     PROJECTS_READ = "linear.projects.read"
     ISSUES_CREATE = "linear.issues.create"
     COMMENTS_CREATE = "linear.comments.create"
+    PROJECTS_CREATE = "linear.projects.create"
+    PROJECTS_UPDATE = "linear.projects.update"
 
 
 # Linear is a single GraphQL endpoint (POST https://api.linear.app/graphql); the
@@ -74,6 +76,18 @@ _ENDPOINTS: list[EndpointSpec] = [
         normalised_name="Comment on an issue",
         description="Add a comment to an issue.",
         matches=(GraphQLOp(operation_type="mutation", field="commentCreate"),),
+    ),
+    EndpointSpec(
+        id=LinearAction.PROJECTS_CREATE,
+        normalised_name="Create a project",
+        description="Create a new project.",
+        matches=(GraphQLOp(operation_type="mutation", field="projectCreate"),),
+    ),
+    EndpointSpec(
+        id=LinearAction.PROJECTS_UPDATE,
+        normalised_name="Edit a project",
+        description="Update an existing project.",
+        matches=(GraphQLOp(operation_type="mutation", field="projectUpdate"),),
     ),
 ]
 

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -25,6 +25,7 @@ class SlackAction(ExternalAppAction):
     USERS_READ = "slack.users.read"
     SEARCH_READ = "slack.search.read"
     MESSAGES_WRITE = "slack.messages.write"
+    DM_OPEN = "slack.dm.open"
 
 
 # Slack Web API calls are POST to https://slack.com/api/<method>; the action is
@@ -32,15 +33,23 @@ class SlackAction(ExternalAppAction):
 _ENDPOINTS: list[EndpointSpec] = [
     EndpointSpec(
         id=SlackAction.CHANNELS_READ,
-        normalised_name="List channels",
-        description="List the workspace's channels and conversations.",
-        matches=(RestRoute(method="POST", path="/api/conversations.list"),),
+        normalised_name="View channels & conversations",
+        description=(
+            "List the workspace's channels and conversations and look up a "
+            "single conversation's metadata."
+        ),
+        matches=(
+            RestRoute(method="POST", path="/api/conversations.list"),
+            RestRoute(method="POST", path="/api/conversations.info"),
+        ),
         default_policy=EndpointPolicy.ALWAYS,
     ),
     EndpointSpec(
         id=SlackAction.MESSAGES_READ,
-        normalised_name="Read channel messages",
-        description="Read messages and thread replies in a channel.",
+        normalised_name="Read messages",
+        description=(
+            "Read messages and thread replies in a channel or direct message."
+        ),
         matches=(
             RestRoute(method="POST", path="/api/conversations.history"),
             RestRoute(method="POST", path="/api/conversations.replies"),
@@ -70,6 +79,12 @@ _ENDPOINTS: list[EndpointSpec] = [
         description="Post a message to a channel or conversation.",
         matches=(RestRoute(method="POST", path="/api/chat.postMessage"),),
     ),
+    EndpointSpec(
+        id=SlackAction.DM_OPEN,
+        normalised_name="Open a direct message",
+        description="Open (or resume) a direct message conversation with a user.",
+        matches=(RestRoute(method="POST", path="/api/conversations.open"),),
+    ),
 ]
 
 
@@ -82,13 +97,14 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
             token_url="https://slack.com/api/oauth.v2.access",
             scope=",".join(
                 [
-                    "chat:write",
                     "channels:history",
                     "channels:read",
+                    "chat:write",
                     "groups:history",
                     "groups:read",
                     "im:history",
                     "im:read",
+                    "im:write",
                     "users:read",
                 ]
             ),
@@ -123,10 +139,11 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "Create a Slack app at api.slack.com/apps. Under OAuth & "
                 "Permissions, add this Onyx instance's callback URL "
                 "(/craft/v1/apps/oauth/callback) to Redirect URLs, and add the "
-                "User Token Scopes you want the agent to use (e.g. chat:write, "
-                "channels:history, channels:read, im:history, users:read). No "
-                "bot user is required. Then paste the app's Client ID and "
-                "Client Secret below."
+                "User Token Scopes you want the agent to use (channels:history, "
+                "channels:read, chat:write, groups:history, groups:read, "
+                "im:history, im:read, im:write, users:read). No bot user is "
+                "required. Then paste the app's Client ID and Client Secret "
+                "below."
             ),
         ),
         endpoint_catalog=_ENDPOINTS,

--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -105,6 +105,7 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                     "im:history",
                     "im:read",
                     "im:write",
+                    "search:read",
                     "users:read",
                 ]
             ),
@@ -141,9 +142,9 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "(/craft/v1/apps/oauth/callback) to Redirect URLs, and add the "
                 "User Token Scopes you want the agent to use (channels:history, "
                 "channels:read, chat:write, groups:history, groups:read, "
-                "im:history, im:read, im:write, users:read). No bot user is "
-                "required. Then paste the app's Client ID and Client Secret "
-                "below."
+                "im:history, im:read, im:write, search:read, users:read). No "
+                "bot user is required. Then paste the app's Client ID and "
+                "Client Secret below."
             ),
         ),
         endpoint_catalog=_ENDPOINTS,

--- a/backend/tests/unit/external_apps/test_google_drive_provider.py
+++ b/backend/tests/unit/external_apps/test_google_drive_provider.py
@@ -17,6 +17,7 @@ _READ_ACTIONS = {
     GoogleDriveAction.FILES_READ,
     GoogleDriveAction.FILES_EXPORT,
     GoogleDriveAction.DRIVES_READ,
+    GoogleDriveAction.DOCS_READ,
 }
 
 
@@ -34,11 +35,14 @@ def test_registered_as_managed_drive_provider() -> None:
 
 def test_scope_and_patterns_cover_read_and_upload() -> None:
     spec = _provider().spec
+    # The single `auth/drive` scope also authorizes the Google Docs API.
     assert spec.oauth.scope == "https://www.googleapis.com/auth/drive"
-    # The /upload host path is required for content uploads to be token-injected.
+    # The /upload host path is required for content uploads to be token-injected;
+    # the Docs API lives on its own `docs.googleapis.com` host.
     assert spec.descriptor.upstream_url_patterns == [
         "https://www\\.googleapis\\.com/drive/.*",
         "https://www\\.googleapis\\.com/upload/drive/.*",
+        "https://docs\\.googleapis\\.com/.*",
     ]
     assert spec.descriptor.auth_template == {"Authorization": "Bearer {access_token}"}
 
@@ -82,6 +86,9 @@ def test_catalog_recognises_helper_request_paths() -> None:
         ("PATCH", "/drive/v3/files/ABC123"),  # update metadata / trash
         ("PATCH", "/upload/drive/v3/files/ABC123"),  # replace content
         ("DELETE", "/drive/v3/files/ABC123"),  # delete
+        ("GET", "/v1/documents/ABC123"),  # read a Google Doc (Docs API)
+        ("POST", "/v1/documents"),  # create a Google Doc
+        ("POST", "/v1/documents/ABC123:batchUpdate"),  # edit a Google Doc
     ]
     for method, path in helper_calls:
         matched = [r for r in routes if r[0] == method and path_matches(r[1], path)]


### PR DESCRIPTION
## Description
Adds the dm write scope to the slack external app.
Also adds docs scope to drive.
Finally adds the project create and update scope to linear

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

closes https://linear.app/onyx-app/issue/ENG-4136/craft-polish-slack-external-app-needs-dm-access
closes https://linear.app/onyx-app/issue/ENG-4140/craft-polish-linear-external-app-needs-project-create-capability
closes https://linear.app/onyx-app/issue/ENG-4137/craft-polish-drive-external-app-needs-docs-api-access

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Slack DM access, Drive Docs API, and Linear project create/update so agents can message users, edit Docs, and manage projects. Addresses ENG-4136, ENG-4137, ENG-4140.

- **New Features**
  - Slack: Add `im:write`; new `DM_OPEN` (`conversations.open`); read DMs; include `conversations.info`; add `groups:read`, `groups:history`, `search:read`; update help text.
  - Google Drive: Add Docs API (`docs.googleapis.com`); new actions `DOCS_READ` (ALWAYS), `DOCS_CREATE`, `DOCS_UPDATE`; same Drive scope.
  - Linear: Add `PROJECTS_CREATE` (`projectCreate`) and `PROJECTS_UPDATE` (`projectUpdate`).

<sup>Written for commit 4aabb0f87fb1cc66fea093e831e1896d528131b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



