### PR TITLE
feat(shared): scaffold @onyx-ai/shared package for web + mobile

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Pull Vercel Environment Information
         run: bunx ${{ env.VERCEL_CLI }} pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Install dependencies and build Opal
+      - name: Install dependencies and build Opal + Shared
         working-directory: ./web
-        run: bun install --frozen-lockfile && bun run --filter './lib/opal' build
+        run: bun install --frozen-lockfile && bun run --filter './lib/opal' build && bun run --filter './lib/shared' build
 
       - name: Build Project Artifacts
         run: bunx ${{ env.VERCEL_CLI }} build --token=${{ secrets.VERCEL_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -226,3 +226,10 @@ repos:
         language: system
         pass_filenames: false
         files: ^(bun\.lock|examples/widget/(.*\.(ts|tsx)|package\.json|tsconfig\.json))$
+
+      - id: shared-typescript-check
+        name: shared TypeScript type check
+        entry: bash -c 'cd web/lib/shared && bunx tsgo --noEmit'
+        language: system
+        pass_filenames: false
+        files: ^web/lib/shared/(.*\.(ts|tsx)|package\.json|tsconfig.*\.json)$

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -95,6 +95,17 @@
         "group": "1"
       },
       "stopAll": true
+    },
+    {
+      "name": "Web Server + Shared Watch",
+      "configurations": [
+        "Web Server",
+        "Shared Watch (rebuild dist)"
+      ],
+      "presentation": {
+        "group": "1"
+      },
+      "stopAll": true
     }
   ],
   "configurations": [
@@ -123,6 +134,22 @@
       },
       "console": "integratedTerminal",
       "consoleTitle": "Web Server Console"
+    },
+    {
+      "name": "Shared Watch (rebuild dist)",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}/web/lib/shared",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "presentation": {
+        "group": "2"
+      },
+      "console": "integratedTerminal",
+      "consoleTitle": "Shared Watch Console"
     },
     {
       "name": "Model Server",

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -23,13 +23,15 @@ COPY --from=bun_source /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun_source /usr/local/bin/bunx /usr/local/bin/bunx
 WORKDIR /app
 
-# Copy package files + the full opal workspace source so that opal's `prepare`
-# lifecycle hook (which runs during `bun install` for workspace packages) can build
+# Copy package files + the full opal AND shared workspace sources so their `prepare`
+# lifecycle hooks (which run during `bun install` for workspace packages) can build
 # `dist/` artifacts before Next.js resolves package exports. opal's tsconfig
 # extends web's `tsconfig.json`, so that file must also be present at install
-# time for the DTS build to succeed.
+# time for the DTS build to succeed. (`lib/shared` uses a standalone tsconfig and
+# builds its design tokens + types via Style Dictionary + tsc in its own `prepare`.)
 COPY package.json bun.lock tsconfig.json ./
 COPY lib/opal/ ./lib/opal/
+COPY lib/shared/ ./lib/shared/
 
 # Install dependencies. opal's `prepare` script builds dist/ as part of install.
 RUN bun install --frozen-lockfile

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -13,6 +13,7 @@
         "@headlessui/react": "^2.2.0",
         "@headlessui/tailwindcss": "^0.2.1",
         "@onyx-ai/opal": "file:./lib/opal",
+        "@onyx-ai/shared": "file:./lib/shared",
         "@phosphor-icons/react": "^2.0.8",
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-avatar": "^1.1.10",
@@ -159,6 +160,14 @@
         "remark-gfm": "^4.0.0",
       },
     },
+    "lib/shared": {
+      "name": "@onyx-ai/shared",
+      "version": "0.1.0",
+      "devDependencies": {
+        "style-dictionary": "^4.0.0",
+        "typescript": "^5.9.3",
+      },
+    },
   },
   "overrides": {
     "@types/react": "19.2.10",
@@ -243,6 +252,12 @@
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, ""],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, ""],
+
+    "@bundled-es-modules/deepmerge": ["@bundled-es-modules/deepmerge@4.3.2", "", { "dependencies": { "deepmerge": "^4.3.1" } }, "sha512-q8doe7ndrY2IolUOFIn0A0++JBX38pMhN7kFhTF4cnjIcILf6X6H2yWczInyv8ZFdR0lrE8088X8XS5efxXz8A=="],
+
+    "@bundled-es-modules/glob": ["@bundled-es-modules/glob@10.4.2", "", { "dependencies": { "buffer": "^6.0.3", "events": "^3.3.0", "glob": "^10.4.2", "patch-package": "^8.0.0", "path": "^0.12.7", "stream": "^0.0.3", "string_decoder": "^1.3.0", "url": "^0.11.3" } }, "sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA=="],
+
+    "@bundled-es-modules/memfs": ["@bundled-es-modules/memfs@4.17.0", "", { "dependencies": { "assert": "^2.1.0", "buffer": "^6.0.3", "events": "^3.3.0", "memfs": "^4.17.0", "path": "^0.12.7", "stream": "^0.0.3", "util": "^0.12.5" } }, "sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
@@ -462,6 +477,34 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, ""],
 
