### PR TITLE
fix(opal): drop CSS imports via esbuild plugin instead of marking as external

### DIFF
--- a/web/lib/opal/tsup.config.ts
+++ b/web/lib/opal/tsup.config.ts
@@ -1,6 +1,27 @@
 import { defineConfig } from "tsup";
 import { preserveDirectivesPlugin } from "esbuild-plugin-preserve-directives";
 
+// CSS imports in Opal source use the @opal/* path alias (e.g.
+// "@opal/components/tooltip/styles.css"). That alias is a dev-only tsconfig
+// path that consumers don't have, and the individual CSS files are not
+// published — only the bundled dist/styles.css is. Keeping them in the dist
+// JS as external imports leaves unresolvable specifiers for every consumer.
+// This plugin drops all CSS imports from the JS output; styles are loaded via
+// the bundled dist/styles.css (or dist/root.css) that bundle-css.mjs produces.
+const dropCssImports = {
+  name: "drop-css-imports",
+  setup(build: import("esbuild").PluginBuild) {
+    build.onResolve({ filter: /\.css$/ }, () => ({
+      path: "drop-css",
+      namespace: "drop-css-ns",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "drop-css-ns" }, () => ({
+      contents: "",
+      loader: "js" as const,
+    }));
+  },
+};
+
 export default defineConfig({
   entry: [
     "src/components/index.ts",
@@ -31,9 +52,9 @@ export default defineConfig({
     "react-markdown",
     "remark-gfm",
     "rehype-sanitize",
-    /\.css$/,
   ],
   esbuildPlugins: [
+    dropCssImports,
     preserveDirectivesPlugin({
       directives: ["use client"],
       include: /\.(jsx?|tsx?)$/,


### PR DESCRIPTION
## Description

Replaces the `external: [/\.css$/]` tsup config with a dedicated `drop-css-imports` esbuild plugin. The old approach marked CSS files as external, which left unresolvable `@opal/*` path-alias import specifiers in the published JS output — consumers don't have that alias and the individual CSS files aren't published anyway (only the bundled `dist/styles.css` produced by `bundle-css.mjs` is).

The plugin intercepts all `.css` resolves and returns empty JS, so no CSS import specifier survives in the dist files.

## How Has This Been Tested?

Verified the built output no longer contains unresolvable CSS import specifiers.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `tsup` CSS externals with a custom `esbuild` plugin that drops CSS imports. This removes unresolvable `@opal/*` CSS paths from published JS while keeping styles in the bundled CSS.

- **Bug Fixes**
  - Intercepts `.css` in `esbuild` and returns empty JS; removes `/\.css$/` from `external` in `tsup.config.ts`.
  - Prevents broken imports for consumers without the `@opal/*` alias; styles still load from `dist/styles.css`/`dist/root.css`.

<sup>Written for commit 2aa06048d63056b0b5c93b8905f31c0f3aea53ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

