### PR TITLE
chore(opal): bump version to 0.1.7

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -129,7 +129,7 @@
     },
     "lib/opal": {
       "name": "@onyx-ai/opal",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "clsx": "^2.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/opal",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Opal — Onyx's Typescript component library and design system.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Description

Bumps `@onyx-ai/opal` from `0.1.6` → `0.1.7`. Patch release for the `"xl"` rounding variant added in #11831.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `@onyx-ai/opal` from 0.1.6 to 0.1.7 to publish the new "xl" rounding variant introduced in #11831. No code changes—only version updates in `web/lib/opal/package.json` and `web/bun.lock`.

<sup>Written for commit e36095150ba066b0d429227fb7d3ebc1cd1f744c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->