### PR TITLE
ci: add python-version input to setup-python action

### DIFF
--- a/.github/actions/setup-python-and-install-dependencies/action.yml
+++ b/.github/actions/setup-python-and-install-dependencies/action.yml
@@ -4,6 +4,10 @@ inputs:
   requirements:
     description: "Newline-separated list of requirement files to install (relative to repo root)"
     required: true
+  python-version:
+    description: "Python version to install. Defaults to 3.13; consumers still on an older runtime (e.g. services pinned to 3.11) can override."
+    required: false
+    default: "3.13"
 runs:
   using: "composite"
   steps:
@@ -43,7 +47,7 @@ runs:
     - name: Setup Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ inputs.python-version }}
 
     - name: Create virtual environment
       shell: bash


### PR DESCRIPTION
## Description

The shared `setup-python-and-install-dependencies` action hardcodes `python-version: "3.13"` (set in #11721), with no override. Consumers still on an older runtime — e.g. `danswer-control-plane`, which deploys on Python 3.11 with 3.11-pinned deps — can't opt out, so their pytest jobs break on 3.13-incompatible deps (asyncpg, SQLAlchemy).

Add an optional `python-version` input, **defaulting to `"3.13"`** (all onyx usages unchanged), so consumers can pass e.g. `"3.11"`.

## How Has This Been Tested?

<!-- Nik to fill in. -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check