### PR TITLE
fix(slack): skip doc-set and persona access checks for anonymous Slack bot users (#11817) to release v4.0

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -142,7 +142,7 @@ def create_chat_session_from_request(
 
     persona_id = chat_session_request.persona_id
     if persona_id != DEFAULT_PERSONA_ID:
-        if not user_can_access_persona(
+        if not user.is_anonymous and not user_can_access_persona(
             db_session=db_session,
             persona_id=persona_id,
             user=user,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -1413,6 +1413,7 @@ def _stream_chat_turn(
             try:
                 if (
                     not bypass_acl
+                    and not user.is_anonymous
                     and new_msg_req.internal_search_filters is not None
                     and new_msg_req.internal_search_filters.document_set is not None
                 ):

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -69,6 +69,7 @@ def _build_index_filters(
     if (
         base_filters.document_set is not None
         and not bypass_acl
+        and not user.is_anonymous
         and db_session is not None
     ):
         accessible_names = filter_document_set_names_by_user_access(

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -567,6 +567,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 and self.user_selected_filters.document_set
                 and not self.bypass_acl
                 and self.user
+                and not self.user.is_anonymous
             ):
                 requested = self.user_selected_filters.document_set
                 accessible = filter_document_set_names_by_user_access(


### PR DESCRIPTION
## Description

Cherry-pick of #11817 to release v4.0.

Slack bots configured with private personas or private document sets broke on the v4.0 upgrade. The v3.3 security fix (#10602) was never in v3.2.x, so bots that worked on v3.2.15 silently fail on v4.0 with `INSUFFICIENT_PERMISSIONS`.

Fix: skip doc-set and persona access checks when `user.is_anonymous`. Document-level ACL (Vespa) is unchanged — anonymous users remain limited to `PUBLIC_DOC_PAT` documents.

## How Has This Been Tested?

Confirmed via live Slack bot logs on a v4.0.5 deployment. See #11817 for full analysis.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Slack bots failing with INSUFFICIENT_PERMISSIONS on v4.0 by skipping persona and document-set access checks for anonymous users. Document-level ACLs remain enforced, so only public documents are returned.

- **Bug Fixes**
  - Skip persona access check in `create_chat_session_from_request` when `user.is_anonymous`.
  - Skip doc-set access filtering for anonymous users in chat streaming, search pipeline, and search tool.
  - Keeps document-level ACL intact; authenticated users still undergo full checks.

<sup>Written for commit fdb8f77e55cbc7e54d99c16b1335e5346ae6f604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

