### PR TITLE
feat(opal): add "xl" rounding variant to Card

### DIFF
--- a/web/lib/opal/src/components/cards/card/components.tsx
+++ b/web/lib/opal/src/components/cards/card/components.tsx
@@ -53,6 +53,7 @@ type CardBaseProps = {
    * | `"sm"` | `rounded-08` |
    * | `"md"` | `rounded-12` |
    * | `"lg"` | `rounded-16` |
+   * | `"xl"` | `rounded-20` |
    *
    * In expandable mode when expanded, rounding applies only to the header's
    * top corners and the expandedContent's bottom corners so the two join seamlessly.

--- a/web/lib/opal/src/shared.ts
+++ b/web/lib/opal/src/shared.ts
@@ -148,6 +148,7 @@ const paddingYVariants: Record<PaddingVariants, string> = {
 };
 
 const cardRoundingVariants: Record<RoundingVariants, string> = {
+  xl: "rounded-20",
   lg: "rounded-16",
   md: "rounded-12",
   sm: "rounded-08",
@@ -155,6 +156,7 @@ const cardRoundingVariants: Record<RoundingVariants, string> = {
 };
 
 const cardTopRoundingVariants: Record<RoundingVariants, string> = {
+  xl: "rounded-t-20",
   lg: "rounded-t-16",
   md: "rounded-t-12",
   sm: "rounded-t-08",
@@ -162,6 +164,7 @@ const cardTopRoundingVariants: Record<RoundingVariants, string> = {
 };
 
 const cardBottomRoundingVariants: Record<RoundingVariants, string> = {
+  xl: "rounded-b-20",
   lg: "rounded-b-16",
   md: "rounded-b-12",
   sm: "rounded-b-08",

--- a/web/lib/opal/src/styles/sizes.css
+++ b/web/lib/opal/src/styles/sizes.css
@@ -182,6 +182,7 @@
   --radius-08: 0.5rem;
   --radius-12: 0.75rem;
   --radius-16: 1rem;
+  --radius-20: 1.25rem;
   --radius-round: 62.5rem;
 
   /* BACKDROP BLUR */

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -21,7 +21,15 @@ import type { SVGProps } from "react";
  * This is the complete scale of size presets available in the design system.
  * Components needing the full range use this type directly.
  */
-export type SizeVariants = "fit" | "full" | "lg" | "md" | "sm" | "xs" | "2xs";
+export type SizeVariants =
+  | "fit"
+  | "full"
+  | "xl"
+  | "lg"
+  | "md"
+  | "sm"
+  | "xs"
+  | "2xs";
 
 // Convenience Size Types:
 //
@@ -35,7 +43,7 @@ export type SizeVariants = "fit" | "full" | "lg" | "md" | "sm" | "xs" | "2xs";
  * Used by components that control height, min-width, and padding.
  * Excludes "full" since containers need a fixed height preset.
  */
-export type ContainerSizeVariants = Exclude<SizeVariants, "full">;
+export type ContainerSizeVariants = Exclude<SizeVariants, "full" | "xl">;
 
 /**
  * Padding size variants.
@@ -59,12 +67,16 @@ export type PaddingVariants = Extract<
  *
  * | Variant | Class        |
  * |---------|--------------|
+ * | `xl`    | `rounded-20` |
  * | `lg`    | `rounded-16` |
  * | `md`    | `rounded-12` |
  * | `sm`    | `rounded-08` |
  * | `xs`    | `rounded-04` |
  */
-export type RoundingVariants = Extract<SizeVariants, "lg" | "md" | "sm" | "xs">;
+export type RoundingVariants = Extract<
+  SizeVariants,
+  "xl" | "lg" | "md" | "sm" | "xs"
+>;
 
 /**
  * Extreme size variants ("fit" and "full" only).

--- a/web/lib/opal/tailwind-preset.cjs
+++ b/web/lib/opal/tailwind-preset.cjs
@@ -229,6 +229,7 @@ module.exports = {
         "08": "var(--radius-08)",
         12: "var(--radius-12)",
         16: "var(--radius-16)",
+        20: "var(--radius-20)",
         full: "var(--radius-round)",
       },
       fontSize: {


### PR DESCRIPTION
## Description

Adds a new `"xl"` rounding variant (`rounded-20` / 1.25rem) to the Opal card rounding scale.

- `"xl"` added to `SizeVariants`
- `RoundingVariants` extended to `Extract<SizeVariants, "xl" | "lg" | "md" | "sm" | "xs">`
- `ContainerSizeVariants` updated to `Exclude<SizeVariants, "full" | "xl">` so existing container maps stay exhaustive without new entries
- `--radius-20` CSS variable and `rounded-20` Tailwind token added
- All three card rounding maps (`cardRoundingVariants`, `cardTopRoundingVariants`, `cardBottomRoundingVariants`) updated with `xl` entries

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "xl" rounding option to the Opal Card for 1.25rem corners using the `rounded-20` token. This extends the rounding scale and updates types, CSS variables, and Tailwind preset support.

- **New Features**
  - Added `xl` to `SizeVariants` and `RoundingVariants`; excluded from `ContainerSizeVariants`.
  - Introduced `--radius-20` and Tailwind `rounded-20`.
  - Updated card rounding maps (top/bottom/all) and Card prop docs.

<sup>Written for commit 266cde654759fe3f212ca1b000ac82ef1e1b411f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->