### PR TITLE
feat(reindex): add port-flow re-embed, PIT scan, and attempt tracking

### DIFF
--- a/backend/alembic/versions/81c4872d9666_add_search_settings_use_port_flow.py
+++ b/backend/alembic/versions/81c4872d9666_add_search_settings_use_port_flow.py
@@ -1,0 +1,34 @@
+"""add search_settings use_port_flow
+
+Revision ID: 81c4872d9666
+Revises: d49e41659191
+Create Date: 2026-06-03 12:11:18.288792
+
+Additive: the per-SearchSettings reindex "port" flow gate. Default false, so
+existing FUTUREs keep the legacy connector-rerun reindex.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "81c4872d9666"
+down_revision = "d49e41659191"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "search_settings",
+        sa.Column(
+            "use_port_flow",
+            sa.Boolean(),
+            server_default=sa.false(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("search_settings", "use_port_flow")

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -384,6 +384,9 @@ VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT = (
 OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE = int(
     os.environ.get("OPENSEARCH_MIGRATION_GET_VESPA_CHUNKS_PAGE_SIZE") or 500
 )
+# Lifetime of a point-in-time used to scan an index consistently (reindex port).
+# Each search extends the lease; an idle PIT self-expires after this.
+PIT_KEEP_ALIVE = os.environ.get("PIT_KEEP_ALIVE") or "5m"
 # If set, will override the default number of shards and replicas for the index.
 OPENSEARCH_INDEX_NUM_SHARDS: int | None = (
     int(os.environ["OPENSEARCH_INDEX_NUM_SHARDS"])

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -51,6 +51,7 @@ class SavedSearchSettings(IndexingSetting):
             embedding_precision=search_settings.embedding_precision,
             reduced_dimension=search_settings.reduced_dimension,
             switchover_type=search_settings.switchover_type,
+            use_port_flow=search_settings.use_port_flow,
             enable_contextual_rag=search_settings.enable_contextual_rag,
             contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         )

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2042,6 +2042,12 @@ class SearchSettings(Base):
         Enum(SwitchoverType, native_enum=False), default=SwitchoverType.REINDEX
     )
 
+    # Reindex "port" flow gate. When True, this FUTURE is filled by porting
+    # chunks from PRESENT (re-embedded) instead of re-running every connector.
+    use_port_flow: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+
     # allows for quantization -> less memory usage for a small performance hit.
     # Defaults to FLOAT (float32). OpenSearch ignores this field and stores
     # vectors as float32 regardless; BFLOAT16 is only honored by Vespa.

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -1,0 +1,167 @@
+"""DB helpers for the reindexing port-attempt lifecycle.
+
+One PortAttempt per (cc_pair, FUTURE SearchSettings) drives the backlog port.
+The partial-unique index `ix_port_attempt_active_unique` guarantees at most one
+active (NOT_STARTED / IN_PROGRESS) attempt per pair; terminal rows accumulate as
+history. Nothing here enqueues celery work — that is the caller's job.
+"""
+
+from sqlalchemy import func
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.models import PortAttempt
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_ACTIVE_STATUSES = [PortAttemptStatus.NOT_STARTED, PortAttemptStatus.IN_PROGRESS]
+
+
+def _get_locked(db_session: Session, port_attempt_id: int) -> PortAttempt:
+    """Row-locked fetch (SELECT ... FOR UPDATE) so status transitions serialize —
+    the port task and the stall watchdog can race to close the same attempt.
+    Mirrors the index_attempt.py transition helpers."""
+    attempt = db_session.execute(
+        select(PortAttempt).where(PortAttempt.id == port_attempt_id).with_for_update()
+    ).scalar_one_or_none()
+    if attempt is None:
+        raise ValueError(f"PortAttempt {port_attempt_id} not found")
+    return attempt
+
+
+def create_port_attempt(
+    db_session: Session,
+    cc_pair_id: int,
+    search_settings_id: int,
+    celery_task_id: str | None = None,
+) -> PortAttempt:
+    """Create a NOT_STARTED attempt. Raises IntegrityError (the active-unique
+    index) if an active attempt already exists for the pair."""
+    attempt = PortAttempt(
+        cc_pair_id=cc_pair_id,
+        search_settings_id=search_settings_id,
+        status=PortAttemptStatus.NOT_STARTED,
+        celery_task_id=celery_task_id,
+    )
+    db_session.add(attempt)
+    try:
+        db_session.commit()
+    except Exception:
+        # The active-unique index violation (expected on a race) leaves the
+        # session in a failed transaction; roll back so the caller's session is
+        # usable, then re-raise.
+        db_session.rollback()
+        raise
+    return attempt
+
+
+def get_port_attempt(db_session: Session, port_attempt_id: int) -> PortAttempt | None:
+    return db_session.get(PortAttempt, port_attempt_id)
+
+
+def get_active_port_attempt(
+    db_session: Session, cc_pair_id: int, search_settings_id: int
+) -> PortAttempt | None:
+    """The single active (NOT_STARTED / IN_PROGRESS) attempt for the pair, if any."""
+    return db_session.execute(
+        select(PortAttempt).where(
+            PortAttempt.cc_pair_id == cc_pair_id,
+            PortAttempt.search_settings_id == search_settings_id,
+            PortAttempt.status.in_(_ACTIVE_STATUSES),
+        )
+    ).scalar_one_or_none()
+
+
+def get_port_attempts_for_future(
+    db_session: Session, search_settings_id: int
+) -> list[PortAttempt]:
+    """All attempts (any status) for a FUTURE, newest first."""
+    return list(
+        db_session.execute(
+            select(PortAttempt)
+            .where(PortAttempt.search_settings_id == search_settings_id)
+            .order_by(PortAttempt.time_created.desc())
+        )
+        .scalars()
+        .all()
+    )
+
+
+def mark_port_in_progress(
+    db_session: Session, port_attempt_id: int, celery_task_id: str | None = None
+) -> None:
+    try:
+        attempt = _get_locked(db_session, port_attempt_id)
+        attempt.status = PortAttemptStatus.IN_PROGRESS
+        attempt.time_started = func.now()
+        attempt.last_progress_time = func.now()
+        if celery_task_id is not None:
+            attempt.celery_task_id = celery_task_id
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        raise
+
+
+def commit_port_cursor(
+    db_session: Session,
+    port_attempt_id: int,
+    last_processed_doc_id: str,
+    docs_ported: int,
+) -> None:
+    """Per-batch durability point: advance the resume cursor + progress clock.
+    `docs_ported` is the cumulative count so far."""
+    try:
+        attempt = _get_locked(db_session, port_attempt_id)
+        attempt.last_processed_doc_id = last_processed_doc_id
+        attempt.docs_ported = docs_ported
+        attempt.last_progress_time = func.now()
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        raise
+
+
+def mark_port_succeeded(db_session: Session, port_attempt_id: int) -> None:
+    _mark_terminal(db_session, port_attempt_id, PortAttemptStatus.SUCCESS)
+
+
+def mark_port_failed(
+    db_session: Session, port_attempt_id: int, error_msg: str | None = None
+) -> None:
+    _mark_terminal(db_session, port_attempt_id, PortAttemptStatus.FAILED, error_msg)
+
+
+def mark_port_canceled(db_session: Session, port_attempt_id: int) -> None:
+    _mark_terminal(db_session, port_attempt_id, PortAttemptStatus.CANCELED)
+
+
+def _mark_terminal(
+    db_session: Session,
+    port_attempt_id: int,
+    status: PortAttemptStatus,
+    error_msg: str | None = None,
+) -> None:
+    try:
+        attempt = _get_locked(db_session, port_attempt_id)
+        if attempt.status.is_terminal():
+            # First terminal write wins: the row lock makes the watchdog-vs-task
+            # race deterministic, so a late SUCCESS can't clobber a watchdog FAILED.
+            logger.debug(
+                "PortAttempt %s already terminal (%s); ignoring %s",
+                port_attempt_id,
+                attempt.status.value,
+                status.value,
+            )
+            db_session.rollback()
+            return
+        attempt.status = status
+        attempt.time_completed = func.now()
+        if error_msg is not None:
+            attempt.error_msg = error_msg
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        raise

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -53,6 +53,7 @@ def create_search_settings(
         enable_contextual_rag=search_settings.enable_contextual_rag,
         contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         switchover_type=search_settings.switchover_type,
+        use_port_flow=search_settings.use_port_flow,
     )
 
     db_session.add(embedding_model)

--- a/backend/onyx/document_index/opensearch/client.py
+++ b/backend/onyx/document_index/opensearch/client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from contextlib import nullcontext
 from http import HTTPStatus
@@ -8,6 +9,7 @@ from typing import Any
 from typing import Generic
 from typing import TypeVar
 
+from opensearchpy import NotFoundError
 from opensearchpy import OpenSearch
 from opensearchpy import TransportError
 from opensearchpy.helpers import bulk
@@ -19,11 +21,18 @@ from onyx.configs.app_configs import OPENSEARCH_ADMIN_USERNAME
 from onyx.configs.app_configs import OPENSEARCH_HOST
 from onyx.configs.app_configs import OPENSEARCH_REST_API_PORT
 from onyx.configs.app_configs import OPENSEARCH_USE_SSL
+from onyx.configs.app_configs import PIT_KEEP_ALIVE
 from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
 from onyx.document_index.opensearch.constants import OpenSearchSearchType
+from onyx.document_index.opensearch.schema import CHUNK_INDEX_FIELD_NAME
+from onyx.document_index.opensearch.schema import CONTENT_VECTOR_FIELD_NAME
+from onyx.document_index.opensearch.schema import DOCUMENT_ID_FIELD_NAME
 from onyx.document_index.opensearch.schema import DocumentChunk
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from onyx.document_index.opensearch.schema import MAX_CHUNK_SIZE_FIELD_NAME
+from onyx.document_index.opensearch.schema import TITLE_VECTOR_FIELD_NAME
 from onyx.document_index.opensearch.search import DEFAULT_OPENSEARCH_MAX_RESULT_WINDOW
 from onyx.server.metrics.opensearch_search import observe_opensearch_search
 from onyx.server.metrics.opensearch_search import record_opensearch_search_error
@@ -131,6 +140,11 @@ class OpenSearchDocumentMissingError(Exception):
 # _RETRYABLE_UPDATE_ERROR_TYPES above). Status codes use http.HTTPStatus.
 _DOCUMENT_MISSING_ERROR_TYPE = "document_missing_exception"
 _VERSION_CONFLICT_ERROR_TYPE = "version_conflict_engine_exception"
+# Raised by a search whose PIT has expired/been deleted; we re-open and retry.
+_SEARCH_CONTEXT_MISSING_ERROR_TYPE = "search_context_missing"
+# Chunks per PIT-scan page. A port doc-batch is small (INDEX_BATCH_SIZE docs), so
+# one page covers a batch; paging still protects against a pathological doc.
+_PIT_SCAN_PAGE_SIZE = 1000
 
 
 def _external_version_ms(document: DocumentChunk) -> int | None:
@@ -1557,6 +1571,214 @@ class OpenSearchIndexClient(OpenSearchClient):
             len(document_chunk_ids),
         )
         return document_chunk_ids
+
+    def open_pit(self, keep_alive: str = PIT_KEEP_ALIVE) -> str:
+        """Opens a point-in-time (PIT) over this index for a consistent scan.
+
+        The PIT pins the index across searches so concurrent writes don't shift
+        the result set. The caller threads the returned id into
+        fetch_chunks_for_doc_ids and releases it with close_pit when done.
+
+        Args:
+            keep_alive: How long the PIT lives between uses; each search extends
+                the lease.
+
+        Raises:
+            RuntimeError: OpenSearch returned no pit_id.
+
+        Returns:
+            The point-in-time id.
+        """
+        response = self._client.create_pit(
+            index=self._index_name, params={"keep_alive": keep_alive}
+        )
+        pit_id = response.get("pit_id")
+        if not pit_id:
+            raise RuntimeError(
+                f"create_pit returned no pit_id for index {self._index_name}."
+            )
+        return pit_id
+
+    def close_pit(self, pit_id: str) -> None:
+        """Releases a PIT. Best-effort — a leaked PIT self-expires after keep_alive.
+
+        Args:
+            pit_id: The point-in-time id to delete.
+        """
+        try:
+            self._client.delete_pit(body={"pit_id": [pit_id]})
+        except NotFoundError:
+            pass
+
+    def fetch_chunks_for_doc_ids(
+        self,
+        pit_id: str,
+        doc_ids: list[str],
+        search_after: list[object] | None = None,
+        page_size: int = _PIT_SCAN_PAGE_SIZE,
+        keep_alive: str = PIT_KEEP_ALIVE,
+    ) -> tuple[list[DocumentChunkWithoutVectors], list[object] | None, str]:
+        """Fetches one page of regular chunks for a batch of documents from a PIT.
+
+        Filters to regular chunks (max_chunk_size == DEFAULT_MAX_CHUNK_SIZE) so
+        large/mini chunks are never ported, sorts by (document_id, chunk_index),
+        and pages with search_after. Vectors are excluded — the port re-embeds.
+        If the PIT expired the scan re-opens it and retries once.
+
+        Args:
+            pit_id: The point-in-time id from open_pit.
+            doc_ids: The document ids whose chunks to fetch.
+            search_after: The sort cursor from the previous page; None for the
+                first page.
+            page_size: Max chunks per page.
+            keep_alive: PIT lease extension applied on each search.
+
+        Raises:
+            OpenSearchServerSideTimeout: The search timed out server-side; the
+                caller should retry the batch.
+            Exception: There was an error searching the index.
+
+        Returns:
+            A tuple of (chunks, next_search_after, pit_id_in_use). next_search_after
+            is None once the batch is exhausted; pit_id_in_use reflects the new PIT
+            when the scan re-opened, so the caller threads it forward.
+        """
+        if not doc_ids:
+            return [], None, pit_id
+
+        # Background scans intentionally skip the user-search metrics/pipeline that
+        # search() applies; we still detect a server-side timeout below so a
+        # truncated page is never mistaken for the end of the scan.
+        try:
+            result = self._client.search(
+                body=self._pit_scan_body(
+                    pit_id, doc_ids, search_after, page_size, keep_alive
+                )
+            )
+        except NotFoundError as e:
+            if not self._is_pit_expired(e):
+                raise
+            logger.debug(
+                "PIT %s expired mid-scan for index %s; reopening.",
+                pit_id,
+                self._index_name,
+            )
+            pit_id = self.open_pit(keep_alive)
+            result = self._client.search(
+                body=self._pit_scan_body(
+                    pit_id, doc_ids, search_after, page_size, keep_alive
+                )
+            )
+
+        if result.get("timed_out"):
+            # A timed-out page returns partial hits; treating it as a short page
+            # would silently end the scan early, so fail and let the caller retry.
+            raise OpenSearchServerSideTimeout(
+                f"PIT scan of index {self._index_name} timed out server-side."
+            )
+
+        hits: list[dict[str, Any]] = result.get("hits", {}).get("hits", [])
+        chunks: list[DocumentChunkWithoutVectors] = []
+        last_sort: list[object] | None = None
+        for hit in hits:
+            source = hit.get("_source")
+            if not source:
+                raise RuntimeError(
+                    f'Document chunk with ID "{hit.get("_id", "")}" has no data.'
+                )
+            chunks.append(DocumentChunkWithoutVectors.model_validate(source))
+            last_sort = hit.get("sort")
+
+        # A short page means the batch is exhausted; a full page means resume from
+        # the last hit's sort values on the next call.
+        next_search_after = last_sort if len(hits) == page_size else None
+        return chunks, next_search_after, pit_id
+
+    def iter_chunks_for_doc_ids(
+        self,
+        doc_ids: list[str],
+        page_size: int = _PIT_SCAN_PAGE_SIZE,
+        keep_alive: str = PIT_KEEP_ALIVE,
+    ) -> Iterator[list[DocumentChunkWithoutVectors]]:
+        """Scans regular chunks for a batch of documents, one page at a time.
+
+        Owns the whole PIT lifecycle: opens it, pages with search_after, re-opens
+        transparently on expiry, and always closes it (even if the consumer
+        raises). The preferred entry point so callers can't leak a PIT.
+
+        Args:
+            doc_ids: The document ids whose chunks to scan.
+            page_size: Max chunks per page.
+            keep_alive: PIT lease extension applied on each search.
+
+        Yields:
+            One page (list) of chunks at a time.
+        """
+        if not doc_ids:
+            return
+        pit_id = self.open_pit(keep_alive)
+        try:
+            search_after: list[object] | None = None
+            while True:
+                chunks, search_after, pit_id = self.fetch_chunks_for_doc_ids(
+                    pit_id,
+                    doc_ids,
+                    search_after=search_after,
+                    page_size=page_size,
+                    keep_alive=keep_alive,
+                )
+                if chunks:
+                    yield chunks
+                if search_after is None:
+                    return
+        finally:
+            self.close_pit(pit_id)
+
+    def _pit_scan_body(
+        self,
+        pit_id: str,
+        doc_ids: list[str],
+        search_after: list[object] | None,
+        page_size: int,
+        keep_alive: str,
+    ) -> dict[str, Any]:
+        """Builds the PIT search body for one page.
+
+        No index= is sent — the PIT pins the index; keep_alive in the pit block
+        extends the lease on every page.
+        """
+        body: dict[str, Any] = {
+            "pit": {"id": pit_id, "keep_alive": keep_alive},
+            "size": page_size,
+            "_source": {
+                "excludes": [CONTENT_VECTOR_FIELD_NAME, TITLE_VECTOR_FIELD_NAME]
+            },
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"terms": {DOCUMENT_ID_FIELD_NAME: doc_ids}},
+                        {"term": {MAX_CHUNK_SIZE_FIELD_NAME: DEFAULT_MAX_CHUNK_SIZE}},
+                    ]
+                }
+            },
+            "sort": [
+                {DOCUMENT_ID_FIELD_NAME: "asc"},
+                {CHUNK_INDEX_FIELD_NAME: "asc"},
+            ],
+        }
+        if search_after is not None:
+            body["search_after"] = search_after
+        return body
+
+    @staticmethod
+    def _is_pit_expired(error: NotFoundError) -> bool:
+        """True if the 404 is an expired/deleted PIT (search_context_missing).
+
+        The type can be nested under root_cause, so match the stringified body.
+        """
+        return _SEARCH_CONTEXT_MISSING_ERROR_TYPE in str(
+            getattr(error, "info", "")
+        ) or _SEARCH_CONTEXT_MISSING_ERROR_TYPE in str(error)
 
     @log_function_time(print_only=True, debug_only=True)
     def refresh_index(self) -> None:

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -197,6 +197,8 @@ class IndexingSetting(EmbeddingModelDetail):
     reduced_dimension: int | None = None
 
     switchover_type: SwitchoverType = SwitchoverType.REINDEX
+    # Reindex "port" flow gate; see SearchSettings.use_port_flow.
+    use_port_flow: bool = False
     enable_contextual_rag: bool
     contextual_rag_model_configuration_id: int | None = None
     # Deprecated: accepted for backward compat but silently ignored on write.
@@ -228,6 +230,7 @@ class IndexingSetting(EmbeddingModelDetail):
             embedding_precision=search_settings.embedding_precision,
             reduced_dimension=search_settings.reduced_dimension,
             switchover_type=search_settings.switchover_type,
+            use_port_flow=search_settings.use_port_flow,
             enable_contextual_rag=search_settings.enable_contextual_rag,
             contextual_rag_model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         )

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -1,0 +1,187 @@
+"""Re-embed stored PRESENT chunks under FUTURE search settings without
+re-fetching the source document (solution-design.md §5.1.1).
+
+Two strategies, chosen by comparing PRESENT vs FUTURE settings:
+
+- MODEL_ONLY (model / prefix / normalize / dimension changed, enrichment did
+  not): the embedding input is unchanged from indexing, so we re-embed the same
+  enriched text — the title prefix, doc summary and chunk context are kept,
+  because the stored vector encoded all of them and the new model must encode
+  the same text. The only catch is that the stored `content` ends with the
+  *keyword* metadata tail while indexing embedded the *semantic* tail, so we
+  swap just that tail back.
+- AUGMENTATION (contextual-RAG toggle or model changed): the enriched text
+  itself changes, so we strip the stored augmentation back to the bare chunk
+  text, re-glue under FUTURE settings, then re-embed.
+
+Only regular chunks are handled (the port reads `max_chunk_size ==
+DEFAULT_MAX_CHUNK_SIZE`); writes are idempotent (external versioning) so we
+re-embed unconditionally rather than diffing content hashes.
+"""
+
+import enum
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
+from onyx.connectors.models import Document
+from onyx.db.models import SearchSettings
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+
+# The chunker's canonical metadata-suffix builder. Reused (rather than
+# replicated) so the rebuilt semantic tail is byte-identical to what indexing
+# produced; replicating it would risk silent drift in the embedding input.
+from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.models import DocAwareChunk
+
+
+class ReembedStrategy(enum.Enum):
+    # Only the embedder changed; re-embed the same enriched text (tail swapped).
+    MODEL_ONLY = "model_only"
+    # The contextual-RAG enrichment changed; rebuild the text, then re-embed.
+    AUGMENTATION = "augmentation"
+
+
+def select_reembed_strategy(
+    present_ss: SearchSettings, future_ss: SearchSettings
+) -> ReembedStrategy:
+    """AUGMENTATION when contextual-RAG settings differ (the embedded text
+    changes), otherwise MODEL_ONLY. Model/prefix/normalize/dimension and
+    multipass changes only alter the vectors (or large/mini chunks the port
+    doesn't read), so they fall through to MODEL_ONLY."""
+    augmentation_changed = (
+        present_ss.enable_contextual_rag != future_ss.enable_contextual_rag
+        or present_ss.contextual_rag_model_configuration_id
+        != future_ss.contextual_rag_model_configuration_id
+    )
+    return (
+        ReembedStrategy.AUGMENTATION
+        if augmentation_changed
+        else ReembedStrategy.MODEL_ONLY
+    )
+
+
+def rebuild_semantic_tail(chunk: DocumentChunkWithoutVectors) -> str:
+    """Rebuild the *semantic* metadata suffix that was embedded, from the stored
+    `metadata_list`. Empty when the chunk has no metadata."""
+    if not chunk.metadata_list:
+        return ""
+    metadata = convert_metadata_list_of_strings_to_dict(chunk.metadata_list)
+    semantic_suffix, _ = _get_metadata_suffix_for_document_index(
+        metadata, include_separator=True
+    )
+    return semantic_suffix
+
+
+def recover_embedding_input(chunk: DocumentChunkWithoutVectors) -> str:
+    """Rebuild the text that was actually embedded when this chunk was indexed.
+
+    The stored `content` is that text except for the metadata at its end: it is
+    stored in keyword form ("Jane Doe") but was embedded in labeled form
+    ("Metadata: author - Jane Doe"). So drop the stored keyword metadata
+    (`metadata_suffix`) and append the labeled form rebuilt from `metadata_list`.
+    If the chunk has no appended metadata, return `content` as-is.
+    """
+    keyword_metadata = chunk.metadata_suffix or ""
+    if not keyword_metadata:
+        return chunk.content
+    without_metadata = chunk.content.removesuffix(keyword_metadata)
+    # If nothing was removed, content didn't end with the stored metadata, so
+    # return it unchanged rather than appending a second metadata block.
+    if without_metadata == chunk.content:
+        return chunk.content
+    return without_metadata + rebuild_semantic_tail(chunk)
+
+
+def _stored_chunk_to_doc_aware(
+    chunk: DocumentChunkWithoutVectors, embed_input: str
+) -> DocAwareChunk:
+    """Minimal DocAwareChunk that drives DefaultIndexingEmbedder unchanged.
+
+    The whole embedding input goes in `content` with every enrichment field
+    empty, so generate_enriched_content_for_chunk_embedding reproduces exactly
+    `embed_input`. The source_document only needs `id` + title for the embedder
+    (`.id`, `.get_title_for_document_index()`)."""
+    source_document = Document(
+        id=chunk.document_id,
+        source=DocumentSource(chunk.source_type),
+        semantic_identifier=chunk.semantic_identifier,
+        # A stored title of None means the source title was empty, which at index
+        # time produced NO title embedding. Pass "" (not None) so
+        # get_title_for_document_index returns None and reproduces that; passing
+        # None would wrongly fall back to semantic_identifier and add a title vector.
+        title=chunk.title if chunk.title is not None else "",
+        sections=[],
+        metadata={},
+    )
+    return DocAwareChunk(
+        chunk_id=chunk.chunk_index,
+        blurb=chunk.blurb,
+        content=embed_input,
+        source_links=None,
+        image_file_id=None,
+        section_continuation=False,
+        source_document=source_document,
+        title_prefix="",
+        metadata_suffix_semantic="",
+        metadata_suffix_keyword="",
+        contextual_rag_reserved_tokens=0,
+        doc_summary="",
+        chunk_context="",
+        mini_chunk_texts=None,
+        large_chunk_id=None,
+        large_chunk_reference_ids=[],
+    )
+
+
+def re_embed_for_future(
+    stored_chunks: list[DocumentChunkWithoutVectors],
+    present_ss: SearchSettings,
+    future_ss: SearchSettings,
+) -> list[DocumentChunk]:
+    """Re-embed PRESENT chunks under FUTURE settings (see module docstring).
+
+    Returns the whole stored chunks as DocumentChunk, in order, with only
+    content_vector and title_vector recomputed (every other field — content,
+    title, metadata, ACL, boost, last_updated, ... — copied through, so the
+    FUTURE write is a faithful copy with new embeddings). Raises
+    NotImplementedError for the AUGMENTATION strategy (see below) — only
+    model/prefix/dimension changes are supported today.
+    """
+    if not stored_chunks:
+        return []
+
+    strategy = select_reembed_strategy(present_ss, future_ss)
+    if strategy is ReembedStrategy.AUGMENTATION:
+        # Augmentation re-embed (strip -> re-glue -> re-embed) is the next
+        # increment; the contextual-RAG-on case additionally needs the source
+        # document text, which the stored chunks don't carry, so the port must
+        # supply it. Fail loudly rather than embed a wrong (un-stripped) input.
+        raise NotImplementedError(
+            "Augmentation-change re-embed (contextual-RAG toggle/model) is not "
+            "yet supported; only model/prefix/dimension changes are."
+        )
+
+    embed_inputs = [recover_embedding_input(chunk) for chunk in stored_chunks]
+    doc_aware_chunks = [
+        _stored_chunk_to_doc_aware(chunk, embed_input)
+        for chunk, embed_input in zip(stored_chunks, embed_inputs)
+    ]
+    embedder = DefaultIndexingEmbedder.from_db_search_settings(future_ss)
+    embedded = embedder.embed_chunks(doc_aware_chunks)
+
+    # Sanity: the embedder must return chunks 1:1 with what it was given.
+    if len(embedded) != len(stored_chunks):
+        raise RuntimeError(
+            f"Embedder returned {len(embedded)} chunks for {len(stored_chunks)} inputs."
+        )
+    # Whole stored chunk + the two new vectors; everything else copied through.
+    return [
+        DocumentChunk(
+            **dict(stored),
+            content_vector=index_chunk.embeddings.full_embedding,
+            title_vector=index_chunk.title_embedding,
+        )
+        for stored, index_chunk in zip(stored_chunks, embedded)
+    ]

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -21,6 +21,12 @@ from onyx.db.enums import PortAttemptStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
 from onyx.db.models import PortAttempt
+from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import mark_port_failed
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
 from onyx.db.search_settings import get_current_search_settings
 from onyx.kg.models import KGStage
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
@@ -133,3 +139,65 @@ def test_mark_secondary_pending_raises_on_missing_document(
 ) -> None:
     with pytest.raises(ValueError):
         mark_document_synced_secondary_pending("does-not-exist", db_session)
+
+
+def test_port_attempt_lifecycle_helpers(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """create -> in_progress -> cursor commit -> success; get_active tracks the
+    active attempt and stops returning it once the attempt is terminal."""
+    ss = get_current_search_settings(db_session)
+
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id, celery_task_id="t-1")
+    attempt_id = attempt.id
+    assert attempt.status == PortAttemptStatus.NOT_STARTED
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is not None
+
+    mark_port_in_progress(db_session, attempt_id, celery_task_id="t-1")
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-50", docs_ported=50
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS
+    assert row.last_processed_doc_id == "doc-50"
+    assert row.docs_ported == 50
+    assert row.time_started is not None and row.last_progress_time is not None
+
+    # a second cursor commit advances the (absolute) cumulative counter
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id="doc-80", docs_ported=80
+    )
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.last_processed_doc_id == "doc-80" and row.docs_ported == 80
+
+    mark_port_succeeded(db_session, attempt_id)
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.time_completed is not None
+    # terminal attempts are no longer "active"
+    assert get_active_port_attempt(db_session, cc_pair.id, ss.id) is None
+
+
+def test_port_attempt_terminal_is_first_write_wins(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """A terminal attempt ignores later transitions, so a late task SUCCESS can't
+    clobber a watchdog FAILED (the row lock makes this deterministic)."""
+    ss = get_current_search_settings(db_session)
+    attempt = create_port_attempt(db_session, cc_pair.id, ss.id)
+    mark_port_in_progress(db_session, attempt.id)
+
+    mark_port_failed(db_session, attempt.id, error_msg="stalled")
+    mark_port_succeeded(db_session, attempt.id)  # no-op: already terminal
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "stalled"

--- a/backend/tests/external_dependency_unit/indexing/test_re_embed_for_future.py
+++ b/backend/tests/external_dependency_unit/indexing/test_re_embed_for_future.py
@@ -1,0 +1,219 @@
+"""Tests for re_embed_for_future (reindex port re-embedding).
+
+These cover the pure re-embed logic: strategy selection, rebuilding the semantic
+metadata tail, the embed-input recovery (the crux — stored content carries the
+keyword tail, but the embedded text used the semantic tail), and the minimal
+DocAwareChunk reconstruction that feeds that input to the embedder.
+
+The embedder is a pure function of its input text, so proving the input differs
+from the raw stored content (here) is equivalent to proving the resulting vector
+differs; the real-embedder path is exercised once the port task is wired.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import convert_metadata_dict_to_list_of_strings
+from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
+from onyx.db.models import SearchSettings
+from onyx.document_index.chunk_content_enrichment import (
+    generate_enriched_content_for_chunk_embedding,
+)
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.models import ChunkEmbedding
+from onyx.indexing.models import DocAwareChunk
+from onyx.indexing.models import IndexChunk
+from onyx.indexing.port_reembed import _stored_chunk_to_doc_aware
+from onyx.indexing.port_reembed import re_embed_for_future
+from onyx.indexing.port_reembed import rebuild_semantic_tail
+from onyx.indexing.port_reembed import recover_embedding_input
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.indexing.port_reembed import select_reembed_strategy
+from onyx.utils.pydantic_util import shallow_model_dump
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+
+def _stored_chunk(
+    content: str,
+    *,
+    metadata_suffix: str | None = None,
+    metadata_list: list[str] | None = None,
+    title: str | None = "Doc Title",
+    chunk_index: int = 0,
+) -> DocumentChunkWithoutVectors:
+    return DocumentChunkWithoutVectors(
+        document_id="doc-1",
+        chunk_index=chunk_index,
+        content=content,
+        source_type=DocumentSource.FILE.value,
+        metadata_list=metadata_list,
+        metadata_suffix=metadata_suffix,
+        title=title,
+        public=True,
+        access_control_list=[],
+        global_boost=0,
+        semantic_identifier="Doc semantic id",
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        tenant_id=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
+    )
+
+
+def _ss(
+    enable_contextual_rag: bool = False,
+    contextual_rag_model_configuration_id: int | None = None,
+) -> SearchSettings:
+    return SearchSettings(
+        enable_contextual_rag=enable_contextual_rag,
+        contextual_rag_model_configuration_id=contextual_rag_model_configuration_id,
+    )
+
+
+def test_select_reembed_strategy() -> None:
+    base = _ss()
+    assert select_reembed_strategy(base, _ss()) is ReembedStrategy.MODEL_ONLY
+    assert (
+        select_reembed_strategy(base, _ss(enable_contextual_rag=True))
+        is ReembedStrategy.AUGMENTATION
+    )
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=2),
+        )
+        is ReembedStrategy.AUGMENTATION
+    )
+
+
+def test_rebuild_semantic_tail() -> None:
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    expected, _ = _get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert rebuild_semantic_tail(
+        _stored_chunk("body", metadata_list=metadata_list)
+    ) == (expected)
+    assert rebuild_semantic_tail(_stored_chunk("body", metadata_list=None)) == ""
+
+
+def test_recover_embedding_input_swaps_semantic_tail() -> None:
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    semantic, keyword = _get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert semantic != keyword  # precondition: the two tails genuinely differ
+
+    # stored content carries the KEYWORD tail
+    chunk = _stored_chunk(
+        "the body text" + keyword,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+    )
+    embed_input = recover_embedding_input(chunk)
+    assert embed_input == "the body text" + semantic
+    # the crux: the embedding input is NOT the stored (keyword-tailed) content
+    assert embed_input != chunk.content
+
+    # no suffix (chunker dropped it) -> content passes through unchanged
+    plain = _stored_chunk("just body", metadata_suffix=None, metadata_list=None)
+    assert recover_embedding_input(plain) == "just body"
+
+    # no keyword tail was glued in (empty metadata_suffix) -> don't add a tail,
+    # even if metadata_list is present
+    no_tail = _stored_chunk(
+        "just body", metadata_suffix=None, metadata_list=metadata_list
+    )
+    assert recover_embedding_input(no_tail) == "just body"
+
+    # content doesn't actually end with the stored suffix -> embed as-is, never
+    # double-append a tail
+    mismatched = _stored_chunk(
+        "body without the tail",
+        metadata_suffix="\n\r\nMetadata: x",
+        metadata_list=metadata_list,
+    )
+    assert recover_embedding_input(mismatched) == "body without the tail"
+
+
+def test_to_doc_aware_chunk_feeds_embed_input() -> None:
+    """The reconstructed DocAwareChunk makes the embedder embed exactly the
+    recovered embedding input (not the stored content), and carries the title
+    for the title vector with a semantic_identifier fallback."""
+    chunk = _stored_chunk("body", title="My Title")
+    embed_input = recover_embedding_input(chunk)
+    doc_aware = _stored_chunk_to_doc_aware(chunk, embed_input)
+
+    assert generate_enriched_content_for_chunk_embedding(doc_aware) == embed_input
+    assert doc_aware.source_document.id == chunk.document_id
+    assert doc_aware.source_document.get_title_for_document_index() == "My Title"
+    assert doc_aware.chunk_id == chunk.chunk_index
+
+    # stored title None == the source title was empty == no title embedding;
+    # it must NOT fall back to semantic_identifier.
+    no_title = _stored_chunk("body", title=None)
+    da = _stored_chunk_to_doc_aware(no_title, "body")
+    assert da.source_document.get_title_for_document_index() is None
+
+
+def test_re_embed_augmentation_not_implemented() -> None:
+    with pytest.raises(NotImplementedError):
+        re_embed_for_future(
+            [_stored_chunk("body")],
+            _ss(enable_contextual_rag=False),
+            _ss(enable_contextual_rag=True),
+        )
+
+
+def test_re_embed_empty_returns_empty() -> None:
+    assert re_embed_for_future([], _ss(), _ss()) == []
+
+
+def test_re_embed_preserves_all_fields_swaps_only_vectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """re_embed_for_future returns the whole stored chunk as a DocumentChunk with
+    only content_vector/title_vector recomputed — every other field is copied
+    through (so the FUTURE write is a faithful copy with new embeddings)."""
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    stored = _stored_chunk(
+        "body text", title="My Title", metadata_list=metadata_list, chunk_index=3
+    )
+    fake_cv, fake_tv = [0.5, 0.5], [0.9, 0.9]
+
+    class _FakeEmbedder:
+        def embed_chunks(self, chunks: list[DocAwareChunk]) -> list[IndexChunk]:
+            return [
+                IndexChunk.model_construct(
+                    **shallow_model_dump(chunk),
+                    embeddings=ChunkEmbedding(
+                        full_embedding=fake_cv, mini_chunk_embeddings=[]
+                    ),
+                    title_embedding=fake_tv,
+                )
+                for chunk in chunks
+            ]
+
+    monkeypatch.setattr(
+        DefaultIndexingEmbedder,
+        "from_db_search_settings",
+        MagicMock(return_value=_FakeEmbedder()),
+    )
+
+    [result] = re_embed_for_future([stored], _ss(), _ss())
+
+    # only the two vectors are new
+    assert result.content_vector == fake_cv
+    assert result.title_vector == fake_tv
+    # every other field is the stored chunk's, unchanged
+    for field in DocumentChunkWithoutVectors.model_fields:
+        assert getattr(result, field) == getattr(stored, field), field

--- a/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_opensearch_client.py
@@ -2533,3 +2533,177 @@ class TestSearchFailureMetrics:
         assert recorded_search_type == OpenSearchSearchType.KEYWORD
         assert isinstance(recorded_exc, OpenSearchServerSideTimeout)
         assert observe_mock.call_count == 0
+
+    @staticmethod
+    def _index_pit_scan_chunks(
+        client: OpenSearchIndexClient,
+        tenant_state: TenantState,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[list[str], set[tuple[str, int]]]:
+        """Index 3 docs x 5 regular chunks plus one large chunk (which the scan
+        must exclude). Returns (doc_ids, expected regular (doc_id, chunk_index))."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        client.create_index(mappings=mappings, settings=settings)
+
+        doc_ids = ["doc-a", "doc-b", "doc-c"]
+        regular = [
+            _create_test_document_chunk(
+                document_id=doc_id,
+                chunk_index=ci,
+                content=f"{doc_id}-{ci}",
+                tenant_state=tenant_state,
+            )
+            for doc_id in doc_ids
+            for ci in range(5)
+        ]
+        expected = {(doc_id, ci) for doc_id in doc_ids for ci in range(5)}
+        # A large chunk (max_chunk_size != 512) shares doc-a/chunk 0 but gets a
+        # distinct _id; the max_chunk_size filter must keep it out of the scan.
+        large = _create_test_document_chunk(
+            document_id="doc-a",
+            chunk_index=0,
+            content="large",
+            tenant_state=tenant_state,
+        ).model_copy(update={"max_chunk_size": 1024})
+        client.bulk_index_documents(
+            documents=regular + [large], tenant_state=tenant_state
+        )
+        client.refresh_index()
+        return doc_ids, expected
+
+    def test_pit_scan_full_coverage_and_order(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Paging the PIT scan covers every regular chunk exactly once, in
+        (document_id, chunk_index) order, excluding the large chunk."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        pit_id = test_client.open_pit()
+        seen: list[tuple[str, int]] = []
+        search_after: list[object] | None = None
+        while True:
+            chunks, search_after, pit_id = test_client.fetch_chunks_for_doc_ids(
+                pit_id, doc_ids, search_after=search_after, page_size=4
+            )
+            seen.extend((c.document_id, c.chunk_index) for c in chunks)
+            if search_after is None:
+                break
+        test_client.close_pit(pit_id)
+
+        assert sorted(seen) == sorted(expected)  # every regular chunk, large excluded
+        assert len(seen) == len(expected)  # exactly once, no dupes
+        assert seen == sorted(seen)  # globally non-decreasing order
+
+    def test_pit_scan_reopens_on_expiry(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A PIT deleted mid-scan is transparently re-opened; the scan resumes
+        from the same cursor and still yields full coverage."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        stale_pit = test_client.open_pit()
+        chunks, search_after, stale_pit = test_client.fetch_chunks_for_doc_ids(
+            stale_pit, doc_ids, page_size=4
+        )
+        seen: list[tuple[str, int]] = [(c.document_id, c.chunk_index) for c in chunks]
+        assert search_after is not None
+
+        # Force expiry: delete the PIT out from under the scan.
+        test_client.close_pit(stale_pit)
+
+        pit_id = stale_pit
+        while True:
+            chunks, search_after, pit_id = test_client.fetch_chunks_for_doc_ids(
+                pit_id, doc_ids, search_after=search_after, page_size=4
+            )
+            seen.extend((c.document_id, c.chunk_index) for c in chunks)
+            if search_after is None:
+                break
+        test_client.close_pit(pit_id)
+
+        assert pit_id != stale_pit  # transparently re-opened
+        assert sorted(seen) == sorted(expected)  # full coverage across the re-open
+
+    def test_pit_scan_iterator_owns_lifecycle(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """iter_chunks_for_doc_ids yields full coverage and closes its PIT once."""
+        tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+        doc_ids, expected = self._index_pit_scan_chunks(
+            test_client, tenant_state, monkeypatch
+        )
+
+        closed: list[str] = []
+        original_close = test_client.close_pit
+
+        def _spy_close(pit_id: str) -> None:
+            closed.append(pit_id)
+            original_close(pit_id)
+
+        monkeypatch.setattr(test_client, "close_pit", _spy_close)
+
+        seen = [
+            (c.document_id, c.chunk_index)
+            for page in test_client.iter_chunks_for_doc_ids(doc_ids, page_size=4)
+            for c in page
+        ]
+
+        assert sorted(seen) == sorted(expected)
+        assert seen == sorted(seen)
+        assert len(closed) == 1  # PIT closed exactly once by the iterator
+
+    def test_pit_scan_retries_reopen_once_then_raises(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A persistently-expiring PIT is retried once (re-open) then the error
+        propagates — no infinite loop."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+        pit_id = test_client.open_pit()
+
+        expired = NotFoundError(
+            404,
+            "search_phase_execution_exception",
+            {"error": {"root_cause": [{"type": "search_context_missing_exception"}]}},
+        )
+        mock_search = MagicMock(side_effect=expired)
+        monkeypatch.setattr(test_client._client, "search", mock_search)
+
+        with pytest.raises(NotFoundError):
+            test_client.fetch_chunks_for_doc_ids(pit_id, ["doc-a"], page_size=4)
+        assert mock_search.call_count == 2  # original attempt + one reopened retry
+
+    def test_pit_scan_raises_on_server_timeout(
+        self, test_client: OpenSearchIndexClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A server-side timeout must raise, not be read as a short (final) page."""
+        _patch_global_tenant_state(monkeypatch, False)
+        mappings = DocumentSchema.get_document_schema(
+            vector_dimension=128, multitenant=False
+        )
+        settings = DocumentSchema.get_index_settings_based_on_environment()
+        test_client.create_index(mappings=mappings, settings=settings)
+        pit_id = test_client.open_pit()
+
+        monkeypatch.setattr(
+            test_client._client,
+            "search",
+            MagicMock(return_value={"timed_out": True, "hits": {"hits": []}}),
+        )
+
+        with pytest.raises(OpenSearchServerSideTimeout):
+            test_client.fetch_chunks_for_doc_ids(pit_id, ["doc-a"], page_size=4)


### PR DESCRIPTION
## Description

  - Add a `use_port_flow` gate on search settings (default off) so a new embedding model's index can be filled by porting existing chunks instead of re-running every connector
  - Track the port lifecycle per connector/model pair — one active attempt at a time, with a resume cursor, progress, and terminal-state history
  - Read stored chunks consistently during a port via point-in-time (PIT) scanning in the OpenSearch client, so concurrent writes don't shift or duplicate results
  - Re-embed stored chunks under the new search settings without re-fetching source documents (model/prefix/dimension changes; contextual-RAG changes not yet supported)

## How Has This Been Tested?
- Unit tests added for port-attempt status transitions, PIT scan paging/re-open, and re-embedding input recovery

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional “port” reindex flow that re-embeds existing chunks into a FUTURE index without rerunning connectors, using consistent PIT scans and per-connector attempt tracking. Supports model-only changes; contextual-RAG changes are not yet supported.

- **New Features**
  - `use_port_flow` on search settings (default off) to port PRESENT chunks into FUTURE by re-embedding, skipping connector reruns.
  - Port attempt tracking: one active per connector pair; resume cursor, progress timestamps, and terminal-state history.
  - Consistent reads via OpenSearch PIT scanning with paging and auto re-open on expiry; excludes vectors and non-regular chunks.
  - Re-embedding for model/prefix/dimension changes only; rebuilds the original embedding input and updates only vectors.
  - Config: `PIT_KEEP_ALIVE` env to control PIT lease duration.

- **Migration**
  - Run the DB migration and deploy.
  - Feature is off by default; enable by setting `use_port_flow` on the FUTURE search settings.
  - If contextual-RAG settings differ between PRESENT and FUTURE, porting will fail; use legacy reindex or align settings.

<sup>Written for commit 823a58dca35e9c1406975ad9a5d2d142375b838f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

