### PR TITLE
ci(nightly-llm): surface local reproduce command on provider failure

### DIFF
--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -47,6 +47,8 @@ jobs:
         uses: ./.github/actions/slack-notify
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          failed-jobs: provider-chat-test
+          details: |
+            *Failed job:* provider-chat-test
+            Each failed provider job's *Summary* tab (and its annotations) includes a copy-paste command to reproduce the failure locally.
           title: "🚨 Scheduled LLM Provider Chat Tests failed!"
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/nightly-llm-provider-chat.yml
+++ b/.github/workflows/nightly-llm-provider-chat.yml
@@ -43,12 +43,43 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Download reproduce commands
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: reproduce-command-nightly-*
+          path: reproduce-commands
+          merge-multiple: true
+
+      - name: Build Slack details
+        id: slack-details
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          DETAILS="*Failed job:* provider-chat-test"
+
+          shopt -s nullglob
+          files=(reproduce-commands/*.txt)
+          if [ ${#files[@]} -gt 0 ]; then
+            DETAILS="${DETAILS}"$'\n'"Supply your own credentials, then run from the Onyx dev container:"
+            for f in "${files[@]}"; do
+              DETAILS="${DETAILS}"$'\n\n'"$(cat "$f")"
+            done
+          else
+            DETAILS="${DETAILS}"$'\n'"Open each failed provider job's *Summary* tab for a copy-paste command to reproduce locally."
+          fi
+
+          {
+            echo "details<<SLACK_DETAILS_EOF"
+            printf '%s\n' "$DETAILS"
+            echo "SLACK_DETAILS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send Slack notification
         uses: ./.github/actions/slack-notify
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK }}
-          details: |
-            *Failed job:* provider-chat-test
-            Each failed provider job's *Summary* tab (and its annotations) includes a copy-paste command to reproduce the failure locally.
+          details: ${{ steps.slack-details.outputs.details }}
           title: "🚨 Scheduled LLM Provider Chat Tests failed!"
           ref-name: ${{ github.ref_name }}

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -301,7 +301,7 @@ jobs:
           for line in "${lines[@]}"; do
             CMD="${CMD}${line} \\"$'\n'
           done
-          CMD="${CMD}uv run pytest -v --tb=short -rs ${TEST_PATH}"
+          CMD="${CMD}uv run pytest ${TEST_PATH}"
 
           # Rich, copy-pasteable block in the job summary.
           {

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -273,26 +273,18 @@ jobs:
           API_BASE: ${{ matrix.api_base }}
           API_VERSION: ${{ matrix.api_version }}
           DEPLOYMENT_NAME: ${{ matrix.deployment_name }}
-          USES_API_KEY: ${{ matrix.api_key_env != '' }}
-          USES_CUSTOM_CONFIG: ${{ matrix.custom_config_env != '' }}
           STRICT: ${{ inputs.strict && 'true' || 'false' }}
         run: |
           set -uo pipefail
 
           TEST_PATH="backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py"
 
-          # Build the env-var prefix, omitting unset optional values. Secrets are
-          # shown as placeholders so the developer supplies their own credentials.
+          # Build the env-var prefix, omitting unset optional values. Credentials
+          # (NIGHTLY_LLM_API_KEY / NIGHTLY_LLM_CUSTOM_CONFIG_JSON) are intentionally
+          # left out — supply your own when running locally.
           lines=()
-          lines+=("INTEGRATION_TESTS_MODE=true")
           lines+=("NIGHTLY_LLM_PROVIDER='${PROVIDER}'")
           lines+=("NIGHTLY_LLM_MODELS='${MODELS}'")
-          if [ "${USES_API_KEY}" = "true" ]; then
-            lines+=("NIGHTLY_LLM_API_KEY='<your-${PROVIDER}-api-key>'")
-          fi
-          if [ "${USES_CUSTOM_CONFIG}" = "true" ]; then
-            lines+=("NIGHTLY_LLM_CUSTOM_CONFIG_JSON='<your-${PROVIDER}-custom-config-json>'")
-          fi
           if [ -n "${API_BASE}" ]; then
             lines+=("NIGHTLY_LLM_API_BASE='${API_BASE}'")
           fi

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -264,6 +264,68 @@ jobs:
           docker-username: ${{ env.DOCKER_USERNAME }}
           docker-token: ${{ env.DOCKER_TOKEN }}
 
+      - name: Print local reproduce command on failure
+        if: failure()
+        shell: bash
+        env:
+          PROVIDER: ${{ matrix.provider }}
+          MODELS: ${{ matrix.models }}
+          API_BASE: ${{ matrix.api_base }}
+          API_VERSION: ${{ matrix.api_version }}
+          DEPLOYMENT_NAME: ${{ matrix.deployment_name }}
+          USES_API_KEY: ${{ matrix.api_key_env != '' }}
+          USES_CUSTOM_CONFIG: ${{ matrix.custom_config_env != '' }}
+          STRICT: ${{ inputs.strict && 'true' || 'false' }}
+        run: |
+          set -uo pipefail
+
+          TEST_PATH="backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py"
+
+          # Build the env-var prefix, omitting unset optional values. Secrets are
+          # shown as placeholders so the developer supplies their own credentials.
+          lines=()
+          lines+=("INTEGRATION_TESTS_MODE=true")
+          lines+=("NIGHTLY_LLM_PROVIDER='${PROVIDER}'")
+          lines+=("NIGHTLY_LLM_MODELS='${MODELS}'")
+          if [ "${USES_API_KEY}" = "true" ]; then
+            lines+=("NIGHTLY_LLM_API_KEY='<your-${PROVIDER}-api-key>'")
+          fi
+          if [ "${USES_CUSTOM_CONFIG}" = "true" ]; then
+            lines+=("NIGHTLY_LLM_CUSTOM_CONFIG_JSON='<your-${PROVIDER}-custom-config-json>'")
+          fi
+          if [ -n "${API_BASE}" ]; then
+            lines+=("NIGHTLY_LLM_API_BASE='${API_BASE}'")
+          fi
+          if [ -n "${API_VERSION}" ]; then
+            lines+=("NIGHTLY_LLM_API_VERSION='${API_VERSION}'")
+          fi
+          if [ -n "${DEPLOYMENT_NAME}" ]; then
+            lines+=("NIGHTLY_LLM_DEPLOYMENT_NAME='${DEPLOYMENT_NAME}'")
+          fi
+          lines+=("NIGHTLY_LLM_STRICT='${STRICT}'")
+
+          # Compose the command: one env var per line, then the pytest invocation.
+          CMD=""
+          for line in "${lines[@]}"; do
+            CMD="${CMD}${line} \\"$'\n'
+          done
+          CMD="${CMD}python -m dotenv -f .vscode/.env run -- \\"$'\n'
+          CMD="${CMD}  pytest -v --tb=short -rs ${TEST_PATH}"
+
+          # Rich, copy-pasteable block in the job summary.
+          {
+            echo "### 🔁 Reproduce \`${PROVIDER}\` failure locally"
+            echo ""
+            echo "From the Onyx dev container (all services running), supply your own credentials and run:"
+            echo ""
+            echo '```bash'
+            echo "${CMD}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Annotation surfaced at the top of the run (newlines encoded as %0A).
+          echo "::notice title=Reproduce ${PROVIDER} failure locally::${CMD//$'\n'/%0A}"
+
       - name: Dump API server logs
         if: always()
         run: |

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -309,8 +309,7 @@ jobs:
           for line in "${lines[@]}"; do
             CMD="${CMD}${line} \\"$'\n'
           done
-          CMD="${CMD}python -m dotenv -f .vscode/.env run -- \\"$'\n'
-          CMD="${CMD}  pytest -v --tb=short -rs ${TEST_PATH}"
+          CMD="${CMD}uv run pytest -v --tb=short -rs ${TEST_PATH}"
 
           # Rich, copy-pasteable block in the job summary.
           {

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -317,6 +317,22 @@ jobs:
           # Annotation surfaced at the top of the run (newlines encoded as %0A).
           echo "::notice title=Reproduce ${PROVIDER} failure locally::${CMD//$'\n'/%0A}"
 
+          # Persist a Slack-ready snippet so the notify job can inline the command.
+          {
+            echo "*Reproduce \`${PROVIDER}\` failure locally:*"
+            echo '```'
+            echo "${CMD}"
+            echo '```'
+          } > "reproduce-command-${PROVIDER}.txt"
+
+      - name: Upload reproduce command
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: reproduce-command-nightly-${{ matrix.provider }}
+          path: reproduce-command-${{ matrix.provider }}.txt
+          if-no-files-found: ignore
+
       - name: Dump API server logs
         if: always()
         run: |


### PR DESCRIPTION
## What

When a nightly LLM provider chat job fails, surface a copy-pasteable command to reproduce the failure **locally**, so on-call doesn't have to reverse-engineer the matrix env vars from the workflow.

## How

- **`reusable-nightly-llm-provider-chat.yml`** — adds a `Print local reproduce command on failure` step to the per-provider matrix job (right after the test runs). On `failure()` it:
  - Writes a `bash` code block to the **job summary** (`$GITHUB_STEP_SUMMARY`), and
  - Emits a **`::notice::` annotation** with the same command at the top of the run.

  This lives in the matrix job because that's the only place with the per-provider context (`provider`, `models`, `api_base`, `api_version`, `deployment_name`, `strict`). The generated command:
  - Omits optional env vars when unset (e.g. no `API_BASE` line for Anthropic).
  - Handles both credential shapes — `NIGHTLY_LLM_API_KEY` for key-based providers vs. `NIGHTLY_LLM_CUSTOM_CONFIG_JSON` for `vertex_ai`.
  - Uses a **placeholder** for the secret (`<your-anthropic-api-key>`) so nothing sensitive is logged.
  - Pins `INTEGRATION_TESTS_MODE=true` so the test's `_assert_integration_mode_enabled()` passes even though `.vscode/.env` is gitignored.

- **`nightly-llm-provider-chat.yml`** — the Slack failure alert now uses `details` (the non-deprecated input) to name the failed job and point readers to each failed provider job's **Summary tab / annotations** for the reproduce command. The existing "View Workflow Run" button already deep-links there.

## Example (Anthropic)

```bash
INTEGRATION_TESTS_MODE=true \
NIGHTLY_LLM_PROVIDER='anthropic' \
NIGHTLY_LLM_MODELS='claude-haiku-4-5' \
NIGHTLY_LLM_API_KEY='<your-anthropic-api-key>' \
NIGHTLY_LLM_STRICT='true' \
python -m dotenv -f .vscode/.env run -- \
  pytest -v --tb=short -rs backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
```

## Notes

- Used `::notice::` (informational) rather than `::error::` for the annotation, so it isn't misread as a *second* failure cause. Easy to flip if you'd prefer it red/more prominent.
- Kept Slack pointing at the summary rather than inlining per-provider commands — inlining would require threading matrix context into the separate notify job via job outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a copy‑paste command to reproduce failed nightly LLM provider chat tests locally. The command appears in each failed matrix job and is inlined in the Slack alert when available.

- **New Features**
  - Builds a provider-scoped command with only set env vars (`NIGHTLY_LLM_PROVIDER`, `NIGHTLY_LLM_MODELS`, optional `NIGHTLY_LLM_API_BASE`, `NIGHTLY_LLM_API_VERSION`, `NIGHTLY_LLM_DEPLOYMENT_NAME`, `NIGHTLY_LLM_STRICT`); omits credentials and `INTEGRATION_TESTS_MODE`; runs via `uv run pytest` with no extra flags.
  - Surfaces the command in the job Summary and as a notice, uploads a per-provider snippet artifact, and inlines all available commands in the Slack failure alert (falls back to “check the Summary” when no artifacts exist).

<sup>Written for commit cef97b1ff0a283f4176e39f7819aa502c76ca4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

