### PR TITLE
feat(reindex-port): wire port flow to run and simplify swap gate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -318,7 +318,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",
@@ -606,7 +606,7 @@
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration"
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port"
       ],
       "presentation": {
         "group": "2",

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -158,6 +158,7 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.doc_permission_syncing",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.opensearch_migration",
             # Sandbox cleanup tasks (isolated in build feature)
             "onyx.server.features.build.sandbox.tasks",

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -350,6 +350,7 @@ celery_app.autodiscover_tasks(
         [
             "onyx.background.celery.tasks.connector_deletion",
             "onyx.background.celery.tasks.docprocessing",
+            "onyx.background.celery.tasks.port",
             "onyx.background.celery.tasks.evals",
             "onyx.background.celery.tasks.hierarchyfetching",
             "onyx.background.celery.tasks.pruning",

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -150,6 +150,7 @@ def _collect_queue_metrics(redis_celery: Redis) -> list[Metric]:
     queue_mappings = {
         "celery_queue_length": OnyxCeleryQueues.PRIMARY,
         "docprocessing_queue_length": OnyxCeleryQueues.DOCPROCESSING,
+        "port_queue_length": OnyxCeleryQueues.PORT,
         "docfetching_queue_length": OnyxCeleryQueues.CONNECTOR_DOC_FETCHING,
         "sync_queue_length": OnyxCeleryQueues.VESPA_METADATA_SYNC,
         "deletion_queue_length": OnyxCeleryQueues.CONNECTOR_DELETION,
@@ -910,6 +911,7 @@ def monitor_celery_queues_helper(
         OnyxCeleryQueues.CONNECTOR_DOC_FETCHING, r_celery
     )
     n_docprocessing = celery_get_queue_length(OnyxCeleryQueues.DOCPROCESSING, r_celery)
+    n_port = celery_get_queue_length(OnyxCeleryQueues.PORT, r_celery)
 
     n_user_file_processing = celery_get_queue_length(
         OnyxCeleryQueues.USER_FILE_PROCESSING, r_celery
@@ -966,6 +968,7 @@ def monitor_celery_queues_helper(
         f"docfetching_prefetched={len(n_docfetching_prefetched)} "
         f"docprocessing={n_docprocessing} "
         f"docprocessing_prefetched={len(n_docprocessing_prefetched)} "
+        f"port={n_port} "
         f"user_file_processing={n_user_file_processing} "
         f"user_file_project_sync={n_user_file_project_sync} "
         f"user_file_delete={n_user_file_delete} "

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -240,6 +240,20 @@ def _fail_stalled_port_attempts(
         )
 
 
+def _enqueue_run_port_attempt(
+    celery_app: Celery, port_attempt_id: int, tenant_id: str
+) -> None:
+    """Enqueue run_port_attempt for one attempt. The TTL means a task not consumed
+    within BEAT_EXPIRES_DEFAULT is dropped; check_for_port re-issues it next tick."""
+    celery_app.send_task(
+        OnyxCeleryTask.RUN_PORT_ATTEMPT,
+        kwargs={"port_attempt_id": port_attempt_id, "tenant_id": tenant_id},
+        queue=OnyxCeleryQueues.PORT,
+        priority=OnyxCeleryPriority.MEDIUM,
+        expires=BEAT_EXPIRES_DEFAULT,
+    )
+
+
 def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
     """Lifted out of check_for_port so tests can pass a mock celery app.
 
@@ -274,12 +288,37 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
 
             _fail_stalled_port_attempts(db_session, search_settings_id, lock_beat)
 
+            # A NOT_STARTED attempt older than the task TTL had its enqueued
+            # run_port_attempt dropped (worker down/absent when it was created); it
+            # would otherwise strand forever since it still counts as "active".
+            not_started_expired_before = datetime.now(timezone.utc) - timedelta(
+                seconds=BEAT_EXPIRES_DEFAULT
+            )
+
             for cc_pair_id in cc_pair_ids:
                 lock_beat.reacquire()
-                if (
-                    get_active_port_attempt(db_session, cc_pair_id, search_settings_id)
-                    is not None
-                ):
+                active = get_active_port_attempt(
+                    db_session, cc_pair_id, search_settings_id
+                )
+                if active is not None:
+                    # IN_PROGRESS is the stall watchdog's job; a recent NOT_STARTED is
+                    # still in flight. Only re-issue a NOT_STARTED whose task has
+                    # definitely expired -- idempotent (the run task's terminal-check
+                    # + the active-unique index make a re-send safe, and the original
+                    # task is already gone, so there's no double-run).
+                    if (
+                        active.status == PortAttemptStatus.NOT_STARTED
+                        and active.time_created < not_started_expired_before
+                    ):
+                        try:
+                            _enqueue_run_port_attempt(celery_app, active.id, tenant_id)
+                            tasks_created += 1
+                        except Exception:
+                            task_logger.exception(
+                                "check_for_port: re-enqueue failed for stale "
+                                "NOT_STARTED PortAttempt %s",
+                                active.id,
+                            )
                     continue
                 latest = get_latest_port_attempt(
                     db_session, cc_pair_id, search_settings_id
@@ -306,13 +345,7 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
                     )
                     continue
                 try:
-                    celery_app.send_task(
-                        OnyxCeleryTask.RUN_PORT_ATTEMPT,
-                        kwargs={"port_attempt_id": attempt.id, "tenant_id": tenant_id},
-                        queue=OnyxCeleryQueues.DOCPROCESSING,
-                        priority=OnyxCeleryPriority.MEDIUM,
-                        expires=BEAT_EXPIRES_DEFAULT,
-                    )
+                    _enqueue_run_port_attempt(celery_app, attempt.id, tenant_id)
                 except Exception:
                     # Row is committed; on enqueue failure mark it FAILED so the
                     # next tick recreates it (else an orphaned NOT_STARTED sticks).

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -12,9 +12,11 @@ SUCCESS/CANCELED are left alone).
 
 import logging
 import time
+from collections.abc import MutableMapping
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from typing import Any
 
 from celery import Celery
 from celery import shared_task
@@ -66,6 +68,24 @@ _PORT_BATCH_RETRY_SLEEP_S = 2
 _PORT_STALL_THRESHOLD_SECONDS = _PORT_SOFT_TIME_LIMIT + 15 * 60  # 45 minutes
 
 
+class _PortLogAdapter(logging.LoggerAdapter):
+    """Prefix every port log line with its attempt + cc_pair so concurrent ports
+    are distinguishable in the shared worker log (mirrors the indexing
+    [Index Attempt][CC Pair] prefix). cc_pair_id is filled in once the attempt is
+    read, so the few lines logged before that omit it."""
+
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> tuple[str, MutableMapping[str, Any]]:
+        extra = self.extra or {}
+        cc_pair_id = extra.get("cc_pair_id")
+        cc_prefix = f"[CC Pair: {cc_pair_id}] " if cc_pair_id is not None else ""
+        return (
+            f"[Port Attempt: {extra.get('port_attempt_id')}] {cc_prefix}{msg}",
+            kwargs,
+        )
+
+
 def _copy_batch_with_retry(
     copier: PortCopier, doc_ids: list[str], log: logging.LoggerAdapter
 ) -> int:
@@ -104,9 +124,13 @@ def run_port_attempt(port_attempt_id: int, celery_task_id: str | None = None) ->
     each batch, so a fresh attempt continues `WHERE document_id > cursor` rather
     than re-porting from the start.
     """
-    log = logging.LoggerAdapter(
+    log = _PortLogAdapter(
         task_logger,
-        extra={"port_attempt_id": port_attempt_id, "celery_task_id": celery_task_id},
+        {
+            "port_attempt_id": port_attempt_id,
+            "celery_task_id": celery_task_id,
+            "cc_pair_id": None,
+        },
     )
 
     # PortCopier must be built while the search settings are session-attached, so
@@ -124,6 +148,8 @@ def run_port_attempt(port_attempt_id: int, celery_task_id: str | None = None) ->
             return
 
         cc_pair_id = attempt.cc_pair_id
+        # Replace extra (a read-only Mapping) so every later line carries the cc_pair.
+        log.extra = {**(log.extra or {}), "cc_pair_id": cc_pair_id}
         cursor = attempt.last_processed_doc_id
         docs_ported = attempt.docs_ported or 0
 
@@ -169,7 +195,7 @@ def run_port_attempt(port_attempt_id: int, celery_task_id: str | None = None) ->
                 cc_pair is None
                 or cc_pair.status == ConnectorCredentialPairStatus.DELETING
             ):
-                log.info("cc_pair %s gone/deleting, stopping port", cc_pair_id)
+                log.info("cc_pair gone/deleting, stopping port")
                 return
             doc_ids = get_document_ids_for_cc_pair_batch(
                 db_session, cc_pair_id, after_doc_id=cursor, limit=INDEX_BATCH_SIZE
@@ -234,7 +260,11 @@ def _fail_stalled_port_attempts(
         fresh = get_port_attempt(db_session, stale.id)
         if fresh is None or fresh.status.is_terminal():
             continue
-        task_logger.warning("check_for_port: failing stalled PortAttempt %s", stale.id)
+        task_logger.warning(
+            "check_for_port: failing stalled PortAttempt %s (cc_pair %s)",
+            stale.id,
+            stale.cc_pair_id,
+        )
         mark_port_failed(
             db_session, stale.id, error_msg="stalled: no progress within threshold"
         )

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -474,7 +474,8 @@ def connector_document_extraction(
             and (from_beginning or not has_successful_attempt)
         )
 
-        # Set up time windows for polling
+        # Set up time windows for polling. A port-flow FUTURE's resume cursor comes from its
+        # synthetic seed (get_last_successful_... keeps ignore_synthetic_seed=False by default).
         last_successful_index_poll_range_end = (
             earliest_index_time
             if from_beginning

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -440,6 +440,10 @@ class OnyxCeleryQueues:
     DOCPROCESSING = "docprocessing"
     CONNECTOR_DOC_FETCHING = "connector_doc_fetching"
 
+    # Reindex port queue (heavy PRESENT -> FUTURE re-embed; kept off the
+    # docprocessing queue so a migration doesn't starve live indexing)
+    PORT = "port"
+
     # Monitoring queue
     MONITORING = "monitoring"
 

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -331,11 +331,16 @@ def get_last_successful_attempt_poll_range_end(
     search_settings: SearchSettings,
     db_session: Session,
     ignore_targeted_reindex: bool = True,
-    ignore_synthetic_seed: bool = True,
+    ignore_synthetic_seed: bool = False,
 ) -> float:
     """Used to get the latest `poll_range_end` for a given connector and credential.
 
     This can be used to determine the next "start" time for a new index attempt.
+
+    A reindex-port synthetic seed carries PRESENT's poll cursor and IS a valid resume
+    point, so it is considered by default - the FUTURE's first connector attempt resumes
+    from it instead of refetching full history. This differs from the count/latest helpers,
+    which keep `ignore_synthetic_seed=True` because a seed is not a real indexing run.
 
     Note that the attempts time_started is not necessarily correct - that gets set
     separately and is similar but not exactly the same as the `poll_range_end`.

--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -4,7 +4,6 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import VESPA_NUM_ATTEMPTS_ON_STARTUP
-from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import KV_REINDEX_KEY
 from onyx.db.connector_credential_pair import (
     fetch_indexable_standard_connector_credential_pair_ids,
@@ -14,7 +13,6 @@ from onyx.db.connector_credential_pair import resync_cc_pair
 from onyx.db.document import count_secondary_only_sync_pending_documents
 from onyx.db.document import delete_all_documents_for_connector_credential_pair
 from onyx.db.enums import ConnectorCredentialPairStatus
-from onyx.db.enums import IndexingStatus
 from onyx.db.enums import IndexModelStatus
 from onyx.db.enums import SwitchoverType
 from onyx.db.index_attempt import cancel_indexing_attempts_for_search_settings
@@ -22,8 +20,6 @@ from onyx.db.index_attempt import (
     count_unique_active_cc_pairs_with_successful_index_attempts,
 )
 from onyx.db.index_attempt import count_unique_cc_pairs_with_successful_index_attempts
-from onyx.db.index_attempt import get_last_attempt_for_cc_pair
-from onyx.db.index_attempt import get_latest_successful_index_attempt_for_cc_pair_id
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import ConnectorCredentialPair
@@ -151,15 +147,6 @@ def _perform_index_swap(
     return current_search_settings
 
 
-def _is_push_based_pair(cc_pair: ConnectorCredentialPair) -> bool:
-    """Ingestion-API pairs push docs in and never run a connector index attempt, so
-    their docs reach FUTURE only via the port."""
-    return (
-        cc_pair.connector_id == 0
-        or cc_pair.connector.source == DocumentSource.INGESTION_API
-    )
-
-
 def _required_cc_pairs_for_switchover(
     db_session: Session,
     all_cc_pairs: list[ConnectorCredentialPair],
@@ -187,41 +174,15 @@ def _port_swap_ready(
     new_search_settings: SearchSettings,
     required_cc_pairs: list[ConnectorCredentialPair],
 ) -> bool:
-    """Port-flow swap gate: True only when every required cc_pair's port is SUCCESS
-    (none active) and — for standard connectors — a real (non-seed) FUTURE index
-    attempt landed after the port with none in progress (push-based pairs skip that
-    index check), and the deferred metadata-sync backlog has drained.
-    """
+    """Port-flow swap gate: True once every required cc_pair's port is SUCCESS
+    (none active) and the deferred metadata-sync backlog has drained. The port copy
+    is the whole bar — we do not wait for a post-port connector index attempt."""
     ss_id = new_search_settings.id
     for cc_pair in required_cc_pairs:
         if get_active_port_attempt(db_session, cc_pair.id, ss_id) is not None:
             return False
         latest_port = get_latest_port_attempt(db_session, cc_pair.id, ss_id)
         if latest_port is None or not latest_port.status.is_successful():
-            return False
-
-        # No connector index attempt to wait on; port success is the whole gate.
-        if _is_push_based_pair(cc_pair):
-            continue
-
-        # the synthetic seed can't satisfy this: it's excluded by the T5 helper and
-        # would fail the time_started >= time_completed check anyway.
-        latest_index = get_latest_successful_index_attempt_for_cc_pair_id(
-            db_session, cc_pair.id, secondary_index=True
-        )
-        if (
-            latest_index is None
-            or latest_index.time_started is None
-            or latest_port.time_completed is None
-            or latest_index.time_started < latest_port.time_completed
-        ):
-            return False
-
-        last_attempt = get_last_attempt_for_cc_pair(cc_pair.id, ss_id, db_session)
-        if last_attempt is not None and last_attempt.status in (
-            IndexingStatus.NOT_STARTED,
-            IndexingStatus.IN_PROGRESS,
-        ):
             return False
 
     return count_secondary_only_sync_pending_documents(db_session) == 0

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -77,6 +77,7 @@ from onyx.indexing.vector_db_insertion import write_chunks_to_vector_db_with_bac
 from onyx.llm.factory import get_contextual_rag_llm_for_search_settings
 from onyx.llm.factory import get_default_llm_with_vision
 from onyx.llm.interfaces import LLM
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LLMRateLimitError
 from onyx.llm.utils import llm_response_to_string
@@ -101,6 +102,11 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+
+# Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
+# model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the
+# visible summary returns empty, so disable reasoning for these calls.
+CONTEXTUAL_RAG_REASONING_EFFORT = ReasoningEffort.OFF
 
 
 class _DocsToUpdateResult(NamedTuple):
@@ -860,7 +866,11 @@ def add_document_summaries(
         flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
         input_messages=[prompt_msg],
     ) as span_generation:
-        response = llm.invoke(prompt_msg, max_tokens=MAX_CONTEXT_TOKENS)
+        response = llm.invoke(
+            prompt_msg,
+            max_tokens=MAX_CONTEXT_TOKENS,
+            reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+        )
         record_llm_response(span_generation, response)
     doc_summary = llm_response_to_string(response)
 
@@ -909,7 +919,11 @@ def add_chunk_summaries(
             flow=LLMFlow.CONTEXTUAL_RAG_DOC_SUMMARY,
             input_messages=[fallback_prompt],
         ) as span_generation:
-            response = llm.invoke(fallback_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+            response = llm.invoke(
+                fallback_prompt,
+                max_tokens=MAX_CONTEXT_TOKENS,
+                reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+            )
             record_llm_response(span_generation, response)
         doc_info = llm_response_to_string(response)
 
@@ -934,7 +948,11 @@ def add_chunk_summaries(
                 flow=LLMFlow.CONTEXTUAL_RAG_CHUNK_CONTEXT,
                 input_messages=[processed_prompt],
             ) as span_generation:
-                response = llm.invoke(processed_prompt, max_tokens=MAX_CONTEXT_TOKENS)
+                response = llm.invoke(
+                    processed_prompt,
+                    max_tokens=MAX_CONTEXT_TOKENS,
+                    reasoning_effort=CONTEXTUAL_RAG_REASONING_EFFORT,
+                )
                 record_llm_response(span_generation, response)
             chunk.chunk_context = llm_response_to_string(response)
 

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -104,6 +104,12 @@ def set_new_search_settings(
             **search_settings_new.model_dump()
         )
 
+    # Every new (FUTURE) search settings drives its reindex through the port flow:
+    # re-embed PRESENT -> FUTURE in place rather than re-fetching from connectors.
+    new_search_settings_request = new_search_settings_request.model_copy(
+        update={"use_port_flow": True}
+    )
+
     secondary_search_settings = get_secondary_search_settings(db_session)
 
     if secondary_search_settings:

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -17,6 +17,7 @@ from onyx.db.enums import Permission
 from onyx.db.enums import SwitchoverType
 from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.index_attempt import expire_index_attempts
+from onyx.db.llm import fetch_default_contextual_rag_model
 from onyx.db.llm import update_default_contextual_model
 from onyx.db.llm import update_no_default_contextual_rag_provider
 from onyx.db.models import IndexModelStatus
@@ -84,6 +85,7 @@ def set_new_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings_new.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings_new.enable_contextual_rag,
     )
 
     search_settings = get_current_search_settings(db_session)
@@ -295,6 +297,7 @@ def update_saved_search_settings(
     validate_contextual_rag_model(
         model_configuration_id=search_settings.contextual_rag_model_configuration_id,
         db_session=db_session,
+        enable_contextual_rag=search_settings.enable_contextual_rag,
     )
 
     update_current_search_settings(
@@ -335,8 +338,18 @@ def delete_unstructured_api_key_endpoint(
 def validate_contextual_rag_model(
     model_configuration_id: int | None,
     db_session: Session,
+    enable_contextual_rag: bool = False,
 ) -> None:
     if model_configuration_id is None:
+        if (
+            enable_contextual_rag
+            and fetch_default_contextual_rag_model(db_session) is None
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Contextual Retrieval is enabled but no Contextual Retrieval "
+                "model is configured, and no tenant default exists.",
+            )
         return
     from onyx.db.models import ModelConfiguration
 

--- a/backend/scripts/dev_run_background_jobs.py
+++ b/backend/scripts/dev_run_background_jobs.py
@@ -41,7 +41,7 @@ def run_jobs() -> None:
         "--loglevel=INFO",
         "--hostname=light@%n",
         "-Q",
-        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+        "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
     ]
 
     cmd_worker_docprocessing = [

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_flow_e2e.py
@@ -23,9 +23,9 @@ from uuid import uuid4
 from sqlalchemy.orm import Session
 
 from onyx.access.models import DocumentAccess
-from onyx.background.celery.tasks.docprocessing import port_task
-from onyx.background.celery.tasks.docprocessing.port_task import run_check_for_port
-from onyx.background.celery.tasks.docprocessing.port_task import run_port_attempt
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
 from onyx.configs.constants import DocumentSource
 from onyx.configs.model_configs import ASYM_PASSAGE_PREFIX
 from onyx.configs.model_configs import ASYM_QUERY_PREFIX

--- a/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
+++ b/backend/tests/external_dependency_unit/db/test_port_metadata_defer_e2e.py
@@ -1,0 +1,322 @@
+"""End-to-end deferred-metadata-sync (permission) test for the reindex port.
+
+The existing sync-priority tests mock the document index and assert the producer's
+LOW/MEDIUM/HIGH *decision*. This test instead drives the real OpenSearch
+`OpenSearchIndexPair.update()` defer path against live indices, proving the
+correctness invariant the swap gate relies on:
+
+  D1 (inflight): a metadata/permission update on a doc PRESENT has but FUTURE does
+      not yet lands in PRESENT and is *deferred* for FUTURE -- surfaced as the typed
+      SecondaryIndexDocumentMissingError carrying exactly the missing doc id.
+  flag lifecycle: mark_document_synced_secondary_pending sets the gate flag;
+      mark_document_as_synced clears it once FUTURE catches up.
+  D4 (no stale-permission leak): after the port copies the doc into FUTURE carrying
+      the OLD access, the deferred-sync drain re-applies and FUTURE ends with the
+      NEW access -- not the stale one the port wrote.
+
+Uses real Postgres + OpenSearch. Mirrors test_port_flow_e2e's index lifecycle.
+"""
+
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.access.models import DocumentAccess
+from onyx.configs.constants import DocumentSource
+from onyx.db.document import count_secondary_only_sync_pending_documents
+from onyx.db.document import mark_document_as_synced
+from onyx.db.document import mark_document_synced_secondary_pending
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Document as DbDocument
+from onyx.document_index.interfaces_new import MetadataUpdateRequest
+from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
+from onyx.document_index.opensearch.opensearch_document_index import (
+    generate_opensearch_filtered_access_control_list,
+)
+from onyx.document_index.opensearch.opensearch_document_index import (
+    OpenSearchDocumentIndex,
+)
+from onyx.document_index.opensearch.opensearch_document_index import OpenSearchIndexPair
+from onyx.document_index.opensearch.schema import DocumentChunk
+from onyx.document_index.opensearch.schema import DocumentSchema
+from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+_VECTOR_DIM = 8  # tiny: this test never re-embeds, it only updates metadata
+_CHUNKS_PER_DOC = 2
+_PLACEHOLDER_VECTOR = [0.1] * _VECTOR_DIM
+
+# Two distinct *non-public* access states so PRESENT vs FUTURE acls are
+# unambiguously comparable (a public state would collapse to an empty acl).
+_ACCESS_OLD = DocumentAccess.build(
+    user_emails=["bob@example.com"],
+    user_groups=[],
+    external_user_emails=[],
+    external_user_group_ids=[],
+    is_public=False,
+)
+_ACCESS_NEW = DocumentAccess.build(
+    user_emails=["alice@example.com"],
+    user_groups=[],
+    external_user_emails=[],
+    external_user_group_ids=[],
+    is_public=False,
+)
+_ACL_OLD = set(generate_opensearch_filtered_access_control_list(_ACCESS_OLD))
+_ACL_NEW = set(generate_opensearch_filtered_access_control_list(_ACCESS_NEW))
+
+_TENANT_STATE = TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False)
+
+
+def _make_chunk(
+    document_id: str,
+    chunk_index: int,
+    access: DocumentAccess,
+    last_updated: datetime | None = None,
+) -> DocumentChunk:
+    # The port re-copies the SAME stored PRESENT chunk on a batch retry, so its
+    # doc_updated_at (the external version) is identical across retries — callers
+    # exercising the retry race must pin last_updated rather than take now().
+    if last_updated is None:
+        last_updated = datetime.now(timezone.utc).replace(microsecond=0)
+    return DocumentChunk(
+        document_id=document_id,
+        chunk_index=chunk_index,
+        title=None,
+        title_vector=None,
+        content=f"chunk {chunk_index} of {document_id}",
+        content_vector=list(_PLACEHOLDER_VECTOR),
+        source_type=DocumentSource.FILE.value,
+        metadata_list=None,
+        last_updated=last_updated,
+        public=access.is_public,
+        access_control_list=generate_opensearch_filtered_access_control_list(access),
+        hidden=False,
+        global_boost=0,
+        semantic_identifier=f"semantic-{document_id}",
+        image_file_id=None,
+        source_links=None,
+        blurb="blurb",
+        doc_summary="",
+        chunk_context="",
+        document_sets=None,
+        user_projects=None,
+        primary_owners=None,
+        secondary_owners=None,
+        tenant_id=_TENANT_STATE,
+    )
+
+
+def _create_os_index(index_name: str) -> OpenSearchIndexClient:
+    client = OpenSearchIndexClient(index_name=index_name)
+    client.create_index(
+        mappings=DocumentSchema.get_document_schema(
+            vector_dimension=_VECTOR_DIM, multitenant=False
+        ),
+        settings=DocumentSchema.get_index_settings_based_on_environment(),
+    )
+    return client
+
+
+def _index(index_name: str) -> OpenSearchDocumentIndex:
+    return OpenSearchDocumentIndex(
+        tenant_state=_TENANT_STATE,
+        index_name=index_name,
+        embedding_dim=_VECTOR_DIM,
+        embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+
+
+def _read_acl(client: OpenSearchIndexClient, doc_id: str, chunk_index: int) -> set[str]:
+    chunk_id = get_opensearch_doc_chunk_id(
+        tenant_state=_TENANT_STATE, document_id=doc_id, chunk_index=chunk_index
+    )
+    return set(client.get_document(document_chunk_id=chunk_id).access_control_list)
+
+
+@pytest.fixture
+def env(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[
+    tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+    None,
+    None,
+]:
+    pair = make_cc_pair(db_session)
+    doc_id = f"deferdoc-{uuid4().hex[:8]}"
+    db_session.add(DbDocument(id=doc_id, semantic_id=doc_id))
+    db_session.commit()
+
+    present_name = f"test_defer_present_{uuid4().hex[:8]}"
+    future_name = f"test_defer_future_{uuid4().hex[:8]}"
+    present_client = _create_os_index(present_name)
+    future_client = _create_os_index(future_name)
+    try:
+        yield pair, doc_id, present_client, future_client, present_name, future_name
+    finally:
+        db_session.rollback()
+        db_session.query(DbDocument).filter(DbDocument.id == doc_id).delete(
+            synchronize_session="fetch"
+        )
+        db_session.commit()
+        cleanup_cc_pair(db_session, pair)
+        for client in (present_client, future_client):
+            try:
+                client.delete_index()
+            except Exception:
+                pass
+            finally:
+                client.close()
+
+
+def test_deferred_metadata_sync_no_stale_permission_leak(
+    db_session: Session,
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> None:
+    pair, doc_id, present_client, future_client, present_name, future_name = env
+
+    # --- PRESENT has the doc (old access); FUTURE does not yet (mid-port). ---
+    present_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+    )
+    present_client.refresh_index()
+
+    pair_index = OpenSearchIndexPair(
+        primary=_index(present_name),
+        secondary=_index(future_name),
+        secondary_embedding_dim=_VECTOR_DIM,
+        secondary_embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    req = MetadataUpdateRequest(
+        document_ids=[doc_id],
+        doc_id_to_chunk_cnt={doc_id: _CHUNKS_PER_DOC},
+        access=_ACCESS_NEW,
+    )
+
+    baseline_deferred = count_secondary_only_sync_pending_documents(db_session)
+
+    # --- D1: permission change. PRESENT applies; FUTURE is missing -> typed signal. ---
+    with pytest.raises(SecondaryIndexDocumentMissingError) as exc:
+        pair_index.update([req])
+    assert exc.value.document_ids == [doc_id]
+
+    # mimic document_index_metadata_sync_task's deferral branch
+    mark_document_synced_secondary_pending(doc_id, db_session)
+
+    present_client.refresh_index()
+    assert _read_acl(present_client, doc_id, 0) == _ACL_NEW  # PRESENT got new access
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is True
+    assert (
+        count_secondary_only_sync_pending_documents(db_session) == baseline_deferred + 1
+    )
+
+    # --- the port copies the doc into FUTURE carrying the OLD (pre-change) access. ---
+    future_client.bulk_index_documents(
+        documents=[
+            _make_chunk(doc_id, c_i, _ACCESS_OLD) for c_i in range(_CHUNKS_PER_DOC)
+        ],
+        tenant_state=_TENANT_STATE,
+        use_external_versioning=True,
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD  # FUTURE is stale right now
+
+    # --- D4: the deferred-sync drain re-applies; both indices now carry new access. ---
+    pair_index.update([req])  # FUTURE present now -> no raise
+    mark_document_as_synced(doc_id, db_session)
+
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW  # no stale-permission leak
+    assert _read_acl(future_client, doc_id, 1) == _ACL_NEW
+    db_session.expire_all()
+    doc = db_session.get(DbDocument, doc_id)
+    assert doc is not None and doc.secondary_only_sync_pending is False
+    assert count_secondary_only_sync_pending_documents(db_session) == baseline_deferred
+
+
+def test_port_batch_retry_does_not_revert_a_newer_metadata_update(
+    env: tuple[
+        ConnectorCredentialPair,
+        str,
+        OpenSearchIndexClient,
+        OpenSearchIndexClient,
+        str,
+        str,
+    ],
+) -> None:
+    """The residual race: a port BATCH RETRY re-writes a chunk the port already
+    copied, AFTER a live metadata sync applied a newer access to FUTURE. The
+    retry's full-chunk write carries the SAME doc_updated_at as the first copy
+    (it re-reads the same PRESENT chunk). External versioning must reject it as a
+    benign 409 so the newer metadata update is NOT reverted.
+
+    Unlike the existing index-vs-index `newest_wins` test, this exercises a
+    *partial* metadata update (no external version) followed by an
+    *external-versioned* full re-index — the interleaving the reindex port can hit
+    when a metadata sync lands between two retry attempts of the same batch.
+    """
+    _, doc_id, _present_client, future_client, _present_name, future_name = env
+    future_index = _index(future_name)
+    pinned_ts = datetime(2026, 6, 1, tzinfo=timezone.utc)  # stable external version
+
+    # 1. Port copies the chunk into FUTURE with OLD access (doc_updated_at=pinned).
+    future_client.bulk_index_documents(
+        documents=[_make_chunk(doc_id, 0, _ACCESS_OLD, last_updated=pinned_ts)],
+        tenant_state=_TENANT_STATE,
+        use_external_versioning=True,
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_OLD
+
+    # 2. A live metadata sync applies NEW access (partial update, not versioned).
+    future_index.update(
+        [
+            MetadataUpdateRequest(
+                document_ids=[doc_id],
+                doc_id_to_chunk_cnt={doc_id: 1},
+                access=_ACCESS_NEW,
+            )
+        ]
+    )
+    future_client.refresh_index()
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW
+
+    # 3. Port BATCH RETRY re-writes the SAME chunk (OLD access, SAME doc_updated_at).
+    future_client.bulk_index_documents(
+        documents=[_make_chunk(doc_id, 0, _ACCESS_OLD, last_updated=pinned_ts)],
+        tenant_state=_TENANT_STATE,
+        use_external_versioning=True,
+    )
+    future_client.refresh_index()
+
+    # 4. The newer metadata update must survive — the stale retry is a benign 409.
+    assert _read_acl(future_client, doc_id, 0) == _ACL_NEW

--- a/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
+++ b/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
@@ -14,7 +14,6 @@ from other cc_pairs); the `check_and_perform_index_swap` cases patch
 
 from collections.abc import Generator
 from datetime import datetime
-from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -24,12 +23,9 @@ from onyx.configs.constants import DocumentSource
 from onyx.db import swap_index
 from onyx.db.document import mark_document_synced_secondary_pending
 from onyx.db.enums import ConnectorCredentialPairStatus
-from onyx.db.enums import IndexingStatus
 from onyx.db.enums import SwitchoverType
-from onyx.db.index_attempt import create_synthetic_seed_attempt
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Document as DbDocument
-from onyx.db.models import IndexAttempt
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
 from onyx.db.port_attempt import create_port_attempt
@@ -74,37 +70,15 @@ def _make_success_port(db_session: Session, cc_pair_id: int, ss_id: int) -> date
     return row.time_completed
 
 
-def _make_real_index_attempt(
-    db_session: Session,
-    cc_pair_id: int,
-    ss_id: int,
-    time_started: object,
-    status: IndexingStatus = IndexingStatus.SUCCESS,
-) -> None:
-    db_session.add(
-        IndexAttempt(
-            connector_credential_pair_id=cc_pair_id,
-            search_settings_id=ss_id,
-            from_beginning=False,
-            status=status,
-            is_synthetic_seed=False,
-            time_started=time_started,
-            time_updated=time_started,
-        )
-    )
-    db_session.commit()
-
-
-def test_port_swap_ready_all_conditions_met(
+def test_port_swap_ready_when_port_succeeded(
     db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
 ) -> None:
+    """A successful port (no active attempt) with a drained sync backlog is ready —
+    no post-port connector index attempt is required."""
     cc_pair, future_id = cc_pair_and_future
     future_ss = db_session.get(SearchSettings, future_id)
     assert future_ss is not None
-    port_done = _make_success_port(db_session, cc_pair.id, future_id)
-    _make_real_index_attempt(
-        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
-    )
+    _make_success_port(db_session, cc_pair.id, future_id)
     assert _port_swap_ready(db_session, future_ss, [cc_pair]) is True
 
 
@@ -128,65 +102,14 @@ def test_port_swap_blocks_on_active_port(
     assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
 
 
-def test_port_swap_blocks_on_seed_only_future(
-    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
-) -> None:
-    cc_pair, future_id = cc_pair_and_future
-    future_ss = db_session.get(SearchSettings, future_id)
-    assert future_ss is not None
-    _make_success_port(db_session, cc_pair.id, future_id)
-    # only a synthetic seed exists -> no real (non-seed) post-port attempt
-    create_synthetic_seed_attempt(
-        cc_pair.id, future_id, poll_range_end=1000.0, db_session=db_session
-    )
-    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
-
-
-def test_port_swap_blocks_on_stale_post_port_poll(
-    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
-) -> None:
-    cc_pair, future_id = cc_pair_and_future
-    future_ss = db_session.get(SearchSettings, future_id)
-    assert future_ss is not None
-    port_done = _make_success_port(db_session, cc_pair.id, future_id)
-    # a real success, but it started BEFORE the port completed -> not "post-port"
-    _make_real_index_attempt(
-        db_session, cc_pair.id, future_id, port_done - timedelta(seconds=5)
-    )
-    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
-
-
-def test_port_swap_blocks_on_in_progress_index(
-    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
-) -> None:
-    cc_pair, future_id = cc_pair_and_future
-    future_ss = db_session.get(SearchSettings, future_id)
-    assert future_ss is not None
-    port_done = _make_success_port(db_session, cc_pair.id, future_id)
-    _make_real_index_attempt(
-        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
-    )
-    _make_real_index_attempt(
-        db_session,
-        cc_pair.id,
-        future_id,
-        port_done + timedelta(seconds=2),
-        status=IndexingStatus.IN_PROGRESS,
-    )
-    assert _port_swap_ready(db_session, future_ss, [cc_pair]) is False
-
-
 def test_port_swap_blocks_on_pending_sync_backlog(
     db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
 ) -> None:
     cc_pair, future_id = cc_pair_and_future
     future_ss = db_session.get(SearchSettings, future_id)
     assert future_ss is not None
-    port_done = _make_success_port(db_session, cc_pair.id, future_id)
-    _make_real_index_attempt(
-        db_session, cc_pair.id, future_id, port_done + timedelta(seconds=1)
-    )
-    # a deferred-sync doc remains -> condition (d) fails (tenant-global count)
+    _make_success_port(db_session, cc_pair.id, future_id)
+    # a deferred-sync doc remains -> the backlog gate fails (tenant-global count)
     doc_id = f"{_PENDING_DOC_PREFIX}pending"
     db_session.add(
         DbDocument(id=doc_id, semantic_id=doc_id, kg_stage=KGStage.NOT_STARTED)

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -29,10 +29,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
-from onyx.background.celery.tasks.docprocessing import port_task
-from onyx.background.celery.tasks.docprocessing.port_task import run_check_for_port
-from onyx.background.celery.tasks.docprocessing.port_task import run_port_attempt
 from onyx.background.celery.tasks.docprocessing.utils import should_index
+from onyx.background.celery.tasks.port import tasks as port_task
+from onyx.background.celery.tasks.port.tasks import run_check_for_port
+from onyx.background.celery.tasks.port.tasks import run_port_attempt
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -760,7 +760,7 @@ def test_check_for_port_creates_and_enqueues(
         "port_attempt_id": attempts[0].id,
         "tenant_id": get_current_tenant_id(),
     }
-    assert call.kwargs["queue"] == OnyxCeleryQueues.DOCPROCESSING
+    assert call.kwargs["queue"] == OnyxCeleryQueues.PORT
     assert call.kwargs["expires"] == BEAT_EXPIRES_DEFAULT
 
 
@@ -881,6 +881,69 @@ def test_check_for_port_leaves_active_in_progress(
         .count()
         == 1
     )
+
+
+def test_check_for_port_reissues_stale_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A NOT_STARTED attempt whose enqueued task was lost/expired (created before the
+    TTL window) is re-enqueued in place — not stranded, not duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    stale = create_port_attempt(db_session, cc_pair.id, future_id)
+    # backdate time_created past the task TTL so its enqueued task is "expired"
+    old = datetime.now(timezone.utc) - timedelta(seconds=BEAT_EXPIRES_DEFAULT + 60)
+    db_session.query(PortAttempt).filter(PortAttempt.id == stale.id).update(
+        {PortAttempt.time_created: old}
+    )
+    db_session.commit()
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1
+    celery_app.send_task.assert_called_once()
+    assert (
+        celery_app.send_task.call_args.kwargs["kwargs"]["port_attempt_id"] == stale.id
+    )
+    # re-issued in place: still the same single attempt, still NOT_STARTED
+    db_session.expire_all()
+    rows = (
+        db_session.query(PortAttempt).filter(PortAttempt.cc_pair_id == cc_pair.id).all()
+    )
+    assert len(rows) == 1 and rows[0].id == stale.id
+    assert rows[0].status == PortAttemptStatus.NOT_STARTED
+
+
+def test_check_for_port_leaves_fresh_not_started(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A recently-created NOT_STARTED attempt (task still in flight, within the TTL)
+    is left alone — not re-enqueued or duplicated."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    fresh = create_port_attempt(db_session, cc_pair.id, future_id)  # time_created = now
+
+    result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(PortAttempt.cc_pair_id == cc_pair.id)
+        .count()
+        == 1
+    )
+    row = db_session.get(PortAttempt, fresh.id)
+    assert row is not None and row.status == PortAttemptStatus.NOT_STARTED
 
 
 def test_check_for_port_fails_attempt_when_enqueue_raises(

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -8,9 +8,10 @@ covered by applying the migration, which this repo does not test programmaticall
   and first-terminal-write-wins
 - mark_document_synced_secondary_pending sets the flag (and clears needs-sync),
   and a later mark_document_as_synced clears it again
-- the synthetic seed: writer row shape, seed-blind filtering (a seed must not count
-  toward the swap or masquerade as the poll cursor), and the gated should_index
-  FUTURE branch (legacy once-only vs port-flow continuous)
+- the synthetic seed: writer row shape, seed-blind filtering for counts/latest/swap (a
+  seed must not count toward the swap or appear as the latest run) while it DOES prime the
+  resume poll cursor, and the gated should_index FUTURE branch (legacy once-only vs
+  port-flow continuous)
 - run_port_attempt: ports docs in batches, advances/commits the cursor, retries a
   failed batch then marks FAILED (cursor left at the prior good batch)
 """
@@ -368,8 +369,6 @@ def test_seed_excluded_from_latest_and_counts(
     db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
 ) -> None:
     cc_pair, future_id = cc_pair_and_future
-    future_ss = db_session.get(SearchSettings, future_id)
-    assert future_ss is not None
 
     # only a synthetic seed exists
     create_synthetic_seed_attempt(
@@ -391,13 +390,6 @@ def test_seed_excluded_from_latest_and_counts(
         )
         is None
     )
-    # the seed's cursor is invisible to the seed-blind helper -> earliest fallback
-    assert (
-        get_last_successful_attempt_poll_range_end(
-            cc_pair.id, 42.0, future_ss, db_session
-        )
-        == 42.0
-    )
 
     # a real SUCCESS attempt IS counted and returned
     real_id = mock_successful_index_attempt(
@@ -411,6 +403,47 @@ def test_seed_excluded_from_latest_and_counts(
         db_session, cc_pair.id, secondary_index=True
     )
     assert latest is not None and latest.id == real_id
+
+
+def test_seed_primes_poll_cursor(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The seed IS the resume cursor: with only a seed present, the FUTURE's first
+    connector attempt starts from PRESENT's cursor (carried by the seed), not the
+    earliest_index fallback. A later real SUCCESS attempt then supersedes the seed."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    seed_cursor = 1000.0
+    create_synthetic_seed_attempt(
+        cc_pair.id, future_id, poll_range_end=seed_cursor, db_session=db_session
+    )
+    db_session.expire_all()
+    # resume from the seed cursor, not the earliest_index arg (42.0)
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == seed_cursor
+    )
+
+    # a real SUCCESS attempt with a later cursor supersedes the seed
+    later_cursor = seed_cursor + 5000.0
+    real_id = mock_successful_index_attempt(
+        cc_pair.id, future_id, docs_indexed=5, db_session=db_session
+    )
+    real = db_session.get(IndexAttempt, real_id)
+    assert real is not None
+    real.poll_range_end = datetime.fromtimestamp(later_cursor, tz=timezone.utc)
+    db_session.commit()
+    db_session.expire_all()
+    assert (
+        get_last_successful_attempt_poll_range_end(
+            cc_pair.id, 42.0, future_ss, db_session
+        )
+        == later_cursor
+    )
 
 
 def test_should_index_future_gated_on_port_flow(

--- a/backend/tests/external_dependency_unit/indexing_helpers.py
+++ b/backend/tests/external_dependency_unit/indexing_helpers.py
@@ -205,18 +205,21 @@ def make_future_search_settings(
     db_session: Session,
     *,
     status: IndexModelStatus = IndexModelStatus.FUTURE,
-    use_port_flow: bool | None = None,
+    use_port_flow: bool = False,
 ) -> SearchSettings:
     """An isolated secondary SearchSettings cloned from the live PRESENT row with a
     unique index_name, so the tenant-global port/count/cursor helpers see only this
-    test's rows. `use_port_flow` is left at the row default unless set; pass
-    `status=PAST` for round-trip tests that must not collide with concurrent FUTUREs.
+    test's rows. `use_port_flow` is set explicitly (default False) so the fixture
+    never inherits the live PRESENT row's flag; pass `status=PAST` for round-trip
+    tests that must not collide with concurrent FUTUREs.
     """
     present = get_current_search_settings(db_session)
-    update: dict[str, object] = {"index_name": f"test_future_{uuid4().hex[:8]}"}
-    if use_port_flow is not None:
-        update["use_port_flow"] = use_port_flow
-    saved = SavedSearchSettings.from_db_model(present).model_copy(update=update)
+    saved = SavedSearchSettings.from_db_model(present).model_copy(
+        update={
+            "index_name": f"test_future_{uuid4().hex[:8]}",
+            "use_port_flow": use_port_flow,
+        }
+    )
     return create_search_settings(saved, db_session, status=status)
 
 

--- a/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_port_wiring.py
@@ -1,0 +1,68 @@
+"""Guards the Celery wiring of the reindex-port flow.
+
+The port logic itself is covered by the external_dependency_unit `db/test_*port*`
+suites (which run against real Postgres/OpenSearch). Those mock the celery app, so
+nothing there proves a beat-enqueued port task actually reaches a worker. These
+unit tests guard exactly that transport seam — the part a dropped autodiscover line
+or `-Q` entry would silently break with every other test still green:
+
+  beat schedules check_for_port  ->  light worker consumes the `port` queue
+  ->  light worker has run_port_attempt registered to execute it.
+"""
+
+from pathlib import Path
+
+from onyx.background.celery.tasks.beat_schedule import beat_task_templates
+from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.constants import OnyxCeleryQueues
+from onyx.configs.constants import OnyxCeleryTask
+
+
+def _find_supervisord_conf() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "supervisord.conf"
+        if candidate.is_file():
+            return candidate
+    raise AssertionError("supervisord.conf not found above this test")
+
+
+def _worker_queues(program: str) -> set[str]:
+    """The `-Q` queue set a supervisord worker program consumes."""
+    lines = _find_supervisord_conf().read_text().splitlines()
+    in_program = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("[program:"):
+            in_program = stripped == f"[program:{program}]"
+        elif in_program and stripped.startswith("-Q "):
+            return {q.strip() for q in stripped[len("-Q ") :].split(",")}
+    raise AssertionError(f"no -Q line found for [program:{program}]")
+
+
+def test_check_for_port_scheduled_in_beat() -> None:
+    # check_for_port is the only producer of PortAttempts; if it falls out of the
+    # beat schedule the whole flow stops with zero other test failures.
+    scheduled = {t["task"] for t in beat_task_templates}
+    if DISABLE_VECTOR_DB:
+        # Vector-DB-gated: must be filtered out of minimal-mode deployments.
+        assert OnyxCeleryTask.CHECK_FOR_PORT not in scheduled
+    else:
+        assert OnyxCeleryTask.CHECK_FOR_PORT in scheduled
+
+
+def test_light_worker_consumes_port_queue() -> None:
+    # run_port_attempt is enqueued to the PORT queue; the light worker is its only
+    # consumer. Dropping `port` from this `-Q` list strands every port task.
+    assert OnyxCeleryQueues.PORT in _worker_queues("celery_worker_light")
+
+
+def test_light_worker_registers_port_tasks() -> None:
+    # Consuming the queue is moot if autodiscovery doesn't register the task body:
+    # the worker would reject it as unknown. Importing + loading the light app
+    # mirrors worker bootstrap, so both port tasks must resolve by name.
+    from onyx.background.celery.apps.light import celery_app
+
+    celery_app.loader.import_default_modules()
+    registered = set(celery_app.tasks.keys())
+    assert OnyxCeleryTask.RUN_PORT_ATTEMPT in registered
+    assert OnyxCeleryTask.CHECK_FOR_PORT in registered

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -70,7 +70,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,port",
             ]
           ports:
             - name: metrics

--- a/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
+++ b/web/src/refresh-pages/admin/IndexSettingsPage/index.tsx
@@ -925,6 +925,17 @@ export default function IndexSettingsPage() {
             enableReinitialize
             initialValues={initialFormValues}
             onSubmit={async (values) => {
+              // Contextual Retrieval re-embeds each chunk through an LLM; with
+              // the toggle on but no model chosen the port fails, so block here.
+              if (
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null
+              ) {
+                toast.error(
+                  "Select a Contextual Retrieval LLM before re-indexing."
+                );
+                return;
+              }
               // Custom self-hosted models live outside the static registry,
               // so the form carries their spec (`modelDim`, `normalize`, etc.)
               // in `custom_model` for submission. The provider, however, is
@@ -968,6 +979,10 @@ export default function IndexSettingsPage() {
                 !!values.model_name;
               const stagedModelName = isModelStaged ? values.model_name : null;
               const statusVariant = dirty ? "warning" : undefined;
+              // Block apply when Contextual Retrieval is on but no LLM is set.
+              const contextualRagModelMissing =
+                values.enable_contextual_rag &&
+                values.contextual_rag_model_configuration_id === null;
 
               return (
                 <>
@@ -1026,11 +1041,19 @@ export default function IndexSettingsPage() {
                   ) : (
                     !NEXT_PUBLIC_CLOUD_ENABLED && (
                       <MessageCard
-                        variant={statusVariant}
+                        variant={
+                          contextualRagModelMissing ? "error" : statusVariant
+                        }
                         headerPadding="sm"
-                        title="Changes require a full re-index."
+                        title={
+                          contextualRagModelMissing
+                            ? "Select a Contextual Retrieval LLM"
+                            : "Changes require a full re-index."
+                        }
                         description={markdown(
-                          "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
+                          contextualRagModelMissing
+                            ? "Contextual Retrieval is enabled but no model is selected. Pick a Contextual Retrieval LLM below before re-indexing — without one, the re-index cannot run."
+                            : "Modifying embedding or retrieval settings requires a full re-index of all documents to take effect, which may take **hours or days** depending on corpus size. [Learn More](https://docs.onyx.app/security/architecture/data_flows)"
                         )}
                         bottomChildren={
                           dirty ? (
@@ -1081,7 +1104,10 @@ export default function IndexSettingsPage() {
                                 >
                                   Revert
                                 </Button>
-                                <Button onClick={() => void submitForm()}>
+                                <Button
+                                  onClick={() => void submitForm()}
+                                  disabled={contextualRagModelMissing}
+                                >
                                   Apply & Re-index
                                 </Button>
                               </div>


### PR DESCRIPTION
## Description
  - Route reindex re-embedding through a dedicated `port` Celery queue so a migration can't starve live document indexing
  - Turn the port flow on automatically for every new search settings — reindex re-embeds PRESENT → FUTURE in place instead of re-fetching from connectors
  - Recover stale reindex attempts whose worker task was dropped (e.g. worker down when enqueued) instead of stranding them, without double-running
  - Gate the index swap on port success alone, dropping the redundant post-port connector index-attempt checks

## How Has This Been Tested?
  - Port-flow unit tests updated — added stale/fresh NOT_STARTED recovery cases and trimmed the swap-gate suite to match the simplified gate

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the reindex port flow on a dedicated Celery `port` queue and enable it by default for new search settings to keep live indexing fast. Simplifies the swap gate to rely on port success and adds Contextual Retrieval validation and LLM tuning.

- **New Features**
  - Route `RUN_PORT_ATTEMPT` to `port` and consume it on the light worker; autodiscover tasks under `onyx.background.celery.tasks.port`; add `port_queue_length` metric.
  - Enable `use_port_flow` for all new FUTURE search settings; the synthetic seed now primes the FUTURE poll cursor to resume from PRESENT (no connector re-fetch).
  - Re-enqueue stale `NOT_STARTED` attempts after the task TTL; require a Contextual Retrieval LLM when enabled (UI blocks Apply & Re-index and backend validates); disable reasoning for Contextual Retrieval summaries to prevent empty outputs.

- **Refactors**
  - Simplify port swap readiness: swap once ports are successful (no active attempts) and the deferred metadata-sync backlog is drained; remove post-port connector index checks and helpers.
  - Improve port logs with attempt + cc_pair prefixes for easier tracing.

<sup>Written for commit 3802f6a3a53ec3ee2cd88e5a01d5c1784d5964b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

