### PR TITLE
ci(nightly): drop backend image from LLM provider chat tests

### DIFF
--- a/.github/actions/run-nightly-provider-chat-test/action.yml
+++ b/.github/actions/run-nightly-provider-chat-test/action.yml
@@ -68,10 +68,12 @@ runs:
         INTEGRATION_TESTS_MODE=true
         AUTO_LLM_UPDATE_INTERVAL_SECONDS=10
         AWS_REGION_NAME=us-west-2
-        ONYX_BACKEND_IMAGE=${ECR_CACHE}:nightly-llm-it-backend-${RUN_ID}
         ONYX_MODEL_SERVER_IMAGE=${ECR_CACHE}:nightly-llm-it-model-server-${RUN_ID}
         EOF2
 
+    # The api_server runs in-process inside pytest via FastAPI TestClient (see
+    # tests/integration/conftest.py), so no backend image / api_server container
+    # is needed here — just the supporting services.
     - name: Start Docker containers
       shell: bash
       run: |
@@ -81,14 +83,7 @@ runs:
           opensearch \
           cache \
           minio \
-          api_server \
           inference_model_server
-
-    - name: Seed dev license
-      shell: bash
-      run: |
-        docker exec -e ONYX_DEV_LICENSE onyx-api_server-1 \
-          python -m scripts.seed_dev_license
 
     - name: Install Python deps and generate OpenAPI client
       uses: ./.github/actions/install-deps-and-generate-openapi-client
@@ -128,7 +123,6 @@ runs:
             -e POSTGRES_USE_NULL_POOL=true \
             -e OPENSEARCH_HOST=opensearch \
             -e REDIS_HOST=cache \
-            -e API_SERVER_HOST=api_server \
             -e MODEL_SERVER_HOST=inference_model_server \
             -e INDEXING_MODEL_SERVER_HOST=inference_model_server \
             -e TEST_WEB_HOSTNAME=test-runner \
@@ -144,5 +138,6 @@ runs:
             -e NIGHTLY_LLM_DEPLOYMENT_NAME="${NIGHTLY_LLM_DEPLOYMENT_NAME}" \
             -e NIGHTLY_LLM_CUSTOM_CONFIG_JSON="${NIGHTLY_LLM_CUSTOM_CONFIG_JSON}" \
             -e NIGHTLY_LLM_STRICT="${NIGHTLY_LLM_STRICT}" \
+            -e ONYX_DEV_LICENSE \
             ${RUNS_ON_ECR_CACHE}:nightly-llm-it-devcontainer-${RUN_ID} \
             uv run --no-sync pytest -v --tb=short -rs tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -58,35 +58,6 @@ permissions:
   id-token: write
 
 jobs:
-  build-backend-image:
-    runs-on:
-      [
-        runs-on,
-        runner=1cpu-linux-arm64,
-        "run-id=${{ github.run_id }}-build-backend-image",
-        "extras=ecr-cache",
-      ]
-    timeout-minutes: 45
-    environment: ci-protected
-    steps:
-      - uses: runs-on/action@d141ef83eb66d096ce8afc767e09115a65c63b60
-
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Build backend image
-        uses: ./.github/actions/build-backend-image
-        with:
-          runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
-          ref-name: ${{ github.ref_name }}
-          pr-number: ${{ github.event.pull_request.number }}
-          github-sha: ${{ github.sha }}
-          run-id: ${{ github.run_id }}
-          ecr-registry: ${{ vars.ECR_REGISTRY }}
-          docker-no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' && 'true' || 'false' }}
-
   build-model-server-image:
     runs-on:
       [
@@ -146,7 +117,6 @@ jobs:
   provider-chat-test:
     needs:
       [
-        build-backend-image,
         build-model-server-image,
         build-devcontainer-image,
       ]
@@ -264,12 +234,10 @@ jobs:
           docker-username: ${{ env.DOCKER_USERNAME }}
           docker-token: ${{ env.DOCKER_TOKEN }}
 
-      - name: Dump API server logs
-        if: always()
-        run: |
-          cd deployment/docker_compose
-          docker compose logs --no-color api_server > $GITHUB_WORKSPACE/api_server.log || true
-
+      # The api_server runs in-process inside pytest via FastAPI TestClient, so its
+      # logs are captured directly in the test-runner stdout (the workflow log for
+      # the "Run nightly provider chat test" step) — only the supporting containers
+      # need a separate dump here.
       - name: Dump all-container logs
         if: always()
         run: |
@@ -282,7 +250,6 @@ jobs:
         with:
           name: docker-all-logs-nightly-${{ matrix.provider }}-llm-provider
           path: |
-            ${{ github.workspace }}/api_server.log
             ${{ github.workspace }}/docker-compose.log
 
       - name: Stop Docker containers


### PR DESCRIPTION
Running ad-hoc job: https://github.com/onyx-dot-app/onyx/actions/runs/27158560786

## What

Drops the backend image / `api_server` container from the **Nightly LLM Provider Chat Tests**.

Since 6f72d7a602 (#11300), the integration tests run the api_server **in-process** via FastAPI `TestClient` (built in `backend/tests/integration/conftest.py`), so this workflow no longer needs a running `api_server` container or the backend image behind it. This brings the nightly workflow in line with the no-backend-image pattern already used by `pr-integration-tests.yml`.

## Changes

**`.github/workflows/reusable-nightly-llm-provider-chat.yml`**
- Remove the `build-backend-image` job and its `needs` reference on `provider-chat-test`.
- Remove the "Dump API server logs" step and the `api_server.log` artifact — those logs now land in the test-runner stdout (the workflow log).

**`.github/actions/run-nightly-provider-chat-test/action.yml`**
- Remove `ONYX_BACKEND_IMAGE` from the compose `.env` and drop `api_server` from the started services.
- Replace the `docker exec onyx-api_server-1 ... seed_dev_license` step with the in-process `seed_dev_license_for_session` fixture by passing `ONYX_DEV_LICENSE` into the test-runner (the nightly `.env` sets `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true`, so the license is still required).
- Remove the now-stale `API_SERVER_HOST=api_server` env (TestClient routes via ASGI in-process; `pr-integration-tests.yml` doesn't set it either).

## Verification

- Cross-checked against `pr-integration-tests.yml`, which already follows the identical no-backend-image pattern.
- Confirmed `ONYX_DEV_LICENSE` is fetched in the reusable workflow's `Get AWS Secrets` step, so it's available for `-e ONYX_DEV_LICENSE`.
- Confirmed `pr-python-connector-tests.yml` (which reuses the `nightly-llm-it-backend` tag name) builds its own backend image in its own run — unaffected.
- Both files parse as valid YAML.

This only touches CI orchestration, so real confirmation is a `workflow_dispatch` run of the nightly workflow (or the next scheduled run going green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the backend Docker image and `api_server` container from Nightly LLM Provider Chat tests. The API server now runs in-process via FastAPI TestClient, simplifying CI and reducing build time.

- **Refactors**
  - Removed `build-backend-image` job and its `needs` in the nightly workflow.
  - Dropped `api_server` service and `ONYX_BACKEND_IMAGE`; pass `ONYX_DEV_LICENSE` to pytest for the in-process seeding fixture.
  - Removed `API_SERVER_HOST` env; TestClient routes in-process.
  - Stopped dumping `api_server` logs; they appear in the test-runner output; keep other container logs.
  - Matches the no-backend-image pattern in `pr-integration-tests.yml`; other workflows (e.g., `pr-python-connector-tests.yml`) are unaffected.

<sup>Written for commit eb7c738ce38c57656c14b45c30f7acd72fc71579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

