### PR TITLE
feat(notifications): paginate retrieval api

### DIFF
--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from sqlalchemy import cast
 from sqlalchemy import select
+from sqlalchemy import update
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
@@ -161,14 +162,19 @@ def dismiss_user_notifications(
     db_session: Session,
     notif_type: NotificationType | None = None,
 ) -> None:
-    query = db_session.query(Notification).filter(
-        *_notification_filters(
-            user=user,
-            notif_type=notif_type,
-            include_dismissed=False,
+    stmt = (
+        update(Notification)
+        .where(
+            *_notification_filters(
+                user=user,
+                notif_type=notif_type,
+                include_dismissed=False,
+            )
         )
+        .values(dismissed=True)
+        .execution_options(synchronize_session=False)
     )
-    query.update({"dismissed": True}, synchronize_session=False)
+    db_session.execute(stmt)
     db_session.commit()
 
 

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -121,6 +121,7 @@ def get_notifications(
     query = query.order_by(
         Notification.dismissed.asc(),
         Notification.first_shown.desc(),
+        Notification.id.desc(),
     )
     if limit is not None:
         query = query.limit(limit).offset(offset)

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -8,11 +8,27 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
+from sqlalchemy.sql.elements import ColumnElement
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import NotificationType
 from onyx.db.models import Notification
 from onyx.db.models import User
+
+
+def _notification_filters(
+    user: User | None,
+    notif_type: NotificationType | None = None,
+    include_dismissed: bool = True,
+) -> list[ColumnElement[bool]]:
+    filters = [
+        Notification.user_id == user.id if user else Notification.user_id.is_(None)
+    ]
+    if not include_dismissed:
+        filters.append(Notification.dismissed.is_(False))
+    if notif_type:
+        filters.append(Notification.notif_type == notif_type)
+    return filters
 
 
 def create_notification(
@@ -23,6 +39,7 @@ def create_notification(
     description: str | None = None,
     additional_data: dict | None = None,
     autocommit: bool = True,
+    refresh_existing: bool = True,
 ) -> Notification:
     # Previously, we only matched the first identical, undismissed notification
     # Now, we assume some uniqueness to notifications
@@ -44,8 +61,9 @@ def create_notification(
     )
 
     if existing_notification:
-        # Update the last_shown timestamp if the notification is not dismissed
-        if not existing_notification.dismissed:
+        # Read-triggered ensure paths should not mutate existing rows: changing
+        # last_shown makes notification GET responses differ on every request.
+        if refresh_existing and not existing_notification.dismissed:
             existing_notification.last_shown = func.now()
             if autocommit:
                 db_session.commit()
@@ -89,20 +107,42 @@ def get_notifications(
     db_session: Session,
     notif_type: NotificationType | None = None,
     include_dismissed: bool = True,
+    limit: int | None = None,
+    offset: int = 0,
 ) -> list[Notification]:
     query = select(Notification).where(
-        Notification.user_id == user.id if user else Notification.user_id.is_(None)
+        *_notification_filters(
+            user=user,
+            notif_type=notif_type,
+            include_dismissed=include_dismissed,
+        )
     )
-    if not include_dismissed:
-        query = query.where(Notification.dismissed.is_(False))
-    if notif_type:
-        query = query.where(Notification.notif_type == notif_type)
     # Sort: undismissed first, then by date (newest first)
     query = query.order_by(
         Notification.dismissed.asc(),
         Notification.first_shown.desc(),
     )
+    if limit is not None:
+        query = query.limit(limit).offset(offset)
     return list(db_session.execute(query).scalars().all())
+
+
+def count_notifications(
+    user: User | None,
+    db_session: Session,
+    notif_type: NotificationType | None = None,
+) -> tuple[int, int]:
+    query = select(
+        func.count(Notification.id),
+        func.count(Notification.id).filter(Notification.dismissed.is_(False)),
+    ).where(
+        *_notification_filters(
+            user=user,
+            notif_type=notif_type,
+        )
+    )
+    total_items, undismissed_count = db_session.execute(query).one()
+    return total_items or 0, undismissed_count or 0
 
 
 def dismiss_all_notifications(
@@ -112,6 +152,22 @@ def dismiss_all_notifications(
     db_session.query(Notification).filter(Notification.notif_type == notif_type).update(
         {"dismissed": True}
     )
+    db_session.commit()
+
+
+def dismiss_user_notifications(
+    user: User,
+    db_session: Session,
+    notif_type: NotificationType | None = None,
+) -> None:
+    query = db_session.query(Notification).filter(
+        *_notification_filters(
+            user=user,
+            notif_type=notif_type,
+            include_dismissed=False,
+        )
+    )
+    query.update({"dismissed": True}, synchronize_session=False)
     db_session.commit()
 
 

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -952,7 +952,7 @@ class GateAddon:
                 user_id=ctx.user_id,
                 notif_type=NotificationType.APPROVAL_REQUESTED,
                 db_session=db,
-                title="Craft is awaiting approval",
+                title="Craft is requesting approval",
                 additional_data={
                     "approval_id": str(approval_id),
                     "session_id": str(ctx.session_id),

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -159,4 +159,5 @@ def ensure_build_mode_intro_notification(user: User, db_session: Session) -> Non
         title="Introducing Onyx Craft",
         description="Unleash Onyx to create dashboards, slides, documents, and more with your connected data.",
         additional_data={"feature": BUILD_MODE_FEATURE_ID},
+        refresh_existing=False,
     )

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -127,8 +127,8 @@ def get_notifications_summary_api(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> NotificationSummary:
-    # Preserve badge behavior from the old mounted list hook: notifications that
-    # are lazily created on read should exist before we compute unread counts.
+    # Preserve app-load notification bootstrap behavior: notifications that are
+    # lazily created on read should exist before we compute badge counts.
     _ensure_notifications_for_type(user, db_session, notif_type=None)
     total_items, undismissed_count = count_notifications(
         user=user,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -34,39 +34,28 @@ DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
 
 
-def _run_read_triggered_notification_checks(
+def _check_for_notifications_to_create(
     user: User,
     db_session: Session,
-    requested_notif_type: NotificationType | None,
 ) -> None:
-    if (
-        requested_notif_type is None
-        or requested_notif_type == NotificationType.FEATURE_ANNOUNCEMENT
-    ):
-        try:
-            ensure_build_mode_intro_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for build mode intro in notifications endpoint"
-            )
+    try:
+        ensure_build_mode_intro_notification(user, db_session)
+    except Exception:
+        logger.exception(
+            "Failed to check for build mode intro in notifications endpoint"
+        )
 
-        try:
-            ensure_permissions_migration_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-            )
+    try:
+        ensure_permissions_migration_notification(user, db_session)
+    except Exception:
+        logger.exception(
+            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+        )
 
-    if (
-        requested_notif_type is None
-        or requested_notif_type == NotificationType.RELEASE_NOTES
-    ):
-        try:
-            ensure_release_notes_fresh_and_notify(db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for release notes in notifications endpoint"
-            )
+    try:
+        ensure_release_notes_fresh_and_notify(db_session)
+    except Exception:
+        logger.exception("Failed to check for release notes in notifications endpoint")
 
 
 @router.get("")
@@ -90,7 +79,7 @@ def get_notifications_api(
     - Explicitly announcing breaking changes
     """
     if page_num == 0:
-        _run_read_triggered_notification_checks(user, db_session, notif_type)
+        _check_for_notifications_to_create(user, db_session)
 
     total_items, undismissed_count = count_notifications(
         user=user,
@@ -126,11 +115,7 @@ def get_notifications_summary_api(
 ) -> NotificationSummary:
     # Preserve app-load notification bootstrap behavior: notifications that are
     # lazily created on read should exist before we compute badge counts.
-    _run_read_triggered_notification_checks(
-        user=user,
-        db_session=db_session,
-        requested_notif_type=None,
-    )
+    _check_for_notifications_to_create(user=user, db_session=db_session)
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -1,69 +1,114 @@
 from fastapi import APIRouter
 from fastapi import Depends
-from fastapi import HTTPException
+from fastapi import Query
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.notification import count_notifications
 from onyx.db.notification import dismiss_notification
+from onyx.db.notification import dismiss_user_notifications
 from onyx.db.notification import get_notification_by_id
 from onyx.db.notification import get_notifications
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.utils import ensure_build_mode_intro_notification
+from onyx.server.features.notifications.models import Notification as NotificationModel
+from onyx.server.features.notifications.models import PaginatedNotifications
 from onyx.server.features.notifications.utils import (
     ensure_permissions_migration_notification,
 )
 from onyx.server.features.release_notes.utils import (
     ensure_release_notes_fresh_and_notify,
 )
-from onyx.server.settings.models import Notification as NotificationModel
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 router = APIRouter(prefix="/notifications")
 
+DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
+MAX_NOTIFICATIONS_PAGE_SIZE = 50
+
 
 @router.get("")
 def get_notifications_api(
+    page_num: int = Query(0, ge=0),
+    page_size: int = Query(
+        DEFAULT_NOTIFICATIONS_PAGE_SIZE, ge=1, le=MAX_NOTIFICATIONS_PAGE_SIZE
+    ),
+    notif_type: NotificationType | None = Query(default=None),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
-) -> list[NotificationModel]:
+) -> PaginatedNotifications:
     """
-    Get all undismissed notifications for the current user.
+    Get a page of notifications for the current user.
 
-    Note: also executes background checks that should create notifications.
+    Note: the first page also executes checks that should create notifications.
 
     Examples of checks that create new notifications:
     - Checking for new release notes the user hasn't seen
     - Checking for misconfigurations due to version changes
     - Explicitly announcing breaking changes
     """
-    # Background checks that create notifications
-    try:
-        ensure_build_mode_intro_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to check for build mode intro in notifications endpoint"
-        )
+    if page_num == 0:
+        # Background checks that create notifications
+        try:
+            ensure_build_mode_intro_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for build mode intro in notifications endpoint"
+            )
 
-    try:
-        ensure_release_notes_fresh_and_notify(db_session)
-    except Exception:
-        logger.exception("Failed to check for release notes in notifications endpoint")
+        try:
+            ensure_release_notes_fresh_and_notify(db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for release notes in notifications endpoint"
+            )
 
-    try:
-        ensure_permissions_migration_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-        )
+        try:
+            ensure_permissions_migration_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+            )
 
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=notif_type,
+    )
+    offset = page_num * page_size
     notifications = [
-        NotificationModel.from_model(notif)
-        for notif in get_notifications(user, db_session, include_dismissed=True)
+        NotificationModel.model_validate(notif)
+        for notif in get_notifications(
+            user=user,
+            db_session=db_session,
+            notif_type=notif_type,
+            include_dismissed=True,
+            limit=page_size,
+            offset=offset,
+        )
     ]
-    return notifications
+    return PaginatedNotifications(
+        notifications=notifications,
+        total_items=total_items,
+        undismissed_count=undismissed_count,
+        page_num=page_num,
+        page_size=page_size,
+        has_more=offset + page_size < total_items,
+    )
+
+
+@router.post("/dismiss-all")
+def dismiss_all_notifications_endpoint(
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    dismiss_user_notifications(user=user, db_session=db_session)
 
 
 @router.post("/{notification_id}/dismiss")
@@ -74,11 +119,15 @@ def dismiss_notification_endpoint(
 ) -> None:
     try:
         notification = get_notification_by_id(notification_id, user, db_session)
-    except PermissionError:
-        raise HTTPException(
-            status_code=403, detail="Not authorized to dismiss this notification"
-        )
-    except ValueError:
-        raise HTTPException(status_code=404, detail="Notification not found")
+    except PermissionError as e:
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "Not authorized to dismiss this notification",
+        ) from e
+    except ValueError as e:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "Notification not found",
+        ) from e
 
     dismiss_notification(notification, db_session)

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -34,35 +34,39 @@ DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
 
 
-def _ensure_feature_announcement_notifications(
+def _run_read_triggered_notification_checks(
     user: User,
     db_session: Session,
+    requested_notif_type: NotificationType | None,
 ) -> None:
-    try:
-        ensure_build_mode_intro_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to check for build mode intro in notifications endpoint"
-        )
+    if (
+        requested_notif_type is None
+        or requested_notif_type == NotificationType.FEATURE_ANNOUNCEMENT
+    ):
+        try:
+            ensure_build_mode_intro_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for build mode intro in notifications endpoint"
+            )
 
-    try:
-        ensure_permissions_migration_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-        )
+        try:
+            ensure_permissions_migration_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+            )
 
-
-def _ensure_release_note_notifications(db_session: Session) -> None:
-    try:
-        ensure_release_notes_fresh_and_notify(db_session)
-    except Exception:
-        logger.exception("Failed to check for release notes in notifications endpoint")
-
-
-def _ensure_app_load_notifications(user: User, db_session: Session) -> None:
-    _ensure_feature_announcement_notifications(user, db_session)
-    _ensure_release_note_notifications(db_session)
+    if (
+        requested_notif_type is None
+        or requested_notif_type == NotificationType.RELEASE_NOTES
+    ):
+        try:
+            ensure_release_notes_fresh_and_notify(db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for release notes in notifications endpoint"
+            )
 
 
 @router.get("")
@@ -86,12 +90,7 @@ def get_notifications_api(
     - Explicitly announcing breaking changes
     """
     if page_num == 0:
-        if notif_type is None:
-            _ensure_app_load_notifications(user, db_session)
-        elif notif_type == NotificationType.FEATURE_ANNOUNCEMENT:
-            _ensure_feature_announcement_notifications(user, db_session)
-        elif notif_type == NotificationType.RELEASE_NOTES:
-            _ensure_release_note_notifications(db_session)
+        _run_read_triggered_notification_checks(user, db_session, notif_type)
 
     total_items, undismissed_count = count_notifications(
         user=user,
@@ -127,7 +126,11 @@ def get_notifications_summary_api(
 ) -> NotificationSummary:
     # Preserve app-load notification bootstrap behavior: notifications that are
     # lazily created on read should exist before we compute badge counts.
-    _ensure_app_load_notifications(user, db_session)
+    _run_read_triggered_notification_checks(
+        user=user,
+        db_session=db_session,
+        requested_notif_type=None,
+    )
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -34,42 +34,35 @@ DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
 
 
-def _should_run_notification_check(
-    requested_notif_type: NotificationType | None,
-    check_notif_type: NotificationType,
-) -> bool:
-    return requested_notif_type is None or requested_notif_type == check_notif_type
-
-
-def _ensure_notifications_for_type(
+def _ensure_feature_announcement_notifications(
     user: User,
     db_session: Session,
-    notif_type: NotificationType | None,
 ) -> None:
-    if _should_run_notification_check(
-        notif_type, NotificationType.FEATURE_ANNOUNCEMENT
-    ):
-        try:
-            ensure_build_mode_intro_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for build mode intro in notifications endpoint"
-            )
+    try:
+        ensure_build_mode_intro_notification(user, db_session)
+    except Exception:
+        logger.exception(
+            "Failed to check for build mode intro in notifications endpoint"
+        )
 
-        try:
-            ensure_permissions_migration_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-            )
+    try:
+        ensure_permissions_migration_notification(user, db_session)
+    except Exception:
+        logger.exception(
+            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+        )
 
-    if _should_run_notification_check(notif_type, NotificationType.RELEASE_NOTES):
-        try:
-            ensure_release_notes_fresh_and_notify(db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for release notes in notifications endpoint"
-            )
+
+def _ensure_release_note_notifications(db_session: Session) -> None:
+    try:
+        ensure_release_notes_fresh_and_notify(db_session)
+    except Exception:
+        logger.exception("Failed to check for release notes in notifications endpoint")
+
+
+def _ensure_app_load_notifications(user: User, db_session: Session) -> None:
+    _ensure_feature_announcement_notifications(user, db_session)
+    _ensure_release_note_notifications(db_session)
 
 
 @router.get("")
@@ -93,7 +86,12 @@ def get_notifications_api(
     - Explicitly announcing breaking changes
     """
     if page_num == 0:
-        _ensure_notifications_for_type(user, db_session, notif_type)
+        if notif_type is None:
+            _ensure_app_load_notifications(user, db_session)
+        elif notif_type == NotificationType.FEATURE_ANNOUNCEMENT:
+            _ensure_feature_announcement_notifications(user, db_session)
+        elif notif_type == NotificationType.RELEASE_NOTES:
+            _ensure_release_note_notifications(db_session)
 
     total_items, undismissed_count = count_notifications(
         user=user,
@@ -129,7 +127,7 @@ def get_notifications_summary_api(
 ) -> NotificationSummary:
     # Preserve app-load notification bootstrap behavior: notifications that are
     # lazily created on read should exist before we compute badge counts.
-    _ensure_notifications_for_type(user, db_session, notif_type=None)
+    _ensure_app_load_notifications(user, db_session)
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -4,7 +4,6 @@ from fastapi import Query
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
-from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
@@ -64,7 +63,6 @@ def get_notifications_api(
     page_size: int = Query(
         DEFAULT_NOTIFICATIONS_PAGE_SIZE, ge=1, le=MAX_NOTIFICATIONS_PAGE_SIZE
     ),
-    notif_type: NotificationType | None = Query(default=None),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PaginatedNotifications:
@@ -84,7 +82,6 @@ def get_notifications_api(
     total_items, undismissed_count = count_notifications(
         user=user,
         db_session=db_session,
-        notif_type=notif_type,
     )
     offset = page_num * page_size
     notifications = [
@@ -92,7 +89,6 @@ def get_notifications_api(
         for notif in get_notifications(
             user=user,
             db_session=db_session,
-            notif_type=notif_type,
             include_dismissed=True,
             limit=page_size,
             offset=offset,

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -16,7 +16,8 @@ from onyx.db.notification import get_notifications
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.utils import ensure_build_mode_intro_notification
-from onyx.server.features.notifications.models import Notification as NotificationModel
+from onyx.server.features.notifications.models import NotificationResponse
+from onyx.server.features.notifications.models import NotificationSummary
 from onyx.server.features.notifications.models import PaginatedNotifications
 from onyx.server.features.notifications.utils import (
     ensure_permissions_migration_notification,
@@ -31,6 +32,44 @@ router = APIRouter(prefix="/notifications")
 
 DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
+
+
+def _should_run_notification_check(
+    requested_notif_type: NotificationType | None,
+    check_notif_type: NotificationType,
+) -> bool:
+    return requested_notif_type is None or requested_notif_type == check_notif_type
+
+
+def _ensure_notifications_for_type(
+    user: User,
+    db_session: Session,
+    notif_type: NotificationType | None,
+) -> None:
+    if _should_run_notification_check(
+        notif_type, NotificationType.FEATURE_ANNOUNCEMENT
+    ):
+        try:
+            ensure_build_mode_intro_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for build mode intro in notifications endpoint"
+            )
+
+        try:
+            ensure_permissions_migration_notification(user, db_session)
+        except Exception:
+            logger.exception(
+                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
+            )
+
+    if _should_run_notification_check(notif_type, NotificationType.RELEASE_NOTES):
+        try:
+            ensure_release_notes_fresh_and_notify(db_session)
+        except Exception:
+            logger.exception(
+                "Failed to check for release notes in notifications endpoint"
+            )
 
 
 @router.get("")
@@ -54,27 +93,7 @@ def get_notifications_api(
     - Explicitly announcing breaking changes
     """
     if page_num == 0:
-        # Background checks that create notifications
-        try:
-            ensure_build_mode_intro_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for build mode intro in notifications endpoint"
-            )
-
-        try:
-            ensure_release_notes_fresh_and_notify(db_session)
-        except Exception:
-            logger.exception(
-                "Failed to check for release notes in notifications endpoint"
-            )
-
-        try:
-            ensure_permissions_migration_notification(user, db_session)
-        except Exception:
-            logger.exception(
-                "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-            )
+        _ensure_notifications_for_type(user, db_session, notif_type)
 
     total_items, undismissed_count = count_notifications(
         user=user,
@@ -83,7 +102,7 @@ def get_notifications_api(
     )
     offset = page_num * page_size
     notifications = [
-        NotificationModel.model_validate(notif)
+        NotificationResponse.model_validate(notif)
         for notif in get_notifications(
             user=user,
             db_session=db_session,
@@ -100,6 +119,24 @@ def get_notifications_api(
         page_num=page_num,
         page_size=page_size,
         has_more=offset + page_size < total_items,
+    )
+
+
+@router.get("/summary")
+def get_notifications_summary_api(
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> NotificationSummary:
+    # Preserve badge behavior from the old mounted list hook: notifications that
+    # are lazily created on read should exist before we compute unread counts.
+    _ensure_notifications_for_type(user, db_session, notif_type=None)
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+    )
+    return NotificationSummary(
+        total_items=total_items,
+        undismissed_count=undismissed_count,
     )
 
 

--- a/backend/onyx/server/features/notifications/models.py
+++ b/backend/onyx/server/features/notifications/models.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+from onyx.configs.constants import NotificationType
+
+
+class Notification(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    notif_type: NotificationType
+    dismissed: bool
+    last_shown: datetime
+    first_shown: datetime
+    title: str
+    description: str | None = None
+    additional_data: dict | None = None
+
+
+class PaginatedNotifications(BaseModel):
+    notifications: list[Notification]
+    total_items: int
+    undismissed_count: int
+    page_num: int
+    page_size: int
+    has_more: bool

--- a/backend/onyx/server/features/notifications/models.py
+++ b/backend/onyx/server/features/notifications/models.py
@@ -6,7 +6,7 @@ from pydantic import ConfigDict
 from onyx.configs.constants import NotificationType
 
 
-class Notification(BaseModel):
+class NotificationResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
@@ -20,9 +20,14 @@ class Notification(BaseModel):
 
 
 class PaginatedNotifications(BaseModel):
-    notifications: list[Notification]
+    notifications: list[NotificationResponse]
     total_items: int
     undismissed_count: int
     page_num: int
     page_size: int
     has_more: bool
+
+
+class NotificationSummary(BaseModel):
+    total_items: int
+    undismissed_count: int

--- a/backend/onyx/server/features/notifications/utils.py
+++ b/backend/onyx/server/features/notifications/utils.py
@@ -18,4 +18,5 @@ def ensure_permissions_migration_notification(user: User, db_session: Session) -
             "feature": "permissions_migration_v1",
             "link": "https://docs.onyx.app/admins/permissions/whats_changing",
         },
+        refresh_existing=False,
     )

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -24,7 +24,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.server.features.build.utils import is_onyx_craft_enabled
-from onyx.server.features.notifications.models import Notification
+from onyx.server.features.notifications.models import NotificationResponse
 from onyx.server.settings.models import (
     DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_NO_VECTOR_DB,
 )
@@ -153,7 +153,9 @@ def fetch_settings(
     )
 
 
-def get_settings_notifications(user: User, db_session: Session) -> list[Notification]:
+def get_settings_notifications(
+    user: User, db_session: Session
+) -> list[NotificationResponse]:
     """Get notifications for settings page, including product gating and reindex notifications"""
     # Check for product gating notification
     product_notif = get_notifications(
@@ -162,7 +164,7 @@ def get_settings_notifications(user: User, db_session: Session) -> list[Notifica
         db_session=db_session,
     )
     notifications = (
-        [Notification.model_validate(product_notif[0])] if product_notif else []
+        [NotificationResponse.model_validate(product_notif[0])] if product_notif else []
     )
 
     # Only show reindex notifications to admins
@@ -201,7 +203,7 @@ def get_settings_notifications(user: User, db_session: Session) -> list[Notifica
         )
 
         db_session.commit()
-        notifications.append(Notification.model_validate(reindex_notif))
+        notifications.append(NotificationResponse.model_validate(reindex_notif))
         return notifications
     except SQLAlchemyError:
         logger.exception("Error while processing notifications")

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -24,11 +24,11 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.server.features.build.utils import is_onyx_craft_enabled
+from onyx.server.features.notifications.models import Notification
 from onyx.server.settings.models import (
     DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_NO_VECTOR_DB,
 )
 from onyx.server.settings.models import DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_VECTOR_DB
-from onyx.server.settings.models import Notification
 from onyx.server.settings.models import Settings
 from onyx.server.settings.models import Tier
 from onyx.server.settings.models import UserSettings
@@ -161,7 +161,9 @@ def get_settings_notifications(user: User, db_session: Session) -> list[Notifica
         notif_type=NotificationType.TRIAL_ENDS_TWO_DAYS,
         db_session=db_session,
     )
-    notifications = [Notification.from_model(product_notif[0])] if product_notif else []
+    notifications = (
+        [Notification.model_validate(product_notif[0])] if product_notif else []
+    )
 
     # Only show reindex notifications to admins
     if not is_user_admin(user):
@@ -199,7 +201,7 @@ def get_settings_notifications(user: User, db_session: Session) -> list[Notifica
         )
 
         db_session.commit()
-        notifications.append(Notification.from_model(reindex_notif))
+        notifications.append(Notification.model_validate(reindex_notif))
         return notifications
     except SQLAlchemyError:
         logger.exception("Error while processing notifications")

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel
@@ -8,9 +7,8 @@ from onyx.configs.app_configs import DEFAULT_PRUNING_FREQ
 from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
-from onyx.configs.constants import NotificationType
 from onyx.configs.constants import QueryHistoryType
-from onyx.db.models import Notification as NotificationDBModel
+from onyx.server.features.notifications.models import Notification
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_VECTOR_DB = 200
@@ -34,30 +32,6 @@ class Tier(str, Enum):
     COMMUNITY = "community"
     BUSINESS = "business"
     ENTERPRISE = "enterprise"
-
-
-class Notification(BaseModel):
-    id: int
-    notif_type: NotificationType
-    dismissed: bool
-    last_shown: datetime
-    first_shown: datetime
-    title: str
-    description: str | None = None
-    additional_data: dict | None = None
-
-    @classmethod
-    def from_model(cls, notif: NotificationDBModel) -> "Notification":
-        return cls(
-            id=notif.id,
-            notif_type=notif.notif_type,
-            dismissed=notif.dismissed,
-            last_shown=notif.last_shown,
-            first_shown=notif.first_shown,
-            title=notif.title,
-            description=notif.description,
-            additional_data=notif.additional_data,
-        )
 
 
 class Settings(BaseModel):

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -8,7 +8,7 @@ from onyx.configs.app_configs import DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import MAX_ALLOWED_UPLOAD_SIZE_MB
 from onyx.configs.constants import QueryHistoryType
-from onyx.server.features.notifications.models import Notification
+from onyx.server.features.notifications.models import NotificationResponse
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_VECTOR_DB = 200
@@ -95,7 +95,7 @@ class Settings(BaseModel):
 
 
 class UserSettings(Settings):
-    notifications: list[Notification]
+    notifications: list[NotificationResponse]
     needs_reindexing: bool
     tenant_id: str = POSTGRES_DEFAULT_SCHEMA
     # Feature flag for Onyx Craft (Build Mode) - used for server-side redirects

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -254,12 +254,50 @@ def test_get_notifications_api_scopes_ensure_checks(
     assert calls == []
 
 
-def test_notification_summary_and_dismiss_all_api(
+def test_notification_summary_runs_ensure_checks_before_counting(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _disable_notification_ensure_checks(monkeypatch)
+    user = create_test_user(db_session, "notification_summary_no_checks")
+    calls: list[str] = []
+
+    def record_call(name: str) -> Callable[..., None]:
+        def _record_call(*_args: object, **_kwargs: object) -> None:
+            calls.append(name)
+
+        return _record_call
+
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_build_mode_intro_notification",
+        record_call("build"),
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_permissions_migration_notification",
+        record_call("permissions"),
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_release_notes_fresh_and_notify",
+        record_call("release_notes"),
+    )
+
+    summary = notifications_api.get_notifications_summary_api(
+        user=user,
+        db_session=db_session,
+    )
+
+    assert summary.total_items == 0
+    assert summary.undismissed_count == 0
+    assert calls == ["build", "permissions", "release_notes"]
+
+
+def test_notification_summary_and_dismiss_all_api(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
     user = create_test_user(db_session, "notification_summary")
     other_user = create_test_user(db_session, "notification_summary_other")
     first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -1,7 +1,9 @@
+from collections.abc import Callable
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 
+import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -12,6 +14,7 @@ from onyx.db.notification import count_notifications
 from onyx.db.notification import create_notification
 from onyx.db.notification import dismiss_user_notifications
 from onyx.db.notification import get_notifications
+from onyx.server.features.notifications import api as notifications_api
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -98,6 +101,37 @@ def test_notification_pagination_counts_and_bulk_dismissal(
     assert other_user_row.dismissed is False
 
 
+def test_notification_pagination_uses_stable_tie_breaker(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_tie_break")
+    first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    created_notifications = [
+        _create_notification(
+            db_session=db_session,
+            user=user,
+            index=index,
+            first_shown=first_shown,
+            dismissed=False,
+        )
+        for index in range(3)
+    ]
+    db_session.commit()
+
+    page = get_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        include_dismissed=True,
+        limit=3,
+    )
+
+    assert [notification.id for notification in page] == sorted(
+        notification.id for notification in created_notifications
+    )[::-1]
+
+
 def test_create_notification_can_preserve_existing_last_shown(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
@@ -125,3 +159,173 @@ def test_create_notification_can_preserve_existing_last_shown(
 
     assert existing_notification.id == notification.id
     assert existing_notification.last_shown == original_last_shown
+
+
+def test_get_notifications_api_returns_paginated_response(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_notification_ensure_checks(monkeypatch)
+    user = create_test_user(db_session, "notification_api_page")
+    base_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    for index in range(3):
+        _create_notification(
+            db_session=db_session,
+            user=user,
+            index=index,
+            first_shown=base_time + timedelta(minutes=index),
+            dismissed=index == 0,
+        )
+    db_session.commit()
+
+    response = notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=2,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert len(response.notifications) == 2
+    assert response.total_items == 3
+    assert response.undismissed_count == 2
+    assert response.page_num == 0
+    assert response.page_size == 2
+    assert response.has_more is True
+
+
+def test_get_notifications_api_scopes_ensure_checks(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "notification_api_scoped_checks")
+    calls: list[str] = []
+
+    def record_call(name: str) -> Callable[..., None]:
+        def _record_call(*_args: object, **_kwargs: object) -> None:
+            calls.append(name)
+
+        return _record_call
+
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_build_mode_intro_notification",
+        record_call("build"),
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_permissions_migration_notification",
+        record_call("permissions"),
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_release_notes_fresh_and_notify",
+        record_call("release_notes"),
+    )
+
+    notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=2,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        user=user,
+        db_session=db_session,
+    )
+    assert calls == []
+
+    notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=2,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        user=user,
+        db_session=db_session,
+    )
+    assert calls == ["build", "permissions"]
+
+    calls.clear()
+    notifications_api.get_notifications_api(
+        page_num=1,
+        page_size=2,
+        notif_type=None,
+        user=user,
+        db_session=db_session,
+    )
+    assert calls == []
+
+
+def test_notification_summary_and_dismiss_all_api(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _disable_notification_ensure_checks(monkeypatch)
+    user = create_test_user(db_session, "notification_summary")
+    other_user = create_test_user(db_session, "notification_summary_other")
+    first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    _create_notification(
+        db_session=db_session,
+        user=user,
+        index=1,
+        first_shown=first_shown,
+        dismissed=False,
+    )
+    _create_notification(
+        db_session=db_session,
+        user=user,
+        index=2,
+        first_shown=first_shown + timedelta(minutes=1),
+        dismissed=True,
+    )
+    other_user_notification = _create_notification(
+        db_session=db_session,
+        user=other_user,
+        index=3,
+        first_shown=first_shown + timedelta(minutes=2),
+        dismissed=False,
+    )
+    db_session.commit()
+
+    summary = notifications_api.get_notifications_summary_api(
+        user=user,
+        db_session=db_session,
+    )
+    assert summary.total_items == 2
+    assert summary.undismissed_count == 1
+
+    notifications_api.dismiss_all_notifications_endpoint(
+        user=user,
+        db_session=db_session,
+    )
+
+    summary = notifications_api.get_notifications_summary_api(
+        user=user,
+        db_session=db_session,
+    )
+    assert summary.total_items == 2
+    assert summary.undismissed_count == 0
+    other_user_row = db_session.scalars(
+        select(Notification).where(Notification.id == other_user_notification.id)
+    ).one()
+    assert other_user_row.dismissed is False
+
+
+def _disable_notification_ensure_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    def noop_ensure(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_build_mode_intro_notification",
+        noop_ensure,
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_permissions_migration_notification",
+        noop_ensure,
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_release_notes_fresh_and_notify",
+        noop_ensure,
+    )

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -195,12 +195,12 @@ def test_get_notifications_api_returns_paginated_response(
     assert response.has_more is True
 
 
-def test_get_notifications_api_scopes_ensure_checks(
+def test_get_notifications_api_runs_ensure_checks_on_first_page(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    user = create_test_user(db_session, "notification_api_scoped_checks")
+    user = create_test_user(db_session, "notification_api_ensure_checks")
     calls: list[str] = []
 
     def record_call(name: str) -> Callable[..., None]:
@@ -232,26 +232,7 @@ def test_get_notifications_api_scopes_ensure_checks(
         user=user,
         db_session=db_session,
     )
-    assert calls == []
-
-    notifications_api.get_notifications_api(
-        page_num=0,
-        page_size=2,
-        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
-        user=user,
-        db_session=db_session,
-    )
-    assert calls == ["build", "permissions"]
-
-    calls.clear()
-    notifications_api.get_notifications_api(
-        page_num=0,
-        page_size=2,
-        notif_type=NotificationType.RELEASE_NOTES,
-        user=user,
-        db_session=db_session,
-    )
-    assert calls == ["release_notes"]
+    assert calls == ["build", "permissions", "release_notes"]
 
     calls.clear()
     notifications_api.get_notifications_api(

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -182,7 +182,6 @@ def test_get_notifications_api_returns_paginated_response(
     response = notifications_api.get_notifications_api(
         page_num=0,
         page_size=2,
-        notif_type=NotificationType.APPROVAL_REQUESTED,
         user=user,
         db_session=db_session,
     )
@@ -228,7 +227,6 @@ def test_get_notifications_api_runs_ensure_checks_on_first_page(
     notifications_api.get_notifications_api(
         page_num=0,
         page_size=2,
-        notif_type=NotificationType.APPROVAL_REQUESTED,
         user=user,
         db_session=db_session,
     )
@@ -238,7 +236,6 @@ def test_get_notifications_api_runs_ensure_checks_on_first_page(
     notifications_api.get_notifications_api(
         page_num=1,
         page_size=2,
-        notif_type=None,
         user=user,
         db_session=db_session,
     )

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -288,7 +288,9 @@ def test_notification_summary_runs_ensure_checks_before_counting(
 def test_notification_summary_and_dismiss_all_api(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _disable_notification_ensure_checks(monkeypatch)
     user = create_test_user(db_session, "notification_summary")
     other_user = create_test_user(db_session, "notification_summary_other")
     first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import NotificationType
+from onyx.db.models import Notification
+from onyx.db.models import User
+from onyx.db.notification import count_notifications
+from onyx.db.notification import create_notification
+from onyx.db.notification import dismiss_user_notifications
+from onyx.db.notification import get_notifications
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _create_notification(
+    db_session: Session,
+    user: User,
+    index: int,
+    first_shown: datetime,
+    dismissed: bool,
+) -> Notification:
+    notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=dismissed,
+        last_shown=first_shown,
+        first_shown=first_shown,
+        title=f"Approval {index}",
+        additional_data={"test_position": index},
+    )
+    db_session.add(notification)
+    return notification
+
+
+def test_notification_pagination_counts_and_bulk_dismissal(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_page")
+    other_user = create_test_user(db_session, "notification_page_other")
+    base_time = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    created_notifications = [
+        _create_notification(
+            db_session=db_session,
+            user=user,
+            index=index,
+            first_shown=base_time + timedelta(minutes=index),
+            dismissed=index in {1, 3},
+        )
+        for index in range(5)
+    ]
+    other_user_notification = _create_notification(
+        db_session=db_session,
+        user=other_user,
+        index=99,
+        first_shown=base_time + timedelta(minutes=99),
+        dismissed=False,
+    )
+    db_session.commit()
+
+    page = get_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        include_dismissed=True,
+        limit=2,
+        offset=2,
+    )
+
+    assert [notification.id for notification in page] == [
+        created_notifications[0].id,
+        created_notifications[3].id,
+    ]
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+    )
+    assert total_items == 5
+    assert undismissed_count == 3
+
+    dismiss_user_notifications(user=user, db_session=db_session)
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+    )
+    assert total_items == 5
+    assert undismissed_count == 0
+
+    other_user_row = db_session.scalars(
+        select(Notification).where(Notification.id == other_user_notification.id)
+    ).one()
+    assert other_user_row.dismissed is False
+
+
+def test_create_notification_can_preserve_existing_last_shown(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_touch")
+    original_last_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = _create_notification(
+        db_session=db_session,
+        user=user,
+        index=1,
+        first_shown=original_last_shown,
+        dismissed=False,
+    )
+    notification.last_shown = original_last_shown
+    db_session.commit()
+
+    existing_notification = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="Approval 1",
+        additional_data={"test_position": 1},
+        refresh_existing=False,
+    )
+
+    assert existing_notification.id == notification.id
+    assert existing_notification.last_shown == original_last_shown

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -245,6 +245,16 @@ def test_get_notifications_api_scopes_ensure_checks(
 
     calls.clear()
     notifications_api.get_notifications_api(
+        page_num=0,
+        page_size=2,
+        notif_type=NotificationType.RELEASE_NOTES,
+        user=user,
+        db_session=db_session,
+    )
+    assert calls == ["release_notes"]
+
+    calls.clear()
+    notifications_api.get_notifications_api(
         page_num=1,
         page_size=2,
         notif_type=None,

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -6,11 +6,15 @@ import Link from "next/link";
 import type { Route } from "next";
 import Cookies from "js-cookie";
 import { SvgX } from "@opal/icons";
+import { dismissNotification } from "@/lib/notifications/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { useSWRConfig } from "swr";
 const DISMISSED_NOTIFICATION_COOKIE_PREFIX = "dismissed_notification_";
 const COOKIE_EXPIRY_DAYS = 1;
 
 export function AnnouncementBanner() {
   const settings = useContext(SettingsContext);
+  const { mutate } = useSWRConfig();
   const [localNotifications, setLocalNotifications] = useState(
     settings?.settings.notifications || []
   );
@@ -31,26 +35,18 @@ export function AnnouncementBanner() {
 
   const handleDismiss = async (notificationId: number) => {
     try {
-      const response = await fetch(
-        `/api/notifications/${notificationId}/dismiss`,
-        {
-          method: "POST",
-        }
+      await dismissNotification(notificationId);
+      Cookies.set(
+        `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notificationId}`,
+        "true",
+        { expires: COOKIE_EXPIRY_DAYS }
       );
-      if (response.ok) {
-        Cookies.set(
-          `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notificationId}`,
-          "true",
-          { expires: COOKIE_EXPIRY_DAYS }
-        );
-        setLocalNotifications((prevNotifications) =>
-          prevNotifications.filter(
-            (notification) => notification.id !== notificationId
-          )
-        );
-      } else {
-        console.error("Failed to dismiss notification");
-      }
+      setLocalNotifications((prevNotifications) =>
+        prevNotifications.filter(
+          (notification) => notification.id !== notificationId
+        )
+      );
+      void mutate(SWR_KEYS.notificationsSummary);
     } catch (error) {
       console.error("Error dismissing notification:", error);
     }

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import useSWRInfinite from "swr/infinite";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -104,16 +104,20 @@ export default function useNotifications({
   const isLoading = enabled && !error && !data;
   const isLoadingMore =
     enabled && data !== undefined && size > 0 && data[size - 1] === undefined;
+  const loadMoreInFlightRef = useRef(false);
 
   const loadMore = useCallback(async () => {
-    if (isLoadingMore || !hasMore) {
+    if (loadMoreInFlightRef.current || isLoadingMore || !hasMore) {
       return;
     }
 
+    loadMoreInFlightRef.current = true;
     try {
       await setSize((currentSize) => currentSize + 1);
     } catch (err) {
       console.error("Failed to load more notifications:", err);
+    } finally {
+      loadMoreInFlightRef.current = false;
     }
   }, [hasMore, isLoadingMore, setSize]);
 

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -6,7 +6,6 @@ import useSWRInfinite from "swr/infinite";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type {
-  NotificationType,
   Notification,
   NotificationSummary,
   NotificationsResponse,
@@ -16,7 +15,6 @@ const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
 
 interface UseNotificationsOptions {
   pageSize?: number;
-  notificationType?: NotificationType;
   enabled?: boolean;
 }
 
@@ -57,7 +55,6 @@ export function useNotificationSummary() {
  */
 export default function useNotifications({
   pageSize = DEFAULT_NOTIFICATIONS_PAGE_SIZE,
-  notificationType,
   enabled = true,
 }: UseNotificationsOptions = {}) {
   const { mutate: mutateGlobal } = useSWRConfig();
@@ -69,9 +66,9 @@ export default function useNotifications({
       if (!enabled) return null;
       if (previousPageData && !previousPageData.has_more) return null;
 
-      return SWR_KEYS.notificationsPage(pageIndex, pageSize, notificationType);
+      return SWR_KEYS.notificationsPage(pageIndex, pageSize);
     },
-    [enabled, notificationType, pageSize]
+    [enabled, pageSize]
   );
 
   const { data, error, mutate, size, setSize } =

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -1,9 +1,67 @@
 "use client";
 
-import useSWR from "swr";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import useSWR, { useSWRConfig } from "swr";
+import useSWRInfinite from "swr/infinite";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import type { Notification } from "@/lib/notifications/interfaces";
+import type {
+  NotificationType,
+  Notification,
+  NotificationsResponse,
+} from "@/lib/notifications/interfaces";
+
+const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
+const NOTIFICATIONS_SUMMARY_PAGE_SIZE = 1;
+
+function buildNotificationsUrl({
+  pageNum,
+  pageSize,
+  notificationType,
+}: {
+  pageNum: number;
+  pageSize: number;
+  notificationType?: NotificationType;
+}): string {
+  const params = new URLSearchParams({
+    page_num: pageNum.toString(),
+    page_size: pageSize.toString(),
+  });
+  if (notificationType) {
+    params.set("notif_type", notificationType);
+  }
+  return `${SWR_KEYS.notifications}?${params.toString()}`;
+}
+
+interface UseNotificationsOptions {
+  pageSize?: number;
+  notificationType?: NotificationType;
+  enabled?: boolean;
+}
+
+export function useNotificationSummary() {
+  const summaryKey = buildNotificationsUrl({
+    pageNum: 0,
+    pageSize: NOTIFICATIONS_SUMMARY_PAGE_SIZE,
+  });
+  const { data, error, isLoading, mutate } = useSWR<NotificationsResponse>(
+    summaryKey,
+    errorHandlingFetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      dedupingInterval: 30000,
+    }
+  );
+
+  return {
+    totalItems: data?.total_items ?? 0,
+    undismissedCount: data?.undismissed_count ?? 0,
+    isLoading,
+    error,
+    refresh: mutate,
+  };
+}
 
 /**
  * Fetches the current user's notifications.
@@ -14,25 +72,115 @@ import type { Notification } from "@/lib/notifications/interfaces";
  * @returns Object containing:
  *   - notifications: Array of Notification objects (empty array while loading)
  *   - undismissedCount: Number of notifications that haven't been dismissed
+ *   - totalItems: Total number of matching notifications
  *   - isLoading: Boolean indicating if data is being fetched
  *   - error: Any error that occurred during fetch
  *   - refresh: Function to manually revalidate the data
+ *   - hasMore: Whether another page is available
+ *   - isLoadingMore: Whether a subsequent page is loading
+ *   - loadMore: Function to fetch the next page
  */
-export default function useNotifications() {
-  const { data, error, isLoading, mutate } = useSWR<Notification[]>(
-    SWR_KEYS.notifications,
-    errorHandlingFetcher,
-    { revalidateOnFocus: false }
+export default function useNotifications({
+  pageSize = DEFAULT_NOTIFICATIONS_PAGE_SIZE,
+  notificationType,
+  enabled = true,
+}: UseNotificationsOptions = {}) {
+  const { mutate: mutateGlobal } = useSWRConfig();
+  const getKey = useCallback(
+    (
+      pageIndex: number,
+      previousPageData: NotificationsResponse | null
+    ): string | null => {
+      if (!enabled) return null;
+      if (previousPageData && !previousPageData.has_more) return null;
+
+      return buildNotificationsUrl({
+        pageNum: pageIndex,
+        pageSize,
+        notificationType,
+      });
+    },
+    [enabled, notificationType, pageSize]
   );
 
-  const notifications = data ?? [];
-  const undismissedCount = notifications.filter((n) => !n.dismissed).length;
+  const { data, error, mutate, setSize } =
+    useSWRInfinite<NotificationsResponse>(getKey, errorHandlingFetcher, {
+      revalidateOnFocus: false,
+      revalidateIfStale: false,
+      revalidateFirstPage: false,
+      revalidateAll: false,
+      dedupingInterval: 30000,
+    });
+
+  const notifications = useMemo<Notification[]>(
+    () => (data ? data.flatMap((page) => page.notifications) : []),
+    [data]
+  );
+  const firstPage = data?.[0];
+  const lastPage = data?.[data.length - 1];
+  const undismissedCount = firstPage?.undismissed_count ?? 0;
+  const totalItems = firstPage?.total_items ?? 0;
+  const hasMore = lastPage?.has_more ?? false;
+  const loadedPageCount = data?.length ?? 0;
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const loadedPageCountRef = useRef(loadedPageCount);
+  const hasMoreRef = useRef(hasMore);
+  const requestedPageCountRef = useRef(loadedPageCount);
+  const loadMoreInFlightRef = useRef(false);
+
+  useEffect(() => {
+    loadedPageCountRef.current = loadedPageCount;
+    hasMoreRef.current = hasMore;
+
+    if (loadedPageCount >= requestedPageCountRef.current) {
+      loadMoreInFlightRef.current = false;
+      setIsLoadingMore(false);
+    }
+  }, [hasMore, loadedPageCount]);
+
+  const loadMore = useCallback(async () => {
+    const currentLoadedPageCount = loadedPageCountRef.current;
+    if (
+      loadMoreInFlightRef.current ||
+      requestedPageCountRef.current > currentLoadedPageCount ||
+      !hasMoreRef.current
+    ) {
+      return;
+    }
+
+    const nextPageCount = currentLoadedPageCount + 1;
+    requestedPageCountRef.current = nextPageCount;
+    loadMoreInFlightRef.current = true;
+    setIsLoadingMore(true);
+    try {
+      await setSize(nextPageCount);
+    } catch (err) {
+      requestedPageCountRef.current = currentLoadedPageCount;
+      loadMoreInFlightRef.current = false;
+      setIsLoadingMore(false);
+      console.error("Failed to load more notifications:", err);
+    }
+  }, [setSize]);
+
+  const refresh = useCallback(() => {
+    mutateGlobal(
+      buildNotificationsUrl({
+        pageNum: 0,
+        pageSize: NOTIFICATIONS_SUMMARY_PAGE_SIZE,
+      })
+    );
+    return mutate();
+  }, [mutate, mutateGlobal]);
 
   return {
     notifications,
     undismissedCount,
-    isLoading,
+    totalItems,
+    isLoading: !error && !data,
     error,
-    refresh: mutate,
+    refresh,
+    hasMore,
+    isLoadingMore,
+    loadMore,
   };
 }

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -8,11 +8,12 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import type {
   NotificationType,
   Notification,
+  NotificationSummary,
   NotificationsResponse,
 } from "@/lib/notifications/interfaces";
 
 const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
-const NOTIFICATIONS_SUMMARY_PAGE_SIZE = 1;
+const NOTIFICATIONS_SUMMARY_URL = `${SWR_KEYS.notifications}/summary`;
 
 function buildNotificationsUrl({
   pageNum,
@@ -40,16 +41,11 @@ interface UseNotificationsOptions {
 }
 
 export function useNotificationSummary() {
-  const summaryKey = buildNotificationsUrl({
-    pageNum: 0,
-    pageSize: NOTIFICATIONS_SUMMARY_PAGE_SIZE,
-  });
-  const { data, error, isLoading, mutate } = useSWR<NotificationsResponse>(
-    summaryKey,
+  const { data, error, isLoading, mutate } = useSWR<NotificationSummary>(
+    NOTIFICATIONS_SUMMARY_URL,
     errorHandlingFetcher,
     {
       revalidateOnFocus: false,
-      revalidateIfStale: false,
       dedupingInterval: 30000,
     }
   );
@@ -66,8 +62,7 @@ export function useNotificationSummary() {
 /**
  * Fetches the current user's notifications.
  *
- * The GET endpoint also triggers a server-side refresh if release notes
- * are stale, so simply mounting this hook keeps notifications up to date.
+ * The first page can also trigger server-side checks that create notifications.
  *
  * @returns Object containing:
  *   - notifications: Array of Notification objects (empty array while loading)
@@ -86,6 +81,15 @@ export default function useNotifications({
   enabled = true,
 }: UseNotificationsOptions = {}) {
   const { mutate: mutateGlobal } = useSWRConfig();
+  const firstPageKey = useMemo(
+    () =>
+      buildNotificationsUrl({
+        pageNum: 0,
+        pageSize,
+        notificationType,
+      }),
+    [notificationType, pageSize]
+  );
   const getKey = useCallback(
     (
       pageIndex: number,
@@ -94,28 +98,39 @@ export default function useNotifications({
       if (!enabled) return null;
       if (previousPageData && !previousPageData.has_more) return null;
 
+      if (pageIndex === 0) return firstPageKey;
+
       return buildNotificationsUrl({
         pageNum: pageIndex,
         pageSize,
         notificationType,
       });
     },
-    [enabled, notificationType, pageSize]
+    [enabled, firstPageKey, notificationType, pageSize]
   );
 
   const { data, error, mutate, setSize } =
     useSWRInfinite<NotificationsResponse>(getKey, errorHandlingFetcher, {
       revalidateOnFocus: false,
-      revalidateIfStale: false,
       revalidateFirstPage: false,
       revalidateAll: false,
       dedupingInterval: 30000,
     });
 
-  const notifications = useMemo<Notification[]>(
-    () => (data ? data.flatMap((page) => page.notifications) : []),
-    [data]
-  );
+  const notifications = useMemo<Notification[]>(() => {
+    if (!data) return [];
+
+    const seenNotificationIds = new Set<number>();
+    return data.flatMap((page) =>
+      page.notifications.filter((notification) => {
+        if (seenNotificationIds.has(notification.id)) {
+          return false;
+        }
+        seenNotificationIds.add(notification.id);
+        return true;
+      })
+    );
+  }, [data]);
   const firstPage = data?.[0];
   const lastPage = data?.[data.length - 1];
   const undismissedCount = firstPage?.undismissed_count ?? 0;
@@ -163,20 +178,19 @@ export default function useNotifications({
   }, [setSize]);
 
   const refresh = useCallback(() => {
-    mutateGlobal(
-      buildNotificationsUrl({
-        pageNum: 0,
-        pageSize: NOTIFICATIONS_SUMMARY_PAGE_SIZE,
-      })
-    );
-    return mutate();
-  }, [mutate, mutateGlobal]);
+    mutateGlobal(NOTIFICATIONS_SUMMARY_URL);
+    if (!enabled) return Promise.resolve(undefined);
+
+    return mutate(undefined, {
+      revalidate: (_pageData, pageArg) => pageArg === firstPageKey,
+    });
+  }, [enabled, firstPageKey, mutate, mutateGlobal]);
 
   return {
     notifications,
     undismissedCount,
     totalItems,
-    isLoading: !error && !data,
+    isLoading: enabled && !error && !data,
     error,
     refresh,
     hasMore,

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import useSWR, { useSWRConfig } from "swr";
 import useSWRInfinite from "swr/infinite";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -61,10 +61,6 @@ export default function useNotifications({
   enabled = true,
 }: UseNotificationsOptions = {}) {
   const { mutate: mutateGlobal } = useSWRConfig();
-  const firstPageKey = useMemo(
-    () => SWR_KEYS.notificationsPage(0, pageSize, notificationType),
-    [notificationType, pageSize]
-  );
   const getKey = useCallback(
     (
       pageIndex: number,
@@ -73,14 +69,12 @@ export default function useNotifications({
       if (!enabled) return null;
       if (previousPageData && !previousPageData.has_more) return null;
 
-      if (pageIndex === 0) return firstPageKey;
-
       return SWR_KEYS.notificationsPage(pageIndex, pageSize, notificationType);
     },
-    [enabled, firstPageKey, notificationType, pageSize]
+    [enabled, notificationType, pageSize]
   );
 
-  const { data, error, mutate, setSize } =
+  const { data, error, mutate, size, setSize } =
     useSWRInfinite<NotificationsResponse>(getKey, errorHandlingFetcher, {
       revalidateOnFocus: false,
       revalidateFirstPage: false,
@@ -107,46 +101,21 @@ export default function useNotifications({
   const undismissedCount = firstPage?.undismissed_count ?? 0;
   const totalItems = firstPage?.total_items ?? 0;
   const hasMore = lastPage?.has_more ?? false;
-  const loadedPageCount = data?.length ?? 0;
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const loadedPageCountRef = useRef(loadedPageCount);
-  const hasMoreRef = useRef(hasMore);
-  const requestedPageCountRef = useRef(loadedPageCount);
-  const loadMoreInFlightRef = useRef(false);
-
-  useEffect(() => {
-    loadedPageCountRef.current = loadedPageCount;
-    hasMoreRef.current = hasMore;
-
-    if (loadedPageCount >= requestedPageCountRef.current) {
-      loadMoreInFlightRef.current = false;
-      setIsLoadingMore(false);
-    }
-  }, [hasMore, loadedPageCount]);
+  const isLoading = enabled && !error && !data;
+  const isLoadingMore =
+    enabled && data !== undefined && size > 0 && data[size - 1] === undefined;
 
   const loadMore = useCallback(async () => {
-    const currentLoadedPageCount = loadedPageCountRef.current;
-    if (
-      loadMoreInFlightRef.current ||
-      requestedPageCountRef.current > currentLoadedPageCount ||
-      !hasMoreRef.current
-    ) {
+    if (isLoadingMore || !hasMore) {
       return;
     }
 
-    const nextPageCount = currentLoadedPageCount + 1;
-    requestedPageCountRef.current = nextPageCount;
-    loadMoreInFlightRef.current = true;
-    setIsLoadingMore(true);
     try {
-      await setSize(nextPageCount);
+      await setSize((currentSize) => currentSize + 1);
     } catch (err) {
-      requestedPageCountRef.current = currentLoadedPageCount;
-      loadMoreInFlightRef.current = false;
-      setIsLoadingMore(false);
       console.error("Failed to load more notifications:", err);
     }
-  }, [setSize]);
+  }, [hasMore, isLoadingMore, setSize]);
 
   const refresh = useCallback(() => {
     void mutateGlobal(SWR_KEYS.notificationsSummary);
@@ -159,7 +128,7 @@ export default function useNotifications({
     notifications,
     undismissedCount,
     totalItems,
-    isLoading: enabled && !error && !data,
+    isLoading,
     error,
     refresh,
     hasMore,

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -178,13 +178,14 @@ export default function useNotifications({
   }, [setSize]);
 
   const refresh = useCallback(() => {
-    mutateGlobal(NOTIFICATIONS_SUMMARY_URL);
+    void mutateGlobal(NOTIFICATIONS_SUMMARY_URL);
     if (!enabled) return Promise.resolve(undefined);
 
-    return mutate(undefined, {
-      revalidate: (_pageData, pageArg) => pageArg === firstPageKey,
+    return mutate((currentData) => currentData, {
+      populateCache: false,
+      revalidate: true,
     });
-  }, [enabled, firstPageKey, mutate, mutateGlobal]);
+  }, [enabled, mutate, mutateGlobal]);
 
   return {
     notifications,

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -13,26 +13,6 @@ import type {
 } from "@/lib/notifications/interfaces";
 
 const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
-const NOTIFICATIONS_SUMMARY_URL = `${SWR_KEYS.notifications}/summary`;
-
-function buildNotificationsUrl({
-  pageNum,
-  pageSize,
-  notificationType,
-}: {
-  pageNum: number;
-  pageSize: number;
-  notificationType?: NotificationType;
-}): string {
-  const params = new URLSearchParams({
-    page_num: pageNum.toString(),
-    page_size: pageSize.toString(),
-  });
-  if (notificationType) {
-    params.set("notif_type", notificationType);
-  }
-  return `${SWR_KEYS.notifications}?${params.toString()}`;
-}
 
 interface UseNotificationsOptions {
   pageSize?: number;
@@ -42,7 +22,7 @@ interface UseNotificationsOptions {
 
 export function useNotificationSummary() {
   const { data, error, isLoading, mutate } = useSWR<NotificationSummary>(
-    NOTIFICATIONS_SUMMARY_URL,
+    SWR_KEYS.notificationsSummary,
     errorHandlingFetcher,
     {
       revalidateOnFocus: false,
@@ -82,12 +62,7 @@ export default function useNotifications({
 }: UseNotificationsOptions = {}) {
   const { mutate: mutateGlobal } = useSWRConfig();
   const firstPageKey = useMemo(
-    () =>
-      buildNotificationsUrl({
-        pageNum: 0,
-        pageSize,
-        notificationType,
-      }),
+    () => SWR_KEYS.notificationsPage(0, pageSize, notificationType),
     [notificationType, pageSize]
   );
   const getKey = useCallback(
@@ -100,11 +75,7 @@ export default function useNotifications({
 
       if (pageIndex === 0) return firstPageKey;
 
-      return buildNotificationsUrl({
-        pageNum: pageIndex,
-        pageSize,
-        notificationType,
-      });
+      return SWR_KEYS.notificationsPage(pageIndex, pageSize, notificationType);
     },
     [enabled, firstPageKey, notificationType, pageSize]
   );
@@ -178,7 +149,7 @@ export default function useNotifications({
   }, [setSize]);
 
   const refresh = useCallback(() => {
-    void mutateGlobal(NOTIFICATIONS_SUMMARY_URL);
+    void mutateGlobal(SWR_KEYS.notificationsSummary);
     if (!enabled) return Promise.resolve(undefined);
 
     return mutate();

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -181,10 +181,7 @@ export default function useNotifications({
     void mutateGlobal(NOTIFICATIONS_SUMMARY_URL);
     if (!enabled) return Promise.resolve(undefined);
 
-    return mutate((currentData) => currentData, {
-      populateCache: false,
-      revalidate: true,
-    });
+    return mutate();
   }, [enabled, mutate, mutateGlobal]);
 
   return {

--- a/web/src/lib/notifications/api.ts
+++ b/web/src/lib/notifications/api.ts
@@ -1,0 +1,30 @@
+async function handleNotificationMutation(
+  response: Response,
+  fallbackMessage: string
+): Promise<void> {
+  if (response.ok) {
+    return;
+  }
+
+  const error = await response.json().catch(() => ({}));
+  throw new Error(error.detail || fallbackMessage);
+}
+
+export async function dismissNotification(
+  notificationId: number
+): Promise<void> {
+  const response = await fetch(`/api/notifications/${notificationId}/dismiss`, {
+    method: "POST",
+  });
+  return handleNotificationMutation(response, "Failed to dismiss notification");
+}
+
+export async function dismissAllNotifications(): Promise<void> {
+  const response = await fetch("/api/notifications/dismiss-all", {
+    method: "POST",
+  });
+  return handleNotificationMutation(
+    response,
+    "Failed to dismiss notifications"
+  );
+}

--- a/web/src/lib/notifications/index.ts
+++ b/web/src/lib/notifications/index.ts
@@ -9,10 +9,15 @@ export function getNotificationIcon(
     case NotificationType.PERSONA_SHARED:
     case NotificationType.REINDEX:
     case NotificationType.ASSISTANT_FILES_READY:
+    case NotificationType.CONNECTOR_REPEATED_ERRORS:
+    case NotificationType.SCHEDULED_TASK_PRE_APPROVED_ACTION:
+    case NotificationType.APPROVAL_REQUESTED:
       return SvgAlertCircle;
 
     case NotificationType.TRIAL_ENDS_TWO_DAYS:
     case NotificationType.LICENSE_EXPIRY_WARNING:
+    case NotificationType.SCHEDULED_TASK_FAILED:
+    case NotificationType.SCHEDULED_TASK_AWAITING_APPROVAL:
       return SvgAlertTriangle;
 
     case NotificationType.RELEASE_NOTES:

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -3,10 +3,15 @@ export enum NotificationType {
   PERSONA_SHARED = "persona_shared",
   REINDEX = "reindex",
   ASSISTANT_FILES_READY = "assistant_files_ready",
+  CONNECTOR_REPEATED_ERRORS = "connector_repeated_errors",
+  SCHEDULED_TASK_PRE_APPROVED_ACTION = "scheduled_task_pre_approved_action",
+  APPROVAL_REQUESTED = "approval_requested",
 
   // SvgAlertTriangle
   TRIAL_ENDS_TWO_DAYS = "two_day_trial_ending",
   LICENSE_EXPIRY_WARNING = "license_expiry_warning",
+  SCHEDULED_TASK_FAILED = "scheduled_task_failed",
+  SCHEDULED_TASK_AWAITING_APPROVAL = "scheduled_task_awaiting_approval",
 
   // SvgBullhorn
   RELEASE_NOTES = "release_notes",
@@ -15,7 +20,7 @@ export enum NotificationType {
 
 export interface Notification {
   id: number;
-  notif_type: string;
+  notif_type: NotificationType;
   title: string;
   description: string | null;
   dismissed: boolean;
@@ -27,4 +32,13 @@ export interface Notification {
     version?: string; // For release notes notifications
     [key: string]: any;
   };
+}
+
+export interface NotificationsResponse {
+  notifications: Notification[];
+  total_items: number;
+  undismissed_count: number;
+  page_num: number;
+  page_size: number;
+  has_more: boolean;
 }

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -31,7 +31,7 @@ export interface Notification {
     link?: string;
     version?: string; // For release notes notifications
     [key: string]: any;
-  };
+  } | null;
 }
 
 export interface NotificationsResponse {
@@ -41,4 +41,9 @@ export interface NotificationsResponse {
   page_num: number;
   page_size: number;
   has_more: boolean;
+}
+
+export interface NotificationSummary {
+  total_items: number;
+  undismissed_count: number;
 }

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -1,3 +1,5 @@
+import type { NotificationType } from "@/lib/notifications/interfaces";
+
 /**
  * Centralized SWR cache key registry.
  *
@@ -83,6 +85,21 @@ export const SWR_KEYS = {
   userPats: "/api/user/pats",
   userPatScopes: "/api/user/pats/scopes",
   notifications: "/api/notifications",
+  notificationsSummary: "/api/notifications/summary",
+  notificationsPage: (
+    pageNum: number,
+    pageSize: number,
+    notificationType?: NotificationType
+  ) => {
+    const params = new URLSearchParams({
+      page_num: pageNum.toString(),
+      page_size: pageSize.toString(),
+    });
+    if (notificationType) {
+      params.set("notif_type", notificationType);
+    }
+    return `/api/notifications?${params.toString()}`;
+  },
 
   // ── Users ─────────────────────────────────────────────────────────────────
   acceptedUsers: "/api/manage/users/accepted/all",

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -1,5 +1,3 @@
-import type { NotificationType } from "@/lib/notifications/interfaces";
-
 /**
  * Centralized SWR cache key registry.
  *
@@ -86,18 +84,11 @@ export const SWR_KEYS = {
   userPatScopes: "/api/user/pats/scopes",
   notifications: "/api/notifications",
   notificationsSummary: "/api/notifications/summary",
-  notificationsPage: (
-    pageNum: number,
-    pageSize: number,
-    notificationType?: NotificationType
-  ) => {
+  notificationsPage: (pageNum: number, pageSize: number) => {
     const params = new URLSearchParams({
       page_num: pageNum.toString(),
       page_size: pageSize.toString(),
     });
-    if (notificationType) {
-      params.set("notif_type", notificationType);
-    }
     return `/api/notifications?${params.toString()}`;
   },
 

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -33,21 +33,22 @@ import {
   useSettingsContext,
 } from "@/providers/SettingsProvider";
 import UserAvatar from "@/refresh-components/avatars/UserAvatar";
-import useNotifications from "@/hooks/useNotifications";
+import { useNotificationSummary } from "@/hooks/useNotifications";
 import { SvgOnyxLogo } from "@opal/logos";
 import { markdown } from "@opal/utils";
 
 interface SettingsPopoverProps {
   onUserSettingsClick: () => void;
   onOpenNotifications: () => void;
+  undismissedCount: number;
 }
 
 function SettingsPopover({
   onUserSettingsClick,
   onOpenNotifications,
+  undismissedCount,
 }: SettingsPopoverProps) {
   const { user } = useUser();
-  const { undismissedCount } = useNotifications();
   const settings = useSettingsContext();
   const router = useRouter();
   const pathname = usePathname();
@@ -204,7 +205,7 @@ export default function AccountPopover({
   const { user } = useUser();
   const appFocus = useAppFocus();
   const vectorDbEnabled = useVectorDbEnabled();
-  const { undismissedCount } = useNotifications();
+  const { undismissedCount } = useNotificationSummary();
   const userDisplayName = getUserDisplayName(user);
 
   const handlePopoverOpen = (state: boolean) => {
@@ -259,6 +260,7 @@ export default function AccountPopover({
               setPopupState(undefined);
             }}
             onOpenNotifications={() => setPopupState("Notifications")}
+            undismissedCount={undismissedCount}
           />
         )}
         {popupState === "Notifications" && (

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -205,7 +205,8 @@ export default function AccountPopover({
   const { user } = useUser();
   const appFocus = useAppFocus();
   const vectorDbEnabled = useVectorDbEnabled();
-  const { undismissedCount } = useNotificationSummary();
+  const { undismissedCount, refresh: refreshNotificationSummary } =
+    useNotificationSummary();
   const userDisplayName = getUserDisplayName(user);
 
   const handlePopoverOpen = (state: boolean) => {
@@ -217,6 +218,7 @@ export default function AccountPopover({
         preload("/api/manage/connector-status", errorHandlingFetcher);
       }
       preload("/api/llm/provider", errorHandlingFetcher);
+      void refreshNotificationSummary();
       setPopupState("Settings");
     } else {
       setPopupState(undefined);

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -256,7 +256,6 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
 
   // Fetch notifications for build mode intro
   const { notifications, refresh: mutateNotifications } = useNotifications({
-    notificationType: NotificationType.FEATURE_ANNOUNCEMENT,
     enabled: isOnyxCraftEnabled,
   });
 

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -79,6 +79,7 @@ import { usePostHog } from "posthog-js/react";
 import { track, AnalyticsEvent } from "@/lib/analytics";
 import { motion, AnimatePresence } from "motion/react";
 import { NotificationType } from "@/lib/notifications/interfaces";
+import { dismissNotification } from "@/lib/notifications/api";
 import AccountPopover from "@/sections/sidebar/AccountPopover";
 import ChatSearchCommandMenu from "@/sections/sidebar/ChatSearchCommandMenu";
 import { useQueryController } from "@/providers/QueryControllerProvider";
@@ -303,9 +304,7 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
   const dismissBuildModeNotification = useCallback(async () => {
     if (!buildModeNotification) return;
     try {
-      await fetch(`/api/notifications/${buildModeNotification.id}/dismiss`, {
-        method: "POST",
-      });
+      await dismissNotification(buildModeNotification.id);
       mutateNotifications();
     } catch (error) {
       console.error("Error dismissing notification:", error);

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -248,13 +248,16 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
   const [showMoveCustomAgentModal, setShowMoveCustomAgentModal] =
     useState(false);
 
-  // Fetch notifications for build mode intro
-  const { notifications, refresh: mutateNotifications } = useNotifications();
-
   // Check if Onyx Craft is enabled via settings (backed by PostHog feature flag)
   // Only explicit true enables the feature; false or undefined = disabled
   const isOnyxCraftEnabled =
     combinedSettings?.settings?.onyx_craft_enabled === true;
+
+  // Fetch notifications for build mode intro
+  const { notifications, refresh: mutateNotifications } = useNotifications({
+    notificationType: NotificationType.FEATURE_ANNOUNCEMENT,
+    enabled: isOnyxCraftEnabled,
+  });
 
   // Find build_mode feature announcement notification (only if Onyx Craft is enabled)
   const buildModeNotification = isOnyxCraftEnabled

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Route } from "next";
 import { track, AnalyticsEvent } from "@/lib/analytics";
@@ -110,7 +110,14 @@ export default function NotificationsPopover({
     undismissedCount,
     isLoading,
     refresh: mutate,
+    hasMore,
+    isLoadingMore,
+    loadMore,
   } = useNotifications();
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
 
   // Track IDs dismissed during this session (before popover closes)
   const [sessionDismissedIds, setSessionDismissedIds] = useState<Set<number>>(
@@ -196,13 +203,54 @@ export default function NotificationsPopover({
   );
 
   const handleDismissAll = useCallback(async () => {
-    for (const n of newNotifications) {
-      await handleDismiss(n.id);
+    try {
+      const response = await fetch("/api/notifications/dismiss-all", {
+        method: "POST",
+      });
+      if (response.ok) {
+        setSessionDismissedIds((prev) => {
+          const next = new Set(prev);
+          newNotifications.forEach((notification) => {
+            next.add(notification.id);
+          });
+          return next;
+        });
+        mutate();
+      }
+    } catch (error) {
+      console.error("Error dismissing notifications:", error);
     }
-  }, [newNotifications, handleDismiss]);
+  }, [mutate, newNotifications]);
+
+  useEffect(() => {
+    if (!hasMore || isLoadingMore) return;
+
+    const scrollContainer = scrollContainerRef.current;
+    const sentinel = sentinelRef.current;
+    if (!scrollContainer || !sentinel) return;
+
+    let didRequestLoad = false;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !didRequestLoad) {
+          didRequestLoad = true;
+          observer.disconnect();
+          loadMoreRef.current();
+        }
+      },
+      {
+        root: scrollContainer,
+        rootMargin: "64px 0px",
+        threshold: 0,
+      }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoadingMore]);
 
   return (
-    <Section gap={0}>
+    <Section gap={0} justifyContent="start" alignItems="stretch">
       <Section flexDirection="row" padding={0.325}>
         <Section flexDirection="row" gap={0.25} justifyContent="start">
           <Button
@@ -247,7 +295,10 @@ export default function NotificationsPopover({
           </Section>
         </div>
       ) : (
-        <div className="max-h-(--notifications-popover) overflow-y-auto flex flex-col gap-1">
+        <div
+          ref={scrollContainerRef}
+          className="h-(--notifications-popover) w-full min-w-0 overflow-y-auto [scrollbar-gutter:stable] flex flex-col gap-1"
+        >
           {newNotifications.length > 0 && (
             <>
               <Divider title="New" />
@@ -280,6 +331,17 @@ export default function NotificationsPopover({
                 ))}
               </div>
             </>
+          )}
+
+          {hasMore && (
+            <div
+              ref={sentinelRef}
+              className="h-8 flex items-center justify-center transition-opacity duration-300"
+            >
+              <SvgSimpleLoader
+                className={isLoadingMore ? "opacity-100" : "opacity-40"}
+              />
+            </div>
           )}
         </div>
       )}

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -109,7 +109,7 @@ export default function NotificationsPopover({
     notifications,
     undismissedCount,
     isLoading,
-    refresh: mutate,
+    refresh,
     hasMore,
     isLoadingMore,
     loadMore,
@@ -117,12 +117,17 @@ export default function NotificationsPopover({
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const loadMoreRef = useRef(loadMore);
+  const lastLoadScrollTopRef = useRef<number | null>(null);
   loadMoreRef.current = loadMore;
 
   // Track IDs dismissed during this session (before popover closes)
   const [sessionDismissedIds, setSessionDismissedIds] = useState<Set<number>>(
     new Set()
   );
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
 
   const handleDismiss = useCallback(
     async (notificationId: number) => {
@@ -137,13 +142,13 @@ export default function NotificationsPopover({
             next.add(notificationId);
             return next;
           });
-          mutate();
+          void refresh();
         }
       } catch (error) {
         console.error("Error dismissing notification:", error);
       }
     },
-    [mutate]
+    [refresh]
   );
 
   const handleNotificationClick = useCallback(
@@ -215,12 +220,12 @@ export default function NotificationsPopover({
           });
           return next;
         });
-        mutate();
+        void refresh();
       }
     } catch (error) {
       console.error("Error dismissing notifications:", error);
     }
-  }, [mutate, newNotifications]);
+  }, [refresh, newNotifications]);
 
   useEffect(() => {
     if (!hasMore || isLoadingMore) return;
@@ -228,11 +233,16 @@ export default function NotificationsPopover({
     const scrollContainer = scrollContainerRef.current;
     const sentinel = sentinelRef.current;
     if (!scrollContainer || !sentinel) return;
+    lastLoadScrollTopRef.current ??= Math.round(scrollContainer.scrollTop);
 
     let didRequestLoad = false;
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting && !didRequestLoad) {
+          const currentScrollTop = Math.round(scrollContainer.scrollTop);
+          if (lastLoadScrollTopRef.current === currentScrollTop) return;
+
+          lastLoadScrollTopRef.current = currentScrollTop;
           didRequestLoad = true;
           observer.disconnect();
           loadMoreRef.current();
@@ -297,7 +307,7 @@ export default function NotificationsPopover({
       ) : (
         <div
           ref={scrollContainerRef}
-          className="h-(--notifications-popover) w-full min-w-0 overflow-y-auto [scrollbar-gutter:stable] flex flex-col gap-1"
+          className="h-(--notifications-popover) w-full min-w-0 overflow-y-auto [overflow-anchor:none] [scrollbar-gutter:stable] flex flex-col gap-1"
         >
           {newNotifications.length > 0 && (
             <>

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -7,6 +7,10 @@ import { track, AnalyticsEvent } from "@/lib/analytics";
 import type { Notification as NotificationData } from "@/lib/notifications/interfaces";
 import { NotificationType } from "@/lib/notifications/interfaces";
 import { getNotificationIcon } from "@/lib/notifications";
+import {
+  dismissAllNotifications,
+  dismissNotification,
+} from "@/lib/notifications/api";
 import { timeAgo } from "@opal/time";
 import useNotifications from "@/hooks/useNotifications";
 import {
@@ -128,18 +132,13 @@ export default function NotificationsPopover({
   const handleDismiss = useCallback(
     async (notificationId: number) => {
       try {
-        const response = await fetch(
-          `/api/notifications/${notificationId}/dismiss`,
-          { method: "POST" }
-        );
-        if (response.ok) {
-          setSessionDismissedIds((prev) => {
-            const next = new Set(prev);
-            next.add(notificationId);
-            return next;
-          });
-          void refresh();
-        }
+        await dismissNotification(notificationId);
+        setSessionDismissedIds((prev) => {
+          const next = new Set(prev);
+          next.add(notificationId);
+          return next;
+        });
+        void refresh();
       } catch (error) {
         console.error("Error dismissing notification:", error);
       }
@@ -205,19 +204,15 @@ export default function NotificationsPopover({
 
   const handleDismissAll = useCallback(async () => {
     try {
-      const response = await fetch("/api/notifications/dismiss-all", {
-        method: "POST",
-      });
-      if (response.ok) {
-        setSessionDismissedIds((prev) => {
-          const next = new Set(prev);
-          newNotifications.forEach((notification) => {
-            next.add(notification.id);
-          });
-          return next;
+      await dismissAllNotifications();
+      setSessionDismissedIds((prev) => {
+        const next = new Set(prev);
+        newNotifications.forEach((notification) => {
+          next.add(notification.id);
         });
-        void refresh();
-      }
+        return next;
+      });
+      void refresh();
     } catch (error) {
       console.error("Error dismissing notifications:", error);
     }

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -125,10 +125,6 @@ export default function NotificationsPopover({
     new Set()
   );
 
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
   const handleDismiss = useCallback(
     async (notificationId: number) => {
       try {
@@ -240,7 +236,14 @@ export default function NotificationsPopover({
       (entries) => {
         if (entries[0]?.isIntersecting && !didRequestLoad) {
           const currentScrollTop = Math.round(scrollContainer.scrollTop);
-          if (lastLoadScrollTopRef.current === currentScrollTop) return;
+          const isScrollable =
+            scrollContainer.scrollHeight > scrollContainer.clientHeight + 1;
+          if (
+            isScrollable &&
+            lastLoadScrollTopRef.current === currentScrollTop
+          ) {
+            return;
+          }
 
           lastLoadScrollTopRef.current = currentScrollTop;
           didRequestLoad = true;


### PR DESCRIPTION


https://github.com/user-attachments/assets/77b7628e-3ef5-4f86-9d58-40449f46be41

Fixes: https://linear.app/onyx-app/issue/ENG-4145/craft-polish-paginate-notifications

## Summary
- Add paginated notification API responses, summary counts, and bulk dismissal.
- Move notification response models under the notifications feature module and reuse them from settings.
- Convert the notifications popover to infinite scroll while keeping app-load notification bootstrap behavior.
- Stabilize SWR refresh behavior so dismisses revalidate loaded pages without clearing the infinite cache or causing fetch bursts.

## Validation
- e2e in app


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a paginated notifications API with summary counts and a bulk-dismiss endpoint, plus an infinite-scroll UI and centralized dismiss actions. Fulfills ENG-4145 and stabilizes refresh so dismissals revalidate loaded pages without cache bursts.

- New Features
  - `GET /api/notifications` is paginated (`page_num`, `page_size`) and returns notifications, totals, and `has_more`; the first page also runs ensure checks.
  - `GET /api/notifications/summary` returns badge counts; runs ensure checks before counting.
  - `POST /api/notifications/dismiss-all` bulk-dismisses the current user’s notifications via a single SQL update.
  - Web: `useNotifications` uses `useSWRInfinite`, de-dupes items, and supports `pageSize`/`enabled`; added `useNotificationSummary`; registered `SWR_KEYS.notificationsPage` and `SWR_KEYS.notificationsSummary`; popover adds infinite scroll with a sentinel loader and server-side bulk dismiss; banner, popover, and sidebar now use centralized helpers in `@/lib/notifications/api`; `AppSidebar` fetches feature announcements only when Craft is enabled; added new notification types and icon mappings (e.g. `APPROVAL_REQUESTED`, scheduled task states, connector errors).

- Bug Fixes
  - Stable ordering with ID tie-breaker to avoid paging jitter.
  - After individual or bulk dismiss, refresh revalidates loaded pages and summary without clearing the infinite cache; consolidated the list cache to avoid redundant keys.
  - Guarded against duplicate page loads; read-triggered ensures no longer bump `last_shown` (`refresh_existing=false`); API errors standardized via `OnyxError`; copy tweak: “Craft is requesting approval.”

<sup>Written for commit 077556c7ede6b0bd0799ee748c25a392320d39fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