+    "@jsonjoy.com/base64": ["@jsonjoy.com/base64@1.1.2", "", { "peerDependencies": { "tslib": "2" } }, "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA=="],
+
+    "@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw=="],
+
+    "@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@1.0.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g=="],
+
+    "@jsonjoy.com/fs-core": ["@jsonjoy.com/fs-core@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-node-builtins": "4.57.6", "@jsonjoy.com/fs-node-utils": "4.57.6", "thingies": "^2.5.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-uI++Wx6VkBJqVmkb4ZeExwAVpZiA2Do5NrEtXoDk0Pdvce3ytFXJoviT1sLOj16+qDIMnD5nWPfOhVpnDmRJKg=="],
+
+    "@jsonjoy.com/fs-fsa": ["@jsonjoy.com/fs-fsa@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.57.6", "@jsonjoy.com/fs-node-builtins": "4.57.6", "@jsonjoy.com/fs-node-utils": "4.57.6", "thingies": "^2.5.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-pKkw/yC5CzSZKhIIUIsH1przOa+K5jGmZIg1sWaSF24JojyrUFbjcQv7QrcGAudriei6HQ6R0BFj+V8NbQinJw=="],
+
+    "@jsonjoy.com/fs-node": ["@jsonjoy.com/fs-node@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.57.6", "@jsonjoy.com/fs-node-builtins": "4.57.6", "@jsonjoy.com/fs-node-utils": "4.57.6", "@jsonjoy.com/fs-print": "4.57.6", "@jsonjoy.com/fs-snapshot": "4.57.6", "glob-to-regex.js": "^1.0.0", "thingies": "^2.5.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-Kbn1jdkvDN4F2+BhoB6mMu7NCbhP0bgA5NcI1aJj/Q5UcU+I1JLLW+dEQean33iV4tXv35AzBVKPICnDltBpxw=="],
+
+    "@jsonjoy.com/fs-node-builtins": ["@jsonjoy.com/fs-node-builtins@4.57.6", "", { "peerDependencies": { "tslib": "2" } }, "sha512-V4DgEFT3Cg5S9fCMOZSCVdTxdJWWLBO0WnAazV7hnCM96u5zXHyW/ubDAfcSVwqjkMJ50W1Y44IXtxRoIwaCVg=="],
+
+    "@jsonjoy.com/fs-node-to-fsa": ["@jsonjoy.com/fs-node-to-fsa@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-fsa": "4.57.6", "@jsonjoy.com/fs-node-builtins": "4.57.6", "@jsonjoy.com/fs-node-utils": "4.57.6" }, "peerDependencies": { "tslib": "2" } }, "sha512-+JptNw3iifihxH2rEXrninDzX4FFVW8JD/wPR8GbJPAeL9CQUSblrlumOPB5gZuS7tYRX+PJPLtT7XzKoRhv/Q=="],
+
+    "@jsonjoy.com/fs-node-utils": ["@jsonjoy.com/fs-node-utils@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-node-builtins": "4.57.6" }, "peerDependencies": { "tslib": "2" } }, "sha512-foyUrfS7WmYEUzqYXSNxmJBcSj04TABrkpFabwO9SCDCpVCfJ+qG+2sk5FjfiflG2n0SDFZDCJ6vYlJAEpxJFg=="],
+
+    "@jsonjoy.com/fs-print": ["@jsonjoy.com/fs-print@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-node-utils": "4.57.6", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-96eAn4Dudtt67LTeuU47yUD+pg9/G/oKpI10zei9ljk3X3WK4lYKc+n3cpaPCAbKPzoyfxl0mXm8f8Y7BOSFXw=="],
+
+    "@jsonjoy.com/fs-snapshot": ["@jsonjoy.com/fs-snapshot@4.57.6", "", { "dependencies": { "@jsonjoy.com/buffers": "^17.65.0", "@jsonjoy.com/fs-node-utils": "4.57.6", "@jsonjoy.com/json-pack": "^17.65.0", "@jsonjoy.com/util": "^17.65.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-V57CMzbOgTzUWGOWQ8GzHQdpJP6JnrYVNCtTBNxVYEnlVRvo4uEJqHhtAT8vhDFrIuJOXLrTL1Fki4h5oI7xxg=="],
+
+    "@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@1.21.0", "", { "dependencies": { "@jsonjoy.com/base64": "^1.1.2", "@jsonjoy.com/buffers": "^1.2.0", "@jsonjoy.com/codegen": "^1.0.0", "@jsonjoy.com/json-pointer": "^1.0.2", "@jsonjoy.com/util": "^1.9.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg=="],
+
+    "@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@1.0.2", "", { "dependencies": { "@jsonjoy.com/codegen": "^1.0.0", "@jsonjoy.com/util": "^1.9.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg=="],
+
+    "@jsonjoy.com/util": ["@jsonjoy.com/util@1.9.0", "", { "dependencies": { "@jsonjoy.com/buffers": "^1.0.0", "@jsonjoy.com/codegen": "^1.0.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ=="],
+
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
 
     "@next/env": ["@next/env@16.2.6", "", {}, "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw=="],
@@ -483,6 +526,8 @@
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@onyx-ai/opal": ["@onyx-ai/opal@workspace:lib/opal"],
+
+    "@onyx-ai/shared": ["@onyx-ai/shared@workspace:lib/shared"],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -1096,6 +1141,10 @@
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, ""],
 
+    "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
+
+    "@zip.js/zip.js": ["@zip.js/zip.js@2.8.26", "", {}, "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
@@ -1126,6 +1175,8 @@
 
     "aria-query": ["aria-query@5.3.2", "", {}, ""],
 
+    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
+
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "attr-accept": ["attr-accept@2.2.5", "", {}, ""],
@@ -1150,6 +1201,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": "dist/cli.js" }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
     "better-opn": ["better-opn@3.0.2", "", { "dependencies": { "open": "^8.0.4" } }, "sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ=="],
@@ -1165,6 +1218,8 @@
     "bs-logger": ["bs-logger@0.2.6", "", { "dependencies": { "fast-json-stable-stringify": "2.x" } }, ""],
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, ""],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, ""],
 
@@ -1189,6 +1244,8 @@
     "ccount": ["ccount@2.0.1", "", {}, ""],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, ""],
+
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, ""],
 
@@ -1235,6 +1292,8 @@
     "commander": ["commander@8.3.0", "", {}, ""],
 
     "commondir": ["commondir@1.0.1", "", {}, ""],
+
+    "component-emitter": ["component-emitter@2.0.0", "", {}, "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, ""],
 
@@ -1315,6 +1374,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, ""],
 
     "define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
+
+    "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "dequal": ["dequal@2.0.3", "", {}, ""],
 
@@ -1424,6 +1485,8 @@
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, ""],
 
+    "find-yarn-workspace-root": ["find-yarn-workspace-root@2.0.0", "", { "dependencies": { "micromatch": "^4.0.2" } }, "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, ""],
@@ -1433,6 +1496,8 @@
     "formik": ["formik@2.4.6", "", { "dependencies": { "@types/hoist-non-react-statics": "^3.3.1", "deepmerge": "^2.1.1", "hoist-non-react-statics": "^3.3.0", "lodash": "^4.17.21", "lodash-es": "^4.17.21", "react-fast-compare": "^2.0.1", "tiny-warning": "^1.0.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, ""],
 
     "framer-motion": ["framer-motion@12.29.0", "", { "dependencies": { "motion-dom": "^12.29.0", "motion-utils": "^12.27.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-1gEFGXHYV2BD42ZPTFmSU9buehppU+bCuOnHU0AD18DKh9j4DuTx47MvqY5ax+NNWRtK32qIcJf1UxKo1WwjWg=="],
+
+    "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, ""],
 
@@ -1457,6 +1522,8 @@
     "get-stream": ["get-stream@6.0.1", "", {}, ""],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "glob-to-regex.js": ["glob-to-regex.js@1.2.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ=="],
 
     "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
@@ -1522,9 +1589,13 @@
 
     "human-signals": ["human-signals@2.1.0", "", {}, ""],
 
+    "hyperdyperid": ["hyperdyperid@1.2.0", "", {}, "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="],
+
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "identity-obj-proxy": ["identity-obj-proxy@3.0.0", "", { "dependencies": { "harmony-reflect": "^1.4.6" } }, ""],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "image-size": ["image-size@1.2.1", "", { "dependencies": { "queue": "6.0.2" }, "bin": "bin/image-size.js" }, "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw=="],
 
@@ -1571,6 +1642,8 @@
     "is-generator-function": ["is-generator-function@1.1.2", "", { "dependencies": { "call-bound": "^1.0.4", "generator-function": "^2.0.0", "get-proto": "^1.0.1", "has-tostringtag": "^1.0.2", "safe-regex-test": "^1.1.0" } }, ""],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, ""],
+
+    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
 
     "is-number": ["is-number@7.0.0", "", {}, ""],
 
@@ -1678,11 +1751,19 @@
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, ""],
 
+    "json-stable-stringify": ["json-stable-stringify@1.3.0", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.4", "isarray": "^2.0.5", "jsonify": "^0.0.1", "object-keys": "^1.1.1" } }, "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg=="],
+
     "json5": ["json5@2.2.3", "", { "bin": "lib/cli.js" }, ""],
+
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "jsonify": ["jsonify@0.0.1", "", {}, "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="],
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "katex": ["katex@0.16.38", "", { "dependencies": { "commander": "^8.3.0" }, "bin": "cli.js" }, "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ=="],
+
+    "klaw-sync": ["klaw-sync@6.0.0", "", { "dependencies": { "graceful-fs": "^4.1.11" } }, "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ=="],
 
     "kleur": ["kleur@3.0.3", "", {}, ""],
 
@@ -1791,6 +1872,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, ""],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, ""],
+
+    "memfs": ["memfs@4.57.6", "", { "dependencies": { "@jsonjoy.com/fs-core": "4.57.6", "@jsonjoy.com/fs-fsa": "4.57.6", "@jsonjoy.com/fs-node": "4.57.6", "@jsonjoy.com/fs-node-builtins": "4.57.6", "@jsonjoy.com/fs-node-to-fsa": "4.57.6", "@jsonjoy.com/fs-node-utils": "4.57.6", "@jsonjoy.com/fs-print": "4.57.6", "@jsonjoy.com/fs-snapshot": "4.57.6", "@jsonjoy.com/json-pack": "^1.11.0", "@jsonjoy.com/util": "^1.9.0", "glob-to-regex.js": "^1.0.1", "thingies": "^2.5.0", "tree-dump": "^1.0.3", "tslib": "^2.0.0" } }, "sha512-WQK+DGjKCnPdpSyJUXphz+COF2uEhhsxQ3VIWBSbzpbbXuch3h4FePMqXrXGdLjsTgo4JFzBFsP6AWd9pVazGw=="],
 
     "memoize-one": ["memoize-one@6.0.0", "", {}, ""],
 
@@ -1914,11 +1997,17 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, ""],
 
+    "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
+
+    "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
+
+    "object.assign": ["object.assign@4.1.7", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0", "has-symbols": "^1.1.0", "object-keys": "^1.1.1" } }, "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, ""],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, ""],
 
-    "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+    "open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
     "oxfmt": ["oxfmt@0.49.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.49.0", "@oxfmt/binding-android-arm64": "0.49.0", "@oxfmt/binding-darwin-arm64": "0.49.0", "@oxfmt/binding-darwin-x64": "0.49.0", "@oxfmt/binding-freebsd-x64": "0.49.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.49.0", "@oxfmt/binding-linux-arm-musleabihf": "0.49.0", "@oxfmt/binding-linux-arm64-gnu": "0.49.0", "@oxfmt/binding-linux-arm64-musl": "0.49.0", "@oxfmt/binding-linux-ppc64-gnu": "0.49.0", "@oxfmt/binding-linux-riscv64-gnu": "0.49.0", "@oxfmt/binding-linux-riscv64-musl": "0.49.0", "@oxfmt/binding-linux-s390x-gnu": "0.49.0", "@oxfmt/binding-linux-x64-gnu": "0.49.0", "@oxfmt/binding-linux-x64-musl": "0.49.0", "@oxfmt/binding-openharmony-arm64": "0.49.0", "@oxfmt/binding-win32-arm64-msvc": "0.49.0", "@oxfmt/binding-win32-ia32-msvc": "0.49.0", "@oxfmt/binding-win32-x64-msvc": "0.49.0" }, "peerDependencies": { "svelte": "^5.0.0" }, "optionalPeers": ["svelte"], "bin": "bin/oxfmt" }, "sha512-IAHFMdlJSWe+oAr65dx22UvjCtV9DBMisAuLnKpDqMQrctzCkGnj3QRwNHm0d+uwSWPalsDF8ZYLz9rh6nH2IQ=="],
 
@@ -1942,6 +2031,10 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, ""],
 
