### PR TITLE
fix(tools): disambiguate colliding MCP tool names for the LLM

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -63,6 +63,7 @@ from onyx.tools.tool_implementations.python.python_tool import PythonTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet_map
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
+from onyx.tools.tool_name import disambiguate_tool_names
 from onyx.tools.tool_runner import run_tool_calls
 from onyx.tracing.framework.create import trace
 from onyx.utils.logger import setup_logger
@@ -636,6 +637,13 @@ def run_llm_loop(
         )  # Here for lazy load LiteLLM
 
         initialize_litellm()
+
+        # Ensure tool names sent to the LLM are unique. Multiple MCP servers can
+        # expose tools with the same name (e.g. "search"), which produces
+        # duplicate function declarations that some providers (e.g. Gemini)
+        # reject. This renames only the colliding MCP tools and leaves their
+        # user-facing display names untouched.
+        disambiguate_tool_names(tools)
 
         # Normalize chat_files to a mutable list so we can extend it mid-loop
         # when a search hit carries an attached file the Python tool should

--- a/backend/onyx/tools/interface.py
+++ b/backend/onyx/tools/interface.py
@@ -18,6 +18,8 @@ class Tool(abc.ABC, Generic[TOverride]):
     def __init__(self, emitter: Emitter | None = None):
         """Initialize tool with optional emitter. Emitter can be set later via set_emitter()."""
         self._emitter = emitter
+        # When set, overrides the name sent to the LLM (see set_llm_name_override).
+        self._llm_name_override: str | None = None
 
     @property
     def emitter(self) -> Emitter:
@@ -27,6 +29,17 @@ class Tool(abc.ABC, Generic[TOverride]):
                 f"Emitter not set on tool {self.name}. Call set_emitter() first."
             )
         return self._emitter
+
+    def set_llm_name_override(self, name: str | None) -> None:
+        """Override the name presented to the LLM for this tool.
+
+        Used to disambiguate tools whose names would otherwise collide within a
+        single request (some providers, e.g. Gemini, reject duplicate function
+        declarations). Subclasses that support overriding must consult
+        ``self._llm_name_override`` from their ``name`` property. The user-facing
+        ``display_name`` is intentionally left unchanged.
+        """
+        self._llm_name_override = name
 
     @property
     @abc.abstractmethod

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -79,7 +79,6 @@ class MCPTool(Tool[None]):
         self._tool_definition = tool_definition
         self._description = tool_description
         self._display_name = tool_definition.get("displayName", tool_name)
-        self._llm_name = f"mcp:{mcp_server.name}:{tool_name}"
 
     @property
     def id(self) -> int:
@@ -87,7 +86,12 @@ class MCPTool(Tool[None]):
 
     @property
     def name(self) -> str:
-        return self._name
+        # Honor a disambiguation override (set when this tool's name would
+        # collide with another tool in the same request). Falls back to the
+        # raw MCP tool name. This is the single name used both in the LLM tool
+        # definition and for dispatching the resulting tool call, so the two
+        # always stay in sync.
+        return self._llm_name_override or self._name
 
     @property
     def description(self) -> str:
@@ -97,17 +101,15 @@ class MCPTool(Tool[None]):
     def display_name(self) -> str:
         return self._display_name
 
-    @property
-    def llm_name(self) -> str:
-        return self._llm_name
-
     def tool_definition(self) -> dict:
         """Return the tool definition from the MCP server"""
