### PR TITLE
feat(craft): add session-scoped approvals

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -303,6 +303,7 @@ class ApprovalDecidedVia(str, PyEnum):
     # NULL on legacy rows and proxy-written EXPIRED claims.
     USER = "USER"
     PRE_APPROVAL = "PRE_APPROVAL"
+    SESSION_GRANT = "SESSION_GRANT"
 
 
 class ScheduledTaskStatus(str, PyEnum):

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -1,6 +1,8 @@
 """Composes recognition + policy resolution into a single verdict for an
 outbound request."""
 
+from collections.abc import Iterable
+from collections.abc import Mapping
 from typing import Any
 
 from pydantic import BaseModel
@@ -62,6 +64,37 @@ class AllMatchedActions(BaseModel):
     def governing_action(self) -> MatchedAction:
         """The action whose policy drove the verdict (head of the sorted list)."""
         return self.actions[0]
+
+
+PersistedMatchedAction = Mapping[str, Any]
+ActionLike = MatchedAction | PersistedMatchedAction
+
+
+def actions_requiring_approval(actions: Iterable[ActionLike]) -> list[str]:
+    """Return the action types whose policy requires a user approval.
+
+    The live gate works with ``MatchedAction`` models while the approval API
+    reads the same shape back from JSONB. Keeping both paths here avoids
+    mismatched grant semantics between current and persisted requests.
+    """
+    action_types: set[str] = set()
+    for action in actions:
+        if isinstance(action, MatchedAction):
+            policy = action.policy
+            action_type = action.action_type
+        else:
+            try:
+                policy = EndpointPolicy(action["policy"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            raw_action_type = action.get("action_type")
+            if not isinstance(raw_action_type, str):
+                continue
+            action_type = raw_action_type
+
+        if policy is EndpointPolicy.ASK:
+            action_types.add(action_type)
+    return sorted(action_types)
 
 
 def _app_name(app: ExternalApp) -> str:

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -29,6 +29,7 @@ from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
 from onyx.db.scheduled_task import get_live_scheduled_run_grants
 from onyx.db.scheduled_task import ScheduledRunGrants
+from onyx.external_apps.matching.engine import actions_requiring_approval
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
@@ -71,18 +72,17 @@ _CRAFT_SESSION_LINK_TEMPLATE = "/craft/v1?sessionId={session_id}"
 
 
 @dataclass(frozen=True)
-class _AutoApproval:
+class _ApprovalGrant:
     """A decision to approve a gated request without parking it.
 
-    Produced by a grant source in ``_resolve_auto_approval``; the
-    mint/inject/notify path that consumes it is source-agnostic. Carries how to
-    attribute the audit row (``decided_via``) and the bell entry to raise.
+    Produced by a grant source in ``_resolve_approval_grant``. Carries how to
+    attribute the audit row (``decided_via``) and any bell entry to raise.
     """
 
     decided_via: ApprovalDecidedVia
-    notif_type: NotificationType
-    notification_title: str
-    notification_data: dict[str, str | int]
+    notif_type: NotificationType | None = None
+    notification_title: str | None = None
+    notification_data: dict[str, str | int] | None = None
 
 
 # TTL bounds staleness past a run's RUNNING -> terminal transition.
@@ -137,7 +137,8 @@ class GateAddon:
         self._snapshot_policy = snapshot_policy
         self._stream_responses = stream_responses
         # Invariant: `_persist_approval_row` is the only writer;
-        # `_await_decision`'s finally is the only remover.
+        # `_await_decision`'s finally and the post-persist grant recheck are the
+        # only removers.
         self._parked = ParkedApprovals()
         # client connection id -> session tag, captured from the CONNECT's
         # Proxy-Authorization (only place it's visible for MITM'd HTTPS).
@@ -258,23 +259,10 @@ class GateAddon:
             return
         ctx, matched_actions = gate_target
 
-        # Auto-approval short-circuit: a grant source (today: a RUNNING
-        # scheduled run pre-approving this app) skips the park. Off-thread to
-        # keep sync DB work off the event loop; failure falls through to park.
-        try:
-            auto_approved = await asyncio.to_thread(
-                self._try_auto_approve, ctx, matched_actions
-            )
-        except Exception:
-            logger.exception(
-                "gate.auto_approval_check_error session_id=%s tenant_id=%s "
-                "action_type=%s",
-                ctx.session_id,
-                ctx.tenant_id,
-                matched_actions.governing_action.action_type,
-            )
-            auto_approved = False
-        if auto_approved:
+        # Grant sources can approve without asking the user. Check
+        # before we insert a pending row, then re-check after insert to close the
+        # window where a session grant appears between those two steps.
+        if await self._approval_grant_applies(ctx, matched_actions):
             # Fail closed: an unguarded raise here would let mitmproxy forward
             # the original request, bypassing the gate after an APPROVED row
             # exists.
@@ -287,7 +275,7 @@ class GateAddon:
                 )
             except Exception:
                 logger.exception(
-                    "gate.auto_approved_dispatch_error session_id=%s tenant_id=%s "
+                    "gate.approval_grant_dispatch_error session_id=%s tenant_id=%s "
                     "action_type=%s",
                     ctx.session_id,
                     ctx.tenant_id,
@@ -301,7 +289,13 @@ class GateAddon:
         approval_id: UUID | None = None
         try:
             approval_id = self._persist_approval_row(ctx, matched_actions)
-            decision = await self._await_decision(approval_id, ctx, matched_actions)
+            if await self._approval_grant_applies(
+                ctx, matched_actions, approval_id=approval_id
+            ):
+                self._parked.remove(ctx.tenant_id, approval_id)
+                decision = ApprovalDecision.APPROVED
+            else:
+                decision = await self._await_decision(approval_id, ctx, matched_actions)
             self._write_response_for_decision(flow, decision)
             if decision == ApprovalDecision.APPROVED:
                 # Off-thread: the external-app resolver may refresh an expiring
@@ -483,14 +477,14 @@ class GateAddon:
         )
         return ctx, matched_actions
 
-    def _resolve_auto_approval(
+    def _resolve_approval_grant(
         self, db: Session, ctx: SessionContext, matched_actions: AllMatchedActions
-    ) -> _AutoApproval | None:
-        """Resolve a gated request to an auto-approval, or ``None`` to park."""
-        # Scheduled-task grants are the only auto-approval type today. As other
-        # types appear (session-scoped, per-action), each becomes a source
-        # resolved here — first hit wins.
-        return self._scheduled_task_grant(db, ctx, matched_actions)
+    ) -> _ApprovalGrant | None:
+        """Resolve a gated request to a reusable approval grant, or ``None``."""
+        # Grant sources are checked in order, first hit wins.
+        return self._scheduled_task_grant(db, ctx, matched_actions) or (
+            self._session_grant(db, ctx, matched_actions)
+        )
 
     @cachedmethod(
         operator.attrgetter("_grant_cache"),
@@ -502,7 +496,7 @@ class GateAddon:
 
     def _scheduled_task_grant(
         self, db: Session, ctx: SessionContext, matched_actions: AllMatchedActions
-    ) -> _AutoApproval | None:
+    ) -> _ApprovalGrant | None:
         """
         Grant source: a RUNNING scheduled run whose task pre-approves the
         matched app.
@@ -513,7 +507,7 @@ class GateAddon:
         run_id, granted_app_ids = grants
         if matched_actions.external_app_id not in granted_app_ids:
             return None
-        return _AutoApproval(
+        return _ApprovalGrant(
             decided_via=ApprovalDecidedVia.PRE_APPROVAL,
             notif_type=NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION,
             notification_title=f"Scheduled task used {matched_actions.app_name} (pre-approved)",
@@ -523,49 +517,148 @@ class GateAddon:
             },
         )
 
-    def _try_auto_approve(
-        self, ctx: SessionContext, matched_actions: AllMatchedActions
-    ) -> bool:
-        """
-        Mints a pre-decided APPROVED row if a grant source covers this request;
-        False otherwise (falls through to the park). Source-agnostic.
-
-        Bypassing ``try_record_decision``'s arbiter is safe: nothing parks on a
-        pre-decided row.
-        """
-        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
-            approval = self._resolve_auto_approval(db, ctx, matched_actions)
-            if approval is None:
-                return False
-            row = action_approval.insert_action_approval(
-                db,
+    def _session_grant(
+        self, db: Session, ctx: SessionContext, matched_actions: AllMatchedActions
+    ) -> _ApprovalGrant | None:
+        """The user approved this app/action for the session."""
+        action_types = actions_requiring_approval(matched_actions.actions)
+        if not action_types:
+            return None
+        cache: CacheBackend | None = None
+        try:
+            cache = self._cache_factory(ctx.tenant_id)
+            if approval_cache.cached_session_grants_cover(
                 session_id=ctx.session_id,
-                actions=[a.model_dump(mode="json") for a in matched_actions.actions],
-                app_name=matched_actions.app_name,
-                payload=matched_actions.payload,
                 external_app_id=matched_actions.external_app_id,
-                decision=ApprovalDecision.APPROVED,
-                decided_via=approval.decided_via,
+                action_types=action_types,
+                cache=cache,
+            ):
+                return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
+        except CACHE_TRANSIENT_ERRORS as e:
+            logger.warning(
+                "gate.session_grant_cache_check_failed session_id=%s "
+                "tenant_id=%s external_app_id=%s error=%s",
+                ctx.session_id,
+                ctx.tenant_id,
+                matched_actions.external_app_id,
+                str(e),
             )
-            approval_id = row.approval_id
+
+        grant_source_rows = action_approval.list_session_grant_action_approvals(
+            db,
+            session_id=ctx.session_id,
+            external_app_id=matched_actions.external_app_id,
+        )
+        granted_action_types: set[str] = set()
+        for grant_source_row in grant_source_rows:
+            granted_action_types.update(
+                actions_requiring_approval(grant_source_row.actions)
+            )
+        if not set(action_types).issubset(granted_action_types):
+            return None
+
+        if cache is not None:
+            try:
+                for grant_source_row in grant_source_rows:
+                    approval_cache.cache_session_grant_actions(
+                        session_id=ctx.session_id,
+                        external_app_id=matched_actions.external_app_id,
+                        action_types=actions_requiring_approval(
+                            grant_source_row.actions
+                        ),
+                        source_approval_id=grant_source_row.approval_id,
+                        cache=cache,
+                    )
+            except CACHE_TRANSIENT_ERRORS as e:
+                logger.warning(
+                    "gate.session_grant_cache_hydrate_failed session_id=%s "
+                    "tenant_id=%s external_app_id=%s error=%s",
+                    ctx.session_id,
+                    ctx.tenant_id,
+                    matched_actions.external_app_id,
+                    str(e),
+                )
+        return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
+
+    async def _approval_grant_applies(
+        self,
+        ctx: SessionContext,
+        matched_actions: AllMatchedActions,
+        *,
+        approval_id: UUID | None = None,
+    ) -> bool:
+        try:
+            return await asyncio.to_thread(
+                self._try_apply_approval_grant,
+                ctx,
+                matched_actions,
+                approval_id,
+            )
+        except Exception:
+            logger.exception(
+                "gate.approval_grant_check_error session_id=%s tenant_id=%s "
+                "approval_id=%s action_type=%s",
+                ctx.session_id,
+                ctx.tenant_id,
+                approval_id,
+                matched_actions.governing_action.action_type,
+            )
+            return False
+
+    def _try_apply_approval_grant(
+        self,
+        ctx: SessionContext,
+        matched_actions: AllMatchedActions,
+        approval_id: UUID | None,
+    ) -> bool:
+        """Apply an existing approval grant to a new or already-persisted row."""
+        with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
+            grant = self._resolve_approval_grant(db, ctx, matched_actions)
+            if grant is None:
+                return False
+            if approval_id is None:
+                row = action_approval.insert_action_approval(
+                    db,
+                    session_id=ctx.session_id,
+                    actions=[
+                        a.model_dump(mode="json") for a in matched_actions.actions
+                    ],
+                    app_name=matched_actions.app_name,
+                    payload=matched_actions.payload,
+                    external_app_id=matched_actions.external_app_id,
+                    decision=ApprovalDecision.APPROVED,
+                    decided_via=grant.decided_via,
+                )
+                applied_approval_id = row.approval_id
+            else:
+                decided = action_approval.try_record_decision(
+                    db,
+                    approval_id=approval_id,
+                    decision=ApprovalDecision.APPROVED,
+                    decided_via=grant.decided_via,
+                )
+                if decided is None:
+                    return False
+                applied_approval_id = approval_id
             db.commit()
 
         logger.info(
-            "gate.auto_approved approval_id=%s session_id=%s tenant_id=%s "
+            "gate.approval_grant_applied approval_id=%s session_id=%s tenant_id=%s "
             "decided_via=%s external_app_id=%s action_type=%s",
-            approval_id,
+            applied_approval_id,
             ctx.session_id,
             ctx.tenant_id,
-            approval.decided_via,
+            grant.decided_via,
             matched_actions.external_app_id,
             matched_actions.governing_action.action_type,
         )
         try:
-            self._notify_auto_approved(ctx, approval)
+            if grant.notif_type is not None:
+                self._notify_approval_grant(ctx, grant)
         except Exception as e:
             logger.warning(
-                "gate.auto_approve_notify_failed approval_id=%s error=%s",
-                approval_id,
+                "gate.approval_grant_notify_failed approval_id=%s error=%s",
+                applied_approval_id,
                 str(e),
             )
         return True
@@ -821,8 +914,8 @@ class GateAddon:
     # Notification dispatch
     # --------------------------------------------------------------------------
 
-    def _notify_auto_approved(
-        self, ctx: SessionContext, approval: _AutoApproval
+    def _notify_approval_grant(
+        self, ctx: SessionContext, grant: _ApprovalGrant
     ) -> None:
         """Best-effort bell entry for an auto-approved action.
 
@@ -830,13 +923,19 @@ class GateAddon:
         grant source must keep ``notification_data`` a stable per-scope key —
         anything per-request would defeat the dedup.
         """
+        if (
+            grant.notif_type is None
+            or grant.notification_title is None
+            or grant.notification_data is None
+        ):
+            return
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
             create_notification(
                 user_id=ctx.user_id,
-                notif_type=approval.notif_type,
+                notif_type=grant.notif_type,
                 db_session=db,
-                title=approval.notification_title,
-                additional_data=approval.notification_data,
+                title=grant.notification_title,
+                additional_data=grant.notification_data,
                 autocommit=True,
             )
 

--- a/backend/onyx/sandbox_proxy/approval_cache.py
+++ b/backend/onyx/sandbox_proxy/approval_cache.py
@@ -11,6 +11,7 @@ here is best-effort over `CacheBackend`. Two lists:
 """
 
 import asyncio
+from collections.abc import Iterable
 from uuid import UUID
 
 from onyx.cache.interface import CacheBackend
@@ -24,6 +25,10 @@ WAIT_TIMEOUT_S = 180
 ANNOUNCE_TTL_S = 60
 WAKE_TTL_S = 30
 
+# Session grant cache keys are an acceleration layer. The durable grant source is
+# the action_approval row whose decision was recorded via SESSION_GRANT.
+SESSION_GRANT_TTL_S = 60 * 60
+
 
 def announce_key(session_id: UUID) -> str:
     return f"approval:announce:{session_id}"
@@ -33,9 +38,62 @@ def _wake_key(approval_id: UUID) -> str:
     return f"approval:wake:{approval_id}"
 
 
+def _session_grant_key(session_id: UUID, external_app_id: int, action_type: str) -> str:
+    return f"approval:session-grant:{session_id}:{external_app_id}:{action_type}"
+
+
 def announce_approval(approval_id: UUID, session_id: UUID, cache: CacheBackend) -> None:
     cache.rpush(announce_key(session_id), str(approval_id))
     cache.expire(announce_key(session_id), ANNOUNCE_TTL_S)
+
+
+def cache_session_grant_actions(
+    *,
+    session_id: UUID,
+    external_app_id: int,
+    action_types: Iterable[str],
+    source_approval_id: UUID,
+    cache: CacheBackend,
+) -> None:
+    """Cache the same app/action types for this BuildSession.
+
+    One key per action keeps matching simple and conservative: a future
+    multi-action request is auto-approved only when every ASK action it invokes
+    has an active key.
+    """
+    for action_type in set(action_types):
+        cache.set(
+            _session_grant_key(session_id, external_app_id, action_type),
+            str(source_approval_id),
+            ex=SESSION_GRANT_TTL_S,
+        )
+
+
+def cached_session_grants_cover(
+    *,
+    session_id: UUID,
+    external_app_id: int,
+    action_types: Iterable[str],
+    cache: CacheBackend,
+) -> bool:
+    """Return true iff every action type has an active cached session grant.
+
+    The TTL is sliding while the grant is used. On miss, callers should consult
+    the durable DB grant source and rehydrate this cache when covered.
+    """
+    unique_action_types = set(action_types)
+    if not unique_action_types:
+        return False
+    keys = [
+        _session_grant_key(session_id, external_app_id, action_type)
+        for action_type in unique_action_types
+    ]
+    for key in keys:
+        if cache.get(key) is None:
+            return False
+    for key in keys:
+        cache.expire(key, SESSION_GRANT_TTL_S)
+    return True
 
 
 async def wait_for_wake(

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -30,6 +30,7 @@ from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.matching.engine import actions_requiring_approval
 from onyx.external_apps.matching.engine import MatchedAction
 from onyx.external_apps.presentation.decode import decode_payload
 from onyx.sandbox_proxy import approval_cache
@@ -84,6 +85,18 @@ class ApprovalView(BaseModel):
 
 class ApprovalListResponse(BaseModel):
     items: list[ApprovalView]
+
+
+def _send_wake_best_effort(approval_id: UUID, decision: ApprovalDecision) -> None:
+    try:
+        cache = get_cache_backend(tenant_id=get_current_tenant_id())
+        approval_cache.send_wake(approval_id, decision, cache)
+    except CACHE_TRANSIENT_ERRORS as e:
+        logger.warning(
+            "approval.wake_failed approval_id=%s error=%s",
+            approval_id,
+            str(e),
+        )
 
 
 def _existing_decision_response(
@@ -207,14 +220,141 @@ def submit_decision(
         body.decision.value,
     )
 
+    _send_wake_best_effort(approval_id, body.decision)
+
+    return ApprovalView.model_validate(decided)
+
+
+@router.post("/{approval_id}/session-grant")
+def submit_session_grant(
+    approval_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> ApprovalView:
+    """Approve this request and similar app/action requests for the session."""
+    current = action_approval.get_action_approval_for_user(
+        db_session, approval_id, user.id
+    )
+    if current is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "approval request not found")
+    if current.external_app_id is None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "approval request cannot be granted for a session",
+        )
+    if current.decision is not None:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "approval request already resolved",
+        )
+    cutoff = datetime.now(timezone.utc) - timedelta(
+        seconds=approval_cache.WAIT_TIMEOUT_S
+    )
+    if current.created_at < cutoff:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "approval request is no longer live",
+        )
+
+    grant_action_types = actions_requiring_approval(current.actions)
+    if not grant_action_types:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "approval request has no grantable actions",
+        )
+
+    approved_ids: list[UUID] = []
+    decided_current = action_approval.try_record_decision(
+        db_session,
+        approval_id=approval_id,
+        decision=ApprovalDecision.APPROVED,
+        decided_via=ApprovalDecidedVia.SESSION_GRANT,
+    )
+    if decided_current is None:
+        db_session.expire(current)
+        winner = action_approval.get_action_approval(db_session, approval_id)
+        if winner is None:
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "approval request not found")
+        if winner.decision is None:
+            raise OnyxError(
+                OnyxErrorCode.INTERNAL_ERROR,
+                "approval row reverted to pending unexpectedly",
+            )
+        existing = winner.decision.value
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            f"approval request already resolved ({existing})",
+        )
+    approved_ids.append(approval_id)
+
+    db_session.commit()
+
+    grant_source_rows = action_approval.list_session_grant_action_approvals(
+        db_session,
+        session_id=current.session_id,
+        external_app_id=current.external_app_id,
+    )
+    granted_action_types: set[str] = set()
+    for grant_source_row in grant_source_rows:
+        granted_action_types.update(
+            actions_requiring_approval(grant_source_row.actions)
+        )
+
     try:
         cache = get_cache_backend(tenant_id=get_current_tenant_id())
