### PR TITLE
fix(craft): prewarm agent sessions before first prompt

### DIFF
--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -213,6 +213,7 @@ class _ServeMixin:
         self,
         sandbox_id: UUID,
         session_id: UUID,
+        opencode_session_id: str | None = None,
     ) -> str | None:
         """Idempotent preflight to mint (or look up) the opencode-serve
         session id for this build session. Caller persists it so later
@@ -220,14 +221,15 @@ class _ServeMixin:
         session_path = self._session_directory(session_id)
         logger.info(
             "[SESSION-LIFECYCLE] sandbox.ensure_opencode_session: build_session=%s "
-            "sandbox=%s directory=%s (passing id=None, so client will POST /session)",
+            "sandbox=%s directory=%s caller-supplied opencode_session_id=%s",
             session_id,
             sandbox_id,
             session_path,
+            opencode_session_id,
         )
         with self._build_serve_client(sandbox_id, session_path) as client:
             return client.ensure_session(
-                None,
+                opencode_session_id,
                 directory=session_path,
                 title=f"build-session-{str(session_id)[:8]}",
             )

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -771,9 +771,9 @@ class SessionManager:
         Sets the interrupt fence and returns. The active stream's consume loop
         polls the fence (~1/s) and self-terminates — aborting opencode and
         emitting its own ``PromptResponse`` rather than waiting on a
-        ``session.idle`` that may never arrive after an abort. Setting a flag
-        (vs. a direct abort) is also what survives the first-turn race, where
-        the opencode session id isn't minted until inside the stream.
+        ``session.idle`` that may never arrive after an abort. A flag-based
+        approach (vs. a direct abort) is safe to call at any point in the turn
+        lifecycle, including before the stream has started consuming events.
         """
         session = get_build_session(session_id, user_id, self._db_session)
         if session is None:

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -212,6 +212,33 @@ class SessionManager:
                 "Failed to push user library to sandbox %s", sandbox_id, exc_info=True
             )
 
+    def _prewarm_opencode_session(
+        self, sandbox_id: UUID, session: BuildSession
+    ) -> None:
+        """Mint and persist the opencode-serve session before the first prompt.
+
+        The caller owns the surrounding transaction. This keeps the empty Craft
+        session's frontend-ready state aligned with the agent runtime being
+        ready to accept the first user message.
+        """
+        opencode_session_id = self._sandbox_manager.ensure_opencode_session(
+            sandbox_id=sandbox_id,
+            session_id=session.id,
+            opencode_session_id=session.opencode_session_id,
+        )
+        if opencode_session_id is None:
+            raise RuntimeError(
+                f"Failed to prewarm opencode session for build session {session.id}"
+            )
+        if session.opencode_session_id != opencode_session_id:
+            logger.info(
+                "Prewarmed opencode session %s for build session %s",
+                opencode_session_id,
+                session.id,
+            )
+            session.opencode_session_id = opencode_session_id
+            self._db_session.flush()
+
     def ensure_sandbox_running(
         self,
         user_id: UUID,
@@ -367,6 +394,7 @@ class SessionManager:
         )
         self._hydrate_skills(sandbox.id, user, files=skills_files)
         self._hydrate_user_library(sandbox.id, user_id)