+    "patch-package": ["patch-package@8.0.1", "", { "dependencies": { "@yarnpkg/lockfile": "^1.1.0", "chalk": "^4.1.2", "ci-info": "^3.7.0", "cross-spawn": "^7.0.3", "find-yarn-workspace-root": "^2.0.0", "fs-extra": "^10.0.0", "json-stable-stringify": "^1.0.2", "klaw-sync": "^6.0.0", "minimist": "^1.2.6", "open": "^7.4.2", "semver": "^7.5.3", "slash": "^2.0.0", "tmp": "^0.2.4", "yaml": "^2.2.2" }, "bin": { "patch-package": "index.js" } }, "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw=="],
+
+    "path": ["path@0.12.7", "", { "dependencies": { "process": "^0.11.1", "util": "^0.10.3" } }, "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, ""],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, ""],
@@ -1953,6 +2046,8 @@
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, ""],
 
     "path-type": ["path-type@4.0.0", "", {}, ""],
+
+    "path-unified": ["path-unified@0.2.0", "", {}, "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1988,6 +2083,8 @@
 
     "preact": ["preact@10.28.2", "", {}, "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA=="],
 
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+
     "pretty-format": ["pretty-format@29.7.0", "", { "dependencies": { "@jest/schemas": "^29.6.3", "ansi-styles": "^5.0.0", "react-is": "^18.0.0" } }, ""],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
@@ -2008,7 +2105,7 @@
 
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, ""],
+    "punycode": ["punycode@1.4.1", "", {}, "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="],
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, ""],
 
