### PR TITLE
feat(reindex): add resumable port machinery and port-aware swap

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -73,6 +73,16 @@ beat_task_templates: list[dict] = [
         },
     },
     {
+        "name": "check-for-port",
+        "task": OnyxCeleryTask.CHECK_FOR_PORT,
+        "schedule": timedelta(seconds=30),
+        "options": {
+            "priority": OnyxCeleryPriority.MEDIUM,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            "work_gated": True,
+        },
+    },
+    {
         "name": "check-for-checkpoint-cleanup",
         "task": OnyxCeleryTask.CHECK_FOR_CHECKPOINT_CLEANUP,
         "schedule": timedelta(hours=1),
@@ -294,6 +304,7 @@ if (
 # Beat task names that require a vector DB. Filtered out when DISABLE_VECTOR_DB.
 _VECTOR_DB_BEAT_TASK_NAMES: set[str] = {
     "check-for-indexing",
+    "check-for-port",
     "check-for-connector-deletion",
     "check-for-vespa-sync",
     "check-for-pruning",

--- a/backend/onyx/background/celery/tasks/docprocessing/port_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/port_task.py
@@ -1,0 +1,339 @@
+"""Reindexing port machinery: the producer task plus the beat scheduler.
+
+`run_port_attempt` (producer) drains one PortAttempt, copying a cc_pair's
+documents PRESENT -> FUTURE (re-embedded under the new model) and committing a
+per-batch cursor so a crash or stall resumes rather than restarts.
+
+`check_for_port` (beat scheduler) runs once per tick: it fails stalled attempts,
+then creates + enqueues a fresh PortAttempt for every in-scope cc_pair of a
+use_port_flow FUTURE with pending work (a FAILED attempt resumes its cursor;
+SUCCESS/CANCELED are left alone).
+"""
+
+import logging
+import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from celery import Celery
+from celery import shared_task
+from celery import Task
+from redis.lock import Lock as RedisLock
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.apps.app_base import task_logger
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+from onyx.configs.constants import OnyxRedisLocks
+from onyx.db.connector_credential_pair import (
+    fetch_indexable_standard_connector_credential_pair_ids,
+)
+from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
+from onyx.db.document import get_document_ids_for_cc_pair_batch
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.port_attempt import commit_port_cursor
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
+from onyx.db.port_attempt import get_port_attempt
+from onyx.db.port_attempt import get_stale_in_progress_port_attempts
+from onyx.db.port_attempt import mark_port_failed
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.search_settings import get_search_settings_by_id
+from onyx.db.search_settings import get_secondary_search_settings
+from onyx.document_index.opensearch.port_copy import PortCopier
+from onyx.redis.redis_pool import get_redis_client
+
+_PORT_SOFT_TIME_LIMIT = 60 * 30  # 30 minutes
+_PORT_TIME_LIMIT = _PORT_SOFT_TIME_LIMIT + 60
+
+_PORT_BATCH_MAX_RETRIES = 5
+_PORT_BATCH_RETRY_SLEEP_S = 2
+
+# Kept above the soft time limit so check_for_port only reschedules genuinely dead
+# workers, never a slow-but-alive batch (one batch can run ~10min under embedder
+# rate-limit retries; the task self-yields at the soft limit anyway).
+_PORT_STALL_THRESHOLD_SECONDS = _PORT_SOFT_TIME_LIMIT + 15 * 60  # 45 minutes
+
+
+def _copy_batch_with_retry(
+    copier: PortCopier, doc_ids: list[str], log: logging.LoggerAdapter
+) -> int:
+    """Copy one batch, retrying up to _PORT_BATCH_MAX_RETRIES on any failure.
+
+    Re-raises the last error on exhaustion so the caller fails the attempt with
+    the cursor still at the prior good batch. Retrying is safe because the write
+    is idempotent (deterministic _id + newest-wins external versioning).
+
+    The delay is fixed, not exponential: the embedder and OpenSearch layers
+    already back off internally on rate-limits/transients, so a second curve here
+    would just stack on theirs. This only guards a whole-pipeline hiccup that
+    outlived them.
+    """
+    last_error: Exception | None = None
+    for attempt_num in range(1, _PORT_BATCH_MAX_RETRIES + 1):
+        try:
+            return copier.copy_doc_batch(doc_ids)
+        except Exception as e:
+            last_error = e
+            log.warning(
+                "Port batch attempt %d/%d failed: %s",
+                attempt_num,
+                _PORT_BATCH_MAX_RETRIES,
+                e,
+            )
+            if attempt_num < _PORT_BATCH_MAX_RETRIES:
+                time.sleep(_PORT_BATCH_RETRY_SLEEP_S)
+    assert last_error is not None
+    raise last_error
+
+
+def run_port_attempt(port_attempt_id: int, celery_task_id: str | None = None) -> None:
+    """Body of the port task, lifted out of @shared_task so tests call it
+    directly. Resumes from the attempt's cursor and commits a new cursor after
+    each batch, so a fresh attempt continues `WHERE document_id > cursor` rather
+    than re-porting from the start.
+    """
+    log = logging.LoggerAdapter(
+        task_logger,
+        extra={"port_attempt_id": port_attempt_id, "celery_task_id": celery_task_id},
+    )
+
+    # PortCopier must be built while the search settings are session-attached, so
+    # do all setup here; the scan/embed/write loop below then holds no connection.
+    with get_session_with_current_tenant() as db_session:
+        attempt = get_port_attempt(db_session, port_attempt_id)
+        if attempt is None:
+            log.warning("PortAttempt not found, dropping task")
+            return
+        if attempt.status.is_terminal():
+            log.info(
+                "PortAttempt already terminal (%s), dropping task",
+                attempt.status.value,
+            )
+            return
+
+        cc_pair_id = attempt.cc_pair_id
+        cursor = attempt.last_processed_doc_id
+        docs_ported = attempt.docs_ported or 0
+
+        future_search_settings = get_search_settings_by_id(
+            db_session, attempt.search_settings_id
+        )
+        if future_search_settings is None:
+            mark_port_failed(
+                db_session, port_attempt_id, error_msg="FUTURE search settings missing"
+            )
+            return
+        present_search_settings = get_current_search_settings(db_session)
+
+        mark_port_in_progress(
+            db_session, port_attempt_id, celery_task_id=celery_task_id
+        )
+
+        try:
+            copier = PortCopier(present_search_settings, future_search_settings)
+        except Exception as e:
+            log.exception("Failed to build port copier; marking FAILED")
+            mark_port_failed(db_session, port_attempt_id, error_msg=str(e))
+            return
+
+    start_monotonic = time.monotonic()
+    chunks_ported = 0
+    while True:
+        if time.monotonic() - start_monotonic > _PORT_SOFT_TIME_LIMIT:
+            # Thread-pool tasks ignore celery's soft_time_limit, so enforce it
+            # here; check_for_port reschedules from the committed cursor.
+            log.info("Port soft time limit reached, yielding")
+            return
+
+        # Fresh session per batch: frees the connection across the scan/embed/write,
+        # and re-reads the row so a CANCEL or stall-FAIL committed elsewhere is seen.
+        with get_session_with_current_tenant() as db_session:
+            attempt = get_port_attempt(db_session, port_attempt_id)
+            if attempt is None or attempt.status.is_terminal():
+                log.info("PortAttempt gone/terminal, stopping")
+                return
+            cc_pair = get_connector_credential_pair_from_id(db_session, cc_pair_id)
+            if (
+                cc_pair is None
+                or cc_pair.status == ConnectorCredentialPairStatus.DELETING
+            ):
+                log.info("cc_pair %s gone/deleting, stopping port", cc_pair_id)
+                return
+            doc_ids = get_document_ids_for_cc_pair_batch(
+                db_session, cc_pair_id, after_doc_id=cursor, limit=INDEX_BATCH_SIZE
+            )
+
+        if not doc_ids:
+            break
+
+        try:
+            chunks_ported += _copy_batch_with_retry(copier, doc_ids, log)
+        except Exception as e:
+            log.exception("Port batch failed after retries; marking FAILED")
+            with get_session_with_current_tenant() as db_session:
+                mark_port_failed(db_session, port_attempt_id, error_msg=str(e))
+            return
+
+        cursor = doc_ids[-1]
+        docs_ported += len(doc_ids)
+        with get_session_with_current_tenant() as db_session:
+            commit_port_cursor(
+                db_session,
+                port_attempt_id,
+                last_processed_doc_id=cursor,
+                docs_ported=docs_ported,
+            )
+
+    with get_session_with_current_tenant() as db_session:
+        mark_port_succeeded(db_session, port_attempt_id)
+    log.info("Port complete: %d docs, %d chunks", docs_ported, chunks_ported)
+
+
+@shared_task(
+    name=OnyxCeleryTask.RUN_PORT_ATTEMPT,
+    soft_time_limit=_PORT_SOFT_TIME_LIMIT,
+    time_limit=_PORT_TIME_LIMIT,
+    bind=True,
+)
+def run_port_attempt_task(
+    self: Task,
+    *,
+    port_attempt_id: int,
+    tenant_id: str,  # noqa: ARG001  # consumed by TenantAwareTask wrapper
+) -> None:
+    run_port_attempt(
+        port_attempt_id=port_attempt_id,
+        celery_task_id=self.request.id,
+    )
+
+
+def _fail_stalled_port_attempts(
+    db_session: Session, search_settings_id: int, lock_beat: RedisLock
+) -> None:
+    """Fail IN_PROGRESS attempts whose last_progress_time is past the stall
+    threshold (a dead or self-yielded worker) so a fresh attempt can resume."""
+    stale_before = datetime.now(timezone.utc) - timedelta(
+        seconds=_PORT_STALL_THRESHOLD_SECONDS
+    )
+    for stale in get_stale_in_progress_port_attempts(
+        db_session, search_settings_id, stale_before
+    ):
+        lock_beat.reacquire()
+        fresh = get_port_attempt(db_session, stale.id)
+        if fresh is None or fresh.status.is_terminal():
+            continue
+        task_logger.warning("check_for_port: failing stalled PortAttempt %s", stale.id)
+        mark_port_failed(
+            db_session, stale.id, error_msg="stalled: no progress within threshold"
+        )
+
+
+def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
+    """Lifted out of check_for_port so tests can pass a mock celery app.
+
+    Returns the number of attempts enqueued, or None if the lock was contended or
+    there is no port-flow FUTURE.
+    """
+    redis_client = get_redis_client()
+    lock_beat: RedisLock = redis_client.lock(
+        OnyxRedisLocks.CHECK_PORT_BEAT_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+    if not lock_beat.acquire(blocking=False):
+        return None
+
+    tasks_created = 0
+    try:
+        with get_session_with_current_tenant() as db_session:
+            future_search_settings = get_secondary_search_settings(db_session)
+            if (
+                future_search_settings is None
+                or not future_search_settings.use_port_flow
+            ):
+                return None
+            search_settings_id = future_search_settings.id
+
+            include_paused = (
+                future_search_settings.switchover_type != SwitchoverType.ACTIVE_ONLY
+            )
+            cc_pair_ids = fetch_indexable_standard_connector_credential_pair_ids(
+                db_session, active_cc_pairs_only=not include_paused
+            )
+
+            _fail_stalled_port_attempts(db_session, search_settings_id, lock_beat)
+
+            for cc_pair_id in cc_pair_ids:
+                lock_beat.reacquire()
+                if (
+                    get_active_port_attempt(db_session, cc_pair_id, search_settings_id)
+                    is not None
+                ):
+                    continue
+                latest = get_latest_port_attempt(
+                    db_session, cc_pair_id, search_settings_id
+                )
+                # SUCCESS -> backlog already ported; CANCELED -> operator stopped it.
+                # Only a FAILED (or no) attempt warrants a fresh run.
+                if latest is not None and latest.status != PortAttemptStatus.FAILED:
+                    continue
+                resume_cursor = (
+                    latest.last_processed_doc_id if latest is not None else None
+                )
+                try:
+                    attempt = create_port_attempt(
+                        db_session,
+                        cc_pair_id,
+                        search_settings_id,
+                        resume_from_doc_id=resume_cursor,
+                    )
+                except Exception:
+                    # One cc_pair's failure (unique-index race, transient DB error)
+                    # must not abort the tick; the next tick retries it.
+                    task_logger.exception(
+                        "check_for_port: create failed for cc_pair %s", cc_pair_id
+                    )
+                    continue
+                try:
+                    celery_app.send_task(
+                        OnyxCeleryTask.RUN_PORT_ATTEMPT,
+                        kwargs={"port_attempt_id": attempt.id, "tenant_id": tenant_id},
+                        queue=OnyxCeleryQueues.DOCPROCESSING,
+                        priority=OnyxCeleryPriority.MEDIUM,
+                        expires=BEAT_EXPIRES_DEFAULT,
+                    )
+                except Exception:
+                    # Row is committed; on enqueue failure mark it FAILED so the
+                    # next tick recreates it (else an orphaned NOT_STARTED sticks).
+                    task_logger.exception(
+                        "check_for_port: enqueue failed; failing PortAttempt %s",
+                        attempt.id,
+                    )
+                    mark_port_failed(db_session, attempt.id, error_msg="enqueue failed")
+                    continue
+                tasks_created += 1
+    finally:
+        if lock_beat.owned():
+            lock_beat.release()
+
+    return tasks_created
+
+
+@shared_task(
+    name=OnyxCeleryTask.CHECK_FOR_PORT,
+    soft_time_limit=300,
+    bind=True,
+)
+def check_for_port(self: Task, *, tenant_id: str) -> int | None:
+    return run_check_for_port(tenant_id, self.app)

--- a/backend/onyx/background/celery/tasks/docprocessing/utils.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/utils.py
@@ -221,8 +221,14 @@ def should_index(
             # )
             return False
 
-    # When switching over models, always index at least once
-    if search_settings_instance.status == IndexModelStatus.FUTURE:
+    # Legacy FUTURE reindex indexes once, then stops so the swap can fire. A
+    # port-flow FUTURE polls continuously like PRESENT (its synthetic seed primes
+    # the cursor), so skip this block and fall through. Drop this branch once all
+    # FUTUREs use the port flow.
+    if (
+        search_settings_instance.status == IndexModelStatus.FUTURE
+        and not search_settings_instance.use_port_flow
+    ):
         if last_index_attempt:
             # No new index if the last index attempt succeeded
             # Once is enough. The model will never be able to swap otherwise.

--- a/backend/onyx/background/celery/tasks/vespa/document_sync.py
+++ b/backend/onyx/background/celery/tasks/vespa/document_sync.py
@@ -7,13 +7,18 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DB_YIELD_PER_DEFAULT
+from onyx.configs.constants import CELERY_DOCUMENT_SYNC_TASK_EXPIRES
 from onyx.configs.constants import CELERY_VESPA_SYNC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisConstants
-from onyx.db.document import construct_document_id_select_by_needs_sync
-from onyx.db.document import count_documents_by_needs_sync
+from onyx.db.document import (
+    construct_document_id_select_by_needs_sync_or_secondary_pending,
+)
+from onyx.db.document import count_documents_by_needs_sync_or_secondary_pending
+from onyx.db.document import count_secondary_only_sync_pending_documents
+from onyx.db.port_attempt import any_future_port_in_progress
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.logger import setup_logger
@@ -94,10 +99,17 @@ def generate_document_sync_tasks(
     num_tasks_sent = 0
     num_docs = 0
 
-    # Get all documents that need syncing
-    stmt = construct_document_id_select_by_needs_sync()
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    port_running = any_future_port_in_progress(db_session)
+    # The backlog>0 guard keeps "no active port" from also matching normal steady
+    # state, which would wrongly demote every needs_sync to LOW.
+    draining_for_flip = (
+        not port_running and count_secondary_only_sync_pending_documents(db_session) > 0
+    )
 
-    for doc_id in db_session.scalars(stmt).yield_per(DB_YIELD_PER_DEFAULT):
+    for doc_id, is_secondary_pending in db_session.execute(stmt).yield_per(
+        DB_YIELD_PER_DEFAULT
+    ):
         doc_id = cast(str, doc_id)
         current_time = time.monotonic()
 
@@ -115,13 +127,26 @@ def generate_document_sync_tasks(
         r.sadd(DOCUMENT_SYNC_TASKSET_KEY, custom_task_id)
         r.expire(DOCUMENT_SYNC_TASKSET_KEY, TASKSET_TTL)
 
+        # Deferred FUTURE sync: LOW mid-port (may not be in FUTURE yet; don't
+        # starve needs_sync), HIGH post-port since that drain gates the flip —
+        # which is also why needs_sync yields to LOW during it.
+        if is_secondary_pending:
+            priority = (
+                OnyxCeleryPriority.LOW if port_running else OnyxCeleryPriority.HIGH
+            )
+        elif draining_for_flip:
+            priority = OnyxCeleryPriority.LOW
+        else:
+            priority = OnyxCeleryPriority.MEDIUM
+
         # Create the Celery task
         celery_app.send_task(
             OnyxCeleryTask.DOCUMENT_INDEX_METADATA_SYNC_TASK,
             kwargs=dict(document_id=doc_id, tenant_id=tenant_id),
             queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
             task_id=custom_task_id,
-            priority=OnyxCeleryPriority.MEDIUM,
+            priority=priority,
+            expires=CELERY_DOCUMENT_SYNC_TASK_EXPIRES,
             ignore_result=True,
         )
 
@@ -146,7 +171,7 @@ def try_generate_stale_document_sync_tasks(
         return None
 
     # add tasks to celery and build up the task set to monitor in redis
-    stale_doc_count = count_documents_by_needs_sync(db_session)
+    stale_doc_count = count_documents_by_needs_sync_or_secondary_pending(db_session)
     if stale_doc_count == 0:
         logger.info("No stale documents found. Skipping sync tasks generation.")
         return None

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -192,6 +192,11 @@ CELERY_USER_FILE_PROJECT_SYNC_LOCK_TIMEOUT = 5 * 60  # 5 minutes (in seconds)
 # files are stuck in DELETING status and the beat keeps re-enqueuing them.
 CELERY_USER_FILE_DELETE_TASK_EXPIRES = 60  # 1 minute (in seconds)
 
+# Per-doc metadata-sync task expiry: bounds queue growth if consumers stall. An
+# expired task's doc stays needs_sync / secondary_only_sync_pending and is
+# re-enqueued on the next vespa-sync beat pass, so dropping it is safe.
+CELERY_DOCUMENT_SYNC_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
+
 # Max queue depth before the delete beat stops enqueuing more delete tasks.
 USER_FILE_DELETE_MAX_QUEUE_DEPTH = 500
 
@@ -454,6 +459,7 @@ class OnyxRedisLocks:
     CHECK_PRUNE_BEAT_LOCK = "da_lock:check_prune_beat"
     CHECK_HIERARCHY_FETCHING_BEAT_LOCK = "da_lock:check_hierarchy_fetching_beat"
     CHECK_INDEXING_BEAT_LOCK = "da_lock:check_indexing_beat"
+    CHECK_PORT_BEAT_LOCK = "da_lock:check_port_beat"
     CHECK_CHECKPOINT_CLEANUP_BEAT_LOCK = "da_lock:check_checkpoint_cleanup_beat"
     CHECK_INDEX_ATTEMPT_CLEANUP_BEAT_LOCK = "da_lock:check_index_attempt_cleanup_beat"
     CHECK_CONNECTOR_DOC_PERMISSIONS_SYNC_BEAT_LOCK = (
@@ -579,6 +585,10 @@ class OnyxCeleryTask:
 
     # Targeted reindex
     TARGETED_REINDEX_TASK = "targeted_reindex_task"
+
+    # Reindex port (PRESENT -> FUTURE chunk copy)
+    RUN_PORT_ATTEMPT = "run_port_attempt"
+    CHECK_FOR_PORT = "check_for_port"
 
     # Connector checkpoint cleanup
     CHECK_FOR_CHECKPOINT_CLEANUP = "check_for_checkpoint_cleanup"

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -331,6 +331,7 @@ def get_last_successful_attempt_poll_range_end(
     search_settings: SearchSettings,
     db_session: Session,
     ignore_targeted_reindex: bool = True,
+    ignore_synthetic_seed: bool = True,
 ) -> float:
     """Used to get the latest `poll_range_end` for a given connector and credential.
 
@@ -353,6 +354,8 @@ def get_last_successful_attempt_poll_range_end(
     )
     if ignore_targeted_reindex:
         query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    if ignore_synthetic_seed:
+        query = query.filter(IndexAttempt.is_synthetic_seed.is_(False))
     latest_successful_index_attempt = query.order_by(
         IndexAttempt.poll_range_end.desc()
     ).first()

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -10,9 +10,11 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import and_
+from sqlalchemy import CompoundSelect
 from sqlalchemy import delete
 from sqlalchemy import exists
 from sqlalchemy import func
+from sqlalchemy import literal
 from sqlalchemy import or_
 from sqlalchemy import Select
 from sqlalchemy import select
@@ -92,20 +94,62 @@ def count_documents_by_needs_sync(session: Session) -> int:
     )
 
 
-def construct_document_id_select_by_needs_sync() -> Select:
-    """Get all document IDs that need syncing across all connector credential pairs.
+def count_secondary_only_sync_pending_documents(db_session: Session) -> int:
+    """Count docs whose FUTURE metadata sync was deferred (D2) and not yet drained.
 
-    Returns a Select statement for documents where:
-    1. last_modified is newer than last_synced
-    2. last_synced is null (meaning we've never synced)
-    AND the document has a relationship with a connector/credential pair
+    Uses the partial index ix_document_secondary_only_sync_pending. The port-aware
+    swap holds until this reaches 0 (the deferred-sync backlog is fully applied).
     """
-    return select(DbDocument.id).where(
-        or_(
-            DbDocument.last_modified > DbDocument.last_synced,
-            DbDocument.last_synced.is_(None),
+    return db_session.execute(
+        select(func.count()).where(DbDocument.secondary_only_sync_pending.is_(True))
+    ).scalar_one()
+
+
+def count_documents_by_needs_sync_or_secondary_pending(session: Session) -> int:
+    """count_documents_by_needs_sync plus docs whose FUTURE sync was deferred.
+
+    The vespa sync producer gates on this so a deferred-only backlog still
+    generates drain tasks — a deferred doc has its needs_sync already cleared, so
+    count_documents_by_needs_sync alone would miss it.
+    """
+    return (
+        session.query(DbDocument.id)
+        .filter(
+            or_(
+                DbDocument.last_modified > DbDocument.last_synced,
+                DbDocument.last_synced.is_(None),
+                DbDocument.secondary_only_sync_pending.is_(True),
+            )
         )
+        .count()
     )
+
+
+def construct_document_id_select_by_needs_sync_or_secondary_pending() -> CompoundSelect:
+    """Document ids that need a metadata sync, each tagged whether it is a *purely
+    deferred* FUTURE sync (so the producer can drop it to LOW while a port runs).
+
+    Two SQL-disjoint legs, unioned:
+      - needs_sync rows -> tag False. These have real work and drain at normal
+        priority even if also flagged deferred.
+      - deferred-only rows (flagged and NOT needs_sync) -> tag True.
+    A doc that is both needs_sync and deferred falls in the first leg (tag False),
+    so it is never under-prioritized to LOW.
+    """
+    needs_sync_predicate = or_(
+        DbDocument.last_modified > DbDocument.last_synced,
+        DbDocument.last_synced.is_(None),
+    )
+    needs_sync = select(
+        DbDocument.id, literal(False).label("secondary_only_sync_pending")
+    ).where(needs_sync_predicate)
+    deferred_only = select(
+        DbDocument.id, literal(True).label("secondary_only_sync_pending")
+    ).where(
+        DbDocument.secondary_only_sync_pending.is_(True),
+        ~needs_sync_predicate,
+    )
+    return needs_sync.union(deferred_only)
 
 
 def construct_document_id_select_for_connector_credential_pair(
@@ -162,6 +206,40 @@ def get_document_ids_for_connector_credential_pair(
         )
     )
     return list(db_session.execute(doc_ids_stmt).scalars().all())
+
+
+def get_document_ids_for_cc_pair_batch(
+    db_session: Session,
+    cc_pair_id: int,
+    after_doc_id: str | None,
+    limit: int,
+) -> list[str]:
+    """An ordered page of a cc_pair's document ids, for a cursor scan.
+
+    Returns ids `> after_doc_id` ascending, capped at `limit`. Pass the last id
+    of a page back as `after_doc_id` to resume past it — the reindex port stores
+    that cursor on the PortAttempt so a fresh attempt continues deterministically
+    rather than restarting.
+    """
+    cc_pair = get_connector_credential_pair_from_id(
+        db_session=db_session, cc_pair_id=cc_pair_id
+    )
+    if not cc_pair:
+        raise ValueError(f"No CC pair found with ID: {cc_pair_id}")
+
+    stmt = (
+        select(DocumentByConnectorCredentialPair.id)
+        .where(
+            DocumentByConnectorCredentialPair.connector_id == cc_pair.connector_id,
+            DocumentByConnectorCredentialPair.credential_id == cc_pair.credential_id,
+        )
+        .distinct()
+        .order_by(DocumentByConnectorCredentialPair.id)
+        .limit(limit)
+    )
+    if after_doc_id is not None:
+        stmt = stmt.where(DocumentByConnectorCredentialPair.id > after_doc_id)
+    return list(db_session.execute(stmt).scalars().all())
 
 
 def get_documents_for_connector_credential_pair_limited_columns(

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -157,6 +157,34 @@ def create_index_attempt(
     return new_attempt.id
 
 
+def create_synthetic_seed_attempt(
+    connector_credential_pair_id: int,
+    search_settings_id: int,
+    poll_range_end: float,
+    db_session: Session,
+) -> int:
+    """Insert a SUCCESS IndexAttempt with no connector run (the reindex port's
+    resume marker). It carries PRESENT's poll cursor so the FUTURE
+    connector-incremental resumes from there. time_started == time_created (both
+    func.now() in one statement) so the swap criterion's "real attempt after the
+    port" comparison is well-defined for the run that later supersedes the seed.
+    Excluded from the latest/count helpers via ignore_synthetic_seed."""
+    db_now = func.now()
+    seed = IndexAttempt(
+        connector_credential_pair_id=connector_credential_pair_id,
+        search_settings_id=search_settings_id,
+        from_beginning=True,
+        status=IndexingStatus.SUCCESS,
+        is_synthetic_seed=True,
+        time_started=db_now,
+        time_updated=db_now,
+        poll_range_end=datetime.fromtimestamp(poll_range_end, tz=timezone.utc),
+    )
+    db_session.add(seed)
+    db_session.commit()
+    return seed.id
+
+
 def delete_index_attempt(db_session: Session, index_attempt_id: int) -> None:
     index_attempt = get_index_attempt(db_session, index_attempt_id)
     if index_attempt:
@@ -655,6 +683,7 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
     connector_credential_pair_id: int,
     secondary_index: bool = False,
     ignore_targeted_reindex: bool = True,
+    ignore_synthetic_seed: bool = True,
 ) -> IndexAttempt | None:
     """Returns the most recent successful index attempt for the given cc pair,
     filtered to the current (or future) search settings.
@@ -668,6 +697,8 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
     )
     if ignore_targeted_reindex:
         stmt = stmt.where(IndexAttempt.targeted_reindex_job_id.is_(None))
+    if ignore_synthetic_seed:
+        stmt = stmt.where(IndexAttempt.is_synthetic_seed.is_(False))
     stmt = (
         stmt.join(SearchSettings)
         .where(SearchSettings.status == status)
@@ -680,6 +711,7 @@ def get_latest_successful_index_attempt_for_cc_pair_id(
 def get_latest_successful_index_attempts_parallel(
     secondary_index: bool = False,
     ignore_targeted_reindex: bool = True,
+    ignore_synthetic_seed: bool = True,
 ) -> Sequence[IndexAttempt]:
     """Batch version: returns the latest successful index attempt per cc pair.
     Covers both SUCCESS and COMPLETED_WITH_ERRORS (matching is_successful())."""
@@ -704,6 +736,8 @@ def get_latest_successful_index_attempts_parallel(
             latest_ids = latest_ids.where(
                 IndexAttempt.targeted_reindex_job_id.is_(None)
             )
+        if ignore_synthetic_seed:
+            latest_ids = latest_ids.where(IndexAttempt.is_synthetic_seed.is_(False))
         latest_ids = latest_ids.group_by(
             IndexAttempt.connector_credential_pair_id
         ).subquery()
@@ -932,6 +966,7 @@ def count_unique_cc_pairs_with_successful_index_attempts(
     search_settings_id: int | None,
     db_session: Session,
     ignore_targeted_reindex: bool = True,
+    ignore_synthetic_seed: bool = True,
 ) -> int:
     """Collect all of the Index Attempts that are successful and for the specified embedding model
     Then do distinct by connector_id and credential_id which is equivalent to the cc-pair. Finally,
@@ -946,6 +981,8 @@ def count_unique_cc_pairs_with_successful_index_attempts(
     )
     if ignore_targeted_reindex:
         query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    if ignore_synthetic_seed:
+        query = query.filter(IndexAttempt.is_synthetic_seed.is_(False))
     return query.distinct().count()
 
 
@@ -953,6 +990,7 @@ def count_unique_active_cc_pairs_with_successful_index_attempts(
     search_settings_id: int | None,
     db_session: Session,
     ignore_targeted_reindex: bool = True,
+    ignore_synthetic_seed: bool = True,
 ) -> int:
     """Collect all of the Index Attempts that are successful and for the specified embedding model,
     but only for non-paused connector-credential pairs. Then do distinct by connector_id and credential_id
@@ -969,6 +1007,8 @@ def count_unique_active_cc_pairs_with_successful_index_attempts(
     )
     if ignore_targeted_reindex:
         query = query.filter(IndexAttempt.targeted_reindex_job_id.is_(None))
+    if ignore_synthetic_seed:
+        query = query.filter(IndexAttempt.is_synthetic_seed.is_(False))
     return query.distinct().count()
 
 

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -6,12 +6,19 @@ active (NOT_STARTED / IN_PROGRESS) attempt per pair; terminal rows accumulate as
 history. Nothing here enqueues celery work — that is the caller's job.
 """
 
+from datetime import datetime
+
+from sqlalchemy import and_
+from sqlalchemy import exists
 from sqlalchemy import func
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import PortAttemptStatus
 from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -36,14 +43,20 @@ def create_port_attempt(
     cc_pair_id: int,
     search_settings_id: int,
     celery_task_id: str | None = None,
+    resume_from_doc_id: str | None = None,
 ) -> PortAttempt:
     """Create a NOT_STARTED attempt. Raises IntegrityError (the active-unique
-    index) if an active attempt already exists for the pair."""
+    index) if an active attempt already exists for the pair.
+
+    `resume_from_doc_id` seeds the cursor so the run continues `WHERE
+    document_id > resume_from_doc_id` — used when rescheduling a FAILED attempt.
+    """
     attempt = PortAttempt(
         cc_pair_id=cc_pair_id,
         search_settings_id=search_settings_id,
         status=PortAttemptStatus.NOT_STARTED,
         celery_task_id=celery_task_id,
+        last_processed_doc_id=resume_from_doc_id,
     )
     db_session.add(attempt)
     try:
@@ -83,6 +96,64 @@ def get_port_attempts_for_future(
             select(PortAttempt)
             .where(PortAttempt.search_settings_id == search_settings_id)
             .order_by(PortAttempt.time_created.desc())
+        )
+        .scalars()
+        .all()
+    )
+
+
+def get_latest_port_attempt(
+    db_session: Session, cc_pair_id: int, search_settings_id: int
+) -> PortAttempt | None:
+    """The most recent attempt (any status) for a (cc_pair, FUTURE). The watchdog
+    reads its status/cursor to decide whether to skip (SUCCESS/CANCELED) or
+    reschedule resuming the cursor (FAILED)."""
+    return (
+        db_session.execute(
+            select(PortAttempt)
+            .where(
+                PortAttempt.cc_pair_id == cc_pair_id,
+                PortAttempt.search_settings_id == search_settings_id,
+            )
+            .order_by(PortAttempt.time_created.desc())
+        )
+        .scalars()
+        .first()
+    )
+
+
+def any_future_port_in_progress(db_session: Session) -> bool:
+    """True if any PortAttempt against a FUTURE SearchSettings is active
+    (NOT_STARTED / IN_PROGRESS). The vespa sync producer drops deferred-doc syncs
+    to LOW priority while a port runs so they don't starve normal needs_sync work."""
+    stmt = select(
+        exists()
+        .where(PortAttempt.search_settings_id == SearchSettings.id)
+        .where(SearchSettings.status == IndexModelStatus.FUTURE)
+        .where(PortAttempt.status.in_(_ACTIVE_STATUSES))
+    )
+    return bool(db_session.execute(stmt).scalar())
+
+
+def get_stale_in_progress_port_attempts(
+    db_session: Session, search_settings_id: int, stale_before: datetime
+) -> list[PortAttempt]:
+    """IN_PROGRESS attempts for a FUTURE with no progress since `stale_before`
+    (last_progress_time older than that, or never set and started before it).
+    The watchdog fails these so a fresh attempt can resume from the cursor."""
+    return list(
+        db_session.execute(
+            select(PortAttempt).where(
+                PortAttempt.search_settings_id == search_settings_id,
+                PortAttempt.status == PortAttemptStatus.IN_PROGRESS,
+                or_(
+                    PortAttempt.last_progress_time < stale_before,
+                    and_(
+                        PortAttempt.last_progress_time.is_(None),
+                        PortAttempt.time_started < stale_before,
+                    ),
+                ),
+            )
         )
         .scalars()
         .all()

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -144,6 +144,12 @@ def get_secondary_search_settings(db_session: Session) -> SearchSettings | None:
     return latest_settings
 
 
+def get_search_settings_by_id(
+    db_session: Session, search_settings_id: int
+) -> SearchSettings | None:
+    return db_session.get(SearchSettings, search_settings_id)
+
+
 def get_active_search_settings(db_session: Session) -> ActiveSearchSettings:
     """Returns active search settings. Secondary search settings may be None."""
 

--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -4,11 +4,17 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import VESPA_NUM_ATTEMPTS_ON_STARTUP
+from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import KV_REINDEX_KEY
+from onyx.db.connector_credential_pair import (
+    fetch_indexable_standard_connector_credential_pair_ids,
+)
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
 from onyx.db.connector_credential_pair import resync_cc_pair
+from onyx.db.document import count_secondary_only_sync_pending_documents
 from onyx.db.document import delete_all_documents_for_connector_credential_pair
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import SwitchoverType
 from onyx.db.index_attempt import cancel_indexing_attempts_for_search_settings
@@ -16,10 +22,14 @@ from onyx.db.index_attempt import (
     count_unique_active_cc_pairs_with_successful_index_attempts,
 )
 from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
+from onyx.db.index_attempt import get_last_attempt_for_cc_pair
+from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import get_latest_port_attempt
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.search_settings import update_search_settings_status
@@ -141,6 +151,82 @@ def _perform_index_swap(
     return current_search_settings
 
 
+def _is_push_based_pair(cc_pair: ConnectorCredentialPair) -> bool:
+    """Ingestion-API pairs push docs in and never run a connector index attempt, so
+    their docs reach FUTURE only via the port."""
+    return (
+        cc_pair.connector_id == 0
+        or cc_pair.connector.source == DocumentSource.INGESTION_API
+    )
+
+
+def _required_cc_pairs_for_switchover(
+    db_session: Session,
+    all_cc_pairs: list[ConnectorCredentialPair],
+    switchover_type: SwitchoverType,
+) -> list[ConnectorCredentialPair]:
+    """The cc_pairs whose port must finish before a port-flow swap.
+
+    Scoped through the SAME helper check_for_port uses, so the gated set stays a
+    subset of what the watchdog ports — gating on a cc_pair it never ports (e.g.
+    INVALID, excluded by indexable_statuses()) would deadlock the swap. ACTIVE_ONLY
+    restricts to active statuses; other modes also include PAUSED. The Ingestion
+    pair is kept in: check_for_port ports it too, so its port must gate the swap.
+    """
+    portable_ids = set(
+        fetch_indexable_standard_connector_credential_pair_ids(
+            db_session,
+            active_cc_pairs_only=(switchover_type == SwitchoverType.ACTIVE_ONLY),
+        )
+    )
+    return [cc_pair for cc_pair in all_cc_pairs if cc_pair.id in portable_ids]
+
+
+def _port_swap_ready(
+    db_session: Session,
+    new_search_settings: SearchSettings,
+    required_cc_pairs: list[ConnectorCredentialPair],
+) -> bool:
+    """Port-flow swap gate: True only when every required cc_pair's port is SUCCESS
+    (none active) and — for standard connectors — a real (non-seed) FUTURE index
+    attempt landed after the port with none in progress (push-based pairs skip that
+    index check), and the deferred metadata-sync backlog has drained.
+    """
+    ss_id = new_search_settings.id
+    for cc_pair in required_cc_pairs:
+        if get_active_port_attempt(db_session, cc_pair.id, ss_id) is not None:
+            return False
+        latest_port = get_latest_port_attempt(db_session, cc_pair.id, ss_id)
+        if latest_port is None or not latest_port.status.is_successful():
+            return False
+
+        # No connector index attempt to wait on; port success is the whole gate.
+        if _is_push_based_pair(cc_pair):
+            continue
+
+        # the synthetic seed can't satisfy this: it's excluded by the T5 helper and
+        # would fail the time_started >= time_completed check anyway.
+        latest_index = get_latest_successful_index_attempt_for_cc_pair_id(
+            db_session, cc_pair.id, secondary_index=True
+        )
+        if (
+            latest_index is None
+            or latest_index.time_started is None
+            or latest_port.time_completed is None
+            or latest_index.time_started < latest_port.time_completed
+        ):
+            return False
+
+        last_attempt = get_last_attempt_for_cc_pair(cc_pair.id, ss_id, db_session)
+        if last_attempt is not None and last_attempt.status in (
+            IndexingStatus.NOT_STARTED,
+            IndexingStatus.IN_PROGRESS,
+        ):
+            return False
+
+    return count_secondary_only_sync_pending_documents(db_session) == 0
+
+
 def check_and_perform_index_swap(db_session: Session) -> SearchSettings | None:
     """Get count of cc-pairs and count of successful index_attempts for the
     new model grouped by connector + credential, if it's the same, then assume
@@ -162,6 +248,30 @@ def check_and_perform_index_swap(db_session: Session) -> SearchSettings | None:
 
     # Handle switchover based on switchover_type
     switchover_type = new_search_settings.switchover_type
+
+    # Port-flow FUTURE: swap on the port-aware criterion, not the legacy
+    # successful-index count (a broken connector must not block the swap).
+    if new_search_settings.use_port_flow:
+        if switchover_type == SwitchoverType.INSTANT:
+            # Mode C: swap immediately; the criteria gate retirement, not the swap.
+            return _perform_index_swap(
+                db_session=db_session,
+                new_search_settings=new_search_settings,
+                all_cc_pairs=all_cc_pairs,
+                cleanup_documents=True,
+            )
+        required_cc_pairs = _required_cc_pairs_for_switchover(
+            db_session, all_cc_pairs, switchover_type
+        )
+        if not required_cc_pairs or _port_swap_ready(
+            db_session, new_search_settings, required_cc_pairs
+        ):
+            return _perform_index_swap(
+                db_session=db_session,
+                new_search_settings=new_search_settings,
+                all_cc_pairs=all_cc_pairs,
+            )
+        return None
 
     # INSTANT: Swap immediately without waiting
     if switchover_type == SwitchoverType.INSTANT:

--- a/backend/onyx/document_index/factory.py
+++ b/backend/onyx/document_index/factory.py
@@ -24,29 +24,35 @@ def _build_tenant_state() -> TenantState:
     return TenantState(tenant_id=get_current_tenant_id(), multitenant=MULTI_TENANT)
 
 
-def _build_opensearch_pair(
+def build_opensearch_document_index(
     search_settings: SearchSettings,
-    secondary_search_settings: SearchSettings | None,
-) -> OpenSearchIndexPair:
-    tenant_state = _build_tenant_state()
+) -> OpenSearchDocumentIndex:
+    """A single OpenSearch index handle for one search settings.
+
+    The reindex port needs the lone index (to scan a PIT / call index_raw_chunks),
+    not the primary+secondary pair `get_default_document_index` returns. Shared
+    with `_build_opensearch_pair` so the construction lives in one place.
+    """
     indexing_setting = IndexingSetting.from_db_model(search_settings)
-    primary = OpenSearchDocumentIndex(
-        tenant_state=tenant_state,
+    return OpenSearchDocumentIndex(
+        tenant_state=_build_tenant_state(),
         index_name=search_settings.index_name,
         embedding_dim=indexing_setting.final_embedding_dim,
         embedding_precision=indexing_setting.embedding_precision,
     )
+
+
+def _build_opensearch_pair(
+    search_settings: SearchSettings,
+    secondary_search_settings: SearchSettings | None,
+) -> OpenSearchIndexPair:
+    primary = build_opensearch_document_index(search_settings)
     if secondary_search_settings is None:
         return OpenSearchIndexPair(primary=primary, secondary=None)
     secondary_indexing_setting = IndexingSetting.from_db_model(
         secondary_search_settings
     )
-    secondary = OpenSearchDocumentIndex(
-        tenant_state=tenant_state,
-        index_name=secondary_search_settings.index_name,
-        embedding_dim=secondary_indexing_setting.final_embedding_dim,
-        embedding_precision=secondary_indexing_setting.embedding_precision,
-    )
+    secondary = build_opensearch_document_index(secondary_search_settings)
     return OpenSearchIndexPair(
         primary=primary,
         secondary=secondary,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -905,11 +905,15 @@ class OpenSearchDocumentIndex(DocumentIndex):
 
         return inference_chunks
 
-    def index_raw_chunks(self, chunks: list[DocumentChunk]) -> None:
+    def index_raw_chunks(
+        self, chunks: list[DocumentChunk], use_external_versioning: bool = False
+    ) -> None:
         """Indexes raw document chunks into OpenSearch.
 
-        Used in the Vespa migration task. Can be deleted after migrations are
-        complete.
+        Used by the Vespa migration task and the reindex port. When
+        use_external_versioning is True the write is ordered by doc_updated_at
+        (newest-wins, 409 benign) so a slower port write can't clobber a newer
+        live sync to the same chunk.
         """
         logger.debug(
             "[OpenSearchDocumentIndex] Indexing %s raw chunks for index %s.",
@@ -920,7 +924,10 @@ class OpenSearchDocumentIndex(DocumentIndex):
         # because the document may already have been indexed during the
         # OpenSearch transition period.
         self._client.bulk_index_documents(
-            documents=chunks, tenant_state=self._tenant_state, update_if_exists=True
+            documents=chunks,
+            tenant_state=self._tenant_state,
+            update_if_exists=True,
+            use_external_versioning=use_external_versioning,
         )
 
 

--- a/backend/onyx/document_index/opensearch/port_copy.py
+++ b/backend/onyx/document_index/opensearch/port_copy.py
@@ -1,0 +1,75 @@
+"""PRESENT -> FUTURE chunk copy for the reindex port.
+
+Reads a document's existing chunks from the PRESENT OpenSearch index via the PIT
+scan, re-embeds them under the FUTURE model, and writes them to the FUTURE index
+with external versioning (newest-wins). The port Celery task drives this per
+batch and owns lifecycle (cursor, stall); keeping the OpenSearch specifics here
+keeps them off the generic docprocessing worker.
+"""
+
+from onyx.db.models import SearchSettings
+from onyx.document_index.factory import build_opensearch_document_index
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder
+from onyx.indexing.port_reembed import re_embed_chunks
+from onyx.indexing.port_reembed import ReembedStrategy
+from onyx.indexing.port_reembed import select_reembed_strategy
+
+
+def copy_present_chunks_to_future(
+    present_client: OpenSearchIndexClient,
+    future_index: OpenSearchDocumentIndex,
+    doc_ids: list[str],
+    strategy: ReembedStrategy,
+    embedder: IndexingEmbedder,
+) -> int:
+    """Port one batch of documents PRESENT -> FUTURE; returns chunks written."""
+    chunks_written = 0
+    for present_chunks in present_client.iter_chunks_for_doc_ids(doc_ids):
+        reembedded = re_embed_chunks(present_chunks, strategy, embedder)
+        if not reembedded:
+            continue
+        future_index.index_raw_chunks(reembedded, use_external_versioning=True)
+        chunks_written += len(reembedded)
+    return chunks_written
+
+
+class PortCopier:
+    """Resolves the OpenSearch handles, reembed strategy, and embedder once so
+    copy_doc_batch runs with no DB session held. Build it while the search
+    settings are session-attached: the FUTURE provider credentials lazy-load.
+    """
+
+    def __init__(
+        self,
+        present_search_settings: SearchSettings,
+        future_search_settings: SearchSettings,
+    ) -> None:
+        self._strategy = select_reembed_strategy(
+            present_search_settings, future_search_settings
+        )
+        if self._strategy is ReembedStrategy.AUGMENTATION:
+            raise NotImplementedError(
+                "Augmentation-change re-embed (contextual-RAG toggle/model) is not "
+                "yet supported; only model/prefix/dimension changes are."
+            )
+        self._present_client = OpenSearchIndexClient(
+            index_name=present_search_settings.index_name
+        )
+        self._future_index = build_opensearch_document_index(future_search_settings)
+        self._embedder = DefaultIndexingEmbedder.from_db_search_settings(
+            future_search_settings
+        )
+
+    def copy_doc_batch(self, doc_ids: list[str]) -> int:
+        return copy_present_chunks_to_future(
+            present_client=self._present_client,
+            future_index=self._future_index,
+            doc_ids=doc_ids,
+            strategy=self._strategy,
+            embedder=self._embedder,
+        )

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -32,7 +32,7 @@ from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 # replicated) so the rebuilt semantic tail is byte-identical to what indexing
 # produced; replicating it would risk silent drift in the embedding input.
 from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
-from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import DocAwareChunk
 
 
@@ -135,24 +135,21 @@ def _stored_chunk_to_doc_aware(
     )
 
 
-def re_embed_for_future(
+def re_embed_chunks(
     stored_chunks: list[DocumentChunkWithoutVectors],
-    present_ss: SearchSettings,
-    future_ss: SearchSettings,
+    strategy: ReembedStrategy,
+    embedder: IndexingEmbedder,
 ) -> list[DocumentChunk]:
-    """Re-embed PRESENT chunks under FUTURE settings (see module docstring).
+    """Re-embed stored chunks under a prebuilt strategy + embedder (no DB access).
 
     Returns the whole stored chunks as DocumentChunk, in order, with only
-    content_vector and title_vector recomputed (every other field — content,
-    title, metadata, ACL, boost, last_updated, ... — copied through, so the
-    FUTURE write is a faithful copy with new embeddings). Raises
-    NotImplementedError for the AUGMENTATION strategy (see below) — only
-    model/prefix/dimension changes are supported today.
+    content_vector and title_vector recomputed (every other field copied through,
+    so the FUTURE write is a faithful copy with new embeddings). Raises
+    NotImplementedError for AUGMENTATION — only model/prefix/dimension changes are
+    supported today.
     """
     if not stored_chunks:
         return []
-
-    strategy = select_reembed_strategy(present_ss, future_ss)
     if strategy is ReembedStrategy.AUGMENTATION:
         # Augmentation re-embed (strip -> re-glue -> re-embed) is the next
         # increment; the contextual-RAG-on case additionally needs the source
@@ -168,7 +165,6 @@ def re_embed_for_future(
         _stored_chunk_to_doc_aware(chunk, embed_input)
         for chunk, embed_input in zip(stored_chunks, embed_inputs)
     ]
-    embedder = DefaultIndexingEmbedder.from_db_search_settings(future_ss)
     embedded = embedder.embed_chunks(doc_aware_chunks)
 
     # Sanity: the embedder must return chunks 1:1 with what it was given.

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -9,9 +9,13 @@ from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
 from onyx.context.search.models import SavedSearchSettings
 from onyx.context.search.models import SearchSettingsCreationRequest
 from onyx.db.connector_credential_pair import get_connector_credential_pairs
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.connector_credential_pair import resync_cc_pair
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import Permission
+from onyx.db.enums import SwitchoverType
+from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.index_attempt import expire_index_attempts
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
@@ -137,6 +141,33 @@ def set_new_search_settings(
             resync_cc_pair(
                 cc_pair=cc_pair,
                 search_settings_id=new_search_settings.id,
+                db_session=db_session,
+            )
+
+    # Seed the port flow: one SUCCESS synthetic IndexAttempt per in-scope cc_pair
+    # carrying PRESENT's poll cursor, so the FUTURE connector-incremental resumes
+    # from there rather than re-scanning. INSTANT swaps immediately (nothing to
+    # poll), so it is not seeded. Scope mirrors the swap criterion: ACTIVE_ONLY
+    # seeds active cc_pairs only; otherwise all non-deleting.
+    if (
+        new_search_settings.use_port_flow
+        and new_search_settings.switchover_type != SwitchoverType.INSTANT
+    ):
+        active_only = new_search_settings.switchover_type == SwitchoverType.ACTIVE_ONLY
+        for cc_pair in get_connector_credential_pairs(db_session):
+            if active_only and not cc_pair.status.is_active():
+                continue
+            if cc_pair.status == ConnectorCredentialPairStatus.DELETING:
+                continue
+            indexing_start = cc_pair.connector.indexing_start
+            earliest_index = indexing_start.timestamp() if indexing_start else 0.0
+            poll_range_end = get_last_successful_attempt_poll_range_end(
+                cc_pair.id, earliest_index, search_settings, db_session
+            )
+            create_synthetic_seed_attempt(
+                connector_credential_pair_id=cc_pair.id,
+                search_settings_id=new_search_settings.id,
+                poll_range_end=poll_range_end,
                 db_session=db_session,
             )
 

--- a/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
+++ b/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
@@ -1,0 +1,349 @@
+"""External dependency unit tests for the port-aware swap criterion (T7/D8).
+
+The port-flow branch of `check_and_perform_index_swap` swaps on four conditions
+rather than the legacy successful-index count: every required cc_pair's port is
+SUCCESS, a real (non-seed) FUTURE index attempt landed after the port, nothing is
+in progress, and the deferred metadata-sync backlog has drained. The push-based
+Ingestion pair is gated on its port only (it never runs a connector index attempt).
+Mode C (INSTANT) swaps immediately; the legacy (flag-off) path is untouched.
+
+`_port_swap_ready` is tested directly with an explicit required list (isolated
+from other cc_pairs); the `check_and_perform_index_swap` cases patch
+`_perform_index_swap` so no destructive real swap runs.
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db import swap_index
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.index_attempt import create_synthetic_seed_attempt
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.db.swap_index import _port_swap_ready
+from onyx.db.swap_index import _required_cc_pairs_for_switchover
+from onyx.db.swap_index import check_and_perform_index_swap
+from onyx.kg.models import KGStage
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+_PENDING_DOC_PREFIX = "swapdoc-"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    pair = make_cc_pair(db_session)
+    present = get_current_search_settings(db_session)
+    saved = SavedSearchSettings.from_db_model(present).model_copy(
+        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
+    )
+    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
+    future_id = future.id
+    try:
+        yield pair, future_id
+    finally:
+        db_session.rollback()
+        db_session.query(DbDocument).filter(
+            DbDocument.id.like(f"{_PENDING_DOC_PREFIX}%")
+        ).delete(synchronize_session="fetch")
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(PortAttempt).filter(
+            PortAttempt.search_settings_id == future_id
+        ).delete(synchronize_session="fetch")
+        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _make_success_port(db_session: Session, cc_pair_id: int, ss_id: int) -> datetime:
+    """A SUCCESS port attempt; returns its (non-None) completion time so callers can
+    order index attempts relative to it."""
+    attempt = create_port_attempt(db_session, cc_pair_id, ss_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt.id)
+    assert row is not None and row.time_completed is not None
+    return row.time_completed
+
+
+def _make_real_index_attempt(
+    db_session: Session,
+    cc_pair_id: int,
+    ss_id: int,
+    time_started: object,
+    status: IndexingStatus = IndexingStatus.SUCCESS,
+) -> None:
+    db_session.add(
+        IndexAttempt(
+            connector_credential_pair_id=cc_pair_id,
+            search_settings_id=ss_id,
+            from_beginning=False,
+            status=status,
+            is_synthetic_seed=False,
+            time_started=time_started,
+            time_updated=time_started,
+        )
+    )
+    db_session.commit()
+
+
+def test_port_swap_ready_all_conditions_met(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    port_done = _make_success_port(db_session, cc_pair.id, future_id)
+    _make_real_index_attempt(
+        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
+    )
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is True
+
+
+def test_port_swap_blocks_when_no_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_active_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)  # active, not terminal
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_seed_only_future(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    _make_success_port(db_session, cc_pair.id, future_id)
+    # only a synthetic seed exists -> no real (non-seed) post-port attempt
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=1000.0, db_session=db_session
+    )
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_stale_post_port_poll(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    port_done = _make_success_port(db_session, cc_pair.id, future_id)
+    # a real success, but it started BEFORE the port completed -> not "post-port"
+    _make_real_index_attempt(
+        db_session, cc_pair.id, future_id, port_done - timedelta(seconds=5)
+    )
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_in_progress_index(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    port_done = _make_success_port(db_session, cc_pair.id, future_id)
+    _make_real_index_attempt(
+        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
+    )
+    _make_real_index_attempt(
+        db_session,
+        cc_pair.id,
+        future_id,
+        port_done + timedelta(seconds=2),
+        status=IndexingStatus.IN_PROGRESS,
+    )
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_pending_sync_backlog(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    port_done = _make_success_port(db_session, cc_pair.id, future_id)
+    _make_real_index_attempt(
+        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
+    )
+    # a deferred-sync doc remains -> condition (d) fails (tenant-global count)
+    doc_id = f"{_PENDING_DOC_PREFIX}pending"
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    mark_document_synced_secondary_pending(doc_id, db_session)
+    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
+
+
+def test_port_swap_blocks_on_unfinished_ingestion_port(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """check_for_port ports the push-based Ingestion pair too, and the port is its
+    only path into FUTURE — so an unfinished Ingestion port must hold the swap, even
+    though it never yields a FUTURE index attempt."""
+    _standard, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    ingestion = make_cc_pair(db_session, source=DocumentSource.INGESTION_API)
+    try:
+        attempt = create_port_attempt(db_session, ingestion.id, future_id)
+        mark_port_in_progress(db_session, attempt.id)  # active -> not done
+        assert _port_swap_ready(db_session, future_ss, [ingestion]) is False
+    finally:
+        db_session.query(PortAttempt).filter(
+            PortAttempt.cc_pair_id == ingestion.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, ingestion)
+
+
+def test_port_swap_ready_ingestion_skips_index_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Once its port succeeds, the Ingestion pair is ready with NO FUTURE index
+    attempt — the post-port index condition standard connectors face is skipped."""
+    _standard, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    ingestion = make_cc_pair(db_session, source=DocumentSource.INGESTION_API)
+    try:
+        _make_success_port(db_session, ingestion.id, future_id)
+        assert _port_swap_ready(db_session, future_ss, [ingestion]) is True
+    finally:
+        db_session.query(PortAttempt).filter(
+            PortAttempt.cc_pair_id == ingestion.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        cleanup_cc_pair(db_session, ingestion)
+
+
+def test_required_cc_pairs_for_switchover_scopes_by_mode(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    active = make_cc_pair(db_session)
+    paused = make_cc_pair(db_session)
+    deleting = make_cc_pair(db_session)
+    paused.status = ConnectorCredentialPairStatus.PAUSED
+    deleting.status = ConnectorCredentialPairStatus.DELETING
+    db_session.commit()
+    all_ccp = [active, paused, deleting]
+    try:
+        # REINDEX uses indexable_statuses (incl PAUSED, excl DELETING)
+        reindex = _required_cc_pairs_for_switchover(
+            db_session, all_ccp, SwitchoverType.REINDEX
+        )
+        assert {c.id for c in reindex} == {active.id, paused.id}
+
+        # ACTIVE_ONLY uses active_statuses (excl PAUSED + DELETING)
+        active_only = _required_cc_pairs_for_switchover(
+            db_session, all_ccp, SwitchoverType.ACTIVE_ONLY
+        )
+        assert {c.id for c in active_only} == {active.id}
+    finally:
+        for cc_pair in (active, paused, deleting):
+            cleanup_cc_pair(db_session, cc_pair)
+
+
+def test_swap_holds_when_port_not_ready(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    future_ss.switchover_type = SwitchoverType.REINDEX  # not INSTANT -> gated
+    db_session.commit()
+
+    with patch.object(swap_index, "_perform_index_swap") as mock_swap:
+        result = check_and_perform_index_swap(db_session)
+
+    assert result is None
+    mock_swap.assert_not_called()
+
+
+def test_mode_c_swaps_immediately(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    future_ss.switchover_type = SwitchoverType.INSTANT
+    db_session.commit()
+
+    sentinel = object()
+    with patch.object(
+        swap_index, "_perform_index_swap", return_value=sentinel
+    ) as mock_swap:
+        result = check_and_perform_index_swap(db_session)
+
+    assert result is sentinel
+    mock_swap.assert_called_once()
+    assert mock_swap.call_args.kwargs["cleanup_documents"] is True
+
+
+def test_legacy_path_does_not_consult_port_helpers(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future  # use_port_flow stays False (default)
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.switchover_type = SwitchoverType.REINDEX  # non-INSTANT legacy path
+    db_session.commit()
+
+    with (
+        patch.object(
+            swap_index,
+            "_port_swap_ready",
+            side_effect=AssertionError("legacy must not use the port path"),
+        ) as mock_ready,
+        patch.object(swap_index, "_perform_index_swap") as mock_swap,
+    ):
+        result = check_and_perform_index_swap(db_session)
+
+    mock_ready.assert_not_called()
+    # legacy REINDEX holds (cc_pairs without successful FUTURE indexings) -> no swap
+    assert result is None
+    mock_swap.assert_not_called()

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -11,24 +11,38 @@ covered by applying the migration, which this repo does not test programmaticall
 - the synthetic seed: writer row shape, seed-blind filtering (a seed must not count
   toward the swap or masquerade as the poll cursor), and the gated should_index
   FUTURE branch (legacy once-only vs port-flow continuous)
+- run_port_attempt: ports docs in batches, advances/commits the cursor, retries a
+  failed batch then marks FAILED (cursor left at the prior good batch)
 """
 
 from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from typing import cast
+from unittest.mock import MagicMock
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
+from onyx.background.celery.tasks.docprocessing import port_task
+from onyx.background.celery.tasks.docprocessing.port_task import run_check_for_port
+from onyx.background.celery.tasks.docprocessing.port_task import run_port_attempt
 from onyx.background.celery.tasks.docprocessing.utils import should_index
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
+from onyx.db.document import get_document_ids_for_cc_pair_batch
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
 from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import PortAttemptStatus
@@ -41,20 +55,73 @@ from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pai
 from onyx.db.index_attempt import mock_successful_index_attempt
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
+from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import commit_port_cursor
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import get_active_port_attempt
+from onyx.db.port_attempt import mark_port_canceled
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
 from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import get_current_search_settings
+from onyx.document_index.opensearch import port_copy
+from onyx.document_index.opensearch.port_copy import copy_present_chunks_to_future
+from onyx.indexing.port_reembed import ReembedStrategy
 from onyx.kg.models import KGStage
+from shared_configs.contextvars import get_current_tenant_id
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def _seed_cc_pair_documents(
+    db_session: Session, cc_pair: ConnectorCredentialPair, count: int
+) -> list[str]:
+    """Create `count` documents linked to the cc_pair; returns their ids, sorted."""
+    doc_ids = [f"portdoc-{i:03d}" for i in range(1, count + 1)]
+    for doc_id in doc_ids:
+        db_session.add(
+            DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+        )
+    db_session.flush()
+    for doc_id in doc_ids:
+        db_session.add(
+            DocumentByConnectorCredentialPair(
+                id=doc_id,
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+                has_been_indexed=True,
+            )
+        )
+    db_session.commit()
+    return doc_ids
+
+
+def _run_check_for_port(
+    cc_pair: ConnectorCredentialPair,
+    future_id: int,
+    celery_app: MagicMock | None = None,
+) -> tuple[int | None, MagicMock]:
+    """Run check_for_port scoped to this test's FUTURE + cc_pair (the real
+    get_secondary/fetch helpers are global). Returns (result, celery_app)."""
+    celery_app = celery_app or MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+    return result, celery_app
 
 
 @pytest.fixture
@@ -366,4 +433,453 @@ def test_should_index_future_gated_on_port_flow(
             cc_pair, future_ss, secondary_index_building=True, db_session=db_session
         )
         is True
+    )
+
+
+def test_get_document_ids_for_cc_pair_batch(
+    db_session: Session, cc_pair: ConnectorCredentialPair
+) -> None:
+    """Cursor pagination over a cc_pair's doc ids: ascending, exclusive of the
+    cursor, capped at limit, empty once exhausted -> the port's resume scan."""
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+
+    first = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=None, limit=2
+    )
+    assert first == doc_ids[:2]
+
+    # resume past the last id of the prior page
+    second = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=first[-1], limit=2
+    )
+    assert second == doc_ids[2:4]
+
+    third = get_document_ids_for_cc_pair_batch(
+        db_session, cc_pair.id, after_doc_id=second[-1], limit=2
+    )
+    assert third == doc_ids[4:]
+
+    # cursor at/after the last id -> exhausted
+    assert (
+        get_document_ids_for_cc_pair_batch(
+            db_session, cc_pair.id, after_doc_id=doc_ids[-1], limit=2
+        )
+        == []
+    )
+
+
+def test_copy_present_chunks_to_future_orchestration() -> None:
+    """Per batch: each PIT-scan page is re-embedded and written to FUTURE with
+    external versioning; the return is the total chunks written. Mocks the
+    OpenSearch read/write + re-embed (covered by their own tests)."""
+    present_client = MagicMock()
+    future_index = MagicMock()
+    strategy = cast(ReembedStrategy, MagicMock())
+    embedder = MagicMock()
+    # two pages out of the PIT scan
+    present_client.iter_chunks_for_doc_ids.return_value = iter([["c1", "c2"], ["c3"]])
+
+    with patch.object(
+        port_copy,
+        "re_embed_chunks",
+        side_effect=lambda chunks, _strategy, _embedder: [f"re:{c}" for c in chunks],
+    ) as mock_reembed:
+        written = copy_present_chunks_to_future(
+            present_client, future_index, ["d1", "d2"], strategy, embedder
+        )
+
+    assert written == 3
+    present_client.iter_chunks_for_doc_ids.assert_called_once_with(["d1", "d2"])
+    # re-embed once per page, with that page's chunks + prebuilt strategy/embedder
+    assert mock_reembed.call_count == 2
+    assert mock_reembed.call_args_list[0].args == (["c1", "c2"], strategy, embedder)
+    # FUTURE write once per page, always external-versioned
+    assert future_index.index_raw_chunks.call_count == 2
+    first_write = future_index.index_raw_chunks.call_args_list[0]
+    assert first_write.args[0] == ["re:c1", "re:c2"]
+    assert first_write.kwargs == {"use_external_versioning": True}
+
+
+def test_run_port_attempt_happy_path(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Ports every doc in INDEX_BATCH_SIZE batches: copier called once per batch,
+    cursor advanced to the last id, docs_ported == total, status SUCCESS."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids: len(ids)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # two batches: a full INDEX_BATCH_SIZE then the remaining 4
+    assert mock_copier.copy_doc_batch.call_count == 2
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[0].args[0]
+        == doc_ids[:INDEX_BATCH_SIZE]
+    )
+    assert (
+        mock_copier.copy_doc_batch.call_args_list[1].args[0]
+        == doc_ids[INDEX_BATCH_SIZE:]
+    )
+
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == len(doc_ids)
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_batch_retry_then_failed(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A batch that keeps failing is retried _PORT_BATCH_MAX_RETRIES times, then
+    the attempt is FAILED with the cursor un-advanced (a fresh attempt resumes
+    from the prior good batch -- here, the start)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = RuntimeError("opensearch down")
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task.time, "sleep"),  # don't sleep between retries
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == port_task._PORT_BATCH_MAX_RETRIES
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.FAILED
+    assert row.error_msg == "opensearch down"
+    assert row.last_processed_doc_id is None  # cursor never advanced
+    assert row.docs_ported == 0
+    assert row.time_completed is not None
+
+
+def test_run_port_attempt_resumes_from_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A resumed attempt scans only ids past its stored cursor and accumulates
+    docs_ported on top of the prior count."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, 5)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    # simulate a prior partial run: cursor at the 2nd doc, 2 docs ported
+    mark_port_in_progress(db_session, attempt_id)
+    commit_port_cursor(
+        db_session, attempt_id, last_processed_doc_id=doc_ids[1], docs_ported=2
+    )
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = lambda ids: len(ids)
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # only the docs after the cursor are copied
+    assert mock_copier.copy_doc_batch.call_count == 1
+    assert mock_copier.copy_doc_batch.call_args_list[0].args[0] == doc_ids[2:]
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.SUCCESS
+    assert row.last_processed_doc_id == doc_ids[-1]
+    assert row.docs_ported == 5  # 2 prior + 3 newly ported
+
+
+def test_run_port_attempt_stops_when_canceled(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """An external CANCEL (operator) marks the attempt terminal; the task stops at
+    the next batch boundary with its partial cursor preserved."""
+    cc_pair, future_id = cc_pair_and_future
+    doc_ids = _seed_cc_pair_documents(db_session, cc_pair, INDEX_BATCH_SIZE + 4)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    def copy_then_cancel(ids: list[str]) -> int:
+        mark_port_canceled(db_session, attempt_id)  # operator cancels after batch 1
+        return len(ids)
+
+    mock_copier = MagicMock()
+    mock_copier.copy_doc_batch.side_effect = copy_then_cancel
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    # first batch ran; the CANCELED status stops it at the next boundary
+    assert mock_copier.copy_doc_batch.call_count == 1
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.CANCELED
+    assert row.last_processed_doc_id == doc_ids[INDEX_BATCH_SIZE - 1]
+    assert row.docs_ported == INDEX_BATCH_SIZE
+
+
+def test_run_port_attempt_exits_when_cc_pair_deleting(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A cc_pair flipped to DELETING stops the port at the boundary before any
+    copy (the CASCADE will remove the attempt row)."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+    cc_pair.status = ConnectorCredentialPairStatus.DELETING
+    db_session.commit()
+
+    mock_copier = MagicMock()
+    with patch.object(port_task, "PortCopier", return_value=mock_copier):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # left for the CASCADE to remove
+
+
+def test_run_port_attempt_soft_time_limit_yields(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Hitting the self-enforced soft time limit yields (no copy, no terminal
+    mark) so the watchdog can reschedule from the cursor."""
+    cc_pair, future_id = cc_pair_and_future
+    _seed_cc_pair_documents(db_session, cc_pair, 3)
+    attempt_id = create_port_attempt(db_session, cc_pair.id, future_id).id
+
+    mock_copier = MagicMock()
+    with (
+        patch.object(port_task, "PortCopier", return_value=mock_copier),
+        patch.object(port_task, "_PORT_SOFT_TIME_LIMIT", -1),  # already "expired"
+    ):
+        run_port_attempt(attempt_id)
+
+    assert mock_copier.copy_doc_batch.call_count == 0
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, attempt_id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # not terminal; watchdog resumes
+
+
+def test_check_for_port_creates_and_enqueues(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A use_port_flow FUTURE with an in-scope cc_pair and no active attempt ->
+    one NOT_STARTED PortAttempt created + run_port_attempt enqueued."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.search_settings_id == future_id,
+        )
+        .all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.NOT_STARTED
+    celery_app.send_task.assert_called_once()
+    call = celery_app.send_task.call_args
+    assert call.args[0] == OnyxCeleryTask.RUN_PORT_ATTEMPT
+    assert call.kwargs["kwargs"] == {
+        "port_attempt_id": attempts[0].id,
+        "tenant_id": get_current_tenant_id(),
+    }
+    assert call.kwargs["queue"] == OnyxCeleryQueues.DOCPROCESSING
+    assert call.kwargs["expires"] == BEAT_EXPIRES_DEFAULT
+
+
+def test_check_for_port_gated_off_when_not_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A legacy FUTURE (use_port_flow=False) is a no-op -> nothing created/enqueued."""
+    cc_pair, future_id = cc_pair_and_future  # use_port_flow stays False (default)
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result is None
+    celery_app.send_task.assert_not_called()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
+    )
+
+
+def test_check_for_port_resumes_failed_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A prior FAILED attempt is rescheduled with its cursor carried forward."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    failed = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, failed.id)
+    commit_port_cursor(
+        db_session, failed.id, last_processed_doc_id="portdoc-042", docs_ported=42
+    )
+    mark_port_failed(db_session, failed.id, error_msg="boom")
+
+    result, _ = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    db_session.expire_all()
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert fresh[0].last_processed_doc_id == "portdoc-042"  # resumed cursor
+
+
+def test_check_for_port_fails_stale_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A stalled IN_PROGRESS attempt is FAILED, then a fresh attempt is created
+    and enqueued to resume."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, stale.id)
+    # force last_progress_time well past the stall threshold
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.query(PortAttempt).filter(PortAttempt.id == stale.id).update(
+        {PortAttempt.last_progress_time: old}
+    )
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    db_session.expire_all()
+    stale_row = db_session.get(PortAttempt, stale.id)
+    assert stale_row is not None
+    assert stale_row.status == PortAttemptStatus.FAILED  # watchdog failed the stall
+    fresh = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .all()
+    )
+    assert len(fresh) == 1
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+
+
+def test_check_for_port_leaves_active_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A healthy (recent) IN_PROGRESS attempt is left untouched and not duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)  # recent last_progress_time
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, active.id)
+    assert row is not None
+    assert row.status == PortAttemptStatus.IN_PROGRESS  # untouched
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+
+
+def test_check_for_port_fails_attempt_when_enqueue_raises(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """If send_task fails after the row is committed, the attempt is FAILED (not
+    left orphaned NOT_STARTED) so the next tick recreates + re-enqueues it."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    celery_app.send_task.side_effect = RuntimeError("broker down")
+    _run_check_for_port(cc_pair, future_id, celery_app=celery_app)
+
+    db_session.expire_all()
+    attempts = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(attempts) == 1
+    assert attempts[0].status == PortAttemptStatus.FAILED  # not orphaned NOT_STARTED
+    assert attempts[0].error_msg == "enqueue failed"
+
+
+def test_check_for_port_survives_create_failure(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A create_port_attempt failure for one cc_pair is swallowed so the tick
+    completes (the next tick retries) rather than aborting every other cc_pair."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    celery_app = MagicMock()
+    with (
+        patch.object(
+            port_task,
+            "get_secondary_search_settings",
+            lambda db, *_, **__: db.get(SearchSettings, future_id),
+        ),
+        patch.object(
+            port_task,
+            "fetch_indexable_standard_connector_credential_pair_ids",
+            lambda *_, **__: [cc_pair.id],
+        ),
+        patch.object(
+            port_task, "create_port_attempt", side_effect=RuntimeError("db blip")
+        ),
+    ):
+        result = run_check_for_port(get_current_tenant_id(), celery_app)
+
+    assert result == 0  # tick completed; the failed create was skipped
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 0
     )

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -4,29 +4,53 @@ Scoped to behavior/invariants worth guarding (the column existence + defaults ar
 covered by applying the migration, which this repo does not test programmatically):
 - the partial-unique "one active attempt per (cc_pair, FUTURE)" index — and that
   its predicate matches the stored (uppercase) enum name, not the value
+- the PortAttempt lifecycle helpers (create -> in_progress -> cursor -> terminal)
+  and first-terminal-write-wins
 - mark_document_synced_secondary_pending sets the flag (and clears needs-sync),
   and a later mark_document_as_synced clears it again
+- the synthetic seed: writer row shape, seed-blind filtering (a seed must not count
+  toward the swap or masquerade as the poll cursor), and the gated should_index
+  FUTURE branch (legacy once-only vs port-flow continuous)
 """
 
 from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.background.celery.tasks.docprocessing.utils import should_index
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db.connector_credential_pair import get_last_successful_attempt_poll_range_end
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
 from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import PortAttemptStatus
+from onyx.db.index_attempt import (
+    count_unique_active_cc_pairs_with_successful_index_attempts,
+)
+from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
+from onyx.db.index_attempt import create_synthetic_seed_attempt
+from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
+from onyx.db.index_attempt import mock_successful_index_attempt
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
+from onyx.db.models import IndexAttempt
 from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import commit_port_cursor
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import get_active_port_attempt
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import get_current_search_settings
 from onyx.kg.models import KGStage
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
@@ -201,3 +225,145 @@ def test_port_attempt_terminal_is_first_write_wins(
     assert row is not None
     assert row.status == PortAttemptStatus.FAILED
     assert row.error_msg == "stalled"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    """A cc_pair plus an isolated FUTURE SearchSettings (unique index_name) so the
+    global count/cursor helpers see only this test's attempts."""
+    pair = make_cc_pair(db_session)
+    present = get_current_search_settings(db_session)
+    saved = SavedSearchSettings.from_db_model(present).model_copy(
+        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
+    )
+    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
+    future_id = future.id
+    try:
+        yield pair, future_id
+    finally:
+        db_session.rollback()
+        db_session.query(IndexAttempt).filter(
+            IndexAttempt.connector_credential_pair_id == pair.id
+        ).delete(synchronize_session="fetch")
+        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def test_create_synthetic_seed_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    epoch = 1_700_000_000.0
+
+    seed_id = create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=epoch, db_session=db_session
+    )
+    db_session.expire_all()
+    seed = db_session.get(IndexAttempt, seed_id)
+    assert seed is not None
+    assert seed.status == IndexingStatus.SUCCESS
+    assert seed.is_synthetic_seed is True
+    # time_started == time_created so the swap criterion's "real attempt after the
+    # port" comparison is well-defined for the run that supersedes the seed
+    assert seed.time_started is not None and seed.time_created is not None
+    assert seed.time_started == seed.time_created
+    assert seed.poll_range_end is not None
+    assert seed.poll_range_end.timestamp() == epoch
+
+
+def test_seed_excluded_from_latest_and_counts(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # only a synthetic seed exists
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=1000.0, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 0
+    )
+    assert (
+        count_unique_active_cc_pairs_with_successful_index_attempts(
+            future_id, db_session
+        )
+        == 0
+    )
+    assert (
+        get_latest_successful_index_attempt_for_cc_pair_id(
+            db_session, cc_pair.id, secondary_index=True
+        )
+        is None
+    )
+    # the seed's cursor is invisible to the seed-blind helper -> earliest fallback
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == 42.0
+    )
+
+    # a real SUCCESS attempt IS counted and returned
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    db_session.expire_all()
+    assert (
+        count_unique_cc_pairs_with_successful_index_attempts(future_id, db_session) == 1
+    )
+    latest = get_latest_successful_index_attempt_for_cc_pair_id(
+        db_session, cc_pair.id, secondary_index=True
+    )
+    assert latest is not None and latest.id == real_id
+
+
+def test_should_index_future_gated_on_port_flow(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    # make the connector pollable on the continuous path
+    cc_pair.connector.refresh_freq = 60
+    # a real SUCCESS attempt, old enough to be re-pollable
+    old = datetime.now(timezone.utc) - timedelta(hours=1)
+    db_session.add(
+        IndexAttempt(
+            connector_credential_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            from_beginning=True,
+            status=IndexingStatus.SUCCESS,
+            time_started=old,
+            time_updated=old,
+        )
+    )
+    db_session.commit()
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    # legacy (flag off): one success is enough -> don't index again
+    future_ss.use_port_flow = False
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is False
+    )
+
+    # port flow (flag on): polls continuously -> index again
+    future_ss.use_port_flow = True
+    db_session.commit()
+    assert (
+        should_index(
+            cc_pair, future_ss, secondary_index_building=True, db_session=db_session
+        )
+        is True
+    )

--- a/backend/tests/external_dependency_unit/db/test_sync_priority.py
+++ b/backend/tests/external_dependency_unit/db/test_sync_priority.py
@@ -1,0 +1,196 @@
+"""External dependency unit tests for the reindex-port sync-enqueue priority (T8/D9).
+
+Covers: the UNION select surfacing needs_sync + deferred docs (each self-tagged);
+the gate count including deferred-only docs; the any-FUTURE-port-in-progress
+pre-query; and the producer's per-doc priority (deferred doc LOW while a port runs,
+HIGH once it stops; needs_sync MEDIUM normally but LOW while a completed port's
+backlog drains) plus the expires= on every enqueue. The Celery send_task is mocked
+— we assert the producer's decision, not real dispatch.
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.vespa.document_sync import (
+    generate_document_sync_tasks,
+)
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db.document import (
+    construct_document_id_select_by_needs_sync_or_secondary_pending,
+)
+from onyx.db.document import count_documents_by_needs_sync
+from onyx.db.document import count_documents_by_needs_sync_or_secondary_pending
+from onyx.db.document import mark_document_as_modified
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import IndexModelStatus
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import any_future_port_in_progress
+from onyx.db.port_attempt import create_port_attempt
+from onyx.db.port_attempt import mark_port_in_progress
+from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.kg.models import KGStage
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+_DOC_PREFIX = "syncdoc-"
+
+
+@pytest.fixture
+def cc_pair_and_future(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
+    pair = make_cc_pair(db_session)
+    present = get_current_search_settings(db_session)
+    saved = SavedSearchSettings.from_db_model(present).model_copy(
+        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
+    )
+    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
+    future_id = future.id
+    try:
+        yield pair, future_id
+    finally:
+        db_session.rollback()
+        db_session.query(DbDocument).filter(
+            DbDocument.id.like(f"{_DOC_PREFIX}%")
+        ).delete(synchronize_session="fetch")
+        db_session.query(PortAttempt).filter(
+            PortAttempt.search_settings_id == future_id
+        ).delete(synchronize_session="fetch")
+        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+
+
+def _make_doc(db_session: Session, doc_id: str) -> None:
+    db_session.add(
+        DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+    )
+    db_session.commit()
+    mark_document_as_modified(doc_id, db_session)  # needs_sync
+
+
+def _run_generate(db_session: Session) -> dict[str, dict[str, int]]:
+    """Run the producer with mocked Celery/Redis; return {doc_id: {priority, expires}}
+    for this test's docs only (the select is tenant-global)."""
+    celery_app = MagicMock()
+    generate_document_sync_tasks(
+        MagicMock(),  # redis client
+        10**9,  # max_tasks (process everything)
+        celery_app,
+        db_session,
+        MagicMock(),  # lock
+        "test-tenant",
+    )
+    captured: dict[str, dict[str, int]] = {}
+    for call in celery_app.send_task.call_args_list:
+        doc_id = call.kwargs["kwargs"]["document_id"]
+        if doc_id.startswith(_DOC_PREFIX):
+            captured[doc_id] = {
+                "priority": call.kwargs["priority"],
+                "expires": call.kwargs["expires"],
+            }
+    return captured
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_select_needs_sync_or_secondary_pending_surfaces_both(
+    db_session: Session,
+) -> None:
+    _make_doc(db_session, f"{_DOC_PREFIX}A")  # needs_sync
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    rows = {
+        (doc_id, flag)
+        for doc_id, flag in db_session.execute(stmt)
+        if doc_id.startswith(_DOC_PREFIX)
+    }
+    assert (f"{_DOC_PREFIX}A", False) in rows  # needs_sync leg, self-tagged False
+    assert (f"{_DOC_PREFIX}B", True) in rows  # deferred leg, self-tagged True
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_needs_sync_and_deferred_doc_tags_false(db_session: Session) -> None:
+    """A doc that is BOTH needs_sync and deferred surfaces once via the needs_sync
+    leg (tag False) -> real work wins, never under-prioritized to LOW."""
+    doc_id = f"{_DOC_PREFIX}C"
+    _make_doc(db_session, doc_id)  # needs_sync
+    mark_document_synced_secondary_pending(
+        doc_id, db_session
+    )  # deferred (needs_sync cleared)
+    mark_document_as_modified(doc_id, db_session)  # re-dirty -> needs_sync AND deferred
+
+    stmt = construct_document_id_select_by_needs_sync_or_secondary_pending()
+    rows = {(d, f) for d, f in db_session.execute(stmt) if d.startswith(_DOC_PREFIX)}
+    assert (doc_id, False) in rows
+    assert (doc_id, True) not in rows
+
+
+@pytest.mark.usefixtures("cc_pair_and_future")
+def test_count_or_includes_deferred_only(
+    db_session: Session,
+) -> None:
+    before_or = count_documents_by_needs_sync_or_secondary_pending(db_session)
+    before_needs_sync = count_documents_by_needs_sync(db_session)
+
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    # the OR-count sees the deferred doc; the plain needs_sync count does not
+    assert (
+        count_documents_by_needs_sync_or_secondary_pending(db_session) == before_or + 1
+    )
+    assert count_documents_by_needs_sync(db_session) == before_needs_sync
+
+
+def test_any_future_port_in_progress(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    assert any_future_port_in_progress(db_session) is False
+
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    assert any_future_port_in_progress(db_session) is True
+
+    mark_port_succeeded(db_session, attempt.id)
+    assert any_future_port_in_progress(db_session) is False
+
+
+def test_sync_priority_across_three_states(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    cc_pair, future_id = cc_pair_and_future
+    _make_doc(db_session, f"{_DOC_PREFIX}A")  # needs_sync
+    _make_doc(db_session, f"{_DOC_PREFIX}B")
+    mark_document_synced_secondary_pending(f"{_DOC_PREFIX}B", db_session)  # deferred
+
+    # port running: needs_sync stays MEDIUM, deferred drops to LOW
+    attempt = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, attempt.id)
+    captured = _run_generate(db_session)
+    assert captured[f"{_DOC_PREFIX}A"]["priority"] == OnyxCeleryPriority.MEDIUM
+    assert captured[f"{_DOC_PREFIX}B"]["priority"] == OnyxCeleryPriority.LOW
+    assert captured[f"{_DOC_PREFIX}A"]["expires"] > 0
+    assert captured[f"{_DOC_PREFIX}B"]["expires"] > 0
+
+    # port stopped with a deferred backlog still pending: that drain is the swap
+    # gate, so the deferred doc goes HIGH and needs_sync yields to LOW
+    mark_port_succeeded(db_session, attempt.id)
+    captured = _run_generate(db_session)
+    assert captured[f"{_DOC_PREFIX}B"]["priority"] == OnyxCeleryPriority.HIGH
+    assert captured[f"{_DOC_PREFIX}A"]["priority"] == OnyxCeleryPriority.LOW

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -1,4 +1,4 @@
-"""Tests for re_embed_for_future (reindex port re-embedding).
+"""Tests for the reindex-port re-embedding (port_reembed).
 
 These cover the pure re-embed logic: strategy selection, rebuilding the semantic
 metadata tail, the embed-input recovery (the crux — stored content carries the
@@ -10,6 +10,7 @@ from the raw stored content (here) is equivalent to proving the resulting vector
 differs; the real-embedder path is exercised once the port task is wired.
 """
 
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -24,12 +25,12 @@ from onyx.document_index.chunk_content_enrichment import (
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
-from onyx.indexing.embedder import DefaultIndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocAwareChunk
 from onyx.indexing.models import IndexChunk
 from onyx.indexing.port_reembed import _stored_chunk_to_doc_aware
-from onyx.indexing.port_reembed import re_embed_for_future
+from onyx.indexing.port_reembed import re_embed_chunks
 from onyx.indexing.port_reembed import rebuild_semantic_tail
 from onyx.indexing.port_reembed import recover_embedding_input
 from onyx.indexing.port_reembed import ReembedStrategy
@@ -167,23 +168,19 @@ def test_to_doc_aware_chunk_feeds_embed_input() -> None:
 
 def test_re_embed_augmentation_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
-        re_embed_for_future(
-            [_stored_chunk("body")],
-            _ss(enable_contextual_rag=False),
-            _ss(enable_contextual_rag=True),
+        re_embed_chunks(
+            [_stored_chunk("body")], ReembedStrategy.AUGMENTATION, MagicMock()
         )
 
 
 def test_re_embed_empty_returns_empty() -> None:
-    assert re_embed_for_future([], _ss(), _ss()) == []
+    assert re_embed_chunks([], ReembedStrategy.MODEL_ONLY, MagicMock()) == []
 
 
-def test_re_embed_preserves_all_fields_swaps_only_vectors(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """re_embed_for_future returns the whole stored chunk as a DocumentChunk with
-    only content_vector/title_vector recomputed — every other field is copied
-    through (so the FUTURE write is a faithful copy with new embeddings)."""
+def test_re_embed_preserves_all_fields_swaps_only_vectors() -> None:
+    """re_embed_chunks returns the whole stored chunk as a DocumentChunk with only
+    content_vector/title_vector recomputed — every other field is copied through
+    (so the FUTURE write is a faithful copy with new embeddings)."""
     metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
     stored = _stored_chunk(
         "body text", title="My Title", metadata_list=metadata_list, chunk_index=3
@@ -203,13 +200,9 @@ def test_re_embed_preserves_all_fields_swaps_only_vectors(
                 for chunk in chunks
             ]
 
-    monkeypatch.setattr(
-        DefaultIndexingEmbedder,
-        "from_db_search_settings",
-        MagicMock(return_value=_FakeEmbedder()),
+    [result] = re_embed_chunks(
+        [stored], ReembedStrategy.MODEL_ONLY, cast(IndexingEmbedder, _FakeEmbedder())
     )
-
-    [result] = re_embed_for_future([stored], _ss(), _ss())
 
     # only the two vectors are new
     assert result.content_vector == fake_cv

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -76,14 +76,18 @@ def get_filerecord(db_session: Session, file_id: str) -> FileRecord | None:
     return get_filerecord_by_file_id_optional(file_id=file_id, db_session=db_session)
 
 
-def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
+def make_cc_pair(
+    db_session: Session,
+    source: DocumentSource = DocumentSource.MOCK_CONNECTOR,
+) -> ConnectorCredentialPair:
     """Create a Connector + Credential + ConnectorCredentialPair for a test.
 
-    All names are UUID-suffixed so parallel test runs don't collide.
+    All names are UUID-suffixed so parallel test runs don't collide. Pass `source`
+    to build a non-standard pair (e.g. INGESTION_API for push-based-pair tests).
     """
     connector = Connector(
         name=f"test-connector-{uuid4().hex[:8]}",
-        source=DocumentSource.MOCK_CONNECTOR,
+        source=source,
         input_type=InputType.LOAD_STATE,
         connector_specific_config={},
         refresh_freq=None,
@@ -94,7 +98,7 @@ def make_cc_pair(db_session: Session) -> ConnectorCredentialPair:
     db_session.flush()
 
     credential = Credential(
-        source=DocumentSource.MOCK_CONNECTOR,
+        source=source,
         credential_json={},
     )
     db_session.add(credential)


### PR DESCRIPTION
## Description
  - Add the reindex port: a beat scheduler (`check_for_port`, every 30s) plus a producer task that copies each connector's documents from the live index into the new-model index, committing a per-batch cursor so a crash or stall resumes instead of restarting
  - Re-embed copied chunks under the new model and write them newest-wins, so a slower port write can't clobber an in-flight live update to the same chunk
  - Seed each in-scope connector with a synthetic successful attempt carrying the live poll cursor, so the new model resumes incrementally instead of re-scanning every document from scratch
  - Gate the model swap on port completion (and the deferred metadata-sync backlog draining), so a single broken connector can no longer block switching to the new model
  - Deprioritize background metadata syncs during a port and prioritize the post-port drain, so porting doesn't starve normal sync work and the flip isn't held up

## How Has This Been Tested?
  Added unit tests for the port flow, swap criterion, sync prioritization, and chunk re-embed (`test_reindex_port`, `test_port_swap_criterion`, `test_sync_priority`, `test_port_reembed`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a resumable reindex port and a port-aware swap so model upgrades are faster, incremental, and safe. Chunks are copied PRESENT → FUTURE, re-embedded under the new model, and written newest-wins; the swap waits for ports and the metadata-sync backlog to finish.

- New Features
  - Beat scheduler `check_for_port` (every 30s) and producer `run_port_attempt` with per-batch cursors to resume after crashes.
  - OpenSearch PIT copy with re-embedding and external versioning via `index_raw_chunks(use_external_versioning=True)`.
  - Synthetic SUCCESS seed attempts carry the PRESENT poll cursor so FUTURE indexing resumes incrementally; `should_index` keeps FUTURE polling for port-flow models.
  - Port-aware swap: swap when all required ports are SUCCESS, a real FUTURE attempt landed after the port, nothing is in progress, and deferred metadata-sync has drained; ingestion pairs are gated only on their port.
  - Metadata sync prioritization: during a port, deprioritize background syncs; after port, prioritize draining deferred docs. Adds `CELERY_DOCUMENT_SYNC_TASK_EXPIRES`, UNION select for needs_sync + deferred, and per-doc priority rules; includes `any_future_port_in_progress` gating.
  - Helpers/utilities: document queries for deferred counts, `build_opensearch_document_index`, and Redis lock `CHECK_PORT_BEAT_LOCK`. Beat list now includes `check-for-port`.
  - Tests: coverage for port flow, swap criterion, sync prioritization, and re-embedding.

<sup>Written for commit 7d3bedd287c16d4894c739182e51681a4f46dcd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

