### PR TITLE
fix(slack): skip doc-set and persona ACL checks for anonymous Slack bot users

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -142,7 +142,7 @@ def create_chat_session_from_request(
 
     persona_id = chat_session_request.persona_id
     if persona_id != DEFAULT_PERSONA_ID:
-        if not user_can_access_persona(
+        if not user.is_anonymous and not user_can_access_persona(
             db_session=db_session,
             persona_id=persona_id,
             user=user,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1413,6 +1413,7 @@ def _stream_chat_turn(
             try:
                 if (
                     not bypass_acl
+                    and not user.is_anonymous
                     and new_msg_req.internal_search_filters is not None
                     and new_msg_req.internal_search_filters.document_set is not None
                 ):

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -69,6 +69,7 @@ def _build_index_filters(
     if (
         base_filters.document_set is not None
         and not bypass_acl
+        and not user.is_anonymous
         and db_session is not None
     ):
         accessible_names = filter_document_set_names_by_user_access(

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -567,6 +567,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 and self.user_selected_filters.document_set
                 and not self.bypass_acl
                 and self.user
+                and not self.user.is_anonymous
             ):
                 requested = self.user_selected_filters.document_set
                 accessible = filter_document_set_names_by_user_access(


### PR DESCRIPTION
## Description

v4.0 regression: Slack bots configured with private personas or private document sets stopped working after the v4.0 upgrade.

**Root cause:** The v3.3 security fix ([#10602](https://github.com/onyx-dot-app/onyx/pull/10602)) added access checks that enforce users can only query document sets and personas they have explicit access to. This fix was never backported to v3.2.x, so bots that worked fine on v3.2.x silently broke on the v4.0 upgrade.

The Slack bot uses an anonymous user identity for public channels. The access checks correctly block anonymous users from private resources, but the persona and doc sets are **admin-configured** (from `slack_channel_config`) — not user-supplied — so the restriction is inappropriate for this code path.

**Changes (4 one-liners across 4 files):**
- `process_message.py` — skip doc-set check when `user.is_anonymous`
- `search_tool.py` — skip doc-set check when `self.user.is_anonymous`
- `pipeline.py` — skip doc-set check when `user.is_anonymous`
- `chat_utils.py` — skip persona check when `user.is_anonymous`

**Security guarantee preserved:** Document-level ACL (Vespa) still runs unconditionally. Anonymous users are limited to `PUBLIC_DOC_PAT` documents regardless of which doc set or persona is queried — this is enforced in both MIT and EE `_get_acl_for_user`. The API-layer bypass that #10602 was designed to close (authenticated users injecting arbitrary doc set names) is **still enforced** for all non-anonymous callers.

## How Has This Been Tested?

Confirmed via live Slack bot logs showing `OnyxError INSUFFICIENT_PERMISSIONS: User does not have access to document sets` on every message, retrying 5 times then failing silently. Traced the call stack to the three doc-set check sites and the persona check site.

The fix restores the pre-v3.3 behavior for anonymous users, which was the intended behavior for admin-configured Slack bots.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a v4.0 regression that blocked Slack bots using private personas or document sets by skipping persona and doc-set access checks for anonymous Slack users. Document-level ACLs still apply; non-anonymous users keep full checks.

- **Bug Fixes**
  - `chat_utils.py`: only check persona access when `not user.is_anonymous`.
  - `process_message.py`, `pipeline.py`, `search_tool.py`: skip document-set checks when `user.is_anonymous` (still honor `bypass_acl` flags).
  - Vespa document-level ACLs remain enforced; anonymous users are limited to `PUBLIC_DOC_PAT`.

<sup>Written for commit cccf2947302999973e17f4951348457e677e245a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