@@ -2162,13 +2259,15 @@
 
     "storybook": ["storybook@8.6.18", "", { "dependencies": { "@storybook/core": "8.6.18" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": { "getstorybook": "bin/index.cjs", "sb": "bin/index.cjs", "storybook": "bin/index.cjs" } }, "sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ=="],
 
+    "stream": ["stream@0.0.3", "", { "dependencies": { "component-emitter": "^2.0.0" } }, "sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A=="],
+
     "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, ""],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, ""],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, ""],
 
-    "string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, ""],
 
@@ -2185,6 +2284,8 @@
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, ""],
 
     "stripe": ["stripe@17.7.0", "", { "dependencies": { "@types/node": ">=8.1.0", "qs": "^6.11.0" } }, ""],
+
+    "style-dictionary": ["style-dictionary@4.4.0", "", { "dependencies": { "@bundled-es-modules/deepmerge": "^4.3.1", "@bundled-es-modules/glob": "^10.4.2", "@bundled-es-modules/memfs": "^4.9.4", "@zip.js/zip.js": "^2.7.44", "chalk": "^5.3.0", "change-case": "^5.3.0", "commander": "^12.1.0", "is-plain-obj": "^4.1.0", "json5": "^2.2.2", "patch-package": "^8.0.0", "path-unified": "^0.2.0", "prettier": "^3.3.3", "tinycolor2": "^1.6.0" }, "bin": { "style-dictionary": "bin/style-dictionary.js" } }, "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ=="],
 
     "style-to-js": ["style-to-js@1.1.19", "", { "dependencies": { "style-to-object": "1.0.12" } }, ""],
 
@@ -2224,6 +2325,8 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, ""],
 
+    "thingies": ["thingies@2.6.0", "", { "peerDependencies": { "tslib": "^2" } }, "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg=="],
+
     "tiny-case": ["tiny-case@1.0.3", "", {}, ""],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, ""],
@@ -2242,6 +2345,8 @@
 
     "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
 
+    "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
+
     "tmpl": ["tmpl@1.0.5", "", {}, ""],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, ""],
@@ -2253,6 +2358,8 @@
     "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
 
     "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "tree-dump": ["tree-dump@1.1.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": "cli.js" }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -2304,9 +2411,13 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, ""],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
     "unplugin": ["unplugin@1.16.1", "", { "dependencies": { "acorn": "^8.14.0", "webpack-virtual-modules": "^0.6.2" } }, "sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": "cli.js" }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, ""],
 
@@ -2406,6 +2517,8 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": "bin/semver.js" }, ""],
 
+    "@bundled-es-modules/deepmerge/deepmerge": ["deepmerge@4.3.1", "", {}, ""],
+
     "@emotion/babel-plugin/@emotion/memoize": ["@emotion/memoize@0.9.0", "", {}, ""],
 
     "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, ""],
@@ -2457,6 +2570,14 @@
     "@jest/reporters/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, ""],
 
     "@joshwooding/vite-plugin-react-docgen-typescript/magic-string": ["magic-string@0.27.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.13" } }, "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack": ["@jsonjoy.com/json-pack@17.67.0", "", { "dependencies": { "@jsonjoy.com/base64": "17.67.0", "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0", "@jsonjoy.com/json-pointer": "17.67.0", "@jsonjoy.com/util": "17.67.0", "hyperdyperid": "^1.2.0", "thingies": "^2.5.0", "tree-dump": "^1.1.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util": ["@jsonjoy.com/util@17.67.0", "", { "dependencies": { "@jsonjoy.com/buffers": "17.67.0", "@jsonjoy.com/codegen": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew=="],
+
+    "@jsonjoy.com/json-pack/@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@1.2.1", "", { "peerDependencies": { "tslib": "2" } }, "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="],
+
+    "@jsonjoy.com/util/@jsonjoy.com/buffers": ["@jsonjoy.com/buffers@1.2.1", "", { "peerDependencies": { "tslib": "2" } }, "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="],
 
     "@onyx-ai/opal/tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
@@ -2534,6 +2655,8 @@
 
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, ""],
 
+    "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
+
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, ""],
 
     "cmdk/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.4", "", { "dependencies": { "@radix-ui/react-slot": "1.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" } }, ""],
@@ -2590,6 +2713,8 @@
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, ""],
 
+    "json-stable-stringify/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, ""],
@@ -2599,6 +2724,12 @@
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, ""],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, ""],
+
+    "patch-package/slash": ["slash@2.0.0", "", {}, "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="],
+
+    "patch-package/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "path/util": ["util@0.10.4", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -2612,6 +2743,8 @@
 
     "react-day-picker/date-fns": ["date-fns@4.1.0", "", {}, ""],
 
+    "readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
+
     "recast/source-map": ["source-map@0.6.1", "", {}, ""],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, ""],
@@ -2623,6 +2756,12 @@
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, ""],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, ""],
+
+    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "style-dictionary/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "style-dictionary/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "styled-components/csstype": ["csstype@3.1.3", "", {}, ""],
 
