### PR TITLE
fix(fireflies): re-scan an overlap window so late transcripts aren't dropped

### DIFF
--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -51,7 +51,14 @@ _FIREFLIES_API_QUERY = """
     }
 """
 
-ONE_MINUTE = 60
+# Fireflies surfaces a transcript only after the meeting ends and processing
+# completes, and `transcripts(fromDate, toDate)` filters on the meeting START
+# time. Because the poll cursor only moves forward, a transcript that becomes
+# available after its start-time window was already polled would be skipped
+# permanently. So each poll re-scans an overlap window large enough to cover the
+# longest meeting plus Fireflies' processing lag. Re-seen transcripts are cheap:
+# Onyx's content-hash check skips re-chunking/re-embedding anything already indexed.
+_FIREFLIES_POLL_OVERLAP_SECONDS = 8 * 60 * 60  # 8 hours
 
 
 def _create_doc_from_transcript(transcript: dict) -> Document | None:
@@ -238,9 +245,10 @@ class FirefliesConnector(PollConnector, LoadConnector):
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> GenerateDocumentsOutput:
-        # add some leeway to account for any timezone funkiness and/or bad handling
-        # of start time on the Fireflies side
-        start = max(0, start - ONE_MINUTE)
+        # Re-scan an overlap window so transcripts that became available after
+        # their start-time window was first polled are still picked up (see
+        # _FIREFLIES_POLL_OVERLAP_SECONDS).
+        start = max(0, start - _FIREFLIES_POLL_OVERLAP_SECONDS)
         start_datetime = datetime.fromtimestamp(start, tz=timezone.utc).strftime(
             "%Y-%m-%dT%H:%M:%S.000Z"
         )

--- a/backend/tests/unit/onyx/connectors/fireflies/test_fireflies_poll_overlap.py
+++ b/backend/tests/unit/onyx/connectors/fireflies/test_fireflies_poll_overlap.py
@@ -1,0 +1,46 @@
+from datetime import datetime
+from datetime import timezone
+from unittest.mock import patch
+
+from onyx.connectors.fireflies.connector import _FIREFLIES_POLL_OVERLAP_SECONDS
+from onyx.connectors.fireflies.connector import FirefliesConnector
+
+
+def _fmt(epoch_seconds: int) -> str:
+    return datetime.fromtimestamp(epoch_seconds, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.000Z"
+    )
+
+
+def test_poll_source_subtracts_overlap_from_start() -> None:
+    """poll_source must look back by the overlap so transcripts that became
+    available after their start-time window was first polled are still fetched."""
+    connector = FirefliesConnector()
+    connector.load_credentials({"fireflies_api_key": "test-key"})
+
+    start = 1_700_000_000
+    end = start + 3600
+
+    with patch.object(
+        FirefliesConnector, "_process_transcripts", return_value=iter([])
+    ) as mock_proc:
+        list(connector.poll_source(start, end))
+
+    mock_proc.assert_called_once()
+    start_datetime, end_datetime = mock_proc.call_args.args
+    assert start_datetime == _fmt(start - _FIREFLIES_POLL_OVERLAP_SECONDS)
+    assert end_datetime == _fmt(end)
+
+
+def test_poll_source_clamps_overlap_at_epoch() -> None:
+    """A start within the overlap of epoch 0 must not go negative."""
+    connector = FirefliesConnector()
+    connector.load_credentials({"fireflies_api_key": "test-key"})
+
+    with patch.object(
+        FirefliesConnector, "_process_transcripts", return_value=iter([])
+    ) as mock_proc:
+        list(connector.poll_source(100, 200))
+
+    start_datetime, _ = mock_proc.call_args.args
+    assert start_datetime == _fmt(0)

--- a/backend/tests/unit/onyx/connectors/fireflies/test_fireflies_poll_overlap.py
+++ b/backend/tests/unit/onyx/connectors/fireflies/test_fireflies_poll_overlap.py
@@ -22,7 +22,7 @@ def test_poll_source_subtracts_overlap_from_start() -> None:
     end = start + 3600
 
     with patch.object(
-        FirefliesConnector, "_process_transcripts", return_value=iter([])
+        FirefliesConnector, "_process_transcripts", side_effect=lambda *_: iter([])
     ) as mock_proc:
         list(connector.poll_source(start, end))
 
