### PR TITLE
fix(craft): prevent stuck opencode turns

### DIFF
--- a/backend/onyx/cache/redis_backend.py
+++ b/backend/onyx/cache/redis_backend.py
@@ -71,7 +71,7 @@ class RedisCacheBackend(CacheBackend):
     # -- distributed lock --------------------------------------------------
 
     def lock(self, name: str, timeout: float | None = None) -> CacheLock:
-        return RedisCacheLock(self._r.lock(name, timeout=timeout))
+        return RedisCacheLock(self._r.lock(name, timeout=timeout, thread_local=False))
 
     # -- blocking list (MCP OAuth BLPOP pattern) ---------------------------
 

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -303,25 +303,34 @@ class PodEventBus:
                             )
 
         sid = _extract_session_id(evt)
-        if sid is None:
-            return
 
         # Deliver to sid's own subscribers AND to every ancestor's subscribers
         # so a turn subscribed only to the parent session also sees descendant
         # (subagent) events. Walk _child_to_parent up to the root, deduping so
         # no subscriber receives the event twice.
         with self._lock:
-            target_sids = [sid]
-            ancestor = self._child_to_parent.get(sid)
-            seen_sids = {sid}
-            while ancestor is not None and ancestor not in seen_sids:
-                target_sids.append(ancestor)
-                seen_sids.add(ancestor)
-                ancestor = self._child_to_parent.get(ancestor)
             queues: list[_Subscription] = []
             seen_subs: set[int] = set()
-            for target_sid in target_sids:
-                for sub in self._subscribers.get(target_sid, ()):
+            if sid is None:
+                if not _is_unscoped_terminal_event(evt):
+                    return
+                # Some opencode terminal events are published without a
+                # sessionID. The bus is directory-scoped, so active subscribers
+                # are the only consumers that can observe that turn ending.
+                subscriber_groups = self._subscribers.values()
+            else:
+                target_sids = [sid]
+                ancestor = self._child_to_parent.get(sid)
+                seen_sids = {sid}
+                while ancestor is not None and ancestor not in seen_sids:
+                    target_sids.append(ancestor)
+                    seen_sids.add(ancestor)
+                    ancestor = self._child_to_parent.get(ancestor)
+                subscriber_groups = (
+                    self._subscribers.get(target_sid, ()) for target_sid in target_sids
+                )
+            for subs in subscriber_groups:
+                for sub in subs:
                     if id(sub) not in seen_subs:
                         seen_subs.add(id(sub))
                         queues.append(sub)
@@ -367,6 +376,19 @@ def _extract_session_id(evt: dict[str, Any]) -> str | None:
         if isinstance(nested, str) and nested:
             return nested
     return None
+
+
+def _is_unscoped_terminal_event(evt: dict[str, Any]) -> bool:
+    etype = evt.get("type")
+    if etype in ("session.error", "session.idle"):
+        return True
+    if etype != "session.status":
+        return False
+    props = evt.get("properties")
+    if not isinstance(props, dict):
+        return False
+    status = props.get("status")
+    return isinstance(status, dict) and status.get("type") == "idle"
 
 
 def _parse_sse_block(block: str) -> dict[str, Any] | None:

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -275,11 +275,11 @@ class PodEventBus:
         self._auth = new_auth
         logger.info("PodEventBus reloaded auth after 401 on %s/event", self._base_url)
 
-    def _dispatch(self, evt: dict[str, Any]) -> None:
-        etype = evt.get("type")
-        props = evt.get("properties") or {}
+    def _dispatch(self, event: dict[str, Any]) -> None:
+        event_type = event.get("type")
+        props = event.get("properties") or {}
 
-        if etype == "session.created":
+        if event_type == "session.created":
             info = props.get("info") if isinstance(props, dict) else None
             if isinstance(info, dict):
                 child_id = info.get("id")
@@ -302,49 +302,54 @@ class PodEventBus:
                                 parent_id,
                             )
 
