### PR TITLE
feat(metrics): add optional METRICS_AUTH_TOKEN for the /metrics endpoint

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -275,6 +275,17 @@ if AUTH_TYPE == AuthType.BASIC and not USER_AUTH_SECRET:
         "and email verification tokens. Please set USER_AUTH_SECRET in production."
     )
 
+# Bearer token guarding the API server's /metrics endpoint. Auth is required by
+# default: scrapers must present this token as `Authorization: Bearer <token>`
+# (the standard Prometheus scrape format). If neither this nor
+# DISABLE_METRICS_AUTH is set, /metrics is locked (returns 401) — set one or the
+# other deliberately.
+METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN") or ""
+
+# Explicit opt-out: expose /metrics with no authentication. Only honored as a
+# deliberate choice, since auth is otherwise required by default.
+DISABLE_METRICS_AUTH = os.environ.get("DISABLE_METRICS_AUTH", "").lower() == "true"
+
 # Duration (in seconds) for which the FastAPI Users JWT token remains valid in the user's browser.
 # By default, this is set to match the Redis expiry time for consistency.
 AUTH_COOKIE_EXPIRE_TIME_SECONDS = int(

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -47,12 +47,14 @@ class OnyxError(Exception):
         detail: str | None = None,
         *,
         status_code_override: int | None = None,
+        headers: dict[str, str] | None = None,
     ) -> None:
         resolved_detail = detail or error_code.code
         super().__init__(resolved_detail)
         self.error_code = error_code
         self.detail = resolved_detail
         self._status_code_override = status_code_override
+        self.headers = headers
 
     @property
     def status_code(self) -> int:
@@ -72,6 +74,7 @@ def onyx_error_to_json_response(exc: OnyxError) -> JSONResponse:
     return JSONResponse(
         status_code=exc.status_code,
         content=exc.error_code.detail(exc.detail),
+        headers=exc.headers,
     )
 
 

