### PR TITLE
feat(security): gate API docs/schema behind ENABLE_PUBLIC_DOCS (default off)

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -286,6 +286,12 @@ METRICS_AUTH_TOKEN = os.environ.get("METRICS_AUTH_TOKEN") or ""
 # deliberate choice, since auth is otherwise required by default.
 DISABLE_METRICS_AUTH = os.environ.get("DISABLE_METRICS_AUTH", "").lower() == "true"
 
+# Explicit opt-in: serve the interactive API docs and schema (/openapi.json,
+# /docs, /redoc) publicly with no authentication. Default off so the API surface
+# is not exposed on a fresh deployment. When disabled the routes are not
+# registered at all (404). Note: these renderers never bypass per-route auth.
+ENABLE_PUBLIC_DOCS = os.environ.get("ENABLE_PUBLIC_DOCS", "").lower() == "true"
+
 # Duration (in seconds) for which the FastAPI Users JWT token remains valid in the user's browser.
 # By default, this is set to match the Redis expiry time for consistency.
 AUTH_COOKIE_EXPIRE_TIME_SECONDS = int(

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -40,6 +40,7 @@ from onyx.configs.app_configs import AUTH_RATE_LIMITING_ENABLED
 from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.configs.app_configs import ENABLE_PUBLIC_DOCS
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
 from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
@@ -457,6 +458,12 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
         servers=[
             {"url": f"{WEB_DOMAIN.rstrip('/')}/api", "description": "Onyx API Server"}
         ],
+        # The interactive docs and schema are opt-in (see ENABLE_PUBLIC_DOCS).
+        # When disabled, these routes are not registered at all (404), so the
+        # API surface is not exposed publicly on a default deployment.
+        openapi_url="/openapi.json" if ENABLE_PUBLIC_DOCS else None,
+        docs_url="/docs" if ENABLE_PUBLIC_DOCS else None,
+        redoc_url="/redoc" if ENABLE_PUBLIC_DOCS else None,
         lifespan=lifespan_override or lifespan,
     )
     if SENTRY_DSN:

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -14,7 +14,11 @@ from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 PUBLIC_ENDPOINT_SPECS = [
-    # built-in documentation functions
+    # Built-in API docs / schema. These routes only exist when ENABLE_PUBLIC_DOCS
+    # is set (see get_application); they are gated off by default so the API
+    # surface is not exposed publicly. When the flag is off the routes are not
+    # registered, so these specs simply go unmatched. When on, they are served
+    # publicly with no session (the renderers never bypass per-route auth).
     ("/openapi.json", {"GET", "HEAD"}),
     ("/docs", {"GET", "HEAD"}),
     ("/docs/oauth2-redirect", {"GET", "HEAD"}),

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -66,6 +66,10 @@ USER_AUTH_SECRET=""
 # METRICS_AUTH_TOKEN=
 ### Set to "true" to expose /metrics with NO authentication (explicit opt-out).
 # DISABLE_METRICS_AUTH=
+### Set to "true" to expose the interactive API docs and schema (/openapi.json,
+### /docs, /redoc) publicly with NO authentication. Off by default so the API
+### surface is not exposed; when off these routes are not registered (404).
+# ENABLE_PUBLIC_DOCS=
 ### Optional
 # API_KEY_HASH_ROUNDS=
 ### You can add a comma separated list of domains like onyx.app, only those domains will be allowed to signup/log in

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.5.18
+version: 0.5.19
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,11 +17,10 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: added
-      description: '`auth.metricsAuth` bearer token guarding the API server''s
-        /metrics endpoint. /metrics returns 401 by default until you enable
-        auth.metricsAuth (injects `METRICS_AUTH_TOKEN`, and the api ServiceMonitor
-        scrapes with `Authorization: Bearer <token>`) or explicitly opt out via
-        configMap.DISABLE_METRICS_AUTH=true.'
+      description: '`configMap.ENABLE_PUBLIC_DOCS` flag (default off) gating the
+        interactive API docs and schema. When unset, /openapi.json, /docs, and
+        /redoc are not registered (404); set to "true" to expose them publicly
+        with no authentication.'
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1410,6 +1410,10 @@ configMap:
   # (enable auth.metricsAuth) OR you explicitly opt out here. Set to "true" to
   # expose /metrics with NO authentication.
   DISABLE_METRICS_AUTH: ""
+  # The interactive API docs and schema (/openapi.json, /docs, /redoc) are off by
+  # default and the routes are not registered (404). Set to "true" to expose them
+  # publicly with NO authentication.
+  ENABLE_PUBLIC_DOCS: ""
   # For sending verification emails, true or false
   REQUIRE_EMAIL_VERIFICATION: ""
   # If unspecified then defaults to 'smtp.gmail.com'


### PR DESCRIPTION
## Summary

`/openapi.json`, `/docs`, and `/redoc` are currently reachable without authentication — the full API surface (367+ paths) is enumerable, and `/api/docs` returns 200 through the public ingress. These are introspection/UI routes with no programmatic need to be open by default.

This adds an **`ENABLE_PUBLIC_DOCS`** env flag, **default off**:

- **Off (default):** the `openapi`/`docs`/`redoc` routes are not registered on the FastAPI app at all → **404**. The API surface is not exposed on a fresh deployment.
- **On:** all three are served publicly, as before.

No session is required either way — the flag controls *existence* of the routes, not auth. The renderers never bypassed per-route auth (`Depends(current_user)` is unaffected); this is purely about not advertising the schema/UI publicly.

## Why a flag instead of requiring a session

`/docs` and `/redoc` fetch `/openapi.json` unauthenticated from the browser, and FastAPI's built-in docs routes can't take an auth dependency without replacing them with custom routes. A single default-off flag is the simplest way to harden the default while keeping the docs available for anyone who opts in.

## ⚠️ Deployment note

Because the flag defaults off, **existing deployments will start returning 404 for `/openapi.json`, `/api/docs`, and `/api/redoc` after this ships** unless `ENABLE_PUBLIC_DOCS=true` is set. This is intended. Anyone relying on the live schema/docs should set the env var deliberately.

## Changes

- `backend/onyx/configs/app_configs.py` — new `ENABLE_PUBLIC_DOCS` flag (default `False`).
- `backend/onyx/main.py` — `get_application` sets `openapi_url`/`docs_url`/`redoc_url` to `None` unless the flag is on.
- `backend/onyx/server/auth_check.py` — documented the flag gating on the existing public-spec entries (kept: needed when enabled, inert when not).
- `deployment/docker_compose/env.template`, `deployment/helm/charts/onyx/values.yaml` — documented the toggle alongside `DISABLE_METRICS_AUTH`.

## Testing

- Built the app with the flag **off** and **on**; verified the three routes are absent (404) by default and present when enabled. `check_router_auth` passes in both modes.
- Ran `scripts/onyx_openapi_schema.py` with the flag off — still generates the full schema (459 paths). The doc/client-generation pipeline reads `app.routes` directly and is unaffected by the live route being disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the FastAPI docs and schema behind an `ENABLE_PUBLIC_DOCS` flag (default off). When off, `/openapi.json`, `/docs`, and `/redoc` are not registered (404); turning it on restores public access.

- **New Features**
  - Added `ENABLE_PUBLIC_DOCS` to control docs/schema routes.
  - Helm: bumped chart to `0.5.19` and documented `configMap.ENABLE_PUBLIC_DOCS`.
  - Per-route auth and schema/client generation are unchanged.

- **Migration**
  - If you rely on live docs, set `ENABLE_PUBLIC_DOCS=true`; otherwise these endpoints will 404 after deploy.

<sup>Written for commit 29a23d2d6dbc4595bc02959fbafcd8ffd6a929ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