-        sid = _extract_session_id(evt)
+        session_id = _extract_session_id(event)
+        log_session_id = session_id or "<unscoped>"
 
-        # Deliver to sid's own subscribers AND to every ancestor's subscribers
+        # Deliver to session_id's own subscribers AND to every ancestor's subscribers
         # so a turn subscribed only to the parent session also sees descendant
         # (subagent) events. Walk _child_to_parent up to the root, deduping so
         # no subscriber receives the event twice.
         with self._lock:
-            queues: list[_Subscription] = []
-            seen_subs: set[int] = set()
-            if sid is None:
-                if not _is_unscoped_terminal_event(evt):
+            target_subscriptions: list[_Subscription] = []
+            seen_subscriptions: set[int] = set()
+            if session_id is None:
+                if not _is_unscoped_terminal_event(event):
                     return
                 # Some opencode terminal events are published without a
                 # sessionID. The bus is directory-scoped, so active subscribers
                 # are the only consumers that can observe that turn ending.
                 subscriber_groups = self._subscribers.values()
             else:
-                target_sids = [sid]
-                ancestor = self._child_to_parent.get(sid)
-                seen_sids = {sid}
-                while ancestor is not None and ancestor not in seen_sids:
-                    target_sids.append(ancestor)
-                    seen_sids.add(ancestor)
+                target_session_ids = [session_id]
+                ancestor = self._child_to_parent.get(session_id)
+                seen_session_ids = {session_id}
+                while ancestor is not None and ancestor not in seen_session_ids:
+                    target_session_ids.append(ancestor)
+                    seen_session_ids.add(ancestor)
                     ancestor = self._child_to_parent.get(ancestor)
                 subscriber_groups = (
-                    self._subscribers.get(target_sid, ()) for target_sid in target_sids
+                    self._subscribers.get(target_session_id, ())
+                    for target_session_id in target_session_ids
                 )
-            for subs in subscriber_groups:
-                for sub in subs:
-                    if id(sub) not in seen_subs:
-                        seen_subs.add(id(sub))
-                        queues.append(sub)
-        for sub in queues:
+            for subscribers in subscriber_groups:
+                for subscription in subscribers:
+                    if id(subscription) not in seen_subscriptions:
+                        seen_subscriptions.add(id(subscription))
+                        target_subscriptions.append(subscription)
+        for subscription in target_subscriptions:
             try:
-                sub.queue.put_nowait(evt)
+                subscription.queue.put_nowait(event)
             except Full:
-                sub.dropped_count += 1
-                if sub.dropped_count == 1 or sub.dropped_count % 50 == 0:
+                subscription.dropped_count += 1
+                if (
+                    subscription.dropped_count == 1
+                    or subscription.dropped_count % 50 == 0
+                ):
                     logger.warning(
                         "PodEventBus dropped event for session %s "
                         "(queue full; total dropped=%d)",
-                        sid,
-                        sub.dropped_count,
+                        log_session_id,
+                        subscription.dropped_count,
                     )
 
 
@@ -378,13 +383,13 @@ def _extract_session_id(evt: dict[str, Any]) -> str | None:
     return None
 
 
-def _is_unscoped_terminal_event(evt: dict[str, Any]) -> bool:
-    etype = evt.get("type")
-    if etype in ("session.error", "session.idle"):
+def _is_unscoped_terminal_event(event: dict[str, Any]) -> bool:
+    event_type = event.get("type")
+    if event_type in ("session.error", "session.idle"):
         return True
-    if etype != "session.status":
+    if event_type != "session.status":
         return False
-    props = evt.get("properties")
+    props = event.get("properties")
     if not isinstance(props, dict):
         return False
     status = props.get("status")

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -1261,7 +1261,7 @@ class OpencodeServeClient:
                 parent_resolver=parent_resolver,
                 children_resolver=children_resolver,
             ):
