### PR TITLE
fix(scim): promote shadow EXT_PERM_USER on SCIM adoption

### DIFF
--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -46,6 +46,7 @@ from onyx.db.models import ScimUserMapping
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
+from onyx.db.models import UserRole
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -250,6 +251,8 @@ class ScimDAL(DAL):
         email: str | None = None,
         is_active: bool | None = None,
         personal_name: str | None = None,
+        role: UserRole | None = None,
+        account_type: AccountType | None = None,
     ) -> None:
         """Update user attributes. Only sets fields that are provided."""
         if email is not None:
@@ -258,6 +261,10 @@ class ScimDAL(DAL):
             user.is_active = is_active
         if personal_name is not None:
             user.personal_name = personal_name
+        if role is not None:
+            user.role = role
+        if account_type is not None:
+            user.account_type = account_type
 
     def deactivate_user(self, user: User) -> None:
         """Mark a user as inactive."""

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -479,6 +479,11 @@ def create_user(
         )
 
         try:
+            # A promoted shadow user is now a real STANDARD account and must
+            # land in the Basic default group like any net-new SCIM user
+            # (the shadow EXT_PERM_USER role made this a no-op before).
+            if promote:
+                assign_user_to_default_groups__no_commit(db_session, existing_user)
             dal.create_user_mapping(
                 external_id=external_id,
                 user_id=existing_user.id,
@@ -603,8 +608,9 @@ def replace_user(
         account_type=AccountType.STANDARD if promote else None,
     )
 
-    # Reconcile default-group membership on reactivation
-    if is_reactivation:
+    # Reconcile default-group membership on reactivation or promotion — a
+    # promoted shadow user is now a real account and needs the Basic group.
+    if is_reactivation or promote:
         assign_user_to_default_groups__no_commit(
             db_session, user, is_admin=(user.role == UserRole.ADMIN)
         )
@@ -707,8 +713,9 @@ def patch_user(
         account_type=AccountType.STANDARD if promote else None,
     )
 
-    # Reconcile default-group membership on reactivation
-    if is_reactivation:
+    # Reconcile default-group membership on reactivation or promotion — a
+    # promoted shadow user is now a real account and needs the Basic group.
+    if is_reactivation or promote:
         assign_user_to_default_groups__no_commit(
             db_session, user, is_admin=(user.role == UserRole.ADMIN)
         )

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -225,7 +225,7 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     return None
 
 
-def _is_shadow_user(user: User) -> bool:
+def _is_ext_perm_user(user: User) -> bool:
     """Whether *user* is a shadow ``EXT_PERM_USER`` being adopted into SCIM.
 
     ``EXT_PERM_USER`` accounts are created by external permission sync and do
@@ -463,7 +463,7 @@ def create_user(
         # Becoming an active, seat-counting account consumes a seat — that
         # happens when we reactivate a deactivated user OR promote a shadow
         # EXT_PERM_USER (which doesn't count toward seats) to STANDARD.
-        promote = _is_shadow_user(existing_user)
+        promote = _is_ext_perm_user(existing_user)
         if user_resource.active and (not existing_user.is_active or promote):
             seat_error = _check_seat_availability(dal)
             if seat_error:
@@ -590,7 +590,7 @@ def replace_user(
     # Handle activation (need seat check) / deactivation. Promoting a shadow
     # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
     # re-syncs after being adopted while still in the shadow role.
-    promote = _is_shadow_user(user)
+    promote = _is_ext_perm_user(user)
     is_reactivation = user_resource.active and not user.is_active
     if user_resource.active and (is_reactivation or promote):
         seat_error = _check_seat_availability(dal)
@@ -682,7 +682,7 @@ def patch_user(
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted
     # to a real STANDARD account on re-sync.
-    promote = _is_shadow_user(user)
+    promote = _is_ext_perm_user(user)
     is_reactivation = patched.active and not user.is_active
     if patched.active and (patched.active != user.is_active or promote):
         seat_error = _check_seat_availability(dal)

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -225,6 +225,17 @@ def _check_seat_availability(dal: ScimDAL) -> str | None:
     return None
 
 
+def _is_shadow_user(user: User) -> bool:
+    """Whether *user* is a shadow ``EXT_PERM_USER`` being adopted into SCIM.
+
+    ``EXT_PERM_USER`` accounts are created by external permission sync and do
+    not count toward the seat limit. When SCIM adopts one it must be promoted
+    to a real STANDARD account — which consumes a seat. Real users
+    (BASIC/ADMIN) are left untouched so we never demote an admin.
+    """
+    return user.role == UserRole.EXT_PERM_USER
+
+
 def _fetch_user_or_404(user_id: str, dal: ScimDAL) -> User | ScimJSONResponse:
     """Parse *user_id* as UUID, look up the user, or return a 404 error."""
     try:
@@ -449,9 +460,11 @@ def create_user(
             return _scim_error_response(409, f"User with email {email} already exists")
 
         # Adopt pre-existing user into SCIM management.
-        # Reactivating a deactivated user consumes a seat, so enforce the
-        # seat limit the same way replace_user does.
-        if user_resource.active and not existing_user.is_active:
+        # Becoming an active, seat-counting account consumes a seat — that
+        # happens when we reactivate a deactivated user OR promote a shadow
+        # EXT_PERM_USER (which doesn't count toward seats) to STANDARD.
+        promote = _is_shadow_user(existing_user)
+        if user_resource.active and (not existing_user.is_active or promote):
             seat_error = _check_seat_availability(dal)
             if seat_error:
                 return _scim_error_response(403, seat_error)
@@ -460,6 +473,8 @@ def create_user(
         dal.update_user(
             existing_user,
             is_active=user_resource.active,
+            role=UserRole.BASIC if promote else None,
+            account_type=AccountType.STANDARD if promote else None,
             **({"personal_name": personal_name} if personal_name else {}),
         )
 
@@ -567,9 +582,12 @@ def replace_user(
         return result
     user = result
 
-    # Handle activation (need seat check) / deactivation
+    # Handle activation (need seat check) / deactivation. Promoting a shadow
+    # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
+    # re-syncs after being adopted while still in the shadow role.
+    promote = _is_shadow_user(user)
     is_reactivation = user_resource.active and not user.is_active
-    if is_reactivation:
+    if user_resource.active and (is_reactivation or promote):
         seat_error = _check_seat_availability(dal)
         if seat_error:
             return _scim_error_response(403, seat_error)
@@ -581,6 +599,8 @@ def replace_user(
         email=user_resource.userName.strip(),
         is_active=user_resource.active,
         personal_name=personal_name,
+        role=UserRole.BASIC if promote else None,
+        account_type=AccountType.STANDARD if promote else None,
     )
 
     # Reconcile default-group membership on reactivation
@@ -653,13 +673,15 @@ def patch_user(
     except ScimPatchError as e:
         return _scim_error_response(e.status, e.detail)
 
-    # Apply changes back to the DB model
+    # Apply changes back to the DB model. A seat is consumed when the user
+    # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted
+    # to a real STANDARD account on re-sync.
+    promote = _is_shadow_user(user)
     is_reactivation = patched.active and not user.is_active
-    if patched.active != user.is_active:
-        if patched.active:
-            seat_error = _check_seat_availability(dal)
-            if seat_error:
-                return _scim_error_response(403, seat_error)
+    if patched.active and (patched.active != user.is_active or promote):
+        seat_error = _check_seat_availability(dal)
+        if seat_error:
+            return _scim_error_response(403, seat_error)
 
     # Track the scim_username — if userName was patched, update it
     new_scim_username = patched.userName.strip() if patched.userName else None
@@ -681,6 +703,8 @@ def patch_user(
         ),
         is_active=patched.active if patched.active != user.is_active else None,
         personal_name=personal_name,
+        role=UserRole.BASIC if promote else None,
+        account_type=AccountType.STANDARD if promote else None,
     )
 
     # Reconcile default-group membership on reactivation

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -236,6 +236,31 @@ def _is_ext_perm_user(user: User) -> bool:
     return user.role == UserRole.EXT_PERM_USER
 
 
+def _assign_default_groups_or_error(
+    dal: ScimDAL,
+    db_session: Session,
+    user: User,
+    email: str,
+    is_admin: bool = False,
+) -> ScimJSONResponse | None:
+    """Assign *user* to the Basic/Admin default group, or return a SCIM error.
+
+    ``assign_user_to_default_groups__no_commit`` raises (e.g. ``RuntimeError``)
+    if the default group is missing, so failures are rolled back and surfaced
+    as a structured SCIM 500 instead of leaking a raw 500. Returns the error
+    response on failure, else ``None``.
+    """
+    try:
+        assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
+    except Exception:
+        dal.rollback()
+        logger.exception("Failed to assign SCIM user %s to default groups", email)
+        return _scim_error_response(
+            500, f"Failed to assign user {email} to default group"
+        )
+    return None
+
+
 def _fetch_user_or_404(user_id: str, dal: ScimDAL) -> User | ScimJSONResponse:
     """Parse *user_id* as UUID, look up the user, or return a 404 error."""
     try:
@@ -478,12 +503,17 @@ def create_user(
             **({"personal_name": personal_name} if personal_name else {}),
         )
 
+        # A promoted shadow user is now a real STANDARD account and must land
+        # in the Basic default group like any net-new SCIM user (the shadow
+        # EXT_PERM_USER role made this a no-op before).
+        if promote:
+            error = _assign_default_groups_or_error(
+                dal, db_session, existing_user, email
+            )
+            if error:
+                return error
+
         try:
-            # A promoted shadow user is now a real STANDARD account and must
-            # land in the Basic default group like any net-new SCIM user
-            # (the shadow EXT_PERM_USER role made this a no-op before).
-            if promote:
-                assign_user_to_default_groups__no_commit(db_session, existing_user)
             dal.create_user_mapping(
                 external_id=external_id,
                 user_id=existing_user.id,
@@ -548,14 +578,9 @@ def create_user(
 
     # Assign user to default group BEFORE commit so everything is atomic.
     # If this fails, the entire user creation rolls back and IdP can retry.
-    try:
-        assign_user_to_default_groups__no_commit(db_session, user)
-    except Exception:
-        dal.rollback()
-        logger.exception("Failed to assign SCIM user %s to default groups", email)
-        return _scim_error_response(
-            500, f"Failed to assign user {email} to default group"
-        )
+    error = _assign_default_groups_or_error(dal, db_session, user, email)
+    if error:
+        return error
 
     dal.commit()
 
@@ -611,9 +636,11 @@ def replace_user(
     # Reconcile default-group membership on reactivation or promotion — a
     # promoted shadow user is now a real account and needs the Basic group.
     if is_reactivation or promote:
-        assign_user_to_default_groups__no_commit(
-            db_session, user, is_admin=(user.role == UserRole.ADMIN)
+        error = _assign_default_groups_or_error(
+            dal, db_session, user, user.email, is_admin=(user.role == UserRole.ADMIN)
         )
+        if error:
+            return error
 
     new_external_id = user_resource.externalId
     scim_username = user_resource.userName.strip()
@@ -716,9 +743,11 @@ def patch_user(
     # Reconcile default-group membership on reactivation or promotion — a
     # promoted shadow user is now a real account and needs the Basic group.
     if is_reactivation or promote:
-        assign_user_to_default_groups__no_commit(
-            db_session, user, is_admin=(user.role == UserRole.ADMIN)
+        error = _assign_default_groups_or_error(
+            dal, db_session, user, user.email, is_admin=(user.role == UserRole.ADMIN)
         )
+        if error:
+            return error
 
     # Build updated fields by merging PATCH enterprise data with current values
     cf = current_fields or ScimMappingFields()

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -388,6 +388,41 @@ class TestCreateUser:
         assert_scim_error(result, 403)
         mock_dal.update_user.assert_not_called()
 
+    @patch(
+        "ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit",
+        side_effect=RuntimeError("Default group 'Basic' not found"),
+    )
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_promotion_default_group_failure_returns_500(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_assign: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """If default-group assignment raises during promotion, roll back and
+        return a structured SCIM 500 instead of leaking a raw 500."""
+        existing = make_db_user(
+            email="champion@example.com",
+            role=UserRole.EXT_PERM_USER,
+            is_active=True,
+        )
+        mock_dal.get_user_by_email.return_value = existing
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+
+        result = create_user(
+            user_resource=make_scim_user(userName="champion@example.com"),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 500)
+        mock_dal.rollback.assert_called_once()
+        mock_dal.create_user_mapping.assert_not_called()
+
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
     def test_integrity_error_returns_409(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -308,17 +308,20 @@ class TestCreateUser:
         mock_dal.create_user_mapping.assert_called_once()
         mock_dal.commit.assert_called_once()
 
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
     def test_adopting_shadow_ext_perm_user_promotes_to_standard(
         self,
         mock_seats: MagicMock,
+        mock_assign: MagicMock,
         mock_db_session: MagicMock,
         mock_token: MagicMock,
         mock_dal: MagicMock,
         provider: ScimProvider,
     ) -> None:
         """A pre-existing EXT_PERM_USER shadow gets promoted to BASIC/STANDARD,
-        seat-checked even though the user is already active.
+        seat-checked, and added to the Basic default group even though the
+        user is already active.
         """
         existing = make_db_user(
             email="champion@example.com",
@@ -350,6 +353,8 @@ class TestCreateUser:
             account_type=AccountType.STANDARD,
             personal_name="Test User",
         )
+        # Promoted shadow user must land in the Basic default group
+        mock_assign.assert_called_once()
         mock_dal.create_user_mapping.assert_called_once()
         mock_dal.commit.assert_called_once()
 
@@ -524,6 +529,64 @@ class TestReplaceUser:
         assert_scim_error(result, 403)
         mock_seats.assert_called_once()
 
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_promotes_already_active_shadow_user(
+        self,
+        mock_seats: MagicMock,
+        mock_assign: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """An already-active EXT_PERM_USER re-synced via PUT is promoted to
+        STANDARD, seat-checked, and added to the Basic default group."""
+        user = make_db_user(role=UserRole.EXT_PERM_USER, is_active=True)
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(active=True)
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        # Promotion consumes a seat even though the user was already active
+        mock_seats.assert_called_once()
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["role"] == UserRole.BASIC
+        assert kwargs["account_type"] == AccountType.STANDARD
+        mock_assign.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_promotion_respects_seat_limit(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Promoting an already-active shadow user past the cap returns 403."""
+        mock_seats.return_value = "No seats"
+        user = make_db_user(role=UserRole.EXT_PERM_USER, is_active=True)
+        mock_dal.get_user.return_value = user
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=make_scim_user(active=True),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_seats.assert_called_once()
+
     def test_syncs_external_id(
         self,
         mock_db_session: MagicMock,
@@ -588,6 +651,46 @@ class TestPatchUser:
 
         parse_scim_user(result)
         mock_dal.update_user.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_promotes_already_active_shadow_user(
+        self,
+        mock_seats: MagicMock,
+        mock_assign: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """PATCH on an already-active EXT_PERM_USER promotes it to STANDARD,
+        seat-checks the promotion, and assigns the Basic default group."""
+        user = make_db_user(role=UserRole.EXT_PERM_USER, is_active=True)
+        mock_dal.get_user.return_value = user
+        patch_req = ScimPatchRequest(
+            Operations=[
+                ScimPatchOperation(
+                    op=ScimPatchOperationType.REPLACE,
+                    path="active",
+                    value=True,
+                )
+            ]
+        )
+
+        result = patch_user(
+            user_id=str(user.id),
+            patch_request=patch_req,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_seats.assert_called_once()
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["role"] == UserRole.BASIC
+        assert kwargs["account_type"] == AccountType.STANDARD
+        mock_assign.assert_called_once()
 
     def test_not_found_returns_404(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -26,6 +26,8 @@ from ee.onyx.server.scim.models import ScimPatchRequest
 from ee.onyx.server.scim.models import ScimUserResource
 from ee.onyx.server.scim.patch import ScimPatchError
 from ee.onyx.server.scim.providers.base import ScimProvider
+from onyx.db.enums import AccountType
+from onyx.db.models import UserRole
 from tests.unit.onyx.server.scim.conftest import assert_scim_error
 from tests.unit.onyx.server.scim.conftest import make_db_user
 from tests.unit.onyx.server.scim.conftest import make_scim_user
@@ -294,13 +296,92 @@ class TestCreateUser:
         assert parsed.userName == "admin@example.com"
         # Should NOT create a new user — reuse existing
         mock_dal.add_user.assert_not_called()
-        # Should sync is_active and personal_name from the SCIM request
+        # Already a real (BASIC) user — synced but NOT re-roled
         mock_dal.update_user.assert_called_once_with(
-            existing, is_active=True, personal_name="Test User"
+            existing,
+            is_active=True,
+            role=None,
+            account_type=None,
+            personal_name="Test User",
         )
         # Should create a SCIM mapping for the existing user
         mock_dal.create_user_mapping.assert_called_once()
         mock_dal.commit.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_adopting_shadow_ext_perm_user_promotes_to_standard(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A pre-existing EXT_PERM_USER shadow gets promoted to BASIC/STANDARD,
+        seat-checked even though the user is already active.
+        """
+        existing = make_db_user(
+            email="champion@example.com",
+            personal_name=None,
+            role=UserRole.EXT_PERM_USER,
+            is_active=True,
+        )
+        mock_dal.get_user_by_email.return_value = existing
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+        resource = make_scim_user(
+            userName="champion@example.com", externalId="ext-champ"
+        )
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result, status=201)
+        mock_dal.add_user.assert_not_called()
+        # Promotion consumes a seat -> seat check runs despite already-active user
+        mock_seats.assert_called_once()
+        mock_dal.update_user.assert_called_once_with(
+            existing,
+            is_active=True,
+            role=UserRole.BASIC,
+            account_type=AccountType.STANDARD,
+            personal_name="Test User",
+        )
+        mock_dal.create_user_mapping.assert_called_once()
+        mock_dal.commit.assert_called_once()
+
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_adopting_shadow_ext_perm_user_respects_seat_limit(
+        self,
+        mock_seats: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """Promoting a shadow user that would exceed the seat cap returns 403."""
+        mock_seats.return_value = "Seat limit reached"
+        existing = make_db_user(
+            email="champion@example.com",
+            role=UserRole.EXT_PERM_USER,
+            is_active=True,
+        )
+        mock_dal.get_user_by_email.return_value = existing
+        mock_dal.get_user_mapping_by_user_id.return_value = None
+        resource = make_scim_user(userName="champion@example.com")
+
+        result = create_user(
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 403)
+        mock_dal.update_user.assert_not_called()
 
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
     def test_integrity_error_returns_409(


### PR DESCRIPTION
## Description

**Bug:** A SCIM-synced group shows its full member count (e.g. "90 Members") but the member detail and Users page list only a couple — and most synced users never count as active.

**Cause:** When SCIM provisions a user whose email already exists as an `EXT_PERM_USER` shadow (created by external permission sync, which doesn't count toward seats), `create_user` / `replace_user` / `patch_user` adopt the row and link a SCIM mapping but never promote the role. The user stays `EXT_PERM_USER`, so it's filtered out of the Users page and group member lists while still counted in the raw `user__user_group` total.

**Fix:** Promote adopted shadow users to `BASIC` / `STANDARD` and seat-check the promotion — an `EXT_PERM_USER` → `STANDARD` transition consumes a seat even when the user is already active. Real `BASIC` / `ADMIN` users are left untouched, so admins are never demoted.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check