### PR TITLE
feat(search): show active conversation name in browser tab title

### DIFF
--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -148,6 +148,17 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   // settings are passed in via Context and therefore aren't
   // available in server-side components
   const settings = useSettingsContext();
+
+  useEffect(() => {
+    const appName = settings.enterpriseSettings?.application_name || "Onyx";
+    document.title = currentChatSession?.name
+      ? `${currentChatSession.name} — ${appName}`
+      : appName;
+    return () => {
+      document.title = appName;
+    };
+  }, [currentChatSession?.name, settings.enterpriseSettings?.application_name]);
+
   const vectorDbEnabled = useVectorDbEnabled();
   const { ccPairs } = useCCPairs(vectorDbEnabled);
   const { tags } = useTags();

--- a/web/src/refresh-pages/AppPage.tsx
+++ b/web/src/refresh-pages/AppPage.tsx
@@ -149,15 +149,19 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   // available in server-side components
   const settings = useSettingsContext();
 
+  const appNameRef = useRef<string>("Onyx");
   useEffect(() => {
     const appName = settings.enterpriseSettings?.application_name || "Onyx";
+    appNameRef.current = appName;
     document.title = currentChatSession?.name
       ? `${currentChatSession.name} — ${appName}`
       : appName;
-    return () => {
-      document.title = appName;
-    };
   }, [currentChatSession?.name, settings.enterpriseSettings?.application_name]);
+  useEffect(() => {
+    return () => {
+      document.title = appNameRef.current;
+    };
+  }, []);
 
   const vectorDbEnabled = useVectorDbEnabled();
   const { ccPairs } = useCCPairs(vectorDbEnabled);


### PR DESCRIPTION
## Description

Browser tab title now shows the active conversation name alongside the app name (e.g. `Q3 budget analysis — Onyx`). Falls back to just the app name when no conversation is active. Respects a custom `application_name` set via enterprise settings.

Previously all search/chat tabs showed the same title, making it hard to tell tabs apart.

## How Has This Been Tested?

Manually verified in the local dev environment:
- Opening a conversation updates the tab title to `<name> — Onyx`
- Switching between two named conversations goes directly from one name to the other (no flash)
- Starting a new conversation resets the tab to just `Onyx`

<img width="161" height="46" alt="Screenshot 2026-06-08 at 2 19 01 PM" src="https://github.com/user-attachments/assets/a47fbc73-6d75-4dec-aa1b-7d84d14b1f96" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the active conversation name in the browser tab title (e.g., “Q3 budget analysis — Onyx”) and avoid title flash when switching between named conversations. Falls back to the app name when no conversation is active and respects a custom `application_name`.

<sup>Written for commit 8640f02271e11a40bcf866d3a1466b4de69d8f44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