-                if isinstance(sandbox_event, PromptResponse):
+                if isinstance(sandbox_event, (Error, PromptResponse)):
                     terminated_locally = True
                 yield sandbox_event
 

--- a/backend/tests/unit/onyx/cache/test_redis_backend.py
+++ b/backend/tests/unit/onyx/cache/test_redis_backend.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import threading
+from queue import Queue
+from types import SimpleNamespace
+from typing import cast
+
+from onyx.cache.redis_backend import RedisCacheBackend
+from onyx.redis.tenant_redis_client import TenantRedisClient
+
+
+class _RedisLikeLock:
+    """Minimal redis-py Lock behavior needed to reproduce token locality."""
+
+    def __init__(self, *, thread_local: bool) -> None:
+        self.local = threading.local() if thread_local else SimpleNamespace()
+        self.local.token = None
+
+    def acquire(
+        self,
+        blocking: bool = True,  # noqa: ARG002
+        blocking_timeout: float | None = None,  # noqa: ARG002
+    ) -> bool:
+        self.local.token = b"token"
+        return True
+
+    def release(self) -> None:
+        token = getattr(self.local, "token", None)
+        if token is None:
+            raise RuntimeError("Cannot release an unlocked lock")
+        self.local.token = None
+
+    def owned(self) -> bool:
+        return getattr(self.local, "token", None) is not None
+
+
+class _RecordingRedisClient:
+    def __init__(self) -> None:
+        self.lock_calls: list[dict[str, object]] = []
+        self.lock_obj: _RedisLikeLock | None = None
+
+    def lock(
+        self,
+        name: str,
+        timeout: float | None = None,
+        *,
+        thread_local: bool = True,
+    ) -> object:
+        self.lock_calls.append(
+            {"name": name, "timeout": timeout, "thread_local": thread_local}
+        )
+        self.lock_obj = _RedisLikeLock(thread_local=thread_local)
+        return self.lock_obj
+
+
+def test_redis_cache_locks_can_release_from_a_different_thread() -> None:
+    redis_client = _RecordingRedisClient()
+    backend = RedisCacheBackend(cast(TenantRedisClient, redis_client))
+    lock = backend.lock("lock-key", timeout=90)
+
+    assert lock.acquire()
+
+    release_errors: Queue[BaseException] = Queue()
+
+    def release_lock() -> None:
+        try:
+            lock.release()
+        except BaseException as e:
+            release_errors.put(e)
+
+    release_thread = threading.Thread(target=release_lock)
+    release_thread.start()
+    release_thread.join(timeout=2)
+
+    assert redis_client.lock_calls == [
+        {"name": "lock-key", "timeout": 90, "thread_local": False}
+    ]
+    assert release_thread.is_alive() is False
+    assert release_errors.empty()

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -186,6 +186,50 @@ def test_dispatch_drops_global_events_without_sessionid(bus: PodEventBus) -> Non
         sub.queue.get_nowait()
 
 
+def test_dispatch_fans_out_unscoped_session_error(bus: PodEventBus) -> None:
+    """opencode can publish terminal session events without sessionID. Since the
+    bus is directory-scoped, deliver those to active subscribers instead of
+    dropping them and leaving send-message to emit keepalives until timeout."""
+    sub_a = bus.subscribe("ses_A")
+    sub_b = bus.subscribe("ses_B")
+
+    bus._dispatch(
+        {
+            "type": "session.error",
+            "properties": {"error": {"data": {"message": "upstream reset"}}},
+        }
+    )
+
+    item_a = sub_a.queue.get_nowait()
+    item_b = sub_b.queue.get_nowait()
+    assert item_a is not None
+    assert item_b is not None
+    assert item_a["type"] == "session.error"
+    assert item_b["type"] == "session.error"
+    assert item_a["properties"]["error"]["data"]["message"] == "upstream reset"
+
+
+def test_dispatch_fans_out_unscoped_idle_status(bus: PodEventBus) -> None:
+    sub = bus.subscribe("ses_A")
+
+    bus._dispatch(
+        {"type": "session.status", "properties": {"status": {"type": "idle"}}}
+    )
+
+    item = sub.queue.get_nowait()
+    assert item is not None
+    assert item["type"] == "session.status"
+
+
+def test_dispatch_drops_unscoped_non_terminal_event(bus: PodEventBus) -> None:
+    sub = bus.subscribe("ses_A")
+
+    bus._dispatch({"type": "session.updated", "properties": {}})
+
+    with pytest.raises(Empty):
+        sub.queue.get_nowait()
+
+
 def test_dispatch_extracts_sessionid_from_nested_info(bus: PodEventBus) -> None:
     """``message.updated`` puts sessionID on the inner Message object."""
     sub = bus.subscribe("ses_A")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