@@ -38,7 +38,7 @@ def test_poll_source_clamps_overlap_at_epoch() -> None:
     connector.load_credentials({"fireflies_api_key": "test-key"})
 
     with patch.object(
-        FirefliesConnector, "_process_transcripts", return_value=iter([])
+        FirefliesConnector, "_process_transcripts", side_effect=lambda *_: iter([])
     ) as mock_proc:
         list(connector.poll_source(100, 200))
 


### PR DESCRIPTION
## Description
https://linear.app/onyx-app/issue/ENG-4118/agent-wiki

The Fireflies connector silently drops meetings. It polls `transcripts(fromDate, toDate)` filtered on the **meeting start time** with a forward-only cursor and only a 1-minute leeway (`ONE_MINUTE`). But Fireflies surfaces a transcript **only after the meeting ends and processing completes** — so the poll window covering a meeting's start runs *before* the transcript exists (returns nothing), the cursor advances, and the transcript (stamped with the meeting start time) is never re-queried. The meeting is lost permanently.

Observed on a live instance: **9 of 19 meetings (Jun 3–8) were never indexed.** Each missing meeting's covering poll ran ~7–38 min after the meeting start (i.e. *during* the meeting), returned `new=0`, and the window was never revisited.

**Fix:** re-scan an **8-hour overlap window** each poll (replacing `ONE_MINUTE`), large enough to cover the longest meeting plus Fireflies' processing lag. Onyx's content-hash gate skips re-chunking/re-embedding anything already indexed, so re-seen transcripts are cheap.

### Why 8h, and why not a checkpoint
- The window must cover `meeting duration + processing lag`. The `transcripts()` API filters only on meeting start (`fromDate`/`toDate`) and exposes **no transcript-availability timestamp**, so we can't key on "when the transcript became ready." 8h covers a long meeting (~2–3h) + processing with margin, independent of `POLL_CONNECTOR_OFFSET` (which only absorbs scheduling jitter, not transcript lag).
- A `CheckpointedConnector` "seen ids" set wouldn't help: `get_latest_valid_checkpoint` only resumes `FAILED`/`CANCELED` attempts, so the checkpoint is dropped after every successful poll. Cross-poll dedup is handled by Onyx's content hash instead.

### Cost of the 8h overlap
Each poll re-fetches transcripts from the last 8h (~1/3 of a day's meetings). Measured payload ≈ 43 KB/transcript; cadence every 30 min (≈48 polls/day):

| meetings/day | re-fetched per poll | re-download/day | Fireflies API calls/day |
|---|---|---|---|
| 15 | ~5 (~215 KB) | ~10 MB | ~48 |
| 30 | ~10 (~430 KB) | ~20 MB | ~48 |

Only the Fireflies fetch + a content-hash compute repeat — **embedding/chunking are skipped** by the hash gate and no duplicate documents are written. Net added cost ≈ 10–20 MB/day of bandwidth and ~48 small API calls/day (well within Fireflies rate limits). Negligible relative to the data loss it prevents.

## How Has This Been Tested?

- Added unit test `tests/unit/onyx/connectors/fireflies/test_fireflies_poll_overlap.py` — asserts `poll_source` queries Fireflies with `fromDate == start − 8h` and clamps the lookback at epoch 0. Passes.
- `ruff`, `ruff format`, and `ty` (pre-commit) all pass.
- Root cause validated against the live `onyx-st-dev` Fireflies connector: 9/19 meetings missed; each covering poll ran during the meeting with `new_docs_indexed=0`, and the transcripts are present in Fireflies' API for those exact windows.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-scan an 8-hour overlap window when polling Fireflies transcripts so late-available transcripts aren’t missed; replaces the 1-minute leeway and relies on Onyx’s content-hash to avoid reprocessing duplicates.

- **Bug Fixes**
  - Polls `transcripts(fromDate, toDate)` from `start − 8h` (clamped at epoch) to catch transcripts that appear after meetings end.
  - Tests: added unit tests for overlap subtraction and epoch clamping via `_FIREFLIES_POLL_OVERLAP_SECONDS`; added `tests/unit/onyx/connectors/fireflies/__init__.py` and switched to `side_effect` for the empty iterator to avoid reuse.

<sup>Written for commit 373079949903949b5a9be8e407d6f945389638ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



