### PR TITLE
fix(users): revalidate users table + counts after invite

### DIFF
--- a/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
+++ b/web/src/refresh-pages/admin/UsersPage/InviteUsersModal.tsx
@@ -8,6 +8,8 @@ import InputChipField from "@/refresh-components/inputs/InputChipField";
 import type { ChipItem } from "@/refresh-components/inputs/InputChipField";
 import Text from "@/refresh-components/texts/Text";
 import { toast } from "@/hooks/useToast";
+import { mutate } from "swr";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { inviteUsers } from "./svc";
 
 // ---------------------------------------------------------------------------
@@ -116,6 +118,15 @@ export default function InviteUsersModal({
     setIsSubmitting(true);
     try {
       await inviteUsers(validEmails);
+      // Fire-and-forget revalidation so the invitee shows up immediately rather
+      // than only on the next SWR focus revalidation. Not awaited: the invite
+      // already succeeded, so a failing revalidation GET must not fall into the
+      // catch below and surface an error toast / keep the modal open.
+      void Promise.all([
+        mutate(SWR_KEYS.invitedUsers),
+        mutate(SWR_KEYS.acceptedUsers),
+        mutate(SWR_KEYS.userCounts),
+      ]).catch(() => {});
       toast.success(
         `Invited ${validEmails.length} user${validEmails.length > 1 ? "s" : ""}`
       );


### PR DESCRIPTION
## Description

**Bug:** `InviteUsersModal` awaited the invite request but never revalidated any SWR key, so a successfully-invited user did not appear in the table until the next focus revalidation — making a working invite look like a no-op.

**Fix:** Revalidate `invitedUsers` / `acceptedUsers` / `userCounts` on success so the row and the toast land together.

## How Has This Been Tested?

<!-- Nik to fill in. oxfmt/oxlint/tsc green locally. -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check