+        self._prewarm_opencode_session(sandbox.id, build_session)
 
         logger.info(
             "Successfully created session %s with workspace in sandbox %s",
@@ -429,6 +457,7 @@ class SessionManager:
                     else:
                         self._hydrate_skills(sandbox.id, user)
                     self._hydrate_user_library(sandbox.id, user_id)
+                    self._prewarm_opencode_session(sandbox.id, existing)
                     logger.info(
                         "Returning existing empty session %s for user %s",
                         existing.id,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -372,6 +372,7 @@ class StubSandboxManager(SandboxManager):
         self,
         sandbox_id: UUID,
         session_id: UUID,
+        opencode_session_id: str | None = None,
     ) -> str | None:
         # Override the real _ServeMixin preflight (which POSTs /session over
         # HTTP to a pod) so send_message tests run fully in-memory.
@@ -379,6 +380,7 @@ class StubSandboxManager(SandboxManager):
         self.last_ensure_opencode_session_payload = {
             "sandbox_id": sandbox_id,
             "session_id": session_id,
+            "opencode_session_id": opencode_session_id,
         }
         return self.ensure_opencode_session_returns
 

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -91,6 +91,13 @@ class TestCreateSession:
         # provision() was called exactly once for this first creation.
         assert stub_sandbox_manager.provision_count == 1
         assert build_session.user_id == test_user.id
+        assert build_session.opencode_session_id == "stub-opencode-session"
+        assert stub_sandbox_manager.ensure_opencode_session_count == 1
+        assert stub_sandbox_manager.last_ensure_opencode_session_payload == {
+            "sandbox_id": sandbox_row.id,
+            "session_id": build_session.id,
+            "opencode_session_id": None,
+        }
 
     def test_create_session_reuses_existing_sandbox(
         self,
@@ -121,6 +128,13 @@ class TestCreateSession:
 
         assert stub_sandbox_manager.provision_count == 0
         assert stub_sandbox_manager.health_check_count >= 1
+        assert new_session.opencode_session_id == "stub-opencode-session"
+        assert stub_sandbox_manager.ensure_opencode_session_count == 1
+        assert stub_sandbox_manager.last_ensure_opencode_session_payload == {
+            "sandbox_id": existing_id,
+            "session_id": new_session.id,
+            "opencode_session_id": None,
+        }
 
 
 # =============================================================================
@@ -144,19 +158,30 @@ class TestEmptySessionReuse:
             user_id=test_user.id,
             name="pre-provisioned",
             status=BuildSessionStatus.ACTIVE,
+            opencode_session_id="stale-opencode-session",
         )
         db_session.add(existing_empty)
         db_session.commit()
 
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.session_workspace_exists_returns = True
+        stub_sandbox_manager.ensure_opencode_session_returns = (
+            "refreshed-opencode-session"
+        )
         stub_sandbox_manager.write_files_to_sandbox_silent = True
 
         sm = session_manager_with_stub
         result = sm.get_or_create_empty_session(user_id=test_user.id)
         db_session.commit()
+        db_session.refresh(result)
 
         assert result.id == existing_empty.id
+        assert result.opencode_session_id == "refreshed-opencode-session"
+        assert stub_sandbox_manager.last_ensure_opencode_session_payload == {
+            "sandbox_id": sandbox_row.id,
+            "session_id": existing_empty.id,
+            "opencode_session_id": "stale-opencode-session",
+        }
         # No new sandbox was provisioned, and only one BuildSession row exists
         # for this user.
         rows = (

--- a/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
@@ -12,7 +12,7 @@ from onyx.server.features.build.session.manager import SessionManager
 class _FakeSandboxManager:
     def __init__(self, result: str | None) -> None:
         self.result = result
-        self.calls: list[dict[str, UUID | str | None]] = []
+        self.calls: list[tuple[UUID, UUID, str | None]] = []
 
     def ensure_opencode_session(
         self,
@@ -20,13 +20,7 @@ class _FakeSandboxManager:
         session_id: UUID,
         opencode_session_id: str | None = None,
     ) -> str | None:
-        self.calls.append(
-            {
-                "sandbox_id": sandbox_id,
-                "session_id": session_id,
-                "opencode_session_id": opencode_session_id,
-            }
-        )
+        self.calls.append((sandbox_id, session_id, opencode_session_id))
         return self.result
 
 
@@ -55,54 +49,29 @@ def _build_session(opencode_session_id: str | None = None) -> BuildSession:
     )
 
 
-def test_prewarm_opencode_session_persists_new_session_id() -> None:
+@pytest.mark.parametrize(
+    ("initial_id", "resolved_id", "flush_count"),
+    [
+        pytest.param(None, "opencode-1", 1, id="new-id"),
+        pytest.param("stale-opencode", "fresh-opencode", 1, id="stale-id"),
+        pytest.param("valid-opencode", "valid-opencode", 0, id="valid-id"),
+    ],
+)
+def test_prewarm_opencode_session_persists_resolved_id(
+    initial_id: str | None,
+    resolved_id: str,
+    flush_count: int,
+) -> None:
     sandbox_id = uuid4()
-    session = _build_session()
-    sandbox_manager = _FakeSandboxManager("opencode-1")
+    session = _build_session(initial_id)
+    sandbox_manager = _FakeSandboxManager(resolved_id)
     db_session = _FakeDbSession()
 
     _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
 
-    assert session.opencode_session_id == "opencode-1"
-    assert db_session.flush_count == 1
-    assert sandbox_manager.calls == [
-        {
-            "sandbox_id": sandbox_id,
-            "session_id": session.id,
-            "opencode_session_id": None,
-        }
-    ]
-
-
-def test_prewarm_opencode_session_refreshes_stale_session_id() -> None:
-    sandbox_id = uuid4()
-    session = _build_session("stale-opencode")
-    sandbox_manager = _FakeSandboxManager("fresh-opencode")
-    db_session = _FakeDbSession()
-
-    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
-
-    assert session.opencode_session_id == "fresh-opencode"
-    assert db_session.flush_count == 1
-    assert sandbox_manager.calls == [
-        {
-            "sandbox_id": sandbox_id,
-            "session_id": session.id,
-            "opencode_session_id": "stale-opencode",
-        }
-    ]
-
-
-def test_prewarm_opencode_session_keeps_valid_session_id_without_flush() -> None:
-    sandbox_id = uuid4()
-    session = _build_session("valid-opencode")
-    sandbox_manager = _FakeSandboxManager("valid-opencode")
-    db_session = _FakeDbSession()
-
-    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
-
-    assert session.opencode_session_id == "valid-opencode"
-    assert db_session.flush_count == 0
+    assert session.opencode_session_id == resolved_id
+    assert db_session.flush_count == flush_count
+    assert sandbox_manager.calls == [(sandbox_id, session.id, initial_id)]
 
 
 def test_prewarm_opencode_session_raises_when_runtime_returns_no_id() -> None:

--- a/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.db.models import BuildSession
+from onyx.server.features.build.session.manager import SessionManager
+
+
+class _FakeSandboxManager:
+    def __init__(self, result: str | None) -> None:
+        self.result = result
+        self.calls: list[dict[str, UUID | str | None]] = []
+
+    def ensure_opencode_session(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_session_id: str | None = None,
+    ) -> str | None:
+        self.calls.append(
+            {
+                "sandbox_id": sandbox_id,
+                "session_id": session_id,
+                "opencode_session_id": opencode_session_id,
+            }
+        )
+        return self.result
+
+
+class _FakeDbSession:
+    def __init__(self) -> None:
+        self.flush_count = 0
+
+    def flush(self) -> None:
+        self.flush_count += 1
+
+
+def _manager(
+    sandbox_manager: _FakeSandboxManager, db_session: _FakeDbSession
+) -> SessionManager:
+    manager = SessionManager.__new__(SessionManager)
+    manager._sandbox_manager = sandbox_manager
+    manager._db_session = db_session
+    return manager
+
+
+def _build_session(opencode_session_id: str | None = None) -> BuildSession:
+    return BuildSession(
+        id=uuid4(),
+        user_id=uuid4(),
+        opencode_session_id=opencode_session_id,
+    )
+
+
+def test_prewarm_opencode_session_persists_new_session_id() -> None:
+    sandbox_id = uuid4()
+    session = _build_session()
+    sandbox_manager = _FakeSandboxManager("opencode-1")
+    db_session = _FakeDbSession()
+
+    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
+
+    assert session.opencode_session_id == "opencode-1"
+    assert db_session.flush_count == 1
+    assert sandbox_manager.calls == [
+        {
+            "sandbox_id": sandbox_id,
+            "session_id": session.id,
+            "opencode_session_id": None,
+        }
+    ]
+
+
+def test_prewarm_opencode_session_refreshes_stale_session_id() -> None:
+    sandbox_id = uuid4()
+    session = _build_session("stale-opencode")
+    sandbox_manager = _FakeSandboxManager("fresh-opencode")
+    db_session = _FakeDbSession()
+
+    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
+
+    assert session.opencode_session_id == "fresh-opencode"
+    assert db_session.flush_count == 1
+    assert sandbox_manager.calls == [
+        {
+            "sandbox_id": sandbox_id,
+            "session_id": session.id,
+            "opencode_session_id": "stale-opencode",
+        }
+    ]
+
+
+def test_prewarm_opencode_session_keeps_valid_session_id_without_flush() -> None:
+    sandbox_id = uuid4()
+    session = _build_session("valid-opencode")
+    sandbox_manager = _FakeSandboxManager("valid-opencode")
+    db_session = _FakeDbSession()
+
+    _manager(sandbox_manager, db_session)._prewarm_opencode_session(sandbox_id, session)
+
+    assert session.opencode_session_id == "valid-opencode"
+    assert db_session.flush_count == 0
+
+
+def test_prewarm_opencode_session_raises_when_runtime_returns_no_id() -> None:
+    sandbox_id = uuid4()
+    session = _build_session()
+    sandbox_manager = _FakeSandboxManager(None)
+    db_session = _FakeDbSession()
+
+    with pytest.raises(RuntimeError, match="Failed to prewarm opencode session"):
+        _manager(sandbox_manager, db_session)._prewarm_opencode_session(
+            sandbox_id, session
+        )
+
+    assert session.opencode_session_id is None
+    assert db_session.flush_count == 0


### PR DESCRIPTION
## Description

- Prewarm and persist the opencode-serve session id when a Craft session is created or reused for pre-provisioning.
- Allow opencode session preflight to validate an existing id so stale ids are healed before first prompt.
- Add DB-free unit coverage plus lifecycle assertions for fresh and reused empty sessions.

Craft pre-provisioning created the backend session/workspace, but the opencode-serve session id was still minted inside the first `/send-message` stream. That made the first user-visible prompt pay the runtime session-create cost while later prompts reused the persisted id.

Linear: https://linear.app/onyx-app/issue/ENG-4138/craft-polish-first-message-is-always-slow-subsequent-messages-are-fast

## How Has This Been Tested?

```
Benchmark results

   Scenario                                                               Result
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━
   Prewarmed first send, API path                        2.59s TTFB, 2.67s total
  ────────────────────────────────────────────────────  ─────────────────────────
   Stale-id healed, then first send                      2.08s TTFB, 2.13s total
  ────────────────────────────────────────────────────  ─────────────────────────
   Browser/UI first send                                  Next logged 2.9s total
  ────────────────────────────────────────────────────  ─────────────────────────
   Simulated old fallback after opencode already warm    2.59s TTFB, 2.75s total
```

- `ruff format --check` on touched files
- `ruff check` on touched files
- `python -m py_compile` on touched files
- `pytest backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_session.py backend/tests/unit/onyx/server/features/build/sandbox/test_cold_pod_retry.py backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py -q`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
