### PR TITLE
fix(opal): remove double-span when rendering markdown inside Text

### DIFF
--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -22,9 +22,7 @@ const sanitizeSchema = {
 const ALLOWED_ELEMENTS = ["p", "br", "a", "strong", "em", "code", "del"];
 
 const INLINE_COMPONENTS = {
-  p: ({ children }: { children?: ReactNode }) => (
-    <span className="block">{children}</span>
-  ),
+  p: ({ children }: { children?: ReactNode }) => <>{children}</>,
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
     if (!href) return <>{children}</>;
     // rehype-sanitize has already stripped unsafe hrefs — routing decision only.


### PR DESCRIPTION
## Description

`<Text>{markdown(...)}</Text>` was producing a redundant `<span>` inside the outer `<span>` rendered by `Text`.

**Render path before this fix:**

```
<Text>                   →  <span class="px-[2px] font-... text-...">
  {markdown("*hello*")}      <span class="block">           ← redundant wrapper from p override
                               <em>hello</em>
                             </span>
                           </span>
```

**Root cause:** The `p` component override in `InlineMarkdown` wrapped every paragraph node in `<span className="block">` to make multi-paragraph content stack vertically. But `Text` already provides an outer container element, so the inner wrapper is always superfluous.

**Fix:** Replace the `<span className="block">` wrapper with a bare fragment `<>{children}</>`.

Multi-line content is unaffected — `markdown()` joins its arguments with `\n`, which `InlineMarkdown` converts to CommonMark hard line breaks (`  \n` → `<br>`). No new `<p>` nodes are generated in normal usage, so nothing visually changes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double <span> nesting when rendering `markdown()` inside `Text`. Replaces the `p` override in `InlineMarkdown` from `<span className="block">...</span>` to a fragment, removing the redundant wrapper without affecting multi-line rendering.

<sup>Written for commit 2516681d2dc961a4054f8927409d0b84715e85fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->