@@ -2639,6 +2778,8 @@
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, ""],
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "tr46/punycode": ["punycode@2.3.1", "", {}, ""],
 
     "ts-unused-exports/tsconfig-paths": ["tsconfig-paths@3.15.0", "", { "dependencies": { "@types/json5": "^0.0.29", "json5": "^1.0.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, ""],
 
@@ -2677,6 +2818,14 @@
     "@jest/globals/@jest/environment/@jest/fake-timers": ["@jest/fake-timers@29.7.0", "", { "dependencies": { "@jest/types": "^29.6.3", "@sinonjs/fake-timers": "^10.0.2", "@types/node": "*", "jest-message-util": "^29.7.0", "jest-mock": "^29.7.0", "jest-util": "^29.7.0" } }, ""],
 
     "@jest/reporters/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/base64": ["@jsonjoy.com/base64@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/json-pack/@jsonjoy.com/json-pointer": ["@jsonjoy.com/json-pointer@17.67.0", "", { "dependencies": { "@jsonjoy.com/util": "17.67.0" }, "peerDependencies": { "tslib": "2" } }, "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA=="],
+
+    "@jsonjoy.com/fs-snapshot/@jsonjoy.com/util/@jsonjoy.com/codegen": ["@jsonjoy.com/codegen@17.67.0", "", { "peerDependencies": { "tslib": "2" } }, "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="],
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.39.0", "", {}, "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg=="],
 
@@ -2823,6 +2972,8 @@
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, ""],
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, ""],
+
+    "path/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, ""],
 

--- a/web/lib/shared/.gitignore
+++ b/web/lib/shared/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tgz

--- a/web/lib/shared/README.md
+++ b/web/lib/shared/README.md
@@ -45,11 +45,16 @@ source of record for now; this token set is the future cross-platform source.
 
 ```bash
 bun run build       # tokens + TypeScript (tsc) -> dist/
+bun run dev         # watch src/ + tokens/ and rebuild dist/ on save (local dev)
 bun run typecheck   # type-check only
 bun run clean       # remove dist/
 ```
 
 `dist/` is generated and git-ignored; `prepare` rebuilds it on install.
+
+Web consumes the built `dist/`, so edits don't hot-reload until `dist/` is
+rebuilt. Run `bun run dev` here (alongside web's `bun run dev`) so saves
+auto-rebuild `dist/` and the web dev server refreshes.
 
 ## Consuming from web
 

--- a/web/lib/shared/README.md
+++ b/web/lib/shared/README.md
@@ -1,0 +1,83 @@
+# @onyx-ai/shared
+
+Platform-agnostic code shared between Onyx **web** and the future **mobile** app.
+
+It holds four things, none of which depend on any UI framework:
+
+| Subpath | Contents |
+| --- | --- |
+| `@onyx-ai/shared/tokens.css` | Design tokens as **CSS custom properties** (`--sh-*`) — for web. |
+| `@onyx-ai/shared/tokens` | The same tokens as a **typed JS object** (unitless numbers) — for mobile. |
+| `@onyx-ai/shared/utils` | Pure TypeScript utilities (no DOM / Node / React). |
+| `@onyx-ai/shared/contracts` | Cross-platform component API contracts (React-free, generic over the platform's icon/node type). |
+| `@onyx-ai/shared/types` | Common DTOs and enums. |
+
+## The one rule: zero runtime dependencies
+
+This package ships **no runtime `dependencies`** and is **type-system-forbidden**
+from touching DOM / Node / React (its `tsconfig` uses `lib: ["ES2020"]` with no
+`"DOM"` and `types: []`). That is what guarantees it can be consumed by web and
+mobile without ever causing a dependency conflict.
+
+When extending it:
+
+- **Do not** add anything to `dependencies`, and do not add a `react` /
+  `react-native` / `next` dependency or peer dependency.
+- **Do not** reference `window`, `document`, `process`, `Buffer`, etc. — these
+  are compile errors here, by design.
+- Component contracts must stay generic over platform types (e.g.
+  `ButtonContract<TIcon>`) rather than importing a UI framework's types.
+
+## Tokens
+
+Edit the **source** in `tokens/**/*.json` — never the generated output in
+`dist/`. The build (Style Dictionary) regenerates both platform outputs:
+
+```bash
+bun run build:tokens   # tokens/*.json -> dist/tokens.css + dist/tokens.js + dist/tokens.d.ts
+```
+
+The `--sh-*` prefix namespaces these variables so they never collide with
+Opal's existing `--color-*` / `--text-*`. Opal remains web's design-system
+source of record for now; this token set is the future cross-platform source.
+
+## Build
+
+```bash
+bun run build       # tokens + TypeScript (tsc) -> dist/
+bun run typecheck   # type-check only
+bun run clean       # remove dist/
+```
+
+`dist/` is generated and git-ignored; `prepare` rebuilds it on install.
+
+## Consuming from web
+
+This package is staged at `web/lib/shared`, beside Opal (`web/lib/opal`), and is
+a **web workspace** package — so web's Turbopack reads it in-root (it's symlinked
+into `web/node_modules/@onyx-ai/shared`, exactly like Opal) and the **full
+surface** works with no extra tooling:
+
+- web lists it in `workspaces` and depends on it via
+  `"@onyx-ai/shared": "file:./lib/shared"`, and adds it to `transpilePackages`
+  in `next.config.js` alongside Opal.
+- **Tokens:** `globals.css` does `@import "@onyx-ai/shared/tokens.css";`.
+- **Types, contracts, and runtime utilities:** imported through `@/lib/shared`.
+
+`web/tsconfig*.json` excludes `lib/shared` from web's own compile; web resolves
+the package through its built `dist` types via the `exports` map (so run
+`bun run build` here — `prepare` also does it on a fresh install).
+
+Mobile (Metro/Expo) consumes the same package — tokens via the JS object
+(`@onyx-ai/shared/tokens`), plus types, contracts, and utils — by pointing a
+`file:` dependency at `web/lib/shared` and adding it to Metro `watchFolders`
+(with `resolver.unstable_enablePackageExports` so the subpath `exports` resolve).
+Metro has no filesystem-root fence, so the package's location under `web/` is
+invisible to it.
+
+## Future: extract to a private npm package
+
+This package and Opal are both staged under `web/lib/` and are destined to become
+their own repos + a **private npm package** consumed by web, mobile, and Opal. At
+that point each consumer swaps its `file:` dependency for the registry version —
+no other changes needed (and mobile no longer needs the `watchFolders` entry).

--- a/web/lib/shared/package.json
+++ b/web/lib/shared/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@onyx-ai/shared",
+  "version": "0.1.0",
+  "description": "Platform-agnostic shared design tokens, types, contracts, and utilities for Onyx web + mobile.",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "files": ["dist"],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./contracts": {
+      "types": "./dist/contracts/index.d.ts",
+      "import": "./dist/contracts/index.js"
+    },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/types/index.js"
+    },
+    "./utils": {
+      "types": "./dist/utils/index.d.ts",
+      "import": "./dist/utils/index.js"
+    },
+    "./tokens": {
+      "types": "./dist/tokens.d.ts",
+      "import": "./dist/tokens.js"
+    },
+    "./tokens.css": "./dist/tokens.css"
+  },
+  "scripts": {
+    "build:tokens": "node style-dictionary.config.mjs",
+    "build:ts": "tsc -p tsconfig.build.json",
+    "build": "bun run build:tokens && bun run build:ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "rm -rf dist",
+    "prepare": "bun run build"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "style-dictionary": "^4.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/web/lib/shared/package.json
+++ b/web/lib/shared/package.json
@@ -36,6 +36,7 @@
     "build:tokens": "node style-dictionary.config.mjs",
     "build:ts": "tsc -p tsconfig.build.json",
     "build": "bun run build:tokens && bun run build:ts",
+    "dev": "node scripts/watch.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "rm -rf dist",
     "prepare": "bun run build"

--- a/web/lib/shared/scripts/watch.mjs
+++ b/web/lib/shared/scripts/watch.mjs
@@ -1,0 +1,31 @@
+// Local dev watcher for @onyx-ai/shared. Rebuilds dist/ on edits so the web
+// dev server (which consumes dist/, not src/) picks up changes on save.
+//   - src/**         -> tsc --watch (incremental rebuild of JS + d.ts)
+//   - tokens/**.json -> re-runs the Style Dictionary token build
+//
+// Run with `bun run dev`. Dev convenience only — never used by CI/build.
+// Note: recursive fs.watch is supported on macOS/Windows; on Linux, re-run
+// `bun run build:tokens` manually after editing tokens.
+
+import { spawn } from "node:child_process";
+import { watch } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const run = (script, extra = []) =>
+  spawn("bun", ["run", script, ...extra], { cwd: root, stdio: "inherit" });
+
+run("build:tokens"); // initial token build
+run("build:ts", ["--", "--watch", "--preserveWatchOutput"]); // incremental TS watch
+
+let timer;
+watch(resolve(root, "tokens"), { recursive: true }, (_event, file) => {
+  if (file && !file.endsWith(".json")) return;
+  clearTimeout(timer);
+  timer = setTimeout(() => run("build:tokens"), 150);
+});
+
+console.log(
+  "[shared] watching src/ (tsc) + tokens/ (style-dictionary) — Ctrl-C to stop"
+);

--- a/web/lib/shared/src/contracts/button.ts
+++ b/web/lib/shared/src/contracts/button.ts
@@ -1,0 +1,24 @@
+import type { A11yProps, Handler, SizeToken, Slot } from "./primitives";
+
+/** Visual-emphasis variants every platform's Button must support. */
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+
+/**
+ * Cross-platform API contract for a Button. Web and mobile each implement a
+ * component whose props satisfy this contract, guaranteeing a consistent API
+ * surface without sharing any rendering code.
+ *
+ * @typeParam TIcon - the platform's icon type (a React icon component on web,
+ * an RN component on mobile). The contract never imports it directly.
+ */
+export interface ButtonContract<TIcon = unknown> extends A11yProps {
+  label: string;
+  variant?: ButtonVariant;
+  size?: SizeToken;
+  disabled?: boolean;
+  loading?: boolean;
+  /** Leading icon, platform-typed via `TIcon`. */
+  leadingIcon?: Slot<TIcon>;
+  /** Platform-neutral press handler (web maps to onClick, mobile to onPress). */
+  onPress?: Handler;
+}

--- a/web/lib/shared/src/contracts/index.ts
+++ b/web/lib/shared/src/contracts/index.ts
@@ -1,0 +1,2 @@
+export type { A11yProps, Handler, SizeToken, Slot } from "./primitives";
+export type { ButtonContract, ButtonVariant } from "./button";

--- a/web/lib/shared/src/contracts/primitives.ts
+++ b/web/lib/shared/src/contracts/primitives.ts
@@ -1,0 +1,26 @@
+/**
+ * Platform-agnostic building blocks for component API contracts.
+ *
+ * These intentionally avoid importing React / React Native types. When a
+ * contract needs a platform-specific value (an icon component, a rendered
+ * node), it is expressed as a generic type parameter the consumer supplies
+ * (web -> a React component, mobile -> an RN component). This is what keeps
+ * the package free of any UI-framework dependency.
+ */
+
+/** A platform-supplied slot value (e.g. an icon or node); defaults to `unknown`. */
+export type Slot<T = unknown> = T;
+
+/** The lowest-common-denominator event handler: no args, no return. */
+export type Handler = () => void;
+
+/** Platform-neutral size scale used across contracts. */
+export type SizeToken = "xs" | "sm" | "md" | "lg" | "xl";
+
+/** Accessibility metadata each platform maps to its own native props. */
+export interface A11yProps {
+  /** Human-readable label for assistive technologies. */
+  a11yLabel?: string;
+  /** Marks the element as disabled for assistive technologies. */
+  a11yDisabled?: boolean;
+}

--- a/web/lib/shared/src/index.ts
+++ b/web/lib/shared/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @onyx-ai/shared — platform-agnostic code shared between Onyx web and mobile.
+ *
+ * Design tokens are NOT re-exported here: they are generated build artifacts,
+ * consumed via the dedicated subpaths "@onyx-ai/shared/tokens" (mobile JS
+ * object) and "@onyx-ai/shared/tokens.css" (web CSS variables).
+ */
+export * from "./contracts";
+export * from "./types";
+export * from "./utils";

--- a/web/lib/shared/src/types/dto.ts
+++ b/web/lib/shared/src/types/dto.ts
@@ -1,0 +1,15 @@
+/**
+ * Common data-transfer shapes used "across methods" by both web and mobile data
+ * layers, so each platform consumes the same contract for the same backend data.
+ */
+
+/** A single page of a cursor-paginated collection. */
+export interface Page<T> {
+  items: T[];
+  nextCursor?: string;
+}
+
+/** Result of an operation that can fail without throwing. */
+export type Result<T, E = string> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };

--- a/web/lib/shared/src/types/enums.ts
+++ b/web/lib/shared/src/types/enums.ts
@@ -1,0 +1,6 @@
+/** Color-theme preference shared across platforms. */
+export enum Theme {
+  Light = "light",
+  Dark = "dark",
+  System = "system",
+}

--- a/web/lib/shared/src/types/index.ts
+++ b/web/lib/shared/src/types/index.ts
@@ -1,0 +1,2 @@
+export { Theme } from "./enums";
+export type { Page, Result } from "./dto";

--- a/web/lib/shared/src/utils/format.ts
+++ b/web/lib/shared/src/utils/format.ts
@@ -6,7 +6,10 @@ const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
 
 /** Human-readable byte size, e.g. `formatBytes(1536)` -> `"1.5 KB"`. */
 export function formatBytes(bytes: number, decimals = 1): string {
-  if (bytes <= 0) {
+  if (bytes < 0) {
+    throw new Error(`formatBytes: bytes (${bytes}) must be >= 0`);
+  }
+  if (bytes === 0) {
     return "0 B";
   }
   const exponent = Math.min(
@@ -18,10 +21,16 @@ export function formatBytes(bytes: number, decimals = 1): string {
   return `${rounded} ${BYTE_UNITS[exponent]}`;
 }
 
-/** Truncate `input` to `max` characters, appending an ellipsis when cut. */
+/**
+ * Truncate `input` to at most `max` characters (including the ellipsis).
+ * When `max` is 0 the result is an empty string.
+ */
 export function truncate(input: string, max: number): string {
   if (max < 0) {
     throw new Error(`truncate: max (${max}) must be >= 0`);
   }
-  return input.length <= max ? input : `${input.slice(0, max)}…`;
+  if (input.length <= max) {
+    return input;
+  }
+  return max === 0 ? "" : `${input.slice(0, max - 1)}…`;
 }

--- a/web/lib/shared/src/utils/format.ts
+++ b/web/lib/shared/src/utils/format.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure formatting helpers. No platform APIs — see ./numbers for the constraint.
+ */
+
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
+
+/** Human-readable byte size, e.g. `formatBytes(1536)` -> `"1.5 KB"`. */
+export function formatBytes(bytes: number, decimals = 1): string {
+  if (bytes <= 0) {
+    return "0 B";
+  }
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    BYTE_UNITS.length - 1
+  );
+  const value = bytes / 1024 ** exponent;
+  const rounded = Number(value.toFixed(decimals));
+  return `${rounded} ${BYTE_UNITS[exponent]}`;
+}
+
+/** Truncate `input` to `max` characters, appending an ellipsis when cut. */
+export function truncate(input: string, max: number): string {
+  if (max < 0) {
+    throw new Error(`truncate: max (${max}) must be >= 0`);
+  }
+  return input.length <= max ? input : `${input.slice(0, max)}…`;
+}

--- a/web/lib/shared/src/utils/index.ts
+++ b/web/lib/shared/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { clamp, roundTo } from "./numbers";
+export { formatBytes, truncate } from "./format";

--- a/web/lib/shared/src/utils/numbers.ts
+++ b/web/lib/shared/src/utils/numbers.ts
@@ -1,0 +1,18 @@
+/**
+ * Pure numeric helpers. No platform APIs (no DOM, Node, or React) — safe to run
+ * identically in a browser, Node, and React Native's Hermes engine.
+ */
+
+/** Clamp `value` into the inclusive range [`min`, `max`]. */
+export function clamp(value: number, min: number, max: number): number {
+  if (min > max) {
+    throw new Error(`clamp: min (${min}) must be <= max (${max})`);
+  }
+  return Math.min(Math.max(value, min), max);
+}
+
+/** Round `value` to `decimals` decimal places. */
+export function roundTo(value: number, decimals = 0): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}

--- a/web/lib/shared/src/utils/numbers.ts
+++ b/web/lib/shared/src/utils/numbers.ts
@@ -14,5 +14,7 @@ export function clamp(value: number, min: number, max: number): number {
 /** Round `value` to `decimals` decimal places. */
 export function roundTo(value: number, decimals = 0): number {
   const factor = 10 ** decimals;
-  return Math.round(value * factor) / factor;
+  // Nudge by EPSILON before scaling so values like 1.005 round to 1.01 rather
+  // than 1 (binary float can't represent 1.005 exactly).
+  return Math.round((value + Number.EPSILON) * factor) / factor;
 }

--- a/web/lib/shared/style-dictionary.config.mjs
+++ b/web/lib/shared/style-dictionary.config.mjs
@@ -1,0 +1,73 @@
+// Style Dictionary build script (programmatic API, Style Dictionary v4).
+//
+// Single token source (tokens/**/*.json) -> two platform outputs:
+//   - web:    dist/tokens.css  (CSS custom properties, units applied, e.g. 16px)
+//   - mobile: dist/tokens.js + dist/tokens.d.ts (typed JS object, unitless numbers)
+//
+// Run via `node style-dictionary.config.mjs` (wired as the `build:tokens` script).
+// This file is build-time only — `style-dictionary` is a devDependency and never
+// ships in the package output, so it cannot affect consumers' runtime dependency graphs.
+
+import StyleDictionary from "style-dictionary";
+
+const isDimension = (token) => (token.type ?? token.$type) === "dimension";
+const rawValue = (token) => token.value ?? token.$value;
+
+// Web wants CSS dimensions with units (e.g. "16px").
+StyleDictionary.registerTransform({
+  name: "size/sh-px",
+  type: "value",
+  filter: isDimension,
+  transform: (token) => `${rawValue(token)}px`,
+});
+
+// React Native wants unitless numbers (e.g. 16) for style objects.
+StyleDictionary.registerTransform({
+  name: "size/sh-unitless",
+  type: "value",
+  filter: isDimension,
+  transform: (token) => Number(rawValue(token)),
+});
+
+const sd = new StyleDictionary({
+  source: ["tokens/**/*.json"],
+  // Token sources are authored in the legacy { value, type } shape.
+  log: { verbosity: "default" },
+  platforms: {
+    // ---- Web: CSS custom properties (namespaced `--sh-*` to avoid colliding
+    // with Opal's existing `--color-*` / `--text-*` variables) ----
+    css: {
+      transforms: ["attribute/cti", "name/kebab", "color/css", "size/sh-px"],
+      prefix: "sh",
+      buildPath: "dist/",
+      files: [
+        {
+          destination: "tokens.css",
+          format: "css/variables",
+        },
+      ],
+    },
+    // ---- Mobile: typed JS object + declarations ----
+    ts: {
+      transforms: [
+        "attribute/cti",
+        "name/camel",
+        "color/hex",
+        "size/sh-unitless",
+      ],
+      buildPath: "dist/",
+      files: [
+        {
+          destination: "tokens.js",
+          format: "javascript/es6",
+        },
+        {
+          destination: "tokens.d.ts",
+          format: "typescript/es6-declarations",
+        },
+      ],
+    },
+  },
+});
+
+await sd.buildAllPlatforms();

--- a/web/lib/shared/tokens/color/core.json
+++ b/web/lib/shared/tokens/color/core.json
@@ -1,0 +1,12 @@
+{
+  "color": {
+    "brand": {
+      "primary": { "value": "#5B5BD6", "type": "color" },
+      "on-primary": { "value": "#FFFFFF", "type": "color" }
+    },
+    "text": {
+      "default": { "value": "#0A0A0A", "type": "color" },
+      "muted": { "value": "#6B7280", "type": "color" }
+    }
+  }
+}

--- a/web/lib/shared/tokens/size/spacing.json
+++ b/web/lib/shared/tokens/size/spacing.json
@@ -1,0 +1,10 @@
+{
+  "size": {
+    "spacing": {
+      "xs": { "value": "4", "type": "dimension" },
+      "sm": { "value": "8", "type": "dimension" },
+      "md": { "value": "16", "type": "dimension" },
+      "lg": { "value": "24", "type": "dimension" }
+    }
+  }
+}

--- a/web/lib/shared/tsconfig.build.json
+++ b/web/lib/shared/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  }
+}