--- a/backend/onyx/server/metrics/metrics_auth.py
+++ b/backend/onyx/server/metrics/metrics_auth.py
@@ -1,0 +1,62 @@
+"""Bearer-token auth for the API server's /metrics endpoint.
+
+Auth is required by default. Scrapers must present ``METRICS_AUTH_TOKEN`` as
+``Authorization: Bearer <token>`` — the standard Prometheus scrape format
+(``authorization: { credentials: <token> }`` in a scrape config).
+
+Set ``DISABLE_METRICS_AUTH=true`` to deliberately expose /metrics with no
+authentication. If neither the token nor the opt-out is set, /metrics is locked
+(every request gets 401) so it can never be exposed by accident.
+"""
+
+import secrets
+
+from fastapi import Request
+
+from onyx.auth.constants import BEARER_PREFIX
+from onyx.configs.app_configs import DISABLE_METRICS_AUTH
+from onyx.configs.app_configs import METRICS_AUTH_TOKEN
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+# RFC 6750 §3: a 401 from a bearer-protected resource must advertise the scheme.
+_WWW_AUTHENTICATE = {"WWW-Authenticate": "Bearer"}
+
+
+def verify_metrics_token(request: Request) -> None:
+    """FastAPI dependency guarding the /metrics endpoint.
+
+    No-op only when ``DISABLE_METRICS_AUTH`` is set. Otherwise a matching bearer
+    token is required: if ``METRICS_AUTH_TOKEN`` is unset the endpoint is locked,
+    and any missing/invalid token raises ``OnyxError(UNAUTHENTICATED)``. The token
+    comparison is constant-time to avoid leaking it via response timing.
+    """
+    if DISABLE_METRICS_AUTH:
+        return
+
+    expected = METRICS_AUTH_TOKEN
+    if not expected:
+        # Fail secure: auth is required but no token is configured, so there is
+        # no valid credential. Lock the endpoint rather than exposing it.
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHENTICATED,
+            "/metrics auth not configured; set METRICS_AUTH_TOKEN or "
+            "DISABLE_METRICS_AUTH",
+            headers=_WWW_AUTHENTICATE,
+        )
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith(BEARER_PREFIX):
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHENTICATED,
+            "Missing or invalid metrics bearer token",
+            headers=_WWW_AUTHENTICATE,
+        )
+
+    provided = auth_header[len(BEARER_PREFIX) :].strip()
+    if not secrets.compare_digest(provided, expected):
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHENTICATED,
+            "Invalid metrics bearer token",
+            headers=_WWW_AUTHENTICATE,
+        )

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -10,11 +10,13 @@ SQLAlchemy connection pool metrics are registered separately via
 (after engines are created).
 """
 
+from fastapi import Depends
 from prometheus_fastapi_instrumentator import Instrumentator
 from prometheus_fastapi_instrumentator.metrics import default as default_metrics
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from starlette.applications import Starlette
 
+from onyx.server.metrics.metrics_auth import verify_metrics_token
 from onyx.server.metrics.per_tenant import per_tenant_request_callback
 from onyx.server.metrics.postgres_connection_pool import pool_timeout_handler
 from onyx.server.metrics.slow_requests import slow_request_callback
@@ -72,4 +74,8 @@ def setup_prometheus_metrics(app: Starlette) -> None:
     instrumentator.add(slow_request_callback)
     instrumentator.add(per_tenant_request_callback)
 
-    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(app)
+    # `dependencies` is forwarded to the FastAPI route created by `.expose()`.
+    # `verify_metrics_token` is a no-op unless METRICS_AUTH_TOKEN is configured.
+    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(
+        app, dependencies=[Depends(verify_metrics_token)]
+    )

--- a/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
+++ b/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
@@ -98,7 +98,11 @@ def test_setup_attaches_instrumentator_to_app() -> None:
                 10.0,
             ),
         )
-        mock_instance.expose.assert_called_once_with(app)
+        mock_instance.expose.assert_called_once()
+        expose_args, expose_kwargs = mock_instance.expose.call_args
+        assert expose_args == (app,)
+        assert list(expose_kwargs) == ["dependencies"]
+        assert len(expose_kwargs["dependencies"]) == 1
 
 
 def test_per_tenant_callback_increments_with_tenant_id() -> None:

--- a/backend/tests/unit/server/metrics/test_metrics_auth.py
+++ b/backend/tests/unit/server/metrics/test_metrics_auth.py
@@ -1,0 +1,82 @@
+"""Unit tests for the /metrics bearer-token auth dependency.
+
+Auth is required by default; ``DISABLE_METRICS_AUTH`` is the explicit opt-out.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.metrics import metrics_auth
+from onyx.server.metrics.metrics_auth import verify_metrics_token
+
+
+@pytest.fixture(autouse=True)
+def _baseline_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to 'auth required, nothing configured' so each test is isolated
+    from the ambient environment and overrides only what it exercises."""
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "")
+    monkeypatch.setattr(metrics_auth, "DISABLE_METRICS_AUTH", False)
+
+
+def _request_with_auth(auth_header: str | None) -> MagicMock:
+    """Build a fake Request whose headers return the given Authorization value."""
+    headers: dict[str, str] = {}
+    if auth_header is not None:
+        headers["Authorization"] = auth_header
+    request = MagicMock()
+    request.headers.get.side_effect = lambda key, default="": headers.get(key, default)
+    return request
+
+
+def test_locked_when_unconfigured() -> None:
+    """No token and not explicitly disabled => fail secure (lock the endpoint)."""
+    with pytest.raises(OnyxError) as exc_info:
+        verify_metrics_token(_request_with_auth(None))
+    assert exc_info.value.error_code == OnyxErrorCode.UNAUTHENTICATED
+    # RFC 6750: advertise the bearer scheme on 401.
+    assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+    # Even a bearer header can't satisfy a locked endpoint with no configured token.
+    with pytest.raises(OnyxError):
+        verify_metrics_token(_request_with_auth("Bearer anything"))
+
+
+def test_no_op_when_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DISABLE_METRICS_AUTH opts out entirely, regardless of token/header."""
+    monkeypatch.setattr(metrics_auth, "DISABLE_METRICS_AUTH", True)
+
+    verify_metrics_token(_request_with_auth(None))
+    verify_metrics_token(_request_with_auth("Bearer whatever"))
+
+
+def test_valid_token_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "s3cret")
+
+    verify_metrics_token(_request_with_auth("Bearer s3cret"))
+
+
+def test_missing_header_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "s3cret")
+
+    with pytest.raises(OnyxError) as exc_info:
+        verify_metrics_token(_request_with_auth(None))
+    assert exc_info.value.error_code == OnyxErrorCode.UNAUTHENTICATED
+
+
+def test_non_bearer_header_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "s3cret")
+
+    with pytest.raises(OnyxError) as exc_info:
+        verify_metrics_token(_request_with_auth("s3cret"))
+    assert exc_info.value.error_code == OnyxErrorCode.UNAUTHENTICATED
+
+
+def test_wrong_token_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "s3cret")
+
+    with pytest.raises(OnyxError) as exc_info:
+        verify_metrics_token(_request_with_auth("Bearer wrong"))
+    assert exc_info.value.error_code == OnyxErrorCode.UNAUTHENTICATED

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -59,6 +59,13 @@ AUTH_TYPE=basic
 USER_AUTH_SECRET=""
 ### Recommend to set this for security
 # ENCRYPTION_KEY_SECRET=
