### PR TITLE
fix(scim): don't promote EXT_PERM_USER on a deactivating SCIM request

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -487,8 +487,10 @@ def create_user(
         # Adopt pre-existing user into SCIM management.
         # Becoming an active, seat-counting account consumes a seat — that
         # happens when we reactivate a deactivated user OR promote a shadow
-        # EXT_PERM_USER (which doesn't count toward seats) to STANDARD.
-        promote = _is_ext_perm_user(existing_user)
+        # EXT_PERM_USER (which doesn't count toward seats) to STANDARD. Only
+        # promote when the request keeps the user active — a deactivating
+        # request should just deactivate, not rewrite the role on the way out.
+        promote = _is_ext_perm_user(existing_user) and user_resource.active
         if user_resource.active and (not existing_user.is_active or promote):
             seat_error = _check_seat_availability(dal)
             if seat_error:
@@ -614,8 +616,9 @@ def replace_user(
 
     # Handle activation (need seat check) / deactivation. Promoting a shadow
     # EXT_PERM_USER also consumes a seat, so self-heal any that the IdP
-    # re-syncs after being adopted while still in the shadow role.
-    promote = _is_ext_perm_user(user)
+    # re-syncs after being adopted while still in the shadow role. Gate on
+    # active so a deactivating PUT just deactivates rather than rewriting role.
+    promote = _is_ext_perm_user(user) and user_resource.active
     is_reactivation = user_resource.active and not user.is_active
     if user_resource.active and (is_reactivation or promote):
         seat_error = _check_seat_availability(dal)
@@ -708,8 +711,9 @@ def patch_user(
 
     # Apply changes back to the DB model. A seat is consumed when the user
     # becomes active (reactivation) or when a shadow EXT_PERM_USER is promoted
-    # to a real STANDARD account on re-sync.
-    promote = _is_ext_perm_user(user)
+    # to a real STANDARD account on re-sync. Gate promotion on active so a
+    # deactivating PATCH just deactivates rather than rewriting role.
+    promote = _is_ext_perm_user(user) and patched.active
     is_reactivation = patched.active and not user.is_active
     if patched.active and (patched.active != user.is_active or promote):
         seat_error = _check_seat_availability(dal)

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -622,6 +622,39 @@ class TestReplaceUser:
         assert_scim_error(result, 403)
         mock_seats.assert_called_once()
 
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
+    @patch("ee.onyx.server.scim.api._check_seat_availability")
+    def test_deactivating_shadow_user_does_not_promote(
+        self,
+        mock_seats: MagicMock,
+        mock_assign: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A deactivating PUT for a shadow EXT_PERM_USER just deactivates — it
+        must not rewrite the role, assign default groups, or seat-check."""
+        user = make_db_user(role=UserRole.EXT_PERM_USER, is_active=True)
+        mock_dal.get_user.return_value = user
+        resource = make_scim_user(active=False)
+
+        result = replace_user(
+            user_id=str(user.id),
+            user_resource=resource,
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        parse_scim_user(result)
+        mock_seats.assert_not_called()
+        mock_assign.assert_not_called()
+        _, kwargs = mock_dal.update_user.call_args
+        assert kwargs["role"] is None
+        assert kwargs["account_type"] is None
+        assert kwargs["is_active"] is False
+
     def test_syncs_external_id(
         self,
         mock_db_session: MagicMock,


### PR DESCRIPTION
## Description

Follow-up to #11814 (already merged). Greptile flagged a P1 on the release cherry-picks.

**Bug:** `promote` was derived from role alone, so a SCIM PUT/PATCH that *deactivates* a shadow `EXT_PERM_USER` still rewrote its role to `BASIC`/`STANDARD` and enrolled it in the Basic group on the way out — corrupting the role record (no seat impact, since inactive users don't count, but external-permission sync keys off the `EXT_PERM_USER` role).

**Fix:** Gate promotion on the effective active state in all three handlers — `promote = _is_ext_perm_user(user) and <active>`. A deactivating request now just deactivates. Adds a `replace_user` test asserting a deactivating PUT leaves role/account_type untouched and skips group assignment + seat check.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check