### PR TITLE
Use a service worker to stream responses on the web, allowing for tab switching and conversation recovery

### DIFF
--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -91,6 +91,7 @@ class ChatFullResponse(BaseModel):
 
     # Metadata
     message_id: int
+    user_message_id: int | None = None
     chat_session_id: UUID | None = None
     error_msg: str | None = None
 

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1840,6 +1840,7 @@ def gather_stream_full(
     citations: list[CitationInfo] = []
     error_msg: str | None = None
     message_id: int | None = None
+    user_message_id: int | None = None
     top_documents: list[SearchDoc] = []
     chat_session_id: UUID | None = None
 
@@ -1859,6 +1860,7 @@ def gather_stream_full(
             error_msg = packet.error
         elif isinstance(packet, MessageResponseIDInfo):
             message_id = packet.reserved_assistant_message_id
+            user_message_id = packet.user_message_id
         elif isinstance(packet, CreateChatSessionID):
             chat_session_id = packet.chat_session_id
 
@@ -1892,6 +1894,7 @@ def gather_stream_full(
         top_documents=top_documents,
         citation_info=citations,
         message_id=message_id,
+        user_message_id=user_message_id,
         chat_session_id=chat_session_id,
         error_msg=error_msg,
     )

--- a/backend/tests/unit/onyx/chat/test_full_response.py
+++ b/backend/tests/unit/onyx/chat/test_full_response.py
@@ -1,0 +1,134 @@
+from onyx.chat import process_message
+from onyx.chat.chat_state import ChatStateContainer
+from onyx.chat.models import ChatFullResponse
+from onyx.chat.models import AnswerStream
+from onyx.chat.models import StreamingError
+from onyx.server.query_and_chat.models import MessageResponseIDInfo
+from onyx.server.query_and_chat.placement import Placement
+from onyx.server.query_and_chat.streaming_models import CitationInfo
+from onyx.server.query_and_chat.streaming_models import Packet
+
+
+def test_chat_full_response_user_message_id_defaults_to_none() -> None:
+    """ChatFullResponse.user_message_id defaults to None for backwards compat."""
+    response = ChatFullResponse(
+        answer="hello",
+        answer_citationless="hello",
+        top_documents=[],
+        citation_info=[],
+        message_id=42,
+    )
+    assert response.user_message_id is None
+
+
+def test_chat_full_response_user_message_id_explicit() -> None:
+    """ChatFullResponse accepts an explicit user_message_id value."""
+    response = ChatFullResponse(
+        answer="hello",
+        answer_citationless="hello",
+        top_documents=[],
+        citation_info=[],
+        message_id=42,
+        user_message_id=7,
+    )
+    assert response.user_message_id == 7
+
+
+def test_gather_stream_full_captures_user_message_id() -> None:
+    """gather_stream_full captures user_message_id from MessageResponseIDInfo."""
+    from onyx.chat.chat_state import ChatStateContainer
+
+    packets: AnswerStream = iter(
+        [
+            MessageResponseIDInfo(
+                user_message_id=7,
+                reserved_assistant_message_id=42,
+            ),
+            StreamingError(
+                error="test error",
+                error_code="TEST_ERROR",
+            ),
+        ]
+    )
+
+    state_container = ChatStateContainer()
+
+    result = process_message.gather_stream_full(packets, state_container)
+
+    assert result.user_message_id == 7
+    assert result.message_id == 42
+    assert result.error_msg == "test error"
+
+
+def test_gather_stream_full_user_message_id_none_when_missing() -> None:
+    """gather_stream_full defaults user_message_id to None when packet has null."""
+    from onyx.chat.chat_state import ChatStateContainer
+
+    packets: AnswerStream = iter(
+        [
+            MessageResponseIDInfo(
+                user_message_id=None,
+                reserved_assistant_message_id=42,
+            ),
+            StreamingError(
+                error="test error",
+                error_code="TEST_ERROR",
+            ),
+        ]
+    )
+
+    state_container = ChatStateContainer()
+
+    result = process_message.gather_stream_full(packets, state_container)
+
+    assert result.user_message_id is None
+    assert result.message_id == 42
+
+
+def test_gather_stream_full_preserves_all_fields() -> None:
+    """gather_stream_full preserves citations, documents, and metadata."""
+    from onyx.chat.chat_state import ChatStateContainer
+    from onyx.server.query_and_chat.streaming_models import Packet
+    from onyx.server.query_and_chat.placement import Placement
+
+    placement = Placement(turn_index=0)
+    packets: AnswerStream = iter(
+        [
+            MessageResponseIDInfo(
+                user_message_id=7,
+                reserved_assistant_message_id=42,
+            ),
+            Packet(
+                placement=placement,
+                obj=CitationInfo(
+                    citation_number=1,
+                    document_id="doc-1",
+                ),
+            ),
+            Packet(
+                placement=placement,
+                obj=CitationInfo(
+                    citation_number=2,
+                    document_id="doc-2",
+                ),
+            ),
+            StreamingError(
+                error="test error",
+                error_code="TEST_ERROR",
+            ),
+        ]
+    )
+
+    state_container = ChatStateContainer()
+
+    result = process_message.gather_stream_full(packets, state_container)
+
+    assert result.user_message_id == 7
+    assert result.message_id == 42
+    assert result.error_msg == "test error"
+    assert len(result.citation_info) == 2
+    assert result.citation_info[0].citation_number == 1
+    assert result.citation_info[0].document_id == "doc-1"
+    assert result.citation_info[1].citation_number == 2
+    assert result.citation_info[1].document_id == "doc-2"
+    assert result.answer == ""

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -5,6 +5,7 @@ const { PHASE_DEVELOPMENT_SERVER } = require("next/constants");
 const cspHeader = `
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     font-src 'self' https://fonts.gstatic.com;
+    worker-src 'self';
     object-src 'none';
     base-uri 'self';
     form-action 'self';

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,206 @@
+/**
+ * Onyx Background Chat Service Worker
+ *
+ * Intercepts /api/chat/send-chat-message requests and processes them with
+ * stream=false so the response completes even when the browser tab is
+ * backgrounded (mobile sleep, app switch, tab switch).
+ *
+ * The SW converts ChatFullResponse to NDJSON lines matching the streaming
+ * packet format so the page's existing handleSSEStream + useChatController
+ * pipeline processes the result identically to a live streaming response.
+ */
+
+var CHAT_PATH = "/api/chat/send-chat-message";
+
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("fetch", function (event) {
+  var url = new URL(event.request.url);
+
+  if (!url.pathname.endsWith(CHAT_PATH)) return;
+  if (event.request.method !== "POST") return;
+
+  event.respondWith(handleChatRequest(event));
+});
+
+function handleChatRequest(event) {
+  return event.request
+    .clone()
+    .json()
+    .then(function (originalBody) {
+      originalBody.stream = false;
+
+      return fetch(event.request.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(originalBody),
+      });
+    })
+    .then(function (httpResponse) {
+      if (!httpResponse.ok) {
+        return httpResponse;
+      }
+      return httpResponse.json().then(function (fullResponse) {
+        var ndjsonLines = convertFullResponseToNDJSON(fullResponse);
+        var ndjsonBody = ndjsonLines.join("\n") + "\n";
+
+        return new Response(ndjsonBody, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Background-Processed": "true",
+          },
+        });
+      });
+    })
+    .catch(function () {
+      return fetch(event.request);
+    });
+}
+
+/**
+ * Convert ChatFullResponse to NDJSON lines matching the streaming packet
+ * format the page's handleSSEStream / useChatController expects.
+ *
+ * Packet order:
+ *   1. MessageResponseIDInfo  (user_message_id + reserved_assistant_message_id)
+ *   2. Packet:MessageStart    (final_documents)
+ *   3. Packet:MessageDelta    (answer text)
+ *   4. Packet:CitationInfo    (one per citation)
+ *   5. StreamingError         (if error_msg is set — MUST come before BackendMessage
+ *                              because the loop checks Object.hasOwn("error") first)
+ *   6. Packet:OverallStop     (stop_reason)
+ *   7. BackendMessage         (citations map, tool_call, etc. — error is null here)
+ */
+function convertFullResponseToNDJSON(resp) {
+  var lines = [];
+
+  lines.push(
+    JSON.stringify({
+      user_message_id:
+        resp.user_message_id != null ? resp.user_message_id : null,
+      reserved_assistant_message_id: resp.message_id,
+    })
+  );
+
+  var docs = resp.top_documents || [];
+  lines.push(
+    JSON.stringify({
+      placement: { turn_index: 0 },
+      obj: {
+        type: "message_start",
+        id: "",
+        content: "",
+        final_documents: docs,
+      },
+    })
+  );
+
+  lines.push(
+    JSON.stringify({
+      placement: { turn_index: 0 },
+      obj: {
+        type: "message_delta",
+        content: resp.answer || "",
+      },
+    })
+  );
+
+  if (resp.citation_info) {
+    for (var i = 0; i < resp.citation_info.length; i++) {
+      var c = resp.citation_info[i];
+      lines.push(
+        JSON.stringify({
+          placement: { turn_index: 0 },
+          obj: {
+            type: "citation_info",
+            citation_number: c.citation_number,
+            document_id: c.document_id,
+          },
+        })
+      );
+    }
+  }
+
+  var errorMsg = resp.error_msg;
+  if (errorMsg) {
+    lines.push(
+      JSON.stringify({
+        error: errorMsg,
+        stack_trace: null,
+        error_code: null,
+        is_retryable: true,
+      })
+    );
+  }
+
+  lines.push(
+    JSON.stringify({
+      placement: { turn_index: 0 },
+      obj: {
+        type: "stop",
+        stop_reason: errorMsg ? "error" : "finished",
+      },
+    })
+  );
+
+  var citationsMap = buildCitationMap(resp.citation_info);
+
+  var toolCalls = resp.tool_calls;
+  var toolCall = null;
+  if (toolCalls && toolCalls.length > 0) {
+    toolCall = {
+      tool_name: toolCalls[0].tool_name,
+      tool_args: toolCalls[0].tool_arguments,
+      tool_result: toolCalls[0].tool_result,
+    };
+  }
+
+  lines.push(
+    JSON.stringify({
+      message_id: resp.message_id,
+      message_type: "assistant",
+      parent_message: null,
+      latest_child_message: null,
+      message: resp.answer || "",
+      rephrased_query: null,
+      context_docs: docs,
+      time_sent: new Date().toISOString(),
+      overridden_model: "",
+      alternate_assistant_id: null,
+      chat_session_id: resp.chat_session_id || "",
+      citations: citationsMap,
+      files: [],
+      tool_call: toolCall,
+      current_feedback: null,
+      sub_questions: [],
+      comments: null,
+      parentMessageId: null,
+      refined_answer_improvement: null,
+      is_agentic: null,
+      preferred_response_id: null,
+      model_display_name: null,
+      error: null,
+    })
+  );
+
+  return lines;
+}
+
+function buildCitationMap(citationInfo) {
+  if (!citationInfo) return {};
+  var map = {};
+  for (var i = 0; i < citationInfo.length; i++) {
+    var c = citationInfo[i];
+    map[c.citation_number] = c.document_id;
+  }
+  return map;
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -19,6 +19,7 @@ import LicenseExpiryBanner from "@/sections/LicenseExpiryBanner";
 import CustomAnalyticsScript from "@/providers/CustomAnalyticsScript";
 import ProductGatingWrapper from "@/providers/ProductGatingWrapper";
 import SWRConfigProvider from "@/providers/SWRConfigProvider";
+import { ServiceWorkerRegistration } from "@/lib/service-worker/ServiceWorkerRegistration";
 
 const hankenGrotesk = Hanken_Grotesk({
   subsets: ["latin"],
@@ -95,6 +96,7 @@ export default function RootLayout({
       </head>
 
       <body className={`relative font-hanken`}>
+        <ServiceWorkerRegistration />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/web/src/lib/service-worker/ServiceWorkerRegistration.tsx
+++ b/web/src/lib/service-worker/ServiceWorkerRegistration.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if (typeof window === "undefined" || !("serviceWorker" in navigator)) return;
+
+    let unregistered = false;
+
+    const registerSW = async () => {
+      try {
+        const registration = await navigator.serviceWorker.register("/sw.js", {
+          scope: "/",
+        });
+
+        if (unregistered) {
+          registration.unregister();
+          return;
+        }
+
+        registration.addEventListener("updatefound", () => {
+          const installingWorker = registration.installing;
+          if (!installingWorker) return;
+
+          installingWorker.addEventListener("statechange", () => {
+            if (
+              installingWorker.state === "installed" &&
+              navigator.serviceWorker.controller
+            ) {
+              installingWorker.postMessage({ type: "SKIP_WAITING" });
+            }
+          });
+        });
+
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener("controllerchange", () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
+        });
+      } catch (err) {
+        console.warn("Service worker registration failed:", err);
+      }
+    };
+
+    registerSW();
+
+    return () => {
+      unregistered = true;
+    };
+  }, []);
+
+  return null;
+}

--- a/web/tests/e2e/chat/background_processing.spec.ts
+++ b/web/tests/e2e/chat/background_processing.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@tests/e2e/chat/fixtures";
+import { sendMessage } from "@tests/e2e/utils/chatActions";
+import { buildMockStream } from "@tests/e2e/utils/chatMock";
+
+test.describe("Background Chat Processing", () => {
+  test("renders answer from a single-burst NDJSON response (simulating background-processed output)", async ({
+    page,
+    chatPage,
+  }) => {
+    await chatPage.goto();
+
+    const mockResponse =
+      "This is a response delivered as a single burst of NDJSON lines, simulating the service worker background-processed output.";
+
+    await page.route("**/api/chat/send-chat-message", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: buildMockStream(mockResponse),
+      });
+    });
+
+    await sendMessage(page, "test message");
+
+    const aiMessage = page.getByTestId("onyx-ai-message").first();
+    await expect(aiMessage).toContainText(mockResponse, {
+      timeout: 15000,
+    });
+  });
+
+  test("renders long content delivered as single burst correctly", async ({
+    page,
+    chatPage,
+  }) => {
+    await chatPage.goto();
+
+    const longAnswer =
+      "This is a much longer response that would normally stream incrementally. ".repeat(
+        20
+      ) +
+      "When delivered by the service worker, all content arrives at once and the frontend handles it identically. " +
+      "The chat controller processes all packets from the FIFO without delay. " +
+      "Citations, documents, and tool calls all arrive in a single burst.";
+
+    await page.route("**/api/chat/send-chat-message", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: buildMockStream(longAnswer),
+      });
+    });
+
+    await sendMessage(page, "long answer test");
+
+    const aiMessage = page.getByTestId("onyx-ai-message").first();
+    await expect(aiMessage).toContainText(
+      "When delivered by the service worker",
+      {
+        timeout: 15000,
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Description

Use a service worker on the web to handle message streaming. I noticed on mobile (iOS) that if I leave the tab while waiting for a response it'll error out and I lose my response. This should fix that.

## How Has This Been Tested?

Automated tests were written. I have not tried it out. I suggest ignoring this PR and letting a full maintainer copy it in spirit to make sure it's properly implemented. 

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams chat responses via a service worker so conversations continue when the tab is backgrounded or the app is switched, preventing lost answers and enabling recovery. The worker fetches with streaming disabled and replays the result as NDJSON to match the existing streaming pipeline.

- New Features
  - Intercepts POSTs to "/api/chat/send-chat-message", sets stream=false, and converts the full response to NDJSON packets (IDs, message_start, message_delta, citation_info, stop, final message) returned as text/event-stream.
  - Registers the service worker in the app layout and updates CSP to allow "worker-src 'self'".
  - Adds user_message_id to ChatFullResponse and wires it through gather_stream_full; includes unit and e2e tests to validate single-burst NDJSON handling.

<sup>Written for commit 6bf0fcb7a72be27c007bb595576cf96baca8e148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