+### Bearer token for the API server's /metrics endpoint. Auth is REQUIRED by
+### default: scrapers must send `Authorization: Bearer <token>` (Prometheus
+### scrape config: `authorization`). If you set neither this token nor
+### DISABLE_METRICS_AUTH, /metrics is locked (returns 401).
+# METRICS_AUTH_TOKEN=
+### Set to "true" to expose /metrics with NO authentication (explicit opt-out).
+# DISABLE_METRICS_AUTH=
 ### Optional
 # API_KEY_HASH_ROUNDS=
 ### You can add a comma separated list of domains like onyx.app, only those domains will be allowed to signup/log in

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.17
+version: 0.5.18
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,11 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Grant the scheduled-tasks worker the same sandbox access as the
-        api_server (it provisions sandboxes headlessly). Inject the restricted
-        `sandboxPushSecret` (`ONYX_SANDBOX_PUSH_PRIVATE_KEY`) into the worker and
-        allow its pods as an ingress source in the sandbox-push NetworkPolicy.
+    - kind: added
+      description: '`auth.metricsAuth` bearer token guarding the API server''s
+        /metrics endpoint. /metrics returns 401 by default until you enable
+        auth.metricsAuth (injects `METRICS_AUTH_TOKEN`, and the api ServiceMonitor
+        scrapes with `Authorization: Bearer <token>`) or explicitly opt out via
+        configMap.DISABLE_METRICS_AUTH=true.'
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
+++ b/deployment/helm/charts/onyx/templates/api-servicemonitor.yaml
@@ -20,4 +20,16 @@ spec:
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
+      {{- /* `dig` keeps this nil-safe for `helm upgrade --reuse-values` where an
+             older stored values map may lack auth.metricsAuth entirely. */}}
+      {{- $metricsAuth := .Values.auth.metricsAuth | default dict }}
+      {{- if dig "enabled" false $metricsAuth }}
+      {{- /* When the /metrics bearer token is enabled, Prometheus must present
+             it. References the chart-managed (or existing) metrics-auth secret;
+             the Prometheus Operator needs RBAC to read it in this namespace. */}}
+      authorization:
+        credentials:
+          name: {{ include "onyx.secretName" $metricsAuth }}
+          key: {{ default "METRICS_AUTH_TOKEN" (dig "secretKeys" "METRICS_AUTH_TOKEN" "" $metricsAuth) }}
+      {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1342,6 +1342,28 @@ auth:
     # If not set, helm install/upgrade will fail when auth.userauth.enabled=true.
     values:
       user_auth_secret: ""
+  metricsAuth:
+    # -- Bearer token guarding the API server's /metrics endpoint. /metrics
+    # returns 401 by default until you either enable this (provide a token) or
+    # explicitly opt out via configMap.DISABLE_METRICS_AUTH="true". When enabled,
+    # scrapers must send the token as `Authorization: Bearer <token>` (Prometheus
+    # scrape config: `authorization`), and the api ServiceMonitor below is wired
+    # to send it automatically.
+    enabled: false
+    # -- Only inject the token into pods that serve the protected /metrics (the
+    # API server), not every backend pod. Routes through onyx.envSecretsRestricted.
+    allPods: false
+    # -- Overwrite the default secret name, ignored if existingSecret is defined
+    secretName: 'onyx-metrics-auth'
+    # -- Use a secret specified elsewhere
+    existingSecret: ""
+    # -- This defines the env var to secret map
+    secretKeys:
+      METRICS_AUTH_TOKEN: metrics_auth_token
+    # -- Secret value. Required when this secret is enabled - generate with: openssl rand -hex 32
+    # If not set, helm install/upgrade will fail when auth.metricsAuth.enabled=true.
+    values:
+      metrics_auth_token: ""
   # Ed25519 private key for sandbox push auth (only the public key reaches sandbox pods).
   # Generate with: python3 -c "import base64; from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey as K; from cryptography.hazmat.primitives.serialization import *; print(base64.b64encode(K.generate().private_bytes(Encoding.Raw,PrivateFormat.Raw,NoEncryption())).decode())"
   sandboxPushSecret:
@@ -1384,6 +1406,10 @@ configMap:
   SESSION_EXPIRE_TIME_SECONDS: "86400"
   # Can be something like onyx.app, as an extra double-check
   VALID_EMAIL_DOMAINS: ""
+  # /metrics requires a bearer token by default and returns 401 until one is set
+  # (enable auth.metricsAuth) OR you explicitly opt out here. Set to "true" to
+  # expose /metrics with NO authentication.
+  DISABLE_METRICS_AUTH: ""
   # For sending verification emails, true or false
   REQUIRE_EMAIL_VERIFICATION: ""
   # If unspecified then defaults to 'smtp.gmail.com'


### PR DESCRIPTION
## Description

Guards the API server's `/metrics` endpoint with bearer-token auth, **required by default (fail secure)**. `/metrics` returns **401** unless:

- **`METRICS_AUTH_TOKEN` is set** → scrapers must send `Authorization: Bearer <token>` (the standard Prometheus scrape format), or
- **`DISABLE_METRICS_AUTH=true` is explicitly set** → exposes `/metrics` with no auth.

With neither set, `/metrics` is locked so it can never be exposed by accident. Closes kanban ticket #1018.

**Backend**
- `verify_metrics_token` FastAPI dependency (`onyx/server/metrics/metrics_auth.py`): fail-secure, constant-time compare (`secrets.compare_digest`), raises `OnyxError(UNAUTHENTICATED)`; wired into the prometheus-fastapi-instrumentator `/metrics` route via `expose(app, dependencies=[...])`.
- 401s carry `WWW-Authenticate: Bearer` (RFC 6750) — `OnyxError` gained an optional, backward-compatible `headers` param.
- `METRICS_AUTH_TOKEN` / `DISABLE_METRICS_AUTH` config, documented in `env.template`.

**Helm**
- New `auth.metricsAuth` secret block (`allPods: false`, disabled by default). Secure by default: the chart sets neither a token nor the opt-out, so `/metrics` returns 401 until an operator enables `auth.metricsAuth` (provides a token) or sets `configMap.DISABLE_METRICS_AUTH=true`. The chart never silently disables auth.
- The api `ServiceMonitor` scrapes `/metrics` with `authorization.credentials` (Bearer) when enabled; nil-safe (`dig`) for `helm upgrade --reuse-values`.
- Chart version `0.5.17 → 0.5.18`.

**Scope:** only the API server's FastAPI `/metrics` is protected. Celery worker metrics servers (`prometheus_client.start_http_server`, internal ports) have no auth hook and are unchanged.

## How Has This Been Tested?

- `backend/tests/unit/server/metrics/test_metrics_auth.py` — locked-when-unconfigured (+ `WWW-Authenticate` header), explicit opt-out no-op, valid token, missing/non-bearer/wrong token.
- Updated `test_prometheus_instrumentation.py` for the new `dependencies=` kwarg on `expose`.
- Local: unit + error-handling suites pass; `ruff` + `ty` clean.
- End-to-end smoke test via FastAPI `TestClient`: locked → 401 / `DISABLE_METRICS_AUTH=true` → 200 / token set → 401 (none) · 401 (wrong) · 200 (correct).
- CI: change-relevant gates green (`helm-chart-check`, `backend-check`, `mypy`/ty, `quality-checks`, Jest). The only failing check is the pre-existing, unrelated `connectors-check` (live daily connector suite; fails identically on the base commit and touches none of this PR's files).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)