### PR TITLE
feat(craft): run interactive turns in background

### DIFF
--- a/backend/onyx/server/features/build/api/api.py
+++ b/backend/onyx/server/features/build/api/api.py
@@ -32,6 +32,7 @@ from onyx.server.features.build.api.messages_api import router as messages_route
 from onyx.server.features.build.api.models import RateLimitResponse
 from onyx.server.features.build.api.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.api.sessions_api import router as sessions_router
+from onyx.server.features.build.api.turns_api import router as turns_router
 from onyx.server.features.build.api.user_library import router as user_library_router
 from onyx.server.features.build.approvals.api import router as approvals_router
 from onyx.server.features.build.db.build_session import get_webapp_access_async
@@ -93,6 +94,7 @@ router = APIRouter(prefix="/build", dependencies=[Depends(require_onyx_craft_ena
 # Include sub-routers for sessions, messages, and user library
 router.include_router(sessions_router, tags=["build"])
 router.include_router(messages_router, tags=["build"])
+router.include_router(turns_router, tags=["build"])
 router.include_router(user_library_router, tags=["build"])
 router.include_router(scheduled_tasks_router, tags=["build"])
 router.include_router(external_apps_router, tags=["build"])

--- a/backend/onyx/server/features/build/api/messages_api.py
+++ b/backend/onyx/server/features/build/api/messages_api.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Generator
 from uuid import UUID
+from uuid import uuid4
 
 from fastapi import APIRouter
 from fastapi import Depends
@@ -10,17 +11,35 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.cache.factory import get_cache_backend
+from onyx.configs.constants import MessageType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import Permission
+from onyx.db.models import BuildMessage
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.api.models import InteractiveTurnResponse
 from onyx.server.features.build.api.models import MessageInterruptResponse
 from onyx.server.features.build.api.models import MessageListResponse
 from onyx.server.features.build.api.models import MessageRequest
 from onyx.server.features.build.api.models import MessageResponse
+from onyx.server.features.build.db.build_session import create_message
+from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
+from onyx.server.features.build.interactive_turns.executor import (
+    start_interactive_turn_runner,
+)
+from onyx.server.features.build.interactive_turns.state import acquire_active_turn_lock
+from onyx.server.features.build.interactive_turns.state import create_interactive_turn
+from onyx.server.features.build.interactive_turns.state import finish_turn
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+from onyx.server.features.build.interactive_turns.state import get_turn_for_request
+from onyx.server.features.build.interactive_turns.state import InteractiveTurnLockError
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
 from onyx.server.features.build.session.errors import RateLimitError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.utils.logger import setup_logger
@@ -76,74 +95,102 @@ def send_message(
     session_id: UUID,
     request: MessageRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
-    _rate_limit_check: None = Depends(check_build_rate_limits),
-) -> StreamingResponse:
-    """
-    Send a message to the CLI agent and stream the response.
+    _rate_limit_check: None = None,
+    db_session: Session = Depends(get_session),
+) -> InteractiveTurnResponse:
+    """Start an interactive Craft turn in the background."""
+    session = get_build_session(session_id, user.id, db_session)
+    if session is None:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
 
-    Enforces rate limiting before executing the agent (via dependency).
-    Returns a Server-Sent Events (SSE) stream with the agent's response.
+    cache = get_cache_backend()
+    client_request_id = request.client_request_id or str(uuid4())
 
-    Follows the same pattern as /chat/send-chat-message for consistency.
-    """
+    try:
+        lock = acquire_active_turn_lock(cache, session_id)
+    except InteractiveTurnLockError as exc:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "This session is busy with a previous turn.",
+        ) from exc
 
-    def stream_generator() -> Generator[str, None, None]:
-        """Stream generator that manages its own database session.
+    lock_released = False
+    try:
+        existing = get_turn_for_request(
+            cache=cache,
+            session_id=session_id,
+            user_id=user.id,
+            client_request_id=client_request_id,
+        )
+        if existing is not None:
+            return InteractiveTurnResponse.from_turn(existing)
 
-        This is necessary because StreamingResponse consumes the generator
-        AFTER the endpoint returns, at which point FastAPI's dependency-injected
-        db_session has already been closed. By creating a new session inside
-        the generator, we ensure the session remains open for the entire
-        streaming duration.
-        """
-        # Capture user info needed for streaming (user object may not be available
-        # after the endpoint returns due to dependency cleanup)
-        user_id = user.id
-        message_content = request.content
-        events_yielded = 0
+        active = get_active_turn(cache=cache, session_id=session_id, user_id=user.id)
+        if active is not None:
+            raise OnyxError(
+                OnyxErrorCode.CONFLICT,
+                "This session is busy with a previous turn.",
+            )
+
+        check_build_rate_limits(user=user, db_session=db_session)
+
+        turn_index = (
+            db_session.query(BuildMessage)
+            .filter(
+                BuildMessage.session_id == session_id,
+                BuildMessage.type == MessageType.USER,
+            )
+            .count()
+        )
+        if request.provider and request.model:
+            session.agent_provider = request.provider
+            session.agent_model = request.model
+        create_message(
+            session_id=session_id,
+            message_type=MessageType.USER,
+            turn_index=turn_index,
+            message_metadata={
+                "type": "user_message",
+                "content": {"type": "text", "text": request.content},
+            },
+            db_session=db_session,
+        )
+
+        turn = create_interactive_turn(
+            cache=cache,
+            session_id=session_id,
+            user_id=user.id,
+            client_request_id=client_request_id,
+            prompt=request.content,
+            turn_index=turn_index,
+        )
 
         try:
-            with get_session_with_current_tenant() as db_session:
-                # Update sandbox heartbeat - this is the only place we track activity
-                # for determining when a sandbox should be put to sleep
-                sandbox = get_sandbox_by_user_id(db_session, user.id)
-                if sandbox and sandbox.status.is_active():
-                    update_sandbox_heartbeat(db_session, sandbox.id)
-
-                session_manager = SessionManager(db_session)
-                for chunk in session_manager.send_message(
-                    session_id,
-                    user_id,
-                    message_content,
-                    agent_provider=request.provider,
-                    agent_model=request.model,
-                ):
-                    events_yielded += 1
-                    yield chunk
-        except GeneratorExit:
-            logger.warning(
-                "Stream disconnected for session %s after %d events "
-                "(client likely closed connection)",
-                session_id,
-                events_yielded,
-            )
+            db_session.commit()
         except Exception:
-            logger.exception(
-                "Stream error for session %s after %d events",
-                session_id,
-                events_yielded,
+            db_session.rollback()
+            lock.release()
+            lock_released = True
+            finish_turn(
+                cache=cache,
+                turn_id=turn.turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail="Failed to persist user message.",
             )
+            raise
+    finally:
+        if not lock_released:
+            lock.release()
 
-    # Stream the CLI agent's response
-    return StreamingResponse(
-        stream_generator(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
-        },
-    )
+    try:
+        start_interactive_turn_runner(turn.turn_id)
+    except Exception:
+        logger.exception(
+            "Failed to start interactive turn %s; attach endpoints will retry",
+            turn.turn_id,
+        )
+
+    return InteractiveTurnResponse.from_turn(turn)
 
 
 @router.post(
@@ -224,8 +271,8 @@ def interrupt_message(
 ) -> MessageInterruptResponse:
     """Interrupt the in-flight agent turn for a session.
 
-    Interrupts the opencode-serve turn inside the sandbox; the corresponding
-    /send-message stream then terminates through its normal completion path.
+    Interrupts the opencode-serve turn inside the sandbox; attached turn-event
+    streams then terminate through their normal completion path.
     """
     session_manager = SessionManager(db_session)
     interrupted = session_manager.interrupt_message(session_id, user.id)

--- a/backend/onyx/server/features/build/api/messages_api.py
+++ b/backend/onyx/server/features/build/api/messages_api.py
@@ -17,7 +17,6 @@ from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import Permission
-from onyx.db.models import BuildMessage
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -26,6 +25,7 @@ from onyx.server.features.build.api.models import MessageInterruptResponse
 from onyx.server.features.build.api.models import MessageListResponse
 from onyx.server.features.build.api.models import MessageRequest
 from onyx.server.features.build.api.models import MessageResponse
+from onyx.server.features.build.db.build_session import count_user_messages
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
@@ -95,7 +95,6 @@ def send_message(
     session_id: UUID,
     request: MessageRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
-    _rate_limit_check: None = None,
     db_session: Session = Depends(get_session),
 ) -> InteractiveTurnResponse:
     """Start an interactive Craft turn in the background."""
@@ -134,14 +133,7 @@ def send_message(
 
         check_build_rate_limits(user=user, db_session=db_session)
 
-        turn_index = (
-            db_session.query(BuildMessage)
-            .filter(
-                BuildMessage.session_id == session_id,
-                BuildMessage.type == MessageType.USER,
-            )
-            .count()
-        )
+        turn_index = count_user_messages(session_id, db_session)
         if request.provider and request.model:
             session.agent_provider = request.provider
             session.agent_model = request.model

--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -17,6 +17,7 @@ from onyx.server.features.build.sandbox.models import FilesystemEntry as FileSys
 if TYPE_CHECKING:
     from onyx.db.models import BuildSession
     from onyx.db.models import Sandbox
+    from onyx.server.features.build.interactive_turns.state import InteractiveTurn
 
 
 # ===== Session Models =====
@@ -183,9 +184,28 @@ class MessageRequest(BaseModel):
     """Request to send a message to the CLI agent."""
 
     content: str
+    client_request_id: str | None = None
     # Per-message model override from the composer; both set together.
     provider: str | None = None
     model: str | None = None
+
+
+class InteractiveTurnResponse(BaseModel):
+    """Interactive turn lifecycle response."""
+
+    turn_id: str
+    session_id: str
+    status: str
+    turn_index: int
+
+    @classmethod
+    def from_turn(cls, turn: "InteractiveTurn") -> "InteractiveTurnResponse":
+        return cls(
+            turn_id=str(turn.turn_id),
+            session_id=str(turn.session_id),
+            status=turn.status,
+            turn_index=turn.turn_index,
+        )
 
 
 class MessageInterruptResponse(BaseModel):

--- a/backend/onyx/server/features/build/api/packets.py
+++ b/backend/onyx/server/features/build/api/packets.py
@@ -20,6 +20,7 @@ Sandbox events (re-emitted from :mod:`sandbox.event_schema`):
 
 Custom Onyx packets (defined here):
 - error: Onyx-specific errors (e.g., session not found)
+- subagent_started: A child opencode session was created under a parent turn
 """
 
 from datetime import datetime
@@ -71,8 +72,16 @@ class ApprovalRequestedPacket(BasePacket):
     session_id: UUID
 
 
+class SubagentStartedPacket(BasePacket):
+    """A child opencode session was created for a parent task tool call."""
+
+    type: Literal["subagent_started"] = "subagent_started"
+    subagent_session_id: str
+    parent_session_id: str
+
+
 # =============================================================================
 # Union Type for Custom Onyx Packets
 # =============================================================================
 
-BuildPacket = ErrorPacket | ApprovalRequestedPacket
+BuildPacket = ErrorPacket | ApprovalRequestedPacket | SubagentStartedPacket

--- a/backend/onyx/server/features/build/api/sessions_api.py
+++ b/backend/onyx/server/features/build/api/sessions_api.py
@@ -1036,7 +1036,7 @@ def get_session_scheduled_run_events(
         stream_generator(),
         media_type="text/event-stream",
         headers={
-            "Cache-Control": "no-cache",
+            "Cache-Control": "no-cache, no-transform",
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },

--- a/backend/onyx/server/features/build/api/turns_api.py
+++ b/backend/onyx/server/features/build/api/turns_api.py
@@ -1,0 +1,259 @@
+"""Attach-only API endpoints for active interactive Craft turns."""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timezone
+from uuid import UUID
+
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from onyx.auth.permissions import require_permission
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CacheBackend
+from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import Permission
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.api.models import InteractiveTurnResponse
+from onyx.server.features.build.db.build_session import get_build_session
+from onyx.server.features.build.interactive_turns.executor import (
+    start_interactive_turn_runner,
+)
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+from onyx.server.features.build.interactive_turns.state import get_turn
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
+from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
+from onyx.utils.logger import setup_logger
+
+router = APIRouter()
+logger = setup_logger()
+
+LIVE_STREAM_READY_POLL_SECONDS = 0.25
+LIVE_STREAM_KEEPALIVE_SECONDS = 15.0
+LIVE_STREAM_RUNNER_RETRY_SECONDS = 5.0
+TERMINAL_STREAM_EVENT_TYPES = frozenset(("prompt_response", "error"))
+
+
+def _format_stream_error(detail: str) -> str:
+    payload = {
+        "type": "error",
+        "message": detail,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+    }
+    return f"event: message\ndata: {json.dumps(payload)}\n\n"
+
+
+def _stream_chunk_type(chunk: str) -> str | None:
+    for line in chunk.splitlines():
+        if not line.startswith("data:"):
+            continue
+        raw_data = line[line.index(":") + 1 :].strip()
+        if not raw_data:
+            continue
+        try:
+            payload = json.loads(raw_data)
+        except json.JSONDecodeError:
+            return None
+        event_type = payload.get("type")
+        return event_type if isinstance(event_type, str) else None
+    return None
+
+
+def _turn_state_for_stream(
+    *,
+    cache: CacheBackend,
+    turn_id: UUID,
+    session_id: UUID,
+    user_id: UUID,
+) -> tuple[bool, str | None]:
+    turn = get_active_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+    )
+    if turn is not None and turn.turn_id == turn_id:
+        return True, None
+    turn = get_turn(cache, turn_id)
+    if turn is None or turn.session_id != session_id or turn.user_id != user_id:
+        return False, None
+    if turn.status != TURN_STATUS_FAILED:
+        return False, None
+    return False, turn.error_detail or "Interactive turn failed."
+
+
+def _try_start_turn_runner(turn_id: UUID) -> None:
+    try:
+        start_interactive_turn_runner(turn_id)
+    except Exception:
+        logger.exception(
+            "Failed to start interactive turn runner for turn %s; will retry on attach",
+            turn_id,
+        )
+
+
+@router.get("/sessions/{session_id}/turns/active", tags=PUBLIC_API_TAGS)
+def get_active_interactive_turn(
+    session_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> InteractiveTurnResponse | None:
+    """Return the active interactive turn for a Craft session, if any."""
+    session = get_build_session(session_id, user.id, db_session)
+    if session is None:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
+
+    cache = get_cache_backend()
+    turn = get_active_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user.id,
+    )
+    return InteractiveTurnResponse.from_turn(turn) if turn else None
+
+
+@router.get("/sessions/{session_id}/turns/{turn_id}/events", tags=PUBLIC_API_TAGS)
+def get_interactive_turn_events(
+    session_id: UUID,
+    turn_id: UUID,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> StreamingResponse:
+    """Attach to live opencode events for an active interactive turn."""
+    session = get_build_session(session_id, user.id, db_session)
+    if session is None:
+        raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
+
+    cache = get_cache_backend()
+    turn = get_active_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user.id,
+    )
+    initial_error_detail: str | None = None
+    if turn is None or turn.turn_id != turn_id:
+        requested_turn = get_turn(cache, turn_id)
+        if (
+            requested_turn is None
+            or requested_turn.session_id != session_id
+            or requested_turn.user_id != user.id
+            or requested_turn.status != TURN_STATUS_FAILED
+        ):
+            raise OnyxError(OnyxErrorCode.CONFLICT, "Interactive turn is not running")
+        initial_error_detail = requested_turn.error_detail or "Interactive turn failed."
+
+    user_id = user.id
+
+    def stream_generator() -> Generator[str, None, None]:
+        if initial_error_detail is not None:
+            yield _format_stream_error(initial_error_detail)
+            return
+
+        last_runner_start_attempt = 0.0
+
+        def maybe_start_runner(*, force: bool = False) -> None:
+            nonlocal last_runner_start_attempt
+            now = time.monotonic()
+            if (
+                not force
+                and now - last_runner_start_attempt < LIVE_STREAM_RUNNER_RETRY_SECONDS
+            ):
+                return
+            last_runner_start_attempt = now
+            _try_start_turn_runner(turn_id)
+
+        maybe_start_runner(force=True)
+        while True:
+            active, error_detail = _turn_state_for_stream(
+                cache=cache,
+                turn_id=turn_id,
+                session_id=session_id,
+                user_id=user_id,
+            )
+            if not active:
+                if error_detail:
+                    yield _format_stream_error(error_detail)
+                return
+
+            with get_session_with_current_tenant() as stream_db_session:
+                session = get_build_session(session_id, user_id, stream_db_session)
+                if session is None:
+                    yield _format_stream_error("Session not found")
+                    return
+                if session.opencode_session_id:
+                    break
+
+            yield SSE_KEEPALIVE
+            maybe_start_runner()
+            time.sleep(LIVE_STREAM_READY_POLL_SECONDS)
+
+        try:
+            with get_session_with_current_tenant() as stream_db_session:
+                session_manager = SessionManager(stream_db_session)
+                terminal_error_detail: str | None = None
+                for chunk in session_manager.subscribe_to_existing_session_events(
+                    session_id,
+                    user_id,
+                    keepalive_seconds=LIVE_STREAM_KEEPALIVE_SECONDS,
+                ):
+                    yield chunk
+                    chunk_type = _stream_chunk_type(chunk)
+                    if chunk_type in TERMINAL_STREAM_EVENT_TYPES:
+                        return
+
+                    stream_db_session.expire_all()
+                    active, error_detail = _turn_state_for_stream(
+                        cache=cache,
+                        turn_id=turn_id,
+                        session_id=session_id,
+                        user_id=user_id,
+                    )
+                    if not active:
+                        terminal_error_detail = error_detail or terminal_error_detail
+                        if chunk_type is None:
+                            if terminal_error_detail:
+                                yield _format_stream_error(terminal_error_detail)
+                            return
+                        # Keep draining already-queued live events until the
+                        # terminal packet arrives or a keepalive proves the
+                        # subscriber queue has gone idle.
+                        continue
+                    terminal_error_detail = None
+                if terminal_error_detail:
+                    yield _format_stream_error(terminal_error_detail)
+        except GeneratorExit:
+            logger.info(
+                "Interactive turn live stream disconnected for session %s turn %s",
+                session_id,
+                turn_id,
+            )
+            raise
+        except OnyxError as exc:
+            yield _format_stream_error(exc.detail)
+        except Exception as exc:
+            logger.exception(
+                "Interactive turn live stream failed for session %s turn %s",
+                session_id,
+                turn_id,
+            )
+            yield _format_stream_error(str(exc))
+
+    return StreamingResponse(
+        stream_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -379,6 +379,18 @@ def create_message(
     return message
 
 
+def count_user_messages(session_id: UUID, db_session: Session) -> int:
+    """Count persisted user messages in a build session."""
+    return (
+        db_session.query(BuildMessage)
+        .filter(
+            BuildMessage.session_id == session_id,
+            BuildMessage.type == MessageType.USER,
+        )
+        .count()
+    )
+
+
 def update_message(
     message_id: UUID,
     message_metadata: dict[str, Any],

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -1,0 +1,270 @@
+"""Background executor for interactive Craft turns."""
+
+from __future__ import annotations
+
+import threading
+import time
+from uuid import UUID
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.server.features.build.db.build_session import update_session_activity
+from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
+from onyx.server.features.build.interactive_turns.state import finish_turn
+from onyx.server.features.build.interactive_turns.state import InteractiveTurn
+from onyx.server.features.build.interactive_turns.state import touch_turn
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_CANCELLED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCEEDED
+from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
+from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.features.build.session.interrupt_signal import clear_interrupt
+from onyx.server.features.build.session.interrupt_signal import is_interrupt_requested
+from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.streaming import BuildStreamingState
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS = 30 * 60
+
+
+def start_interactive_turn_runner(turn_id: UUID) -> None:
+    """Run an interactive turn in this API process if Redis grants ownership."""
+    tenant_id = get_current_tenant_id()
+
+    def run() -> None:
+        token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+        turn: InteractiveTurn | None = None
+        try:
+            turn = claim_turn_for_runner(cache=get_cache_backend(), turn_id=turn_id)
+            if turn is None:
+                return
+
+            run_claimed_interactive_build_turn(turn)
+        except Exception:
+            logger.exception("Interactive turn runner failed for turn %s", turn_id)
+            if turn is not None:
+                finish_turn(
+                    cache=get_cache_backend(),
+                    turn_id=turn.turn_id,
+                    status=TURN_STATUS_FAILED,
+                    error_detail="Interactive turn runner failed.",
+                    runner_id=turn.runner_id,
+                )
+        finally:
+            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    thread = threading.Thread(
+        target=run,
+        name=f"interactive-build-turn-{turn_id}",
+        daemon=True,
+    )
+    thread.start()
+
+
+def run_claimed_interactive_build_turn(
+    turn: InteractiveTurn,
+    *,
+    budget_seconds: int = DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS,
+) -> None:
+    """Execute a turn that this runner has already claimed in CacheBackend."""
+    cache = get_cache_backend()
+    runner_id = turn.runner_id
+    try:
+        _drive_interactive_turn(
+            turn_id=turn.turn_id,
+            session_id=turn.session_id,
+            user_id=turn.user_id,
+            prompt=turn.prompt,
+            turn_index=turn.turn_index,
+            budget_seconds=budget_seconds,
+            runner_id=runner_id,
+        )
+    except Exception as exc:
+        logger.exception(
+            "Interactive turn %s failed before drive loop",
+            turn.turn_id,
+        )
+        finish_turn(
+            cache=cache,
+            turn_id=turn.turn_id,
+            status=TURN_STATUS_FAILED,
+            error_detail=f"{type(exc).__name__}: {str(exc)[:950]}",
+            runner_id=runner_id,
+        )
+
+
+def _drive_interactive_turn(
+    *,
+    turn_id: UUID,
+    session_id: UUID,
+    user_id: UUID,
+    prompt: str,
+    turn_index: int,
+    budget_seconds: int,
+    runner_id: str | None,
+) -> None:
+    cache = get_cache_backend()
+    with get_session_with_current_tenant() as db_session:
+        session_manager = SessionManager(db_session)
+        sandbox = session_manager.ensure_sandbox_running(user_id)
+        db_session.commit()
+
+        if not touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):
+            logger.info("Interactive turn %s runner ownership lost", turn_id)
+            return
+
+        state = BuildStreamingState(turn_index=turn_index)
+        deadline = time.monotonic() + budget_seconds
+        deadline_exceeded = False
+        final_event_seen = False
+        cancelled_event_seen = False
+
+        def interrupt_requested() -> bool:
+            nonlocal deadline_exceeded
+            if time.monotonic() > deadline:
+                deadline_exceeded = True
+                return True
+            try:
+                return is_interrupt_requested(session_id, cache)
+            except CACHE_TRANSIENT_ERRORS:
+                logger.warning(
+                    "[SANDBOX-SERVE] interrupt fence check failed for session %s",
+                    session_id,
+                    exc_info=True,
+                )
+                return False
+
+        prompt_slot_cm = session_manager.prompt_slot(sandbox.id, session_id)
+        if not prompt_slot_cm.__enter__():
+            finish_turn(
+                cache=cache,
+                turn_id=turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail="Concurrent turn in flight for build session.",
+                runner_id=runner_id,
+            )
+            prompt_slot_cm.__exit__(None, None, None)
+            return
+
+        try:
+            update_session_activity(session_id, db_session)
+
+            if interrupt_requested():
+                session_manager.finalize_persist(session_id, state)
+                db_session.commit()
+                finish_turn(
+                    cache=cache,
+                    turn_id=turn_id,
+                    status=TURN_STATUS_CANCELLED,
+                    runner_id=runner_id,
+                )
+                return
+
+            event_stream = session_manager.yield_sandbox_events(
+                sandbox.id,
+                session_id,
+                prompt,
+                should_interrupt=interrupt_requested,
+            )
+
+            for sandbox_event in event_stream:
+                if time.monotonic() > deadline:
+                    deadline_exceeded = True
+                if deadline_exceeded:
+                    continue
+
+                if not touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):
+                    logger.info("Interactive turn %s runner ownership lost", turn_id)
+                    return
+                if isinstance(sandbox_event, SSEKeepalive):
+                    continue
+                session_manager.persist_sandbox_event(session_id, state, sandbox_event)
+                db_session.commit()
+
+                if isinstance(sandbox_event, SandboxError):
+                    session_manager.finalize_persist(session_id, state)
+                    db_session.commit()
+                    finish_turn(
+                        cache=cache,
+                        turn_id=turn_id,
+                        status=TURN_STATUS_FAILED,
+                        error_detail=sandbox_event.message,
+                        runner_id=runner_id,
+                    )
+                    return
+
+                if isinstance(sandbox_event, PromptResponse):
+                    final_event_seen = True
+                    cancelled_event_seen = (
+                        getattr(sandbox_event, "stop_reason", None) == "cancelled"
+                    )
+
+            session_manager.finalize_persist(session_id, state)
+            db_session.commit()
+
+            if deadline_exceeded:
+                finish_turn(
+                    cache=cache,
+                    turn_id=turn_id,
+                    status=TURN_STATUS_FAILED,
+                    error_detail=f"budget exceeded ({budget_seconds}s)",
+                    runner_id=runner_id,
+                )
+                return
+
+            if not final_event_seen:
+                finish_turn(
+                    cache=cache,
+                    turn_id=turn_id,
+                    status=TURN_STATUS_FAILED,
+                    error_detail="Turn ended before opencode returned a final response.",
+                    runner_id=runner_id,
+                )
+                return
+
+            if cancelled_event_seen:
+                finish_turn(
+                    cache=cache,
+                    turn_id=turn_id,
+                    status=TURN_STATUS_CANCELLED,
+                    runner_id=runner_id,
+                )
+                return
+
+            finish_turn(
+                cache=cache,
+                turn_id=turn_id,
+                status=TURN_STATUS_SUCCEEDED,
+                runner_id=runner_id,
+            )
+        except Exception as exc:
+            db_session.rollback()
+            logger.exception("Interactive turn %s failed", turn_id)
+            try:
+                session_manager.finalize_persist(session_id, state)
+                db_session.commit()
+            except Exception:
+                logger.exception("Failed to finalize persistence for turn %s", turn_id)
+            finish_turn(
+                cache=cache,
+                turn_id=turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail=f"{type(exc).__name__}: {str(exc)[:950]}",
+                runner_id=runner_id,
+            )
+        finally:
+            try:
+                clear_interrupt(session_id, cache)
+            except CACHE_TRANSIENT_ERRORS:
+                logger.warning(
+                    "[SANDBOX-SERVE] failed to clear interrupt fence for session %s",
+                    session_id,
+                    exc_info=True,
+                )
+            prompt_slot_cm.__exit__(None, None, None)

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -8,10 +8,12 @@ from uuid import UUID
 
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.cache.interface import CacheBackend
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.server.features.build.db.build_session import update_session_activity
 from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
 from onyx.server.features.build.interactive_turns.state import finish_turn
+from onyx.server.features.build.interactive_turns.state import get_active_turn
 from onyx.server.features.build.interactive_turns.state import InteractiveTurn
 from onyx.server.features.build.interactive_turns.state import touch_turn
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_CANCELLED
@@ -31,6 +33,26 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS = 30 * 60
+
+
+def _can_clear_interrupt_fence(
+    *,
+    cache: CacheBackend,
+    turn_id: UUID,
+    session_id: UUID,
+    user_id: UUID,
+    runner_id: str | None,
+) -> bool:
+    active_turn = get_active_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+    )
+    if active_turn is None:
+        return True
+    return active_turn.turn_id == turn_id and (
+        runner_id is None or active_turn.runner_id == runner_id
+    )
 
 
 def start_interactive_turn_runner(turn_id: UUID) -> None:
@@ -260,7 +282,14 @@ def _drive_interactive_turn(
             )
         finally:
             try:
-                clear_interrupt(session_id, cache)
+                if _can_clear_interrupt_fence(
+                    cache=cache,
+                    turn_id=turn_id,
+                    session_id=session_id,
+                    user_id=user_id,
+                    runner_id=runner_id,
+                ):
+                    clear_interrupt(session_id, cache)
             except CACHE_TRANSIENT_ERRORS:
                 logger.warning(
                     "[SANDBOX-SERVE] failed to clear interrupt fence for session %s",

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -7,17 +7,27 @@ from dataclasses import asdict
 from dataclasses import dataclass
 from datetime import datetime
 from datetime import timezone
+from enum import StrEnum
 from uuid import UUID
 from uuid import uuid4
 
 from onyx.cache.interface import CacheBackend
 from onyx.cache.interface import CacheLock
 
-TURN_STATUS_QUEUED = "QUEUED"
-TURN_STATUS_RUNNING = "RUNNING"
-TURN_STATUS_SUCCEEDED = "SUCCEEDED"
-TURN_STATUS_FAILED = "FAILED"
-TURN_STATUS_CANCELLED = "CANCELLED"
+
+class InteractiveTurnStatus(StrEnum):
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
+
+
+TURN_STATUS_QUEUED = InteractiveTurnStatus.QUEUED
+TURN_STATUS_RUNNING = InteractiveTurnStatus.RUNNING
+TURN_STATUS_SUCCEEDED = InteractiveTurnStatus.SUCCEEDED
+TURN_STATUS_FAILED = InteractiveTurnStatus.FAILED
+TURN_STATUS_CANCELLED = InteractiveTurnStatus.CANCELLED
 
 ACTIVE_TURN_STATUSES = frozenset((TURN_STATUS_QUEUED, TURN_STATUS_RUNNING))
 ACTIVE_TURN_TTL_SECONDS = 45 * 60
@@ -37,7 +47,7 @@ class InteractiveTurn:
     session_id: UUID
     user_id: UUID
     prompt: str
-    status: str
+    status: InteractiveTurnStatus
     turn_index: int
     last_heartbeat_at: datetime | None = None
     error_detail: str | None = None
@@ -202,7 +212,7 @@ def finish_turn(
     *,
     cache: CacheBackend,
     turn_id: UUID,
-    status: str,
+    status: InteractiveTurnStatus,
     error_detail: str | None = None,
     runner_id: str | None = None,
 ) -> InteractiveTurn | None:
@@ -264,7 +274,7 @@ def _load_turn(raw: bytes | None) -> InteractiveTurn | None:
             session_id=UUID(payload["session_id"]),
             user_id=UUID(payload["user_id"]),
             prompt=payload["prompt"],
-            status=payload["status"],
+            status=InteractiveTurnStatus(payload["status"]),
             turn_index=int(payload["turn_index"]),
             last_heartbeat_at=_parse_dt(payload.get("last_heartbeat_at")),
             error_detail=payload.get("error_detail"),

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -1,0 +1,298 @@
+"""Cache-backed lifecycle state for active interactive Craft turns."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timezone
+from uuid import UUID
+from uuid import uuid4
+
+from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CacheLock
+
+TURN_STATUS_QUEUED = "QUEUED"
+TURN_STATUS_RUNNING = "RUNNING"
+TURN_STATUS_SUCCEEDED = "SUCCEEDED"
+TURN_STATUS_FAILED = "FAILED"
+TURN_STATUS_CANCELLED = "CANCELLED"
+
+ACTIVE_TURN_STATUSES = frozenset((TURN_STATUS_QUEUED, TURN_STATUS_RUNNING))
+ACTIVE_TURN_TTL_SECONDS = 45 * 60
+REQUEST_ID_TTL_SECONDS = 60 * 60
+TURN_LOCK_LEASE_SECONDS = 60.0
+TURN_LOCK_WAIT_SECONDS = 10.0
+RUNNER_STALE_AFTER_SECONDS = 90.0
+
+
+class InteractiveTurnLockError(Exception):
+    """Raised when the session active-turn lock cannot be acquired."""
+
+
+@dataclass
+class InteractiveTurn:
+    turn_id: UUID
+    session_id: UUID
+    user_id: UUID
+    prompt: str
+    status: str
+    turn_index: int
+    last_heartbeat_at: datetime | None = None
+    error_detail: str | None = None
+    runner_id: str | None = None
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in ACTIVE_TURN_STATUSES
+
+
+def acquire_active_turn_lock(cache: CacheBackend, session_id: UUID) -> CacheLock:
+    lock = cache.lock(
+        _active_turn_lock_key(session_id), timeout=TURN_LOCK_LEASE_SECONDS
+    )
+    if not lock.acquire(blocking=True, blocking_timeout=TURN_LOCK_WAIT_SECONDS):
+        raise InteractiveTurnLockError("Failed to acquire active turn lock")
+    return lock
+
+
+def create_interactive_turn(
+    *,
+    cache: CacheBackend,
+    session_id: UUID,
+    user_id: UUID,
+    client_request_id: str,
+    prompt: str,
+    turn_index: int,
+) -> InteractiveTurn:
+    now = datetime.now(tz=timezone.utc)
+    turn = InteractiveTurn(
+        turn_id=uuid4(),
+        session_id=session_id,
+        user_id=user_id,
+        prompt=prompt,
+        status=TURN_STATUS_QUEUED,
+        turn_index=turn_index,
+        last_heartbeat_at=now,
+    )
+    _save_turn(cache, turn, ex=ACTIVE_TURN_TTL_SECONDS)
+    cache.set(
+        _active_turn_key(session_id), str(turn.turn_id), ex=ACTIVE_TURN_TTL_SECONDS
+    )
+    cache.set(
+        _request_key(session_id, user_id, client_request_id),
+        str(turn.turn_id),
+        ex=REQUEST_ID_TTL_SECONDS,
+    )
+    return turn
+
+
+def get_turn(cache: CacheBackend, turn_id: UUID) -> InteractiveTurn | None:
+    return _load_turn(cache.get(_turn_key(turn_id)))
+
+
+def get_turn_for_request(
+    *,
+    cache: CacheBackend,
+    session_id: UUID,
+    user_id: UUID,
+    client_request_id: str,
+) -> InteractiveTurn | None:
+    raw_turn_id = cache.get(_request_key(session_id, user_id, client_request_id))
+    if raw_turn_id is None:
+        return None
+    try:
+        turn_id = UUID(_decode(raw_turn_id))
+    except ValueError:
+        return None
+    turn = get_turn(cache, turn_id)
+    if turn is None or turn.session_id != session_id or turn.user_id != user_id:
+        return None
+    return turn
+
+
+def get_active_turn(
+    *,
+    cache: CacheBackend,
+    session_id: UUID,
+    user_id: UUID,
+) -> InteractiveTurn | None:
+    raw_turn_id = cache.get(_active_turn_key(session_id))
+    if raw_turn_id is None:
+        return None
+    try:
+        turn_id = UUID(_decode(raw_turn_id))
+    except ValueError:
+        cache.delete(_active_turn_key(session_id))
+        return None
+    turn = get_turn(cache, turn_id)
+    if turn is None or turn.session_id != session_id or turn.user_id != user_id:
+        cache.delete(_active_turn_key(session_id))
+        return None
+    if not turn.is_active:
+        cache.delete(_active_turn_key(session_id))
+        return None
+    return turn
+
+
+def claim_turn_for_runner(
+    *,
+    cache: CacheBackend,
+    turn_id: UUID,
+    stale_after_seconds: float = RUNNER_STALE_AFTER_SECONDS,
+) -> InteractiveTurn | None:
+    """Atomically claim a queued or stale-running turn for one runner.
+
+    The claim lives in CacheBackend, not process memory, so another API pod can
+    detect and recover a turn whose original runner stopped heartbeating.
+    """
+    turn = get_turn(cache, turn_id)
+    if turn is None or turn.status not in ACTIVE_TURN_STATUSES:
+        return None
+
+    try:
+        lock = acquire_active_turn_lock(cache, turn.session_id)
+    except InteractiveTurnLockError:
+        return None
+
+    try:
+        turn = get_turn(cache, turn_id)
+        if turn is None or turn.status not in ACTIVE_TURN_STATUSES:
+            return None
+        if turn.status == TURN_STATUS_RUNNING and not _runner_is_stale(
+            turn, stale_after_seconds=stale_after_seconds
+        ):
+            return None
+
+        now = datetime.now(tz=timezone.utc)
+        turn.status = TURN_STATUS_RUNNING
+        turn.last_heartbeat_at = now
+        turn.runner_id = str(uuid4())
+        turn.error_detail = None
+        _save_turn(cache, turn, ex=ACTIVE_TURN_TTL_SECONDS)
+        cache.set(
+            _active_turn_key(turn.session_id),
+            str(turn.turn_id),
+            ex=ACTIVE_TURN_TTL_SECONDS,
+        )
+        return turn
+    finally:
+        lock.release()
+
+
+def touch_turn(
+    *,
+    cache: CacheBackend,
+    turn_id: UUID,
+    runner_id: str | None = None,
+) -> bool:
+    turn = get_turn(cache, turn_id)
+    if turn is None or not turn.is_active:
+        return False
+    if runner_id is not None and turn.runner_id != runner_id:
+        return False
+    turn.last_heartbeat_at = datetime.now(tz=timezone.utc)
+    _save_turn(cache, turn, ex=ACTIVE_TURN_TTL_SECONDS)
+    cache.expire(_active_turn_key(turn.session_id), ACTIVE_TURN_TTL_SECONDS)
+    return True
+
+
+def finish_turn(
+    *,
+    cache: CacheBackend,
+    turn_id: UUID,
+    status: str,
+    error_detail: str | None = None,
+    runner_id: str | None = None,
+) -> InteractiveTurn | None:
+    turn = get_turn(cache, turn_id)
+    if turn is None:
+        return None
+    if runner_id is not None and turn.runner_id != runner_id:
+        return None
+    now = datetime.now(tz=timezone.utc)
+    turn.status = status
+    turn.last_heartbeat_at = now
+    turn.error_detail = error_detail
+    turn.runner_id = None
+    _save_turn(cache, turn, ex=REQUEST_ID_TTL_SECONDS)
+    try:
+        lock = acquire_active_turn_lock(cache, turn.session_id)
+    except InteractiveTurnLockError:
+        return turn
+    try:
+        raw_active_id = cache.get(_active_turn_key(turn.session_id))
+        if raw_active_id is not None and _decode(raw_active_id) == str(turn_id):
+            cache.delete(_active_turn_key(turn.session_id))
+    finally:
+        lock.release()
+    return turn
+
+
+def _runner_is_stale(
+    turn: InteractiveTurn,
+    *,
+    stale_after_seconds: float,
+) -> bool:
+    if turn.last_heartbeat_at is None:
+        return True
+    heartbeat = turn.last_heartbeat_at
+    if heartbeat.tzinfo is None:
+        heartbeat = heartbeat.replace(tzinfo=timezone.utc)
+    age = datetime.now(tz=timezone.utc) - heartbeat
+    return age.total_seconds() >= stale_after_seconds
+
+
+def _save_turn(cache: CacheBackend, turn: InteractiveTurn, *, ex: int) -> None:
+    payload = asdict(turn)
+    for field in ("turn_id", "session_id", "user_id"):
+        payload[field] = str(payload[field])
+    for field in ("last_heartbeat_at",):
+        value = payload[field]
+        payload[field] = value.isoformat() if value is not None else None
+    cache.set(_turn_key(turn.turn_id), json.dumps(payload), ex=ex)
+
+
+def _load_turn(raw: bytes | None) -> InteractiveTurn | None:
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(_decode(raw))
+        return InteractiveTurn(
+            turn_id=UUID(payload["turn_id"]),
+            session_id=UUID(payload["session_id"]),
+            user_id=UUID(payload["user_id"]),
+            prompt=payload["prompt"],
+            status=payload["status"],
+            turn_index=int(payload["turn_index"]),
+            last_heartbeat_at=_parse_dt(payload.get("last_heartbeat_at")),
+            error_detail=payload.get("error_detail"),
+            runner_id=payload.get("runner_id"),
+        )
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+def _decode(value: bytes | str) -> str:
+    return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def _turn_key(turn_id: UUID) -> str:
+    return f"craft:interactive_turn:{turn_id}"
+
+
+def _active_turn_key(session_id: UUID) -> str:
+    return f"craft:session:{session_id}:active_turn"
+
+
+def _active_turn_lock_key(session_id: UUID) -> str:
+    return f"craft:session:{session_id}:active_turn_lock"
+
+
+def _request_key(session_id: UUID, user_id: UUID, client_request_id: str) -> str:
+    return f"craft:session:{session_id}:turn_request:{user_id}:{client_request_id}"

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -200,12 +200,24 @@ def touch_turn(
     turn = get_turn(cache, turn_id)
     if turn is None or not turn.is_active:
         return False
-    if runner_id is not None and turn.runner_id != runner_id:
+
+    try:
+        lock = acquire_active_turn_lock(cache, turn.session_id)
+    except InteractiveTurnLockError:
         return False
-    turn.last_heartbeat_at = datetime.now(tz=timezone.utc)
-    _save_turn(cache, turn, ex=ACTIVE_TURN_TTL_SECONDS)
-    cache.expire(_active_turn_key(turn.session_id), ACTIVE_TURN_TTL_SECONDS)
-    return True
+
+    try:
+        turn = get_turn(cache, turn_id)
+        if turn is None or not turn.is_active:
+            return False
+        if runner_id is not None and turn.runner_id != runner_id:
+            return False
+        turn.last_heartbeat_at = datetime.now(tz=timezone.utc)
+        _save_turn(cache, turn, ex=ACTIVE_TURN_TTL_SECONDS)
+        cache.expire(_active_turn_key(turn.session_id), ACTIVE_TURN_TTL_SECONDS)
+        return True
+    finally:
+        lock.release()
 
 
 def finish_turn(
@@ -219,25 +231,31 @@ def finish_turn(
     turn = get_turn(cache, turn_id)
     if turn is None:
         return None
-    if runner_id is not None and turn.runner_id != runner_id:
-        return None
-    now = datetime.now(tz=timezone.utc)
-    turn.status = status
-    turn.last_heartbeat_at = now
-    turn.error_detail = error_detail
-    turn.runner_id = None
-    _save_turn(cache, turn, ex=REQUEST_ID_TTL_SECONDS)
+
     try:
         lock = acquire_active_turn_lock(cache, turn.session_id)
     except InteractiveTurnLockError:
-        return turn
+        return None
+
     try:
+        turn = get_turn(cache, turn_id)
+        if turn is None:
+            return None
+        if runner_id is not None and turn.runner_id != runner_id:
+            return None
+        now = datetime.now(tz=timezone.utc)
+        turn.status = status
+        turn.last_heartbeat_at = now
+        turn.error_detail = error_detail
+        turn.runner_id = None
+        _save_turn(cache, turn, ex=REQUEST_ID_TTL_SECONDS)
+
         raw_active_id = cache.get(_active_turn_key(turn.session_id))
         if raw_active_id is not None and _decode(raw_active_id) == str(turn_id):
             cache.delete(_active_turn_key(turn.session_id))
+        return turn
     finally:
         lock.release()
-    return turn
 
 
 def _runner_is_stale(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1077,6 +1077,18 @@ class KubernetesSandboxManager(SandboxManager):
                     return True
         return False
 
+    @staticmethod
+    def _sandbox_container_is_ready(pod: client.V1Pod) -> bool:
+        """Return True only when the agent container itself is running/ready."""
+        for status in pod.status.container_statuses or []:
+            if status.name != _SANDBOX_CONTAINER_NAME:
+                continue
+            state = status.state
+            return bool(
+                status.ready and state is not None and state.running is not None
+            )
+        return False
+
     def _wait_for_pod_ready(
         self,
         pod_name: str,
@@ -1182,7 +1194,11 @@ class KubernetesSandboxManager(SandboxManager):
             if phase == "Running":
                 conditions = pod.status.conditions or []
                 for condition in conditions:
-                    if condition.type == "Ready" and condition.status == "True":
+                    if (
+                        condition.type == "Ready"
+                        and condition.status == "True"
+                        and self._sandbox_container_is_ready(pod)
+                    ):
                         return True
 
             # Pending is OK too - pod is being created by another request
@@ -2044,7 +2060,20 @@ printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md
         logger.info("Session configuration files regenerated")
 
     def health_check(self, sandbox_id: UUID, timeout: float = 60.0) -> bool:
-        """Check whether the sidecar's /health endpoint responds."""
+        """Check whether the agent container and sidecar are both healthy."""
+        pod_name = self._get_pod_name(str(sandbox_id))
+        try:
+            pod = self._core_api.read_namespaced_pod(
+                name=pod_name,
+                namespace=self._namespace,
+            )
+        except ApiException as e:
+            if e.status == 404:
+                return False
+            raise
+        if not self._sandbox_container_is_ready(pod):
+            return False
+
         for host in self._sandbox_pod_hosts(sandbox_id):
             url = f"http://{host}:{PUSH_DAEMON_PORT}/health"
             try:

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -278,6 +278,7 @@ class PodEventBus:
     def _dispatch(self, event: dict[str, Any]) -> None:
         event_type = event.get("type")
         props = event.get("properties") or {}
+        session_created_parent_id: str | None = None
 
         if event_type == "session.created":
             info = props.get("info") if isinstance(props, dict) else None
@@ -290,6 +291,7 @@ class PodEventBus:
                     and child_id
                     and parent_id
                 ):
+                    session_created_parent_id = parent_id
                     with self._lock:
                         if child_id not in self._child_to_parent:
                             self._child_to_parent[child_id] = parent_id
@@ -303,6 +305,8 @@ class PodEventBus:
                             )
 
         session_id = _extract_session_id(event)
+        if session_id is None:
+            session_id = session_created_parent_id
         log_session_id = session_id or "<unscoped>"
 
         # Deliver to session_id's own subscribers AND to every ancestor's subscribers

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -24,6 +24,7 @@ from typing import cast
 
 import httpx
 
+from onyx.server.features.build.api.packets import SubagentStartedPacket
 from onyx.server.features.build.configs import OPENCODE_SERVE_CONNECT_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVE_REQUEST_TIMEOUT
@@ -45,7 +46,7 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 
-# Acp event union (kept narrow — only the types we actually translate to).
+# Event union (kept narrow — only the types we actually translate to).
 SandboxEvent = (
     AgentMessageChunk
     | AgentThoughtChunk
@@ -53,6 +54,7 @@ SandboxEvent = (
     | ToolCallProgress
     | PromptResponse
     | Error
+    | SubagentStartedPacket
     | SSEKeepalive
 )
 
@@ -115,6 +117,9 @@ class _TurnState:
     user_message_ids: set[str] = field(default_factory=set)
     # `task` callID → claimed child session (parallel tasks get distinct children).
     task_child_by_call: dict[str, str] = field(default_factory=dict)
+    # Descendant sessions share this parent turn stream but not opencode-local
+    # ids. Keep each child session's message/part/tool caches isolated.
+    child_states: dict[str, _TurnState] = field(default_factory=dict)
     # Last LLM finish reason seen on any assistant message.updated. Only the
     # terminator (fired from session.idle/status) consumes it — message.updated
     # itself is per-step and can't terminate the turn.
@@ -337,6 +342,57 @@ def _is_assistant_message(
     return _hydrate_message(state, msg_id, fetch_message) == "assistant"
 
 
+def _emit_text_delta(
+    props: dict[str, Any],
+    state: _TurnState,
+    fetch_message: Callable[[str], dict[str, Any] | None] | None,
+) -> Iterable[SandboxEvent]:
+    field_name = props.get("field")
+    delta = props.get("delta")
+    part_id = props.get("partID")
+    msg_id = props.get("messageID")
+    if not isinstance(delta, str) or not isinstance(part_id, str):
+        return
+    if not delta:
+        return
+    # Assistant-only filter. Deltas race ~300ms ahead of message.updated;
+    # _is_assistant_message hydrates via REST when the role is unknown.
+    if not _is_assistant_message(state, msg_id, fetch_message):
+        return
+    if field_name != "text":
+        # Non-text fields (e.g. tool input streaming, future extensions)
+        # have no sandbox-event mapping yet. Drop silently.
+        return
+    # Route by the PART'S TYPE (not the delta's ``field``, which is
+    # always "text" because that's the part attribute being updated).
+    # opencode emits reasoning content on parts with ``type=reasoning``
+    # and visible text on parts with ``type=text``. The part type is
+    # recorded from prior ``message.part.updated`` events.
+    part_type = state.part_types.get(part_id, "text")
+    if part_type == "reasoning":
+        # Track reasoning accumulator the same way as text so the
+        # post-delta ``message.part.updated`` reconciliation doesn't
+        # double-emit. partID is unique across types, so they share
+        # ``state.local_text`` without collision.
+        state.local_text[part_id] = state.local_text.get(part_id, "") + delta
+        yield AgentThoughtChunk.model_validate(
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": delta},
+            }
+        )
+    elif part_type == "text":
+        state.local_text[part_id] = state.local_text.get(part_id, "") + delta
+        yield AgentMessageChunk.model_validate(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": delta},
+            }
+        )
+    # Other part types (step-start, step-finish, tool, ...) don't carry
+    # user-visible text — ignore.
+
+
 # ---------------------------------------------------------------------------
 # translate_opencode_event — translation has no I/O of its own. Hydration of
 # unknown messageIDs (the delta-before-message.updated race) is delegated to
@@ -363,12 +419,23 @@ def _is_descendant_of(
     return False
 
 
+def _state_for_session(state: _TurnState, session_id: str) -> _TurnState:
+    if session_id == state.session_id:
+        return state
+    child_state = state.child_states.get(session_id)
+    if child_state is None:
+        child_state = _TurnState(session_id=session_id)
+        state.child_states[session_id] = child_state
+    return child_state
+
+
 def translate_opencode_event(
     raw: dict[str, Any],
     state: _TurnState,
     fetch_message: Callable[[str], dict[str, Any] | None] | None = None,
     parent_resolver: Callable[[str], str | None] | None = None,
     children_resolver: Callable[[str], list[str]] | None = None,
+    fetch_message_by_session: Callable[[str, str], dict[str, Any] | None] | None = None,
 ) -> Iterable[SandboxEvent]:
     """Convert one opencode ``/event`` payload into zero-or-more SandboxEvents.
 
@@ -402,73 +469,92 @@ def translate_opencode_event(
         if isinstance(info, dict):
             sess_id = info.get("sessionID")
 
+    if etype == "session.created":
+        info = props.get("info") or {}
+        if not isinstance(info, dict):
+            return
+        child_id = info.get("id")
+        parent_id = info.get("parentID")
+        if (
+            isinstance(child_id, str)
+            and isinstance(parent_id, str)
+            and parent_id == state.session_id
+        ):
+            yield SubagentStartedPacket(
+                subagent_session_id=child_id,
+                parent_session_id=parent_id,
+            )
+        return
+
     if isinstance(sess_id, str) and sess_id != state.session_id:
-        # Event from another session. Forward ONLY descendant tool events,
-        # tagged so the frontend can route them to the right subagent. Child
-        # text/reasoning are dropped for v1 (routing them through
-        # _is_assistant_message would 404: fetch_message is bound to the
-        # parent session).
+        # Event from another session. Forward descendant text/thought/tool
+        # events tagged so the frontend can route them to the live subagent.
         if not _is_descendant_of(sess_id, state.session_id, parent_resolver):
             return  # unrelated session — drop as before
+
+        child_meta = {"sessionId": sess_id, "parentSessionId": state.session_id}
+        child_state = _state_for_session(state, sess_id)
+
+        if etype == "message.updated":
+            info = props.get("info") or {}
+            if not isinstance(info, dict):
+                return
+            if info.get("role") != "assistant":
+                return
+            msg_id = info.get("id")
+            if isinstance(msg_id, str):
+                child_state.assistant_message_ids.add(msg_id)
+            return
+
+        child_fetch_message = (
+            (lambda mid: fetch_message_by_session(sess_id, mid))
+            if fetch_message_by_session is not None
+            else None
+        )
+
+        if etype == "message.part.delta":
+            for event in _emit_text_delta(props, child_state, child_fetch_message):
+                _merge_field_meta(event, child_meta)
+                yield event
+            return
+
         if etype != "message.part.updated":
             return
+
         part = props.get("part") or {}
-        if not isinstance(part, dict) or part.get("type") != "tool":
+        if not isinstance(part, dict):
             return
-        for event in _emit_tool_events(part, state):
-            _merge_field_meta(
-                event,
-                {"sessionId": sess_id, "parentSessionId": state.session_id},
-            )
+
+        part_type = part.get("type")
+        part_id_for_state = part.get("id")
+        if isinstance(part_id_for_state, str) and isinstance(part_type, str):
+            child_state.part_types[part_id_for_state] = part_type
+
+        if part_type == "reasoning":
+            if not _is_assistant_message(
+                child_state, part.get("messageID"), child_fetch_message
+            ):
+                return
+            events = _reconcile_reasoning_part(part, child_state)
+        elif part_type == "text":
+            if not _is_assistant_message(
+                child_state, part.get("messageID"), child_fetch_message
+            ):
+                return
+            events = _reconcile_text_part(part, child_state)
+        elif part_type == "tool":
+            events = _emit_tool_events(part, child_state)
+        else:
+            return
+
+        for event in events:
+            _merge_field_meta(event, child_meta)
             yield event
         return
 
     # ── streaming text deltas ────────────────────────────────────────
     if etype == "message.part.delta":
-        field_name = props.get("field")
-        delta = props.get("delta")
-        part_id = props.get("partID")
-        msg_id = props.get("messageID")
-        if not isinstance(delta, str) or not isinstance(part_id, str):
-            return
-        if not delta:
-            return
-        # Assistant-only filter. Deltas race ~300ms ahead of message.updated;
-        # _is_assistant_message hydrates via REST when the role is unknown.
-        if not _is_assistant_message(state, msg_id, fetch_message):
-            return
-        if field_name != "text":
-            # Non-text fields (e.g. tool input streaming, future extensions)
-            # have no sandbox-event mapping yet. Drop silently.
-            return
-        # Route by the PART'S TYPE (not the delta's ``field``, which is
-        # always "text" because that's the part attribute being updated).
-        # opencode emits reasoning content on parts with ``type=reasoning``
-        # and visible text on parts with ``type=text``. The part type is
-        # recorded from prior ``message.part.updated`` events.
-        part_type = state.part_types.get(part_id, "text")
-        if part_type == "reasoning":
-            # Track reasoning accumulator the same way as text so the
-            # post-delta ``message.part.updated`` reconciliation doesn't
-            # double-emit. partID is unique across types, so they share
-            # ``state.local_text`` without collision.
-            state.local_text[part_id] = state.local_text.get(part_id, "") + delta
-            yield AgentThoughtChunk.model_validate(
-                {
-                    "sessionUpdate": "agent_thought_chunk",
-                    "content": {"type": "text", "text": delta},
-                }
-            )
-        elif part_type == "text":
-            state.local_text[part_id] = state.local_text.get(part_id, "") + delta
-            yield AgentMessageChunk.model_validate(
-                {
-                    "sessionUpdate": "agent_message_chunk",
-                    "content": {"type": "text", "text": delta},
-                }
-            )
-        # Other part types (step-start, step-finish, tool, ...) don't
-        # carry user-visible text — ignore.
+        yield from _emit_text_delta(props, state, fetch_message)
         return
 
     # ── part lifecycle (tool calls + gap-fill anchors for text parts) ──
@@ -1130,23 +1216,26 @@ class OpencodeServeClient:
             )
 
         state = _TurnState(session_id=opencode_session_id)
+        turn_started_at = time.monotonic()
+        prompt_posted = False
 
         def fetch_message(mid: str) -> dict[str, Any] | None:
             return self.get_message(opencode_session_id, mid, directory=directory)
 
         sub = self._event_bus.subscribe(opencode_session_id)
         try:
-            # Block until the bus reader has the stream open, else we'd
-            # POST prompt_async and miss the first events of the turn.
-            if not self._event_bus.stream_ready.wait(
-                timeout=self._timeouts.connect_timeout
-            ):
-                yield Error.model_validate(
-                    {
-                        "code": -3,
-                        "message": "opencode /event stream did not become ready",
-                    }
-                )
+            # Wait until the bus reader has the /event stream open, else we'd
+            # POST prompt_async and miss the first events of the turn. The bus
+            # may be in a reconnect window after a transient disconnect, so do
+            # not fail on the short HTTP connect timeout; wait within the turn's
+            # wall-clock budget while emitting keepalives.
+            ready = yield from self._wait_for_event_stream_ready(
+                sub,
+                timeout,
+                turn_started_at,
+                should_interrupt=should_interrupt,
+            )
+            if not ready:
                 return
 
             try:
@@ -1157,6 +1246,7 @@ class OpencodeServeClient:
                     model_id,
                     directory=directory,
                 )
+                prompt_posted = True
             except httpx.HTTPStatusError as e:
                 yield Error.model_validate(
                     {
@@ -1171,9 +1261,10 @@ class OpencodeServeClient:
                 )
                 return
 
+            remaining_timeout = max(0.0, timeout - (time.monotonic() - turn_started_at))
             yield from self._consume_from_bus(
                 sub,
-                timeout,
+                remaining_timeout,
                 opencode_session_id,
                 state,
                 fetch_message,
@@ -1184,10 +1275,92 @@ class OpencodeServeClient:
             )
 
         except GeneratorExit:
-            self.abort(opencode_session_id, directory=directory)
+            if prompt_posted:
+                self.abort(opencode_session_id, directory=directory)
             raise
         finally:
             self._event_bus.unsubscribe(sub)
+
+    def _wait_for_event_stream_ready(
+        self,
+        sub: _Subscription,
+        timeout: float,
+        turn_started_at: float,
+        *,
+        should_interrupt: Callable[[], bool] | None = None,
+    ) -> Generator[SandboxEvent, None, bool]:
+        """Wait for the shared /event reader to be connected before prompting.
+
+        This absorbs short reconnect windows without dropping the turn. It still
+        respects the caller's turn budget and exits promptly if the bus gives up
+        and self-closes.
+        """
+        last_keepalive = time.monotonic()
+        last_interrupt_check = last_keepalive
+
+        while True:
+            if self._event_bus is None:
+                yield Error.model_validate(
+                    {
+                        "code": -3,
+                        "message": "opencode /event bus is unavailable",
+                    }
+                )
+                return False
+
+            if self._event_bus.closed:
+                yield Error.model_validate(
+                    {
+                        "code": -3,
+                        "message": "event bus closed before /event stream became ready",
+                    }
+                )
+                return False
+
+            if self._event_bus.stream_ready.is_set():
+                return True
+
+            now = time.monotonic()
+            if should_interrupt is not None and now - last_interrupt_check >= 1.0:
+                last_interrupt_check = now
+                if should_interrupt():
+                    yield PromptResponse.model_validate({"stopReason": "cancelled"})
+                    return False
+
+            remaining = timeout - (now - turn_started_at)
+            if remaining <= 0:
+                yield Error.model_validate(
+                    {
+                        "code": -3,
+                        "message": "opencode /event stream did not become ready",
+                    }
+                )
+                return False
+
+            wait_for = min(remaining, 1.0)
+            if self._event_bus.stream_ready.wait(timeout=wait_for):
+                return True
+
+            try:
+                raw = sub.queue.get_nowait()
+            except queue.Empty:
+                if time.monotonic() - last_keepalive >= SSE_KEEPALIVE_INTERVAL:
+                    yield SSEKeepalive()
+                    last_keepalive = time.monotonic()
+                continue
+
+            if raw is BUS_CLOSED_SENTINEL:
+                yield Error.model_validate(
+                    {
+                        "code": -3,
+                        "message": "event bus closed before /event stream became ready",
+                    }
+                )
+                return False
+
+            # Do not translate pre-prompt events; they belong to prior activity
+            # on this opencode session. Loop back to re-check stream readiness,
+            # timeout, and bus closure.
 
     def _consume_from_bus(
         self,
@@ -1262,6 +1435,10 @@ class OpencodeServeClient:
                 fetch_message,
                 parent_resolver=parent_resolver,
                 children_resolver=children_resolver,
+                fetch_message_by_session=lambda session_id,
+                message_id: self.get_message(
+                    session_id, message_id, directory=directory
+                ),
             ):
                 if isinstance(sandbox_event, (Error, PromptResponse)):
                     terminated_locally = True

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -30,6 +30,8 @@ from onyx.server.features.build.configs import OPENCODE_SERVE_EVENT_READ_TIMEOUT
 from onyx.server.features.build.configs import OPENCODE_SERVER_USERNAME
 from onyx.server.features.build.configs import SANDBOX_TURN_TIMEOUT_SECONDS
 from onyx.server.features.build.db.sandbox import get_sandbox_by_id
+from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
+from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
@@ -54,6 +56,11 @@ OPENCODE_SERVE_READY_POLL_INTERVAL_SECONDS = 0.25
 
 # How long a new turn waits for the previous turn's slot before giving up.
 PROMPT_SLOT_ACQUIRE_TIMEOUT_SECONDS = 10.0
+
+# Live attach streams are UI-facing. Coalesce adjacent text deltas just long
+# enough to avoid one React update per tiny opencode token burst, while keeping
+# control packets and final/error packets effectively immediate.
+LIVE_TEXT_COALESCE_SECONDS = 0.04
 
 
 @dataclass(frozen=True)
@@ -667,22 +674,72 @@ class _ServeMixin:
         sub = bus.subscribe(opencode_session_id)
         try:
             last_event = time.monotonic()
+            pending_text_event: SandboxEvent | None = None
+            pending_text_started_at = 0.0
             while True:
+                now = time.monotonic()
+                if (
+                    pending_text_event is not None
+                    and now - pending_text_started_at >= LIVE_TEXT_COALESCE_SECONDS
+                ):
+                    yield pending_text_event
+                    pending_text_event = None
+                    continue
+
+                queue_timeout = 1.0
+                if pending_text_event is not None:
+                    queue_timeout = max(
+                        0.0,
+                        LIVE_TEXT_COALESCE_SECONDS - (now - pending_text_started_at),
+                    )
                 try:
-                    raw = sub.queue.get(timeout=1.0)
+                    raw = sub.queue.get(timeout=queue_timeout)
                 except queue.Empty:
+                    if pending_text_event is not None:
+                        yield pending_text_event
+                        pending_text_event = None
+                        continue
                     if time.monotonic() - last_event >= keepalive_seconds:
                         yield SSEKeepalive()
                         last_event = time.monotonic()
                     continue
                 if raw is BUS_CLOSED_SENTINEL:
+                    if pending_text_event is not None:
+                        yield pending_text_event
                     return
                 last_event = time.monotonic()
                 if raw.get("type") == "server.connected":
                     continue
                 for sandbox_event in translate_opencode_event(
-                    raw, state, fetch_message=fetch_message
+                    raw,
+                    state,
+                    fetch_message=fetch_message,
+                    parent_resolver=bus.parent_of,
+                    children_resolver=bus.list_children,
+                    fetch_message_by_session=lambda session_id,
+                    message_id: client.get_message(
+                        session_id, message_id, directory=directory
+                    ),
                 ):
+                    if pending_text_event is not None:
+                        merged = _merge_text_chunk(pending_text_event, sandbox_event)
+                        if merged is not None:
+                            pending_text_event = merged
+                            continue
+
+                        yield pending_text_event
+                        pending_text_event = None
+
+                    if (
+                        isinstance(
+                            sandbox_event, (AgentMessageChunk, AgentThoughtChunk)
+                        )
+                        and getattr(sandbox_event.content, "type", None) == "text"
+                    ):
+                        pending_text_event = sandbox_event
+                        pending_text_started_at = time.monotonic()
+                        continue
+
                     yield sandbox_event
         finally:
             # Close client first so a flaky unsubscribe doesn't leak the pool.
@@ -698,3 +755,41 @@ class _ServeMixin:
                 logger.exception(
                     "[SANDBOX-SERVE] bus unsubscribe failed in subscribe teardown"
                 )
+
+
+def _merge_text_chunk(
+    pending: SandboxEvent,
+    incoming: SandboxEvent,
+) -> SandboxEvent | None:
+    if type(pending) is not type(incoming):
+        return None
+    if not isinstance(pending, (AgentMessageChunk, AgentThoughtChunk)):
+        return None
+
+    pending_content = pending.content
+    incoming_content = incoming.content
+    if (
+        getattr(pending_content, "type", None) != "text"
+        or getattr(incoming_content, "type", None) != "text"
+    ):
+        return None
+
+    pending_text = getattr(pending_content, "text", None)
+    incoming_text = getattr(incoming_content, "text", None)
+    if not isinstance(pending_text, str) or not isinstance(incoming_text, str):
+        return None
+
+    if getattr(pending_content, "field_meta", None) != getattr(
+        incoming_content, "field_meta", None
+    ) or getattr(pending_content, "annotations", None) != getattr(
+        incoming_content, "annotations", None
+    ):
+        return None
+
+    return pending.model_copy(
+        update={
+            "content": pending_content.model_copy(
+                update={"text": pending_text + incoming_text}
+            )
+        }
+    )

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -20,15 +20,15 @@ Lifecycle (see ``docs/craft/features/scheduled-tasks.md``):
 3. Transition QUEUED -> RUNNING.
 4. Create a fresh ``BuildSession`` with ``origin=SCHEDULED``. Record its
    id on the run row.
-5. Drive the agent via the shared ``_yield_sandbox_events`` generator,
-   persisting each event with ``_persist_sandbox_event``. Enforce a 30 min
+5. Drive the agent via the shared ``yield_sandbox_events`` generator,
+   persisting each event with ``persist_sandbox_event``. Enforce a 30 min
    monotonic budget (Celery thread-pool time limits are silently
    disabled — see CLAUDE.md).
 6. On ``RequestPermissionRequest`` (approval gate): mark
    ``AWAITING_APPROVAL``, emit a notification, return without writing a
    terminal status. Resume mechanics are owned by the approvals project;
    until that ships these runs are "terminal-for-display".
-7. On clean stream completion: ``_finalize_persist``, derive a
+7. On clean stream completion: ``finalize_persist``, derive a
    ~120-char summary, mark ``SUCCEEDED``.
 8. On any exception inside the drive loop: mark ``FAILED`` with the
    exception class/detail and emit a notification. We deliberately
@@ -325,7 +325,7 @@ def _drive_agent(
         AWAITING_APPROVAL). ``False`` otherwise (run status is terminal).
     """
     # We open a single session for the whole drive so that the
-    # `_persist_sandbox_event` calls (which write `BuildMessage` rows) and the
+    # `persist_sandbox_event` calls (which write `BuildMessage` rows) and the
     # final `mark_run_status` happen against the same connection. The
     # session is committed eagerly at key points so observers see progress.
     with get_session_with_current_tenant() as db_session:
@@ -373,17 +373,33 @@ def _drive_agent(
         # contends today, but acquire it anyway so any future change
         # that lets scheduled and interactive runs share a build_session
         # inherits the protection without needing to remember to add it.
-        sandbox_manager = session_manager._sandbox_manager
-
         approval_required = False
         final_event_count = 0
         # Acquire the per-build_session lock for the duration of the
         # agent loop. __enter__/__exit__ used directly (rather than a
         # `with`) to avoid reindenting the existing try/except block.
-        prompt_slot_cm = sandbox_manager.prompt_slot(sandbox_id, session_id)
-        prompt_slot_cm.__enter__()
+        prompt_slot_cm = session_manager.prompt_slot(sandbox_id, session_id)
+        if not prompt_slot_cm.__enter__():
+            prompt_slot_cm.__exit__(None, None, None)
+            mark_run_status(
+                db_session=db_session,
+                run_id=run_id,
+                status=ScheduledTaskRunStatus.FAILED,
+                error_class=ScheduledTaskErrorClass.AGENT_EXCEPTION,
+                error_detail="Concurrent turn in flight for build session.",
+            )
+            _notify(
+                db_session=db_session,
+                user_id=task_user_id,
+                task_name=task_name,
+                task_id=task_id,
+                run_id=run_id,
+                notif_type=NotificationType.SCHEDULED_TASK_FAILED,
+            )
+            db_session.commit()
+            return False
         try:
-            for sandbox_event in session_manager._yield_sandbox_events(
+            for sandbox_event in session_manager.yield_sandbox_events(
                 sandbox_id, session_id, task_prompt
             ):
                 # Approval gate: mark awaiting_approval, return. Resume
@@ -396,7 +412,7 @@ def _drive_agent(
                 # Budget check happens before persistence so a runaway
                 # agent can't keep growing the transcript.
                 if time.monotonic() > deadline:
-                    session_manager._finalize_persist(session_id, state)
+                    session_manager.finalize_persist(session_id, state)
                     mark_run_status(
                         db_session=db_session,
                         run_id=run_id,
@@ -415,7 +431,7 @@ def _drive_agent(
                     db_session.commit()
                     return False
 
-                session_manager._persist_sandbox_event(session_id, state, sandbox_event)
+                session_manager.persist_sandbox_event(session_id, state, sandbox_event)
                 db_session.commit()
                 final_event_count += 1
 
@@ -426,7 +442,7 @@ def _drive_agent(
                 summary_from_chunks = _summary_from_state(state)
                 # Flush any pending chunks so the transcript reflects
                 # what the agent has said before pausing.
-                session_manager._finalize_persist(session_id, state)
+                session_manager.finalize_persist(session_id, state)
                 db_session.commit()
                 summary = summary_from_chunks or _summary_from_session_messages(
                     session_id, db_session
@@ -450,7 +466,7 @@ def _drive_agent(
 
             # Clean completion path.
             summary_from_chunks = _summary_from_state(state)
-            session_manager._finalize_persist(session_id, state)
+            session_manager.finalize_persist(session_id, state)
             db_session.commit()
             summary = summary_from_chunks or _summary_from_session_messages(
                 session_id, db_session

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -11,6 +11,7 @@ import uuid
 import zipfile
 from collections.abc import Callable
 from collections.abc import Generator
+from contextlib import AbstractContextManager
 from datetime import datetime
 from datetime import timezone
 from pathlib import Path
@@ -48,7 +49,6 @@ from onyx.server.features.build.db.build_session import get_empty_session_for_us
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import get_user_build_sessions
 from onyx.server.features.build.db.build_session import update_session_activity
-from onyx.server.features.build.db.build_session import update_session_agent_selection
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
@@ -72,6 +72,7 @@ from onyx.skills.push import build_user_skills_payload
 from onyx.skills.push import hydrate_sandbox_skills
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -680,43 +681,6 @@ class SessionManager:
             return None
         return get_session_messages(session_id, self._db_session)
 
-    def send_message(
-        self,
-        session_id: UUID,
-        user_id: UUID,
-        content: str,
-        agent_provider: str | None = None,
-        agent_model: str | None = None,
-    ) -> Generator[str, None, None]:
-        """
-        Send a message to the CLI agent and stream the response as SSE events.
-
-        Validates session, saves user message, streams agent response,
-        and saves assistant response to database.
-
-        Args:
-            session_id: The session UUID
-            user_id: The user ID
-            content: The message content
-            agent_provider: Optional per-message model provider override
-            agent_model: Optional per-message model name override
-
-        Yields:
-            SSE formatted event strings
-        """
-        # Persist the per-message model override; the turn reads it off the session row.
-        if agent_provider and agent_model:
-            update_session_agent_selection(
-                session_id, agent_provider, agent_model, self._db_session
-            )
-        yield from _streaming.stream_cli_agent_turn(
-            self._db_session,
-            self._sandbox_manager,
-            session_id,
-            content,
-            user_id,
-        )
-
     def send_subagent_message(
         self,
         session_id: UUID,
@@ -759,6 +723,7 @@ class SessionManager:
         user_id: UUID,
         *,
         keepalive_seconds: float = 15.0,
+        include_approval_announces: bool = True,
     ) -> Generator[str, None, None]:
         """Attach to an existing opencode session and stream translated ACP SSE.
 
@@ -785,24 +750,39 @@ class SessionManager:
                 "Session live stream is not ready yet.",
             )
 
-        for acp_event in self._sandbox_manager.subscribe_to_opencode_session(
+        raw_events = self._sandbox_manager.subscribe_to_opencode_session(
             sandbox.id,
             opencode_session_id,
             directory=f"/workspace/sessions/{session_id}",
             keepalive_seconds=keepalive_seconds,
-        ):
+        )
+        if include_approval_announces:
+            raw_events = self.merge_events_with_announces(
+                raw_events,
+                session_id=session_id,
+                tenant_id=get_current_tenant_id(),
+            )
+
+        for acp_event in raw_events:
             yield _streaming.event_to_sse(acp_event)
 
     # ----- Persistence helpers (shared with the headless scheduled-tasks executor) -----
     #
-    # `_yield_sandbox_events` is a thin wrapper around the sandbox manager that drives
+    # `yield_sandbox_events` is a thin wrapper around the sandbox manager that drives
     # the agent to completion and yields raw sandbox events. It does NO database
     # writes, no SSE formatting — making it composable: the SSE endpoint wraps
-    # it with `_persist_sandbox_event` + an SSE formatter, and the headless
-    # scheduled-tasks executor reuses `_persist_sandbox_event` directly so the
+    # it with `persist_sandbox_event` + an SSE formatter, and the headless
+    # scheduled-tasks executor reuses `persist_sandbox_event` directly so the
     # persisted transcript is identical to an interactive run.
 
-    def _yield_sandbox_events(
+    def prompt_slot(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+    ) -> AbstractContextManager[bool]:
+        return self._sandbox_manager.prompt_slot(sandbox_id, session_id)
+
+    def yield_sandbox_events(
         self,
         sandbox_id: UUID,
         session_id: UUID,
@@ -826,7 +806,20 @@ class SessionManager:
             should_interrupt=should_interrupt,
         )
 
-    def _persist_sandbox_event(
+    def merge_events_with_announces(
+        self,
+        event_iter: Generator[Any, None, None],
+        *,
+        session_id: UUID,
+        tenant_id: str,
+    ) -> Generator[Any, None, None]:
+        yield from _streaming.merge_events_with_announces(
+            event_iter,
+            session_id=session_id,
+            tenant_id=tenant_id,
+        )
+
+    def persist_sandbox_event(
         self,
         session_id: UUID,
         state: BuildStreamingState,
@@ -837,7 +830,7 @@ class SessionManager:
             self._db_session, session_id, state, sandbox_event, routing_meta
         )
 
-    def _finalize_persist(
+    def finalize_persist(
         self,
         session_id: UUID,
         state: BuildStreamingState,

--- a/backend/onyx/server/features/build/session/streaming.py
+++ b/backend/onyx/server/features/build/session/streaming.py
@@ -2,10 +2,9 @@
 
 Hosts the per-turn state container (``BuildStreamingState``), the
 event-persistence dispatcher (``persist_sandbox_event`` / ``finalize_persist``),
-the opencode-session-id management, and the two SSE entry points
-(``stream_cli_agent_turn`` for parent turns, ``stream_subagent_turn`` for
-subagent follow-ups). Pure cut from ``manager.py``; SessionManager's
-streaming methods now delegate here.
+the opencode-session-id management, and the subagent SSE entry point. Parent
+interactive turns are driven by the background turn executor so refresh/rejoin
+is not tied to the browser response stream.
 
 The headless scheduled-tasks executor reaches into ``yield_sandbox_events``
 / ``persist_sandbox_event`` / ``finalize_persist`` directly (through
@@ -28,17 +27,15 @@ from uuid import UUID
 from sqlalchemy.orm import Session as DBSession
 
 from onyx.cache.factory import get_cache_backend
-from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.configs.constants import MessageType
 from onyx.db.enums import SandboxStatus
-from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
 from onyx.sandbox_proxy import approval_cache
 from onyx.server.features.build.api.packet_logger import get_packet_logger
-from onyx.server.features.build.api.packet_logger import log_separator
 from onyx.server.features.build.api.packets import ApprovalRequestedPacket
 from onyx.server.features.build.api.packets import BuildPacket
 from onyx.server.features.build.api.packets import ErrorPacket
+from onyx.server.features.build.api.packets import SubagentStartedPacket
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import update_session_activity
@@ -56,10 +53,7 @@ from onyx.server.features.build.sandbox.event_schema import ToolCallProgress
 from onyx.server.features.build.sandbox.event_schema import ToolCallStart
 from onyx.server.features.build.sandbox.opencode.serve_client import _merge_field_meta
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
-from onyx.server.features.build.session.interrupt_signal import clear_interrupt
-from onyx.server.features.build.session.interrupt_signal import is_interrupt_requested
 from onyx.utils.logger import setup_logger
-from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -101,16 +95,23 @@ class BuildStreamingState:
 
         # Track what type of chunk we were last receiving
         self._last_chunk_type: str | None = None
+        self._last_chunk_routing_meta: dict[str, Any] | None = None
 
-    def add_message_chunk(self, text: str) -> None:
+    def add_message_chunk(
+        self, text: str, routing_meta: dict[str, Any] | None = None
+    ) -> None:
         """Accumulate message text."""
         self.message_chunks.append(text)
         self._last_chunk_type = "message"
+        self._last_chunk_routing_meta = dict(routing_meta) if routing_meta else None
 
-    def add_thought_chunk(self, text: str) -> None:
+    def add_thought_chunk(
+        self, text: str, routing_meta: dict[str, Any] | None = None
+    ) -> None:
         """Accumulate thought text."""
         self.thought_chunks.append(text)
         self._last_chunk_type = "thought"
+        self._last_chunk_routing_meta = dict(routing_meta) if routing_meta else None
 
     def finalize_message_chunks(
         self, routing_meta: dict[str, Any] | None = None
@@ -132,8 +133,9 @@ class BuildStreamingState:
             "content": {"type": "text", "text": full_text},
             "sessionUpdate": "agent_message",
         }
-        if routing_meta:
-            result["_meta"] = dict(routing_meta)
+        chunk_routing_meta = routing_meta or self._last_chunk_routing_meta
+        if chunk_routing_meta:
+            result["_meta"] = dict(chunk_routing_meta)
         self.message_chunks.clear()
         return result
 
@@ -157,19 +159,28 @@ class BuildStreamingState:
             "content": {"type": "text", "text": full_text},
             "sessionUpdate": "agent_thought",
         }
-        if routing_meta:
-            result["_meta"] = dict(routing_meta)
+        chunk_routing_meta = routing_meta or self._last_chunk_routing_meta
+        if chunk_routing_meta:
+            result["_meta"] = dict(chunk_routing_meta)
         self.thought_chunks.clear()
         return result
 
-    def should_finalize_chunks(self, new_packet_type: str) -> bool:
+    def should_finalize_chunks(
+        self,
+        new_packet_type: str,
+        routing_meta: dict[str, Any] | None = None,
+    ) -> bool:
         """Check if we should finalize pending chunks before processing new packet.
 
         We finalize when the packet type changes from message/thought chunks
-        to something else (or to a different chunk type).
+        to something else (or to a different chunk type), and when routing
+        changes between parent and subagent chunks.
         """
         if self._last_chunk_type is None:
             return False
+
+        if self._last_chunk_routing_meta != routing_meta:
+            return True
 
         # If we were receiving message chunks and now get something else
         if (
@@ -190,6 +201,7 @@ class BuildStreamingState:
     def clear_last_chunk_type(self) -> None:
         """Clear the last chunk type tracking after finalization."""
         self._last_chunk_type = None
+        self._last_chunk_routing_meta = None
 
 
 def _extract_text_from_content(content: Any) -> str:
@@ -237,6 +249,8 @@ def event_to_sse(event: Any) -> str:
     """
     if isinstance(event, SSEKeepalive):
         return SSE_KEEPALIVE
+    if isinstance(event, (ApprovalRequestedPacket, ErrorPacket, SubagentStartedPacket)):
+        return _format_packet_event(event)
     return _serialize_sandbox_event(event, _get_event_type(event))
 
 
@@ -245,7 +259,7 @@ def _format_packet_event(packet: BuildPacket) -> str:
     return f"event: message\ndata: {packet.model_dump_json(by_alias=True)}\n\n"
 
 
-def _merge_events_with_announces(
+def merge_events_with_announces(
     event_iter: Generator[Any, None, None],
     session_id: UUID,
     tenant_id: str,
@@ -345,6 +359,21 @@ def _save_pending_chunks(
         )
 
     state.clear_last_chunk_type()
+
+
+def _routing_meta_from_event(sandbox_event: Any) -> dict[str, Any] | None:
+    field_meta = getattr(sandbox_event, "field_meta", None)
+    if not isinstance(field_meta, dict):
+        return None
+
+    routing_meta: dict[str, Any] = {}
+    session_id = field_meta.get("sessionId")
+    parent_session_id = field_meta.get("parentSessionId")
+    if isinstance(session_id, str) and session_id:
+        routing_meta["sessionId"] = session_id
+    if isinstance(parent_session_id, str) and parent_session_id:
+        routing_meta["parentSessionId"] = parent_session_id
+    return routing_meta or None
 
 
 def load_turn_session(
@@ -524,19 +553,20 @@ def persist_sandbox_event(
 
     # Flush any pending chunks if the event type changed.
     event_type = _get_event_type(sandbox_event)
-    if state.should_finalize_chunks(event_type):
-        _save_pending_chunks(db_session, session_id, state, routing_meta)
+    event_routing_meta = _routing_meta_from_event(sandbox_event) or routing_meta
+    if state.should_finalize_chunks(event_type, event_routing_meta):
+        _save_pending_chunks(db_session, session_id, state)
 
     if isinstance(sandbox_event, AgentMessageChunk):
         text = _extract_text_from_content(sandbox_event.content)
         if text:
-            state.add_message_chunk(text)
+            state.add_message_chunk(text, event_routing_meta)
         return
 
     if isinstance(sandbox_event, AgentThoughtChunk):
         text = _extract_text_from_content(sandbox_event.content)
         if text:
-            state.add_thought_chunk(text)
+            state.add_thought_chunk(text, event_routing_meta)
         return
 
     if isinstance(sandbox_event, ToolCallStart):
@@ -624,410 +654,6 @@ def finalize_persist(
     _save_pending_chunks(db_session, session_id, state, routing_meta)
 
 
-def stream_cli_agent_turn(
-    db_session: DBSession,
-    sandbox_manager: SandboxManager,
-    session_id: UUID,
-    user_message_content: str,
-    user_id: UUID,
-) -> Generator[str, None, None]:
-    """
-    Stream the CLI agent's response using SSE format.
-
-    Executes the agent via SandboxManager and streams events back to the client.
-    Uses BuildStreamingState to accumulate chunks and track tool calls.
-    At the end of streaming, saves accumulated state to the database.
-
-    Storage behavior:
-    - User message: Saved immediately at start
-    - agent_message_chunk: Accumulated, saved as one synthetic packet at end/type change
-    - agent_thought_chunk: Accumulated, saved as one synthetic packet at end/type change
-    - tool_call_start: Streamed to frontend only, not saved
-    - tool_call_progress: Only saved when status="completed"
-    - agent_plan_update: Upserted (only latest plan kept per turn)
-    """
-
-    # Initialize packet logging
-    packet_logger = get_packet_logger()
-
-    # The log file auto-rotates to keep only the last N lines (default 5000).
-    # Add a prominent separator for visual identification of new message streams.
-    log_separator(
-        f"NEW MESSAGE STREAM - Session: {str(session_id)[:8]} - User: {str(user_id)[:8]}"
-    )
-    packet_logger.log_raw(
-        "STREAM-START",
-        {
-            "session_id": str(session_id),
-            "user_id": str(user_id),
-            "message_preview": user_message_content[:200]
-            + ("..." if len(user_message_content) > 200 else ""),
-        },
-    )
-
-    events_emitted = 0
-    state: BuildStreamingState | None = None
-    # Set inside the SERVE-transport block below; released in finally.
-    prompt_slot_cm: contextlib.AbstractContextManager[bool] | None = None
-
-    try:
-        # Verify session exists and belongs to user
-        session = get_build_session(session_id, user_id, db_session)
-        if session is None:
-            error_packet = ErrorPacket(message="Session not found")
-            packet_logger.log("error", error_packet.model_dump())
-            yield _format_packet_event(error_packet)
-            return
-
-        # Get the user's sandbox (now user-owned, not session-owned)
-        sandbox = get_sandbox_by_user_id(db_session, user_id)
-
-        # Check if sandbox is running
-        if not sandbox or sandbox.status != SandboxStatus.RUNNING:
-            error_packet = ErrorPacket(
-                message="Sandbox is not running. Please wait for it to start."
-            )
-            packet_logger.log("error", error_packet.model_dump())
-            yield _format_packet_event(error_packet)
-            return
-
-        # Update last activity timestamp
-        update_session_activity(session_id, db_session)
-
-        # Acquire a per-build-session lock BEFORE we touch the opencode
-        # session id (preflight + persist + transport). Keying on
-        # build_session_id (not opencode_session_id) is deliberate:
-        # the opencode id can rotate mid-turn via the
-        # on_opencode_session_resolved callback, so a key based on it
-        # would let a concurrent request acquire a DIFFERENT lock and
-        # bypass serialization on exactly the recovery path. It also
-        # blocks first-turn races where two simultaneous prompts on a
-        # fresh build session would each mint their own opencode
-        # session. See SandboxManager.prompt_slot for the full
-        # rationale.
-        #
-        # The slot is released in the matching `finally` at the
-        # bottom of this try/except block.
-        candidate_cm = sandbox_manager.prompt_slot(sandbox.id, session_id)
-        if not candidate_cm.__enter__():
-            # Release the no-op exit so the context manager's
-            # contract is respected, then surface a clean error
-            # without persisting any user_message or contacting
-            # opencode.
-            candidate_cm.__exit__(None, None, None)
-            error_packet = ErrorPacket(
-                message=(
-                    "This session is busy with a previous turn. "
-                    "Please wait for it to finish before sending "
-                    "another message."
-                )
-            )
-            packet_logger.log("error", error_packet.model_dump())
-            yield _format_packet_event(error_packet)
-            return
-        # Slot acquired — hand off ownership to the outer finally,
-        # which releases on every exit path.
-        prompt_slot_cm = candidate_cm
-
-        # NB: we deliberately do NOT clear the fence here. The finally clears
-        # it before releasing the slot, so a prior turn's fence can never
-        # leak to this one. Clearing at turn start instead would wipe an
-        # interrupt that landed while we were blocked acquiring the slot —
-        # losing the very first-turn interrupt this feature must honor.
-        cache = get_cache_backend()
-
-        def interrupt_requested() -> bool:
-            # A cache blip must never fail a healthy turn — fail open.
-            try:
-                return is_interrupt_requested(session_id, cache)
-            except CACHE_TRANSIENT_ERRORS:
-                logger.warning(
-                    "[SANDBOX-SERVE] interrupt fence check failed for "
-                    "session %s; treating as not-interrupted",
-                    session_id,
-                    exc_info=True,
-                )
-                return False
-
-        # Calculate turn_index BEFORE saving user message
-        # turn_index = count of existing USER messages (this will be the Nth user message)
-
-        # Get count of user messages to determine turn index
-        existing_user_count = (
-            db_session.query(BuildMessage)
-            .filter(
-                BuildMessage.session_id == session_id,
-                BuildMessage.type == MessageType.USER,
-            )
-            .count()
-        )
-        turn_index = existing_user_count  # This user message is the Nth (0-indexed)
-
-        # Save user message to database
-        user_message_metadata = {
-            "type": "user_message",
-            "content": {"type": "text", "text": user_message_content},
-        }
-        create_message(
-            session_id=session_id,
-            message_type=MessageType.USER,
-            turn_index=turn_index,
-            message_metadata=user_message_metadata,
-            db_session=db_session,
-        )
-
-        # Initialize streaming state for this turn
-        state = BuildStreamingState(turn_index=turn_index)
-
-        sandbox_id = sandbox.id
-
-        packet_logger.log_raw(
-            "STREAM-BEGIN-AGENT-LOOP",
-            {
-                "session_id": str(session_id),
-                "sandbox_id": str(sandbox_id),
-                "turn_index": turn_index,
-            },
-        )
-
-        # Resolving here (before the interrupt-fence check) means an
-        # interrupt that landed during the slow first-turn opencode mint
-        # still stops us before we drive the agent.
-        opencode_session_id = _ensure_opencode_session_id(
-            db_session, sandbox_manager, sandbox_id, session
-        )
-        if interrupt_requested():
-            clear_interrupt(session_id, cache)
-            logger.info(
-                "[SANDBOX-SERVE] turn interrupted before start: session=%s",
-                session_id,
-            )
-            yield _serialize_sandbox_event(
-                PromptResponse.model_validate({"stopReason": "cancelled"}),
-                "prompt_response",
-            )
-            return
-
-        # Drive the agent. sandbox events are merged with proxy approval
-        # announces onto one SSE stream. `persist_sandbox_event` applies
-        # persistence; SSE formatting + packet-logger book-keeping happen here.
-        # `should_interrupt` lets the consume loop self-terminate on the
-        # fence (abort + its own PromptResponse) within ~1s, even on an
-        # event-less turn — so an interrupt never depends on opencode
-        # emitting session.idle, which can leave the turn (and its slot)
-        # hung until the wall-clock timeout.
-        merged_events = _merge_events_with_announces(
-            yield_sandbox_events(
-                db_session,
-                sandbox_manager,
-                sandbox_id,
-                session_id,
-                user_message_content,
-                opencode_session_id=opencode_session_id,
-                agent_provider=session.agent_provider,
-                agent_model=session.agent_model,
-                should_interrupt=interrupt_requested,
-            ),
-            session_id=session_id,
-            tenant_id=get_current_tenant_id(),
-        )
-        for sandbox_event in merged_events:
-            if isinstance(sandbox_event, ApprovalRequestedPacket):
-                packet_logger.log(
-                    "approval_requested",
-                    sandbox_event.model_dump(mode="json"),
-                )
-                packet_logger.log_sse_emit("approval_requested", session_id)
-                yield _format_packet_event(sandbox_event)
-                continue
-
-            # Handle SSE keepalive - send comment to keep connection alive.
-            if isinstance(sandbox_event, SSEKeepalive):
-                # SSE comments start with : and are ignored by EventSource
-                # but keep the HTTP connection alive.
-                packet_logger.log_sse_emit("keepalive", session_id)
-                yield SSE_KEEPALIVE
-                continue
-
-            # Persistence first so DB writes precede the SSE emit (matches
-            # the prior in-loop ordering, which interleaved them).
-            persist_sandbox_event(db_session, session_id, state, sandbox_event)
-            events_emitted += 1
-
-            # SSE-only branches: log + serialize for the HTTP client.
-            if isinstance(sandbox_event, AgentMessageChunk):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "agent_message_chunk"
-                packet_logger.log("agent_message_chunk", event_data)
-                packet_logger.log_sse_emit("agent_message_chunk", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "agent_message_chunk")
-
-            elif isinstance(sandbox_event, AgentThoughtChunk):
-                packet_logger.log(
-                    "agent_thought_chunk",
-                    sandbox_event.model_dump(mode="json", by_alias=True),
-                )
-                packet_logger.log_sse_emit("agent_thought_chunk", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "agent_thought_chunk")
-
-            elif isinstance(sandbox_event, ToolCallStart):
-                packet_logger.log(
-                    "tool_call_start",
-                    sandbox_event.model_dump(mode="json", by_alias=True),
-                )
-                packet_logger.log_sse_emit("tool_call_start", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "tool_call_start")
-
-            elif isinstance(sandbox_event, ToolCallProgress):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "tool_call_progress"
-                event_data["timestamp"] = datetime.now(tz=timezone.utc).isoformat()
-                packet_logger.log("tool_call_progress", event_data)
-                packet_logger.log_sse_emit("tool_call_progress", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "tool_call_progress")
-
-            elif isinstance(sandbox_event, AgentPlanUpdate):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "agent_plan_update"
-                event_data["timestamp"] = datetime.now(tz=timezone.utc).isoformat()
-                packet_logger.log("agent_plan_update", event_data)
-                packet_logger.log_sse_emit("agent_plan_update", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "agent_plan_update")
-
-            elif isinstance(sandbox_event, CurrentModeUpdate):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "current_mode_update"
-                packet_logger.log("current_mode_update", event_data)
-                packet_logger.log_sse_emit("current_mode_update", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "current_mode_update")
-
-            elif isinstance(sandbox_event, PromptResponse):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "prompt_response"
-                packet_logger.log("prompt_response", event_data)
-                packet_logger.log_sse_emit("prompt_response", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "prompt_response")
-
-            elif isinstance(sandbox_event, SandboxError):
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = "error"
-                packet_logger.log("error", event_data)
-                packet_logger.log_sse_emit("error", session_id)
-                yield _serialize_sandbox_event(sandbox_event, "error")
-
-            else:
-                # Unrecognized packet type - log it but don't stream to frontend.
-                event_type_name = type(sandbox_event).__name__
-                event_data = sandbox_event.model_dump(
-                    mode="json", by_alias=True, exclude_none=False
-                )
-                event_data["type"] = f"unrecognized_{event_type_name.lower()}"
-                packet_logger.log(f"unrecognized_{event_type_name.lower()}", event_data)
-
-        # Flush any pending accumulated chunks at end of stream.
-        finalize_persist(db_session, session_id, state)
-
-        # Log streaming completion
-        packet_logger.log_raw(
-            "STREAM-COMPLETE",
-            {
-                "session_id": str(session_id),
-                "sandbox_id": str(sandbox_id),
-                "turn_index": turn_index,
-                "events_emitted": events_emitted,
-                "message_chunks_accumulated": len(state.message_chunks),
-                "thought_chunks_accumulated": len(state.thought_chunks),
-            },
-        )
-
-        # Update heartbeat after successful message exchange
-        update_sandbox_heartbeat(db_session, sandbox_id)
-
-    except GeneratorExit:
-        logger.warning(
-            "Stream generator closed for session %s after %d events "
-            "(client disconnected mid-stream)",
-            session_id,
-            events_emitted,
-        )
-        if state is not None:
-            finalize_persist(db_session, session_id, state)
-        return
-    except ValueError as e:
-        error_packet = ErrorPacket(message=str(e))
-        packet_logger.log("error", error_packet.model_dump())
-        packet_logger.log_raw(
-            "STREAM-ERROR",
-            {
-                "session_id": str(session_id),
-                "error_type": "ValueError",
-                "error": str(e),
-            },
-        )
-        logger.exception("ValueError in build message streaming")
-        yield _format_packet_event(error_packet)
-    except RuntimeError as e:
-        error_packet = ErrorPacket(message=str(e))
-        packet_logger.log("error", error_packet.model_dump())
-        packet_logger.log_raw(
-            "STREAM-ERROR",
-            {
-                "session_id": str(session_id),
-                "error_type": "RuntimeError",
-                "error": str(e),
-            },
-        )
-        logger.exception("RuntimeError in build message streaming: %s", e)
-        yield _format_packet_event(error_packet)
-    except Exception as e:
-        error_packet = ErrorPacket(message=str(e))
-        packet_logger.log("error", error_packet.model_dump())
-        packet_logger.log_raw(
-            "STREAM-ERROR",
-            {
-                "session_id": str(session_id),
-                "error_type": type(e).__name__,
-                "error": str(e),
-            },
-        )
-        logger.exception("Unexpected error in build message streaming")
-        yield _format_packet_event(error_packet)
-    finally:
-        # Release the per-opencode-session lock acquired above (if any).
-        # Runs on every exit path including bare returns, GeneratorExit,
-        # and exception flow — without this a long-running turn would
-        # leak the lock and permanently block follow-up turns on the
-        # same session.
-        # Clear the fence BEFORE releasing the slot: while we still hold it
-        # no next turn can start, so we can't clobber a fence legitimately
-        # set for that turn. Don't let a fence outlive its turn either.
-        # Guard the cache call — a raise here would skip the slot release
-        # below and leak the lock for the rest of the process's life.
-        try:
-            clear_interrupt(session_id, get_cache_backend())
-        except CACHE_TRANSIENT_ERRORS:
-            logger.warning(
-                "[SANDBOX-SERVE] failed to clear interrupt fence for "
-                "session %s; releasing slot anyway",
-                session_id,
-                exc_info=True,
-            )
-        if prompt_slot_cm is not None:
-            prompt_slot_cm.__exit__(None, None, None)
-
-
 def stream_subagent_turn(
     db_session: DBSession,
     sandbox_manager: SandboxManager,
@@ -1038,8 +664,7 @@ def stream_subagent_turn(
 ) -> Generator[str, None, None]:
     """SSE stream of a follow-up turn against a subagent child session.
 
-    Focused parallel of :func:`stream_cli_agent_turn`: it reuses the same
-    persistence (`persist_sandbox_event`) and SSE serialization
+    Reuses the same persistence (`persist_sandbox_event`) and SSE serialization
     (`_serialize_sandbox_event`) helpers, but drives the child session via
     ``sandbox_manager.send_subagent_message`` and tags routing ``_meta``.
     It does not re-run the parent's first-turn opencode-session preflight

--- a/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
+++ b/backend/tests/external_dependency_unit/craft/test_streaming_persistence.py
@@ -1,37 +1,28 @@
-"""Streaming persistence and stream error semantics tests (ext-dep).
+"""Streaming persistence tests (ext-dep).
 
-The first half covers what ``_persist_sandbox_event`` actually writes to the DB
+These cover what ``persist_sandbox_event`` actually writes to the DB
 (assistant/thought rows, tool-call gating, plan upsert, turn indexing, finalize
-semantics).
-
-The second half covers the user-observable error packets the streaming endpoint
-emits when the upstream agent / sandbox misbehaves.
-
-Tests drive ``SessionManager.send_message`` end-to-end against Postgres with a
-stubbed ``SandboxManager`` so every assertion is on observable DB state /
-yielded SSE text.
+semantics). Tests drive the same shared helpers used by the background
+interactive-turn runner against Postgres with a stubbed ``SandboxManager``.
 """
 
 from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from collections.abc import Generator
 from typing import Any
-from uuid import UUID
-from uuid import uuid4
 
-import pytest
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import MessageType
-from onyx.db.enums import SandboxStatus
+from onyx.db.models import BuildMessage
 from onyx.db.models import BuildSession
 from onyx.db.models import Sandbox
 from onyx.db.models import User
 from onyx.server.features.build.db.build_session import create_message
 from onyx.server.features.build.db.build_session import get_session_messages
 from onyx.server.features.build.db.build_session import upsert_agent_plan
+from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
@@ -96,9 +87,50 @@ def _prompt_response() -> PromptResponse:
     return PromptResponse(stop_reason="end_turn")
 
 
-def _drain(gen: Generator[str, None, None]) -> list[str]:
-    """Consume a streaming generator into a list of SSE frames."""
-    return list(gen)
+def _drive_persisted_turn(
+    *,
+    db_session: Session,
+    mgr: SessionManager,
+    build_session: BuildSession,
+    user: User,
+    content: str,
+) -> None:
+    sandbox = get_sandbox_by_user_id(db_session, user.id)
+    assert sandbox is not None
+
+    turn_index = (
+        db_session.query(BuildMessage)
+        .filter(
+            BuildMessage.session_id == build_session.id,
+            BuildMessage.type == MessageType.USER,
+        )
+        .count()
+    )
+    create_message(
+        session_id=build_session.id,
+        message_type=MessageType.USER,
+        turn_index=turn_index,
+        message_metadata={
+            "type": "user_message",
+            "content": {"type": "text", "text": content},
+        },
+        db_session=db_session,
+    )
+
+    state = BuildStreamingState(turn_index=turn_index)
+    try:
+        for sandbox_event in mgr.yield_sandbox_events(
+            sandbox.id,
+            build_session.id,
+            content,
+            should_interrupt=lambda: False,
+        ):
+            if isinstance(sandbox_event, SSEKeepalive):
+                continue
+            mgr.persist_sandbox_event(build_session.id, state, sandbox_event)
+    finally:
+        mgr.finalize_persist(build_session.id, state)
+    db_session.commit()
 
 
 # =============================================================================
@@ -223,9 +255,13 @@ class TestStreamingPersistence:
             _thought_chunk("think."),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "hi"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="hi",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         thoughts = [
@@ -307,9 +343,13 @@ class TestStreamingPersistence:
             _tool_call_start("tc-1", "Bash"),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "run a command"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="run a command",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         types = [(m.message_metadata or {}).get("type") for m in messages]
@@ -332,9 +372,13 @@ class TestStreamingPersistence:
             _tool_call_progress("tc-1", "Bash", status="completed"),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "run it"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="run it",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         tool_rows = [
@@ -362,9 +406,13 @@ class TestStreamingPersistence:
             _tool_call_progress("tc-1", "Bash", status="in_progress"),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "run it"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="run it",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         tool_rows = [
@@ -392,9 +440,13 @@ class TestStreamingPersistence:
             _tool_call_progress("tw-1", "TodoWrite", status="completed"),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "plan it"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="plan it",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         todo_rows = [
@@ -516,9 +568,13 @@ class TestStreamingPersistence:
             ),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "run subagent"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="run subagent",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         # Tool call row
@@ -558,10 +614,14 @@ class TestStreamingPersistence:
             _text_chunk("ok"),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
         for prompt in ("first", "second", "third"):
-            _drain(mgr.send_message(build_session.id, test_user.id, prompt))
+            _drive_persisted_turn(
+                db_session=db_session,
+                mgr=session_manager_with_stub,
+                build_session=build_session,
+                user=test_user,
+                content=prompt,
+            )
 
         messages = get_session_messages(build_session.id, db_session)
         # 3 user + 3 assistant agent_message rows.
@@ -596,9 +656,13 @@ class TestStreamingPersistence:
             _text_chunk("part two."),
             _prompt_response(),
         ]
-        mgr = session_manager_with_stub
-
-        _drain(mgr.send_message(build_session.id, test_user.id, "go"))
+        _drive_persisted_turn(
+            db_session=db_session,
+            mgr=session_manager_with_stub,
+            build_session=build_session,
+            user=test_user,
+            content="go",
+        )
 
         messages = get_session_messages(build_session.id, db_session)
         agent_msgs = [
@@ -610,261 +674,3 @@ class TestStreamingPersistence:
         assert (
             agent_msgs[0].message_metadata["content"]["text"] == "part one. part two."
         )
-
-    def test_finalize_on_client_disconnect_preserves_partial_text(
-        self,
-        db_session: Session,
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Stream gets ``GeneratorExit`` → partial text persisted to DB.
-
-        Regression for SHA ``1594-1602`` finalize fix.
-        """
-        sandbox(user=test_user)
-        stub_sandbox_manager.send_message_events = [
-            _text_chunk("partial "),
-            _text_chunk("text"),
-            _prompt_response(),
-        ]
-        mgr = session_manager_with_stub
-
-        gen = mgr.send_message(build_session.id, test_user.id, "go")
-        # Consume just enough frames to receive both chunks; we read 4 frames
-        # (user-message persistence happens before iteration, then 2 chunk
-        # frames are yielded). Closing the generator triggers GeneratorExit
-        # inside ``_stream_cli_agent_response`` which must finalize chunks.
-        consumed: list[str] = []
-        for i, frame in enumerate(gen):
-            consumed.append(frame)
-            if i >= 1:
-                break
-        gen.close()
-
-        messages = get_session_messages(build_session.id, db_session)
-        agent_msgs = [
-            m
-            for m in messages
-            if (m.message_metadata or {}).get("type") == "agent_message"
-        ]
-        assert len(agent_msgs) == 1
-        # The exact accumulated text depends on how many chunks were processed
-        # before GeneratorExit; the regression contract is that *some* text
-        # is persisted rather than dropped.
-        text = agent_msgs[0].message_metadata["content"]["text"]
-        assert text  # non-empty
-        assert text in ("partial ", "partial text")
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "known: except branches in _stream_cli_agent_response don't call "
-            "_finalize_persist. User-visible streamed text disappears on page "
-            "refresh after an error."
-        ),
-    )
-    def test_finalize_on_exception_preserves_partial_text(
-        self,
-        db_session: Session,
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Accumulated chunks must be flushed to DB before the ErrorPacket is yielded.
-
-        Asserts the *correct* behavior. The current implementation does NOT
-        call ``_finalize_persist`` on the ``except`` branches, so this test
-        will fail today until the ~5 LOC fix lands (see plan Part VIII).
-        Strict-xfail absorbs the failure; the fixer removes the mark.
-        """
-        sandbox(user=test_user)
-
-        def _yield_then_raise(
-            sandbox_id: UUID,  # noqa: ARG001
-            session_id: UUID,  # noqa: ARG001
-            message: str,  # noqa: ARG001
-            **_kwargs: Any,  # absorb serve-transport kwargs (opencode_session_id, etc.)
-        ) -> Generator[Any, None, None]:
-            yield _text_chunk("buffered ")
-            yield _text_chunk("partial")
-            raise RuntimeError("agent crashed mid-stream")
-
-        # Bypass the not-configured guard by replacing send_message wholesale.
-        stub_sandbox_manager.send_message = _yield_then_raise  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(build_session.id, test_user.id, "go"))
-        # An ErrorPacket frame is expected at end of stream.
-        assert any("agent crashed mid-stream" in f for f in frames)
-
-        messages = get_session_messages(build_session.id, db_session)
-        agent_msgs = [
-            m
-            for m in messages
-            if (m.message_metadata or {}).get("type") == "agent_message"
-        ]
-        # Correct behavior: buffered chunks flushed before the error packet.
-        # Current implementation drops them — strict xfail catches the XPASS
-        # once the bug is fixed.
-        assert len(agent_msgs) == 1
-        assert agent_msgs[0].message_metadata["content"]["text"] == "buffered partial"
-
-
-# =============================================================================
-# Stream error semantics (DB-bound, observable)
-# =============================================================================
-
-
-class TestStreamErrorSemantics:
-    """DB-bound tests for user-visible ErrorPacket emission."""
-
-    def test_sandbox_not_running_emits_error_packet_and_closes(
-        self,
-        db_session: Session,  # noqa: ARG002
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Sandbox status SLEEPING → ErrorPacket('Sandbox is not running…') → stream ends."""
-        sandbox(user=test_user, status=SandboxStatus.SLEEPING)
-        # No send_message_events configured: the stub would raise if reached.
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(build_session.id, test_user.id, "anything"))
-
-        assert len(frames) == 1
-        assert "Sandbox is not running" in frames[0]
-        # Stub.send_message must never have been invoked.
-        assert stub_sandbox_manager.send_message_count == 0
-
-    def test_session_not_found_emits_error_packet(
-        self,
-        db_session: Session,  # noqa: ARG002
-        test_user: User,
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Wrong user's session id → ErrorPacket('Session not found')."""
-        bogus_session_id = uuid4()
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(bogus_session_id, test_user.id, "hi"))
-
-        assert len(frames) == 1
-        assert "Session not found" in frames[0]
-        assert stub_sandbox_manager.send_message_count == 0
-
-    def test_agent_exception_during_stream_emits_error_packet(
-        self,
-        db_session: Session,  # noqa: ARG002
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Stub backend raises mid-stream → ErrorPacket carries the message."""
-        sandbox(user=test_user)
-
-        def _boom(
-            sandbox_id: UUID,  # noqa: ARG001
-            session_id: UUID,  # noqa: ARG001
-            message: str,  # noqa: ARG001
-            **_kwargs: Any,  # absorb serve-transport kwargs (opencode_session_id, etc.)
-        ) -> Generator[Any, None, None]:
-            yield _text_chunk("starting")
-            raise RuntimeError("upstream model crashed")
-
-        stub_sandbox_manager.send_message = _boom  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(build_session.id, test_user.id, "go"))
-
-        assert any("upstream model crashed" in f for f in frames)
-        # The final frame is the ErrorPacket.
-        assert "upstream model crashed" in frames[-1]
-
-    def test_turn_timeout_emits_error_packet(
-        self,
-        db_session: Session,  # noqa: ARG002
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        monkeypatch: pytest.MonkeyPatch,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """Stub raises a TimeoutError-shaped exception → ErrorPacket carries the message.
-
-        The serve transport surfaces ``SANDBOX_TURN_TIMEOUT_SECONDS`` overruns
-        as ``TimeoutError`` raised from inside the send_message generator. The
-        stream loop's broad ``except Exception`` catches it and emits an
-        ErrorPacket containing the message — observable contract for the
-        front-end.
-        """
-        sandbox(user=test_user)
-
-        def _timeout(
-            sandbox_id: UUID,  # noqa: ARG001
-            session_id: UUID,  # noqa: ARG001
-            message: str,  # noqa: ARG001
-            **_kwargs: Any,  # absorb serve-transport kwargs (opencode_session_id, etc.)
-        ) -> Generator[Any, None, None]:
-            if False:
-                yield  # pragma: no cover - generator marker
-            raise TimeoutError("sandbox turn timed out after 1.0s")
-
-        stub_sandbox_manager.send_message = _timeout  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
-        monkeypatch.setenv("SANDBOX_TURN_TIMEOUT_SECONDS", "1.0")
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(build_session.id, test_user.id, "slow op"))
-
-        assert any("timed out" in f.lower() for f in frames)
-
-    def test_keepalive_emitted_on_idle_intervals(
-        self,
-        db_session: Session,  # noqa: ARG002
-        test_user: User,
-        build_session: BuildSession,
-        sandbox: Callable[..., Sandbox],
-        session_manager_with_stub: SessionManager,
-        stub_sandbox_manager: StubSandboxManager,
-        monkeypatch: pytest.MonkeyPatch,
-        tenant_context: None,  # noqa: ARG002
-    ) -> None:
-        """``SSEKeepalive`` markers from the sandbox client → ``: keepalive`` SSE frames.
-
-        The serve transport emits ``SSEKeepalive`` after
-        ``SSE_KEEPALIVE_INTERVAL`` seconds of idle. The stream loop
-        converts each one into a ``: keepalive\\n\\n`` SSE comment.
-        """
-        sandbox(user=test_user)
-        # Override the env for parity with the prod keepalive path; the
-        # stub feeds the markers directly without sleeping.
-        monkeypatch.setenv("SSE_KEEPALIVE_INTERVAL", "0.01")
-        stub_sandbox_manager.send_message_events = [
-            SSEKeepalive(),
-            _text_chunk("ok"),
-            SSEKeepalive(),
-            _prompt_response(),
-        ]
-        mgr = session_manager_with_stub
-
-        frames = _drain(mgr.send_message(build_session.id, test_user.id, "go"))
-
-        keepalive_frames = [f for f in frames if f.startswith(": keepalive")]
-        assert len(keepalive_frames) == 2

--- a/backend/tests/integration/common_utils/managers/build_session.py
+++ b/backend/tests/integration/common_utils/managers/build_session.py
@@ -141,19 +141,73 @@ class BuildSessionManager:
         session_id: UUID,
         content: str,
     ) -> Iterator[dict[str, Any]]:
-        # send-message lives under /build/sessions/{id}/send-message but is
-        # registered on the messages_router which mounts at /build (the
-        # router itself declares the /sessions/... prefix).
+        turn = BuildSessionManager.start_turn(user, session_id, content)
+        yield from BuildSessionManager.stream_turn_events(
+            user,
+            session_id,
+            UUID(turn["turn_id"]),
+        )
+
+    @staticmethod
+    def start_turn(
+        user: DATestUser,
+        session_id: UUID,
+        content: str,
+        *,
+        client_request_id: str | None = None,
+    ) -> dict[str, Any]:
         url = _build_url("sessions", str(session_id), "send-message")
-        with client.stream(
-            "POST",
+        body: dict[str, Any] = {"content": content}
+        if client_request_id is not None:
+            body["client_request_id"] = client_request_id
+        response = client.post(
             url,
-            json={"content": content},
+            json=body,
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def get_active_turn(
+        user: DATestUser,
+        session_id: UUID,
+    ) -> dict[str, Any] | None:
+        response = client.get(
+            _build_url("sessions", str(session_id), "turns", "active"),
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @staticmethod
+    def stream_turn_events(
+        user: DATestUser,
+        session_id: UUID,
+        turn_id: UUID,
+    ) -> Iterator[dict[str, Any]]:
+        with client.stream(
+            "GET",
+            _build_url("sessions", str(session_id), "turns", str(turn_id), "events"),
             headers=user.headers,
             cookies=user.cookies,
         ) as response:
+            if response.status_code in (404, 409):
+                return
             response.raise_for_status()
             yield from _parse_sse_lines(response)
+
+    @staticmethod
+    def list_messages(user: DATestUser, session_id: UUID) -> list[dict[str, Any]]:
+        response = client.get(
+            _build_url("sessions", str(session_id), "messages"),
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        response.raise_for_status()
+        return response.json()["messages"]
 
     @staticmethod
     def upload_file(

--- a/backend/tests/integration/tests/craft/conftest.py
+++ b/backend/tests/integration/tests/craft/conftest.py
@@ -14,4 +14,4 @@ from tests.integration.common_utils.reset import reset_all
 def _module_reset_and_seed() -> None:
     reset_all()
     admin = UserManager.create(name=ADMIN_USER_NAME)
-    LLMProviderManager.create(user_performing_action=admin)
+    LLMProviderManager.create(user_performing_action=admin, api_key="test-api-key")

--- a/backend/tests/integration/tests/craft/test_messages_api.py
+++ b/backend/tests/integration/tests/craft/test_messages_api.py
@@ -1,98 +1,111 @@
-"""Stream error semantics tests (HTTP half).
+"""Interactive Craft turn API tests.
 
-These tests drive the ``/build/sessions/{id}/send-message`` SSE endpoint and
-inspect the packet sequence the consumer actually sees. They run against a
-real Onyx deployment using :class:`BuildSessionManager`.
-
-Behaviors that require failure injection (mid-stream exceptions, turn
-timeout, SSEKeepalive emission) are exercised in the ext-dep suite at
-``tests/external_dependency_unit/craft/test_streaming_persistence.py``
-where the sandbox manager can be stubbed.
+These tests exercise the HTTP boundary for the no-migration background-turn
+flow: ``POST /send-message`` starts work and returns turn metadata, while
+``GET /turns/{turn_id}/events`` is attach-only.
 """
 
 from __future__ import annotations
 
 import uuid
 
-import httpx
-
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.build_session import BuildSessionManager
 from tests.integration.common_utils.managers.user import UserManager
-from tests.integration.common_utils.test_models import DATestLLMProvider
 from tests.integration.common_utils.test_models import DATestUser
 
 
-def _drain_packets(user: DATestUser, session_id: uuid.UUID) -> list[dict]:
-    """Drive the SSE stream to completion and collect every JSON packet."""
-    packets: list[dict] = []
-    try:
-        for packet in BuildSessionManager.send_message(user, session_id, "hello"):
-            packets.append(packet)
-    except httpx.RemoteProtocolError:
-        # Server closed the stream after emitting the terminal ErrorPacket;
-        # whatever made it through is already in ``packets``.
-        pass
-    return packets
-
-
-def test_sandbox_not_running_emits_error_packet_and_closes(
+def test_send_message_starts_background_turn_and_is_idempotent(
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001 — ensure default LLM exists
 ) -> None:
-    """A non-RUNNING sandbox short-circuits the stream with an ErrorPacket.
+    body = BuildSessionManager.create(admin_user)
+    session_id = uuid.UUID(body["id"])
+    request_id = f"req-{uuid.uuid4()}"
 
-    Path under test (``manager.py::send_message``):
-        if not sandbox or sandbox.status != SandboxStatus.RUNNING:
-            yield ErrorPacket("Sandbox is not running. Please wait for it to start.")
-            return
+    first = BuildSessionManager.start_turn(
+        admin_user,
+        session_id,
+        "hello",
+        client_request_id=request_id,
+    )
+    same = BuildSessionManager.start_turn(
+        admin_user,
+        session_id,
+        "hello",
+        client_request_id=request_id,
+    )
 
-    We provision a session (so a sandbox exists), then call
-    ``/build/sandbox/reset`` to mark it ``TERMINATED`` — a non-RUNNING status.
-    The next send-message must yield exactly one error packet and end.
-    """
+    assert first["turn_id"] == same["turn_id"]
+    assert first["session_id"] == str(session_id)
+    assert first["status"] in {"QUEUED", "RUNNING"}
+    assert first["turn_index"] == 0
+
+    active_turn = BuildSessionManager.get_active_turn(admin_user, session_id)
+    if active_turn is not None:
+        assert active_turn["turn_id"] == first["turn_id"]
+
+    messages = BuildSessionManager.list_messages(admin_user, session_id)
+    user_messages = [msg for msg in messages if msg["type"] == "user"]
+    assert len(user_messages) == 1
+    assert user_messages[0]["turn_index"] == 0
+
+
+def test_send_message_rejects_concurrent_active_turn(
+    admin_user: DATestUser,
+) -> None:
     body = BuildSessionManager.create(admin_user)
     session_id = uuid.UUID(body["id"])
 
-    # Force the sandbox out of RUNNING. Reset transitions it to TERMINATED.
-    reset_response = client.post(
-        f"{API_SERVER_URL}/build/sandbox/reset",
+    BuildSessionManager.start_turn(
+        admin_user,
+        session_id,
+        "hello",
+        client_request_id=f"req-{uuid.uuid4()}",
+    )
+
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
+        json={
+            "content": "again",
+            "client_request_id": f"req-{uuid.uuid4()}",
+        },
         headers=admin_user.headers,
         cookies=admin_user.cookies,
     )
-    assert reset_response.status_code == 204
 
-    packets = _drain_packets(admin_user, session_id)
-
-    assert packets, "Expected at least one packet on the stream"
-    first = packets[0]
-    assert first.get("type") == "error"
-    assert "not running" in first.get("message", "").lower()
-    # Stream closes right after the ErrorPacket — no further events allowed.
-    assert all(p.get("type") == "error" for p in packets)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "This session is busy with a previous turn."
 
 
-def test_session_not_found_emits_error_packet(
+def test_send_message_404_for_other_users_session(
     admin_user: DATestUser,
-    llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """Streaming against another user's session id yields an ErrorPacket.
+    body = BuildSessionManager.create(admin_user)
+    session_id = body["id"]
+    other_user = UserManager.create(name=f"otheruser-{uuid.uuid4().hex[:8]}")
 
-    Important: the SSE generator catches "session belongs to someone else"
-    inside the manager and emits ErrorPacket("Session not found") *on the
-    stream*, not via the HTTP status. This is deliberate — the FE relies on
-    the in-stream packet to render the error, since the SSE endpoint has
-    already returned a 200 to the client by the time the check runs.
-    """
+    response = client.post(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/send-message",
+        json={"content": "hello"},
+        headers=other_user.headers,
+        cookies=other_user.cookies,
+    )
+
+    assert response.status_code == 404
+
+
+def test_turn_events_requires_active_turn(
+    admin_user: DATestUser,
+) -> None:
     body = BuildSessionManager.create(admin_user)
     session_id = uuid.UUID(body["id"])
 
-    other_user = UserManager.create(name=f"otheruser-{uuid.uuid4().hex[:8]}")
+    response = client.get(
+        f"{API_SERVER_URL}/build/sessions/{session_id}/turns/{uuid.uuid4()}/events",
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
 
-    packets = _drain_packets(other_user, session_id)
-
-    assert packets, "Expected at least one packet on the stream"
-    error_packet = next((p for p in packets if p.get("type") == "error"), None)
-    assert error_packet is not None
-    assert error_packet["message"] == "Session not found"
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Interactive turn is not running"

--- a/backend/tests/integration/tests/craft/test_sessions_api.py
+++ b/backend/tests/integration/tests/craft/test_sessions_api.py
@@ -36,16 +36,16 @@ def _create_session(user: DATestUser) -> dict[str, Any]:
 def _send_one_message(user: DATestUser, session_id: uuid.UUID) -> None:
     """Send a message and wait only until the USER row is persisted.
 
-    The send-message endpoint commits the USER message row BEFORE the SSE
-    stream yields its first ``data:`` packet, so we break out as soon as
-    we receive one packet. Tests using this helper must not depend on
-    assistant-message rows being persisted.
+    The background-turn endpoint commits the USER message row before returning
+    turn metadata. Tests using this helper must not depend on assistant-message
+    rows being persisted.
     """
-    try:
-        for _ in BuildSessionManager.send_message(user, session_id, "hello"):
-            break
-    except httpx.RemoteProtocolError:
-        pass
+    BuildSessionManager.start_turn(
+        user,
+        session_id,
+        "hello",
+        client_request_id=f"session-list-{uuid.uuid4()}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/build/test_session_manager_merger.py
+++ b/backend/tests/unit/build/test_session_manager_merger.py
@@ -1,4 +1,4 @@
-"""Unit tests for `streaming._merge_events_with_announces`.
+"""Unit tests for `streaming.merge_events_with_announces`.
 
 The merger is a generator that interleaves a synchronous event iterator with
 approval-announce events drained from a Redis-style BLPOP. Two daemon threads
@@ -71,7 +71,7 @@ def test_events_only_pass_through(monkeypatch: pytest.MonkeyPatch) -> None:
         yield "c"
 
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=uuid4(), tenant_id="public"
         )
     )
@@ -107,7 +107,7 @@ def test_announce_emitted_as_approval_requested_packet(
         yield "events-end"
 
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=session_id, tenant_id="public"
         )
     )
@@ -119,9 +119,10 @@ def test_announce_emitted_as_approval_requested_packet(
     assert packet.session_id == session_id
     assert packet.type == "approval_requested"
 
-    # Verify the SSE-frame shape the caller produces from this packet.
-    rendered = packet.model_dump_json(by_alias=True)
-    parsed = json.loads(rendered)
+    # Verify the SSE-frame shape the attach stream produces from this packet.
+    rendered = streaming_mod.event_to_sse(packet)
+    assert rendered.startswith("event: message\n")
+    parsed = json.loads(rendered.split("data: ", 1)[1])
     assert parsed["type"] == "approval_requested"
     assert parsed["approval_id"] == str(approval_id)
     assert parsed["session_id"] == str(session_id)
@@ -164,7 +165,7 @@ def test_interleaving_events_and_announce(
         yield "y"
 
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=session_id, tenant_id="public"
         )
     )
@@ -187,7 +188,7 @@ def test_terminates_when_event_iterator_ends(
 
     # Generator must finish even though the announce thread would BLPOP forever.
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=uuid4(), tenant_id="public"
         ),
         timeout_s=1.0,
@@ -208,7 +209,7 @@ def test_no_deadlock_when_announce_thread_sees_nothing(
         yield "q"
 
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=uuid4(), tenant_id="public"
         )
     )
@@ -264,7 +265,7 @@ def test_pop_announcement_exception_is_swallowed(
         yield "still-ok"
 
     out = _collect_with_timeout(
-        streaming_mod._merge_events_with_announces(
+        streaming_mod.merge_events_with_announces(
             events(), session_id=uuid4(), tenant_id="public"
         )
     )

--- a/backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.api import messages_api
+from onyx.server.features.build.api.models import MessageRequest
+from tests.unit.onyx.server.features.build.fakes import FakeCache
+
+
+class _FakeQuery:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def filter(self, *args: object) -> "_FakeQuery":
+        _ = args
+        return self
+
+    def count(self) -> int:
+        return self._count
+
+
+class _FakeDbSession:
+    def __init__(self, user_message_count: int) -> None:
+        self.user_message_count = user_message_count
+        self.commits = 0
+        self.rollbacks = 0
+
+    def query(self, model: object) -> _FakeQuery:
+        _ = model
+        return _FakeQuery(self.user_message_count)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _create_message_noop(**_: object) -> None:
+    return None
+
+
+def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(
+        id=session_id,
+    )
+    db_session = _FakeDbSession(user_message_count=2)
+    persisted: list[tuple[int, str]] = []
+    start_runner = MagicMock()
+
+    def get_session_stub(*_: object, **__: object) -> SimpleNamespace:
+        return session
+
+    def create_message_stub(
+        *,
+        turn_index: int,
+        message_metadata: dict[str, object],
+        **_: object,
+    ) -> None:
+        content = cast(dict[str, str], message_metadata["content"])
+        persisted.append((turn_index, content["text"]))
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(
+        messages_api,
+        "create_message",
+        create_message_stub,
+    )
+    monkeypatch.setattr(
+        messages_api,
+        "start_interactive_turn_runner",
+        start_runner,
+    )
+
+    response = messages_api.send_message(
+        session_id=session_id,
+        request=MessageRequest(
+            content="hello",
+            client_request_id="req-1",
+            provider="openai",
+            model="gpt-5-mini",
+        ),
+        user=cast(User, SimpleNamespace(id=user_id)),
+        _rate_limit_check=None,
+        db_session=cast(Session, db_session),
+    )
+
+    assert response.session_id == str(session_id)
+    assert response.status == "QUEUED"
+    assert response.turn_index == 2
+    assert persisted == [(2, "hello")]
+    assert session.agent_provider == "openai"
+    assert session.agent_model == "gpt-5-mini"
+    assert db_session.commits == 1
+    start_runner.assert_called_once()
+    assert str(start_runner.call_args.args[0]) == response.turn_id
+
+
+def test_send_message_rejects_second_active_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+
+    def get_session_stub(*_: object, **__: object) -> SimpleNamespace:
+        return session
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
+    monkeypatch.setattr(messages_api, "start_interactive_turn_runner", MagicMock())
+
+    first = messages_api.send_message(
+        session_id=session_id,
+        request=MessageRequest(content="hello", client_request_id="req-1"),
+        user=cast(User, SimpleNamespace(id=user_id)),
+        _rate_limit_check=None,
+        db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+    )
+    assert first.status == "QUEUED"
+
+    with pytest.raises(OnyxError):
+        messages_api.send_message(
+            session_id=session_id,
+            request=MessageRequest(content="again", client_request_id="req-2"),
+            user=cast(User, SimpleNamespace(id=user_id)),
+            _rate_limit_check=None,
+            db_session=cast(Session, _FakeDbSession(user_message_count=1)),
+        )
+
+
+def test_send_message_is_idempotent_for_same_client_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+    persisted: list[tuple[int, str]] = []
+    start_runner = MagicMock()
+    rate_limit_check = MagicMock()
+
+    def get_session_stub(*_: object, **__: object) -> SimpleNamespace:
+        return session
+
+    def create_message_stub(
+        *,
+        turn_index: int,
+        message_metadata: dict[str, object],
+        **_: object,
+    ) -> None:
+        content = cast(dict[str, str], message_metadata["content"])
+        persisted.append((turn_index, content["text"]))
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", rate_limit_check)
+    monkeypatch.setattr(
+        messages_api,
+        "create_message",
+        create_message_stub,
+    )
+    monkeypatch.setattr(
+        messages_api,
+        "start_interactive_turn_runner",
+        start_runner,
+    )
+
+    first = messages_api.send_message(
+        session_id=session_id,
+        request=MessageRequest(content="hello", client_request_id="req-1"),
+        user=cast(User, SimpleNamespace(id=user_id)),
+        _rate_limit_check=None,
+        db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+    )
+    same = messages_api.send_message(
+        session_id=session_id,
+        request=MessageRequest(content="hello", client_request_id="req-1"),
+        user=cast(User, SimpleNamespace(id=user_id)),
+        _rate_limit_check=None,
+        db_session=cast(Session, _FakeDbSession(user_message_count=1)),
+    )
+
+    assert same.turn_id == first.turn_id
+    assert persisted == [(0, "hello")]
+    start_runner.assert_called_once()
+    rate_limit_check.assert_called_once()
+
+
+def test_send_message_leaves_turn_active_if_runner_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+
+    def get_session_stub(*_: object, **__: object) -> SimpleNamespace:
+        return session
+
+    def start_runner_stub(_: object) -> None:
+        raise RuntimeError("capacity exhausted")
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
+    monkeypatch.setattr(
+        messages_api,
+        "start_interactive_turn_runner",
+        start_runner_stub,
+    )
+
+    response = messages_api.send_message(
+        session_id=session_id,
+        request=MessageRequest(content="hello", client_request_id="req-1"),
+        user=cast(User, SimpleNamespace(id=user_id)),
+        _rate_limit_check=None,
+        db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+    )
+
+    active = messages_api.get_active_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+    )
+    assert response.status == "QUEUED"
+    assert active is not None
+    assert active.turn_id == UUID(response.turn_id)

--- a/backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py
@@ -95,7 +95,6 @@ def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) ->
             model="gpt-5-mini",
         ),
         user=cast(User, SimpleNamespace(id=user_id)),
-        _rate_limit_check=None,
         db_session=cast(Session, db_session),
     )
 
@@ -131,7 +130,6 @@ def test_send_message_rejects_second_active_turn(
         session_id=session_id,
         request=MessageRequest(content="hello", client_request_id="req-1"),
         user=cast(User, SimpleNamespace(id=user_id)),
-        _rate_limit_check=None,
         db_session=cast(Session, _FakeDbSession(user_message_count=0)),
     )
     assert first.status == "QUEUED"
@@ -141,7 +139,6 @@ def test_send_message_rejects_second_active_turn(
             session_id=session_id,
             request=MessageRequest(content="again", client_request_id="req-2"),
             user=cast(User, SimpleNamespace(id=user_id)),
-            _rate_limit_check=None,
             db_session=cast(Session, _FakeDbSession(user_message_count=1)),
         )
 
@@ -187,14 +184,12 @@ def test_send_message_is_idempotent_for_same_client_request(
         session_id=session_id,
         request=MessageRequest(content="hello", client_request_id="req-1"),
         user=cast(User, SimpleNamespace(id=user_id)),
-        _rate_limit_check=None,
         db_session=cast(Session, _FakeDbSession(user_message_count=0)),
     )
     same = messages_api.send_message(
         session_id=session_id,
         request=MessageRequest(content="hello", client_request_id="req-1"),
         user=cast(User, SimpleNamespace(id=user_id)),
-        _rate_limit_check=None,
         db_session=cast(Session, _FakeDbSession(user_message_count=1)),
     )
 
@@ -232,7 +227,6 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
         session_id=session_id,
         request=MessageRequest(content="hello", client_request_id="req-1"),
         user=cast(User, SimpleNamespace(id=user_id)),
-        _rate_limit_check=None,
         db_session=cast(Session, _FakeDbSession(user_message_count=0)),
     )
 

--- a/backend/tests/unit/onyx/server/features/build/api/test_turns_api.py
+++ b/backend/tests/unit/onyx/server/features/build/api/test_turns_api.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+import time as real_time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import cast
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.api import turns_api
+from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
+from onyx.server.features.build.interactive_turns.state import create_interactive_turn
+from onyx.server.features.build.interactive_turns.state import finish_turn
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCEEDED
+from tests.unit.onyx.server.features.build.fakes import FakeCache
+
+
+class _FakeStreamingResponse:
+    def __init__(
+        self,
+        body: Iterator[str],
+        media_type: str,
+        headers: dict[str, str],
+    ) -> None:
+        self.body = body
+        self.media_type = media_type
+        self.headers = headers
+
+
+class _FakeDbSession:
+    def __init__(self) -> None:
+        self.expire_all_calls = 0
+
+    def expire_all(self) -> None:
+        self.expire_all_calls += 1
+
+
+@contextmanager
+def _fake_db_session_scope() -> Iterator[_FakeDbSession]:
+    yield _FakeDbSession()
+
+
+def _create_running_turn(
+    cache: FakeCache,
+    *,
+    session_id: UUID,
+    user_id: UUID,
+) -> UUID:
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=3,
+    )
+    claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    return turn.turn_id
+
+
+def test_get_active_interactive_turn_returns_cache_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(
+        turns_api,
+        "get_build_session",
+        lambda *_: SimpleNamespace(id=session_id),
+    )
+
+    response = turns_api.get_active_interactive_turn(
+        session_id=session_id,
+        user=cast(User, SimpleNamespace(id=user_id)),
+        db_session=cast(Session, SimpleNamespace()),
+    )
+
+    assert response is not None
+    assert response.turn_id == str(turn_id)
+    assert response.status == "RUNNING"
+    assert response.turn_index == 3
+
+
+def test_get_interactive_turn_events_waits_then_forwards_live_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+    started: list[UUID] = []
+    session_rows = iter(
+        [
+            SimpleNamespace(id=session_id, opencode_session_id=None),
+            SimpleNamespace(id=session_id, opencode_session_id=None),
+            SimpleNamespace(id=session_id, opencode_session_id="opencode-1"),
+        ]
+    )
+
+    class FakeSessionManager:
+        def __init__(self, db_session: object) -> None:
+            _ = db_session
+
+        def subscribe_to_existing_session_events(
+            self,
+            session_id_arg: UUID,
+            user_id_arg: UUID,
+            keepalive_seconds: float,
+        ) -> Iterator[str]:
+            assert session_id_arg == session_id
+            assert user_id_arg == user_id
+            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            finish_turn(
+                cache=cache,
+                turn_id=turn_id,
+                status=TURN_STATUS_SUCCEEDED,
+            )
+            yield 'event: message\ndata: {"type":"text_chunk","text":"hi"}\n\n'
+            yield 'event: message\ndata: {"type":"text_chunk","text":"bye"}\n\n'
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        turns_api,
+        "start_interactive_turn_runner",
+        lambda turn_id_arg: started.append(turn_id_arg) or False,
+    )
+    monkeypatch.setattr(turns_api, "StreamingResponse", _FakeStreamingResponse)
+    monkeypatch.setattr(
+        turns_api,
+        "time",
+        SimpleNamespace(sleep=lambda _: None, monotonic=real_time.monotonic),
+    )
+    monkeypatch.setattr(turns_api, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(
+        turns_api,
+        "get_session_with_current_tenant",
+        _fake_db_session_scope,
+    )
+    monkeypatch.setattr(turns_api, "get_build_session", lambda *_: next(session_rows))
+
+    response = cast(
+        _FakeStreamingResponse,
+        turns_api.get_interactive_turn_events(
+            session_id=session_id,
+            turn_id=turn_id,
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, SimpleNamespace()),
+        ),
+    )
+
+    chunks = list(response.body)
+
+    assert chunks == [
+        turns_api.SSE_KEEPALIVE,
+        'event: message\ndata: {"type":"text_chunk","text":"hi"}\n\n',
+        'event: message\ndata: {"type":"text_chunk","text":"bye"}\n\n',
+    ]
+    assert started == [turn_id]
+
+
+def test_get_interactive_turn_events_streams_retained_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+    finish_turn(
+        cache=cache,
+        turn_id=turn_id,
+        status=TURN_STATUS_FAILED,
+        error_detail="provider model not found",
+    )
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(turns_api, "StreamingResponse", _FakeStreamingResponse)
+    monkeypatch.setattr(
+        turns_api,
+        "get_build_session",
+        lambda *_: SimpleNamespace(id=session_id),
+    )
+
+    response = cast(
+        _FakeStreamingResponse,
+        turns_api.get_interactive_turn_events(
+            session_id=session_id,
+            turn_id=turn_id,
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, SimpleNamespace()),
+        ),
+    )
+
+    chunks = list(response.body)
+
+    assert len(chunks) == 1
+    assert '"type": "error"' in chunks[0]
+    assert '"message": "provider model not found"' in chunks[0]
+
+
+def test_get_interactive_turn_events_yields_failed_turn_error_before_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(turns_api, "StreamingResponse", _FakeStreamingResponse)
+    monkeypatch.setattr(
+        turns_api,
+        "time",
+        SimpleNamespace(sleep=lambda _: None, monotonic=real_time.monotonic),
+    )
+    monkeypatch.setattr(
+        turns_api,
+        "get_session_with_current_tenant",
+        _fake_db_session_scope,
+    )
+    monkeypatch.setattr(
+        turns_api,
+        "get_build_session",
+        lambda *_: SimpleNamespace(id=session_id, opencode_session_id=None),
+    )
+
+    response = cast(
+        _FakeStreamingResponse,
+        turns_api.get_interactive_turn_events(
+            session_id=session_id,
+            turn_id=turn_id,
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, SimpleNamespace()),
+        ),
+    )
+
+    chunks = response.body
+    assert next(chunks) == turns_api.SSE_KEEPALIVE
+
+    finish_turn(
+        cache=cache,
+        turn_id=turn_id,
+        status=TURN_STATUS_FAILED,
+        error_detail="provider model not found",
+    )
+
+    error_chunk = next(chunks)
+    assert '"type": "error"' in error_chunk
+    assert '"message": "provider model not found"' in error_chunk
+
+    with pytest.raises(StopIteration):
+        next(chunks)
+
+
+def test_get_interactive_turn_events_yields_failed_turn_error_after_stream_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn_id = _create_running_turn(cache, session_id=session_id, user_id=user_id)
+
+    class FakeSessionManager:
+        def __init__(self, db_session: object) -> None:
+            _ = db_session
+
+        def subscribe_to_existing_session_events(
+            self,
+            session_id_arg: UUID,
+            user_id_arg: UUID,
+            keepalive_seconds: float,
+        ) -> Iterator[str]:
+            assert session_id_arg == session_id
+            assert user_id_arg == user_id
+            assert keepalive_seconds == turns_api.LIVE_STREAM_KEEPALIVE_SECONDS
+            finish_turn(
+                cache=cache,
+                turn_id=turn_id,
+                status=TURN_STATUS_FAILED,
+                error_detail="provider model not found",
+            )
+            yield 'event: message\ndata: {"type":"text_chunk","text":"partial"}\n\n'
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(turns_api, "StreamingResponse", _FakeStreamingResponse)
+    monkeypatch.setattr(turns_api, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(
+        turns_api,
+        "get_session_with_current_tenant",
+        _fake_db_session_scope,
+    )
+    monkeypatch.setattr(
+        turns_api,
+        "get_build_session",
+        lambda *_: SimpleNamespace(id=session_id, opencode_session_id="opencode-1"),
+    )
+
+    response = turns_api.get_interactive_turn_events(
+        session_id=session_id,
+        turn_id=turn_id,
+        user=cast(User, SimpleNamespace(id=user_id)),
+        db_session=cast(Session, SimpleNamespace()),
+    )
+
+    chunks = list(response.body)
+
+    assert chunks[0] == (
+        'event: message\ndata: {"type":"text_chunk","text":"partial"}\n\n'
+    )
+    assert '"type": "error"' in chunks[1]
+    assert '"message": "provider model not found"' in chunks[1]
+    assert len(chunks) == 2
+
+
+def test_get_interactive_turn_events_requires_active_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+
+    monkeypatch.setattr(turns_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(turns_api, "start_interactive_turn_runner", lambda _: False)
+    monkeypatch.setattr(
+        turns_api,
+        "get_build_session",
+        lambda *_: SimpleNamespace(id=session_id),
+    )
+
+    with pytest.raises(OnyxError):
+        turns_api.get_interactive_turn_events(
+            session_id=session_id,
+            turn_id=uuid4(),
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, SimpleNamespace()),
+        )

--- a/backend/tests/unit/onyx/server/features/build/fakes.py
+++ b/backend/tests/unit/onyx/server/features/build/fakes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CacheLock
+
+
+class FakeLock(CacheLock):
+    def __init__(self) -> None:
+        self._owned = False
+
+    def acquire(
+        self,
+        blocking: bool = True,
+        blocking_timeout: float | None = None,
+    ) -> bool:
+        _ = blocking
+        _ = blocking_timeout
+        if self._owned:
+            return False
+        self._owned = True
+        return True
+
+    def release(self) -> None:
+        self._owned = False
+
+    def owned(self) -> bool:
+        return self._owned
+
+
+class FakeCache(CacheBackend):
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.expiries: dict[str, int] = {}
+        self.locks: dict[str, FakeLock] = {}
+
+    def get(self, key: str) -> bytes | None:
+        return self.store.get(key)
+
+    def set(
+        self,
+        key: str,
+        value: str | bytes | int | float,
+        ex: int | None = None,
+    ) -> None:
+        self.store[key] = value if isinstance(value, bytes) else str(value).encode()
+        if ex is not None:
+            self.expiries[key] = ex
+
+    def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+        self.expiries.pop(key, None)
+
+    def exists(self, key: str) -> bool:
+        return key in self.store
+
+    def expire(self, key: str, seconds: int) -> None:
+        self.expiries[key] = seconds
+
+    def ttl(self, key: str) -> int:
+        return 60 if key in self.store else -2
+
+    def lock(self, name: str, timeout: float | None = None) -> CacheLock:
+        _ = timeout
+        return self.locks.setdefault(name, FakeLock())
+
+    def rpush(self, key: str, value: str | bytes) -> None:
+        raise NotImplementedError
+
+    def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:
+        raise NotImplementedError

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
@@ -330,6 +330,96 @@ def test_prompt_slot_busy_does_not_finish_reclaimed_turn(
     assert prompt_slot.exited
 
 
+def test_lost_runner_does_not_clear_reclaimed_turn_interrupt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    db_session = _FakeDbSession()
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox_id = uuid4()
+    prompt_slot = _FakePromptSlot()
+    reclaimed: InteractiveTurn | None = None
+    clear_calls: list[UUID] = []
+
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+    claimed = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert claimed is not None
+
+    class FakeSessionManager:
+        def __init__(self, db_session_arg: _FakeDbSession) -> None:
+            assert db_session_arg is db_session
+
+        def ensure_sandbox_running(self, user_id_arg: UUID) -> SimpleNamespace:
+            assert user_id_arg == user_id
+            return SimpleNamespace(id=sandbox_id)
+
+        def prompt_slot(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+        ) -> _FakePromptSlot:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            return prompt_slot
+
+        def yield_sandbox_events(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+            prompt: str,
+            *,
+            should_interrupt: object,
+        ) -> Iterator[object]:
+            nonlocal reclaimed
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            assert prompt == "hello"
+            assert should_interrupt is not None
+            reclaimed = claim_turn_for_runner(
+                cache=cache,
+                turn_id=turn.turn_id,
+                stale_after_seconds=0,
+            )
+            assert reclaimed is not None
+            yield object()
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        executor,
+        "get_session_with_current_tenant",
+        lambda: _fake_db_scope(db_session),
+    )
+    monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(executor, "update_session_activity", lambda *_: None)
+    monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
+    monkeypatch.setattr(
+        executor,
+        "clear_interrupt",
+        lambda session_id_arg, _: clear_calls.append(session_id_arg),
+    )
+
+    executor.run_claimed_interactive_build_turn(claimed, budget_seconds=30)
+
+    current = get_turn(cache, turn.turn_id)
+    assert current is not None
+    assert reclaimed is not None
+    assert current.status == TURN_STATUS_RUNNING
+    assert current.runner_id == reclaimed.runner_id
+    active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active is not None
+    assert active.runner_id == reclaimed.runner_id
+    assert clear_calls == []
+    assert prompt_slot.exited
+
+
 def test_start_interactive_turn_runner_preserves_tenant_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
@@ -1,0 +1,403 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.interactive_turns import executor
+from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
+from onyx.server.features.build.interactive_turns.state import create_interactive_turn
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+from onyx.server.features.build.interactive_turns.state import get_turn
+from onyx.server.features.build.interactive_turns.state import InteractiveTurn
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_CANCELLED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_RUNNING
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCEEDED
+from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
+from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+from tests.unit.onyx.server.features.build.fakes import FakeCache
+
+
+class _FakeDbSession:
+    def __init__(self) -> None:
+        self.commits = 0
+        self.rollbacks = 0
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _FakePromptSlot:
+    def __init__(
+        self,
+        *,
+        enter_result: bool = True,
+        on_enter: Callable[[], None] | None = None,
+    ) -> None:
+        self._enter_result = enter_result
+        self._on_enter = on_enter
+        self.exited = False
+
+    def __enter__(self) -> bool:
+        if self._on_enter is not None:
+            self._on_enter()
+        return self._enter_result
+
+    def __exit__(self, *_: object) -> None:
+        self.exited = True
+
+
+@contextmanager
+def _fake_db_scope(db_session: _FakeDbSession) -> Iterator[_FakeDbSession]:
+    yield db_session
+
+
+def _run_turn_with_events(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[object],
+) -> SimpleNamespace:
+    cache = FakeCache()
+    db_session = _FakeDbSession()
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox_id = uuid4()
+    prompt_slot = _FakePromptSlot()
+    persisted: list[object] = []
+    finalized: list[UUID] = []
+
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+
+    class FakeSessionManager:
+        def __init__(self, db_session_arg: _FakeDbSession) -> None:
+            assert db_session_arg is db_session
+
+        def ensure_sandbox_running(self, user_id_arg: UUID) -> SimpleNamespace:
+            assert user_id_arg == user_id
+            return SimpleNamespace(id=sandbox_id)
+
+        def prompt_slot(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+        ) -> _FakePromptSlot:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            return prompt_slot
+
+        def yield_sandbox_events(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+            prompt: str,
+            *,
+            should_interrupt: object,
+        ) -> Iterator[object]:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            assert prompt == "hello"
+            assert should_interrupt is not None
+            yield from events
+
+        def merge_events_with_announces(
+            self,
+            stream: Iterator[object],
+            **_: object,
+        ) -> Iterator[object]:
+            yield from stream
+
+        def persist_sandbox_event(
+            self,
+            session_id_arg: UUID,
+            state: object,
+            sandbox_event: object,
+        ) -> None:
+            assert session_id_arg == session_id
+            assert state is not None
+            persisted.append(sandbox_event)
+
+        def finalize_persist(self, session_id_arg: UUID, state: object) -> None:
+            assert state is not None
+            finalized.append(session_id_arg)
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        executor,
+        "get_session_with_current_tenant",
+        lambda: _fake_db_scope(db_session),
+    )
+    monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(executor, "update_session_activity", lambda *_: None)
+    monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
+    monkeypatch.setattr(executor, "clear_interrupt", lambda *_: None)
+
+    claimed = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert claimed is not None
+    executor.run_claimed_interactive_build_turn(claimed, budget_seconds=30)
+
+    return SimpleNamespace(
+        cache=cache,
+        db_session=db_session,
+        finalized=finalized,
+        persisted=persisted,
+        prompt_slot=prompt_slot,
+        session_id=session_id,
+        turn=turn,
+        user_id=user_id,
+    )
+
+
+def test_runner_succeeds_on_prompt_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompt_response = PromptResponse.model_validate({"stopReason": "end_turn"})
+
+    result = _run_turn_with_events(monkeypatch, [prompt_response])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_SUCCEEDED
+    assert (
+        get_active_turn(
+            cache=result.cache,
+            session_id=result.session_id,
+            user_id=result.user_id,
+        )
+        is None
+    )
+    assert result.persisted == [prompt_response]
+    assert result.finalized == [result.session_id]
+    assert result.prompt_slot.exited
+    assert result.db_session.rollbacks == 0
+
+
+def test_runner_fails_turn_on_sandbox_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_error = SandboxError(code=-32000, message="provider model not found")
+
+    result = _run_turn_with_events(monkeypatch, [sandbox_error])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_FAILED
+    assert finished.error_detail == "provider model not found"
+    assert (
+        get_active_turn(
+            cache=result.cache,
+            session_id=result.session_id,
+            user_id=result.user_id,
+        )
+        is None
+    )
+    assert result.persisted == [sandbox_error]
+    assert result.finalized == [result.session_id]
+    assert result.prompt_slot.exited
+    assert result.db_session.rollbacks == 0
+
+
+def test_runner_fails_turn_when_stream_ends_without_prompt_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = _run_turn_with_events(monkeypatch, [])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_FAILED
+    assert (
+        finished.error_detail == "Turn ended before opencode returned a final response."
+    )
+    assert (
+        get_active_turn(
+            cache=result.cache,
+            session_id=result.session_id,
+            user_id=result.user_id,
+        )
+        is None
+    )
+    assert result.persisted == []
+    assert result.finalized == [result.session_id]
+    assert result.prompt_slot.exited
+    assert result.db_session.rollbacks == 0
+
+
+def test_runner_records_cancelled_prompt_response_as_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompt_response = PromptResponse.model_validate({"stopReason": "cancelled"})
+
+    result = _run_turn_with_events(monkeypatch, [prompt_response])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_CANCELLED
+    assert (
+        get_active_turn(
+            cache=result.cache,
+            session_id=result.session_id,
+            user_id=result.user_id,
+        )
+        is None
+    )
+    assert result.persisted == [prompt_response]
+    assert result.finalized == [result.session_id]
+    assert result.prompt_slot.exited
+    assert result.db_session.rollbacks == 0
+
+
+def test_prompt_slot_busy_does_not_finish_reclaimed_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    db_session = _FakeDbSession()
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox_id = uuid4()
+    reclaimed: InteractiveTurn | None = None
+
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+    claimed = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert claimed is not None
+
+    def reclaim_turn() -> None:
+        nonlocal reclaimed
+        reclaimed = claim_turn_for_runner(
+            cache=cache,
+            turn_id=turn.turn_id,
+            stale_after_seconds=0,
+        )
+        assert reclaimed is not None
+
+    prompt_slot = _FakePromptSlot(enter_result=False, on_enter=reclaim_turn)
+
+    class FakeSessionManager:
+        def __init__(self, db_session_arg: _FakeDbSession) -> None:
+            assert db_session_arg is db_session
+
+        def ensure_sandbox_running(self, user_id_arg: UUID) -> SimpleNamespace:
+            assert user_id_arg == user_id
+            return SimpleNamespace(id=sandbox_id)
+
+        def prompt_slot(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+        ) -> _FakePromptSlot:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            return prompt_slot
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        executor,
+        "get_session_with_current_tenant",
+        lambda: _fake_db_scope(db_session),
+    )
+    monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+
+    executor.run_claimed_interactive_build_turn(claimed, budget_seconds=30)
+
+    current = get_turn(cache, turn.turn_id)
+    assert current is not None
+    assert reclaimed is not None
+    assert current.status == TURN_STATUS_RUNNING
+    assert current.runner_id == reclaimed.runner_id
+    active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active is not None
+    assert active.runner_id == reclaimed.runner_id
+    assert prompt_slot.exited
+
+
+def test_start_interactive_turn_runner_preserves_tenant_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+
+    observed: list[tuple[UUID, str | None, str | None]] = []
+
+    def run_logic(turn_arg: InteractiveTurn) -> None:
+        observed.append(
+            (
+                turn_arg.turn_id,
+                CURRENT_TENANT_ID_CONTEXTVAR.get(),
+                turn_arg.runner_id,
+            )
+        )
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(executor, "run_claimed_interactive_build_turn", run_logic)
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant-a")
+    try:
+        executor.start_interactive_turn_runner(turn.turn_id)
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    deadline = time.monotonic() + 5
+    while not observed and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert len(observed) == 1
+    observed_turn_id, observed_tenant, observed_runner_id = observed[0]
+    assert observed_turn_id == turn.turn_id
+    assert observed_tenant == "tenant-a"
+    assert observed_runner_id is not None
+
+
+def test_start_interactive_turn_runner_skips_fresh_running_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = FakeCache()
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=uuid4(),
+        user_id=uuid4(),
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+    assert claim_turn_for_runner(cache=cache, turn_id=turn.turn_id) is not None
+    observed: list[UUID] = []
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        executor,
+        "run_claimed_interactive_build_turn",
+        lambda turn_arg: observed.append(turn_arg.turn_id),
+    )
+
+    executor.start_interactive_turn_runner(turn.turn_id)
+    time.sleep(0.05)
+
+    assert observed == []

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from uuid import UUID
 from uuid import uuid4
 
@@ -8,6 +9,7 @@ from onyx.server.features.build.interactive_turns.state import claim_turn_for_ru
 from onyx.server.features.build.interactive_turns.state import create_interactive_turn
 from onyx.server.features.build.interactive_turns.state import finish_turn
 from onyx.server.features.build.interactive_turns.state import get_active_turn
+from onyx.server.features.build.interactive_turns.state import get_turn
 from onyx.server.features.build.interactive_turns.state import get_turn_for_request
 from onyx.server.features.build.interactive_turns.state import InteractiveTurn
 from onyx.server.features.build.interactive_turns.state import REQUEST_ID_TTL_SECONDS
@@ -16,6 +18,23 @@ from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILE
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_QUEUED
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_RUNNING
 from tests.unit.onyx.server.features.build.fakes import FakeCache
+
+
+class _InterleavingCache(FakeCache):
+    def __init__(self) -> None:
+        super().__init__()
+        self.after_next_turn_read: Callable[[], None] | None = None
+
+    def get(self, key: str) -> bytes | None:
+        value = super().get(key)
+        if (
+            key.startswith("craft:interactive_turn:")
+            and self.after_next_turn_read is not None
+        ):
+            callback = self.after_next_turn_read
+            self.after_next_turn_read = None
+            callback()
+        return value
 
 
 def _create_turn(
@@ -144,6 +163,78 @@ def test_stale_running_turn_can_be_reclaimed_by_new_runner() -> None:
         )
         is None
     )
+    active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active is not None
+    assert active.runner_id == reclaimed.runner_id
+
+
+def test_finish_turn_does_not_clobber_concurrent_reclaim() -> None:
+    cache = _InterleavingCache()
+    session_id, user_id, turn = _create_turn(cache)
+
+    first = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert first is not None
+    first_runner_id = first.runner_id
+    assert first_runner_id is not None
+    reclaimed: InteractiveTurn | None = None
+
+    def reclaim_turn() -> None:
+        nonlocal reclaimed
+        reclaimed = claim_turn_for_runner(
+            cache=cache,
+            turn_id=turn.turn_id,
+            stale_after_seconds=0,
+        )
+
+    cache.after_next_turn_read = reclaim_turn
+
+    assert (
+        finish_turn(
+            cache=cache,
+            turn_id=turn.turn_id,
+            status=TURN_STATUS_FAILED,
+            runner_id=first_runner_id,
+        )
+        is None
+    )
+
+    current = get_turn(cache, turn.turn_id)
+    assert current is not None
+    assert reclaimed is not None
+    assert current.status == TURN_STATUS_RUNNING
+    assert current.runner_id == reclaimed.runner_id
+    active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active is not None
+    assert active.runner_id == reclaimed.runner_id
+
+
+def test_touch_turn_does_not_clobber_concurrent_reclaim() -> None:
+    cache = _InterleavingCache()
+    session_id, user_id, turn = _create_turn(cache)
+
+    first = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert first is not None
+    first_runner_id = first.runner_id
+    assert first_runner_id is not None
+    reclaimed: InteractiveTurn | None = None
+
+    def reclaim_turn() -> None:
+        nonlocal reclaimed
+        reclaimed = claim_turn_for_runner(
+            cache=cache,
+            turn_id=turn.turn_id,
+            stale_after_seconds=0,
+        )
+
+    cache.after_next_turn_read = reclaim_turn
+
+    assert not touch_turn(cache=cache, turn_id=turn.turn_id, runner_id=first_runner_id)
+
+    current = get_turn(cache, turn.turn_id)
+    assert current is not None
+    assert reclaimed is not None
+    assert current.status == TURN_STATUS_RUNNING
+    assert current.runner_id == reclaimed.runner_id
     active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
     assert active is not None
     assert active.runner_id == reclaimed.runner_id

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from uuid import UUID
+from uuid import uuid4
+
+from onyx.server.features.build.interactive_turns.state import acquire_active_turn_lock
+from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
+from onyx.server.features.build.interactive_turns.state import create_interactive_turn
+from onyx.server.features.build.interactive_turns.state import finish_turn
+from onyx.server.features.build.interactive_turns.state import get_active_turn
+from onyx.server.features.build.interactive_turns.state import get_turn_for_request
+from onyx.server.features.build.interactive_turns.state import InteractiveTurn
+from onyx.server.features.build.interactive_turns.state import REQUEST_ID_TTL_SECONDS
+from onyx.server.features.build.interactive_turns.state import touch_turn
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_QUEUED
+from onyx.server.features.build.interactive_turns.state import TURN_STATUS_RUNNING
+from tests.unit.onyx.server.features.build.fakes import FakeCache
+
+
+def _create_turn(
+    cache: FakeCache,
+    *,
+    session_id: UUID | None = None,
+    user_id: UUID | None = None,
+    request_id: str = "req-1",
+) -> tuple[UUID, UUID, InteractiveTurn]:
+    session_id = session_id or uuid4()
+    user_id = user_id or uuid4()
+    lock = acquire_active_turn_lock(cache, session_id)
+    try:
+        turn = create_interactive_turn(
+            cache=cache,
+            session_id=session_id,
+            user_id=user_id,
+            client_request_id=request_id,
+            prompt="hello",
+            turn_index=0,
+        )
+    finally:
+        lock.release()
+    return session_id, user_id, turn
+
+
+def test_create_turn_records_active_and_request_mappings() -> None:
+    cache = FakeCache()
+    request_id = "req-1"
+    session_id, user_id, turn = _create_turn(cache, request_id=request_id)
+
+    assert turn.status == TURN_STATUS_QUEUED
+    active_turn = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active_turn is not None
+    assert active_turn.turn_id == turn.turn_id
+    request_turn = get_turn_for_request(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id=request_id,
+    )
+    assert request_turn is not None
+    assert request_turn.turn_id == turn.turn_id
+
+
+def test_finish_turn_clears_active_marker_but_keeps_request_mapping() -> None:
+    cache = FakeCache()
+    request_id = "req-1"
+    session_id, user_id, turn = _create_turn(cache, request_id=request_id)
+
+    finish_turn(
+        cache=cache,
+        turn_id=turn.turn_id,
+        status=TURN_STATUS_FAILED,
+        error_detail="boom",
+    )
+
+    assert get_active_turn(cache=cache, session_id=session_id, user_id=user_id) is None
+    finished = get_turn_for_request(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id=request_id,
+    )
+    assert finished is not None
+    assert finished.status == TURN_STATUS_FAILED
+    assert finished.error_detail == "boom"
+
+
+def test_terminal_turn_lives_as_long_as_request_mapping() -> None:
+    cache = FakeCache()
+    request_id = "req-1"
+    session_id, user_id, turn = _create_turn(cache, request_id=request_id)
+
+    finish_turn(cache=cache, turn_id=turn.turn_id, status=TURN_STATUS_FAILED)
+
+    assert (
+        cache.expiries[f"craft:interactive_turn:{turn.turn_id}"]
+        == REQUEST_ID_TTL_SECONDS
+    )
+    assert (
+        cache.expiries[
+            f"craft:session:{session_id}:turn_request:{user_id}:{request_id}"
+        ]
+        == REQUEST_ID_TTL_SECONDS
+    )
+
+
+def test_claim_turn_for_runner_sets_running_owner() -> None:
+    cache = FakeCache()
+    _, _, turn = _create_turn(cache)
+
+    claimed = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+
+    assert claimed is not None
+    assert claimed.status == TURN_STATUS_RUNNING
+    assert claimed.runner_id is not None
+    assert claim_turn_for_runner(cache=cache, turn_id=turn.turn_id) is None
+
+
+def test_stale_running_turn_can_be_reclaimed_by_new_runner() -> None:
+    cache = FakeCache()
+    session_id, user_id, turn = _create_turn(cache)
+
+    first = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert first is not None
+    first_runner_id = first.runner_id
+    assert first_runner_id is not None
+
+    reclaimed = claim_turn_for_runner(
+        cache=cache,
+        turn_id=turn.turn_id,
+        stale_after_seconds=0,
+    )
+
+    assert reclaimed is not None
+    assert reclaimed.runner_id is not None
+    assert reclaimed.runner_id != first_runner_id
+    assert not touch_turn(cache=cache, turn_id=turn.turn_id, runner_id=first_runner_id)
+    assert (
+        finish_turn(
+            cache=cache,
+            turn_id=turn.turn_id,
+            status=TURN_STATUS_FAILED,
+            runner_id=first_runner_id,
+        )
+        is None
+    )
+    active = get_active_turn(cache=cache, session_id=session_id, user_id=user_id)
+    assert active is not None
+    assert active.runner_id == reclaimed.runner_id

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -268,6 +268,34 @@ def test_dispatch_session_created_records_parent_child(bus: PodEventBus) -> None
     assert bus.parent_of("ses_child") == "ses_parent"
 
 
+def test_dispatch_session_created_without_sessionid_delivers_to_parent(
+    bus: PodEventBus,
+) -> None:
+    """opencode's session.created shape identifies the child as info.id, not
+    properties.sessionID. Parent subscribers still need the event immediately
+    so the task card can attach to the live child session."""
+    parent_sub = bus.subscribe("ses_parent")
+    child_sub = bus.subscribe("ses_child")
+
+    bus._dispatch(
+        {
+            "type": "session.created",
+            "properties": {
+                "info": {"id": "ses_child", "parentID": "ses_parent"},
+            },
+        }
+    )
+
+    item = parent_sub.queue.get_nowait()
+    assert item is not None
+    assert item["type"] == "session.created"
+    assert item["properties"]["info"]["id"] == "ses_child"
+    assert bus.list_children("ses_parent") == ["ses_child"]
+    assert bus.parent_of("ses_child") == "ses_parent"
+    with pytest.raises(Empty):
+        child_sub.queue.get_nowait()
+
+
 def test_list_children_preserves_spawn_order(bus: PodEventBus) -> None:
     """``list_children`` returns child sessionIDs in the order opencode
     emitted ``session.created`` — NOT lexicographic. Frontends use this
@@ -394,6 +422,27 @@ def test_subscriber_queue_overflow_does_not_block_other_subscribers(
     bus._dispatch(_make_event("message.part.delta", sessionID="ses_A"))
     assert slow.dropped_count == 1
     assert fast.queue.get_nowait() is not None  # fast still gets the event
+
+
+def test_unscoped_queue_overflow_log_uses_sentinel(
+    bus: PodEventBus,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sub = bus.subscribe("ses_A")
+    for _ in range(sub.queue.maxsize):
+        sub.queue.put_nowait({"filler": True})
+
+    with caplog.at_level("WARNING", logger=event_bus_mod.logger.name):
+        bus._dispatch(
+            {
+                "type": "session.error",
+                "properties": {"error": {"data": {"message": "upstream reset"}}},
+            }
+        )
+
+    assert sub.dropped_count == 1
+    assert "session <unscoped>" in caplog.text
+    assert "session None" not in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any
+from typing import cast
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from uuid import UUID
@@ -89,6 +91,13 @@ def _make_manager(*, pod_read_exc: Exception | None = None) -> KubernetesSandbox
     else:
         pod_obj = MagicMock()
         pod_obj.status.pod_ip = "10.0.0.1"
+        pod_obj.status.container_statuses = [
+            SimpleNamespace(
+                name="sandbox",
+                ready=True,
+                state=SimpleNamespace(running=object(), terminated=None),
+            )
+        ]
         core_api.read_namespaced_pod.return_value = pod_obj
 
     mgr._core_api = core_api  # type: ignore[attr-defined]
@@ -110,11 +119,13 @@ def _mock_httpx_client(
     client_instance = MagicMock()
     if raise_exc is not None:
         client_instance.post.side_effect = raise_exc
+        client_instance.get.side_effect = raise_exc
     else:
         resp = MagicMock()
         resp.status_code = response_status
         resp.text = response_text
         client_instance.post.return_value = resp
+        client_instance.get.return_value = resp
 
     ctx = MagicMock()
     ctx.__enter__ = MagicMock(return_value=client_instance)
@@ -261,6 +272,36 @@ def test_health_check_returns_false_on_remote_protocol_error() -> None:
     with patch(_HTTPX_CLIENT_PATH, factory):
         # Bool contract: any transport failure becomes False.
         assert mgr.health_check(_sandbox_id(), timeout=1.0) is False
+
+
+def test_health_check_returns_false_when_sandbox_container_terminated() -> None:
+    """The sidecar can stay alive after the agent container is OOMKilled.
+
+    Restore must treat that sandbox as unhealthy so the recovery path
+    reprovisions it before exec'ing into the session workspace.
+    """
+    mgr = _make_manager()
+    core_api = cast(Any, mgr)._core_api
+    pod = core_api.read_namespaced_pod.return_value
+    pod.status.container_statuses = [
+        SimpleNamespace(
+            name="sandbox",
+            ready=False,
+            state=SimpleNamespace(
+                running=None, terminated=SimpleNamespace(reason="OOMKilled")
+            ),
+        ),
+        SimpleNamespace(
+            name="sidecar",
+            ready=True,
+            state=SimpleNamespace(running=object(), terminated=None),
+        ),
+    ]
+    factory = _mock_httpx_client(response_status=200, response_text="ok")
+
+    with patch(_HTTPX_CLIENT_PATH, factory):
+        assert mgr.health_check(_sandbox_id(), timeout=1.0) is False
+    factory.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
@@ -14,7 +14,8 @@ Coverage targets:
 - Wall-clock timeout posts abort + yields Error
 - ``GeneratorExit`` (browser disconnect) posts abort and re-raises
 - Permission-ask events trigger out-of-band POST (auto-allow)
-- ``stream_ready`` timeout when the bus never connects
+- ``stream_ready`` waits through transient reconnect windows before prompting
+- ``stream_ready`` timeout when the bus never reconnects
 """
 
 from __future__ import annotations
@@ -58,10 +59,11 @@ class _RecordingTransport(httpx.MockTransport):
 
 
 @pytest.fixture
-def bus() -> Generator[PodEventBus, None, None]:
+def bus(monkeypatch: pytest.MonkeyPatch) -> Generator[PodEventBus, None, None]:
     """Bus with no real reader — tests push events directly into subscriber
     queues via ``bus._dispatch`` after ``stream_ready`` is forced set."""
     b = PodEventBus(base_url="http://test.invalid:4096", auth=None)
+    monkeypatch.setattr(b, "_ensure_reader_started", lambda: None)
     # The bus would normally set stream_ready inside its reader after
     # connecting. Force-set it here so send_message doesn't time out
     # waiting for a connection that's never going to happen in unit tests.
@@ -137,6 +139,12 @@ def _wait_for(predicate: Any, *, timeout: float = 3.0) -> bool:
     return False
 
 
+def _prompt_async_posted(transport: _RecordingTransport) -> bool:
+    return any(
+        request.url.path.endswith("/prompt_async") for request in transport.requests
+    )
+
+
 def _dispatch_session_idle(bus: PodEventBus, *, scoped: bool = True) -> None:
     properties = {"sessionID": _SESSION} if scoped else {}
     bus._dispatch({"type": "session.idle", "properties": properties})
@@ -152,6 +160,7 @@ def test_send_message_yields_text_and_terminator(bus: PodEventBus) -> None:
     client = _make_client(bus, transport)
     events, t = _run_send_message(client)
     try:
+        assert _wait_for(lambda: _prompt_async_posted(transport))
         # Set up: an assistant message arrives, then a text part with a delta,
         # then completion.
         bus._dispatch(
@@ -227,6 +236,7 @@ def test_send_message_routes_reasoning_to_thought_chunks(bus: PodEventBus) -> No
     client = _make_client(bus, transport)
     events, t = _run_send_message(client)
     try:
+        assert _wait_for(lambda: _prompt_async_posted(transport))
         # Reasoning part arrives first to register its type, then a delta on
         # the same partID — translator emits AgentThoughtChunk for reasoning.
         bus._dispatch(
@@ -321,6 +331,7 @@ def test_send_message_threads_model_override_into_prompt_async(
         client, model_provider="anthropic", model_id="claude-opus-4-7"
     )
     try:
+        assert _wait_for(lambda: len(posted_bodies) == 1)
         # Completion metadata arrives before the session-level terminator.
         bus._dispatch(
             {
@@ -364,6 +375,7 @@ def test_send_message_omits_model_when_override_missing(bus: PodEventBus) -> Non
     client = _make_client(bus, transport)
     events, t = _run_send_message(client)
     try:
+        assert _wait_for(lambda: len(posted_bodies) == 1)
         bus._dispatch(
             {
                 "type": "message.updated",
@@ -403,6 +415,7 @@ def test_send_message_omits_model_when_only_one_arg_supplied(
     client = _make_client(bus, transport)
     events, t = _run_send_message(client, model_provider="anthropic", model_id=None)
     try:
+        assert _wait_for(lambda: len(posted_bodies) == 1)
         bus._dispatch(
             {
                 "type": "message.updated",
@@ -468,20 +481,54 @@ def test_send_message_yields_error_on_prompt_async_connection_error(
     assert "prompt_async failed" in events[0].message
 
 
-def test_send_message_errors_when_stream_ready_never_set(bus: PodEventBus) -> None:
-    """If the bus never connects (stream_ready stays cleared), send_message
-    surfaces an Error after ``connect_timeout`` rather than blocking
-    indefinitely on prompt_async."""
+def test_send_message_waits_for_event_bus_reconnect_before_prompt_async(
+    bus: PodEventBus,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the shared /event stream is reconnecting, the turn should wait
+    instead of posting prompt_async and missing the first packets."""
+    monkeypatch.setattr(bus, "_ensure_reader_started", lambda: None)
     bus.stream_ready.clear()
-    transport = httpx.MockTransport(_ok_response)
-    client = _make_client(bus, transport, connect_timeout=0.2)
+
+    transport = _RecordingTransport(_ok_response)
+    client = _make_client(bus, transport, connect_timeout=0.05)
+    events, t = _run_send_message(client, timeout=3.0)
+    try:
+        time.sleep(0.1)
+        assert not any(
+            request.url.path.endswith("/prompt_async") for request in transport.requests
+        )
+
+        bus.stream_ready.set()
+        assert _wait_for(lambda: _prompt_async_posted(transport))
+
+        _dispatch_session_idle(bus)
+        assert _wait_for(lambda: any(isinstance(e, PromptResponse) for e in events))
+    finally:
+        t.join(timeout=3.0)
+
+
+def test_send_message_errors_when_stream_ready_never_set(
+    bus: PodEventBus,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the bus never connects (stream_ready stays cleared), send_message
+    surfaces an Error after the turn budget rather than blocking indefinitely
+    on prompt_async."""
+    monkeypatch.setattr(bus, "_ensure_reader_started", lambda: None)
+    bus.stream_ready.clear()
+    transport = _RecordingTransport(_ok_response)
+    client = _make_client(bus, transport, connect_timeout=0.01)
     events = list(
-        client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=2.0)
+        client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=0.2)
     )
     assert len(events) == 1
     assert isinstance(events[0], Error)
     assert events[0].code == -3
     assert "did not become ready" in events[0].message
+    assert not any(
+        request.url.path.endswith("/prompt_async") for request in transport.requests
+    )
 
 
 def test_send_message_errors_when_bus_closes_before_terminator(
@@ -587,33 +634,46 @@ def test_send_message_aborts_on_generator_exit(bus: PodEventBus) -> None:
             aborts.append(request.url.path)
         return httpx.Response(204)
 
-    transport = httpx.MockTransport(handler)
+    transport = _RecordingTransport(handler)
     client = _make_client(bus, transport)
 
-    # Pre-load a non-terminator event into the subscriber queue BEFORE
-    # iterating, so the first ``next()`` returns quickly. We have to
-    # subscribe via the bus path the client uses, so let the client do
-    # its own subscribe; we just dispatch into the bus, which will route
-    # to that subscription.
     gen = client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=5.0)
-    bus._dispatch(
-        {
-            "type": "message.updated",
-            "properties": {
-                "sessionID": _SESSION,
-                "info": {
-                    "id": "msg1",
+
+    def dispatch_first_chunk() -> None:
+        assert _wait_for(lambda: _prompt_async_posted(transport))
+        bus._dispatch(
+            {
+                "type": "message.updated",
+                "properties": {
                     "sessionID": _SESSION,
-                    "role": "assistant",
-                    "time": {"completed": None},
+                    "info": {
+                        "id": "msg1",
+                        "sessionID": _SESSION,
+                        "role": "assistant",
+                        "time": {"completed": None},
+                    },
                 },
-            },
-        }
-    )
-    # First yield drains the event we just dispatched. We don't care what
-    # the value is — only that the generator has executed past the POST
-    # and into the consume loop.
-    next(gen, None)
+            }
+        )
+        bus._dispatch(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": _SESSION,
+                    "part": {
+                        "id": "p1",
+                        "messageID": "msg1",
+                        "sessionID": _SESSION,
+                        "type": "text",
+                        "text": "partial",
+                        "state": {"status": "active"},
+                    },
+                },
+            }
+        )
+
+    threading.Thread(target=dispatch_first_chunk, daemon=True).start()
+    assert isinstance(next(gen), AgentMessageChunk)
     # Close mid-stream: this raises GeneratorExit inside send_message's
     # try/except, which posts /abort and re-raises.
     gen.close()
@@ -643,10 +703,11 @@ def test_send_message_auto_allows_permission_asks(bus: PodEventBus) -> None:
             )
         return httpx.Response(204)
 
-    transport = httpx.MockTransport(handler)
+    transport = _RecordingTransport(handler)
     client = _make_client(bus, transport)
     events, t = _run_send_message(client, timeout=3.0)
     try:
+        assert _wait_for(lambda: _prompt_async_posted(transport))
         bus._dispatch(
             {
                 "type": "permission.asked",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_transport_live_coalescing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_transport_live_coalescing.py
@@ -1,0 +1,234 @@
+"""Tests for live attach stream text coalescing in serve transport."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.api.packets import SubagentStartedPacket
+from onyx.server.features.build.sandbox import serve_transport
+from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
+from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
+
+_DIRECTORY = "/workspace/sessions/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_SESSION = "ses_test"
+
+
+@pytest.fixture
+def mgr(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[KubernetesSandboxManager, None, None]:
+    monkeypatch.setattr(PodEventBus, "_ensure_reader_started", lambda _: None)
+
+    manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    manager._init_serve_state()
+    manager._load_serve_connection_info = (  # type: ignore[assignment]
+        lambda sandbox_id: ServeConnectionInfo(
+            base_url=f"http://{sandbox_id}.invalid:4096",
+            password=None,
+        )
+    )
+
+    try:
+        yield manager
+    finally:
+        with manager._event_buses_lock:
+            buses = list(manager._event_buses.values())
+            manager._event_buses.clear()
+        for bus in buses:
+            bus.close()
+
+
+def _wait_for(predicate: Any, *, timeout: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+def _dispatch_assistant_text_delta(bus: PodEventBus, text: str) -> None:
+    bus._dispatch(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": _SESSION,
+                "messageID": "msg1",
+                "partID": "part1",
+                "field": "text",
+                "delta": text,
+            },
+        }
+    )
+
+
+def test_subscribe_to_opencode_session_coalesces_adjacent_text_deltas(
+    mgr: KubernetesSandboxManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(serve_transport, "LIVE_TEXT_COALESCE_SECONDS", 0.01)
+    sandbox_id = uuid4()
+    bus = PodEventBus(
+        base_url=f"http://{sandbox_id}.invalid:4096",
+        auth=None,
+        directory=_DIRECTORY,
+    )
+    with mgr._event_buses_lock:
+        mgr._event_buses[(sandbox_id, _DIRECTORY)] = bus
+    events: list[Any] = []
+
+    def reader() -> None:
+        for event in mgr.subscribe_to_opencode_session(
+            sandbox_id,
+            _SESSION,
+            directory=_DIRECTORY,
+            keepalive_seconds=60.0,
+        ):
+            events.append(event)
+            if isinstance(event, PromptResponse):
+                return
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    assert _wait_for(lambda: bool(bus._subscribers.get(_SESSION)))
+
+    bus._dispatch(
+        {
+            "type": "message.updated",
+            "properties": {
+                "sessionID": _SESSION,
+                "info": {
+                    "id": "msg1",
+                    "sessionID": _SESSION,
+                    "role": "assistant",
+                },
+            },
+        }
+    )
+    bus._dispatch(
+        {
+            "type": "message.part.updated",
+            "properties": {
+                "sessionID": _SESSION,
+                "part": {
+                    "id": "part1",
+                    "messageID": "msg1",
+                    "sessionID": _SESSION,
+                    "type": "text",
+                    "text": "",
+                    "state": {"status": "active"},
+                },
+            },
+        }
+    )
+    _dispatch_assistant_text_delta(bus, "Hel")
+    _dispatch_assistant_text_delta(bus, "lo")
+    bus._dispatch(
+        {
+            "type": "session.idle",
+            "properties": {"sessionID": _SESSION},
+        }
+    )
+
+    thread.join(timeout=3.0)
+    assert not thread.is_alive()
+
+    assert len(events) == 2
+    assert isinstance(events[0], AgentMessageChunk)
+    assert getattr(events[0].content, "text", None) == "Hello"
+    assert isinstance(events[1], PromptResponse)
+
+
+def test_subscribe_to_opencode_session_forwards_child_events(
+    mgr: KubernetesSandboxManager,
+) -> None:
+    sandbox_id = uuid4()
+    child_session = "ses_child"
+    bus = PodEventBus(
+        base_url=f"http://{sandbox_id}.invalid:4096",
+        auth=None,
+        directory=_DIRECTORY,
+    )
+    with mgr._event_buses_lock:
+        mgr._event_buses[(sandbox_id, _DIRECTORY)] = bus
+    events: list[Any] = []
+
+    def reader() -> None:
+        for event in mgr.subscribe_to_opencode_session(
+            sandbox_id,
+            _SESSION,
+            directory=_DIRECTORY,
+            keepalive_seconds=60.0,
+        ):
+            events.append(event)
+            if isinstance(event, PromptResponse):
+                return
+
+    thread = threading.Thread(target=reader, daemon=True)
+    thread.start()
+    assert _wait_for(lambda: bool(bus._subscribers.get(_SESSION)))
+
+    bus._dispatch(
+        {
+            "type": "session.created",
+            "properties": {
+                "sessionID": child_session,
+                "info": {"id": child_session, "parentID": _SESSION},
+            },
+        }
+    )
+    bus._dispatch(
+        {
+            "type": "message.updated",
+            "properties": {
+                "sessionID": child_session,
+                "info": {
+                    "id": "msg_child",
+                    "sessionID": child_session,
+                    "role": "assistant",
+                },
+            },
+        }
+    )
+    bus._dispatch(
+        {
+            "type": "message.part.delta",
+            "properties": {
+                "sessionID": child_session,
+                "messageID": "msg_child",
+                "partID": "part_child",
+                "field": "text",
+                "delta": "child streamed text",
+            },
+        }
+    )
+    bus._dispatch(
+        {
+            "type": "session.idle",
+            "properties": {"sessionID": _SESSION},
+        }
+    )
+
+    thread.join(timeout=3.0)
+    assert not thread.is_alive()
+
+    assert any(isinstance(event, SubagentStartedPacket) for event in events)
+    child_chunks = [event for event in events if isinstance(event, AgentMessageChunk)]
+    assert len(child_chunks) == 1
+    assert getattr(child_chunks[0].content, "text", None) == "child streamed text"
+    assert child_chunks[0].field_meta == {
+        "sessionId": child_session,
+        "parentSessionId": _SESSION,
+    }
+    assert isinstance(events[-1], PromptResponse)

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_translate_opencode_event.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from onyx.server.features.build.api.packets import SubagentStartedPacket
 from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import Error
@@ -1287,6 +1288,43 @@ def _child_parent_resolver(sess_id: str) -> str | None:
     return PARENT if sess_id == CHILD else None
 
 
+def test_session_created_emits_subagent_started_for_parent() -> None:
+    s = _parent_state()
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "session.created",
+                "properties": {
+                    "info": {"id": CHILD, "parentID": PARENT},
+                },
+            },
+            s,
+        )
+    )
+
+    assert len(out) == 1
+    assert isinstance(out[0], SubagentStartedPacket)
+    assert out[0].subagent_session_id == CHILD
+    assert out[0].parent_session_id == PARENT
+
+
+def test_session_created_for_other_parent_is_ignored() -> None:
+    s = _parent_state()
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "session.created",
+                "properties": {
+                    "info": {"id": CHILD, "parentID": "ses_OTHER"},
+                },
+            },
+            s,
+        )
+    )
+
+    assert out == []
+
+
 def test_child_tool_event_forwarded_and_tagged() -> None:
     """A completed tool event from a descendant subagent session is forwarded
     and tagged with sessionId + parentSessionId routing metadata."""
@@ -1310,6 +1348,204 @@ def test_child_tool_event_forwarded_and_tagged() -> None:
         assert meta["parentSessionId"] == PARENT
         # Existing toolName tag is preserved (merge, not overwrite).
         assert meta["toolName"] == "bash"
+
+
+def test_child_text_delta_forwarded_and_tagged() -> None:
+    """Visible child text should stream into the subagent transcript rather
+    than being dropped while the parent task is still running."""
+    s = _parent_state()
+
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": CHILD,
+                    "messageID": "msg_child",
+                    "partID": "p_child_text",
+                    "field": "text",
+                    "delta": "child response",
+                },
+            },
+            s,
+            parent_resolver=_child_parent_resolver,
+            fetch_message_by_session=lambda session_id, message_id: {
+                "info": {
+                    "id": message_id,
+                    "sessionID": session_id,
+                    "role": "assistant",
+                },
+                "parts": [{"id": "p_child_text", "type": "text"}],
+            },
+        )
+    )
+
+    assert len(out) == 1
+    assert isinstance(out[0], AgentMessageChunk)
+    assert out[0].content.text == "child response"  # type: ignore[union-attr]
+    meta = out[0].field_meta
+    assert meta is not None
+    assert meta["sessionId"] == CHILD
+    assert meta["parentSessionId"] == PARENT
+
+
+def test_child_reasoning_part_forwarded_and_tagged() -> None:
+    s = _parent_state()
+
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "sessionID": CHILD,
+                    "part": {
+                        "id": "p_child_reasoning",
+                        "messageID": "msg_child",
+                        "type": "reasoning",
+                        "text": "child thinking",
+                    },
+                },
+            },
+            s,
+            parent_resolver=_child_parent_resolver,
+            fetch_message_by_session=lambda session_id, message_id: {
+                "info": {
+                    "id": message_id,
+                    "sessionID": session_id,
+                    "role": "assistant",
+                },
+                "parts": [{"id": "p_child_reasoning", "type": "reasoning"}],
+            },
+        )
+    )
+
+    assert len(out) == 1
+    assert isinstance(out[0], AgentThoughtChunk)
+    assert out[0].content.text == "child thinking"  # type: ignore[union-attr]
+    meta = out[0].field_meta
+    assert meta is not None
+    assert meta["sessionId"] == CHILD
+    assert meta["parentSessionId"] == PARENT
+
+
+def test_child_reasoning_delta_forwarded_and_tagged() -> None:
+    s = _parent_state()
+
+    out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": CHILD,
+                    "messageID": "msg_child",
+                    "partID": "p_child_reasoning",
+                    "field": "text",
+                    "delta": "child thinking",
+                },
+            },
+            s,
+            parent_resolver=_child_parent_resolver,
+            fetch_message_by_session=lambda session_id, message_id: {
+                "info": {
+                    "id": message_id,
+                    "sessionID": session_id,
+                    "role": "assistant",
+                },
+                "parts": [{"id": "p_child_reasoning", "type": "reasoning"}],
+            },
+        )
+    )
+
+    assert len(out) == 1
+    assert isinstance(out[0], AgentThoughtChunk)
+    assert out[0].content.text == "child thinking"  # type: ignore[union-attr]
+    meta = out[0].field_meta
+    assert meta is not None
+    assert meta["sessionId"] == CHILD
+    assert meta["parentSessionId"] == PARENT
+
+
+def test_child_finish_does_not_leak_into_parent_terminator() -> None:
+    s = _parent_state()
+
+    _drain(
+        translate_opencode_event(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "sessionID": CHILD,
+                    "info": {
+                        "id": "msg_child",
+                        "sessionID": CHILD,
+                        "role": "assistant",
+                        "finish": "max_tokens",
+                    },
+                },
+            },
+            s,
+            parent_resolver=_child_parent_resolver,
+        )
+    )
+    out = _drain(
+        translate_opencode_event(
+            {"type": "session.idle", "properties": {"sessionID": PARENT}}, s
+        )
+    )
+
+    assert len(out) == 1
+    assert isinstance(out[0], PromptResponse)
+    assert out[0].stop_reason == "end_turn"
+
+
+def test_child_part_type_does_not_collide_with_parent_part_id() -> None:
+    s = _parent_state()
+
+    child_out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": CHILD,
+                    "messageID": "msg_child",
+                    "partID": "shared_part",
+                    "field": "text",
+                    "delta": "child thinking",
+                },
+            },
+            s,
+            parent_resolver=_child_parent_resolver,
+            fetch_message_by_session=lambda session_id, message_id: {
+                "info": {
+                    "id": message_id,
+                    "sessionID": session_id,
+                    "role": "assistant",
+                },
+                "parts": [{"id": "shared_part", "type": "reasoning"}],
+            },
+        )
+    )
+    assert isinstance(child_out[0], AgentThoughtChunk)
+
+    s.assistant_message_ids.add("msg_parent")
+    parent_out = _drain(
+        translate_opencode_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": PARENT,
+                    "messageID": "msg_parent",
+                    "partID": "shared_part",
+                    "field": "text",
+                    "delta": "parent visible text",
+                },
+            },
+            s,
+        )
+    )
+
+    assert len(parent_out) == 1
+    assert isinstance(parent_out[0], AgentMessageChunk)
+    assert parent_out[0].content.text == "parent visible text"  # type: ignore[union-attr]
 
 
 def test_child_tool_event_dropped_when_not_descendant() -> None:

--- a/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py
@@ -5,6 +5,14 @@ Tests for chunk accumulation and finalize semantics — no DB required.
 
 from __future__ import annotations
 
+from typing import Any
+from typing import cast
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
+from onyx.server.features.build.session import streaming
 from onyx.server.features.build.session.streaming import BuildStreamingState
 
 
@@ -61,6 +69,21 @@ class TestBuildStreamingState:
         # Case 4: continuing with another thought chunk → no finalize
         assert state.should_finalize_chunks("agent_thought_chunk") is False
 
+    def test_routing_meta_change_finalizes_previous_chunk(self) -> None:
+        """Parent and child chunks share packet types but must not share one
+        persisted assistant row."""
+        state = BuildStreamingState(turn_index=0)
+        child_meta = {"sessionId": "child", "parentSessionId": "parent"}
+
+        state.add_message_chunk("child text", child_meta)
+
+        assert state.should_finalize_chunks("agent_message_chunk", child_meta) is False
+        assert state.should_finalize_chunks("agent_message_chunk", None) is True
+
+        packet = state.finalize_message_chunks()
+        assert packet is not None
+        assert packet["_meta"] == child_meta
+
     def test_finalize_with_no_chunks_is_noop(self) -> None:
         """Empty finalize returns None / does nothing."""
         state = BuildStreamingState(turn_index=0)
@@ -112,3 +135,65 @@ class TestBuildStreamingState:
         assert state.should_finalize_chunks("some_future_event_type") is False
         assert state.should_finalize_chunks("agent_message_chunk") is False
         assert state.should_finalize_chunks("agent_thought_chunk") is False
+
+
+def test_persist_sandbox_event_splits_chunks_by_routing_meta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persisted: list[dict[str, Any]] = []
+
+    def create_message_stub(**kwargs: Any) -> None:
+        persisted.append(cast(dict[str, Any], kwargs["message_metadata"]))
+
+    monkeypatch.setattr(streaming, "create_message", create_message_stub)
+    state = BuildStreamingState(turn_index=0)
+    session_id = uuid4()
+    child_meta = {"sessionId": "child", "parentSessionId": "parent"}
+
+    parent_first = AgentMessageChunk.model_validate(
+        {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "parent first"},
+        }
+    )
+    child = AgentMessageChunk.model_validate(
+        {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "child"},
+            "_meta": child_meta,
+        }
+    )
+    parent_second = AgentMessageChunk.model_validate(
+        {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "parent second"},
+        }
+    )
+
+    streaming.persist_sandbox_event(
+        cast(Any, object()), session_id, state, parent_first
+    )
+    streaming.persist_sandbox_event(cast(Any, object()), session_id, state, child)
+    streaming.persist_sandbox_event(
+        cast(Any, object()), session_id, state, parent_second
+    )
+    streaming.finalize_persist(cast(Any, object()), session_id, state)
+
+    assert persisted == [
+        {
+            "type": "agent_message",
+            "content": {"type": "text", "text": "parent first"},
+            "sessionUpdate": "agent_message",
+        },
+        {
+            "type": "agent_message",
+            "content": {"type": "text", "text": "child"},
+            "sessionUpdate": "agent_message",
+            "_meta": child_meta,
+        },
+        {
+            "type": "agent_message",
+            "content": {"type": "text", "text": "parent second"},
+            "sessionUpdate": "agent_message",
+        },
+    ]

--- a/docs/craft/background-interactive-turns-plan.md
+++ b/docs/craft/background-interactive-turns-plan.md
@@ -1,0 +1,74 @@
+# Background Interactive Turns Plan
+
+## Issues to Address
+
+Interactive Craft turns were request-bound: `POST /sessions/{id}/send-message`
+owned the generator that drove opencode, persisted packets, and released the
+prompt slot. A browser refresh closed that stream, causing `GeneratorExit` to
+abort the sandbox turn and drop the live UI.
+
+The target shape is to split starting work from watching work:
+
+- `POST /sessions/{id}/send-message` creates one interactive turn and returns
+  turn metadata.
+- A backend runner drives the sandbox opencode session and persists packets.
+- `GET /sessions/{id}/turns/{turn_id}/events` attaches to the live sandbox
+  event stream without owning the turn.
+- The frontend reloads saved messages, asks for an active turn, and attaches
+  instead of resending the prompt.
+
+## Important Notes
+
+- No DB migration should be required. Active turn state can live in
+  `CacheBackend` with TTLs, request idempotency, runner ownership, and
+  heartbeat/stale-claim recovery.
+- Scheduled runs are the closest existing pattern: the runner owns the prompt
+  and persistence loop, while the UI can attach to the sandbox pod's opencode
+  `/event` stream as a viewer.
+- The long-running agent session still happens inside the sandbox pod. The API
+  runner is responsible for draining that session, applying interrupt fencing,
+  and committing durable `BuildMessage` rows.
+- Redis-backed state is required for cross-pod visibility. In-memory caches
+  are not acceptable for active turns, runner ownership, or attach/rejoin.
+- The top-level parent-turn foreground path should be removed once the turns
+  API owns parent interactive turns. Lower-level sandbox `send_message` remains
+  the opencode transport primitive and subagent follow-ups may still stream
+  directly.
+
+## Implementation Strategy
+
+1. Add a CacheBackend-backed interactive turn lifecycle:
+   `QUEUED`, `RUNNING`, terminal statuses, active-turn lookup by session, and
+   idempotency by `client_request_id`.
+2. Change `POST /send-message` to validate ownership, persist the user message,
+   create the turn, start/retry a background runner, and return JSON turn
+   metadata instead of an SSE response.
+3. Build the runner from existing session pieces: `prompt_slot`,
+   `yield_sandbox_events`, `merge_events_with_announces`,
+   `persist_sandbox_event`, `finalize_persist`, interrupt fence checks, and
+   heartbeat updates.
+4. Add attach-only APIs:
+   - `GET /turns/active` for refresh/rejoin discovery.
+   - `GET /turns/{turn_id}/events` for live SSE viewing through
+     `subscribe_to_existing_session_events`.
+5. Update the frontend to track `activeTurnId` and local ownership, call
+   `createTurn`, attach with `streamTurnEvents`, and reattach from
+   `loadSession` when the session has a running active turn.
+6. Delete deprecated parent-turn request-bound code paths and avoid preserving
+   compatibility tests for the removed stream owner.
+
+## Tests
+
+- Unit tests for CacheBackend turn state: idempotency, single active turn,
+  terminal cleanup, runner claiming, stale reclaim, and queued requeue.
+- Unit tests for runner behavior: persistence, prompt slot conflict,
+  sandbox errors, missing final response, and ownership loss.
+- API tests for `send-message`, active-turn lookup, attach-only stream
+  behavior, terminal errors, and stale/not-running turns.
+- Sandbox transport tests for transient opencode `/event` reconnects and
+  coalesced live text bursts.
+- Frontend hook/store tests for `createTurn` + attach, refresh rejoin,
+  attach failures, in-band errors, and stale terminal turn handling.
+- Integration or local smoke tests through `localhost:3000` to confirm
+  refresh/rejoin does not resend the prompt and the UI displays streamed
+  output from the still-running sandbox session.

--- a/web/src/app/api/[...path]/route.ts
+++ b/web/src/app/api/[...path]/route.ts
@@ -131,11 +131,11 @@ async function handleRequest(request: NextRequest, path: string[]) {
       response.headers.get("Transfer-Encoding") === "chunked" ||
       response.headers.get("Content-Type")?.includes("stream")
     ) {
-      // If it's a stream, create a TransformStream to pass the data through
-      const { readable, writable } = new TransformStream();
-      response.body?.pipeTo(writable);
+      responseHeaders.set("Cache-Control", "no-cache, no-transform");
+      responseHeaders.set("X-Accel-Buffering", "no");
+      responseHeaders.delete("content-length");
 
-      const proxyResponse = new NextResponse(readable, {
+      const proxyResponse = new NextResponse(response.body, {
         status: response.status,
         headers: responseHeaders,
       });

--- a/web/src/app/craft/components/BuildMessageList.test.tsx
+++ b/web/src/app/craft/components/BuildMessageList.test.tsx
@@ -153,4 +153,20 @@ describe("BuildMessageList thinking visibility", () => {
 
     expect(screen.getByText("Checking the app structure.")).toBeInTheDocument();
   });
+
+  it("shows stream error packets inline", () => {
+    renderList({
+      streamItems: [
+        {
+          type: "error",
+          id: "error-1",
+          content: "provider model not found",
+        },
+      ],
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "provider model not found"
+    );
+  });
 });

--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo } from "react";
 import { cn } from "@opal/utils";
+import { SvgAlertCircle } from "@opal/icons";
 import { AnimatePresence, motion } from "motion/react";
 import Logo from "@/refresh-components/Logo";
 import TextChunk from "@/app/craft/components/TextChunk";
@@ -80,7 +81,8 @@ export default function BuildMessageList({
   const lastMessage = messages[messages.length - 1];
   const lastMessageIsUser = lastMessage?.type === "user";
   const showStreamingArea =
-    hasStreamItems || (isStreaming && lastMessageIsUser);
+    hasStreamItems ||
+    (isStreaming && (lastMessageIsUser || messages.length === 0));
 
   const renderStreamItems = (
     rawItems: StreamItem[],
@@ -202,6 +204,20 @@ export default function BuildMessageList({
                 todoList={item.todoList}
                 defaultOpen={item.todoList.isOpen}
               />
+            </div>
+          );
+        case "error":
+          return (
+            <div
+              key={item.id}
+              className={cn(
+                topMargin,
+                "flex items-start gap-2 rounded-08 border border-status-error-02 bg-status-error-00 px-3 py-2 text-sm text-status-error-05"
+              )}
+              role="alert"
+            >
+              <SvgAlertCircle className="mt-0.5 size-4 shrink-0 stroke-status-error-05" />
+              <span className="min-w-0 break-words">{item.content}</span>
             </div>
           );
         default:

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -142,14 +142,26 @@ export default function BuildChatPanel({
   const nameBuildSession = useBuildSessionStore(
     (state) => state.nameBuildSession
   );
-  const { streamMessage, interruptStreaming, streamScheduledRunEvents } =
-    useBuildStreaming();
+  const {
+    streamMessage,
+    interruptStreaming,
+    streamScheduledRunEvents,
+    streamTurnEvents,
+  } = useBuildStreaming();
   const isInterrupting = useIsInterrupting();
   const queuedMessages = useQueuedMessages();
   const enqueueMessage = useBuildSessionStore((state) => state.enqueueMessage);
   const removeQueuedMessage = useBuildSessionStore(
     (state) => state.removeQueuedMessage
   );
+  const attachedTurnRef = useRef<{
+    turnId: string;
+    controller: AbortController;
+  } | null>(null);
+  const attachCleanupTimerRef = useRef<{
+    turnId: string;
+    timer: ReturnType<typeof setTimeout>;
+  } | null>(null);
   const isPreProvisioning = useIsPreProvisioning();
   const isPreProvisioningFailed = useIsPreProvisioningFailed();
   const preProvisionedSessionId = usePreProvisionedSessionId();
@@ -210,8 +222,78 @@ export default function BuildChatPanel({
     mutateScheduledRunContext,
   ]);
 
+  const activeTurnId = session?.activeTurnId ?? null;
+  const activeTurnLocalOwner = session?.activeTurnLocalOwner ?? false;
   useEffect(() => {
-    if (!scheduledSessionId || !scheduledRunContext || scheduledRunInFlight) {
+    const pendingCleanup = attachCleanupTimerRef.current;
+    if (pendingCleanup?.turnId === activeTurnId) {
+      clearTimeout(pendingCleanup.timer);
+      attachCleanupTimerRef.current = null;
+    }
+
+    if (
+      !scheduledSessionId ||
+      !activeTurnId ||
+      activeTurnLocalOwner ||
+      scheduledRunInFlight
+    ) {
+      return;
+    }
+
+    const scheduleCleanup = (attachment: {
+      turnId: string;
+      controller: AbortController;
+    }) => {
+      attachCleanupTimerRef.current = {
+        turnId: attachment.turnId,
+        timer: setTimeout(() => {
+          attachment.controller.abort();
+          if (attachedTurnRef.current === attachment) {
+            attachedTurnRef.current = null;
+          }
+          if (attachCleanupTimerRef.current?.turnId === attachment.turnId) {
+            attachCleanupTimerRef.current = null;
+          }
+        }, 0),
+      };
+    };
+
+    const existingAttachment = attachedTurnRef.current;
+    if (existingAttachment?.turnId === activeTurnId) {
+      return () => scheduleCleanup(existingAttachment);
+    }
+
+    existingAttachment?.controller.abort();
+    const controller = new AbortController();
+    const attachment = { turnId: activeTurnId, controller };
+    attachedTurnRef.current = attachment;
+    void streamTurnEvents(
+      scheduledSessionId,
+      activeTurnId,
+      controller.signal,
+      () => {
+        if (attachedTurnRef.current === attachment) {
+          attachedTurnRef.current = null;
+        }
+      }
+    );
+
+    return () => scheduleCleanup(attachment);
+  }, [
+    scheduledSessionId,
+    activeTurnId,
+    activeTurnLocalOwner,
+    scheduledRunInFlight,
+    streamTurnEvents,
+  ]);
+
+  useEffect(() => {
+    if (
+      !scheduledSessionId ||
+      !scheduledRunContext ||
+      scheduledRunInFlight ||
+      activeTurnId
+    ) {
       return;
     }
     updateSessionData(scheduledSessionId, { status: "active" });
@@ -219,6 +301,7 @@ export default function BuildChatPanel({
     scheduledSessionId,
     scheduledRunContext,
     scheduledRunInFlight,
+    activeTurnId,
     updateSessionData,
   ]);
 

--- a/web/src/app/craft/components/SubagentView.test.tsx
+++ b/web/src/app/craft/components/SubagentView.test.tsx
@@ -1,0 +1,203 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import SubagentView from "@/app/craft/components/SubagentView";
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+import type { BuildMessage } from "@/app/craft/types/streamingTypes";
+import type { StreamItem } from "@/app/craft/types/displayTypes";
+
+const mockBuildMessageList = jest.fn(
+  (_props: {
+    messages: BuildMessage[];
+    streamItems: StreamItem[];
+    isStreaming?: boolean;
+  }) => <div data-testid="build-message-list" />
+);
+
+jest.mock("@/app/craft/components/BuildMessageList", () => ({
+  __esModule: true,
+  default: (props: {
+    messages: BuildMessage[];
+    streamItems: StreamItem[];
+    isStreaming?: boolean;
+  }) => mockBuildMessageList(props),
+}));
+
+describe("SubagentView", () => {
+  beforeEach(() => {
+    mockBuildMessageList.mockClear();
+    useBuildSessionStore.setState({
+      currentSessionId: null,
+      sessions: new Map(),
+    } as never);
+  });
+
+  it("renders the running subagent turn through the live stream path", () => {
+    const sessionId = "parent-session";
+    const subagentSessionId = "child-session";
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      status: "active",
+      isLoaded: true,
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+    useBuildSessionStore
+      .getState()
+      .seedSubagentMeta(
+        sessionId,
+        subagentSessionId,
+        "task-call",
+        "task",
+        "Build Space Invaders game",
+        "Build Space Invaders game"
+      );
+    useBuildSessionStore
+      .getState()
+      .appendSubagentThinkingChunk(sessionId, subagentSessionId, "Planning.");
+    useBuildSessionStore
+      .getState()
+      .appendSubagentResponseChunk(sessionId, subagentSessionId, "Live body.");
+
+    render(<SubagentView subagentSessionId={subagentSessionId} />);
+
+    expect(mockBuildMessageList).toHaveBeenCalledTimes(1);
+    const props = mockBuildMessageList.mock.calls[0]![0];
+    expect(props.messages).toEqual([
+      expect.objectContaining({
+        type: "user",
+        content: "Build Space Invaders game",
+      }),
+    ]);
+    expect(props.streamItems).toEqual([
+      expect.objectContaining({
+        type: "thinking",
+        content: "Planning.",
+        isStreaming: false,
+      }),
+      expect.objectContaining({
+        type: "text",
+        content: "Live body.",
+        isStreaming: true,
+      }),
+    ]);
+    expect(props.isStreaming).toBe(true);
+  });
+
+  it("renders the final completion response instead of stale streamed text", () => {
+    const sessionId = "parent-session";
+    const subagentSessionId = "child-session";
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      status: "active",
+      isLoaded: true,
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+    useBuildSessionStore
+      .getState()
+      .seedSubagentMeta(
+        sessionId,
+        subagentSessionId,
+        "task-call",
+        "task",
+        "Build Space Invaders game",
+        "Build Space Invaders game"
+      );
+    useBuildSessionStore
+      .getState()
+      .appendSubagentResponseChunk(sessionId, subagentSessionId, "Partial");
+    useBuildSessionStore
+      .getState()
+      .markSubagentComplete(
+        sessionId,
+        subagentSessionId,
+        "done",
+        "Complete answer"
+      );
+
+    render(<SubagentView subagentSessionId={subagentSessionId} />);
+
+    expect(mockBuildMessageList).toHaveBeenCalledTimes(1);
+    const props = mockBuildMessageList.mock.calls[0]![0];
+    expect(props.streamItems).toEqual([]);
+    expect(props.messages[1]?.message_metadata?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "text",
+        content: "Complete answer",
+        isStreaming: false,
+      }),
+    ]);
+    expect(props.isStreaming).toBe(false);
+  });
+
+  it("uses the subagent name as the dispatch prompt when the prompt is missing", () => {
+    const sessionId = "parent-session";
+    const subagentSessionId = "child-session";
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      status: "active",
+      isLoaded: true,
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+    useBuildSessionStore
+      .getState()
+      .seedSubagentMeta(
+        sessionId,
+        subagentSessionId,
+        "task-call",
+        "task",
+        "Build Snake arcade game",
+        ""
+      );
+    useBuildSessionStore
+      .getState()
+      .appendSubagentResponseChunk(sessionId, subagentSessionId, "Live body.");
+
+    render(<SubagentView subagentSessionId={subagentSessionId} />);
+
+    const props = mockBuildMessageList.mock.calls[0]![0];
+    expect(props.messages).toEqual([
+      expect.objectContaining({
+        type: "user",
+        content: "Build Snake arcade game",
+      }),
+    ]);
+    expect(props.streamItems).toEqual([
+      expect.objectContaining({
+        type: "text",
+        content: "Live body.",
+      }),
+    ]);
+  });
+
+  it("keeps the task name visible when the stored prompt is longer", () => {
+    const sessionId = "parent-session";
+    const subagentSessionId = "child-session";
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      status: "active",
+      isLoaded: true,
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+    useBuildSessionStore
+      .getState()
+      .seedSubagentMeta(
+        sessionId,
+        subagentSessionId,
+        "task-call",
+        "task",
+        "Build Snake arcade game",
+        "You are building ONE retro arcade game as a single React component."
+      );
+    useBuildSessionStore
+      .getState()
+      .appendSubagentResponseChunk(sessionId, subagentSessionId, "Live body.");
+
+    render(<SubagentView subagentSessionId={subagentSessionId} />);
+
+    const props = mockBuildMessageList.mock.calls[0]![0];
+    expect(props.messages[0]).toMatchObject({
+      type: "user",
+      content:
+        "Build Snake arcade game\n\nYou are building ONE retro arcade game as a single React component.",
+    });
+  });
+});

--- a/web/src/app/craft/components/SubagentView.tsx
+++ b/web/src/app/craft/components/SubagentView.tsx
@@ -5,6 +5,10 @@ import { Text } from "@opal/components";
 import { useSubagent } from "@/app/craft/hooks/useBuildSessionStore";
 import BuildMessageList from "@/app/craft/components/BuildMessageList";
 import type { BuildMessage } from "@/app/craft/types/streamingTypes";
+import type {
+  SubagentState,
+  SubagentTurn,
+} from "@/app/craft/types/displayTypes";
 import type { StreamItem } from "@/app/craft/types/displayTypes";
 
 interface SubagentViewProps {
@@ -23,35 +27,34 @@ export default function SubagentView({ subagentSessionId }: SubagentViewProps) {
   // Static transcript (autoScroll off) — ref only satisfies the prop contract.
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  const messages = useMemo<BuildMessage[]>(() => {
-    if (!subagent) return [];
+  const { messages, activeStreamItems } = useMemo<{
+    messages: BuildMessage[];
+    activeStreamItems: StreamItem[];
+  }>(() => {
+    if (!subagent) return { messages: [], activeStreamItems: [] };
     const out: BuildMessage[] = [];
+    let activeItems: StreamItem[] = [];
     subagent.turns.forEach((turn, i) => {
-      if (turn.prompt) {
+      const prompt = promptForTurn(subagent, turn, i);
+      if (prompt) {
         out.push({
           id: `${subagentSessionId}-u${i}`,
           type: "user",
-          content: turn.prompt,
+          content: prompt,
           timestamp: new Date(),
         });
       }
-      const streamItems: StreamItem[] = [
-        ...turn.toolCalls.map((tc) => ({
-          type: "tool_call" as const,
-          id: tc.id,
-          toolCall: tc,
-        })),
-        ...(turn.response !== null
-          ? [
-              {
-                type: "text" as const,
-                id: `${subagentSessionId}-r${i}`,
-                content: turn.response,
-                isStreaming: false,
-              },
-            ]
-          : []),
-      ];
+      const isActiveTurn = isRunningActiveTurn(subagent, i);
+      const streamItems = turnToStreamItems(
+        turn,
+        subagentSessionId,
+        i,
+        isActiveTurn
+      );
+      if (isActiveTurn) {
+        activeItems = streamItems;
+        return;
+      }
       out.push({
         id: `${subagentSessionId}-a${i}`,
         type: "assistant",
@@ -60,7 +63,7 @@ export default function SubagentView({ subagentSessionId }: SubagentViewProps) {
         message_metadata: { streamItems },
       });
     });
-    return out;
+    return { messages: out, activeStreamItems: activeItems };
   }, [subagent, subagentSessionId]);
 
   if (!subagent) {
@@ -76,10 +79,64 @@ export default function SubagentView({ subagentSessionId }: SubagentViewProps) {
   return (
     <BuildMessageList
       messages={messages}
-      streamItems={[]}
-      isStreaming={false}
-      autoScrollEnabled={false}
+      streamItems={activeStreamItems}
+      isStreaming={subagent.status === "running"}
+      autoScrollEnabled={subagent.status === "running"}
       scrollContainerRef={scrollRef}
     />
   );
+}
+
+function promptForTurn(
+  subagent: SubagentState,
+  turn: SubagentTurn,
+  index: number
+): string {
+  const name = index === 0 ? subagent.name : "";
+  if (!turn.prompt) return name;
+  if (!name || turn.prompt.includes(name)) return turn.prompt;
+  return `${name}\n\n${turn.prompt}`;
+}
+
+function isRunningActiveTurn(subagent: SubagentState, index: number): boolean {
+  return subagent.status === "running" && index === subagent.turns.length - 1;
+}
+
+function turnToStreamItems(
+  turn: SubagentTurn,
+  subagentSessionId: string,
+  turnIndex: number,
+  isActiveTurn: boolean
+): StreamItem[] {
+  if (turn.streamItems.length > 0) {
+    return turn.streamItems;
+  }
+
+  return [
+    ...(turn.thinking !== null
+      ? [
+          {
+            type: "thinking" as const,
+            id: `${subagentSessionId}-t${turnIndex}`,
+            content: turn.thinking,
+            isStreaming: isActiveTurn,
+          },
+        ]
+      : []),
+    ...turn.toolCalls.map((tc) => ({
+      type: "tool_call" as const,
+      id: tc.id,
+      toolCall: tc,
+    })),
+    ...(turn.response !== null
+      ? [
+          {
+            type: "text" as const,
+            id: `${subagentSessionId}-r${turnIndex}`,
+            content: turn.response,
+            isStreaming: isActiveTurn,
+          },
+        ]
+      : []),
+  ];
 }

--- a/web/src/app/craft/hooks/loadSessionRestore.test.ts
+++ b/web/src/app/craft/hooks/loadSessionRestore.test.ts
@@ -42,6 +42,7 @@ describe("loadSession restore status", () => {
       currentSessionId: null,
     } as never);
     mockedApi.fetchMessages.mockResolvedValue([] as never);
+    mockedApi.fetchActiveTurn.mockResolvedValue(null as never);
     mockedApi.fetchArtifacts.mockResolvedValue([] as never);
     // Default: webapp already serving, so the readiness gate is a no-op.
     mockedApi.fetchWebappInfo.mockResolvedValue(
@@ -146,9 +147,223 @@ describe("loadSession restore status", () => {
       },
     ]);
   });
+
+  it("keeps child-routed text and thinking out of the parent transcript", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+    mockedApi.fetchMessages.mockResolvedValue([
+      {
+        id: "user-1",
+        type: "user",
+        content: "Build a dashboard",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "user_message",
+          content: { type: "text", text: "Build a dashboard" },
+        },
+      },
+      {
+        id: "child-thought-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_thought",
+          content: { type: "text", text: "Child thinking." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: SESSION_ID,
+          },
+        },
+      },
+      {
+        id: "child-answer-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_message",
+          content: { type: "text", text: "Child answer." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: SESSION_ID,
+          },
+        },
+      },
+    ] as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.messages).toEqual([
+      expect.objectContaining({ id: "user-1", type: "user" }),
+    ]);
+    expect(session?.subagents.get("child-session-1")?.turns[0]).toMatchObject({
+      thinking: "Child thinking.",
+      response: "Child answer.",
+      streamItems: [
+        expect.objectContaining({
+          type: "thinking",
+          content: "Child thinking.",
+          isStreaming: false,
+        }),
+        expect.objectContaining({
+          type: "text",
+          content: "Child answer.",
+          isStreaming: false,
+        }),
+      ],
+    });
+  });
+
+  it("restores subagent prompt and logs when parent task output carries the child id", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+    mockedApi.fetchMessages.mockResolvedValue([
+      {
+        id: "user-1",
+        type: "user",
+        content: "Build a game",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "user_message",
+          content: { type: "text", text: "Build a game" },
+        },
+      },
+      {
+        id: "child-thought-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_thought",
+          content: { type: "text", text: "Child thinking." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: SESSION_ID,
+          },
+        },
+      },
+      {
+        id: "child-answer-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "agent_message",
+          content: { type: "text", text: "Child answer." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: SESSION_ID,
+          },
+        },
+      },
+      {
+        id: "task-progress-1",
+        type: "assistant",
+        content: "",
+        timestamp: new Date(),
+        message_metadata: {
+          type: "tool_call_progress",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          status: "completed",
+          raw_input: {
+            description: "Build Space Invaders game",
+            prompt:
+              "You are building ONE retro arcade game as a single React component.",
+          },
+          raw_output: {
+            output:
+              "task_id: child-session-1 (for resuming to continue this task if needed)\n\n<task_result>Child answer.</task_result>",
+          },
+        },
+      },
+    ] as never);
+
+    await useBuildSessionStore.getState().loadSession(SESSION_ID);
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.subagents.get("child-session-1")).toMatchObject({
+      parentToolCallId: "task-call-1",
+      name: "Build Space Invaders game",
+      status: "done",
+      turns: [
+        expect.objectContaining({
+          prompt:
+            "You are building ONE retro arcade game as a single React component.",
+          thinking: "Child thinking.",
+          response: "Child answer.",
+          streamItems: [
+            expect.objectContaining({ type: "thinking" }),
+            expect.objectContaining({ type: "text", content: "Child answer." }),
+          ],
+        }),
+      ],
+    });
+
+    const assistant = session?.messages.find(
+      (message) => message.type === "assistant"
+    );
+    expect(assistant?.message_metadata?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        id: "task-call-1",
+      }),
+    ]);
+  });
+
+  it("preserves live turn metadata when active turn lookup fails", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+    mockedApi.fetchActiveTurn.mockRejectedValue(
+      new Error("turn endpoint unavailable")
+    );
+    useBuildSessionStore.getState().createSession(SESSION_ID, {
+      status: "running",
+      messages: [
+        {
+          id: "local-user",
+          type: "user",
+          content: "hello",
+          timestamp: new Date(),
+        },
+      ],
+      activeTurnId: "turn-live",
+      activeTurnLocalOwner: false,
+      isLoaded: false,
+    });
+
+    await useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.status).toBe("running");
+    expect(session?.activeTurnId).toBe("turn-live");
+    expect(session?.activeTurnLocalOwner).toBe(false);
+  });
+
+  it("clears stale turn metadata when active turn lookup says no turn is running", async () => {
+    mockedApi.fetchSession.mockResolvedValue(runningSession() as never);
+    mockedApi.fetchActiveTurn.mockResolvedValue(null as never);
+    useBuildSessionStore.getState().createSession(SESSION_ID, {
+      status: "running",
+      activeTurnId: "turn-stale",
+      activeTurnLocalOwner: false,
+      isLoaded: false,
+    });
+
+    await useBuildSessionStore
+      .getState()
+      .loadSession(SESSION_ID, { force: true });
+
+    const session = useBuildSessionStore.getState().sessions.get(SESSION_ID);
+    expect(session?.status).toBe("active");
+    expect(session?.activeTurnId).toBeNull();
+    expect(session?.activeTurnLocalOwner).toBe(false);
+  });
 });
 
 describe("waitForWebappReady", () => {
+  beforeEach(() => jest.clearAllMocks());
   afterEach(() => jest.clearAllMocks());
 
   it("returns immediately when the session has no webapp", async () => {

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -40,6 +40,7 @@ import {
   updateSessionName,
   deleteSession as apiDeleteSession,
   fetchMessages,
+  fetchActiveTurn,
   fetchArtifacts,
   fetchWebappInfo,
   restoreSession,
@@ -86,6 +87,9 @@ function convertMessagesToStreamItems(messages: BuildMessage[]): StreamItem[] {
 
     switch (packet.type) {
       case "text_chunk":
+        if (packet.sessionId && packet.parentSessionId) {
+          break;
+        }
         if (packet.text) {
           items.push({
             type: "text",
@@ -97,6 +101,9 @@ function convertMessagesToStreamItems(messages: BuildMessage[]): StreamItem[] {
         break;
 
       case "thinking_chunk":
+        if (packet.sessionId && packet.parentSessionId) {
+          break;
+        }
         if (packet.text) {
           items.push({
             type: "thinking",
@@ -188,7 +195,95 @@ function convertMessagesToStreamItems(messages: BuildMessage[]): StreamItem[] {
  * them, so identifying fields are backfilled without clobbering known values.
  */
 function emptyTurn(prompt = ""): SubagentTurn {
-  return { prompt, toolCalls: [], response: null };
+  return {
+    prompt,
+    toolCalls: [],
+    thinking: null,
+    response: null,
+    streamItems: [],
+  };
+}
+
+function isPlaceholderSubagentLabel(value: string): boolean {
+  return value.trim() === "Spawning subagent";
+}
+
+function settleStreamItems(items: StreamItem[]): StreamItem[] {
+  return items.map((item) =>
+    item.type === "text" || item.type === "thinking"
+      ? { ...item, isStreaming: false }
+      : item
+  );
+}
+
+function upsertToolStreamItem(
+  items: StreamItem[],
+  toolCall: ToolCallState
+): StreamItem[] {
+  const idx = items.findIndex(
+    (item) => item.type === "tool_call" && item.id === toolCall.id
+  );
+  if (idx >= 0) {
+    return items.map((item, i) =>
+      i === idx ? { type: "tool_call", id: toolCall.id, toolCall } : item
+    );
+  }
+  return [...items, { type: "tool_call", id: toolCall.id, toolCall }];
+}
+
+function appendStreamingSubagentChunk(
+  items: StreamItem[],
+  type: "text" | "thinking",
+  text: string
+): StreamItem[] {
+  const last = items[items.length - 1];
+  if (last?.type === type) {
+    return items.map((item, i) =>
+      i === items.length - 1
+        ? { ...last, content: last.content + text, isStreaming: true }
+        : item.type === "text" || item.type === "thinking"
+          ? { ...item, isStreaming: false }
+          : item
+    );
+  }
+  return [
+    ...settleStreamItems(items),
+    {
+      type,
+      id: genId(type),
+      content: text,
+      isStreaming: true,
+    },
+  ];
+}
+
+function replaceOrAppendSettledTextItem(
+  items: StreamItem[],
+  text: string | null
+): StreamItem[] {
+  const settled = settleStreamItems(items);
+  if (!text) {
+    return settled;
+  }
+
+  let lastTextIndex = -1;
+  settled.forEach((item, index) => {
+    if (item.type === "text") {
+      lastTextIndex = index;
+    }
+  });
+
+  if (lastTextIndex === -1) {
+    return settleStreamItems(
+      appendStreamingSubagentChunk(settled, "text", text)
+    );
+  }
+
+  return settled.map((item, index) =>
+    index === lastTextIndex && item.type === "text"
+      ? { ...item, content: text, isStreaming: false }
+      : item
+  );
 }
 
 function buildSubagentsFromMessages(
@@ -225,7 +320,11 @@ function buildSubagentsFromMessages(
       idx >= 0
         ? last.toolCalls.map((tc, i) => (i === idx ? toolCall : tc))
         : [...last.toolCalls, toolCall];
-    turns[turns.length - 1] = { ...last, toolCalls };
+    turns[turns.length - 1] = {
+      ...last,
+      toolCalls,
+      streamItems: upsertToolStreamItem(last.streamItems, toolCall),
+    };
     return turns;
   }
 
@@ -239,21 +338,37 @@ function buildSubagentsFromMessages(
     // Best-effort follow-up response reconstruction: a child agent_message
     // (tagged with _meta.parentSessionId) carries a follow-up turn's response.
     // Follow-up turns do not persist their prompt, so this is the only signal.
-    if (packet.type === "text_chunk") {
-      const meta = (metadata as Record<string, unknown>)._meta as
-        | Record<string, unknown>
-        | undefined;
-      const childSessionId = meta?.sessionId as string | undefined;
-      const parentSessionId = meta?.parentSessionId as string | undefined;
-      if (childSessionId && parentSessionId && packet.text) {
-        const sa = ensure(childSessionId);
+    if (packet.type === "text_chunk" || packet.type === "thinking_chunk") {
+      if (packet.sessionId && packet.parentSessionId && packet.text) {
+        const sa = ensure(packet.sessionId);
         const turns = sa.turns.length > 0 ? [...sa.turns] : [emptyTurn()];
         const last = turns[turns.length - 1] ?? emptyTurn();
-        turns[turns.length - 1] = {
-          ...last,
-          response: (last.response ?? "") + packet.text,
-        };
-        subagents.set(childSessionId, { ...sa, turns });
+        if (packet.type === "text_chunk") {
+          turns[turns.length - 1] = {
+            ...last,
+            response: (last.response ?? "") + packet.text,
+            streamItems: settleStreamItems(
+              appendStreamingSubagentChunk(
+                last.streamItems,
+                "text",
+                packet.text
+              )
+            ),
+          };
+        } else {
+          turns[turns.length - 1] = {
+            ...last,
+            thinking: (last.thinking ?? "") + packet.text,
+            streamItems: settleStreamItems(
+              appendStreamingSubagentChunk(
+                last.streamItems,
+                "thinking",
+                packet.text
+              )
+            ),
+          };
+        }
+        subagents.set(packet.sessionId, { ...sa, turns });
       }
       continue;
     }
@@ -288,6 +403,10 @@ function buildSubagentsFromMessages(
         ...firstTurn,
         prompt: firstTurn.prompt || packet.command,
         response,
+        streamItems: replaceOrAppendSettledTextItem(
+          firstTurn.streamItems,
+          response
+        ),
       };
       subagents.set(cls.subagentSessionId, {
         ...sa,
@@ -320,52 +439,42 @@ function consolidateMessagesIntoTurns(
   const consolidated: BuildMessage[] = [];
   let currentAgentPackets: BuildMessage[] = [];
 
+  function flushCurrentAgentPackets() {
+    if (currentAgentPackets.length === 0) return;
+
+    const streamItems = convertMessagesToStreamItems(currentAgentPackets);
+    const textContent = streamItems
+      .filter((item) => item.type === "text")
+      .map((item) => item.content)
+      .join("");
+
+    if (streamItems.length > 0 || textContent) {
+      consolidated.push({
+        id: currentAgentPackets[0]?.id || genId("agent-msg"),
+        type: "assistant",
+        content: textContent,
+        timestamp: currentAgentPackets[0]?.timestamp || new Date(),
+        turn_index: currentAgentPackets[0]?.turn_index,
+        message_metadata: {
+          streamItems,
+        },
+      });
+    }
+    currentAgentPackets = [];
+  }
+
   for (const message of rawMessages) {
     if (message.type === "user") {
       // If we have accumulated agent packets, consolidate them into one message
-      if (currentAgentPackets.length > 0) {
-        const streamItems = convertMessagesToStreamItems(currentAgentPackets);
-        const textContent = streamItems
-          .filter((item) => item.type === "text")
-          .map((item) => item.content)
-          .join("");
-
-        consolidated.push({
-          id: currentAgentPackets[0]?.id || genId("agent-msg"),
-          type: "assistant",
-          content: textContent,
-          timestamp: currentAgentPackets[0]?.timestamp || new Date(),
-          message_metadata: {
-            streamItems,
-          },
-        });
-        currentAgentPackets = [];
-      }
+      flushCurrentAgentPackets();
       // Add the user message as-is
       consolidated.push(message);
     } else if (message.type === "assistant") {
       // Check if this message already has consolidated streamItems (from new format)
       if (message.message_metadata?.streamItems) {
         // Already consolidated, add as-is
-        if (currentAgentPackets.length > 0) {
-          // Flush any pending packets first
-          const streamItems = convertMessagesToStreamItems(currentAgentPackets);
-          const textContent = streamItems
-            .filter((item) => item.type === "text")
-            .map((item) => item.content)
-            .join("");
-
-          consolidated.push({
-            id: currentAgentPackets[0]?.id || genId("agent-msg"),
-            type: "assistant",
-            content: textContent,
-            timestamp: currentAgentPackets[0]?.timestamp || new Date(),
-            message_metadata: {
-              streamItems,
-            },
-          });
-          currentAgentPackets = [];
-        }
+        // Flush any pending packets first
+        flushCurrentAgentPackets();
         consolidated.push(message);
       } else {
         // Old format - accumulate for consolidation
@@ -375,25 +484,37 @@ function consolidateMessagesIntoTurns(
   }
 
   // Don't forget any trailing agent packets
-  if (currentAgentPackets.length > 0) {
-    const streamItems = convertMessagesToStreamItems(currentAgentPackets);
-    const textContent = streamItems
-      .filter((item) => item.type === "text")
-      .map((item) => item.content)
-      .join("");
-
-    consolidated.push({
-      id: currentAgentPackets[0]?.id || genId("agent-msg"),
-      type: "assistant",
-      content: textContent,
-      timestamp: currentAgentPackets[0]?.timestamp || new Date(),
-      message_metadata: {
-        streamItems,
-      },
-    });
-  }
+  flushCurrentAgentPackets();
 
   return consolidated;
+}
+
+function splitActiveTurnTranscript(
+  messages: BuildMessage[],
+  activeTurnIndex: number | null
+): { messages: BuildMessage[]; streamItems: StreamItem[] } {
+  if (activeTurnIndex === null) {
+    return { messages, streamItems: [] };
+  }
+
+  const activeStreamItems: StreamItem[] = [];
+  const settledMessages: BuildMessage[] = [];
+
+  for (const message of messages) {
+    if (
+      message.type === "assistant" &&
+      message.turn_index === activeTurnIndex
+    ) {
+      const streamItems = message.message_metadata?.streamItems;
+      if (Array.isArray(streamItems)) {
+        activeStreamItems.push(...(streamItems as StreamItem[]));
+      }
+      continue;
+    }
+    settledMessages.push(message);
+  }
+
+  return { messages: settledMessages, streamItems: activeStreamItems };
 }
 
 // Re-export types for consumers
@@ -460,6 +581,12 @@ export interface BuildSessionData {
   artifacts: Artifact[];
   /** Active tool calls for the current response */
   toolCalls: ToolCall[];
+  /** Active backend turn, if this session is currently running. */
+  activeTurnId: string | null;
+  /** The user-message turn index for the active backend turn. */
+  activeTurnIndex: number | null;
+  /** True when this tab created the active turn and already owns its stream. */
+  activeTurnLocalOwner: boolean;
   /**
    * FIFO stream items for the current agent turn.
    * Items are stored in chronological order as they arrive.
@@ -612,7 +739,10 @@ interface BuildSessionStore {
 
   // Actions - Session Lifecycle
   createNewSession: (prompt: string) => Promise<string | null>;
-  loadSession: (sessionId: string) => Promise<void>;
+  loadSession: (
+    sessionId: string,
+    options?: { force?: boolean }
+  ) => Promise<void>;
 
   // Actions - Session History
   refreshSessionHistory: () => Promise<void>;
@@ -703,6 +833,12 @@ interface BuildSessionStore {
     subagentSessionId: string,
     text: string
   ) => void;
+  /** Append streamed thinking text to the LAST turn's thinking stream. */
+  appendSubagentThinkingChunk: (
+    sessionId: string,
+    subagentSessionId: string,
+    text: string
+  ) => void;
 
   // Tab Navigation History Actions
   navigateTabBack: (sessionId: string) => void;
@@ -722,6 +858,9 @@ const createInitialSessionData = (
   messages: [],
   artifacts: [],
   toolCalls: [],
+  activeTurnId: null,
+  activeTurnIndex: null,
+  activeTurnLocalOwner: false,
   streamItems: [],
   queuedMessages: [],
   isInterrupting: false,
@@ -1473,12 +1612,12 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
     }
   },
 
-  loadSession: async (sessionId: string) => {
+  loadSession: async (sessionId: string, options?: { force?: boolean }) => {
     const { setCurrentSession, updateSessionData, sessions } = get();
 
     // Check if already loaded in cache
     const existingSession = sessions.get(sessionId);
-    if (existingSession?.isLoaded) {
+    if (existingSession?.isLoaded && options?.force !== true) {
       setCurrentSession(sessionId);
       return;
     }
@@ -1512,14 +1651,22 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       // Messages come from DB and don't need the sandbox running.
       // Artifacts need sandbox filesystem, so skip during restore.
       const messages = await fetchMessages(sessionId);
+      let activeTurn: Awaited<ReturnType<typeof fetchActiveTurn>> = null;
+      try {
+        activeTurn = await fetchActiveTurn(sessionId);
+      } catch (err) {
+        console.warn("Failed to fetch active turn:", err);
+      }
       const artifacts = needsRestore ? [] : await fetchArtifacts(sessionId);
 
       // Preserve optimistic messages if actively streaming (pre-provisioned flow).
       const currentSession = get().sessions.get(sessionId);
-      const isStreaming =
-        (currentSession?.messages?.length ?? 0) > 0 &&
-        (currentSession?.status === "running" ||
-          currentSession?.status === "creating");
+      const currentSessionIsLive =
+        currentSession?.status === "running" ||
+        currentSession?.status === "creating";
+      const hasOptimisticMessages =
+        (currentSession?.messages?.length ?? 0) > 0 && currentSessionIsLive;
+      const isStreaming = hasOptimisticMessages;
 
       // Construct webapp URL
       let webappUrl: string | null = null;
@@ -1530,17 +1677,33 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         webappUrl = `http://localhost:${sessionData.sandbox.nextjs_port}`;
       }
 
+      const resolvedActiveTurnId =
+        activeTurn?.turn_id ??
+        (isStreaming ? currentSession!.activeTurnId : null);
+      const resolvedActiveTurnIndex =
+        activeTurn?.turn_index ??
+        (isStreaming ? currentSession!.activeTurnIndex : null);
+
       const status = isStreaming
         ? currentSession!.status
-        : needsRestore
-          ? "creating"
-          : sessionData.status === "active"
-            ? "active"
-            : "idle";
-      const resolvedMessages = isStreaming
+        : activeTurn
+          ? "running"
+          : needsRestore
+            ? "creating"
+            : sessionData.status === "active"
+              ? "active"
+              : "idle";
+      const persistedMessages = isStreaming
         ? currentSession!.messages
         : consolidateMessagesIntoTurns(messages);
-      const streamItems = isStreaming ? currentSession!.streamItems : [];
+      const restoredActiveTurn = isStreaming
+        ? {
+            messages: persistedMessages,
+            streamItems: currentSession!.streamItems,
+          }
+        : splitActiveTurnTranscript(persistedMessages, resolvedActiveTurnIndex);
+      const resolvedMessages = restoredActiveTurn.messages;
+      const streamItems = restoredActiveTurn.streamItems;
       // Reconstruct subagents from the raw (un-consolidated) messages — they
       // carry the per-packet _meta needed for classification. Preserve the
       // live map if actively streaming.
@@ -1562,6 +1725,11 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         sandbox,
         agentProvider: sessionData.agent_provider,
         agentModel: sessionData.agent_model,
+        activeTurnId: resolvedActiveTurnId,
+        activeTurnIndex: resolvedActiveTurnIndex,
+        activeTurnLocalOwner: isStreaming
+          ? currentSession!.activeTurnLocalOwner
+          : false,
         error: null,
         isLoaded: true,
       });
@@ -2252,7 +2420,14 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         tcIndex >= 0
           ? last.toolCalls.map((tc, i) => (i === tcIndex ? toolCall : tc))
           : [...last.toolCalls, toolCall];
-      turns[turns.length - 1] = { ...last, toolCalls };
+      turns[turns.length - 1] = {
+        ...last,
+        toolCalls,
+        streamItems: upsertToolStreamItem(
+          settleStreamItems(last.streamItems),
+          toolCall
+        ),
+      };
 
       const updatedSubagent: SubagentState = {
         ...base,
@@ -2301,18 +2476,28 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
         completedAt: null,
       };
 
-      // Ensure turns[0] exists; backfill its prompt without clobbering a
-      // non-empty existing prompt.
+      // Ensure turns[0] exists; backfill its prompt without clobbering real
+      // known prompts. The early task start can only say "Spawning subagent";
+      // replace that placeholder when later task progress carries the prompt.
       const turns = base.turns.length > 0 ? [...base.turns] : [emptyTurn()];
       const firstTurn = turns[0] ?? emptyTurn();
-      turns[0] = { ...firstTurn, prompt: firstTurn.prompt || prompt };
+      turns[0] = {
+        ...firstTurn,
+        prompt:
+          !firstTurn.prompt || isPlaceholderSubagentLabel(firstTurn.prompt)
+            ? prompt
+            : firstTurn.prompt,
+      };
 
       const updatedSubagent: SubagentState = {
         ...base,
-        // Seed/backfill identifying fields; never clobber known values.
+        // Seed/backfill identifying fields; never clobber real known values.
         parentToolCallId: base.parentToolCallId || parentToolCallId,
         subagentType: base.subagentType ?? subagentType,
-        name: base.name || name,
+        name:
+          !base.name || isPlaceholderSubagentLabel(base.name)
+            ? name
+            : base.name,
         turns,
       };
 
@@ -2348,7 +2533,19 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       if (response !== undefined) {
         turns = existing.turns.length > 0 ? [...existing.turns] : [emptyTurn()];
         const last = turns[turns.length - 1] ?? emptyTurn();
-        turns[turns.length - 1] = { ...last, response };
+        turns[turns.length - 1] = {
+          ...last,
+          response,
+          streamItems: replaceOrAppendSettledTextItem(
+            last.streamItems,
+            response
+          ),
+        };
+      } else {
+        turns = existing.turns.map((turn) => ({
+          ...turn,
+          streamItems: settleStreamItems(turn.streamItems),
+        }));
       }
 
       const subagents = new Map(session.subagents);
@@ -2380,18 +2577,78 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       if (!session) return state;
 
       const existing = session.subagents.get(subagentSessionId);
-      if (!existing) return state;
+      const base: SubagentState = existing ?? {
+        sessionId: subagentSessionId,
+        parentToolCallId: "",
+        subagentType: null,
+        name: "",
+        status: "running",
+        turns: [emptyTurn()],
+        startedAt: Date.now(),
+        completedAt: null,
+      };
 
-      const turns =
-        existing.turns.length > 0 ? [...existing.turns] : [emptyTurn()];
+      const turns = base.turns.length > 0 ? [...base.turns] : [emptyTurn()];
       const last = turns[turns.length - 1] ?? emptyTurn();
       turns[turns.length - 1] = {
         ...last,
         response: (last.response ?? "") + text,
+        streamItems: appendStreamingSubagentChunk(
+          last.streamItems,
+          "text",
+          text
+        ),
       };
 
       const subagents = new Map(session.subagents);
-      subagents.set(subagentSessionId, { ...existing, turns });
+      subagents.set(subagentSessionId, { ...base, turns });
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        subagents,
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  appendSubagentThinkingChunk: (
+    sessionId: string,
+    subagentSessionId: string,
+    text: string
+  ) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const existing = session.subagents.get(subagentSessionId);
+      const base: SubagentState = existing ?? {
+        sessionId: subagentSessionId,
+        parentToolCallId: "",
+        subagentType: null,
+        name: "",
+        status: "running",
+        turns: [emptyTurn()],
+        startedAt: Date.now(),
+        completedAt: null,
+      };
+
+      const turns = base.turns.length > 0 ? [...base.turns] : [emptyTurn()];
+      const last = turns[turns.length - 1] ?? emptyTurn();
+      turns[turns.length - 1] = {
+        ...last,
+        thinking: (last.thinking ?? "") + text,
+        streamItems: appendStreamingSubagentChunk(
+          last.streamItems,
+          "thinking",
+          text
+        ),
+      };
+
+      const subagents = new Map(session.subagents);
+      subagents.set(subagentSessionId, { ...base, turns });
 
       const updatedSession: BuildSessionData = {
         ...session,

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -4,8 +4,13 @@ import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
 import { useBuildStreaming } from "@/app/craft/hooks/useBuildStreaming";
 import type { StreamItem } from "@/app/craft/types/displayTypes";
 import {
+  createTurn,
+  fetchActiveTurn,
+  fetchArtifacts,
+  fetchMessages,
+  fetchSession,
+  fetchTurnEventStream,
   processSSEStream,
-  sendMessageStream,
 } from "@/app/craft/services/apiServices";
 
 jest.mock("swr", () => ({
@@ -14,14 +19,19 @@ jest.mock("swr", () => ({
 
 jest.mock("@/app/craft/services/apiServices", () => ({
   RateLimitError: class RateLimitError extends Error {},
+  createTurn: jest.fn(),
+  fetchActiveTurn: jest.fn(),
+  fetchArtifacts: jest.fn(),
+  fetchMessages: jest.fn(),
   fetchScheduledRunEventStream: jest.fn(),
   fetchSession: jest.fn(),
+  fetchTurnEventStream: jest.fn(),
   interruptMessageStream: jest.fn(),
   processSSEStream: jest.fn(),
-  sendMessageStream: jest.fn(),
 }));
 
 const sessionId = "session-thinking";
+const originalLoadSession = useBuildSessionStore.getState().loadSession;
 
 describe("useBuildStreaming thinking packets", () => {
   beforeEach(() => {
@@ -29,13 +39,20 @@ describe("useBuildStreaming thinking packets", () => {
     useBuildSessionStore.setState({
       currentSessionId: null,
       sessions: new Map(),
+      loadSession: jest.fn().mockResolvedValue(undefined),
     } as never);
     useBuildSessionStore.getState().createSession(sessionId, {
       status: "active",
       isLoaded: true,
     });
 
-    jest.mocked(sendMessageStream).mockResolvedValue({} as Response);
+    jest.mocked(createTurn).mockResolvedValue({
+      session_id: sessionId,
+      turn_id: "turn-thinking",
+      status: "QUEUED",
+      turn_index: 0,
+    });
+    jest.mocked(fetchTurnEventStream).mockResolvedValue({} as Response);
     jest
       .mocked(processSSEStream)
       .mockImplementation(async (_response, onPacket) => {
@@ -63,6 +80,9 @@ describe("useBuildStreaming thinking packets", () => {
     act(() => {
       jest.runOnlyPendingTimers();
     });
+    useBuildSessionStore.setState({
+      loadSession: originalLoadSession,
+    } as never);
     jest.useRealTimers();
   });
 
@@ -86,6 +106,467 @@ describe("useBuildStreaming thinking packets", () => {
     expect(streamItems[1]).toMatchObject({
       type: "tool_call",
       id: "tool-read",
+    });
+  });
+
+  it("seeds clickable subagent metadata from a task start packet", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "other",
+          title: "Task",
+          raw_input: {
+            prompt: "Inspect the repository",
+            subagent_type: "explore",
+          },
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "task",
+            subagentSessionId: "child-session-1",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.subagents.get("child-session-1")).toMatchObject({
+      sessionId: "child-session-1",
+      parentToolCallId: "task-call-1",
+      name: "Inspect the repository",
+      status: "running",
+      turns: [expect.objectContaining({ prompt: "Inspect the repository" })],
+    });
+    expect(session?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        id: "task-call-1",
+        toolCall: expect.objectContaining({
+          command: "Inspect the repository",
+          description: "Spawning subagent: Inspect the repository",
+        }),
+      }),
+    ]);
+  });
+
+  it("links a visible running task row from a subagent_started packet", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          title: "Task",
+          raw_input: {
+            prompt: "Build Space Invaders game",
+          },
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "unknown",
+          },
+        } as never);
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          status: "in_progress",
+          raw_input: {
+            prompt: "Build Space Invaders game",
+            description: "Build Space Invaders game",
+          },
+          raw_output: null,
+          _meta: {
+            toolName: "task",
+          },
+        } as never);
+        onPacket({
+          type: "subagent_started",
+          subagent_session_id: "child-session-1",
+          parent_session_id: "parent-session-1",
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.subagents.get("child-session-1")).toMatchObject({
+      sessionId: "child-session-1",
+      parentToolCallId: "task-call-1",
+      name: "Build Space Invaders game",
+      status: "running",
+      turns: [expect.objectContaining({ prompt: "Build Space Invaders game" })],
+    });
+    expect(session?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        id: "task-call-1",
+        toolCall: expect.objectContaining({
+          status: "in_progress",
+          description: "Spawning subagent: Build Space Invaders game",
+        }),
+      }),
+    ]);
+  });
+
+  it("replaces placeholder subagent metadata when task progress names the child", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "other",
+          title: "Running task",
+          raw_input: null,
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "task",
+          },
+        } as never);
+        onPacket({
+          type: "subagent_started",
+          subagent_session_id: "child-session-1",
+          parent_session_id: "parent-session-1",
+        } as never);
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "task-call-1",
+          kind: "other",
+          status: "in_progress",
+          raw_input: {
+            description: "Live stream smoke subagent",
+            prompt:
+              "Say hello, inspect one small file if available, then report done.",
+            subagent_type: "general",
+          },
+          raw_output: null,
+          _meta: {
+            toolName: "task",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const subagent = useBuildSessionStore
+      .getState()
+      .sessions.get(sessionId)
+      ?.subagents.get("child-session-1");
+
+    expect(subagent).toMatchObject({
+      name: "Live stream smoke subagent",
+      parentToolCallId: "task-call-1",
+      subagentType: "general",
+      turns: [
+        expect.objectContaining({
+          prompt:
+            "Say hello, inspect one small file if available, then report done.",
+        }),
+      ],
+    });
+  });
+
+  it("streams child text and thinking into the active subagent body", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          title: "Task",
+          raw_input: {
+            prompt: "Build Space Invaders game",
+          },
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "task",
+          },
+        } as never);
+        onPacket({
+          type: "subagent_started",
+          subagent_session_id: "child-session-1",
+          parent_session_id: "parent-session-1",
+        } as never);
+        onPacket({
+          type: "agent_thought_chunk",
+          content: { type: "text", text: "Inspecting files." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+        onPacket({
+          type: "agent_message_chunk",
+          content: { type: "text", text: "Built the game." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const subagent = useBuildSessionStore
+      .getState()
+      .sessions.get(sessionId)
+      ?.subagents.get("child-session-1");
+
+    expect(subagent?.turns[0]).toMatchObject({
+      prompt: "Build Space Invaders game",
+      thinking: "Inspecting files.",
+      response: "Built the game.",
+      streamItems: [
+        expect.objectContaining({
+          type: "thinking",
+          content: "Inspecting files.",
+          isStreaming: false,
+        }),
+        expect.objectContaining({
+          type: "text",
+          content: "Built the game.",
+          isStreaming: true,
+        }),
+      ],
+    });
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.streamItems
+    ).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        id: "task-call-1",
+      }),
+    ]);
+  });
+
+  it("does not drop child chunks that arrive before task metadata", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "agent_message_chunk",
+          content: { type: "text", text: "Early child output." },
+          _meta: {
+            sessionId: "child-session-early",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const subagent = useBuildSessionStore
+      .getState()
+      .sessions.get(sessionId)
+      ?.subagents.get("child-session-early");
+
+    expect(subagent).toMatchObject({
+      sessionId: "child-session-early",
+      status: "running",
+      turns: [
+        expect.objectContaining({
+          response: "Early child output.",
+          streamItems: [
+            expect.objectContaining({
+              type: "text",
+              content: "Early child output.",
+              isStreaming: true,
+            }),
+          ],
+        }),
+      ],
+    });
+  });
+
+  it("records child tool starts in the active subagent stream", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          title: "Task",
+          raw_input: {
+            prompt: "Build Space Invaders game",
+          },
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "task",
+          },
+        } as never);
+        onPacket({
+          type: "subagent_started",
+          subagent_session_id: "child-session-1",
+          parent_session_id: "parent-session-1",
+        } as never);
+        onPacket({
+          type: "agent_thought_chunk",
+          content: { type: "text", text: "Checking the app." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+        onPacket({
+          type: "agent_message_chunk",
+          content: { type: "text", text: "First update." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "child-read-1",
+          kind: "read",
+          status: "pending",
+          raw_input: { file_path: "web/src/app/page.tsx" },
+          raw_output: null,
+          _meta: {
+            toolName: "read",
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+        onPacket({
+          type: "agent_message_chunk",
+          content: { type: "text", text: "Done." },
+          _meta: {
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const subagent = useBuildSessionStore
+      .getState()
+      .sessions.get(sessionId)
+      ?.subagents.get("child-session-1");
+
+    expect(subagent?.turns[0]).toMatchObject({
+      prompt: "Build Space Invaders game",
+      toolCalls: [
+        expect.objectContaining({
+          id: "child-read-1",
+          status: "pending",
+          description: "src/app/page.tsx",
+        }),
+      ],
+      streamItems: [
+        expect.objectContaining({
+          type: "thinking",
+          content: "Checking the app.",
+          isStreaming: false,
+        }),
+        expect.objectContaining({
+          type: "text",
+          content: "First update.",
+          isStreaming: false,
+        }),
+        expect.objectContaining({
+          type: "tool_call",
+          id: "child-read-1",
+        }),
+        expect.objectContaining({
+          type: "text",
+          content: "Done.",
+          isStreaming: true,
+        }),
+      ],
+    });
+  });
+
+  it("links child subagent events to an active task row while streaming", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "task-call-1",
+          kind: "task",
+          title: "Task",
+          raw_input: {
+            prompt: "Build Space Invaders game",
+          },
+          raw_output: null,
+          status: "pending",
+          _meta: {
+            toolName: "unknown",
+          },
+        } as never);
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "child-read-1",
+          kind: "read",
+          status: "completed",
+          raw_input: { file_path: "web/src/app/page.tsx" },
+          raw_output: { output: "page contents" },
+          _meta: {
+            toolName: "read",
+            sessionId: "child-session-1",
+            parentSessionId: "parent-session-1",
+          },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.subagents.get("child-session-1")).toMatchObject({
+      sessionId: "child-session-1",
+      parentToolCallId: "task-call-1",
+      status: "running",
+      turns: [
+        expect.objectContaining({
+          toolCalls: [
+            expect.objectContaining({
+              id: "child-read-1",
+              status: "completed",
+            }),
+          ],
+        }),
+      ],
     });
   });
 
@@ -137,5 +618,325 @@ describe("useBuildStreaming thinking packets", () => {
         isStreaming: false,
       }),
     ]);
+  });
+
+  it("keeps active turn metadata when attach transport fails", async () => {
+    jest
+      .mocked(fetchTurnEventStream)
+      .mockRejectedValueOnce(new Error("stream failed"));
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-failed",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session).toMatchObject({
+      status: "running",
+      activeTurnId: "turn-failed",
+      activeTurnLocalOwner: false,
+    });
+    expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
+      sessionId,
+      { force: true }
+    );
+  });
+
+  it("shows in-band turn errors and clears active turn metadata", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "error",
+          message: "provider model not found",
+        });
+      });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-error",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session).toMatchObject({
+      status: "failed",
+      error: "provider model not found",
+      activeTurnId: null,
+      activeTurnLocalOwner: false,
+    });
+    expect(session?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "error",
+        content: "provider model not found",
+      }),
+    ]);
+  });
+
+  it("clears stale turn metadata when the backend says the turn is not running", async () => {
+    jest.mocked(fetchTurnEventStream).mockResolvedValueOnce(null);
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-stale",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session).toMatchObject({
+      status: "active",
+      activeTurnId: null,
+      activeTurnLocalOwner: false,
+    });
+    expect(useBuildSessionStore.getState().loadSession).toHaveBeenCalledWith(
+      sessionId,
+      { force: true }
+    );
+  });
+
+  it("skips duplicate watchers for a locally owned turn", async () => {
+    jest.mocked(fetchTurnEventStream).mockClear();
+    const owner = new AbortController();
+    useBuildSessionStore.getState().updateSessionData(sessionId, {
+      activeTurnId: "turn-owned",
+      activeTurnLocalOwner: true,
+      abortController: owner,
+    });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-owned",
+        new AbortController().signal
+      );
+    });
+
+    expect(fetchTurnEventStream).not.toHaveBeenCalled();
+  });
+
+  it("loads an active turn from persisted packets and reattaches as one assistant turn", async () => {
+    useBuildSessionStore.setState({
+      loadSession: originalLoadSession,
+    } as never);
+    jest.mocked(fetchSession).mockResolvedValue({
+      id: sessionId,
+      status: "active",
+      session_loaded_in_sandbox: true,
+      sandbox: { id: "sandbox-1", status: "running", nextjs_port: null },
+      agent_provider: "openai",
+      agent_model: "gpt-5-mini",
+    } as never);
+    jest
+      .mocked(fetchActiveTurn)
+      .mockResolvedValueOnce({
+        session_id: sessionId,
+        turn_id: "turn-reattach",
+        status: "RUNNING",
+        turn_index: 2,
+      } as never)
+      .mockResolvedValueOnce(null as never);
+    jest.mocked(fetchArtifacts).mockResolvedValue([] as never);
+    const userMessage = {
+      id: "user-1",
+      type: "user",
+      content: "Build the app",
+      timestamp: new Date("2026-01-01T00:00:00Z"),
+      turn_index: 2,
+      message_metadata: {
+        type: "user_message",
+        content: { type: "text", text: "Build the app" },
+      },
+    };
+    const thoughtMessage = {
+      id: "thought-1",
+      type: "assistant",
+      content: "",
+      timestamp: new Date("2026-01-01T00:00:01Z"),
+      turn_index: 2,
+      message_metadata: {
+        type: "agent_thought",
+        content: { type: "text", text: "Inspecting files." },
+      },
+    };
+    const partialAnswerMessage = {
+      id: "answer-1",
+      type: "assistant",
+      content: "",
+      timestamp: new Date("2026-01-01T00:00:02Z"),
+      turn_index: 2,
+      message_metadata: {
+        type: "agent_message",
+        content: { type: "text", text: "Partial" },
+      },
+    };
+    const tailAnswerMessage = {
+      ...partialAnswerMessage,
+      id: "answer-2",
+      timestamp: new Date("2026-01-01T00:00:03Z"),
+      message_metadata: {
+        type: "agent_message",
+        content: { type: "text", text: " answer" },
+      },
+    };
+    jest
+      .mocked(fetchMessages)
+      .mockResolvedValueOnce([
+        userMessage,
+        thoughtMessage,
+        partialAnswerMessage,
+      ] as never)
+      .mockResolvedValueOnce([
+        userMessage,
+        thoughtMessage,
+        partialAnswerMessage,
+        tailAnswerMessage,
+      ] as never);
+
+    await act(async () => {
+      await useBuildSessionStore
+        .getState()
+        .loadSession(sessionId, { force: true });
+    });
+
+    const restoredSession = useBuildSessionStore
+      .getState()
+      .sessions.get(sessionId);
+    expect(restoredSession).toMatchObject({
+      status: "running",
+      activeTurnId: "turn-reattach",
+      activeTurnIndex: 2,
+    });
+    expect(restoredSession?.messages).toEqual([
+      expect.objectContaining({ id: "user-1", type: "user" }),
+    ]);
+    expect(restoredSession?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "thinking",
+        id: "thought-1",
+        content: "Inspecting files.",
+        isStreaming: false,
+      }),
+      expect.objectContaining({
+        type: "text",
+        id: "answer-1",
+        content: "Partial",
+        isStreaming: false,
+      }),
+    ]);
+
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: " answer" },
+          timestamp: "2026-01-01T00:00:01Z",
+        } as never);
+        onPacket({
+          type: "prompt_response",
+          timestamp: "2026-01-01T00:00:02Z",
+        });
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-reattach",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    const assistantMessage = session?.messages.find(
+      (message) => message.type === "assistant"
+    );
+    const assistantMessages =
+      session?.messages.filter((message) => message.type === "assistant") ?? [];
+
+    expect(session?.streamItems).toEqual([]);
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessage).toMatchObject({
+      content: "Partial answer",
+      turn_index: 2,
+    });
+  });
+
+  it("does not clear a newer turn when an older attach emits prompt_response late", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        useBuildSessionStore.getState().updateSessionData(sessionId, {
+          status: "running",
+          activeTurnId: "turn-new",
+          activeTurnLocalOwner: true,
+        });
+        onPacket({
+          type: "prompt_response",
+          timestamp: "2026-01-01T00:00:02Z",
+        });
+      });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-old",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session).toMatchObject({
+      status: "running",
+      activeTurnId: "turn-new",
+      activeTurnLocalOwner: true,
+    });
+  });
+
+  it("does not fail a newer turn when an older attach emits an error late", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        useBuildSessionStore.getState().updateSessionData(sessionId, {
+          status: "running",
+          activeTurnId: "turn-new",
+          activeTurnLocalOwner: true,
+        });
+        onPacket({
+          type: "error",
+          message: "old turn failed",
+        });
+      });
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamTurnEvents(
+        sessionId,
+        "turn-old",
+        new AbortController().signal
+      );
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session).toMatchObject({
+      status: "running",
+      activeTurnId: "turn-new",
+      activeTurnLocalOwner: true,
+      error: null,
+    });
+    expect(session?.streamItems).toEqual([]);
   });
 });

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -10,7 +10,8 @@ import {
 } from "@/app/craft/types/streamingTypes";
 
 import {
-  sendMessageStream,
+  createTurn,
+  fetchTurnEventStream,
   interruptMessageStream,
   processSSEStream,
   fetchSession,
@@ -19,17 +20,64 @@ import {
 } from "@/app/craft/services/apiServices";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
-import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
-import { StreamItem } from "@/app/craft/types/displayTypes";
+import {
+  useBuildSessionStore,
+  type BuildSessionData,
+} from "@/app/craft/hooks/useBuildSessionStore";
+import { StreamItem, ToolCallState } from "@/app/craft/types/displayTypes";
 
 import { genId } from "@/app/craft/utils/streamItemHelpers";
 import { parsePacket } from "@/app/craft/utils/parsePacket";
 import {
   classifySubagentEvent,
   toolCallStateFromProgress,
+  toolCallStateFromStart,
   subagentNameFromTask,
+  subagentNameFromToolCall,
   cleanTaskOutput,
 } from "@/app/craft/utils/subagentRouting";
+
+function promptFromToolCall(toolCall: ToolCallState): string {
+  const prompt = toolCall.command || toolCall.description || "";
+  return prompt.replace(/^Spawning subagent:\s*/, "").trim();
+}
+
+function findParentTaskToolCall(
+  session: BuildSessionData,
+  subagentSessionId: string
+): ToolCallState | null {
+  const streamItems = [
+    ...session.messages.flatMap((message) => {
+      const items = message.message_metadata?.streamItems;
+      return Array.isArray(items) ? (items as StreamItem[]) : [];
+    }),
+    ...session.streamItems,
+  ];
+  const currentParent =
+    session.subagents.get(subagentSessionId)?.parentToolCallId ?? "";
+  if (currentParent) {
+    const parentItem = streamItems.find(
+      (item) => item.type === "tool_call" && item.toolCall.id === currentParent
+    );
+    return parentItem?.type === "tool_call" ? parentItem.toolCall : null;
+  }
+
+  const linkedParentIds = new Set(
+    Array.from(session.subagents.values())
+      .map((subagent) => subagent.parentToolCallId)
+      .filter(Boolean)
+  );
+  for (const item of [...streamItems].reverse()) {
+    if (item.type !== "tool_call") continue;
+    if (item.toolCall.kind !== "task" && item.toolCall.toolName !== "task") {
+      continue;
+    }
+    if (linkedParentIds.has(item.toolCall.id)) continue;
+    return item.toolCall;
+  }
+
+  return null;
+}
 
 /**
  * Hook for handling message streaming in build sessions.
@@ -96,6 +144,12 @@ export function useBuildStreaming() {
   const markSubagentComplete = useBuildSessionStore(
     (state) => state.markSubagentComplete
   );
+  const appendSubagentResponseChunk = useBuildSessionStore(
+    (state) => state.appendSubagentResponseChunk
+  );
+  const appendSubagentThinkingChunk = useBuildSessionStore(
+    (state) => state.appendSubagentThinkingChunk
+  );
 
   // ── Output file detector registry ──────────────────────────────────────
   // Ordered by priority — first match wins.
@@ -129,10 +183,38 @@ export function useBuildStreaming() {
   );
 
   const createStreamPacketProcessor = useCallback(
-    (sessionId: string, options?: { onPromptResponse?: () => void }) => {
+    (
+      sessionId: string,
+      options?: { onPromptResponse?: () => void; expectedTurnId?: string }
+    ) => {
       let accumulatedText = "";
       let accumulatedThinking = "";
       let lastItemType: "text" | "thinking" | "tool" | null = null;
+      const currentItems =
+        useBuildSessionStore.getState().sessions.get(sessionId)?.streamItems ??
+        [];
+      const lastCurrentItem = currentItems[currentItems.length - 1];
+      if (lastCurrentItem?.type === "text") {
+        accumulatedText = lastCurrentItem.content;
+        lastItemType = "text";
+        if (!lastCurrentItem.isStreaming) {
+          useBuildSessionStore
+            .getState()
+            .updateStreamItem(sessionId, lastCurrentItem.id, {
+              isStreaming: true,
+            });
+        }
+      } else if (lastCurrentItem?.type === "thinking") {
+        accumulatedThinking = lastCurrentItem.content;
+        lastItemType = "thinking";
+        if (!lastCurrentItem.isStreaming) {
+          useBuildSessionStore
+            .getState()
+            .updateStreamItem(sessionId, lastCurrentItem.id, {
+              isStreaming: true,
+            });
+        }
+      }
 
       const finalizeStreaming = () => {
         const session = useBuildSessionStore.getState().sessions.get(sessionId);
@@ -153,12 +235,77 @@ export function useBuildStreaming() {
         }
       };
 
+      const appendErrorItem = (message: string) => {
+        const content = message || "Turn failed.";
+        const session = useBuildSessionStore.getState().sessions.get(sessionId);
+        const lastItem = session?.streamItems[session.streamItems.length - 1];
+
+        finalizeStreaming();
+        if (lastItem?.type === "error" && lastItem.content === content) {
+          return;
+        }
+
+        appendStreamItem(sessionId, {
+          type: "error",
+          id: genId("error"),
+          content,
+        });
+      };
+
+      const seedFromParentTask = (subagentSessionId: string): string => {
+        const session = useBuildSessionStore.getState().sessions.get(sessionId);
+        const parentToolCall = session
+          ? findParentTaskToolCall(session, subagentSessionId)
+          : null;
+        const existing = session?.subagents.get(subagentSessionId);
+        const parentToolCallId =
+          parentToolCall?.id ?? existing?.parentToolCallId ?? "";
+
+        if (parentToolCallId || parentToolCall) {
+          seedSubagentMeta(
+            sessionId,
+            subagentSessionId,
+            parentToolCallId,
+            parentToolCall?.subagentType ?? null,
+            parentToolCall ? subagentNameFromToolCall(parentToolCall) : "",
+            parentToolCall ? promptFromToolCall(parentToolCall) : ""
+          );
+        }
+
+        return parentToolCallId;
+      };
+
       return (rawPacket: unknown) => {
         const parsed = parsePacket(rawPacket);
+        if (options?.expectedTurnId && parsed.type !== "approval_requested") {
+          const currentTurnId = useBuildSessionStore
+            .getState()
+            .sessions.get(sessionId)?.activeTurnId;
+          if (currentTurnId !== options.expectedTurnId) {
+            if (parsed.type === "prompt_response") {
+              options.onPromptResponse?.();
+            }
+            return;
+          }
+        }
 
         switch (parsed.type) {
           case "text_chunk": {
             if (!parsed.text) break;
+
+            if (parsed.parentSessionId !== null && parsed.sessionId !== null) {
+              finalizeStreaming();
+              accumulatedText = "";
+              accumulatedThinking = "";
+              lastItemType = null;
+              seedFromParentTask(parsed.sessionId);
+              appendSubagentResponseChunk(
+                sessionId,
+                parsed.sessionId,
+                parsed.text
+              );
+              break;
+            }
 
             accumulatedText += parsed.text;
 
@@ -182,6 +329,20 @@ export function useBuildStreaming() {
           case "thinking_chunk": {
             if (!parsed.text) break;
 
+            if (parsed.parentSessionId !== null && parsed.sessionId !== null) {
+              finalizeStreaming();
+              accumulatedText = "";
+              accumulatedThinking = "";
+              lastItemType = null;
+              seedFromParentTask(parsed.sessionId);
+              appendSubagentThinkingChunk(
+                sessionId,
+                parsed.sessionId,
+                parsed.text
+              );
+              break;
+            }
+
             accumulatedThinking += parsed.text;
 
             if (lastItemType === "thinking") {
@@ -201,16 +362,48 @@ export function useBuildStreaming() {
             break;
           }
 
+          case "subagent_started": {
+            if (!parsed.subagentSessionId) break;
+            seedFromParentTask(parsed.subagentSessionId);
+            break;
+          }
+
           case "tool_call_start": {
             finalizeStreaming();
             accumulatedText = "";
             accumulatedThinking = "";
 
             // Child (subagent-internal) start: do not add to main transcript.
-            // The subagent pill is created from its progress events.
+            // Record it in the subagent stream immediately so in-progress
+            // tools show before their first progress packet arrives.
             if (parsed.parentSessionId !== null && parsed.sessionId !== null) {
+              const parentToolCallId = seedFromParentTask(parsed.sessionId);
+              recordSubagentToolCall(
+                sessionId,
+                parsed.sessionId,
+                parentToolCallId,
+                toolCallStateFromStart(parsed),
+                parsed.subagentType,
+                ""
+              );
               lastItemType = "tool";
               break;
+            }
+
+            const startedToolCall = toolCallStateFromStart(parsed);
+
+            // Parent `task` start packets can carry the spawned child session
+            // before any progress packet arrives. Seed immediately so the task
+            // row has a click target while the subagent is still running.
+            if (parsed.subagentSessionId !== null) {
+              seedSubagentMeta(
+                sessionId,
+                parsed.subagentSessionId,
+                parsed.toolCallId,
+                parsed.subagentType,
+                subagentNameFromToolCall(startedToolCall),
+                promptFromToolCall(startedToolCall)
+              );
             }
 
             // Skip tool_call_start for TodoWrite; pill is created on progress.
@@ -222,20 +415,7 @@ export function useBuildStreaming() {
             appendStreamItem(sessionId, {
               type: "tool_call",
               id: parsed.toolCallId,
-              toolCall: {
-                id: parsed.toolCallId,
-                kind: parsed.kind,
-                toolName: parsed.toolName,
-                title: parsed.title,
-                status: "pending",
-                description: "",
-                command: "",
-                rawOutput: "",
-                subagentType: undefined,
-                isNewFile: true,
-                oldContent: "",
-                newContent: "",
-              },
+              toolCall: startedToolCall,
             });
             lastItemType = "tool";
             break;
@@ -247,10 +427,13 @@ export function useBuildStreaming() {
             // Child (subagent-internal) event: route to the subagent's own
             // tool-call list, not the main transcript.
             if (subagentClass.kind === "child") {
+              const parentToolCallId = seedFromParentTask(
+                subagentClass.subagentSessionId
+              );
               recordSubagentToolCall(
                 sessionId,
                 subagentClass.subagentSessionId,
-                "",
+                parentToolCallId,
                 toolCallStateFromProgress(parsed),
                 null,
                 ""
@@ -293,6 +476,30 @@ export function useBuildStreaming() {
                   subagentClass.subagentSessionId,
                   "failed",
                   cleanTaskOutput(parsed.taskOutput)
+                );
+              }
+            }
+
+            if (
+              subagentClass.kind === "normal" &&
+              (parsed.kind === "task" || parsed.toolName === "task")
+            ) {
+              const session = useBuildSessionStore
+                .getState()
+                .sessions.get(sessionId);
+              const subagent = Array.from(
+                session?.subagents.values() ?? []
+              ).find((candidate) => {
+                return candidate.parentToolCallId === parsed.toolCallId;
+              });
+              if (subagent) {
+                seedSubagentMeta(
+                  sessionId,
+                  subagent.sessionId,
+                  parsed.toolCallId,
+                  parsed.subagentType,
+                  subagentNameFromTask(parsed),
+                  parsed.command
                 );
               }
             }
@@ -389,6 +596,7 @@ export function useBuildStreaming() {
                 type: "assistant",
                 content: textContent,
                 timestamp: new Date(),
+                turn_index: session.activeTurnIndex ?? undefined,
                 message_metadata: {
                   streamItems: savedStreamItems,
                 },
@@ -399,6 +607,9 @@ export function useBuildStreaming() {
               status: "active",
               streamItems: [],
               isInterrupting: false,
+              activeTurnId: null,
+              activeTurnIndex: null,
+              activeTurnLocalOwner: false,
             });
             options?.onPromptResponse?.();
             break;
@@ -410,10 +621,14 @@ export function useBuildStreaming() {
           }
 
           case "error": {
+            appendErrorItem(parsed.message);
             updateSessionData(sessionId, {
               status: "failed",
               error: parsed.message,
               isInterrupting: false,
+              activeTurnId: null,
+              activeTurnIndex: null,
+              activeTurnLocalOwner: false,
             });
             break;
           }
@@ -437,11 +652,139 @@ export function useBuildStreaming() {
       recordSubagentToolCall,
       seedSubagentMeta,
       markSubagentComplete,
+      appendSubagentResponseChunk,
+      appendSubagentThinkingChunk,
     ]
   );
 
   /**
-   * Stream a message to the given session and process the SSE response.
+   * Attach to a background turn's live event stream.
+   */
+  const streamTurnEvents = useCallback(
+    async (
+      sessionId: string,
+      turnId: string,
+      signal: AbortSignal,
+      onSettled?: () => void
+    ): Promise<void> => {
+      const existingSession = useBuildSessionStore
+        .getState()
+        .sessions.get(sessionId);
+      if (
+        existingSession?.activeTurnId === turnId &&
+        existingSession.activeTurnLocalOwner &&
+        existingSession.abortController.signal !== signal
+      ) {
+        return;
+      }
+
+      updateSessionData(sessionId, {
+        status: "running",
+        isInterrupting: false,
+        activeTurnId: turnId,
+      });
+      if (existingSession?.activeTurnId !== turnId) {
+        clearStreamItems(sessionId);
+      }
+
+      let settledFromPromptResponse = false;
+      let transportError = false;
+      const processor = createStreamPacketProcessor(sessionId, {
+        expectedTurnId: turnId,
+        onPromptResponse: () => {
+          settledFromPromptResponse = true;
+          onSettled?.();
+        },
+      });
+      const clearTurnIfCurrent = (
+        updates: Partial<{
+          status: "active" | "failed";
+          error: string;
+          isInterrupting: boolean;
+        }>
+      ) => {
+        const currentSession = useBuildSessionStore
+          .getState()
+          .sessions.get(sessionId);
+        if (currentSession?.activeTurnId !== turnId) {
+          return;
+        }
+        updateSessionData(sessionId, {
+          ...updates,
+          activeTurnId: null,
+          activeTurnIndex: null,
+          activeTurnLocalOwner: false,
+        });
+      };
+
+      try {
+        const response = await fetchTurnEventStream(sessionId, turnId, signal);
+        if (!response) {
+          clearTurnIfCurrent({
+            status: "active",
+            isInterrupting: false,
+          });
+          return;
+        }
+        await processSSEStream(response, processor);
+      } catch (err) {
+        if ((err as Error).name === "AbortError") {
+          const currentSession = useBuildSessionStore
+            .getState()
+            .sessions.get(sessionId);
+          if (currentSession?.activeTurnId === turnId) {
+            updateSessionData(sessionId, { isInterrupting: false });
+          }
+          return;
+        }
+
+        transportError = true;
+        console.warn("[Streaming] Turn attach stream error:", err);
+        const currentSession = useBuildSessionStore
+          .getState()
+          .sessions.get(sessionId);
+        if (currentSession?.activeTurnId === turnId) {
+          updateSessionData(sessionId, {
+            status: "running",
+            isInterrupting: false,
+          });
+        }
+      } finally {
+        if (!signal.aborted) {
+          const currentSession = useBuildSessionStore
+            .getState()
+            .sessions.get(sessionId);
+          if (
+            !transportError &&
+            currentSession?.status === "running" &&
+            currentSession?.activeTurnId === turnId
+          ) {
+            clearTurnIfCurrent({
+              status: "active",
+            });
+          }
+          const settledStatus = useBuildSessionStore
+            .getState()
+            .sessions.get(sessionId)?.status;
+          if (settledStatus !== "failed") {
+            await useBuildSessionStore
+              .getState()
+              .loadSession(sessionId, { force: true })
+              .catch((err) =>
+                console.warn("[Streaming] Failed to reload settled turn:", err)
+              );
+          }
+          if (!settledFromPromptResponse) {
+            onSettled?.();
+          }
+        }
+      }
+    },
+    [updateSessionData, clearStreamItems, createStreamPacketProcessor]
+  );
+
+  /**
+   * Start an interactive backend turn, then attach to its event stream.
    * Populates streamItems in FIFO order as packets arrive.
    */
   const streamMessage = useCallback(
@@ -463,21 +806,27 @@ export function useBuildStreaming() {
       updateSessionData(sessionId, {
         status: "running",
         isInterrupting: false,
+        activeTurnId: null,
+        activeTurnIndex: null,
+        activeTurnLocalOwner: true,
       });
       clearStreamItems(sessionId);
 
       try {
-        const response = await sendMessageStream(
+        const turn = await createTurn(
           sessionId,
           content,
+          crypto.randomUUID(),
           controller.signal,
           model
         );
+        updateSessionData(sessionId, {
+          activeTurnId: turn.turn_id,
+          activeTurnIndex: turn.turn_index,
+          activeTurnLocalOwner: true,
+        });
 
-        await processSSEStream(
-          response,
-          createStreamPacketProcessor(sessionId)
-        );
+        await streamTurnEvents(sessionId, turn.turn_id, controller.signal);
       } catch (err) {
         if ((err as Error).name === "AbortError") {
           updateSessionData(sessionId, { isInterrupting: false });
@@ -487,6 +836,9 @@ export function useBuildStreaming() {
             status: "active",
             error: SessionErrorCode.RATE_LIMIT_EXCEEDED,
             isInterrupting: false,
+            activeTurnId: null,
+            activeTurnIndex: null,
+            activeTurnLocalOwner: false,
           });
         } else {
           console.error("[Streaming] Stream error:", err);
@@ -494,18 +846,16 @@ export function useBuildStreaming() {
             status: "failed",
             error: (err as Error).message,
             isInterrupting: false,
+            activeTurnId: null,
+            activeTurnIndex: null,
+            activeTurnLocalOwner: false,
           });
         }
       } finally {
         setAbortController(sessionId, new AbortController());
       }
     },
-    [
-      setAbortController,
-      updateSessionData,
-      clearStreamItems,
-      createStreamPacketProcessor,
-    ]
+    [setAbortController, updateSessionData, clearStreamItems, streamTurnEvents]
   );
 
   /**
@@ -587,12 +937,14 @@ export function useBuildStreaming() {
       streamMessage,
       interruptStreaming,
       streamScheduledRunEvents,
+      streamTurnEvents,
       abortStream: abortCurrentSession,
     }),
     [
       streamMessage,
       interruptStreaming,
       streamScheduledRunEvents,
+      streamTurnEvents,
       abortCurrentSession,
     ]
   );

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -2,6 +2,7 @@ import {
   ApiSessionResponse,
   ApiDetailedSessionResponse,
   ApiMessageResponse,
+  ApiInteractiveTurnResponse,
   ApiArtifactResponse,
   ApiUsageLimitsResponse,
   ApiWebappInfoResponse,
@@ -304,6 +305,7 @@ export async function fetchMessages(
   return data.messages.map((m: ApiMessageResponse) => ({
     id: m.id,
     type: m.type,
+    turn_index: m.turn_index,
     // Content is stored in message_metadata, not as a separate field
     content: m.content || extractContentFromMetadata(m.message_metadata),
     message_metadata: m.message_metadata,
@@ -325,16 +327,13 @@ export class RateLimitError extends Error {
   }
 }
 
-/**
- * Send a message and return the streaming response.
- * The caller is responsible for processing the SSE stream.
- */
-export async function sendMessageStream(
+export async function createTurn(
   sessionId: string,
   content: string,
+  clientRequestId: string,
   signal?: AbortSignal,
   model?: { provider: string; modelName: string } | null
-): Promise<Response> {
+): Promise<ApiInteractiveTurnResponse> {
   const res = await fetch(
     `${BUILD_API_BASE}/sessions/${sessionId}/send-message`,
     {
@@ -342,6 +341,7 @@ export async function sendMessageStream(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         content,
+        client_request_id: clientRequestId,
         ...(model ? { provider: model.provider, model: model.modelName } : {}),
       }),
       signal,
@@ -349,11 +349,44 @@ export async function sendMessageStream(
   );
 
   if (!res.ok) {
-    // Handle rate limit errors specifically so UI can show upsell modal
     if (res.status === 429) {
       throw new RateLimitError();
     }
-    throw new Error(`Failed to send message: ${res.status}`);
+    throw new Error(await errorDetail(res, "Failed to create turn"));
+  }
+
+  return res.json();
+}
+
+export async function fetchActiveTurn(
+  sessionId: string
+): Promise<ApiInteractiveTurnResponse | null> {
+  const res = await fetch(
+    `${BUILD_API_BASE}/sessions/${sessionId}/turns/active`
+  );
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch active turn: ${res.status}`);
+  }
+
+  return (await res.json()) as ApiInteractiveTurnResponse | null;
+}
+
+export async function fetchTurnEventStream(
+  sessionId: string,
+  turnId: string,
+  signal?: AbortSignal
+): Promise<Response | null> {
+  const res = await fetch(
+    `${BUILD_API_BASE}/sessions/${sessionId}/turns/${turnId}/events`,
+    { headers: { Accept: "text/event-stream" }, signal }
+  );
+
+  if (!res.ok) {
+    if (res.status === 404 || res.status === 409) {
+      return null;
+    }
+    throw new Error(`Failed to stream turn: ${res.status}`);
   }
 
   return res;
@@ -361,7 +394,7 @@ export async function sendMessageStream(
 
 /**
  * Interrupt the in-flight agent turn for a session. The backend interrupts the
- * sandbox turn; the open /send-message stream then terminates normally.
+ * sandbox turn; any attached live stream then terminates normally.
  */
 export async function interruptMessageStream(sessionId: string): Promise<void> {
   const res = await fetch(`${BUILD_API_BASE}/sessions/${sessionId}/interrupt`, {
@@ -379,7 +412,7 @@ export async function fetchScheduledRunEventStream(
 ): Promise<Response> {
   const res = await fetch(
     `${BUILD_API_BASE}/sessions/${sessionId}/scheduled-run-events`,
-    { signal }
+    { headers: { Accept: "text/event-stream" }, signal }
   );
 
   if (res.status === 409) {

--- a/web/src/app/craft/types/displayTypes.ts
+++ b/web/src/app/craft/types/displayTypes.ts
@@ -95,7 +95,8 @@ export type StreamItem =
   | { type: "text"; id: string; content: string; isStreaming: boolean }
   | { type: "thinking"; id: string; content: string; isStreaming: boolean }
   | { type: "tool_call"; id: string; toolCall: ToolCallState }
-  | { type: "todo_list"; id: string; todoList: TodoListState };
+  | { type: "todo_list"; id: string; todoList: TodoListState }
+  | { type: "error"; id: string; content: string };
 
 /**
  * Discriminated union of transient tabs that the side panel can render.
@@ -143,8 +144,12 @@ export interface SubagentTurn {
   prompt: string;
   /** Tool calls emitted by the subagent during this turn, keyed by ToolCallState.id. */
   toolCalls: ToolCallState[];
+  /** The subagent's reasoning stream for this turn (null until any arrives). */
+  thinking: string | null;
   /** The subagent's response for this turn (null until complete). */
   response: string | null;
+  /** FIFO stream items rendered with the same BuildMessageList path as parent chat. */
+  streamItems: StreamItem[];
 }
 
 export interface SubagentState {

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -74,6 +74,7 @@ export interface BuildMessage {
   type: "user" | "assistant" | "system";
   content: string;
   timestamp: Date;
+  turn_index?: number;
   /** Structured sandbox event data (tool calls, thinking, plans) */
   message_metadata?: Record<string, any> | null;
   /** Tool calls associated with this message (for agent messages) */
@@ -183,10 +184,25 @@ export interface ApiDetailedSessionResponse extends ApiSessionResponse {
 export interface ApiMessageResponse {
   id: string;
   session_id: string;
+  turn_index: number;
   type: "user" | "assistant";
   content: string;
   message_metadata?: Record<string, any> | null;
   created_at: string;
+}
+
+export type InteractiveTurnStatus =
+  | "QUEUED"
+  | "RUNNING"
+  | "SUCCEEDED"
+  | "FAILED"
+  | "CANCELLED";
+
+export interface ApiInteractiveTurnResponse {
+  turn_id: string;
+  session_id: string;
+  status: InteractiveTurnStatus;
+  turn_index: number;
 }
 
 export interface ApiArtifactResponse {

--- a/web/src/app/craft/utils/packetTypes.ts
+++ b/web/src/app/craft/utils/packetTypes.ts
@@ -86,11 +86,19 @@ export type ToolName =
 export interface ParsedTextChunk {
   type: "text_chunk";
   text: string;
+  /** Opencode session this event was emitted on — child's id for subagent child events, else null. */
+  sessionId: string | null;
+  /** Non-null only for subagent child events — the parent opencode session. */
+  parentSessionId: string | null;
 }
 
 export interface ParsedThinkingChunk {
   type: "thinking_chunk";
   text: string;
+  /** Opencode session this event was emitted on — child's id for subagent child events, else null. */
+  sessionId: string | null;
+  /** Non-null only for subagent child events — the parent opencode session. */
+  parentSessionId: string | null;
 }
 
 export interface ParsedToolCallStart {
@@ -101,6 +109,12 @@ export interface ParsedToolCallStart {
   isTodo: boolean;
   /** Best-effort title resolved from toolName/kind, shown until progress arrives. */
   title: string;
+  /** Display description resolved from rawInput, used before progress arrives. */
+  description: string;
+  /** Command or task prompt resolved from rawInput, used before progress arrives. */
+  command: string;
+  /** For task tool calls: the subagent type, when provided. */
+  subagentType: string | null;
   /** Opencode session this event was emitted on — child's id for subagent child events, else null. */
   sessionId: string | null;
   /** Non-null only for subagent child events — the parent opencode session. */
@@ -166,6 +180,12 @@ export interface ParsedApprovalRequested {
   sessionId: string;
 }
 
+export interface ParsedSubagentStarted {
+  type: "subagent_started";
+  subagentSessionId: string;
+  parentSessionId: string | null;
+}
+
 export interface ParsedUnknown {
   type: "unknown";
 }
@@ -178,5 +198,6 @@ export type ParsedPacket =
   | ParsedPromptResponse
   | ParsedArtifact
   | ParsedApprovalRequested
+  | ParsedSubagentStarted
   | ParsedError
   | ParsedUnknown;

--- a/web/src/app/craft/utils/parsePacket.test.ts
+++ b/web/src/app/craft/utils/parsePacket.test.ts
@@ -10,6 +10,8 @@ describe("parsePacket", () => {
     ).toEqual({
       type: "thinking_chunk",
       text: "Inspecting the app state.",
+      sessionId: null,
+      parentSessionId: null,
     });
   });
 
@@ -22,6 +24,48 @@ describe("parsePacket", () => {
     ).toEqual({
       type: "thinking_chunk",
       text: "Inspecting saved context.",
+      sessionId: null,
+      parentSessionId: null,
+    });
+  });
+
+  it("parses task starts from kind-only packets", () => {
+    expect(
+      parsePacket({
+        type: "tool_call_start",
+        tool_call_id: "task-call-1",
+        kind: "task",
+        raw_input: { prompt: "Build Space Invaders game" },
+        _meta: { toolName: "unknown" },
+      })
+    ).toMatchObject({
+      type: "tool_call_start",
+      toolName: "task",
+      kind: "task",
+      command: "Build Space Invaders game",
+      description: "Spawning subagent: Build Space Invaders game",
+    });
+  });
+
+  it("extracts subagent session ids from completed task output", () => {
+    expect(
+      parsePacket({
+        type: "tool_call_progress",
+        tool_call_id: "task-call-1",
+        kind: "task",
+        status: "completed",
+        raw_input: { prompt: "Build Space Invaders game" },
+        raw_output: {
+          output:
+            "task_id: child-session-1 (for resuming to continue this task if needed)\n\n<task_result>done</task_result>",
+        },
+      })
+    ).toMatchObject({
+      type: "tool_call_progress",
+      toolName: "task",
+      subagentSessionId: "child-session-1",
+      taskOutput:
+        "task_id: child-session-1 (for resuming to continue this task if needed)\n\n<task_result>done</task_result>",
     });
   });
 });

--- a/web/src/app/craft/utils/parsePacket.ts
+++ b/web/src/app/craft/utils/parsePacket.ts
@@ -33,11 +33,19 @@ export function parsePacket(raw: unknown): ParsedPacket {
   switch (packetType) {
     case "agent_message_chunk": // Live SSE
     case "agent_message": // DB-stored format
-      return { type: "text_chunk", text: extractText(p.content) };
+      return {
+        type: "text_chunk",
+        text: extractText(p.content),
+        ...extractRoutingMeta(p),
+      };
 
     case "agent_thought_chunk": // Live SSE
     case "agent_thought": // DB-stored format
-      return { type: "thinking_chunk", text: extractText(p.content) };
+      return {
+        type: "thinking_chunk",
+        text: extractText(p.content),
+        ...extractRoutingMeta(p),
+      };
 
     case "tool_call_start":
       return parseToolCallStart(p);
@@ -58,12 +66,34 @@ export function parsePacket(raw: unknown): ParsedPacket {
         sessionId: (p.session_id ?? "") as string,
       };
 
+    case "subagent_started":
+      return {
+        type: "subagent_started",
+        subagentSessionId: (p.subagent_session_id ??
+          p.subagentSessionId ??
+          "") as string,
+        parentSessionId: (p.parent_session_id ?? p.parentSessionId ?? null) as
+          | string
+          | null,
+      };
+
     case "error":
       return { type: "error", message: (p.message ?? "") as string };
 
     default:
       return { type: "unknown" };
   }
+}
+
+function extractRoutingMeta(p: Record<string, unknown>): {
+  sessionId: string | null;
+  parentSessionId: string | null;
+} {
+  const meta = (p._meta as Record<string, unknown> | undefined) ?? {};
+  return {
+    sessionId: (meta.sessionId as string | undefined) ?? null,
+    parentSessionId: (meta.parentSessionId as string | undefined) ?? null,
+  };
 }
 
 // ─── Skill Detection ──────────────────────────────────────────────
@@ -131,6 +161,7 @@ function resolveToolName(p: Record<string, unknown>): ToolName {
   if (rawKind === "edit" || rawKind === "delete" || rawKind === "move")
     return "edit";
   if (rawKind === "search") return "glob";
+  if (rawKind === "task") return "task";
   if (rawKind === "fetch") return "webfetch";
 
   return "unknown";
@@ -283,8 +314,10 @@ function buildDescription(
 ): string {
   // Task tool: spawns a subagent. Read as "Spawning subagent: <description>".
   if (toolName === "task") {
-    return rawDescription
-      ? `Spawning subagent: ${rawDescription}`
+    const taskDescription =
+      rawDescription || (typeof ri?.prompt === "string" ? ri.prompt : "");
+    return taskDescription
+      ? `Spawning subagent: ${sanitizePathsInText(taskDescription)}`
       : "Spawning subagent";
   }
   // Read/edit: show file path. For new-file writes, append a line count
@@ -478,6 +511,19 @@ function extractTaskOutput(ro: Record<string, unknown> | null): string | null {
   );
 }
 
+function extractTaskSessionId(
+  ro: Record<string, unknown> | null
+): string | null {
+  if (!ro?.output || typeof ro.output !== "string") return null;
+  const text = ro.output;
+  const taskIdMatch = text.match(/^task_id:\s*([^\s(]+)/m);
+  if (taskIdMatch?.[1]) return taskIdMatch[1];
+  const metadataMatch = text.match(
+    /<task_metadata>[\s\S]*?(?:session_id|task_id):\s*([^\s<]+)[\s\S]*?<\/task_metadata>/i
+  );
+  return metadataMatch?.[1] ?? null;
+}
+
 // ─── Artifact Parsing ─────────────────────────────────────────────
 
 function parseArtifact(p: Record<string, unknown>): ParsedArtifact {
@@ -500,7 +546,17 @@ function parseToolCallStart(p: Record<string, unknown>): ParsedToolCallStart {
   const toolName = resolveToolName(p);
   const rawKind = p.kind as string | null;
   const kind = resolveKind(toolName, rawKind);
+  const ri = getRawInput(p);
   const meta = (p._meta as Record<string, unknown> | undefined) ?? {};
+  const rawCommand = (ri?.command ??
+    (toolName === "task" ? ri?.prompt : undefined) ??
+    "") as string;
+  const rawDescription = (ri?.description ?? "") as string;
+  const rawFilePath = (ri?.file_path ??
+    ri?.filePath ??
+    ri?.path ??
+    "") as string;
+  const filePath = rawFilePath ? stripSessionPrefix(rawFilePath) : "";
   return {
     type: "tool_call_start",
     toolCallId: getToolCallId(p),
@@ -508,6 +564,11 @@ function parseToolCallStart(p: Record<string, unknown>): ParsedToolCallStart {
     kind,
     isTodo: toolName === "todowrite",
     title: buildTitle(toolName, kind, true),
+    description: buildDescription(toolName, kind, filePath, ri, rawDescription),
+    command: sanitizePathsInText(rawCommand),
+    subagentType: (ri?.subagent_type ?? ri?.subagentType ?? null) as
+      | string
+      | null,
     sessionId: (meta.sessionId as string | undefined) ?? null,
     parentSessionId: (meta.parentSessionId as string | undefined) ?? null,
     subagentSessionId: (meta.subagentSessionId as string | undefined) ?? null,
@@ -616,7 +677,8 @@ function parseToolCallProgress(
   const sessionId = (meta.sessionId as string | undefined) ?? null;
   const parentSessionId = (meta.parentSessionId as string | undefined) ?? null;
   const subagentSessionId =
-    (meta.subagentSessionId as string | undefined) ?? null;
+    (meta.subagentSessionId as string | undefined) ??
+    (toolName === "task" ? extractTaskSessionId(ro) : null);
 
   return {
     type: "tool_call_progress",

--- a/web/src/app/craft/utils/subagentRouting.ts
+++ b/web/src/app/craft/utils/subagentRouting.ts
@@ -14,7 +14,10 @@
  * - Normal event: all three null → main transcript, unchanged.
  */
 
-import type { ParsedToolCallProgress } from "./packetTypes";
+import type {
+  ParsedToolCallProgress,
+  ParsedToolCallStart,
+} from "./packetTypes";
 import type { ToolCallState } from "../types/displayTypes";
 
 export type SubagentEventClass =
@@ -66,6 +69,25 @@ export function toolCallStateFromProgress(
   };
 }
 
+export function toolCallStateFromStart(
+  parsed: ParsedToolCallStart
+): ToolCallState {
+  return {
+    id: parsed.toolCallId,
+    kind: parsed.kind,
+    title: parsed.title,
+    description: parsed.description,
+    command: parsed.command,
+    status: "pending",
+    rawOutput: "",
+    toolName: parsed.toolName,
+    subagentType: parsed.subagentType ?? undefined,
+    isNewFile: true,
+    oldContent: "",
+    newContent: "",
+  };
+}
+
 /**
  * Clean a raw task-output string for display in the subagent panel.
  *
@@ -99,9 +121,24 @@ export function cleanTaskOutput(raw: string | null): string | null {
 
 /** Derive a short subagent display name from a parsed parent `task` packet. */
 export function subagentNameFromTask(parsed: ParsedToolCallProgress): string {
-  const firstLine = (parsed.command || "").split("\n")[0]?.trim() ?? "";
+  const displayDescription = parsed.description
+    .replace(/^Spawning subagent:\s*/, "")
+    .trim();
+  const firstLine =
+    (displayDescription || parsed.command).split("\n")[0]?.trim() ?? "";
   if (firstLine) {
     return firstLine.length > 40 ? `${firstLine.slice(0, 40)}…` : firstLine;
   }
   return parsed.subagentType ?? "subagent";
+}
+
+export function subagentNameFromToolCall(toolCall: ToolCallState): string {
+  const firstLine = (toolCall.command || toolCall.description || "")
+    .replace(/^Spawning subagent:\s*/, "")
+    .split("\n")[0]
+    ?.trim();
+  if (firstLine) {
+    return firstLine.length > 40 ? `${firstLine.slice(0, 40)}…` : firstLine;
+  }
+  return toolCall.subagentType ?? "subagent";
 }


### PR DESCRIPTION
## Description

- Moves interactive Craft `send-message` from request-owned streaming to a cache-backed turn creator that enqueues a scheduled-task Celery runner.
- Adds attach-only active-turn APIs so the frontend can reload persisted `BuildMessage` rows and attach to the live opencode session after refresh without resending the prompt.
- Reuses the existing prompt slot, sandbox event persistence, finalize persistence, interrupt fence, and heartbeat flow in the background runner without adding DB tables or migrations.
- Handles transient opencode `/event` disconnects before prompt posting so reconnect windows do not abort otherwise healthy turns.

Related Linear:
- https://linear.app/onyx-app/issue/ENG-4149/idle-cleanup-reaps-a-sandbox-mid-turn-wedging-the-session-two-ways
- https://linear.app/onyx-app/issue/ENG-4135/craft-polish-stale-opencode-password-fails-event-bus-subscription

## How Has This Been Tested?

- `git diff --check`
- `.venv/bin/ruff check backend/onyx/server/features/build/api/messages_api.py backend/onyx/server/features/build/api/turns_api.py backend/onyx/server/features/build/interactive_turns/executor.py backend/onyx/server/features/build/interactive_turns/state.py backend/onyx/server/features/build/sandbox/opencode/serve_client.py backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py backend/onyx/configs/constants.py backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py backend/tests/unit/onyx/server/features/build/api/test_turns_api.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py backend/tests/integration/tests/craft/test_messages_api.py backend/tests/integration/tests/craft/test_sessions_api.py backend/tests/integration/common_utils/managers/build_session.py`
- `.venv/bin/python -m py_compile backend/onyx/server/features/build/api/messages_api.py backend/onyx/server/features/build/api/turns_api.py backend/onyx/server/features/build/interactive_turns/executor.py backend/onyx/server/features/build/interactive_turns/state.py backend/onyx/server/features/build/sandbox/opencode/serve_client.py backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py backend/onyx/configs/constants.py`
- `.venv/bin/python -m pytest -q backend/tests/unit/onyx/server/features/build/interactive_turns/test_state.py backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py backend/tests/unit/onyx/server/features/build/api/test_messages_background_turn.py backend/tests/unit/onyx/server/features/build/api/test_turns_api.py backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py backend/tests/unit/onyx/server/features/build/session/test_streaming_state.py`
- `cd backend && PATH="$PWD/../.venv/bin:$PATH" ../.venv/bin/python -m dotenv -f ../.vscode/.env run -- env POSTGRES_HOST=10.96.113.142 REDIS_HOST=10.96.49.176 OPENSEARCH_HOST=10.96.97.136 ../.venv/bin/python -m pytest -q tests/integration/tests/craft/test_messages_api.py`
- `cd web && bun run lint -- tests/e2e/pages/CraftPage.ts tests/e2e/craft/live_turn_rejoin.spec.ts src/app/craft/services/apiServices.ts src/app/craft/hooks/useBuildStreaming.ts src/app/craft/hooks/useBuildSessionStore.ts src/app/craft/components/ChatPanel.tsx src/app/craft/types/streamingTypes.ts`
- `cd web && bunx oxfmt --check tests/e2e/pages/CraftPage.ts tests/e2e/craft/live_turn_rejoin.spec.ts src/app/craft/services/apiServices.ts src/app/craft/hooks/useBuildStreaming.ts src/app/craft/hooks/useBuildSessionStore.ts src/app/craft/components/ChatPanel.tsx src/app/craft/types/streamingTypes.ts`
- `cd web && bun run types:check`
- `cd web && BASE_URL=http://localhost:3210 bunx playwright test tests/e2e/craft/live_turn_rejoin.spec.ts --project=admin`
- `cd web && bun run test -- --runTestsByPath src/app/craft/hooks/loadSessionRestore.test.ts src/app/craft/hooks/useBuildStreaming.test.tsx --ci --maxWorkers=50%`
- `cd web && bun run lint -- src/app/craft/hooks/loadSessionRestore.test.ts src/app/craft/hooks/useBuildStreaming.test.tsx && bunx oxfmt --check src/app/craft/hooks/loadSessionRestore.test.ts src/app/craft/hooks/useBuildStreaming.test.tsx`
- `cd web && bun run test -- --ci --maxWorkers=50%`
- Pre-commit on all commits, including `ty`, `ruff`, `ruff format`, `ripsecrets`, `oxfmt`, `oxlint`, and TypeScript type check.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