-        approval_cache.send_wake(approval_id, body.decision, cache)
+        for grant_source_row in grant_source_rows:
+            approval_cache.cache_session_grant_actions(
+                session_id=current.session_id,
+                external_app_id=current.external_app_id,
+                action_types=actions_requiring_approval(grant_source_row.actions),
+                source_approval_id=grant_source_row.approval_id,
+                cache=cache,
+            )
     except CACHE_TRANSIENT_ERRORS as e:
         logger.warning(
-            "approval.wake_failed approval_id=%s error=%s",
+            "approval.session_grant_cache_failed approval_id=%s session_id=%s error=%s",
             approval_id,
+            current.session_id,
             str(e),
         )
 
-    return ApprovalView.model_validate(decided)
+    pending_rows = action_approval.list_session_pending_action_approvals(
+        db_session, current.session_id, created_after=cutoff
+    )
+    for row in pending_rows:
+        if row.approval_id == approval_id:
+            continue
+        if row.external_app_id != current.external_app_id:
+            continue
+        row_action_types = set(actions_requiring_approval(row.actions))
+        covered = bool(row_action_types) and row_action_types.issubset(
+            granted_action_types
+        )
+        if not covered:
+            continue
+        decided = action_approval.try_record_decision(
+            db_session,
+            approval_id=row.approval_id,
+            decision=ApprovalDecision.APPROVED,
+            decided_via=ApprovalDecidedVia.SESSION_GRANT,
+        )
+        if decided is not None:
+            approved_ids.append(row.approval_id)
+
+    db_session.commit()
+
+    for approved_id in approved_ids:
+        _send_wake_best_effort(approved_id, ApprovalDecision.APPROVED)
+
+    logger.info(
+        "approval.session_grant_recorded approval_id=%s session_id=%s "
+        "user_id=%s external_app_id=%s action_types=%s approved_count=%s",
+        approval_id,
+        current.session_id,
+        user.id,
+        current.external_app_id,
+        grant_action_types,
+        len(approved_ids),
+    )
+
+    return ApprovalView.model_validate(decided_current)

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -237,7 +237,9 @@ def submit_session_grant(
     )
     if current is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "approval request not found")