-        # Convert MCP tool definition to OpenAI function calling format
+        # Convert MCP tool definition to OpenAI function calling format.
+        # Use self.name (not self._name) so any disambiguation override is
+        # reflected in the function name presented to the LLM.
         return {
             "type": "function",
             "function": {
-                "name": self._name,
+                "name": self.name,
                 "description": self._description,
                 "parameters": _normalize_parameters_schema(self._tool_definition),
             },

--- a/backend/onyx/tools/tool_name.py
+++ b/backend/onyx/tools/tool_name.py
@@ -1,10 +1,75 @@
+from __future__ import annotations
+
 import re
+from collections import defaultdict
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from onyx.tools.interface import Tool
 
 # Bedrock rejects toolUse.name values that don't match [a-zA-Z0-9_-]+, and
 # OpenAI imposes the same constraint on function names. User-supplied Tool.name
 # and OpenAPI operationId can contain spaces, dots, etc.
 _INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 
+# OpenAI caps function names at 64 characters; keep generated names within that.
+_MAX_TOOL_NAME_LEN = 64
+
 
 def sanitize_tool_name(name: str) -> str:
     return _INVALID_TOOL_NAME_CHARS.sub("_", name)
+
+
+def _truncate_tool_name(name: str, reserve: int = 0) -> str:
+    limit = _MAX_TOOL_NAME_LEN - reserve
+    if limit <= 0:
+        return name[:_MAX_TOOL_NAME_LEN]
+    return name if len(name) <= limit else name[:limit]
+
+
+def disambiguate_tool_names(tools: list["Tool"]) -> None:
+    """Ensure the names presented to the LLM are unique across ``tools``.
+
+    Several MCP servers expose tools with the same generic name (e.g. ``search``).
+    When two such tools are attached to one assistant, the LLM receives duplicate
+    function declarations; some providers (notably Gemini) reject the request with
+    a ``Duplicate function declaration`` error, and even tolerant providers cannot
+    reliably tell the tools apart.
+
+    To fix this without churning every tool name, we rename only on collision and
+    only rename MCP tools (built-in tools keep their stable, well-known names). A
+    colliding MCP tool is renamed to ``<server>_<tool>`` (sanitized, truncated and
+    de-duplicated). The override is applied to the tool object, so it flows through
+    both the tool definition sent to the LLM and the name used to dispatch the
+    resulting tool call, keeping the two in sync. The user-facing ``display_name``
+    is left unchanged.
+    """
+    # Imported lazily to avoid a circular import at module load time.
+    from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+    name_counts: dict[str, int] = defaultdict(int)
+    for tool in tools:
+        name_counts[tool.name] += 1
+
+    colliding_names = {name for name, count in name_counts.items() if count > 1}
+    if not colliding_names:
+        return
+
+    used_names = {tool.name for tool in tools}
+    for tool in tools:
+        if tool.name not in colliding_names:
+            continue
+        # Keep non-MCP (built-in) tool names stable; rename MCP tools around them.
+        if not isinstance(tool, MCPTool):
+            continue
+
+        prefixed = sanitize_tool_name(f"{tool.mcp_server.name}_{tool.name}")
+        candidate = _truncate_tool_name(prefixed)
+        suffix_num = 2
+        while candidate in used_names:
+            suffix = f"_{suffix_num}"
+            candidate = _truncate_tool_name(prefixed, reserve=len(suffix)) + suffix
+            suffix_num += 1
+
+        tool.set_llm_name_override(candidate)
+        used_names.add(candidate)

--- a/backend/tests/unit/onyx/tools/test_tool_name.py
+++ b/backend/tests/unit/onyx/tools/test_tool_name.py
@@ -1,0 +1,160 @@
+"""Tests for tool-name sanitization and collision disambiguation.
+
+Multiple MCP servers commonly expose tools with the same generic name (e.g.
+``search``). When attached to the same assistant they produce duplicate LLM
+function declarations, which providers like Gemini reject with
+``Duplicate function declaration found: search``. ``disambiguate_tool_names``
+renames the colliding MCP tools (prefixing with the server name) while leaving
+built-in tool names and user-facing display names untouched.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.tools.interface import Tool
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+from onyx.tools.tool_name import disambiguate_tool_names
+from onyx.tools.tool_name import sanitize_tool_name
+
+# OpenAI's documented function-name length limit; generated names must fit.
+MAX_TOOL_NAME_LEN = 64
+
+
+def _make_mcp_tool(server_name: str, tool_name: str) -> MCPTool:
+    mcp_server = MagicMock()
+    mcp_server.name = server_name
+    return MCPTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        mcp_server=mcp_server,
+        tool_name=tool_name,
+        tool_description="desc",
+        tool_definition={"type": "object", "properties": {}},
+    )
+
+
+class _FakeBuiltInTool(Tool[None]):
+    """Minimal non-MCP tool to verify built-in names stay stable."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(emitter=MagicMock())
+        self._name = name
+
+    @property
+    def id(self) -> int:
+        return 99
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return "fake"
+
+    @property
+    def display_name(self) -> str:
+        return self._name
+
+    def tool_definition(self) -> dict:
+        return {"type": "function", "function": {"name": self._name}}
+
+    def emit_start(self, placement: object) -> None:  # noqa: ARG002
+        return None
+
+    def run(
+        self, placement: object, override_kwargs: None = None, **llm_kwargs: object
+    ):  # type: ignore[override]  # noqa: ARG002
+        raise NotImplementedError
+
+
+class TestSanitizeToolName:
+    def test_replaces_invalid_chars(self) -> None:
+        assert sanitize_tool_name("mcp:server:search") == "mcp_server_search"
+
+    def test_keeps_valid_chars(self) -> None:
+        assert sanitize_tool_name("get_sheet-1") == "get_sheet-1"
+
+
+class TestDisambiguateToolNames:
+    def test_no_collision_is_noop(self) -> None:
+        a = _make_mcp_tool("atlassian", "search")
+        b = _make_mcp_tool("smartsheet", "get_sheet")
+
+        disambiguate_tool_names([a, b])
+
+        assert a.name == "search"
+        assert b.name == "get_sheet"
+
+    def test_two_mcp_servers_same_tool_name_get_namespaced(self) -> None:
+        a = _make_mcp_tool("atlassian", "search")
+        b = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([a, b])
+
+        # Both renamed, both unique, both prefixed with their server.
+        assert a.name == "atlassian_search"
+        assert b.name == "smartsheet_search"
+        assert a.name != b.name
+
+    def test_namespacing_flows_into_tool_definition(self) -> None:
+        a = _make_mcp_tool("atlassian", "search")
+        b = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([a, b])
+
+        assert a.tool_definition()["function"]["name"] == "atlassian_search"
+        assert b.tool_definition()["function"]["name"] == "smartsheet_search"
+
+    def test_display_name_is_unchanged(self) -> None:
+        a = _make_mcp_tool("atlassian", "search")
+        b = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([a, b])
+
+        # UI keeps showing the original tool name.
+        assert a.display_name == "search"
+        assert b.display_name == "search"
+
+    def test_builtin_name_stays_stable_mcp_renamed_around_it(self) -> None:
+        builtin = _FakeBuiltInTool("search")
+        mcp = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([builtin, mcp])
+
+        # Built-in keeps its well-known name; the MCP tool is renamed away.
+        assert builtin.name == "search"
+        assert mcp.name == "smartsheet_search"
+
+    def test_server_name_with_invalid_chars_is_sanitized(self) -> None:
+        a = _make_mcp_tool("Atlassian Rovo", "search")
+        b = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([a, b])
+
+        assert a.name == "Atlassian_Rovo_search"
+        assert all(c.isalnum() or c in "_-" for c in a.name)
+
+    def test_same_server_same_tool_twice_stays_unique(self) -> None:
+        # Pathological: two tools that prefix to the identical name.
+        a = _make_mcp_tool("dup", "search")
+        b = _make_mcp_tool("dup", "search")
+
+        disambiguate_tool_names([a, b])
+
+        assert a.name != b.name
+        assert {a.name, b.name} == {"dup_search", "dup_search_2"}
+
+    def test_long_names_are_truncated_to_limit(self) -> None:
+        long_server = "s" * 80
+        a = _make_mcp_tool(long_server, "search")
+        b = _make_mcp_tool("smartsheet", "search")
+
+        disambiguate_tool_names([a, b])
+
+        assert len(a.name) <= MAX_TOOL_NAME_LEN
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xv"])


### PR DESCRIPTION
## Problem

Multiple MCP servers commonly expose tools with the same generic name (e.g. `search`). When two such tools are attached to a single assistant/persona, the LLM receives **duplicate function declarations**:

- **Gemini** rejects the request outright: `400 Duplicate function declaration found: search`.
- **OpenAI / Anthropic / Bedrock** tolerate the duplicate, but the model cannot reliably tell the two tools apart, and dispatch may resolve to the wrong server's tool.

Repro: connect two MCP servers that each expose a `search` tool (e.g. Atlassian Rovo + Smartsheet), attach both to one persona, set the model to Gemini, send any message → 400.

## Fix

Disambiguate tool names **only on collision**, and only for **MCP tools** (built-in tools keep their stable, well-known names). A colliding MCP tool is renamed to `<server>_<tool>`, sanitized via the existing `sanitize_tool_name`, truncated to the 64-char function-name limit, and de-duplicated with a numeric suffix if needed.

The rename is applied to the tool object through a new `Tool.set_llm_name_override(...)`. Because both the tool definition sent to the LLM (`tool.tool_definition()`) and every dispatch map (`{tool.name: tool}`) key off `tool.name`, overriding it in one place keeps the declaration and the reverse-dispatch automatically in sync. The user-facing `display_name` is intentionally left unchanged, so the UI still shows the original tool name.

This also removes the previously unused `MCPTool.llm_name` property, whose namespacing intent is now realized on the actual definition/dispatch path.

### Why prefix-on-collision (not always-prefix)

Keeps tool names stable and short in the common (no-collision) case, avoids churning names users and the model are used to, and limits the behavior change to exactly the broken scenario.

## Changes

- `tools/interface.py` — add `set_llm_name_override` + backing field on the base `Tool`.
- `tools/tool_implementations/mcp/mcp_tool.py` — `name` honors the override; `tool_definition()` uses `self.name`; remove dead `llm_name`. The real server-side tool name (`self._name`) is still used for the actual MCP call and UI packets.
- `tools/tool_name.py` — add `disambiguate_tool_names()` (+ 64-char truncation helper).
- `chat/llm_loop.py` — call `disambiguate_tool_names(tools)` once before the LLM cycle.
- `tests/unit/onyx/tools/test_tool_name.py` — unit tests.

## Tests

New unit tests cover: no-collision no-op, two MCP servers sharing a tool name, override flowing into `tool_definition()`, `display_name` unchanged, built-in names staying stable while MCP renames around them, server-name sanitization, same-server duplicate uniqueness, and 64-char truncation.

```
backend/tests/unit/onyx/tools/  445 passed
ruff check / ruff format / ty check  clean on changed files
```

## Notes / scope

- Applied in the main chat loop (`run_llm_loop`), which is where the reported failure occurs. Other tool-list assembly paths (deep research / research agent) could reuse the same helper as a follow-up if desired.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLM tool name collisions from MCP servers by renaming only the colliding MCP tools, unblocking Gemini and improving tool dispatch accuracy. Names change only for the LLM; the UI keeps the original labels.

- **Bug Fixes**
  - Added `disambiguate_tool_names()` to prefix colliding MCP tools with their server, sanitize names, truncate to 64 chars, and add numeric suffixes if needed.
  - Introduced `Tool.set_llm_name_override()`; `MCPTool.name` and `tool_definition()` honor it so the LLM declaration and dispatch stay in sync.
  - Disambiguation runs once in the chat loop; built-in tool names and `display_name` remain unchanged. Tests cover no-op, collisions, sanitization, truncation, and uniqueness.

<sup>Written for commit 6a470c478642b28eca849cbf9ec43b5c6ea4d745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