--- a/web/lib/shared/tsconfig.json
+++ b/web/lib/shared/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -20,7 +20,7 @@ const cspHeader = `
 const nextConfig = {
   productionBrowserSourceMaps: false,
   output: "standalone",
-  transpilePackages: ["@onyx-ai/opal"],
+  transpilePackages: ["@onyx-ai/opal", "@onyx-ai/shared"],
   typedRoutes: true,
   // NOTE: `reactCompiler` is set per-phase in module.exports below — enabled for
   // builds, disabled for the dev server. See the comment there for the rationale.

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0-dev",
   "private": true,
   "workspaces": [
-    "lib/opal"
+    "lib/opal",
+    "lib/shared"
   ],
   "scripts": {
     "dev": "next dev",
@@ -36,6 +37,7 @@
     "@headlessui/react": "^2.2.0",
     "@headlessui/tailwindcss": "^0.2.1",
     "@onyx-ai/opal": "file:./lib/opal",
+    "@onyx-ai/shared": "file:./lib/shared",
     "@phosphor-icons/react": "^2.0.8",
     "@radix-ui/react-accordion": "^1.2.2",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "@onyx-ai/opal/root.css";
+@import "@onyx-ai/shared/tokens.css";
 @import "./css/attachment-button.css" layer(base);
 @import "./css/button.css" layer(base);
 @import "./css/content-editable.css" layer(base);

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -51,6 +51,7 @@
   ],
   "exclude": [
     "node_modules",
-    "lib/opal"
+    "lib/opal",
+    "lib/shared"
   ]
 }

--- a/web/tsconfig.types.json
+++ b/web/tsconfig.types.json
@@ -18,5 +18,5 @@
     ".next/dev/types/**/*.ts",
     "types/**/*.d.ts"
   ],
-  "exclude": ["node_modules", "lib/opal"]
+  "exclude": ["node_modules", "lib/opal", "lib/shared"]
 }


### PR DESCRIPTION
## Description

- Add `@onyx-ai/shared` — an initial, dependency-isolated scaffold (`web/lib/shared`, beside Opal) for code shared between web and the upcoming mobile app: design tokens, common types, component API contracts, and pure utilities (zero runtime deps).
- Introduce a Style Dictionary token pipeline — one JSON source emits web CSS variables (`--sh-*`) and a typed token object for mobile, so the two platforms can't drift.
- Consume it from web — import the shared token CSS in `globals.css` and register the package as a web workspace.
- Build the package's `dist/` in the web Docker image and the Vercel preview workflow so production and preview deploys keep working.

## How Has This Been Tested?

- Package + web type-check and build pass; verified in-browser that the `--sh-*` tokens render and a shared runtime util executes; simulated the Docker clean-install build to confirm `dist/` is produced.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded `@onyx-ai/shared` for code shared by web and the upcoming mobile app. Provides cross‑platform tokens, types, contracts, and pure utilities, and updates web build/deploy and dev tooling to include it; also fixes small utility edge cases.

- **New Features**
  - Added `@onyx-ai/shared` (`web/lib/shared`) with zero runtime deps: tokens, types, contracts, utils.
  - Style Dictionary: one JSON → `@onyx-ai/shared/tokens.css` (web `--sh-*`) + `@onyx-ai/shared/tokens` (typed JS for mobile).
  - Integration & DX: import token CSS in `globals.css`; add to `workspaces` + `transpilePackages`; `bun run dev` watcher rebuilds `dist/` on save; pre-commit typecheck for `web/lib/shared`; VS Code “Shared Watch” and “Web Server + Shared Watch”.
  - Build/deploy: Dockerfile copies/builds `lib/shared` during install; preview workflow builds it so previews and production deploys work.

- **Bug Fixes**
  - `truncate` counts the ellipsis within `max`; `max === 0` → `""`.
  - `formatBytes` throws on negative input instead of returning `0 B`.
  - `roundTo` uses `Number.EPSILON` to fix cases like `1.005 → 1.01`.

<sup>Written for commit 083309561e8a1fada73c9a68a23227f4c395018c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

