### PR TITLE
 feat(reindex): contextual-RAG re-embed + cancel superseded ports

### DIFF
--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -168,7 +168,8 @@ def create_synthetic_seed_attempt(
     connector-incremental resumes from there. time_started == time_created (both
     func.now() in one statement) so the swap criterion's "real attempt after the
     port" comparison is well-defined for the run that later supersedes the seed.
-    Excluded from the latest/count helpers via ignore_synthetic_seed."""
+    Excluded from the latest/count helpers via ignore_synthetic_seed. Flushes to
+    populate the returned id but does not commit; the caller commits."""
     db_now = func.now()
     seed = IndexAttempt(
         connector_credential_pair_id=connector_credential_pair_id,
@@ -181,7 +182,7 @@ def create_synthetic_seed_attempt(
         poll_range_end=datetime.fromtimestamp(poll_range_end, tz=timezone.utc),
     )
     db_session.add(seed)
-    db_session.commit()
+    db_session.flush()
     return seed.id
 
 

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -13,6 +13,7 @@ from sqlalchemy import exists
 from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import select
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import IndexModelStatus
@@ -236,3 +237,24 @@ def _mark_terminal(
     except Exception:
         db_session.rollback()
         raise
+
+
+def cancel_active_port_attempts(db_session: Session, search_settings_id: int) -> int:
+    """Cancel all active (NOT_STARTED / IN_PROGRESS) attempts for a FUTURE that has
+    been superseded by a newer reindex. A running port task re-reads its row each
+    batch and stops once it sees CANCELED; only active rows are touched, preserving
+    first-terminal-write-wins. Returns the number canceled."""
+    result = db_session.execute(
+        update(PortAttempt)
+        .where(
+            PortAttempt.search_settings_id == search_settings_id,
+            PortAttempt.status.in_(_ACTIVE_STATUSES),
+        )
+        .values(
+            status=PortAttemptStatus.CANCELED,
+            time_completed=func.now(),
+            error_msg="Canceled: superseded by a newer reindex",
+        )
+    )
+    db_session.commit()
+    return result.rowcount  # ty: ignore[unresolved-attribute]

--- a/backend/onyx/document_index/chunk_content_enrichment.py
+++ b/backend/onyx/document_index/chunk_content_enrichment.py
@@ -3,10 +3,9 @@ from onyx.configs.constants import RETURN_SEPARATOR
 from onyx.context.search.models import InferenceChunk
 from onyx.context.search.models import InferenceChunkUncleaned
 from onyx.indexing.models import DocAwareChunk
-from onyx.indexing.models import DocMetadataAwareIndexChunk
 
 
-def generate_enriched_content_for_chunk_text(chunk: DocMetadataAwareIndexChunk) -> str:
+def generate_enriched_content_for_chunk_text(chunk: DocAwareChunk) -> str:
     return f"{chunk.title_prefix}{chunk.doc_summary}{chunk.content}{chunk.chunk_context}{chunk.metadata_suffix_keyword}"
 
 

--- a/backend/onyx/document_index/opensearch/port_copy.py
+++ b/backend/onyx/document_index/opensearch/port_copy.py
@@ -5,7 +5,14 @@ scan, re-embeds them under the FUTURE model, and writes them to the FUTURE index
 with external versioning (newest-wins). The port Celery task drives this per
 batch and owns lifecycle (cursor, stall); keeping the OpenSearch specifics here
 keeps them off the generic docprocessing worker.
+
+The AUGMENTATION strategy (contextual-RAG toggle/model change) re-enriches each
+document, which needs all of a document's chunks together to reconstruct the doc
+text — and a document's chunks can span PIT pages — so that path buffers the
+batch into a single page, while MODEL_ONLY streams page by page.
 """
+
+from collections.abc import Iterable
 
 from onyx.db.models import SearchSettings
 from onyx.document_index.factory import build_opensearch_document_index
@@ -13,11 +20,50 @@ from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.document_index.opensearch.opensearch_document_index import (
     OpenSearchDocumentIndex,
 )
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.indexing.chunker import DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.embedder import IndexingEmbedder
+from onyx.indexing.port_reembed import AugmentationReembedContext
 from onyx.indexing.port_reembed import re_embed_chunks
 from onyx.indexing.port_reembed import ReembedStrategy
 from onyx.indexing.port_reembed import select_reembed_strategy
+from onyx.llm.factory import get_contextual_rag_llm_for_search_settings
+from onyx.natural_language_processing.utils import get_tokenizer
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
+
+logger = setup_logger()
+
+
+def _build_augmentation_ctx(
+    future_search_settings: SearchSettings,
+) -> AugmentationReembedContext:
+    """Prepare the AUGMENTATION inputs while a DB session is available. For
+    FUTURE-RAG-off only the flag matters; for FUTURE-RAG-on we also resolve the
+    contextual LLM/tokenizer and the same token budgets the chunker uses."""
+    if not future_search_settings.enable_contextual_rag:
+        return AugmentationReembedContext(future_enable_contextual_rag=False)
+
+    llm = get_contextual_rag_llm_for_search_settings(future_search_settings)
+    if llm is None:
+        raise ValueError(
+            "contextual-RAG is enabled on the FUTURE search settings but no "
+            "contextual RAG model is configured (and no tenant default exists)"
+        )
+    tokenizer = get_tokenizer(
+        model_name=llm.config.model_name,
+        provider_type=llm.config.model_provider,
+    )
+    return AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=llm,
+        tokenizer=tokenizer,
+        # The same *2 fudge factor over the chunk size that the indexing
+        # pipeline applies to absorb embedder-vs-LLM tokenizer drift.
+        chunk_token_limit=DOC_EMBEDDING_CONTEXT_SIZE * 2,
+        contextual_rag_reserved_tokens=DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS,
+    )
 
 
 def copy_present_chunks_to_future(
@@ -26,11 +72,29 @@ def copy_present_chunks_to_future(
     doc_ids: list[str],
     strategy: ReembedStrategy,
     embedder: IndexingEmbedder,
+    augmentation_ctx: AugmentationReembedContext | None = None,
 ) -> int:
     """Port one batch of documents PRESENT -> FUTURE; returns chunks written."""
+    pages: Iterable[list[DocumentChunkWithoutVectors]]
+    if strategy is ReembedStrategy.AUGMENTATION:
+        # Buffer the batch into one page: re-enrichment needs each document's
+        # chunks complete (they can span PIT pages), and one page also means one
+        # embed round-trip + one bulk write for the whole batch.
+        pages = [
+            [
+                chunk
+                for page in present_client.iter_chunks_for_doc_ids(doc_ids)
+                for chunk in page
+            ]
+        ]
+    else:
+        pages = present_client.iter_chunks_for_doc_ids(doc_ids)
+
     chunks_written = 0
-    for present_chunks in present_client.iter_chunks_for_doc_ids(doc_ids):
-        reembedded = re_embed_chunks(present_chunks, strategy, embedder)
+    for page_chunks in pages:
+        reembedded = re_embed_chunks(
+            page_chunks, strategy, embedder, augmentation_ctx=augmentation_ctx
+        )
         if not reembedded:
             continue
         future_index.index_raw_chunks(reembedded, use_external_versioning=True)
@@ -41,7 +105,8 @@ def copy_present_chunks_to_future(
 class PortCopier:
     """Resolves the OpenSearch handles, reembed strategy, and embedder once so
     copy_doc_batch runs with no DB session held. Build it while the search
-    settings are session-attached: the FUTURE provider credentials lazy-load.
+    settings are session-attached: the FUTURE provider credentials lazy-load,
+    and the AUGMENTATION contextual LLM/model-config resolution needs a session.
     """
 
     def __init__(
@@ -52,11 +117,6 @@ class PortCopier:
         self._strategy = select_reembed_strategy(
             present_search_settings, future_search_settings
         )
-        if self._strategy is ReembedStrategy.AUGMENTATION:
-            raise NotImplementedError(
-                "Augmentation-change re-embed (contextual-RAG toggle/model) is not "
-                "yet supported; only model/prefix/dimension changes are."
-            )
         self._present_client = OpenSearchIndexClient(
             index_name=present_search_settings.index_name
         )
@@ -64,6 +124,9 @@ class PortCopier:
         self._embedder = DefaultIndexingEmbedder.from_db_search_settings(
             future_search_settings
         )
+        self._augmentation_ctx: AugmentationReembedContext | None = None
+        if self._strategy is ReembedStrategy.AUGMENTATION:
+            self._augmentation_ctx = _build_augmentation_ctx(future_search_settings)
 
     def copy_doc_batch(self, doc_ids: list[str]) -> int:
         return copy_present_chunks_to_future(
@@ -72,4 +135,5 @@ class PortCopier:
             doc_ids=doc_ids,
             strategy=self._strategy,
             embedder=self._embedder,
+            augmentation_ctx=self._augmentation_ctx,
         )

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -30,6 +30,11 @@ CHUNK_OVERLAP = 0
 # overwhelm the actual contents of the chunk
 MAX_METADATA_PERCENTAGE = 0.25
 CHUNK_MIN_CONTENT = 256
+# Tokens reserved per chunk for the contextual-RAG doc summary + chunk context.
+# Single source of truth — the reindex port reuses it to mirror indexing budgets.
+DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS = MAX_CONTEXT_TOKENS * (
+    int(USE_CHUNK_SUMMARY) + int(USE_DOCUMENT_SUMMARY)
+)
 
 logger = setup_logger()
 
@@ -144,8 +149,8 @@ class Chunker:
             assert USE_CHUNK_SUMMARY or USE_DOCUMENT_SUMMARY, (
                 "Contextual RAG requires at least one of chunk summary and document summary enabled"
             )
-        self.default_contextual_rag_reserved_tokens = MAX_CONTEXT_TOKENS * (
-            int(USE_CHUNK_SUMMARY) + int(USE_DOCUMENT_SUMMARY)
+        self.default_contextual_rag_reserved_tokens = (
+            DEFAULT_CONTEXTUAL_RAG_RESERVED_TOKENS
         )
         self.tokenizer = tokenizer
         self.callback = callback

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -74,8 +74,8 @@ from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.indexing.models import IndexingBatchAdapter
 from onyx.indexing.models import UpdatableChunkData
 from onyx.indexing.vector_db_insertion import write_chunks_to_vector_db_with_backoff
+from onyx.llm.factory import get_contextual_rag_llm_for_search_settings
 from onyx.llm.factory import get_default_llm_with_vision
-from onyx.llm.factory import get_llm_for_contextual_rag
 from onyx.llm.interfaces import LLM
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LLMRateLimitError
@@ -1507,16 +1507,7 @@ def run_indexing_pipeline(
     )
     llm = None
     if enable_contextual_rag:
-        mc_id = search_settings.contextual_rag_model_configuration_id
-        if mc_id is None:
-            # Fall back to the global default contextual RAG model (LLMModelFlow).
-            from onyx.db.llm import fetch_default_contextual_rag_model
-
-            with get_session_with_current_tenant() as fallback_session:
-                mc = fetch_default_contextual_rag_model(fallback_session)
-            mc_id = mc.id if mc else None
-        if mc_id is not None:
-            llm = get_llm_for_contextual_rag(mc_id)
+        llm = get_contextual_rag_llm_for_search_settings(search_settings)
 
     chunker = chunker or Chunker(
         tokenizer=embedder.embedding_model.tokenizer,

--- a/backend/onyx/indexing/port_reembed.py
+++ b/backend/onyx/indexing/port_reembed.py
@@ -12,19 +12,41 @@ Two strategies, chosen by comparing PRESENT vs FUTURE settings:
   swap just that tail back.
 - AUGMENTATION (contextual-RAG toggle or model changed): the enriched text
   itself changes, so we strip the stored augmentation back to the bare chunk
-  text, re-glue under FUTURE settings, then re-embed.
+  text, re-glue under FUTURE settings, then re-embed. Two sub-cases keyed on the
+  FUTURE `enable_contextual_rag`:
+    * FUTURE RAG off — strip the doc summary / chunk context / title / metadata
+      and re-embed the bare chunk (no LLM).
+    * FUTURE RAG on — additionally regenerate the doc summary + chunk context
+      under the FUTURE contextual LLM. The full document text the LLM needs is
+      *reconstructed by concatenating the document's own (bare) chunks* in chunk
+      order; the port never re-fetches the source. This duplicates chunk-overlap
+      regions and loses the original section boundaries, so the reconstructed
+      text is not byte-identical to the source — an accepted imprecision (the LLM
+      truncates to a token budget anyway, and re-fetching the source is the
+      fragility this feature exists to remove).
 
 Only regular chunks are handled (the port reads `max_chunk_size ==
 DEFAULT_MAX_CHUNK_SIZE`); writes are idempotent (external versioning) so we
 re-embed unconditionally rather than diffing content hashes.
 """
 
+from __future__ import annotations
+
 import enum
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import RETURN_SEPARATOR
 from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
 from onyx.connectors.models import Document
+from onyx.connectors.models import TextSection
 from onyx.db.models import SearchSettings
+from onyx.document_index.chunk_content_enrichment import cleanup_content_for_chunks
+from onyx.document_index.chunk_content_enrichment import (
+    generate_enriched_content_for_chunk_text,
+)
 from onyx.document_index.opensearch.schema import DocumentChunk
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 
@@ -35,6 +57,10 @@ from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
 from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import DocAwareChunk
 
+if TYPE_CHECKING:
+    from onyx.llm.interfaces import LLM
+    from onyx.natural_language_processing.utils import BaseTokenizer
+
 
 class ReembedStrategy(enum.Enum):
     # Only the embedder changed; re-embed the same enriched text (tail swapped).
@@ -43,17 +69,39 @@ class ReembedStrategy(enum.Enum):
     AUGMENTATION = "augmentation"
 
 
+@dataclass
+class AugmentationReembedContext:
+    """Everything the AUGMENTATION path needs beyond the embedder. Built once by
+    the port copier (which holds a DB session); `re_embed_chunks` itself stays
+    DB-free. For the FUTURE-RAG-off (strip) case only `future_enable_contextual_rag`
+    is needed; the LLM/tokenizer/budgets are required only when regenerating."""
+
+    future_enable_contextual_rag: bool
+    llm: "LLM | None" = None
+    tokenizer: "BaseTokenizer | None" = None
+    chunk_token_limit: int = 0
+    contextual_rag_reserved_tokens: int = 0
+
+
 def select_reembed_strategy(
     present_ss: SearchSettings, future_ss: SearchSettings
 ) -> ReembedStrategy:
-    """AUGMENTATION when contextual-RAG settings differ (the embedded text
-    changes), otherwise MODEL_ONLY. Model/prefix/normalize/dimension and
-    multipass changes only alter the vectors (or large/mini chunks the port
-    doesn't read), so they fall through to MODEL_ONLY."""
+    """AUGMENTATION when the contextual-RAG *enrichment* differs (the embedded
+    text changes), otherwise MODEL_ONLY. A change in
+    `contextual_rag_model_configuration_id` only matters when contextual RAG is
+    on in present or future — if it is off in both, no enrichment exists in
+    either index, so a stale model-id difference must not force AUGMENTATION.
+    Model/prefix/normalize/dimension and multipass changes only alter the vectors
+    (or large/mini chunks the port doesn't read), so they fall through to
+    MODEL_ONLY."""
+    rag_relevant = present_ss.enable_contextual_rag or future_ss.enable_contextual_rag
     augmentation_changed = (
         present_ss.enable_contextual_rag != future_ss.enable_contextual_rag
-        or present_ss.contextual_rag_model_configuration_id
-        != future_ss.contextual_rag_model_configuration_id
+        or (
+            rag_relevant
+            and present_ss.contextual_rag_model_configuration_id
+            != future_ss.contextual_rag_model_configuration_id
+        )
     )
     return (
         ReembedStrategy.AUGMENTATION
@@ -92,6 +140,15 @@ def recover_embedding_input(chunk: DocumentChunkWithoutVectors) -> str:
     if without_metadata == chunk.content:
         return chunk.content
     return without_metadata + rebuild_semantic_tail(chunk)
+
+
+def _title_prefix(chunk: DocumentChunkWithoutVectors) -> str:
+    """The title prefix the chunker prepends to content (`extract_blurb(title) +
+    RETURN_SEPARATOR`). Approximated with the full stored title; for very long
+    titles the chunker truncates to BLURB_SIZE tokens, so the rebuilt prefix can
+    be marginally longer — accepted imprecision (the title is also encoded
+    separately as `title_vector`)."""
+    return f"{chunk.title}{RETURN_SEPARATOR}" if chunk.title else ""
 
 
 def _stored_chunk_to_doc_aware(
@@ -139,26 +196,26 @@ def re_embed_chunks(
     stored_chunks: list[DocumentChunkWithoutVectors],
     strategy: ReembedStrategy,
     embedder: IndexingEmbedder,
+    augmentation_ctx: AugmentationReembedContext | None = None,
 ) -> list[DocumentChunk]:
     """Re-embed stored chunks under a prebuilt strategy + embedder (no DB access).
 
-    Returns the whole stored chunks as DocumentChunk, in order, with only
-    content_vector and title_vector recomputed (every other field copied through,
-    so the FUTURE write is a faithful copy with new embeddings). Raises
-    NotImplementedError for AUGMENTATION — only model/prefix/dimension changes are
-    supported today.
+    Returns DocumentChunks ready to write to the FUTURE index. For MODEL_ONLY only
+    `content_vector`/`title_vector` change; every other field is copied through.
+    For AUGMENTATION the stored `content`, `doc_summary` and `chunk_context` are
+    also rebuilt under FUTURE settings (`augmentation_ctx` is required, and for
+    FUTURE-RAG-on must carry the contextual LLM). Chunks may span documents, but
+    each document's chunks must ALL be in the same call — the doc-text
+    reconstruction needs the document complete.
     """
     if not stored_chunks:
         return []
     if strategy is ReembedStrategy.AUGMENTATION:
-        # Augmentation re-embed (strip -> re-glue -> re-embed) is the next
-        # increment; the contextual-RAG-on case additionally needs the source
-        # document text, which the stored chunks don't carry, so the port must
-        # supply it. Fail loudly rather than embed a wrong (un-stripped) input.
-        raise NotImplementedError(
-            "Augmentation-change re-embed (contextual-RAG toggle/model) is not "
-            "yet supported; only model/prefix/dimension changes are."
-        )
+        if augmentation_ctx is None:
+            raise ValueError(
+                "AUGMENTATION re-embed requires an AugmentationReembedContext"
+            )
+        return _augmentation_reembed(stored_chunks, embedder, augmentation_ctx)
 
     embed_inputs = [recover_embedding_input(chunk) for chunk in stored_chunks]
     doc_aware_chunks = [
@@ -181,3 +238,133 @@ def re_embed_chunks(
         )
         for stored, index_chunk in zip(stored_chunks, embedded)
     ]
+
+
+def _bare_contents(stored_chunks: list[DocumentChunkWithoutVectors]) -> list[str]:
+    """Strip every stored chunk back to its original (un-augmented) text via the
+    canonical inverse of the indexing-time enrichment."""
+    # Lazy import: opensearch_document_index is a heavy module and only needed on
+    # the AUGMENTATION path; keeps port_reembed's import surface light + cycle-free.
+    from onyx.document_index.opensearch.opensearch_document_index import (
+        _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned,
+    )
+
+    uncleaned = [
+        _convert_retrieved_opensearch_chunk_to_inference_chunk_uncleaned(
+            chunk, None, {}
+        )
+        for chunk in stored_chunks
+    ]
+    cleaned = cleanup_content_for_chunks(uncleaned)
+    return [chunk.content for chunk in cleaned]
+
+
+def _reconstruct_source_document(
+    stored_chunks: list[DocumentChunkWithoutVectors], bare_contents: list[str]
+) -> Document:
+    """Rebuild a minimal Document whose get_text_content() returns the document
+    text reconstructed from its bare chunks (chunk-index order). Used by the
+    contextual LLM to regenerate summaries — see the module docstring on the
+    accepted imprecision of concatenating overlapping chunks."""
+    ordered = sorted(
+        zip(stored_chunks, bare_contents), key=lambda pair: pair[0].chunk_index
+    )
+    doc_text = " ".join(bare for _, bare in ordered if bare)
+    first = stored_chunks[0]
+    return Document(
+        id=first.document_id,
+        source=DocumentSource(first.source_type),
+        semantic_identifier=first.semantic_identifier,
+        title=first.title if first.title is not None else "",
+        sections=[TextSection(text=doc_text)],
+        metadata={},
+    )
+
+
+def _augmentation_reembed(
+    stored_chunks: list[DocumentChunkWithoutVectors],
+    embedder: IndexingEmbedder,
+    ctx: AugmentationReembedContext,
+) -> list[DocumentChunk]:
+    bare_contents = _bare_contents(stored_chunks)
+    future_rag_on = ctx.future_enable_contextual_rag
+    reserved = ctx.contextual_rag_reserved_tokens if future_rag_on else 0
+
+    # One reconstructed Document per document_id — the input may span documents,
+    # and each chunk's enrichment must see only its own document's text.
+    pairs_by_doc: dict[str, list[tuple[DocumentChunkWithoutVectors, str]]] = (
+        defaultdict(list)
+    )
+    for chunk, bare in zip(stored_chunks, bare_contents):
+        pairs_by_doc[chunk.document_id].append((chunk, bare))
+    source_documents = {
+        doc_id: _reconstruct_source_document(
+            [chunk for chunk, _ in pairs], [bare for _, bare in pairs]
+        )
+        for doc_id, pairs in pairs_by_doc.items()
+    }
+
+    # Rebuild each chunk from its bare content under FUTURE enrichment settings.
+    # title_prefix + metadata are unchanged by a RAG toggle, so they are restored;
+    # doc_summary/chunk_context start empty and are filled below when RAG is on.
+    doc_aware_chunks = [
+        DocAwareChunk(
+            chunk_id=chunk.chunk_index,
+            blurb=chunk.blurb,
+            content=bare,
+            source_links=None,
+            image_file_id=None,
+            section_continuation=False,
+            source_document=source_documents[chunk.document_id],
+            title_prefix=_title_prefix(chunk),
+            metadata_suffix_semantic=rebuild_semantic_tail(chunk),
+            metadata_suffix_keyword=chunk.metadata_suffix or "",
+            contextual_rag_reserved_tokens=reserved,
+            doc_summary="",
+            chunk_context="",
+            mini_chunk_texts=None,
+            large_chunk_id=None,
+            large_chunk_reference_ids=[],
+        )
+        for chunk, bare in zip(stored_chunks, bare_contents)
+    ]
+
+    if future_rag_on:
+        if ctx.llm is None or ctx.tokenizer is None:
+            raise ValueError(
+                "contextual-RAG-on re-embed requires an LLM + tokenizer in the context"
+            )
+        # Lazy import to avoid an import cycle with the indexing pipeline.
+        from onyx.indexing.indexing_pipeline import add_contextual_summaries
+
+        # Groups by source_document.id internally, so the mixed-doc input is fine.
+        add_contextual_summaries(
+            chunks=doc_aware_chunks,
+            llm=ctx.llm,
+            tokenizer=ctx.tokenizer,
+            chunk_token_limit=ctx.chunk_token_limit,
+        )
+
+    embedded = embedder.embed_chunks(doc_aware_chunks)
+    if len(embedded) != len(stored_chunks):
+        raise RuntimeError(
+            f"Embedder returned {len(embedded)} chunks for {len(stored_chunks)} inputs."
+        )
+
+    results: list[DocumentChunk] = []
+    for stored, doc_aware, index_chunk in zip(
+        stored_chunks, doc_aware_chunks, embedded
+    ):
+        fields = dict(stored)
+        # The stored (BM25) content, rebuilt under FUTURE enrichment.
+        fields["content"] = generate_enriched_content_for_chunk_text(doc_aware)
+        fields["doc_summary"] = doc_aware.doc_summary
+        fields["chunk_context"] = doc_aware.chunk_context
+        results.append(
+            DocumentChunk(
+                **fields,
+                content_vector=index_chunk.embeddings.full_embedding,
+                title_vector=index_chunk.title_embedding,
+            )
+        )
+    return results

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -8,6 +8,7 @@ from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.llm import can_user_access_llm_provider
+from onyx.db.llm import fetch_default_contextual_rag_model
 from onyx.db.llm import fetch_default_llm_model
 from onyx.db.llm import fetch_default_vision_model
 from onyx.db.llm import fetch_existing_llm_provider
@@ -16,6 +17,7 @@ from onyx.db.llm import fetch_model_configuration_by_id
 from onyx.db.llm import fetch_user_group_ids
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import Persona
+from onyx.db.models import SearchSettings
 from onyx.db.models import User
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM
@@ -345,6 +347,19 @@ def get_llm_for_contextual_rag(model_configuration_id: int) -> LLM:
             model_name=mc.name,
             llm_provider=LLMProviderView.from_model(mc.llm_provider),
         )
+
+
+def get_contextual_rag_llm_for_search_settings(
+    search_settings: SearchSettings,
+) -> LLM | None:
+    """Resolve the contextual-RAG LLM for the given search settings: the explicit
+    model configuration if set, else the tenant default; None when neither exists."""
+    mc_id = search_settings.contextual_rag_model_configuration_id
+    if mc_id is None:
+        with get_session_with_current_tenant() as db_session:
+            mc = fetch_default_contextual_rag_model(db_session)
+        mc_id = mc.id if mc else None
+    return get_llm_for_contextual_rag(mc_id) if mc_id is not None else None
 
 
 def get_default_llm(

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -21,6 +21,7 @@ from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import IndexModelStatus
 from onyx.db.models import User
+from onyx.db.port_attempt import cancel_active_port_attempts
 from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import delete_search_settings
 from onyx.db.search_settings import get_current_search_settings
@@ -118,6 +119,14 @@ def set_new_search_settings(
             db_session=db_session,
         )
 
+        # Cancel in-flight reindex ports for the superseded FUTURE. After the PAST
+        # flip so check_for_port (which only targets the current secondary) won't
+        # enqueue a replacement; the running port task stops at its next batch
+        # boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
+        )
+
     new_search_settings = create_search_settings(
         search_settings=new_search_settings_request, db_session=db_session
     )
@@ -191,6 +200,12 @@ def cancel_new_embedding(
             search_settings=secondary_search_settings,
             new_status=IndexModelStatus.PAST,
             db_session=db_session,
+        )
+
+        # Stop any in-flight reindex port for the canceled FUTURE; the running
+        # task stops at its next batch boundary once it sees CANCELED.
+        cancel_active_port_attempts(
+            db_session, search_settings_id=secondary_search_settings.id
         )
 
         # remove the old index from the vector db

--- a/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
@@ -1,0 +1,378 @@
+"""End-to-end composition test for the reindex port flow (MODEL_ONLY strategy).
+
+Proves the layers COMPOSE with NO PortCopier mocking: check_for_port kickoff ->
+run_port_attempt (real PIT scan of PRESENT + real re-embed under the FUTURE model
+via the local model server + external-versioned write to FUTURE) -> the port-aware
+swap promotion. Asserts the FUTURE chunks carry the seeded content with a freshly
+re-embedded 768-dim vector (different from the seeded placeholder), and that the
+swap flips our FUTURE row to PRESENT and the present-like row to PAST.
+
+Uses real Postgres + Redis + OpenSearch + the indexing model server.
+Restores the dev DB's real current
+SearchSettings row in teardown (this dev DB has a leftover PRESENT row + a stale
+FUTURE row, so we never rely on the live current/secondary settings being ours).
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.access.models import DocumentAccess
+from onyx.background.celery.tasks.docprocessing import port_task
+from onyx.background.celery.tasks.docprocessing.port_task import run_check_for_port
+from onyx.background.celery.tasks.docprocessing.port_task import run_port_attempt
+from onyx.configs.constants import DocumentSource
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.context.search.models import SavedSearchSettings
+from onyx.db import swap_index
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.enums import PortAttemptStatus
+from onyx.db.enums import SwitchoverType
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import IndexAttempt
+from onyx.db.models import PortAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import get_port_attempt
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.constants import DEFAULT_MAX_CHUNK_SIZE
+from onyx.document_index.opensearch.opensearch_document_index import (
+    generate_opensearch_filtered_access_control_list,
+)
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from shared_configs.contextvars import get_current_tenant_id
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import seed_cc_pair_documents
+
+_VECTOR_DIM = 768
+_CHUNKS_PER_DOC = 2
+_NUM_DOCS = 4
+# A constant placeholder vector seeded into PRESENT; the port re-embeds, so the
+# FUTURE vector must differ from this to prove a real embed happened.
+_PLACEHOLDER_VECTOR = [0.123] * _VECTOR_DIM
+# Real sentences so the local embedder produces meaningful, non-degenerate vectors.
+_CHUNK_SENTENCES = [
+    "The migration ports stored chunks from the present index to the future one.",
+    "Each chunk is re-embedded under the new model before it is written.",
+    "External versioning ensures the newest source write wins on a conflict.",
+    "The swap promotes the future settings once every required port succeeds.",
+    "Documents reach the future index only through the reindex port flow.",
+    "A point-in-time scan reads the present chunks without their vectors.",
+    "The embedder runs against the local model server during the port.",
+    "Cursor commits make a crashed or stalled port resume rather than restart.",
+]
+
+
+def _make_chunk(
+    document_id: str,
+    chunk_index: int,
+    content: str,
+    tenant_state: TenantState,
+    last_updated: datetime,
+) -> DocumentChunk:
+    """Minimal PRESENT chunk seeded for the port to scan + re-embed. content is a
+    real sentence; content_vector is the placeholder the port must overwrite."""
+    access = DocumentAccess.build(
+        user_emails=[],
+        user_groups=[],
+        external_user_emails=[],
+        external_user_group_ids=[],
+        is_public=True,
+    )
+    return DocumentChunk(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        title=None,
+        title_vector=None,
+        content=content,
+        content_vector=list(_PLACEHOLDER_VECTOR),
+        source_type=DocumentSource.FILE.value,
+        metadata_list=None,
+        last_updated=last_updated,
+        public=access.is_public,
+        access_control_list=generate_opensearch_filtered_access_control_list(access),
+        hidden=False,
+        global_boost=0,
+        semantic_identifier=f"semantic-{document_id}",
+        image_file_id=None,
+        source_links=None,
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        document_sets=None,
+        user_projects=None,
+        primary_owners=None,
+        secondary_owners=None,
+        tenant_id=tenant_state,
+    )
+
+
+def _make_saved_settings(
+    *,
+    index_name: str,
+    use_port_flow: bool,
+    switchover_type: SwitchoverType,
+) -> SavedSearchSettings:
+    """nomic MODEL_ONLY settings (contextual RAG off, provider None -> local
+    model server)."""
+    return SavedSearchSettings(
+        model_name="nomic-ai/nomic-embed-text-v1",
+        model_dim=_VECTOR_DIM,
+        normalize=True,
+        query_prefix=ASYM_QUERY_PREFIX,
+        passage_prefix=ASYM_PASSAGE_PREFIX,
+        provider_type=None,
+        index_name=index_name,
+        multipass_indexing=False,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+        reduced_dimension=None,
+        enable_contextual_rag=False,
+        contextual_rag_llm_name=None,
+        contextual_rag_llm_provider=None,
+        switchover_type=switchover_type,
+        use_port_flow=use_port_flow,
+    )
+
+
+def _create_os_index(index_name: str) -> OpenSearchIndexClient:
+    client = OpenSearchIndexClient(index_name=index_name)
+    mappings = DocumentSchema.get_document_schema(
+        vector_dimension=_VECTOR_DIM, multitenant=False
+    )
+    settings = DocumentSchema.get_index_settings_based_on_environment()
+    client.create_index(mappings=mappings, settings=settings)
+    return client
+
+
+def test_port_flow_end_to_end(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    tenant_state = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+    present_index_name = f"test_e2e_present_{uuid4().hex[:8]}"
+    future_index_name = f"test_e2e_future_{uuid4().hex[:8]}"
+
+    # The dev DB's real current row — restore this in teardown.
+    original_present_id = get_current_search_settings(db_session).id
+
+    pair: ConnectorCredentialPair | None = None
+    present_like_id: int | None = None
+    future_id: int | None = None
+    present_client: OpenSearchIndexClient | None = None
+    future_client: OpenSearchIndexClient | None = None
+    promoted = False
+
+    try:
+        # --- SETUP: cc_pair + docs ---
+        pair = make_cc_pair(db_session)
+        doc_ids = seed_cc_pair_documents(
+            db_session, pair, _NUM_DOCS, prefix="e2edoc-", unique=True
+        )
+
+        # --- SETUP: SearchSettings (present-like PAST + FUTURE) ---
+        present_like = create_search_settings(
+            _make_saved_settings(
+                index_name=present_index_name,
+                use_port_flow=False,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.PAST,
+        )
+        present_like_id = present_like.id
+        future = create_search_settings(
+            _make_saved_settings(
+                index_name=future_index_name,
+                use_port_flow=True,
+                switchover_type=SwitchoverType.REINDEX,
+            ),
+            db_session,
+            status=IndexModelStatus.FUTURE,
+        )
+        future_id = future.id
+
+        # --- SETUP: OpenSearch indices + seed PRESENT chunks ---
+        present_client = _create_os_index(present_index_name)
+        future_client = _create_os_index(future_index_name)
+
+        seeded_ts = datetime.now(timezone.utc).replace(microsecond=0)
+        seeded_content: dict[tuple[str, int], str] = {}
+        chunks: list[DocumentChunk] = []
+        for d_i, doc_id in enumerate(doc_ids):
+            for c_i in range(_CHUNKS_PER_DOC):
+                content = _CHUNK_SENTENCES[
+                    (d_i * _CHUNKS_PER_DOC + c_i) % len(_CHUNK_SENTENCES)
+                ]
+                seeded_content[(doc_id, c_i)] = content
+                chunks.append(
+                    _make_chunk(doc_id, c_i, content, tenant_state, seeded_ts)
+                )
+        present_client.bulk_index_documents(documents=chunks, tenant_state=tenant_state)
+        present_client.refresh_index()
+
+        # --- KICKOFF: check_for_port scoped to our FUTURE + cc_pair ---
+        celery_app = MagicMock()
+        with (
+            patch.object(
+                port_task,
+                "get_secondary_search_settings",
+                lambda db, *_, **__: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                port_task,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+        ):
+            result = run_check_for_port(get_current_tenant_id(), celery_app)
+        assert result == 1
+        attempt_id = celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"]
+
+        # --- PORT: real PortCopier (re-embed via model server) ---
+        # get_current_search_settings is patched to our present-like row only
+        # (the dev DB's live current row has no real model / index).
+        with patch.object(
+            port_task,
+            "get_current_search_settings",
+            lambda db: db.get(SearchSettings, present_like_id),
+        ):
+            run_port_attempt(attempt_id)
+
+        # --- ASSERT PORT ---
+        db_session.expire_all()
+        attempt = get_port_attempt(db_session, attempt_id)
+        assert attempt is not None
+        assert attempt.status == PortAttemptStatus.SUCCESS
+        assert attempt.last_processed_doc_id == max(doc_ids)
+        assert attempt.docs_ported == _NUM_DOCS
+
+        future_client.refresh_index()
+        for doc_id in doc_ids:
+            for c_i in range(_CHUNKS_PER_DOC):
+                chunk_id = get_opensearch_doc_chunk_id(
+                    tenant_state=tenant_state,
+                    document_id=doc_id,
+                    chunk_index=c_i,
+                    max_chunk_size=DEFAULT_MAX_CHUNK_SIZE,
+                )
+                fetched = future_client.get_document(document_chunk_id=chunk_id)
+                assert fetched.content == seeded_content[(doc_id, c_i)]
+                assert len(fetched.content_vector) == _VECTOR_DIM
+                # The port re-embedded: the vector is NOT the seeded placeholder.
+                assert fetched.content_vector != _PLACEHOLDER_VECTOR
+
+        # --- SWAP ---
+        port_row = get_port_attempt(db_session, attempt_id)
+        assert port_row is not None and port_row.time_completed is not None
+        # A real (non-seed) FUTURE index attempt landing after the port.
+        index_started = port_row.time_completed + timedelta(seconds=1)
+        db_session.add(
+            IndexAttempt(
+                connector_credential_pair_id=pair.id,
+                search_settings_id=future_id,
+                from_beginning=False,
+                status=IndexingStatus.SUCCESS,
+                is_synthetic_seed=False,
+                time_started=index_started,
+                time_updated=index_started,
+            )
+        )
+        db_session.commit()
+
+        # check_and_perform_index_swap fetches the FUTURE row via
+        # get_secondary_search_settings (a stale FUTURE row exists in this dev
+        # DB), and get_all_document_indices would touch real Vespa/OpenSearch
+        # provisioning -> patch both in the swap_index namespace. The deferred
+        # metadata-sync backlog is 0 in this dev DB; if it weren't, the swap
+        # criterion would block, so we don't need to patch the count.
+        # _required_cc_pairs_for_switchover gates the swap on EVERY indexable
+        # cc_pair in the dev DB (via fetch_indexable...), none of which have a
+        # port for our FUTURE -> scope the required set to our cc_pair only.
+        with (
+            patch.object(
+                swap_index,
+                "get_secondary_search_settings",
+                lambda db: db.get(SearchSettings, future_id),
+            ),
+            patch.object(
+                swap_index,
+                "fetch_indexable_standard_connector_credential_pair_ids",
+                lambda *_, **__: [pair.id],
+            ),
+            patch.object(swap_index, "get_all_document_indices", return_value=[]),
+        ):
+            old_settings = swap_index.check_and_perform_index_swap(db_session)
+
+        assert old_settings is not None
+        promoted = True
+
+        # --- ASSERT SWAP ---
+        db_session.expire_all()
+        future_row = db_session.get(SearchSettings, future_id)
+        present_like_row = db_session.get(SearchSettings, present_like_id)
+        assert future_row is not None and present_like_row is not None
+        assert future_row.status == IndexModelStatus.PRESENT
+        assert present_like_row.status == IndexModelStatus.PAST
+    finally:
+        db_session.rollback()
+        # Restore the dev DB's swap state FIRST: original current -> PRESENT, our
+        # promoted row off PRESENT (so get_current_search_settings is correct
+        # again). _perform_index_swap also set original_present_id -> PAST.
+        if promoted and original_present_id is not None:
+            db_session.query(SearchSettings).filter(
+                SearchSettings.id == original_present_id
+            ).update(
+                {SearchSettings.status: IndexModelStatus.PRESENT},
+                synchronize_session="fetch",
+            )
+            if future_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == future_id
+                ).update(
+                    {SearchSettings.status: IndexModelStatus.PAST},
+                    synchronize_session="fetch",
+                )
+            db_session.commit()
+
+        # PortAttempt + IndexAttempt before SearchSettings before cc_pair.
+        if pair is not None:
+            db_session.query(PortAttempt).filter(
+                PortAttempt.cc_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.query(IndexAttempt).filter(
+                IndexAttempt.connector_credential_pair_id == pair.id
+            ).delete(synchronize_session="fetch")
+            db_session.commit()
+
+        for ss_id in (future_id, present_like_id):
+            if ss_id is not None:
+                db_session.query(SearchSettings).filter(
+                    SearchSettings.id == ss_id
+                ).delete(synchronize_session="fetch")
+        db_session.commit()
+
+        if pair is not None:
+            cleanup_cc_pair(db_session, pair)
+
+        for client in (present_client, future_client):
+            if client is not None:
+                try:
+                    client.delete_index()
+                except Exception:
+                    pass
+                finally:
+                    client.close()

--- a/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
+++ b/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
@@ -16,18 +16,15 @@ from collections.abc import Generator
 from datetime import datetime
 from datetime import timedelta
 from unittest.mock import patch
-from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
-from onyx.context.search.models import SavedSearchSettings
 from onyx.db import swap_index
 from onyx.db.document import mark_document_synced_secondary_pending
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingStatus
-from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import SwitchoverType
 from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.models import ConnectorCredentialPair
@@ -38,14 +35,14 @@ from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
-from onyx.db.search_settings import create_search_settings
-from onyx.db.search_settings import get_current_search_settings
 from onyx.db.swap_index import _port_swap_ready
 from onyx.db.swap_index import _required_cc_pairs_for_switchover
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.kg.models import KGStage
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
 
 _PENDING_DOC_PREFIX = "swapdoc-"
 
@@ -56,30 +53,13 @@ def cc_pair_and_future(
     tenant_context: None,  # noqa: ARG001
 ) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
     pair = make_cc_pair(db_session)
-    present = get_current_search_settings(db_session)
-    saved = SavedSearchSettings.from_db_model(present).model_copy(
-        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
-    )
-    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
-    future_id = future.id
+    future_id = make_future_search_settings(db_session).id
     try:
         yield pair, future_id
     finally:
-        db_session.rollback()
-        db_session.query(DbDocument).filter(
-            DbDocument.id.like(f"{_PENDING_DOC_PREFIX}%")
-        ).delete(synchronize_session="fetch")
-        db_session.query(IndexAttempt).filter(
-            IndexAttempt.connector_credential_pair_id == pair.id
-        ).delete(synchronize_session="fetch")
-        db_session.query(PortAttempt).filter(
-            PortAttempt.search_settings_id == future_id
-        ).delete(synchronize_session="fetch")
-        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
-            synchronize_session="fetch"
+        cleanup_cc_pair_and_future(
+            db_session, pair, future_id, doc_prefix=_PENDING_DOC_PREFIX
         )
-        db_session.commit()
-        cleanup_cc_pair(db_session, pair)
 
 
 def _make_success_port(db_session: Session, cc_pair_id: int, ss_id: int) -> datetime:

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -43,6 +43,7 @@ from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_as_synced
 from onyx.db.document import mark_document_synced_secondary_pending
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
 from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import PortAttemptStatus
@@ -55,10 +56,10 @@ from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pai
 from onyx.db.index_attempt import mock_successful_index_attempt
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
-from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import IndexAttempt
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
+from onyx.db.port_attempt import cancel_active_port_attempts
 from onyx.db.port_attempt import commit_port_cursor
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import get_active_port_attempt
@@ -74,30 +75,12 @@ from onyx.indexing.port_reembed import ReembedStrategy
 from onyx.kg.models import KGStage
 from shared_configs.contextvars import get_current_tenant_id
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
-
-
-def _seed_cc_pair_documents(
-    db_session: Session, cc_pair: ConnectorCredentialPair, count: int
-) -> list[str]:
-    """Create `count` documents linked to the cc_pair; returns their ids, sorted."""
-    doc_ids = [f"portdoc-{i:03d}" for i in range(1, count + 1)]
-    for doc_id in doc_ids:
-        db_session.add(
-            DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
-        )
-    db_session.flush()
-    for doc_id in doc_ids:
-        db_session.add(
-            DocumentByConnectorCredentialPair(
-                id=doc_id,
-                connector_id=cc_pair.connector_id,
-                credential_id=cc_pair.credential_id,
-                has_been_indexed=True,
-            )
-        )
-    db_session.commit()
-    return doc_ids
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
+from tests.external_dependency_unit.indexing_helpers import (
+    seed_cc_pair_documents as _seed_cc_pair_documents,
+)
 
 
 def _run_check_for_port(
@@ -302,24 +285,61 @@ def cc_pair_and_future(
     """A cc_pair plus an isolated FUTURE SearchSettings (unique index_name) so the
     global count/cursor helpers see only this test's attempts."""
     pair = make_cc_pair(db_session)
-    present = get_current_search_settings(db_session)
-    saved = SavedSearchSettings.from_db_model(present).model_copy(
-        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
-    )
-    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
-    future_id = future.id
+    future_id = make_future_search_settings(db_session).id
     try:
         yield pair, future_id
     finally:
-        db_session.rollback()
-        db_session.query(IndexAttempt).filter(
-            IndexAttempt.connector_credential_pair_id == pair.id
-        ).delete(synchronize_session="fetch")
-        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
-            synchronize_session="fetch"
+        cleanup_cc_pair_and_future(db_session, pair, future_id)
+
+
+def test_use_port_flow_default_and_round_trip(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """use_port_flow persists as False via the server default when the saved model
+    omits it, and an explicit True round-trips through a fresh read + the
+    SavedSearchSettings mapper the port flow uses. PAST status avoids the
+    PRESENT-uniqueness + concurrent-FUTURE collisions a round-trip test would hit.
+    """
+
+    def _saved() -> SavedSearchSettings:
+        # Minimal explicit settings (not a clone of the polluted live row) so the
+        # omitted use_port_flow falls through to the server default.
+        return SavedSearchSettings(
+            model_name="test-port-flow-model",
+            model_dim=128,
+            normalize=True,
+            query_prefix="",
+            passage_prefix="",
+            provider_type=None,
+            multipass_indexing=False,
+            embedding_precision=EmbeddingPrecision.FLOAT,
+            index_name=f"test_port_flow_{uuid4().hex[:8]}",
+            enable_contextual_rag=False,
         )
+
+    default_id = create_search_settings(
+        _saved(), db_session, status=IndexModelStatus.PAST
+    ).id
+    true_id = create_search_settings(
+        _saved().model_copy(update={"use_port_flow": True}),
+        db_session,
+        status=IndexModelStatus.PAST,
+    ).id
+    try:
+        db_session.expire_all()
+        default_fresh = db_session.get(SearchSettings, default_id)
+        assert default_fresh is not None and default_fresh.use_port_flow is False
+        true_fresh = db_session.get(SearchSettings, true_id)
+        assert true_fresh is not None and true_fresh.use_port_flow is True
+        # Rehydrate through the pydantic mapper the port flow reads through.
+        assert SavedSearchSettings.from_db_model(true_fresh).use_port_flow is True
+    finally:
+        for row_id in (default_id, true_id):
+            row = db_session.get(SearchSettings, row_id)
+            if row is not None:
+                db_session.delete(row)
         db_session.commit()
-        cleanup_cc_pair(db_session, pair)
 
 
 def test_create_synthetic_seed_attempt(
@@ -621,6 +641,46 @@ def test_run_port_attempt_stops_when_canceled(
     assert row.status == PortAttemptStatus.CANCELED
     assert row.last_processed_doc_id == doc_ids[INDEX_BATCH_SIZE - 1]
     assert row.docs_ported == INDEX_BATCH_SIZE
+
+
+def test_cancel_active_port_attempts_on_supersede(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Superseding a FUTURE cancels its active (NOT_STARTED/IN_PROGRESS) port
+    attempts — the running task then stops at its next batch — while terminal
+    attempts are left untouched."""
+    cc_pair, future_id = cc_pair_and_future
+
+    active = create_port_attempt(db_session, cc_pair.id, future_id)
+    mark_port_in_progress(db_session, active.id)
+    # a terminal attempt for the same pair/future must be left alone
+    db_session.add(
+        PortAttempt(
+            cc_pair_id=cc_pair.id,
+            search_settings_id=future_id,
+            status=PortAttemptStatus.SUCCESS,
+        )
+    )
+    db_session.commit()
+
+    canceled = cancel_active_port_attempts(db_session, search_settings_id=future_id)
+    assert canceled == 1
+
+    db_session.expire_all()
+    active_row = db_session.get(PortAttempt, active.id)
+    assert active_row is not None
+    assert active_row.status == PortAttemptStatus.CANCELED
+    assert active_row.time_completed is not None
+    # the terminal SUCCESS is preserved (first-terminal-write-wins)
+    successes = (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.search_settings_id == future_id,
+            PortAttempt.status == PortAttemptStatus.SUCCESS,
+        )
+        .count()
+    )
+    assert successes == 1
 
 
 def test_run_port_attempt_exits_when_cc_pair_deleting(

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -482,7 +482,9 @@ def test_copy_present_chunks_to_future_orchestration() -> None:
     with patch.object(
         port_copy,
         "re_embed_chunks",
-        side_effect=lambda chunks, _strategy, _embedder: [f"re:{c}" for c in chunks],
+        side_effect=lambda chunks, _strategy, _embedder, **_kwargs: [
+            f"re:{c}" for c in chunks
+        ],
     ) as mock_reembed:
         written = copy_present_chunks_to_future(
             present_client, future_index, ["d1", "d2"], strategy, embedder

--- a/backend/tests/external_dependency_unit/db/test_sync_priority.py
+++ b/backend/tests/external_dependency_unit/db/test_sync_priority.py
@@ -10,7 +10,6 @@ backlog drains) plus the expires= on every enqueue. The Celery send_task is mock
 
 from collections.abc import Generator
 from unittest.mock import MagicMock
-from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
@@ -19,7 +18,6 @@ from onyx.background.celery.tasks.vespa.document_sync import (
     generate_document_sync_tasks,
 )
 from onyx.configs.constants import OnyxCeleryPriority
-from onyx.context.search.models import SavedSearchSettings
 from onyx.db.document import (
     construct_document_id_select_by_needs_sync_or_secondary_pending,
 )
@@ -27,20 +25,16 @@ from onyx.db.document import count_documents_by_needs_sync
 from onyx.db.document import count_documents_by_needs_sync_or_secondary_pending
 from onyx.db.document import mark_document_as_modified
 from onyx.db.document import mark_document_synced_secondary_pending
-from onyx.db.enums import IndexModelStatus
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
-from onyx.db.models import PortAttempt
-from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import any_future_port_in_progress
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
-from onyx.db.search_settings import create_search_settings
-from onyx.db.search_settings import get_current_search_settings
 from onyx.kg.models import KGStage
-from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_future_search_settings
 
 _DOC_PREFIX = "syncdoc-"
 
@@ -51,27 +45,11 @@ def cc_pair_and_future(
     tenant_context: None,  # noqa: ARG001
 ) -> Generator[tuple[ConnectorCredentialPair, int], None, None]:
     pair = make_cc_pair(db_session)
-    present = get_current_search_settings(db_session)
-    saved = SavedSearchSettings.from_db_model(present).model_copy(
-        update={"index_name": f"test_future_{uuid4().hex[:8]}"}
-    )
-    future = create_search_settings(saved, db_session, status=IndexModelStatus.FUTURE)
-    future_id = future.id
+    future_id = make_future_search_settings(db_session).id
     try:
         yield pair, future_id
     finally:
-        db_session.rollback()
-        db_session.query(DbDocument).filter(
-            DbDocument.id.like(f"{_DOC_PREFIX}%")
-        ).delete(synchronize_session="fetch")
-        db_session.query(PortAttempt).filter(
-            PortAttempt.search_settings_id == future_id
-        ).delete(synchronize_session="fetch")
-        db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
-            synchronize_session="fetch"
-        )
-        db_session.commit()
-        cleanup_cc_pair(db_session, pair)
+        cleanup_cc_pair_and_future(db_session, pair, future_id, doc_prefix=_DOC_PREFIX)
 
 
 def _make_doc(db_session: Session, doc_id: str) -> None:

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.configs.constants import DocumentSource
+from onyx.configs.constants import RETURN_SEPARATOR
 from onyx.connectors.models import convert_metadata_dict_to_list_of_strings
 from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
 from onyx.db.models import SearchSettings
@@ -29,7 +30,10 @@ from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocAwareChunk
 from onyx.indexing.models import IndexChunk
+from onyx.indexing.port_reembed import _bare_contents
+from onyx.indexing.port_reembed import _reconstruct_source_document
 from onyx.indexing.port_reembed import _stored_chunk_to_doc_aware
+from onyx.indexing.port_reembed import AugmentationReembedContext
 from onyx.indexing.port_reembed import re_embed_chunks
 from onyx.indexing.port_reembed import rebuild_semantic_tail
 from onyx.indexing.port_reembed import recover_embedding_input
@@ -42,13 +46,16 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 def _stored_chunk(
     content: str,
     *,
+    document_id: str = "doc-1",
     metadata_suffix: str | None = None,
     metadata_list: list[str] | None = None,
     title: str | None = "Doc Title",
     chunk_index: int = 0,
+    doc_summary: str = "",
+    chunk_context: str = "",
 ) -> DocumentChunkWithoutVectors:
     return DocumentChunkWithoutVectors(
-        document_id="doc-1",
+        document_id=document_id,
         chunk_index=chunk_index,
         content=content,
         source_type=DocumentSource.FILE.value,
@@ -60,10 +67,37 @@ def _stored_chunk(
         global_boost=0,
         semantic_identifier="Doc semantic id",
         blurb="blurb",
-        doc_summary="",
-        chunk_context="",
+        doc_summary=doc_summary,
+        chunk_context=chunk_context,
         tenant_id=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
     )
+
+
+def _vec(text: str) -> list[float]:
+    """A deterministic, content-dependent fake embedding: different input text
+    yields a different vector, so a test can prove the embedding input changed."""
+    return [float(len(text)), float(sum(ord(ch) for ch in text) % 1000)]
+
+
+class _ContentVecEmbedder:
+    """Fake embedder whose vectors depend on the actual embedding input, so tests
+    can assert that stripping/re-enriching changed what got embedded."""
+
+    def embed_chunks(self, chunks: list[DocAwareChunk]) -> list[IndexChunk]:
+        out = []
+        for chunk in chunks:
+            text = generate_enriched_content_for_chunk_embedding(chunk)
+            title = chunk.source_document.get_title_for_document_index()
+            out.append(
+                IndexChunk.model_construct(
+                    **shallow_model_dump(chunk),
+                    embeddings=ChunkEmbedding(
+                        full_embedding=_vec(text), mini_chunk_embeddings=[]
+                    ),
+                    title_embedding=_vec(title) if title else None,
+                )
+            )
+        return out
 
 
 def _ss(
@@ -83,12 +117,30 @@ def test_select_reembed_strategy() -> None:
         select_reembed_strategy(base, _ss(enable_contextual_rag=True))
         is ReembedStrategy.AUGMENTATION
     )
+    # RAG on in both, model changed -> AUGMENTATION (re-enrich under new LLM)
     assert (
         select_reembed_strategy(
             _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
             _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=2),
         )
         is ReembedStrategy.AUGMENTATION
+    )
+    # RAG on in both, same model -> only the embedder could differ -> MODEL_ONLY
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=True, contextual_rag_model_configuration_id=1),
+        )
+        is ReembedStrategy.MODEL_ONLY
+    )
+    # RAG OFF in both: a stale model-id difference is irrelevant (no enrichment in
+    # either index) -> MODEL_ONLY, not a spurious AUGMENTATION.
+    assert (
+        select_reembed_strategy(
+            _ss(enable_contextual_rag=False, contextual_rag_model_configuration_id=1),
+            _ss(enable_contextual_rag=False, contextual_rag_model_configuration_id=2),
+        )
+        is ReembedStrategy.MODEL_ONLY
     )
 
 
@@ -166,11 +218,200 @@ def test_to_doc_aware_chunk_feeds_embed_input() -> None:
     assert da.source_document.get_title_for_document_index() is None
 
 
-def test_re_embed_augmentation_not_implemented() -> None:
-    with pytest.raises(NotImplementedError):
+def test_augmentation_requires_context() -> None:
+    with pytest.raises(ValueError):
         re_embed_chunks(
             [_stored_chunk("body")], ReembedStrategy.AUGMENTATION, MagicMock()
         )
+
+
+def _augmented_stored_chunk() -> tuple[DocumentChunkWithoutVectors, str]:
+    """A stored chunk whose content carries title prefix + doc summary +
+    chunk context + keyword metadata tail. Returns (chunk, bare_text)."""
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    _semantic, keyword = _get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    title = "My Title"
+    doc_summary = "DOCSUM. "
+    chunk_context = " CTX."
+    bare = "the body text"
+    content = f"{title}{RETURN_SEPARATOR}{doc_summary}{bare}{chunk_context}{keyword}"
+    chunk = _stored_chunk(
+        content,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+        title=title,
+        doc_summary=doc_summary,
+        chunk_context=chunk_context,
+    )
+    return chunk, bare
+
+
+def test_strip_stored_chunk_to_bare_content() -> None:
+    """cleanup strips title prefix, metadata tail, doc summary and chunk context,
+    leaving only the original chunk body."""
+    chunk, bare = _augmented_stored_chunk()
+    assert _bare_contents([chunk]) == [bare]
+
+
+def test_reconstruct_document_text_from_chunks() -> None:
+    """Doc text is reconstructed by joining the bare chunks in chunk-index order."""
+    c0 = _stored_chunk("first part", chunk_index=0, title="T")
+    c1 = _stored_chunk("second part", chunk_index=1, title="T")
+    # pass out of order to prove the helper sorts by chunk_index
+    doc = _reconstruct_source_document([c1, c0], ["second part", "first part"])
+    assert doc.id == "doc-1"
+    assert doc.get_text_content() == "first part second part"
+    assert doc.get_title_for_document_index() == "T"
+
+
+def test_augmentation_strip_off_reembeds_bare() -> None:
+    """RAG on -> off: the FUTURE chunk drops doc_summary/chunk_context from both
+    the stored content and the embedding input, and clears those fields. The
+    embedding input (hence the vector) differs from the MODEL_ONLY (Tier-1)
+    input, which keeps the augmentation glued in."""
+    chunk, bare = _augmented_stored_chunk()
+    keyword = chunk.metadata_suffix or ""
+    semantic = rebuild_semantic_tail(chunk)
+
+    ctx = AugmentationReembedContext(future_enable_contextual_rag=False)
+    [result] = re_embed_chunks(
+        [chunk],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    # stored (BM25) content rebuilt without the contextual-RAG augmentation
+    assert result.content == f"My Title{RETURN_SEPARATOR}{bare}{keyword}"
+    assert result.doc_summary == ""
+    assert result.chunk_context == ""
+
+    # the embedded text was title_prefix + bare + semantic tail (no summary/context)
+    strip_embed_input = f"My Title{RETURN_SEPARATOR}{bare}{semantic}"
+    assert result.content_vector == _vec(strip_embed_input)
+    # ... and that genuinely differs from the Tier-1 (MODEL_ONLY) embed input,
+    # which keeps the doc summary + chunk context.
+    tier1_embed_input = recover_embedding_input(chunk)
+    assert result.content_vector != _vec(tier1_embed_input)
+    # non-augmentation fields are preserved
+    assert result.metadata_suffix == keyword
+    assert result.title == chunk.title
+
+
+def test_augmentation_enrich_on_generates_and_reembeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RAG off -> on: the bare chunk is re-enriched under the FUTURE LLM (stubbed
+    here), and the new doc_summary/chunk_context land in the stored content, the
+    stored fields, and the embedding input. The vector differs from the strip
+    path because the embedded text now carries the regenerated summaries."""
+
+    # Stub the contextual-RAG enrichment (the LLM call is the indexing pipeline's
+    # own tested surface; here we prove the port's strip -> enrich -> re-glue ->
+    # embed wiring). The lazy import inside _augmentation_reembed resolves this.
+    def _fake_enrich(
+        chunks: list[DocAwareChunk], **_kwargs: object
+    ) -> list[DocAwareChunk]:
+        for c in chunks:
+            c.doc_summary = "SUMMARY. "
+            c.chunk_context = " CONTEXT."
+        return chunks
+
+    monkeypatch.setattr(
+        "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
+    )
+
+    bare = "the body text"
+    metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
+    _semantic, keyword = _get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    # PRESENT had RAG off: no doc_summary/chunk_context glued in.
+    chunk = _stored_chunk(
+        f"My Title{RETURN_SEPARATOR}{bare}{keyword}",
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+        title="My Title",
+    )
+    semantic = rebuild_semantic_tail(chunk)
+
+    ctx = AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=MagicMock(),
+        tokenizer=MagicMock(),
+        chunk_token_limit=128,
+        contextual_rag_reserved_tokens=512,
+    )
+    [result] = re_embed_chunks(
+        [chunk],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    # the regenerated summaries are stored both as fields and glued into content
+    assert result.doc_summary == "SUMMARY. "
+    assert result.chunk_context == " CONTEXT."
+    assert (
+        result.content == f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{keyword}"
+    )
+
+    # the embedded text carries the new summaries; vector differs from strip-only
+    enrich_embed_input = f"My Title{RETURN_SEPARATOR}SUMMARY. {bare} CONTEXT.{semantic}"
+    assert result.content_vector == _vec(enrich_embed_input)
+    strip_embed_input = f"My Title{RETURN_SEPARATOR}{bare}{semantic}"
+    assert result.content_vector != _vec(strip_embed_input)
+
+
+def test_augmentation_mixed_docs_enrich_per_document(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One AUGMENTATION call may span documents (the port batches them): each
+    chunk must be enriched against its OWN document's reconstructed text, and
+    output order must match input order."""
+
+    def _fake_enrich(
+        chunks: list[DocAwareChunk], **_kwargs: object
+    ) -> list[DocAwareChunk]:
+        for c in chunks:
+            doc = c.source_document
+            c.doc_summary = f"[{doc.id}:{doc.get_text_content()}] "
+        return chunks
+
+    monkeypatch.setattr(
+        "onyx.indexing.indexing_pipeline.add_contextual_summaries", _fake_enrich
+    )
+
+    a0 = _stored_chunk("a-first", document_id="doc-a", chunk_index=0, title=None)
+    a1 = _stored_chunk("a-second", document_id="doc-a", chunk_index=1, title=None)
+    b0 = _stored_chunk("b-only", document_id="doc-b", chunk_index=0, title=None)
+
+    ctx = AugmentationReembedContext(
+        future_enable_contextual_rag=True,
+        llm=MagicMock(),
+        tokenizer=MagicMock(),
+        chunk_token_limit=128,
+        contextual_rag_reserved_tokens=512,
+    )
+    # interleaved on purpose: the per-doc grouping must not rely on input order
+    results = re_embed_chunks(
+        [a0, b0, a1],
+        ReembedStrategy.AUGMENTATION,
+        cast(IndexingEmbedder, _ContentVecEmbedder()),
+        augmentation_ctx=ctx,
+    )
+
+    assert [(r.document_id, r.chunk_index) for r in results] == [
+        ("doc-a", 0),
+        ("doc-b", 0),
+        ("doc-a", 1),
+    ]
+    # each chunk saw its own document's reconstructed text, not the whole batch's
+    assert results[0].doc_summary == "[doc-a:a-first a-second] "
+    assert results[1].doc_summary == "[doc-b:b-only] "
+    assert results[2].doc_summary == "[doc-a:a-first a-second] "
 
 
 def test_re_embed_empty_returns_empty() -> None:

--- a/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
+++ b/backend/tests/external_dependency_unit/indexing/test_port_reembed.py
@@ -17,6 +17,11 @@ import pytest
 
 from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import RETURN_SEPARATOR
+from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
+from onyx.configs.model_configs import ASYM_QUERY_PREFIX
+from onyx.configs.model_configs import DEFAULT_DOCUMENT_ENCODER_MODEL
+from onyx.configs.model_configs import DOC_EMBEDDING_DIM
+from onyx.configs.model_configs import NORMALIZE_EMBEDDINGS
 from onyx.connectors.models import convert_metadata_dict_to_list_of_strings
 from onyx.connectors.models import convert_metadata_list_of_strings_to_dict
 from onyx.db.models import SearchSettings
@@ -26,6 +31,7 @@ from onyx.document_index.chunk_content_enrichment import (
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
 from onyx.indexing.chunker import _get_metadata_suffix_for_document_index
+from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.embedder import IndexingEmbedder
 from onyx.indexing.models import ChunkEmbedding
 from onyx.indexing.models import DocAwareChunk
@@ -269,8 +275,8 @@ def test_reconstruct_document_text_from_chunks() -> None:
 def test_augmentation_strip_off_reembeds_bare() -> None:
     """RAG on -> off: the FUTURE chunk drops doc_summary/chunk_context from both
     the stored content and the embedding input, and clears those fields. The
-    embedding input (hence the vector) differs from the MODEL_ONLY (Tier-1)
-    input, which keeps the augmentation glued in."""
+    embedding input (hence the vector) differs from the MODEL_ONLY input, which
+    keeps the augmentation glued in."""
     chunk, bare = _augmented_stored_chunk()
     keyword = chunk.metadata_suffix or ""
     semantic = rebuild_semantic_tail(chunk)
@@ -291,10 +297,10 @@ def test_augmentation_strip_off_reembeds_bare() -> None:
     # the embedded text was title_prefix + bare + semantic tail (no summary/context)
     strip_embed_input = f"My Title{RETURN_SEPARATOR}{bare}{semantic}"
     assert result.content_vector == _vec(strip_embed_input)
-    # ... and that genuinely differs from the Tier-1 (MODEL_ONLY) embed input,
-    # which keeps the doc summary + chunk context.
-    tier1_embed_input = recover_embedding_input(chunk)
-    assert result.content_vector != _vec(tier1_embed_input)
+    # ... and that genuinely differs from the MODEL_ONLY embed input, which
+    # keeps the doc summary + chunk context.
+    model_only_embed_input = recover_embedding_input(chunk)
+    assert result.content_vector != _vec(model_only_embed_input)
     # non-augmentation fields are preserved
     assert result.metadata_suffix == keyword
     assert result.title == chunk.title
@@ -414,14 +420,10 @@ def test_augmentation_mixed_docs_enrich_per_document(
     assert results[2].doc_summary == "[doc-a:a-first a-second] "
 
 
-def test_re_embed_empty_returns_empty() -> None:
-    assert re_embed_chunks([], ReembedStrategy.MODEL_ONLY, MagicMock()) == []
-
-
 def test_re_embed_preserves_all_fields_swaps_only_vectors() -> None:
     """re_embed_chunks returns the whole stored chunk as a DocumentChunk with only
     content_vector/title_vector recomputed — every other field is copied through
-    (so the FUTURE write is a faithful copy with new embeddings)."""
+    (so the FUTURE write is a faithful copy with new embeddings). Empty in -> out."""
     metadata_list = convert_metadata_dict_to_list_of_strings({"author": "Jane"})
     stored = _stored_chunk(
         "body text", title="My Title", metadata_list=metadata_list, chunk_index=3
@@ -441,9 +443,10 @@ def test_re_embed_preserves_all_fields_swaps_only_vectors() -> None:
                 for chunk in chunks
             ]
 
-    [result] = re_embed_chunks(
-        [stored], ReembedStrategy.MODEL_ONLY, cast(IndexingEmbedder, _FakeEmbedder())
-    )
+    embedder = cast(IndexingEmbedder, _FakeEmbedder())
+    assert re_embed_chunks([], ReembedStrategy.MODEL_ONLY, embedder) == []
+
+    [result] = re_embed_chunks([stored], ReembedStrategy.MODEL_ONLY, embedder)
 
     # only the two vectors are new
     assert result.content_vector == fake_cv
@@ -451,3 +454,47 @@ def test_re_embed_preserves_all_fields_swaps_only_vectors() -> None:
     # every other field is the stored chunk's, unchanged
     for field in DocumentChunkWithoutVectors.model_fields:
         assert getattr(result, field) == getattr(stored, field), field
+
+
+def test_model_only_reembed_vector_differs_from_naive_stored_content() -> None:
+    """With a REAL embedder, the MODEL_ONLY path embeds the recovered input
+    (semantic metadata tail) which yields a DIFFERENT vector than naively
+    embedding the raw stored content (keyword tail). Proves the tail swap matters
+    end-to-end, not just under the fake embedder."""
+    embedder = DefaultIndexingEmbedder(
+        model_name=DEFAULT_DOCUMENT_ENCODER_MODEL,
+        normalize=NORMALIZE_EMBEDDINGS,
+        query_prefix=ASYM_QUERY_PREFIX,
+        passage_prefix=ASYM_PASSAGE_PREFIX,
+        provider_type=None,
+    )
+
+    metadata_list = convert_metadata_dict_to_list_of_strings(
+        {"author": "Jane Doe", "team": "finance"}
+    )
+    semantic, keyword = _get_metadata_suffix_for_document_index(
+        convert_metadata_list_of_strings_to_dict(metadata_list), include_separator=True
+    )
+    assert semantic != keyword  # precondition: the two tails genuinely differ
+
+    # stored content carries the KEYWORD tail (as indexing wrote it)
+    chunk = _stored_chunk(
+        "the body text" + keyword,
+        metadata_suffix=keyword,
+        metadata_list=metadata_list,
+    )
+
+    # MODEL_ONLY re-embed: input is the recovered (semantic-tail) text.
+    [result] = re_embed_chunks(
+        [chunk], ReembedStrategy.MODEL_ONLY, cast(IndexingEmbedder, embedder)
+    )
+
+    # Naive: embed the RAW stored content (keyword tail) with the SAME embedder.
+    naive_doc_aware = _stored_chunk_to_doc_aware(chunk, chunk.content)
+    [naive_index_chunk] = embedder.embed_chunks([naive_doc_aware])
+    naive_vector = naive_index_chunk.embeddings.full_embedding
+
+    # the crux: the recovered-input vector differs from the naive raw-content vector
+    # (field preservation is covered by the fast fake-embedder test above).
+    assert result.content_vector != naive_vector
+    assert len(result.content_vector) == DOC_EMBEDDING_DIM

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -19,8 +19,10 @@ from onyx.configs.constants import FileOrigin
 from onyx.connectors.models import Document
 from onyx.connectors.models import InputType
 from onyx.connectors.models import TextSection
+from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexModelStatus
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -28,7 +30,12 @@ from onyx.db.models import Credential
 from onyx.db.models import Document as DBDocument
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import FileRecord
+from onyx.db.models import IndexAttempt
+from onyx.db.models import SearchSettings
+from onyx.db.search_settings import create_search_settings
+from onyx.db.search_settings import get_current_search_settings
 from onyx.file_store.file_store import get_default_file_store
+from onyx.kg.models import KGStage
 
 
 def make_doc(
@@ -192,3 +199,87 @@ def cleanup_cc_pair(db_session: Session, pair: ConnectorCredentialPair) -> None:
         synchronize_session="fetch"
     )
     db_session.commit()
+
+
+def make_future_search_settings(
+    db_session: Session,
+    *,
+    status: IndexModelStatus = IndexModelStatus.FUTURE,
+    use_port_flow: bool | None = None,
+) -> SearchSettings:
+    """An isolated secondary SearchSettings cloned from the live PRESENT row with a
+    unique index_name, so the tenant-global port/count/cursor helpers see only this
+    test's rows. `use_port_flow` is left at the row default unless set; pass
+    `status=PAST` for round-trip tests that must not collide with concurrent FUTUREs.
+    """
+    present = get_current_search_settings(db_session)
+    update: dict[str, object] = {"index_name": f"test_future_{uuid4().hex[:8]}"}
+    if use_port_flow is not None:
+        update["use_port_flow"] = use_port_flow
+    saved = SavedSearchSettings.from_db_model(present).model_copy(update=update)
+    return create_search_settings(saved, db_session, status=status)
+
+
+def seed_cc_pair_documents(
+    db_session: Session,
+    cc_pair: ConnectorCredentialPair,
+    count: int,
+    *,
+    prefix: str = "portdoc-",
+    unique: bool = False,
+) -> list[str]:
+    """Create `count` documents linked to the cc_pair; returns their ids, sorted.
+    `unique=True` adds a random suffix so a test seeding a real index across runs
+    never collides."""
+    if unique:
+        doc_ids = sorted(
+            f"{prefix}{i:03d}-{uuid4().hex[:6]}" for i in range(1, count + 1)
+        )
+    else:
+        doc_ids = [f"{prefix}{i:03d}" for i in range(1, count + 1)]
+    for doc_id in doc_ids:
+        db_session.add(
+            DBDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)
+        )
+    db_session.flush()
+    for doc_id in doc_ids:
+        db_session.add(
+            DocumentByConnectorCredentialPair(
+                id=doc_id,
+                connector_id=cc_pair.connector_id,
+                credential_id=cc_pair.credential_id,
+                has_been_indexed=True,
+            )
+        )
+    db_session.commit()
+    return doc_ids
+
+
+def cleanup_cc_pair_and_future(
+    db_session: Session,
+    pair: ConnectorCredentialPair,
+    future_id: int,
+    *,
+    doc_prefix: str | None = None,
+) -> None:
+    """Teardown for the cc_pair + isolated FUTURE settings fixtures.
+
+    Deleting the FUTURE SearchSettings cascades its PortAttempts (FK
+    ondelete=CASCADE), so they need no explicit delete. `doc_prefix` clears any
+    unlinked test docs that cleanup_cc_pair (which only removes cc_pair-linked
+    docs) won't reach. Rolls back first so a failed test's aborted transaction
+    doesn't block the cleanup queries.
+    """
+    db_session.rollback()
+    if doc_prefix is not None:
+        db_session.query(DBDocument).filter(
+            DBDocument.id.like(f"{doc_prefix}%")
+        ).delete(synchronize_session="fetch")
+    db_session.query(IndexAttempt).filter(
+        IndexAttempt.connector_credential_pair_id == pair.id
+    ).delete(synchronize_session="fetch")
+    db_session.query(SearchSettings).filter(SearchSettings.id == future_id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()
+    cleanup_cc_pair(db_session, pair)


### PR DESCRIPTION
## Description
  - Toggling or changing the contextual-RAG model now re-embeds existing chunks during a reindex port instead of erroring — previously only embedder/model/dimension changes were portable, and contextual-RAG changes hit a NotImplementedError.
  - Superseding or canceling a reindex now stops any in-flight port for that search setting, instead of letting it keep running against a target that no longer matters.
  - Reindex enrichment reuses the live indexing pipeline's contextual-RAG model resolution and reserved-token budget, so ported chunks are enriched the same way freshly indexed ones are.

  ## How Has This Been Tested?
  - Added end-to-end port-flow tests plus unit coverage for both augmentation re-embed paths (FUTURE contextual-RAG on and off) and port cancellation; existing port/swap/sync tests updated to match.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