@@ -137,6 +137,11 @@ def _wait_for(predicate: Any, *, timeout: float = 3.0) -> bool:
     return False
 
 
+def _dispatch_session_idle(bus: PodEventBus, *, scoped: bool = True) -> None:
+    properties = {"sessionID": _SESSION} if scoped else {}
+    bus._dispatch({"type": "session.idle", "properties": properties})
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -205,6 +210,7 @@ def test_send_message_yields_text_and_terminator(bus: PodEventBus) -> None:
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -265,7 +271,7 @@ def test_send_message_routes_reasoning_to_thought_chunks(bus: PodEventBus) -> No
                 },
             }
         )
-        # terminator
+        # Completion metadata arrives before the session-level terminator.
         bus._dispatch(
             {
                 "type": "message.updated",
@@ -280,6 +286,7 @@ def test_send_message_routes_reasoning_to_thought_chunks(bus: PodEventBus) -> No
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -314,7 +321,7 @@ def test_send_message_threads_model_override_into_prompt_async(
         client, model_provider="anthropic", model_id="claude-opus-4-7"
     )
     try:
-        # Immediately terminate via a completed message.updated.
+        # Completion metadata arrives before the session-level terminator.
         bus._dispatch(
             {
                 "type": "message.updated",
@@ -329,6 +336,7 @@ def test_send_message_threads_model_override_into_prompt_async(
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -370,6 +378,7 @@ def test_send_message_omits_model_when_override_missing(bus: PodEventBus) -> Non
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -408,6 +417,7 @@ def test_send_message_omits_model_when_only_one_arg_supplied(
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -493,6 +503,52 @@ def test_send_message_errors_when_bus_closes_before_terminator(
     errs = [e for e in events if isinstance(e, Error)]
     assert errs
     assert "event bus closed" in errs[0].message
+
+
+def test_send_message_surfaces_unscoped_session_error_as_terminal(
+    bus: PodEventBus,
+) -> None:
+    """Unscoped opencode session.error must end the turn immediately.
+
+    Without bus fanout this event is dropped. Without treating Error as a
+    local terminator, the Error is yielded but the generator keeps waiting for
+    timeout and the UI sees keepalives after the real failure.
+    """
+    transport = httpx.MockTransport(_ok_response)
+    client = _make_client(bus, transport)
+    events, t = _run_send_message(client, timeout=5.0)
+    try:
+        bus._dispatch(
+            {
+                "type": "session.error",
+                "properties": {
+                    "error": {"data": {"message": "upstream connection reset"}}
+                },
+            }
+        )
+        assert _wait_for(lambda: not t.is_alive(), timeout=1.0)
+    finally:
+        t.join(timeout=3.0)
+
+    errs = [e for e in events if isinstance(e, Error)]
+    assert len(errs) == 1
+    assert "upstream connection reset" in errs[0].message
+    assert not any(isinstance(e, PromptResponse) for e in events)
+
+
+def test_send_message_ends_on_unscoped_session_idle(bus: PodEventBus) -> None:
+    """Unscoped session.idle is still a valid directory-scoped turn terminator."""
+    transport = httpx.MockTransport(_ok_response)
+    client = _make_client(bus, transport)
+    events, t = _run_send_message(client, timeout=5.0)
+    try:
+        _dispatch_session_idle(bus, scoped=False)
+        assert _wait_for(lambda: not t.is_alive(), timeout=1.0)
+    finally:
+        t.join(timeout=3.0)
+
+    assert any(isinstance(e, PromptResponse) for e in events)
+    assert not any(isinstance(e, Error) for e in events)
 
 
 def test_send_message_wall_clock_timeout_aborts(bus: PodEventBus) -> None:
@@ -616,6 +672,7 @@ def test_send_message_auto_allows_permission_asks(bus: PodEventBus) -> None:
                 },
             }
         )
+        _dispatch_session_idle(bus)
         assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
     finally:
         t.join(timeout=3.0)
@@ -640,20 +697,7 @@ def test_send_message_unsubscribes_on_clean_exit(bus: PodEventBus) -> None:
     list(
         _gen_to_completion(
             client,
-            terminator=lambda: bus._dispatch(
-                {
-                    "type": "message.updated",
-                    "properties": {
-                        "sessionID": _SESSION,
-                        "info": {
-                            "id": "msg1",
-                            "sessionID": _SESSION,
-                            "role": "assistant",
-                            "time": {"completed": 1},
-                        },
-                    },
-                }
-            ),
+            terminator=lambda: _dispatch_session_idle(bus),
         )
     )
     # After clean exit, no subscription should remain.


### PR DESCRIPTION
## Description

Fixes the two user-visible Craft turn failure modes that make a session appear stuck after an opencode turn fails:

- Configure Redis-backed cache locks with `thread_local=False` so prompt-slot locks can be released when Starlette/anyio resumes cleanup on a different worker thread. This addresses ENG-4144.
- Fan out unscoped opencode terminal events (`session.error`, `session.idle`, idle `session.status`) to active directory subscribers instead of dropping them.
- Treat translated opencode `Error` events as terminal in `send_message`, so the stream stops on the real failure instead of continuing with keepalives until timeout.

Related: ENG-4149, ENG-4144, ENG-4135. This PR intentionally does not add `/event` reconnect/backoff hardening for ENG-4135; that belongs with the attach-live-stream work.

## How Has This Been Tested?

- `pytest -q backend/tests/unit/onyx/cache/test_redis_backend.py backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py`
- `ruff check backend/onyx/cache/redis_backend.py backend/onyx/server/features/build/sandbox/opencode/event_bus.py backend/onyx/server/features/build/sandbox/opencode/serve_client.py backend/tests/unit/onyx/cache/test_redis_backend.py backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py`
- `ruff format --check backend/onyx/cache/redis_backend.py backend/onyx/server/features/build/sandbox/opencode/event_bus.py backend/onyx/server/features/build/sandbox/opencode/serve_client.py backend/tests/unit/onyx/cache/test_redis_backend.py backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py`
- `git diff --check origin/main...HEAD`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck opencode turns by allowing cross-thread Redis lock release and treating unscoped terminal events as stream terminators. Streams now end promptly on errors or idle, and dispatch logs clearly label dropped unscoped events.

- **Bug Fixes**
  - Set Redis cache locks with thread_local=False so prompt-slot locks can be released from a different thread. Addresses ENG-4144.
  - Fan out unscoped terminal events (`session.error`, `session.idle`, idle `session.status`) to all active directory subscribers to avoid dropping terminators when the event lacks `sessionID`. Addresses ENG-4149.
  - End `send_message` when a translated opencode `Error` is received so the stream stops on the real failure instead of continuing keepalives. Related to ENG-4135.
  - Clarified dispatch naming and drop logs; log "<unscoped>" when a subscriber queue drops an unscoped terminal event.

<sup>Written for commit 26ca4301d46f6cc1f19e14558b59458048e955b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