-    if current.external_app_id is None:
+    session_id = current.session_id
+    external_app_id = current.external_app_id
+    if external_app_id is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "approval request cannot be granted for a session",
@@ -288,11 +290,12 @@ def submit_session_grant(
     approved_ids.append(approval_id)
 
     db_session.commit()
+    _send_wake_best_effort(approval_id, ApprovalDecision.APPROVED)
 
     grant_source_rows = action_approval.list_session_grant_action_approvals(
         db_session,
-        session_id=current.session_id,
-        external_app_id=current.external_app_id,
+        session_id=session_id,
+        external_app_id=external_app_id,
     )
     granted_action_types: set[str] = set()
     for grant_source_row in grant_source_rows:
@@ -304,8 +307,8 @@ def submit_session_grant(
         cache = get_cache_backend(tenant_id=get_current_tenant_id())
         for grant_source_row in grant_source_rows:
             approval_cache.cache_session_grant_actions(
-                session_id=current.session_id,
-                external_app_id=current.external_app_id,
+                session_id=session_id,
+                external_app_id=external_app_id,
                 action_types=actions_requiring_approval(grant_source_row.actions),
                 source_approval_id=grant_source_row.approval_id,
                 cache=cache,
@@ -314,17 +317,17 @@ def submit_session_grant(
         logger.warning(
             "approval.session_grant_cache_failed approval_id=%s session_id=%s error=%s",
             approval_id,
-            current.session_id,
+            session_id,
             str(e),
         )
 
     pending_rows = action_approval.list_session_pending_action_approvals(
-        db_session, current.session_id, created_after=cutoff
+        db_session, session_id, created_after=cutoff
     )
     for row in pending_rows:
         if row.approval_id == approval_id:
             continue
-        if row.external_app_id != current.external_app_id:
+        if row.external_app_id != external_app_id:
             continue
         row_action_types = set(actions_requiring_approval(row.actions))
         covered = bool(row_action_types) and row_action_types.issubset(
@@ -344,15 +347,17 @@ def submit_session_grant(
     db_session.commit()
 
     for approved_id in approved_ids:
+        if approved_id == approval_id:
+            continue
         _send_wake_best_effort(approved_id, ApprovalDecision.APPROVED)
 
     logger.info(
         "approval.session_grant_recorded approval_id=%s session_id=%s "
         "user_id=%s external_app_id=%s action_types=%s approved_count=%s",
         approval_id,
-        current.session_id,
+        session_id,
         user.id,
-        current.external_app_id,
+        external_app_id,
         grant_action_types,
         len(approved_ids),
     )

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -158,3 +158,20 @@ def list_session_pending_action_approvals(
         stmt = stmt.where(ActionApproval.created_at >= created_after)
     stmt = stmt.order_by(ActionApproval.created_at.desc())
     return list(db_session.scalars(stmt))
+
+
+def list_session_grant_action_approvals(
+    db_session: Session,
+    session_id: UUID,
+    external_app_id: int,
+) -> list[ActionApproval]:
+    """Approved rows covered by a durable session-scope grant."""
+    stmt = (
+        select(ActionApproval)
+        .where(ActionApproval.session_id == session_id)
+        .where(ActionApproval.external_app_id == external_app_id)
+        .where(ActionApproval.decision == ApprovalDecision.APPROVED)
+        .where(ActionApproval.decided_via == ApprovalDecidedVia.SESSION_GRANT)
+        .order_by(ActionApproval.decided_at.desc())
+    )
+    return list(db_session.scalars(stmt))

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -610,10 +610,10 @@ def test_submit_session_grant_approves_matching_pending_rows(
     assert matching.decided_via == ApprovalDecidedVia.SESSION_GRANT
     assert broader.decision is None
     assert other.decision is None
-    assert set(wakes) == {
+    assert wakes == [
         (str(current.approval_id), ApprovalDecision.APPROVED),
         (str(matching.approval_id), ApprovalDecision.APPROVED),
-    }
+    ]
 
     cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
     assert approval_cache.cached_session_grants_cover(

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -14,6 +15,7 @@ import redis
 from sqlalchemy.orm import Session
 
 from onyx.cache.factory import get_cache_backend
+from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.models import ActionApproval
@@ -26,12 +28,16 @@ from onyx.server.features.build.approvals.api import DecisionBody
 from onyx.server.features.build.approvals.api import list_live_approvals
 from onyx.server.features.build.approvals.api import list_session_approvals
 from onyx.server.features.build.approvals.api import submit_decision
+from onyx.server.features.build.approvals.api import submit_session_grant
 from onyx.server.features.build.db import action_approval
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.craft._test_helpers import _set_created_at
+from tests.external_dependency_unit.craft._test_helpers import action_entry
 from tests.external_dependency_unit.craft._test_helpers import (
     default_action_entries as _default_actions,
 )
+from tests.external_dependency_unit.craft._test_helpers import make_external_app
+from tests.external_dependency_unit.craft._test_helpers import make_skill
 from tests.external_dependency_unit.craft._test_helpers import make_user
 
 
@@ -524,6 +530,104 @@ def test_submit_decision_pushes_wake_on_redis(
     _key, value = popped
     decoded = value.decode() if isinstance(value, bytes) else value
     assert decoded == ApprovalDecision.APPROVED.value
+
+
+def test_submit_session_grant_approves_matching_pending_rows(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    user = make_user(db_session, email_prefix="session_grant")
+    session = build_session_with_user(user=user)
+    app = make_external_app(db_session, skill=make_skill(db_session), auth_template={})
+    other_app = make_external_app(
+        db_session, skill=make_skill(db_session), auth_template={}
+    )
+    ask_send = action_entry("slack.chat.post")
+    always_read = action_entry("slack.channel.read", policy=EndpointPolicy.ALWAYS)
+    ask_upload = action_entry("slack.files.upload")
+
+    current = action_approval.insert_action_approval(
+        db_session,
+        session_id=session.id,
+        actions=[ask_send, always_read],
+        app_name="Slack",
+        payload={"text": "current"},
+        external_app_id=app.id,
+    )
+    matching = action_approval.insert_action_approval(
+        db_session,
+        session_id=session.id,
+        actions=[ask_send],
+        app_name="Slack",
+        payload={"text": "matching"},
+        external_app_id=app.id,
+    )
+    broader = action_approval.insert_action_approval(
+        db_session,
+        session_id=session.id,
+        actions=[ask_send, ask_upload],
+        app_name="Slack",
+        payload={"text": "broader"},
+        external_app_id=app.id,
+    )
+    other = action_approval.insert_action_approval(
+        db_session,
+        session_id=session.id,
+        actions=[ask_send],
+        app_name="Other",
+        payload={"text": "other"},
+        external_app_id=other_app.id,
+    )
+    db_session.commit()
+
+    wakes: list[tuple[str, ApprovalDecision]] = []
+
+    def _record_wake(
+        approval_id: UUID, decision: ApprovalDecision, *_args: object, **_kwargs: object
+    ) -> None:
+        wakes.append((str(approval_id), decision))
+
+    monkeypatch.setattr(approval_cache, "send_wake", _record_wake)
+
+    response = submit_session_grant(
+        approval_id=current.approval_id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert response.approval_id == current.approval_id
+    assert response.decision == ApprovalDecision.APPROVED
+
+    db_session.refresh(current)
+    db_session.refresh(matching)
+    db_session.refresh(broader)
+    db_session.refresh(other)
+    assert current.decision == ApprovalDecision.APPROVED
+    assert current.decided_via == ApprovalDecidedVia.SESSION_GRANT
+    assert matching.decision == ApprovalDecision.APPROVED
+    assert matching.decided_via == ApprovalDecidedVia.SESSION_GRANT
+    assert broader.decision is None
+    assert other.decision is None
+    assert set(wakes) == {
+        (str(current.approval_id), ApprovalDecision.APPROVED),
+        (str(matching.approval_id), ApprovalDecision.APPROVED),
+    }
+
+    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    assert approval_cache.cached_session_grants_cover(
+        session_id=session.id,
+        external_app_id=app.id,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+    assert not approval_cache.cached_session_grants_cover(
+        session_id=session.id,
+        external_app_id=app.id,
+        action_types=["slack.files.upload"],
+        cache=cache,
+    )
 
 
 def test_submit_decision_swallows_transient_wake_failure(

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
@@ -14,6 +14,8 @@ from onyx.sandbox_proxy import approval_cache as approval_cache_module
 from onyx.sandbox_proxy.approval_cache import _wake_key
 from onyx.sandbox_proxy.approval_cache import announce_approval
 from onyx.sandbox_proxy.approval_cache import announce_key
+from onyx.sandbox_proxy.approval_cache import cache_session_grant_actions
+from onyx.sandbox_proxy.approval_cache import cached_session_grants_cover
 from onyx.sandbox_proxy.approval_cache import pop_announcement
 from onyx.sandbox_proxy.approval_cache import send_wake
 from onyx.sandbox_proxy.approval_cache import wait_for_wake
@@ -113,6 +115,52 @@ def test_send_wake_applies_ttl() -> None:
 
     # Hardcoded spec; the completeness check below pins the constant.
     assert 0 < remaining <= 30
+
+
+# ---------------------------------------------------------------------------
+# Session grants
+# ---------------------------------------------------------------------------
+
+
+def test_cached_session_grants_cover_requires_every_action() -> None:
+    cache = get_cache_backend(tenant_id=TEST_TENANT_ID)
+    session_id = uuid4()
+    approval_id = uuid4()
+    external_app_id = 42
+
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+
+    cache_session_grant_actions(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        source_approval_id=approval_id,
+        cache=cache,
+    )
+
+    assert cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post", "slack.files.upload"],
+        cache=cache,
+    )
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id + 1,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/external_apps/matching/test_approval_actions.py
+++ b/backend/tests/unit/external_apps/matching/test_approval_actions.py
@@ -1,0 +1,37 @@
+from onyx.db.enums import EndpointPolicy
+from onyx.external_apps.matching.engine import actions_requiring_approval
+from onyx.external_apps.matching.engine import MatchedAction
+
+
+def _action(action_type: str, policy: EndpointPolicy) -> MatchedAction:
+    return MatchedAction(
+        action_type=action_type,
+        display_name=action_type,
+        description="description",
+        policy=policy,
+    )
+
+
+def test_actions_requiring_approval_from_live_matched_actions() -> None:
+    actions = [
+        _action("slack.messages.write", EndpointPolicy.ASK),
+        _action("slack.channels.read", EndpointPolicy.ALWAYS),
+        _action("slack.messages.write", EndpointPolicy.ASK),
+    ]
+
+    assert actions_requiring_approval(actions) == ["slack.messages.write"]
+
+
+def test_actions_requiring_approval_from_persisted_action_dicts() -> None:
+    actions = [
+        {"action_type": "slack.files.upload", "policy": "ASK"},
+        {"action_type": "slack.channels.read", "policy": "ALWAYS"},
+        {"action_type": "slack.messages.write", "policy": EndpointPolicy.ASK},
+        {"action_type": "slack.invalid", "policy": "UNKNOWN"},
+        {"policy": "ASK"},
+    ]
+
+    assert actions_requiring_approval(actions) == [
+        "slack.files.upload",
+        "slack.messages.write",
+    ]

--- a/backend/tests/unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/unit/sandbox_proxy/test_approval_cache.py
@@ -1,0 +1,89 @@
+from uuid import uuid4
+
+from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CacheLock
+from onyx.sandbox_proxy.approval_cache import cache_session_grant_actions
+from onyx.sandbox_proxy.approval_cache import cached_session_grants_cover
+
+
+class _MemoryCache(CacheBackend):
+    def __init__(self) -> None:
+        self.values: dict[str, bytes] = {}
+        self.expirations: list[tuple[str, int]] = []
+
+    def get(self, key: str) -> bytes | None:
+        return self.values.get(key)
+
+    def set(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> None:
+        self.values[key] = str(value).encode()
+        if ex is not None:
+            self.expire(key, ex)
+
+    def expire(self, key: str, seconds: int) -> None:
+        self.expirations.append((key, seconds))
+
+    def delete(self, key: str) -> None:
+        self.values.pop(key, None)
+
+    def exists(self, key: str) -> bool:
+        return key in self.values
+
+    def ttl(self, key: str) -> int:  # noqa: ARG002
+        raise NotImplementedError
+
+    def lock(self, name: str, timeout: float | None = None) -> CacheLock:  # noqa: ARG002
+        raise NotImplementedError
+
+    def rpush(self, key: str, value: str | bytes) -> None:  # noqa: ARG002
+        raise NotImplementedError
+
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:  # noqa: ARG002
+        raise NotImplementedError
+
+
+def test_cached_session_grants_cover_requires_every_action() -> None:
+    cache = _MemoryCache()
+    session_id = uuid4()
+    approval_id = uuid4()
+    external_app_id = 42
+
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+
+    cache_session_grant_actions(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        source_approval_id=approval_id,
+        cache=cache,
+    )
+
+    assert cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id,
+        action_types=["slack.chat.post", "slack.files.upload"],
+        cache=cache,
+    )
+    assert not cached_session_grants_cover(
+        session_id=session_id,
+        external_app_id=external_app_id + 1,
+        action_types=["slack.chat.post"],
+        cache=cache,
+    )
+    assert cache.expirations
+    assert all(seconds == 3600 for _key, seconds in cache.expirations)

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -17,6 +17,7 @@ import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from typing import AbstractSet
 from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID
@@ -30,6 +31,7 @@ from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.external_apps.matching.engine import AllMatchedActions
+from onyx.external_apps.matching.engine import MatchedAction
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import GateAddon
 from onyx.sandbox_proxy.addons.gate import ParkedApprovals
@@ -102,6 +104,11 @@ def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
     Default it to a dummy MagicMock-yielding session; tests asserting on
     session-open ordering re-patch it with `_recorder_db_factory(ops)`."""
     monkeypatch.setattr(gate_mod, "get_session_with_tenant", _recorder_db_factory([]))
+    monkeypatch.setattr(
+        gate_mod.action_approval,
+        "list_session_grant_action_approvals",
+        lambda _db, *, session_id, external_app_id: [],  # noqa: ARG005
+    )
 
 
 def _build(
@@ -133,6 +140,25 @@ def _assert_403(flow: http.HTTPFlow, expected_code: SandboxProxyError) -> None:
 
 
 _MATCH = make_matched_actions(payload={"text": "hi"})
+_MATCH_MULTI_ASK = AllMatchedActions(
+    actions=(
+        MatchedAction(
+            action_type="slack.messages.write",
+            display_name="Post a message",
+            description="Post a message to a channel or conversation.",
+            policy=EndpointPolicy.ASK,
+        ),
+        MatchedAction(
+            action_type="slack.files.upload",
+            display_name="Upload a file",
+            description="Upload a file to a channel or conversation.",
+            policy=EndpointPolicy.ASK,
+        ),
+    ),
+    app_name="Slack",
+    external_app_id=42,
+    payload={"text": "hi"},
+)
 _MATCH_ALWAYS = make_matched_actions(
     action_type="slack.channels.read", policy=EndpointPolicy.ALWAYS
 )
@@ -520,6 +546,44 @@ def _spy_pre_approve_insert(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, A
     return inserted
 
 
+class _SessionGrantCache:
+    def __init__(
+        self,
+        granted: bool | list[bool] = False,
+        *,
+        granted_action_types: AbstractSet[str] | None = None,
+    ) -> None:
+        self._grant_results = [granted] if isinstance(granted, bool) else list(granted)
+        self._granted_action_types = granted_action_types
+        self.get_calls: list[str] = []
+        self.set_calls: list[tuple[str, str | bytes | int | float, int | None]] = []
+        self.expire_calls: list[tuple[str, int]] = []
+
+    def get(self, key: str) -> bytes | None:
+        self.get_calls.append(key)
+        if self._granted_action_types is not None:
+            granted = any(
+                key.endswith(f":{action_type}")
+                for action_type in self._granted_action_types
+            )
+        elif len(self._grant_results) > 1:
+            granted = self._grant_results.pop(0)
+        else:
+            granted = self._grant_results[0]
+        return b"approval-id" if granted else None
+
+    def expire(self, key: str, seconds: int) -> None:
+        self.expire_calls.append((key, seconds))
+
+    def set(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> None:
+        self.set_calls.append((key, value, ex))
+
+
 @pytest.mark.asyncio
 async def test_pre_approved_scheduled_run_skips_park(
     monkeypatch: pytest.MonkeyPatch,
@@ -555,6 +619,158 @@ async def test_pre_approved_scheduled_run_skips_park(
         "run_id": str(_RUN_ID),
         "external_app_id": _GRANTED_APP_ID,
     }
+
+
+@pytest.mark.asyncio
+async def test_session_grant_skips_park_without_notification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    sandbox = _sandbox(user_id=user_id)
+    cache = _SessionGrantCache(granted=True)
+    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    addon = _build(
+        resolver=resolver,
+        matcher=_StubMatcher(result=_MATCH),
+        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
+    )
+    spy = _spy_pipeline(addon, monkeypatch)
+    _stub_grants(monkeypatch, None)
+    inserted = _spy_pre_approve_insert(monkeypatch)
+    notified: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        gate_mod, "create_notification", lambda **kw: notified.append(kw)
+    )
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert flow.response is None
+    assert not spy.approval_ran
+    assert spy.awaited == []
+    assert spy.dispatched == [(_MATCH, user_id, sandbox.tenant_id)]
+    assert len(inserted) == 1
+    assert inserted[0]["decision"] == ApprovalDecision.APPROVED
+    assert inserted[0]["decided_via"] == ApprovalDecidedVia.SESSION_GRANT
+    assert notified == []
+    assert cache.get_calls
+    assert cache.expire_calls
+
+
+@pytest.mark.asyncio
+async def test_session_grant_db_fallback_hydrates_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    sandbox = _sandbox(user_id=user_id)
+    cache = _SessionGrantCache(granted=False)
+    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    addon = _build(
+        resolver=resolver,
+        matcher=_StubMatcher(result=_MATCH),
+        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
+    )
+    spy = _spy_pipeline(addon, monkeypatch)
+    _stub_grants(monkeypatch, None)
+    inserted = _spy_pre_approve_insert(monkeypatch)
+    source_approval_id = uuid4()
+    grant_source = MagicMock()
+    grant_source.approval_id = source_approval_id
+    grant_source.actions = [action.model_dump(mode="json") for action in _MATCH.actions]
+
+    monkeypatch.setattr(
+        gate_mod.action_approval,
+        "list_session_grant_action_approvals",
+        lambda _db, *, session_id, external_app_id: [grant_source],  # noqa: ARG005
+    )
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert flow.response is None
+    assert not spy.approval_ran
+    assert spy.awaited == []
+    assert spy.dispatched == [(_MATCH, user_id, sandbox.tenant_id)]
+    assert len(inserted) == 1
+    assert inserted[0]["decision"] == ApprovalDecision.APPROVED
+    assert inserted[0]["decided_via"] == ApprovalDecidedVia.SESSION_GRANT
+    assert cache.get_calls
+    assert any(str(source_approval_id) == value for _key, value, _ex in cache.set_calls)
+
+
+@pytest.mark.asyncio
+async def test_partial_session_grant_still_parks_multi_action_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = _SessionGrantCache(granted_action_types={"slack.messages.write"})
+    resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
+    addon = _build(
+        resolver=resolver,
+        matcher=_StubMatcher(result=_MATCH_MULTI_ASK),
+        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
+    )
+    spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
+    _stub_grants(monkeypatch, None)
+    inserted = _spy_pre_approve_insert(monkeypatch)
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert spy.approval_ran
+    assert spy.awaited == [_MATCH_MULTI_ASK]
+    _assert_403(flow, SandboxProxyError.USER_REJECTED)
+    assert inserted == []
+    assert cache.get_calls
+    assert cache.expire_calls == []
+
+
+@pytest.mark.asyncio
+async def test_session_grant_recheck_after_persist_skips_park(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    sandbox = _sandbox(user_id=user_id)
+    cache = _SessionGrantCache(granted=[False, True])
+    resolver = _StubResolver(sandbox=sandbox, session_by_id=UUID(_TAG_UUID))
+    addon = _build(
+        resolver=resolver,
+        matcher=_StubMatcher(result=_MATCH),
+        cache_factory=lambda tenant_id: cache,  # noqa: ARG005
+    )
+    spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
+    approval_id = uuid4()
+
+    def _persist(ctx: SessionContext, _match: AllMatchedActions) -> UUID:
+        addon._parked.add(ctx.tenant_id, approval_id)
+        return approval_id
+
+    monkeypatch.setattr(addon, "_persist_approval_row", _persist)
+    _stub_grants(monkeypatch, None)
+    decisions: list[dict[str, Any]] = []
+
+    def _record_decision(_db: Any, **kwargs: Any) -> object:
+        decisions.append(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        gate_mod.action_approval, "try_record_decision", _record_decision
+    )
+    flow = _flow(proxy_auth=_basic_auth(_TAG_UUID))
+
+    await addon.request(flow)
+
+    assert flow.response is None
+    assert spy.persisted == []
+    assert spy.awaited == []
+    assert spy.dispatched == [(_MATCH, user_id, sandbox.tenant_id)]
+    assert addon._parked.snapshot() == []
+    assert decisions == [
+        {
+            "approval_id": approval_id,
+            "decision": ApprovalDecision.APPROVED,
+            "decided_via": ApprovalDecidedVia.SESSION_GRANT,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -646,7 +862,11 @@ async def test_no_pre_approval_falls_through_to_park(
 ) -> None:
     """Every non-granted shape (including a lookup crash) parks as usual."""
     resolver = _StubResolver(sandbox=_sandbox(), session_by_id=UUID(_TAG_UUID))
-    addon = _build(resolver=resolver, matcher=_StubMatcher(result=_MATCH))
+    addon = _build(
+        resolver=resolver,
+        matcher=_StubMatcher(result=_MATCH),
+        cache_factory=lambda tenant_id: _SessionGrantCache(False),  # noqa: ARG005
+    )
     spy = _spy_pipeline(addon, monkeypatch, decision=ApprovalDecision.REJECTED)
     _stub_grants(monkeypatch, grants)
     inserted = _spy_pre_approve_insert(monkeypatch)

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
-import { Button, Text } from "@opal/components";
+import { Button, Text, Tooltip } from "@opal/components";
 import { cn } from "@opal/utils";
 import {
   SvgAlertCircle,
@@ -19,6 +19,7 @@ import {
 import {
   ApprovalConflictError,
   postApprovalDecision,
+  postApprovalSessionGrant,
 } from "@/app/craft/services/apiServices";
 import {
   ApprovalAction,
@@ -69,8 +70,8 @@ function ActionList({ actions }: { actions: ApprovalAction[] }) {
 }
 
 /**
- * One row per pending approval. Approve/Reject sit in the header so the
- * user can decide without expanding; the body shows the per-action
+ * One row per pending approval. The header names the action, the action row
+ * lets the user decide without expanding, and the body shows the per-action
  * breakdown (when multi) and the payload.
  */
 export default function ApprovalCard({
@@ -98,28 +99,38 @@ export default function ApprovalCard({
     };
   }, []);
 
-  const headline = approvalHeadline(approval);
   const swrKey = SWR_KEYS.buildSessionLiveApprovals(approval.session_id);
-
   const decided = decision !== null;
   const approved = decision === "APPROVED";
+  const headline = approvalHeadline(approval);
+  const headerText = decided ? headline : `Approval required: ${headline}`;
 
-  async function decide(next: ApprovalSubmitDecision) {
+  async function submitDecision(
+    next: ApprovalSubmitDecision,
+    request: () => Promise<unknown>,
+    refetchDelayMs = SETTLE_HOLD_MS
+  ) {
     setSubmitting(true);
     setErrorMessage(null);
     setDecision(next);
     try {
-      await postApprovalDecision(approval.approval_id, next);
-      settleTimer.current = setTimeout(() => {
+      await request();
+      if (refetchDelayMs === 0) {
         void mutate(swrKey);
-      }, SETTLE_HOLD_MS);
-    } catch (e) {
-      // 409 = already resolved (by someone else, or expired by the
-      // proxy). Same UX as a successful submit: hold the settle, then refetch.
-      if (e instanceof ApprovalConflictError) {
+      } else {
         settleTimer.current = setTimeout(() => {
           void mutate(swrKey);
-        }, SETTLE_HOLD_MS);
+        }, refetchDelayMs);
+      }
+    } catch (e) {
+      // 409 = already resolved (by someone else, or expired by the
+      // proxy). Refetch immediately so optimistic copy cannot imply this
+      // specific decision was accepted.
+      if (e instanceof ApprovalConflictError) {
+        if (mountedRef.current) {
+          setDecision(null);
+        }
+        void mutate(swrKey);
         return;
       }
       console.error("Failed to submit approval decision:", e);
@@ -179,7 +190,7 @@ export default function ApprovalCard({
                   <SvgLoader className="size-4 shrink-0 stroke-status-info-05 animate-spin" />
                 )}
                 <Text font="main-ui-muted" color="text-04" nowrap>
-                  {headline}
+                  {headerText}
                 </Text>
               </button>
             </CollapsibleTrigger>
@@ -194,26 +205,7 @@ export default function ApprovalCard({
                   {approved ? "Approved" : "Rejected"}
                 </Text>
               </div>
-            ) : (
-              <>
-                <Button
-                  prominence="primary"
-                  size="sm"
-                  disabled={submitting}
-                  onClick={() => decide("APPROVED")}
-                >
-                  Approve
-                </Button>
-                <Button
-                  prominence="secondary"
-                  size="sm"
-                  disabled={submitting}
-                  onClick={() => decide("REJECTED")}
-                >
-                  Reject
-                </Button>
-              </>
-            )}
+            ) : null}
             <CollapsibleTrigger asChild>
               <button
                 data-approval-trigger
@@ -229,6 +221,56 @@ export default function ApprovalCard({
               </button>
             </CollapsibleTrigger>
           </div>
+          {!decided && (
+            <div className="flex flex-wrap items-center justify-end gap-1 px-3 pb-2">
+              <Button
+                prominence="primary"
+                size="sm"
+                disabled={submitting}
+                onClick={() =>
+                  void submitDecision("APPROVED", () =>
+                    postApprovalDecision(approval.approval_id, "APPROVED")
+                  )
+                }
+                aria-label="Approve this action once"
+              >
+                Approve once
+              </Button>
+              <Tooltip
+                tooltip="Approve matching actions for this session"
+                delayDuration={200}
+              >
+                <Button
+                  prominence="secondary"
+                  size="sm"
+                  disabled={submitting}
+                  onClick={() =>
+                    void submitDecision(
+                      "APPROVED",
+                      () => postApprovalSessionGrant(approval.approval_id),
+                      0
+                    )
+                  }
+                  aria-label="Approve matching actions for this session"
+                >
+                  Approve for session
+                </Button>
+              </Tooltip>
+              <Button
+                prominence="secondary"
+                size="sm"
+                disabled={submitting}
+                onClick={() =>
+                  void submitDecision("REJECTED", () =>
+                    postApprovalDecision(approval.approval_id, "REJECTED")
+                  )
+                }
+                aria-label="Reject this action"
+              >
+                Reject
+              </Button>
+            </div>
+          )}
           <CollapsibleContent>
             <div className="p-2 flex flex-col gap-3">
               <ActionList actions={approval.actions} />

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -779,6 +779,29 @@ export async function postApprovalDecision(
   return res.json();
 }
 
+export async function postApprovalSessionGrant(
+  approvalId: string
+): Promise<ApprovalView> {
+  const res = await fetch(
+    `${BUILD_API_BASE}/approvals/${approvalId}/session-grant`,
+    {
+      method: "POST",
+    }
+  );
+
+  if (res.status === 409) {
+    const body = (await res.json().catch(() => ({}))) as { detail?: string };
+    throw new ApprovalConflictError(body.detail ?? "decision conflict");
+  }
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(
+      errorData.detail || `Failed to approve for session: ${res.status}`
+    );
+  }
+  return res.json();
+}
+
 // =============================================================================
 // User Library API
 // =============================================================================


### PR DESCRIPTION
## Description
<img width="722" height="110" alt="image" src="https://github.com/user-attachments/assets/c6039108-f61f-4245-90da-a59b3e231c61" />

Adds session-scoped approval grants for Craft sandbox actions so a user can approve a matching action once for the active session instead of approving each sequential request individually.

Fixes: ENG-4152

Key changes:
- Persist session grants through existing `action_approval` rows with `decided_via = SESSION_GRANT`, keeping Postgres as the source of truth.
- Keep Redis as a positive cross-replica cache for fast grant propagation, with DB fallback on cache miss/failure.
- Refactor the sandbox gate to check scheduled-task pre-approvals and session grants through a unified existing-grant flow, including a post-persist recheck to avoid hangs in the approval race window.
- Add the `Approve for session` API and Craft approval card UI updates.
- Cover action filtering, cache behavior, gate grant paths, and API session-grant behavior.

## How Has This Been Tested?

- tested locally e2e


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds session-scoped approvals for Craft sandbox actions so users can approve a matching app/action once per Build session and avoid repeated prompts. Grants propagate quickly via Redis and fall back to Postgres as the source of truth.

- **New Features**
  - API: `POST /approvals/{approval_id}/session-grant` approves this request and auto-approves other pending requests in the session that invoke the same app and covered ASK actions; sends wake events and warms Redis on success.
  - Gate: checks session grants before park and re-checks after persisting to close race windows; falls back to DB on cache miss and hydrates the cache; only auto-approves when all ASK actions in a request are covered.
  - Persistence: records grants in `action_approval` with `decided_via = SESSION_GRANT`; Redis caches per action type with a sliding TTL for fast cross-replica matching.
  - UI: adds “Approve once” and “Approve for session” actions in `ApprovalCard`; conflicts trigger an immediate refetch.

- **Refactors**
  - Unified grant flow for scheduled-run pre-approvals and session grants in the gate.
  - Added `actions_requiring_approval` to keep gate and API semantics aligned for live and persisted actions.
  - Introduced cache helpers for session grants and expanded tests across gate, cache, API, and UI.

<sup>Written for commit adebd7aeb927cc99cc09a98d66cc0c7ac04017af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



