### PR TITLE
feat(opal): own z-index tokens so they survive standalone distribution

### DIFF
--- a/web/lib/opal/src/components/tooltip/styles.css
+++ b/web/lib/opal/src/components/tooltip/styles.css
@@ -1,7 +1,7 @@
 @reference "#reference.css";
 
 .opal-tooltip {
-  z-index: var(--z-tooltip, 1300);
+  z-index: var(--z-tooltip);
   max-width: 20rem;
   @apply rounded-08 px-3 py-2 text-sm
     bg-background-neutral-dark-03 text-text-light-05

--- a/web/lib/opal/src/root.css
+++ b/web/lib/opal/src/root.css
@@ -17,3 +17,4 @@
 @import "./styles/colors.css";
 @import "./styles/sizes.css";
 @import "./styles/typography.css";
+@import "./styles/z-index.css";

--- a/web/lib/opal/src/styles/z-index.css
+++ b/web/lib/opal/src/styles/z-index.css
@@ -1,0 +1,19 @@
+:root {
+  /* Must sit above sticky table headers so the settings page header scrolls
+     over pinned columns without being obscured. */
+  --z-settings-header: 11;
+
+  /* Interactive overlays */
+  --z-popover: 1200;
+  --z-tooltip: 1300;
+}
+
+.z-settings-header {
+  z-index: var(--z-settings-header);
+}
+.z-popover {
+  z-index: var(--z-popover);
+}
+.z-tooltip {
+  z-index: var(--z-tooltip);
+}

--- a/web/lib/opal/tailwind-preset.cjs
+++ b/web/lib/opal/tailwind-preset.cjs
@@ -243,6 +243,11 @@ module.exports = {
         "02": "var(--backdrop-blur-02)",
         "03": "var(--backdrop-blur-03)",
       },
+      zIndex: {
+        "settings-header": "var(--z-settings-header)",
+        popover: "var(--z-popover)",
+        tooltip: "var(--z-tooltip)",
+      },
     },
   },
 };

--- a/web/src/app/css/z-index.css
+++ b/web/src/app/css/z-index.css
@@ -2,9 +2,6 @@
   /* Base layers */
   --z-base: 0;
   --z-content: 1;
-  /* Settings header must sit above sticky table headers (--z-sticky: 10) so
-     the page header scrolls over pinned columns without being obscured. */
-  --z-settings-header: 11;
   --z-app-layout: 9;
   --z-sticky: 10;
 
@@ -12,8 +9,6 @@
   --z-modal-overlay: 900;
   --z-modal: 1000;
   --z-toast: 1100;
-  --z-popover: 1200;
-  --z-tooltip: 1300;
 }
 
 /* Base layers */
@@ -22,9 +17,6 @@
 }
 .z-content {
   z-index: var(--z-content);
-}
-.z-settings-header {
-  z-index: var(--z-settings-header);
 }
 .z-app-layout {
   z-index: var(--z-app-layout);
@@ -42,10 +34,4 @@
 }
 .z-toast {
   z-index: var(--z-toast);
-}
-.z-popover {
-  z-index: var(--z-popover);
-}
-.z-tooltip {
-  z-index: var(--z-tooltip);
 }


### PR DESCRIPTION
## Description

Three z-index tokens that Opal components depend on (`--z-settings-header`, `--z-popover`, `--z-tooltip`) were defined exclusively in the app-level `web/src/app/css/z-index.css`. Any external consumer of the distributed Opal package would be missing those stacking contexts.

This PR moves those tokens fully into Opal:

- **`web/lib/opal/src/styles/z-index.css`** (new) — defines the CSS variables and utility classes
- **`web/lib/opal/src/root.css`** — imports the new stylesheet
- **`web/lib/opal/tailwind-preset.cjs`** — adds `zIndex` entries so Tailwind generates the utility classes for external consumers
- **`web/src/app/css/z-index.css`** — the three migrated tokens are removed (no duplicates)
- **`web/lib/opal/src/components/tooltip/styles.css`** — removes the hardcoded `, 1300` fallback since the variable is now owned by Opal

Tokens that are app-only (`z-base`, `z-content`, `z-app-layout`, `z-sticky`, `z-modal-overlay`, `z-modal`, `z-toast`) are untouched.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves z-index tokens into Opal so standalone consumers get correct stacking contexts for settings header, popovers, and tooltips. Removes app-level duplication and ensures Tailwind z-index utilities are available externally.

- **New Features**
  - Added `web/lib/opal/src/styles/z-index.css` with `--z-settings-header`, `--z-popover`, `--z-tooltip` and utility classes; imported in `root.css`.
  - Extended `tailwind-preset.cjs` with `zIndex` entries to generate `z-` utilities for consumers.
  - Removed migrated tokens from `web/src/app/css/z-index.css` to avoid duplicates.
  - Dropped the hardcoded `, 1300` fallback in tooltip styles since the variable is now defined by Opal.

<sup>Written for commit 45c6cf150d5c56ac3770d9b4da765e4a620736a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->