### PR TITLE
fix(notifications): roll up session approval notifications

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -1031,6 +1031,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                             cc_pair_id=cc_pair.id,
                             status=ConnectorCredentialPairStatus.PAUSED,
                         )
+                    db_session.commit()
 
         # NOTE: At this point, we haven't done heavy checks on whether or not the CC pairs should actually be indexed
         # Heavy check, should_index(), is called in _kickoff_indexing_tasks

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -40,14 +40,12 @@ def create_notification(
     title: str,
     description: str | None = None,
     additional_data: dict[str, Any] | None = None,
-    refresh_existing: bool = True,
 ) -> Notification:
-    """Create one notification identity without committing.
+    """Create a notification if this user/type/data identity does not exist.
 
     The identity matches ix_notification_user_type_data: user, type, and
-    additional_data with NULL treated as '{}'. Dismissed rows are never
-    reopened here; callers that need that behavior should use
-    create_or_resurface_notification.
+    additional_data with NULL treated as '{}'. Existing rows are returned
+    without mutation.
     """
     additional_data_normalized = additional_data if additional_data is not None else {}
     user_filter = (
@@ -67,9 +65,7 @@ def create_notification(
         .limit(1)
     ).scalar_one_or_none()
 
-    if existing_notification:
-        if refresh_existing and not existing_notification.dismissed:
-            existing_notification.last_shown = func.now()
+    if existing_notification is not None:
         return existing_notification
 
     notification = Notification(
@@ -93,25 +89,73 @@ def create_or_resurface_notification(
     title: str,
     description: str | None = None,
     additional_data: dict[str, Any] | None = None,
+    dedupe_by_additional_data: dict[str, Any] | None = None,
 ) -> Notification:
-    """Create a notification or make the existing identity visible again."""
-    notification = create_notification(
-        user_id=user_id,
-        notif_type=notif_type,
-        db_session=db_session,
-        title=title,
-        description=description,
-        additional_data=additional_data,
-        refresh_existing=False,
-    )
+    """Create a notification or make an existing matching notification visible again.
+
+    `dedupe_by_additional_data` is an optional subset of `additional_data` used
+    to find an existing row before resurfacing. Use it when the display payload
+    can change but the notification identity should stay stable.
+    """
+    if dedupe_by_additional_data is not None and not dedupe_by_additional_data:
+        raise ValueError("dedupe_by_additional_data must not be empty")
+    if dedupe_by_additional_data is not None and (
+        additional_data is None
+        or any(
+            additional_data.get(key) != value
+            for key, value in dedupe_by_additional_data.items()
+        )
+    ):
+        raise ValueError(
+            "dedupe_by_additional_data must be contained in additional_data"
+        )
+
+    if dedupe_by_additional_data is None:
+        notification = create_notification(
+            user_id=user_id,
+            notif_type=notif_type,
+            db_session=db_session,
+            title=title,
+            description=description,
+            additional_data=additional_data,
+        )
+    else:
+        user_filter = (
+            Notification.user_id == user_id
+            if user_id is not None
+            else Notification.user_id.is_(None)
+        )
+
+        notification = db_session.execute(
+            select(Notification)
+            .where(
+                user_filter,
+                Notification.notif_type == notif_type,
+                Notification.additional_data.contains(dedupe_by_additional_data),
+            )
+            .order_by(Notification.first_shown.desc(), Notification.id.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if notification is None:
+            notification = create_notification(
+                user_id=user_id,
+                notif_type=notif_type,
+                db_session=db_session,
+                title=title,
+                description=description,
+                additional_data=additional_data,
+            )
+
     was_dismissed = notification.dismissed
     notification.title = title
     notification.description = description
     notification.additional_data = additional_data
     notification.dismissed = False
+    shown_at = func.now()
     if was_dismissed:
-        notification.first_shown = func.now()
-    notification.last_shown = func.now()
+        notification.first_shown = shown_at
+    notification.last_shown = shown_at
     return notification
 
 
@@ -206,9 +250,19 @@ def dismiss_user_notifications(
     db_session.commit()
 
 
-def dismiss_notification(notification: Notification, db_session: Session) -> None:
+def dismiss_notification(
+    notification: Notification,
+    db_session: Session,
+    expected_last_shown: datetime | None = None,
+) -> bool:
+    if (
+        expected_last_shown is not None
+        and notification.last_shown != expected_last_shown
+    ):
+        return False
     notification.dismissed = True
     db_session.commit()
+    return True
 
 
 def batch_dismiss_notifications(

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timezone
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import cast
@@ -38,39 +39,39 @@ def create_notification(
     db_session: Session,
     title: str,
     description: str | None = None,
-    additional_data: dict | None = None,
-    autocommit: bool = True,
+    additional_data: dict[str, Any] | None = None,
     refresh_existing: bool = True,
 ) -> Notification:
-    # Previously, we only matched the first identical, undismissed notification
-    # Now, we assume some uniqueness to notifications
-    # If we previously issued a notification that was dismissed, we no longer issue a new one
+    """Create one notification identity without committing.
 
-    # Normalize additional_data to match the unique index behavior
-    # The index uses COALESCE(additional_data, '{}'::jsonb)
-    # We need to match this logic in our query
+    The identity matches ix_notification_user_type_data: user, type, and
+    additional_data with NULL treated as '{}'. Dismissed rows are never
+    reopened here; callers that need that behavior should use
+    create_or_resurface_notification.
+    """
     additional_data_normalized = additional_data if additional_data is not None else {}
-
-    existing_notification = (
-        db_session.query(Notification)
-        .filter_by(user_id=user_id, notif_type=notif_type)
-        .filter(
-            func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
-            == additional_data_normalized
-        )
-        .first()
+    user_filter = (
+        Notification.user_id == user_id
+        if user_id is not None
+        else Notification.user_id.is_(None)
     )
 
+    existing_notification = db_session.execute(
+        select(Notification)
+        .where(
+            user_filter,
+            Notification.notif_type == notif_type,
+            func.coalesce(Notification.additional_data, cast({}, postgresql.JSONB))
+            == additional_data_normalized,
+        )
+        .limit(1)
+    ).scalar_one_or_none()
+
     if existing_notification:
-        # Read-triggered ensure paths should not mutate existing rows: changing
-        # last_shown makes notification GET responses differ on every request.
         if refresh_existing and not existing_notification.dismissed:
             existing_notification.last_shown = func.now()
-            if autocommit:
-                db_session.commit()
         return existing_notification
 
-    # Create a new notification if none exists
     notification = Notification(
         user_id=user_id,
         notif_type=notif_type,
@@ -82,8 +83,35 @@ def create_notification(
         additional_data=additional_data,
     )
     db_session.add(notification)
-    if autocommit:
-        db_session.commit()
+    return notification
+
+
+def create_or_resurface_notification(
+    user_id: UUID | None,
+    notif_type: NotificationType,
+    db_session: Session,
+    title: str,
+    description: str | None = None,
+    additional_data: dict[str, Any] | None = None,
+) -> Notification:
+    """Create a notification or make the existing identity visible again."""
+    notification = create_notification(
+        user_id=user_id,
+        notif_type=notif_type,
+        db_session=db_session,
+        title=title,
+        description=description,
+        additional_data=additional_data,
+        refresh_existing=False,
+    )
+    was_dismissed = notification.dismissed
+    notification.title = title
+    notification.description = description
+    notification.additional_data = additional_data
+    notification.dismissed = False
+    if was_dismissed:
+        notification.first_shown = func.now()
+    notification.last_shown = func.now()
     return notification
 
 
@@ -198,7 +226,7 @@ def batch_create_notifications(
     db_session: Session,
     title: str,
     description: str | None = None,
-    additional_data: dict | None = None,
+    additional_data: dict[str, Any] | None = None,
 ) -> set[UUID]:
     """
     Create notifications for multiple users in a single batch operation.

--- a/backend/onyx/db/notification.py
+++ b/backend/onyx/db/notification.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from datetime import timezone
 from typing import Any
+from typing import cast as type_cast
 from uuid import UUID
 
 from sqlalchemy import cast
@@ -8,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import func
 from sqlalchemy.sql.elements import ColumnElement
@@ -89,28 +91,17 @@ def create_or_resurface_notification(
     title: str,
     description: str | None = None,
     additional_data: dict[str, Any] | None = None,
-    dedupe_by_additional_data: dict[str, Any] | None = None,
+    identity_data: dict[str, Any] | None = None,
 ) -> Notification:
     """Create a notification or make an existing matching notification visible again.
 
-    `dedupe_by_additional_data` is an optional subset of `additional_data` used
-    to find an existing row before resurfacing. Use it when the display payload
-    can change but the notification identity should stay stable.
+    `identity_data` is the stable lookup identity for a notification whose
+    display payload can change between events.
     """
-    if dedupe_by_additional_data is not None and not dedupe_by_additional_data:
-        raise ValueError("dedupe_by_additional_data must not be empty")
-    if dedupe_by_additional_data is not None and (
-        additional_data is None
-        or any(
-            additional_data.get(key) != value
-            for key, value in dedupe_by_additional_data.items()
-        )
-    ):
-        raise ValueError(
-            "dedupe_by_additional_data must be contained in additional_data"
-        )
+    if identity_data is not None and (not identity_data or additional_data is None):
+        raise ValueError("identity_data requires non-empty additional_data")
 
-    if dedupe_by_additional_data is None:
+    if identity_data is None:
         notification = create_notification(
             user_id=user_id,
             notif_type=notif_type,
@@ -126,18 +117,32 @@ def create_or_resurface_notification(
             else Notification.user_id.is_(None)
         )
 
-        notification = db_session.execute(
+        matching_notifications = db_session.scalars(
             select(Notification)
             .where(
                 user_filter,
                 Notification.notif_type == notif_type,
-                Notification.additional_data.contains(dedupe_by_additional_data),
+                Notification.additional_data.contains(identity_data),
             )
             .order_by(Notification.first_shown.desc(), Notification.id.desc())
-            .limit(1)
-        ).scalar_one_or_none()
+        ).all()
 
-        if notification is None:
+        if matching_notifications:
+            notification = next(
+                (
+                    matching_notification
+                    for matching_notification in matching_notifications
+                    if (matching_notification.additional_data or {})
+                    == (additional_data or {})
+                ),
+                matching_notifications[0],
+            )
+            for duplicate_notification in matching_notifications:
+                if duplicate_notification.id != notification.id:
+                    db_session.delete(duplicate_notification)
+            if len(matching_notifications) > 1:
+                db_session.flush()
+        else:
             notification = create_notification(
                 user_id=user_id,
                 notif_type=notif_type,
@@ -223,9 +228,13 @@ def dismiss_all_notifications(
     notif_type: NotificationType,
     db_session: Session,
 ) -> None:
-    db_session.query(Notification).filter(Notification.notif_type == notif_type).update(
-        {"dismissed": True}
+    stmt = (
+        update(Notification)
+        .where(Notification.notif_type == notif_type)
+        .values(dismissed=True)
+        .execution_options(synchronize_session=False)
     )
+    db_session.execute(stmt)
     db_session.commit()
 
 
@@ -251,18 +260,21 @@ def dismiss_user_notifications(
 
 
 def dismiss_notification(
-    notification: Notification,
+    notification_id: int,
     db_session: Session,
-    expected_last_shown: datetime | None = None,
+    expected_version: datetime | None = None,
 ) -> bool:
-    if (
-        expected_last_shown is not None
-        and notification.last_shown != expected_last_shown
-    ):
-        return False
-    notification.dismissed = True
+    stmt = update(Notification).where(Notification.id == notification_id)
+    if expected_version is not None:
+        stmt = stmt.where(Notification.last_shown == expected_version)
+    result = type_cast(
+        CursorResult[Any],
+        db_session.execute(
+            stmt.values(dismissed=True).execution_options(synchronize_session=False)
+        ),
+    )
     db_session.commit()
-    return True
+    return result.rowcount > 0
 
 
 def batch_dismiss_notifications(

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -234,7 +234,6 @@ class UserFileIndexingAdapter:
                                 "persona_id": assistant.id,
                                 "link": f"/assistants/{assistant.id}",
                             },
-                            autocommit=False,
                         )
 
     def post_index(

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -27,6 +27,7 @@ from onyx.db.enums import ApprovalDecidedVia
 from onyx.db.enums import ApprovalDecision
 from onyx.db.enums import EndpointPolicy
 from onyx.db.notification import create_notification
+from onyx.db.notification import create_or_resurface_notification
 from onyx.db.scheduled_task import get_live_scheduled_run_grants
 from onyx.db.scheduled_task import ScheduledRunGrants
 from onyx.external_apps.matching.engine import actions_requiring_approval
@@ -711,7 +712,7 @@ class GateAddon:
         )
 
         try:
-            self._notify_approval_requested(approval_id, ctx, matched_actions)
+            self._notify_approval_requested(ctx, matched_actions)
         except Exception as e:
             logger.warning(
                 "approval.notify_failed approval_id=%s error=%s",
@@ -936,35 +937,38 @@ class GateAddon:
                 db_session=db,
                 title=grant.notification_title,
                 additional_data=grant.notification_data,
-                autocommit=True,
             )
+            db.commit()
 
     def _notify_approval_requested(
-        self, approval_id: UUID, ctx: SessionContext, matched_actions: AllMatchedActions
+        self,
+        ctx: SessionContext,
+        matched_actions: AllMatchedActions,
     ) -> None:
         """Best-effort APPROVAL_REQUESTED notification dispatch.
 
         Body carries no PII; the full payload lives on the action_approval row,
         which the popover fetches when the chat loads.
         """
+        action_count = len(matched_actions.actions)
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
-            create_notification(
+            create_or_resurface_notification(
                 user_id=ctx.user_id,
                 notif_type=NotificationType.APPROVAL_REQUESTED,
                 db_session=db,
                 title="Craft is requesting approval",
+                description=(
+                    f"{matched_actions.app_name} needs approval for "
+                    f"{action_count} action{'s' if action_count != 1 else ''}."
+                ),
                 additional_data={
-                    "approval_id": str(approval_id),
                     "session_id": str(ctx.session_id),
-                    "action_type": matched_actions.governing_action.action_type,
-                    "action_count": len(matched_actions.actions),
-                    "app_name": matched_actions.app_name,
                     "link": _CRAFT_SESSION_LINK_TEMPLATE.format(
                         session_id=ctx.session_id
                     ),
                 },
-                autocommit=True,
             )
+            db.commit()
 
     # --------------------------------------------------------------------------
     # internal helpers

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -67,11 +67,6 @@ class _IdentityResolver(Protocol):
 CacheFactory = Callable[[str], CacheBackend]
 
 
-# Relative deep link routed through the Next router by NotificationsPopover.tsx;
-# must mirror the frontend's CRAFT_PATH + sessionId search param.
-_CRAFT_SESSION_LINK_TEMPLATE = "/craft/v1?sessionId={session_id}"
-
-
 @dataclass(frozen=True)
 class _ApprovalGrant:
     """A decision to approve a gated request without parking it.
@@ -712,7 +707,7 @@ class GateAddon:
         )
 
         try:
-            self._notify_approval_requested(ctx, matched_actions)
+            self._notify_approval_requested(ctx)
         except Exception as e:
             logger.warning(
                 "approval.notify_failed approval_id=%s error=%s",
@@ -943,30 +938,25 @@ class GateAddon:
     def _notify_approval_requested(
         self,
         ctx: SessionContext,
-        matched_actions: AllMatchedActions,
     ) -> None:
         """Best-effort APPROVAL_REQUESTED notification dispatch.
 
         Body carries no PII; the full payload lives on the action_approval row,
         which the popover fetches when the chat loads.
         """
-        action_count = len(matched_actions.actions)
         with get_session_with_tenant(tenant_id=ctx.tenant_id) as db:
+            session_id = str(ctx.session_id)
             create_or_resurface_notification(
                 user_id=ctx.user_id,
                 notif_type=NotificationType.APPROVAL_REQUESTED,
                 db_session=db,
                 title="Craft is requesting approval",
-                description=(
-                    f"{matched_actions.app_name} needs approval for "
-                    f"{action_count} action{'s' if action_count != 1 else ''}."
-                ),
+                description="This session has pending approvals.",
                 additional_data={
-                    "session_id": str(ctx.session_id),
-                    "link": _CRAFT_SESSION_LINK_TEMPLATE.format(
-                        session_id=ctx.session_id
-                    ),
+                    "session_id": session_id,
+                    "link": f"/craft/v1?sessionId={session_id}",
                 },
+                dedupe_by_additional_data={"session_id": session_id},
             )
             db.commit()
 

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -956,7 +956,7 @@ class GateAddon:
                     "session_id": session_id,
                     "link": f"/craft/v1?sessionId={session_id}",
                 },
-                dedupe_by_additional_data={"session_id": session_id},
+                identity_data={"session_id": session_id},
             )
             db.commit()
 

--- a/backend/onyx/server/features/build/scheduled_tasks/executor.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/executor.py
@@ -138,7 +138,6 @@ def _notify(
                 "task_id": str(task_id),
                 "run_id": str(run_id),
             },
-            autocommit=False,
         )
     except Exception:
         logger.exception(

--- a/backend/onyx/server/features/build/utils.py
+++ b/backend/onyx/server/features/build/utils.py
@@ -159,5 +159,4 @@ def ensure_build_mode_intro_notification(user: User, db_session: Session) -> Non
         title="Introducing Onyx Craft",
         description="Unleash Onyx to create dashboards, slides, documents, and more with your connected data.",
         additional_data={"feature": BUILD_MODE_FEATURE_ID},
-        refresh_existing=False,
     )

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Query
@@ -33,28 +36,40 @@ DEFAULT_NOTIFICATIONS_PAGE_SIZE = 10
 MAX_NOTIFICATIONS_PAGE_SIZE = 50
 
 
+@contextmanager
+def _notification_check_transaction(
+    error_message: str,
+    db_session: Session,
+) -> Iterator[None]:
+    try:
+        yield
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        logger.exception(error_message)
+
+
 def _check_for_notifications_to_create(
     user: User,
     db_session: Session,
 ) -> None:
-    try:
+    with _notification_check_transaction(
+        "Failed to check for build mode intro in notifications endpoint",
+        db_session,
+    ):
         ensure_build_mode_intro_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to check for build mode intro in notifications endpoint"
-        )
 
-    try:
+    with _notification_check_transaction(
+        "Failed to create permissions_migration_v1 announcement in notifications endpoint",
+        db_session,
+    ):
         ensure_permissions_migration_notification(user, db_session)
-    except Exception:
-        logger.exception(
-            "Failed to create permissions_migration_v1 announcement in notifications endpoint"
-        )
 
-    try:
+    with _notification_check_transaction(
+        "Failed to check for release notes in notifications endpoint",
+        db_session,
+    ):
         ensure_release_notes_fresh_and_notify(db_session)
-    except Exception:
-        logger.exception("Failed to check for release notes in notifications endpoint")
 
 
 @router.get("")

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -18,6 +18,7 @@ from onyx.db.notification import get_notifications
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.utils import ensure_build_mode_intro_notification
+from onyx.server.features.notifications.models import DismissNotificationRequest
 from onyx.server.features.notifications.models import NotificationResponse
 from onyx.server.features.notifications.models import NotificationSummary
 from onyx.server.features.notifications.models import PaginatedNotifications
@@ -148,6 +149,7 @@ def dismiss_all_notifications_endpoint(
 @router.post("/{notification_id}/dismiss")
 def dismiss_notification_endpoint(
     notification_id: int,
+    request: DismissNotificationRequest | None = None,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
@@ -164,4 +166,8 @@ def dismiss_notification_endpoint(
             "Notification not found",
         ) from e
 
-    dismiss_notification(notification, db_session)
+    dismiss_notification(
+        notification=notification,
+        db_session=db_session,
+        expected_last_shown=request.expected_last_shown if request else None,
+    )

--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -167,7 +167,7 @@ def dismiss_notification_endpoint(
         ) from e
 
     dismiss_notification(
-        notification=notification,
+        notification_id=notification.id,
         db_session=db_session,
-        expected_last_shown=request.expected_last_shown if request else None,
+        expected_version=request.expected_version if request else None,
     )

--- a/backend/onyx/server/features/notifications/models.py
+++ b/backend/onyx/server/features/notifications/models.py
@@ -1,7 +1,10 @@
 from datetime import datetime
+from typing import Any
 
+from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 from onyx.configs.constants import NotificationType
 
@@ -13,10 +16,11 @@ class NotificationResponse(BaseModel):
     notif_type: NotificationType
     dismissed: bool
     last_shown: datetime
+    version: datetime = Field(validation_alias="last_shown")
     first_shown: datetime
     title: str
     description: str | None = None
-    additional_data: dict | None = None
+    additional_data: dict[str, Any] | None = None
 
 
 class PaginatedNotifications(BaseModel):
@@ -34,4 +38,7 @@ class NotificationSummary(BaseModel):
 
 
 class DismissNotificationRequest(BaseModel):
-    expected_last_shown: datetime | None = None
+    expected_version: datetime | None = Field(
+        default=None,
+        validation_alias=AliasChoices("expected_version", "expected_last_shown"),
+    )

--- a/backend/onyx/server/features/notifications/models.py
+++ b/backend/onyx/server/features/notifications/models.py
@@ -31,3 +31,7 @@ class PaginatedNotifications(BaseModel):
 class NotificationSummary(BaseModel):
     total_items: int
     undismissed_count: int
+
+
+class DismissNotificationRequest(BaseModel):
+    expected_last_shown: datetime | None = None

--- a/backend/onyx/server/features/notifications/utils.py
+++ b/backend/onyx/server/features/notifications/utils.py
@@ -18,5 +18,4 @@ def ensure_permissions_migration_notification(user: User, db_session: Session) -
             "feature": "permissions_migration_v1",
             "link": "https://docs.onyx.app/admins/permissions/whats_changing",
         },
-        refresh_existing=False,
     )

--- a/backend/tests/external_dependency_unit/craft/test_approval_gate.py
+++ b/backend/tests/external_dependency_unit/craft/test_approval_gate.py
@@ -607,7 +607,7 @@ def test_approval_requested_notification_is_created(
             .first()
         )
         if notif is not None and notif.additional_data is not None:
-            if notif.additional_data.get("approval_id") == str(pending.approval_id):
+            if notif.additional_data.get("session_id") == str(session_id):
                 break
         time.sleep(0.5)
 
@@ -615,9 +615,9 @@ def test_approval_requested_notification_is_created(
         f"expected APPROVAL_REQUESTED notification for user {user.id}, got none"
     )
     assert notif.additional_data is not None
-    assert notif.additional_data.get("approval_id") == str(pending.approval_id), (
-        f"notification.additional_data.approval_id should match "
-        f"{pending.approval_id}, got: {notif.additional_data!r}"
+    assert notif.additional_data.get("session_id") == str(session_id), (
+        f"notification.additional_data.session_id should match "
+        f"{session_id}, got: {notif.additional_data!r}"
     )
     # Deep-link spec hardcoded (`/craft/v1?sessionId=<id>`) rather than imported.
     assert notif.additional_data.get("link") == f"/craft/v1?sessionId={session_id}", (

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -133,7 +133,7 @@ def test_notification_pagination_uses_stable_tie_breaker(
     )[::-1]
 
 
-def test_create_notification_can_preserve_existing_last_shown(
+def test_create_notification_does_not_mutate_existing_notification(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
@@ -155,7 +155,6 @@ def test_create_notification_can_preserve_existing_last_shown(
         db_session=db_session,
         title="Approval 1",
         additional_data={"test_position": 1},
-        refresh_existing=False,
     )
     db_session.commit()
 
@@ -205,7 +204,7 @@ def test_create_notification_does_not_reopen_dismissed_existing(
     assert existing_notification.first_shown == original_first_shown
 
 
-def test_create_or_resurface_notification_reopens_existing_matching_additional_data(
+def test_create_or_resurface_notification_reopens_existing_session(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
@@ -219,8 +218,8 @@ def test_create_or_resurface_notification_reopens_existing_matching_additional_d
         first_shown=original_first_shown,
         title="Old approval",
         additional_data={
-            "session_id": "session-1",
-            "link": "/craft/v1?sessionId=session-1",
+            "session_id": "11111111-1111-1111-1111-111111111111",
+            "link": "/craft/v1?sessionId=old-link-format",
         },
     )
     db_session.add(notification)
@@ -233,8 +232,11 @@ def test_create_or_resurface_notification_reopens_existing_matching_additional_d
         title="New approval",
         description="New approval details",
         additional_data={
-            "session_id": "session-1",
-            "link": "/craft/v1?sessionId=session-1",
+            "session_id": "11111111-1111-1111-1111-111111111111",
+            "link": "/craft/v1?sessionId=11111111-1111-1111-1111-111111111111",
+        },
+        dedupe_by_additional_data={
+            "session_id": "11111111-1111-1111-1111-111111111111"
         },
     )
     db_session.commit()
@@ -246,8 +248,8 @@ def test_create_or_resurface_notification_reopens_existing_matching_additional_d
     assert reopened_notification.description == "New approval details"
     assert reopened_notification.additional_data is not None
     assert reopened_notification.additional_data == {
-        "session_id": "session-1",
-        "link": "/craft/v1?sessionId=session-1",
+        "session_id": "11111111-1111-1111-1111-111111111111",
+        "link": "/craft/v1?sessionId=11111111-1111-1111-1111-111111111111",
     }
     assert reopened_notification.first_shown != original_first_shown
 
@@ -272,6 +274,103 @@ def test_create_or_resurface_notification_reopens_existing_matching_additional_d
     )
     assert total_items == 2
     assert undismissed_count == 2
+
+
+def test_create_or_resurface_notification_updates_active_existing_without_restarting_age(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_resurface_active")
+    original_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=False,
+        last_shown=original_shown,
+        first_shown=original_shown,
+        title="Old approval",
+        additional_data={
+            "session_id": "22222222-2222-2222-2222-222222222222",
+            "link": "/craft/v1?sessionId=old-link-format",
+        },
+    )
+    db_session.add(notification)
+    db_session.commit()
+
+    resurfaced_notification = create_or_resurface_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="Latest approval",
+        description="Latest approval details",
+        additional_data={
+            "session_id": "22222222-2222-2222-2222-222222222222",
+            "link": "/craft/v1?sessionId=22222222-2222-2222-2222-222222222222",
+        },
+        dedupe_by_additional_data={
+            "session_id": "22222222-2222-2222-2222-222222222222"
+        },
+    )
+    db_session.commit()
+    db_session.refresh(resurfaced_notification)
+
+    assert resurfaced_notification.id == notification.id
+    assert resurfaced_notification.dismissed is False
+    assert resurfaced_notification.title == "Latest approval"
+    assert resurfaced_notification.description == "Latest approval details"
+    assert resurfaced_notification.additional_data == {
+        "session_id": "22222222-2222-2222-2222-222222222222",
+        "link": "/craft/v1?sessionId=22222222-2222-2222-2222-222222222222",
+    }
+    assert resurfaced_notification.first_shown == original_shown
+    assert resurfaced_notification.last_shown != original_shown
+
+
+def test_create_or_resurface_notification_is_not_approval_specific(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_generic_resurface")
+    original_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        dismissed=True,
+        last_shown=original_shown,
+        first_shown=original_shown,
+        title="Old announcement",
+        additional_data={
+            "feature": "stable-feature",
+            "link": "/old-link",
+        },
+    )
+    db_session.add(notification)
+    db_session.commit()
+
+    resurfaced_notification = create_or_resurface_notification(
+        user_id=user.id,
+        notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+        db_session=db_session,
+        title="Updated announcement",
+        description="Updated announcement details",
+        additional_data={
+            "feature": "stable-feature",
+            "link": "/new-link",
+        },
+        dedupe_by_additional_data={"feature": "stable-feature"},
+    )
+    db_session.commit()
+    db_session.refresh(resurfaced_notification)
+
+    assert resurfaced_notification.id == notification.id
+    assert resurfaced_notification.dismissed is False
+    assert resurfaced_notification.title == "Updated announcement"
+    assert resurfaced_notification.description == "Updated announcement details"
+    assert resurfaced_notification.additional_data == {
+        "feature": "stable-feature",
+        "link": "/new-link",
+    }
+    assert resurfaced_notification.first_shown != original_shown
 
 
 def test_get_notifications_api_returns_paginated_response(
@@ -395,6 +494,77 @@ def test_notification_summary_runs_ensure_checks_before_counting(
     assert calls == ["build", "permissions", "release_notes"]
 
 
+def test_notification_summary_ensure_transactions_commit_and_rollback_independently(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "notification_summary_transactions")
+    user_id = user.id
+    calls: list[str] = []
+
+    def create_ensure_notification(key: str, check_db_session: Session) -> None:
+        create_notification(
+            user_id=user_id,
+            notif_type=NotificationType.APPROVAL_REQUESTED,
+            db_session=check_db_session,
+            title=f"{key} notification",
+            additional_data={"ensure_transaction_key": key},
+        )
+
+    def ensure_build(_user: User, check_db_session: Session) -> None:
+        calls.append("build")
+        create_ensure_notification("build", check_db_session)
+
+    def ensure_permissions(_user: User, check_db_session: Session) -> None:
+        calls.append("permissions")
+        create_ensure_notification("permissions", check_db_session)
+        raise RuntimeError("permissions ensure failed")
+
+    def ensure_release_notes(check_db_session: Session) -> None:
+        calls.append("release_notes")
+        create_ensure_notification("release_notes", check_db_session)
+
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_build_mode_intro_notification",
+        ensure_build,
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_permissions_migration_notification",
+        ensure_permissions,
+    )
+    monkeypatch.setattr(
+        notifications_api,
+        "ensure_release_notes_fresh_and_notify",
+        ensure_release_notes,
+    )
+
+    summary = notifications_api.get_notifications_summary_api(
+        user=user,
+        db_session=db_session,
+    )
+
+    notifications = get_notifications(
+        user=user,
+        db_session=db_session,
+        include_dismissed=True,
+        limit=10,
+    )
+    persisted_keys = {
+        notification.additional_data["ensure_transaction_key"]
+        for notification in notifications
+        if notification.additional_data is not None
+        and "ensure_transaction_key" in notification.additional_data
+    }
+
+    assert calls == ["build", "permissions", "release_notes"]
+    assert persisted_keys == {"build", "release_notes"}
+    assert summary.total_items == 2
+    assert summary.undismissed_count == 2
+
+
 def test_notification_summary_and_dismiss_all_api(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
@@ -449,6 +619,46 @@ def test_notification_summary_and_dismiss_all_api(
         select(Notification).where(Notification.id == other_user_notification.id)
     ).one()
     assert other_user_row.dismissed is False
+
+
+def test_dismiss_notification_api_ignores_stale_last_shown(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_stale_dismiss")
+    first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = _create_notification(
+        db_session=db_session,
+        user=user,
+        index=1,
+        first_shown=first_shown,
+        dismissed=False,
+    )
+    last_shown = first_shown + timedelta(minutes=1)
+    notification.last_shown = last_shown
+    db_session.commit()
+
+    notifications_api.dismiss_notification_endpoint(
+        notification_id=notification.id,
+        request=notifications_api.DismissNotificationRequest(
+            expected_last_shown=last_shown - timedelta(minutes=1)
+        ),
+        user=user,
+        db_session=db_session,
+    )
+    db_session.refresh(notification)
+    assert notification.dismissed is False
+
+    notifications_api.dismiss_notification_endpoint(
+        notification_id=notification.id,
+        request=notifications_api.DismissNotificationRequest(
+            expected_last_shown=last_shown
+        ),
+        user=user,
+        db_session=db_session,
+    )
+    db_session.refresh(notification)
+    assert notification.dismissed is True
 
 
 def _disable_notification_ensure_checks(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -12,6 +12,7 @@ from onyx.db.models import Notification
 from onyx.db.models import User
 from onyx.db.notification import count_notifications
 from onyx.db.notification import create_notification
+from onyx.db.notification import create_or_resurface_notification
 from onyx.db.notification import dismiss_user_notifications
 from onyx.db.notification import get_notifications
 from onyx.server.features.notifications import api as notifications_api
@@ -156,9 +157,121 @@ def test_create_notification_can_preserve_existing_last_shown(
         additional_data={"test_position": 1},
         refresh_existing=False,
     )
+    db_session.commit()
 
     assert existing_notification.id == notification.id
     assert existing_notification.last_shown == original_last_shown
+
+
+def test_create_notification_does_not_reopen_dismissed_existing(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_dismissed_dedupe")
+    original_first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=True,
+        last_shown=original_first_shown,
+        first_shown=original_first_shown,
+        title="Old approval",
+        additional_data={
+            "session_id": "session-1",
+            "link": "/craft/v1?sessionId=session-1",
+        },
+    )
+    db_session.add(notification)
+    db_session.commit()
+
+    existing_notification = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="New approval",
+        description="New approval details",
+        additional_data={
+            "session_id": "session-1",
+            "link": "/craft/v1?sessionId=session-1",
+        },
+    )
+    db_session.commit()
+    db_session.refresh(existing_notification)
+
+    assert existing_notification.id == notification.id
+    assert existing_notification.dismissed is True
+    assert existing_notification.title == "Old approval"
+    assert existing_notification.description is None
+    assert existing_notification.first_shown == original_first_shown
+
+
+def test_create_or_resurface_notification_reopens_existing_matching_additional_data(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_reopen_session")
+    original_first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=True,
+        last_shown=original_first_shown,
+        first_shown=original_first_shown,
+        title="Old approval",
+        additional_data={
+            "session_id": "session-1",
+            "link": "/craft/v1?sessionId=session-1",
+        },
+    )
+    db_session.add(notification)
+    db_session.commit()
+
+    reopened_notification = create_or_resurface_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="New approval",
+        description="New approval details",
+        additional_data={
+            "session_id": "session-1",
+            "link": "/craft/v1?sessionId=session-1",
+        },
+    )
+    db_session.commit()
+    db_session.refresh(reopened_notification)
+
+    assert reopened_notification.id == notification.id
+    assert reopened_notification.dismissed is False
+    assert reopened_notification.title == "New approval"
+    assert reopened_notification.description == "New approval details"
+    assert reopened_notification.additional_data is not None
+    assert reopened_notification.additional_data == {
+        "session_id": "session-1",
+        "link": "/craft/v1?sessionId=session-1",
+    }
+    assert reopened_notification.first_shown != original_first_shown
+
+    new_session_notification = create_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="Different session approval",
+        additional_data={
+            "session_id": "session-2",
+            "link": "/craft/v1?sessionId=session-2",
+        },
+    )
+    db_session.commit()
+    db_session.refresh(new_session_notification)
+
+    assert new_session_notification.id != reopened_notification.id
+    total_items, undismissed_count = count_notifications(
+        user=user,
+        db_session=db_session,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+    )
+    assert total_items == 2
+    assert undismissed_count == 2
 
 
 def test_get_notifications_api_returns_paginated_response(

--- a/backend/tests/external_dependency_unit/db/test_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_notification.py
@@ -5,6 +5,7 @@ from datetime import timezone
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import NotificationType
@@ -13,6 +14,7 @@ from onyx.db.models import User
 from onyx.db.notification import count_notifications
 from onyx.db.notification import create_notification
 from onyx.db.notification import create_or_resurface_notification
+from onyx.db.notification import dismiss_notification
 from onyx.db.notification import dismiss_user_notifications
 from onyx.db.notification import get_notifications
 from onyx.server.features.notifications import api as notifications_api
@@ -235,9 +237,7 @@ def test_create_or_resurface_notification_reopens_existing_session(
             "session_id": "11111111-1111-1111-1111-111111111111",
             "link": "/craft/v1?sessionId=11111111-1111-1111-1111-111111111111",
         },
-        dedupe_by_additional_data={
-            "session_id": "11111111-1111-1111-1111-111111111111"
-        },
+        identity_data={"session_id": "11111111-1111-1111-1111-111111111111"},
     )
     db_session.commit()
     db_session.refresh(reopened_notification)
@@ -307,9 +307,7 @@ def test_create_or_resurface_notification_updates_active_existing_without_restar
             "session_id": "22222222-2222-2222-2222-222222222222",
             "link": "/craft/v1?sessionId=22222222-2222-2222-2222-222222222222",
         },
-        dedupe_by_additional_data={
-            "session_id": "22222222-2222-2222-2222-222222222222"
-        },
+        identity_data={"session_id": "22222222-2222-2222-2222-222222222222"},
     )
     db_session.commit()
     db_session.refresh(resurfaced_notification)
@@ -324,6 +322,78 @@ def test_create_or_resurface_notification_updates_active_existing_without_restar
     }
     assert resurfaced_notification.first_shown == original_shown
     assert resurfaced_notification.last_shown != original_shown
+
+
+def test_create_or_resurface_notification_collapses_duplicate_identity_rows(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_duplicate_session")
+    first_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    session_id = "33333333-3333-3333-3333-333333333333"
+    older_notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=False,
+        last_shown=first_shown,
+        first_shown=first_shown,
+        title="Old approval",
+        additional_data={
+            "session_id": session_id,
+            "approval_id": "approval-1",
+            "link": "/craft/v1?sessionId=old-link-format",
+        },
+    )
+    newer_notification = Notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        dismissed=True,
+        last_shown=first_shown + timedelta(minutes=1),
+        first_shown=first_shown + timedelta(minutes=1),
+        title="Newer dismissed approval",
+        additional_data={
+            "session_id": session_id,
+            "approval_id": "approval-2",
+            "link": "/craft/v1?sessionId=duplicate-link-format",
+        },
+    )
+    db_session.add_all([older_notification, newer_notification])
+    db_session.commit()
+
+    resurfaced_notification = create_or_resurface_notification(
+        user_id=user.id,
+        notif_type=NotificationType.APPROVAL_REQUESTED,
+        db_session=db_session,
+        title="Latest approval",
+        description="Latest approval details",
+        additional_data={
+            "session_id": session_id,
+            "link": f"/craft/v1?sessionId={session_id}",
+        },
+        identity_data={"session_id": session_id},
+    )
+    db_session.commit()
+
+    matching_notifications = list(
+        db_session.execute(
+            select(Notification).where(
+                Notification.user_id == user.id,
+                Notification.notif_type == NotificationType.APPROVAL_REQUESTED,
+                Notification.additional_data.contains({"session_id": session_id}),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(matching_notifications) == 1
+    assert matching_notifications[0].id == resurfaced_notification.id
+    assert matching_notifications[0].dismissed is False
+    assert matching_notifications[0].title == "Latest approval"
+    assert matching_notifications[0].description == "Latest approval details"
+    assert matching_notifications[0].additional_data == {
+        "session_id": session_id,
+        "link": f"/craft/v1?sessionId={session_id}",
+    }
 
 
 def test_create_or_resurface_notification_is_not_approval_specific(
@@ -357,7 +427,7 @@ def test_create_or_resurface_notification_is_not_approval_specific(
             "feature": "stable-feature",
             "link": "/new-link",
         },
-        dedupe_by_additional_data={"feature": "stable-feature"},
+        identity_data={"feature": "stable-feature"},
     )
     db_session.commit()
     db_session.refresh(resurfaced_notification)
@@ -371,6 +441,32 @@ def test_create_or_resurface_notification_is_not_approval_specific(
         "link": "/new-link",
     }
     assert resurfaced_notification.first_shown != original_shown
+
+
+def test_create_or_resurface_notification_rejects_invalid_identity_data(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_identity_validation")
+
+    with pytest.raises(ValueError, match="identity_data requires"):
+        create_or_resurface_notification(
+            user_id=user.id,
+            notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+            db_session=db_session,
+            title="Empty identity",
+            additional_data={"link": "/new-link"},
+            identity_data={},
+        )
+
+    with pytest.raises(ValueError, match="identity_data requires"):
+        create_or_resurface_notification(
+            user_id=user.id,
+            notif_type=NotificationType.FEATURE_ANNOUNCEMENT,
+            db_session=db_session,
+            title="Missing payload",
+            identity_data={"feature": "stable-feature"},
+        )
 
 
 def test_get_notifications_api_returns_paginated_response(
@@ -404,6 +500,7 @@ def test_get_notifications_api_returns_paginated_response(
     assert response.page_num == 0
     assert response.page_size == 2
     assert response.has_more is True
+    assert response.notifications[0].version == response.notifications[0].last_shown
 
 
 def test_get_notifications_api_runs_ensure_checks_on_first_page(
@@ -621,7 +718,7 @@ def test_notification_summary_and_dismiss_all_api(
     assert other_user_row.dismissed is False
 
 
-def test_dismiss_notification_api_ignores_stale_last_shown(
+def test_dismiss_notification_api_ignores_stale_version(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
@@ -641,7 +738,7 @@ def test_dismiss_notification_api_ignores_stale_last_shown(
     notifications_api.dismiss_notification_endpoint(
         notification_id=notification.id,
         request=notifications_api.DismissNotificationRequest(
-            expected_last_shown=last_shown - timedelta(minutes=1)
+            expected_version=last_shown - timedelta(minutes=1)
         ),
         user=user,
         db_session=db_session,
@@ -652,10 +749,58 @@ def test_dismiss_notification_api_ignores_stale_last_shown(
     notifications_api.dismiss_notification_endpoint(
         notification_id=notification.id,
         request=notifications_api.DismissNotificationRequest(
-            expected_last_shown=last_shown
+            expected_version=last_shown
         ),
         user=user,
         db_session=db_session,
+    )
+    db_session.refresh(notification)
+    assert notification.dismissed is True
+
+
+def test_dismiss_notification_uses_atomic_version_update(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    user = create_test_user(db_session, "notification_atomic_dismiss")
+    original_last_shown = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    notification = _create_notification(
+        db_session=db_session,
+        user=user,
+        index=1,
+        first_shown=original_last_shown,
+        dismissed=False,
+    )
+    db_session.commit()
+
+    newer_last_shown = original_last_shown + timedelta(minutes=1)
+    db_session.execute(
+        update(Notification)
+        .where(Notification.id == notification.id)
+        .values(last_shown=newer_last_shown, dismissed=False)
+        .execution_options(synchronize_session=False)
+    )
+    db_session.commit()
+
+    assert (
+        dismiss_notification(
+            notification_id=notification.id,
+            db_session=db_session,
+            expected_version=original_last_shown,
+        )
+        is False
+    )
+    db_session.refresh(notification)
+    assert notification.dismissed is False
+    assert notification.last_shown == newer_last_shown
+
+    assert (
+        dismiss_notification(
+            notification_id=notification.id,
+            db_session=db_session,
+            expected_version=newer_last_shown,
+        )
+        is True
     )
     db_session.refresh(notification)
     assert notification.dismissed is True

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -1547,12 +1547,10 @@ def test_persist_approval_row_announce_failure_is_swallowed(
         cache_factory=lambda tenant_id: cache,  # noqa: ARG005
     )
 
-    notify_calls: list[tuple[UUID, SessionContext, AllMatchedActions]] = []
+    notify_calls: list[SessionContext] = []
 
-    def _fake_notify(
-        _self: Any, aid: UUID, ctx_arg: SessionContext, match_arg: AllMatchedActions
-    ) -> None:
-        notify_calls.append((aid, ctx_arg, match_arg))
+    def _fake_notify(_self: Any, ctx_arg: SessionContext) -> None:
+        notify_calls.append(ctx_arg)
 
     monkeypatch.setattr(GateAddon, "_notify_approval_requested", _fake_notify)
 
@@ -1563,7 +1561,7 @@ def test_persist_approval_row_announce_failure_is_swallowed(
     assert dict(addon._parked.snapshot()) == {"tenant-1": {approval_id}}
 
     # Failed announce must not short-circuit the notify dispatch.
-    assert notify_calls == [(approval_id, ctx, _MATCH)]
+    assert notify_calls == [ctx]
     assert ops.index("insert") < ops.index("commit")
     # rpush raised before recording, so no rpush op is present.
     assert not any(op.startswith("rpush:") for op in ops)

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -6,8 +6,9 @@ import Link from "next/link";
 import type { Route } from "next";
 import Cookies from "js-cookie";
 import { SvgX } from "@opal/icons";
+import type { Notification } from "@/lib/notifications/interfaces";
 import { dismissNotification } from "@/lib/notifications/api";
-import { SWR_KEYS } from "@/lib/swr-keys";
+import { refreshNotificationCaches } from "@/lib/notifications/cache";
 import { useSWRConfig } from "swr";
 const DISMISSED_NOTIFICATION_COOKIE_PREFIX = "dismissed_notification_";
 const COOKIE_EXPIRY_DAYS = 1;
@@ -33,20 +34,20 @@ export function AnnouncementBanner() {
 
   if (!localNotifications || localNotifications.length === 0) return null;
 
-  const handleDismiss = async (notificationId: number) => {
+  const handleDismiss = async (notification: Notification) => {
     try {
-      await dismissNotification(notificationId);
+      await dismissNotification(notification.id, notification.last_shown);
       Cookies.set(
-        `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notificationId}`,
+        `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notification.id}`,
         "true",
         { expires: COOKIE_EXPIRY_DAYS }
       );
       setLocalNotifications((prevNotifications) =>
         prevNotifications.filter(
-          (notification) => notification.id !== notificationId
+          (localNotification) => localNotification.id !== notification.id
         )
       );
-      void mutate(SWR_KEYS.notificationsSummary);
+      void refreshNotificationCaches(mutate);
     } catch (error) {
       console.error("Error dismissing notification:", error);
     }
@@ -87,7 +88,7 @@ export function AnnouncementBanner() {
                 </p>
               ) : null}
               <button
-                onClick={() => handleDismiss(notification.id)}
+                onClick={() => handleDismiss(notification)}
                 className="absolute top-0 right-0 mt-2 mr-2"
                 aria-label="Dismiss"
               >

--- a/web/src/components/header/AnnouncementBanner.tsx
+++ b/web/src/components/header/AnnouncementBanner.tsx
@@ -13,6 +13,10 @@ import { useSWRConfig } from "swr";
 const DISMISSED_NOTIFICATION_COOKIE_PREFIX = "dismissed_notification_";
 const COOKIE_EXPIRY_DAYS = 1;
 
+function dismissedNotificationCookieName(notification: Notification): string {
+  return `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notification.id}_${notification.version}`;
+}
+
 export function AnnouncementBanner() {
   const settings = useContext(SettingsContext);
   const { mutate } = useSWRConfig();
@@ -25,9 +29,7 @@ export function AnnouncementBanner() {
       settings?.settings.notifications || []
     ).filter(
       (notification) =>
-        !Cookies.get(
-          `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notification.id}`
-        )
+        !Cookies.get(dismissedNotificationCookieName(notification))
     );
     setLocalNotifications(filteredNotifications);
   }, [settings?.settings.notifications]);
@@ -36,12 +38,10 @@ export function AnnouncementBanner() {
 
   const handleDismiss = async (notification: Notification) => {
     try {
-      await dismissNotification(notification.id, notification.last_shown);
-      Cookies.set(
-        `${DISMISSED_NOTIFICATION_COOKIE_PREFIX}${notification.id}`,
-        "true",
-        { expires: COOKIE_EXPIRY_DAYS }
-      );
+      await dismissNotification(notification.id, notification.version);
+      Cookies.set(dismissedNotificationCookieName(notification), "true", {
+        expires: COOKIE_EXPIRY_DAYS,
+      });
       setLocalNotifications((prevNotifications) =>
         prevNotifications.filter(
           (localNotification) => localNotification.id !== notification.id

--- a/web/src/hooks/useNotifications.ts
+++ b/web/src/hooks/useNotifications.ts
@@ -5,16 +5,17 @@ import useSWR, { useSWRConfig } from "swr";
 import useSWRInfinite from "swr/infinite";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import {
+  getNotificationsPageKey,
+  refreshNotificationCaches,
+} from "@/lib/notifications/cache";
 import type {
   Notification,
   NotificationSummary,
   NotificationsResponse,
 } from "@/lib/notifications/interfaces";
 
-const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
-
 interface UseNotificationsOptions {
-  pageSize?: number;
   enabled?: boolean;
 }
 
@@ -54,7 +55,6 @@ export function useNotificationSummary() {
  *   - loadMore: Function to fetch the next page
  */
 export default function useNotifications({
-  pageSize = DEFAULT_NOTIFICATIONS_PAGE_SIZE,
   enabled = true,
 }: UseNotificationsOptions = {}) {
   const { mutate: mutateGlobal } = useSWRConfig();
@@ -66,18 +66,21 @@ export default function useNotifications({
       if (!enabled) return null;
       if (previousPageData && !previousPageData.has_more) return null;
 
-      return SWR_KEYS.notificationsPage(pageIndex, pageSize);
+      return getNotificationsPageKey(pageIndex);
     },
-    [enabled, pageSize]
+    [enabled]
   );
 
-  const { data, error, mutate, size, setSize } =
-    useSWRInfinite<NotificationsResponse>(getKey, errorHandlingFetcher, {
+  const { data, error, size, setSize } = useSWRInfinite<NotificationsResponse>(
+    getKey,
+    errorHandlingFetcher,
+    {
       revalidateOnFocus: false,
       revalidateFirstPage: false,
       revalidateAll: false,
       dedupingInterval: 30000,
-    });
+    }
+  );
 
   const notifications = useMemo<Notification[]>(() => {
     if (!data) return [];
@@ -119,11 +122,12 @@ export default function useNotifications({
   }, [hasMore, isLoadingMore, setSize]);
 
   const refresh = useCallback(() => {
-    void mutateGlobal(SWR_KEYS.notificationsSummary);
-    if (!enabled) return Promise.resolve(undefined);
+    if (!enabled) {
+      return mutateGlobal(SWR_KEYS.notificationsSummary).then(() => undefined);
+    }
 
-    return mutate();
-  }, [enabled, mutate, mutateGlobal]);
+    return refreshNotificationCaches(mutateGlobal);
+  }, [enabled, mutateGlobal]);
 
   return {
     notifications,

--- a/web/src/lib/notifications/api.ts
+++ b/web/src/lib/notifications/api.ts
@@ -12,17 +12,12 @@ async function handleNotificationMutation(
 
 export async function dismissNotification(
   notificationId: number,
-  expectedLastShown?: string
+  expectedVersion: string
 ): Promise<void> {
-  const body = expectedLastShown
-    ? {
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ expected_last_shown: expectedLastShown }),
-      }
-    : {};
   const response = await fetch(`/api/notifications/${notificationId}/dismiss`, {
     method: "POST",
-    ...body,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ expected_version: expectedVersion }),
   });
   return handleNotificationMutation(response, "Failed to dismiss notification");
 }

--- a/web/src/lib/notifications/api.ts
+++ b/web/src/lib/notifications/api.ts
@@ -11,10 +11,18 @@ async function handleNotificationMutation(
 }
 
 export async function dismissNotification(
-  notificationId: number
+  notificationId: number,
+  expectedLastShown?: string
 ): Promise<void> {
+  const body = expectedLastShown
+    ? {
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ expected_last_shown: expectedLastShown }),
+      }
+    : {};
   const response = await fetch(`/api/notifications/${notificationId}/dismiss`, {
     method: "POST",
+    ...body,
   });
   return handleNotificationMutation(response, "Failed to dismiss notification");
 }

--- a/web/src/lib/notifications/cache.ts
+++ b/web/src/lib/notifications/cache.ts
@@ -1,0 +1,21 @@
+import type { ScopedMutator } from "swr";
+import { SWR_KEYS } from "@/lib/swr-keys";
+
+const INFINITE_NOTIFICATIONS_KEY_PREFIX = `$inf$${SWR_KEYS.notifications}?`;
+
+function isNotificationsPageCacheKey(key: unknown): boolean {
+  return (
+    typeof key === "string" &&
+    (key.startsWith(`${SWR_KEYS.notifications}?`) ||
+      key.startsWith(INFINITE_NOTIFICATIONS_KEY_PREFIX))
+  );
+}
+
+export async function refreshNotificationCaches(
+  mutate: ScopedMutator
+): Promise<void> {
+  await Promise.all([
+    mutate(SWR_KEYS.notificationsSummary),
+    mutate((key) => isNotificationsPageCacheKey(key)),
+  ]);
+}

--- a/web/src/lib/notifications/cache.ts
+++ b/web/src/lib/notifications/cache.ts
@@ -1,13 +1,23 @@
 import type { ScopedMutator } from "swr";
+import { unstable_serialize } from "swr/infinite";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import type { NotificationsResponse } from "@/lib/notifications/interfaces";
 
-const INFINITE_NOTIFICATIONS_KEY_PREFIX = `$inf$${SWR_KEYS.notifications}?`;
+export const DEFAULT_NOTIFICATIONS_PAGE_SIZE = 25;
 
-function isNotificationsPageCacheKey(key: unknown): boolean {
-  return (
-    typeof key === "string" &&
-    (key.startsWith(`${SWR_KEYS.notifications}?`) ||
-      key.startsWith(INFINITE_NOTIFICATIONS_KEY_PREFIX))
+export function getNotificationsPageKey(pageIndex: number): string {
+  return SWR_KEYS.notificationsPage(pageIndex, DEFAULT_NOTIFICATIONS_PAGE_SIZE);
+}
+
+export function getNotificationsInfiniteKey(): string {
+  return unstable_serialize(
+    (
+      pageIndex: number,
+      previousPageData: NotificationsResponse | null
+    ): string | null => {
+      if (previousPageData && !previousPageData.has_more) return null;
+      return getNotificationsPageKey(pageIndex);
+    }
   );
 }
 
@@ -16,6 +26,6 @@ export async function refreshNotificationCaches(
 ): Promise<void> {
   await Promise.all([
     mutate(SWR_KEYS.notificationsSummary),
-    mutate((key) => isNotificationsPageCacheKey(key)),
+    mutate(getNotificationsInfiniteKey()),
   ]);
 }

--- a/web/src/lib/notifications/interfaces.ts
+++ b/web/src/lib/notifications/interfaces.ts
@@ -26,6 +26,7 @@ export interface Notification {
   dismissed: boolean;
   first_shown: string;
   last_shown: string;
+  version: string;
   additional_data?: {
     persona_id?: number;
     link?: string;

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -305,7 +305,7 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
     try {
       await dismissNotification(
         buildModeNotification.id,
-        buildModeNotification.last_shown
+        buildModeNotification.version
       );
       mutateNotifications();
     } catch (error) {

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -303,7 +303,10 @@ const MemoizedAppSidebarInner = memo(function AppSidebarInner() {
   const dismissBuildModeNotification = useCallback(async () => {
     if (!buildModeNotification) return;
     try {
-      await dismissNotification(buildModeNotification.id);
+      await dismissNotification(
+        buildModeNotification.id,
+        buildModeNotification.last_shown
+      );
       mutateNotifications();
     } catch (error) {
       console.error("Error dismissing notification:", error);

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -124,31 +124,31 @@ export default function NotificationsPopover({
   const lastLoadScrollTopRef = useRef<number | null>(null);
   loadMoreRef.current = loadMore;
 
-  const [sessionDismissedLastShownById, setSessionDismissedLastShownById] =
+  const [sessionDismissedVersionById, setSessionDismissedVersionById] =
     useState<Map<number, string>>(new Map());
   const dismissInFlightIdsRef = useRef<Set<number>>(new Set());
 
   const handleDismiss = useCallback(
     async (notification: NotificationData) => {
       const notificationId = notification.id;
-      const expectedLastShown = notification.last_shown;
+      const expectedVersion = notification.version;
       if (dismissInFlightIdsRef.current.has(notificationId)) {
         return;
       }
 
       dismissInFlightIdsRef.current.add(notificationId);
-      setSessionDismissedLastShownById((prev) => {
+      setSessionDismissedVersionById((prev) => {
         const next = new Map(prev);
-        next.set(notificationId, expectedLastShown);
+        next.set(notificationId, expectedVersion);
         return next;
       });
 
       try {
-        await dismissNotification(notificationId, expectedLastShown);
+        await dismissNotification(notificationId, expectedVersion);
         void refresh();
       } catch (error) {
-        setSessionDismissedLastShownById((prev) => {
-          if (prev.get(notificationId) !== expectedLastShown) {
+        setSessionDismissedVersionById((prev) => {
+          if (prev.get(notificationId) !== expectedVersion) {
             return prev;
           }
           const next = new Map(prev);
@@ -165,18 +165,13 @@ export default function NotificationsPopover({
 
   const getState = useCallback(
     (notification: NotificationData): NotificationState => {
-      const dismissedLastShown = sessionDismissedLastShownById.get(
-        notification.id
-      );
-      if (
-        dismissedLastShown === notification.last_shown ||
-        notification.dismissed
-      ) {
+      const dismissedVersion = sessionDismissedVersionById.get(notification.id);
+      if (dismissedVersion === notification.version || notification.dismissed) {
         return "older";
       }
       return "new";
     },
-    [sessionDismissedLastShownById]
+    [sessionDismissedVersionById]
   );
 
   const handleNotificationClick = useCallback(
@@ -229,10 +224,10 @@ export default function NotificationsPopover({
   const handleDismissAll = useCallback(async () => {
     try {
       await dismissAllNotifications();
-      setSessionDismissedLastShownById((prev) => {
+      setSessionDismissedVersionById((prev) => {
         const next = new Map(prev);
         newNotifications.forEach((notification) => {
-          next.set(notification.id, notification.last_shown);
+          next.set(notification.id, notification.version);
         });
         return next;
       });

--- a/web/src/sections/sidebar/NotificationsPopover.tsx
+++ b/web/src/sections/sidebar/NotificationsPopover.tsx
@@ -124,26 +124,59 @@ export default function NotificationsPopover({
   const lastLoadScrollTopRef = useRef<number | null>(null);
   loadMoreRef.current = loadMore;
 
-  // Track IDs dismissed during this session (before popover closes)
-  const [sessionDismissedIds, setSessionDismissedIds] = useState<Set<number>>(
-    new Set()
-  );
+  const [sessionDismissedLastShownById, setSessionDismissedLastShownById] =
+    useState<Map<number, string>>(new Map());
+  const dismissInFlightIdsRef = useRef<Set<number>>(new Set());
 
   const handleDismiss = useCallback(
-    async (notificationId: number) => {
+    async (notification: NotificationData) => {
+      const notificationId = notification.id;
+      const expectedLastShown = notification.last_shown;
+      if (dismissInFlightIdsRef.current.has(notificationId)) {
+        return;
+      }
+
+      dismissInFlightIdsRef.current.add(notificationId);
+      setSessionDismissedLastShownById((prev) => {
+        const next = new Map(prev);
+        next.set(notificationId, expectedLastShown);
+        return next;
+      });
+
       try {
-        await dismissNotification(notificationId);
-        setSessionDismissedIds((prev) => {
-          const next = new Set(prev);
-          next.add(notificationId);
-          return next;
-        });
+        await dismissNotification(notificationId, expectedLastShown);
         void refresh();
       } catch (error) {
+        setSessionDismissedLastShownById((prev) => {
+          if (prev.get(notificationId) !== expectedLastShown) {
+            return prev;
+          }
+          const next = new Map(prev);
+          next.delete(notificationId);
+          return next;
+        });
         console.error("Error dismissing notification:", error);
+      } finally {
+        dismissInFlightIdsRef.current.delete(notificationId);
       }
     },
     [refresh]
+  );
+
+  const getState = useCallback(
+    (notification: NotificationData): NotificationState => {
+      const dismissedLastShown = sessionDismissedLastShownById.get(
+        notification.id
+      );
+      if (
+        dismissedLastShown === notification.last_shown ||
+        notification.dismissed
+      ) {
+        return "older";
+      }
+      return "new";
+    },
+    [sessionDismissedLastShownById]
   );
 
   const handleNotificationClick = useCallback(
@@ -168,29 +201,20 @@ export default function NotificationsPopover({
       }
 
       if (link.startsWith("http://") || link.startsWith("https://")) {
-        if (!notification.dismissed) {
-          handleDismiss(notification.id);
+        if (getState(notification) === "new") {
+          void handleDismiss(notification);
         }
         window.open(link, "_blank", "noopener,noreferrer");
         return;
       }
 
-      if (!notification.dismissed) {
-        handleDismiss(notification.id);
+      if (getState(notification) === "new") {
+        void handleDismiss(notification);
       }
       onNavigate();
       router.push(link as Route);
     },
-    [handleDismiss, onNavigate, onShowBuildIntro, router]
-  );
-
-  const getState = useCallback(
-    (notification: NotificationData): NotificationState => {
-      if (sessionDismissedIds.has(notification.id) || notification.dismissed)
-        return "older";
-      return "new";
-    },
-    [sessionDismissedIds]
+    [getState, handleDismiss, onNavigate, onShowBuildIntro, router]
   );
 
   const newNotifications = useMemo(
@@ -205,10 +229,10 @@ export default function NotificationsPopover({
   const handleDismissAll = useCallback(async () => {
     try {
       await dismissAllNotifications();
-      setSessionDismissedIds((prev) => {
-        const next = new Set(prev);
+      setSessionDismissedLastShownById((prev) => {
+        const next = new Map(prev);
         newNotifications.forEach((notification) => {
-          next.add(notification.id);
+          next.set(notification.id, notification.last_shown);
         });
         return next;
       });
@@ -317,7 +341,7 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="new"
                     onClick={() => handleNotificationClick(notification)}
-                    dismiss={() => handleDismiss(notification.id)}
+                    dismiss={() => void handleDismiss(notification)}
                   />
                 ))}
               </div>
@@ -334,7 +358,7 @@ export default function NotificationsPopover({
                     notification={notification}
                     state="older"
                     onClick={() => handleNotificationClick(notification)}
-                    dismiss={() => handleDismiss(notification.id)}
+                    dismiss={() => void handleDismiss(notification)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Description

This PR hardens the session-notification rollup behavior for Craft approval requests.

- Roll up approval request notifications by stable session identity instead of changing display payloads.
- Resurface an existing dismissed session notification when a new approval request appears in that session.
- Collapse existing duplicate same-session notification rows when resurfacing.
- Use a notification `version` precondition for dismiss requests so stale UI actions do not hide a newly resurfaced notification.
- Refresh the notification summary and SWR Infinite notification list after dismiss mutations.
- Include notification version in the announcement-banner dismiss cookie so resurfaced rows can show again.

Stacked on `whuang/paginate-notifications` to keep this PR scoped to the session rollup changes.

## How Has This Been Tested?

- `ruff check backend/onyx/db/notification.py backend/onyx/server/features/notifications/api.py backend/onyx/server/features/notifications/models.py backend/onyx/sandbox_proxy/addons/gate.py backend/tests/external_dependency_unit/db/test_notification.py`
- `ruff format --check backend/onyx/db/notification.py backend/onyx/server/features/notifications/api.py backend/onyx/server/features/notifications/models.py backend/onyx/sandbox_proxy/addons/gate.py backend/tests/external_dependency_unit/db/test_notification.py`
- `ty check backend/onyx/db/notification.py backend/onyx/server/features/notifications/api.py backend/onyx/server/features/notifications/models.py backend/onyx/sandbox_proxy/addons/gate.py backend/tests/external_dependency_unit/db/test_notification.py`
- `bunx oxfmt --check web/src/lib/notifications/cache.ts web/src/hooks/useNotifications.ts web/src/components/header/AnnouncementBanner.tsx web/src/lib/notifications/api.ts web/src/lib/notifications/interfaces.ts web/src/sections/sidebar/NotificationsPopover.tsx web/src/sections/sidebar/AppSidebar.tsx`
- `bun run lint`
- `bun run types:check`
- `pytest -q backend/tests/unit/sandbox_proxy/test_gate.py -x`

DB-backed external dependency notification tests were not runnable locally because Postgres at `127.0.0.1:5432` refused connections.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls up Craft session approval notifications by stable session_id, resurfaces and de-dupes them, and adds versioned dismiss so stale UI actions don't hide resurfaced items. Updates backend and web to pass a notification `version`, refresh caches, and keep lists consistent.

- **Bug Fixes**
  - Rollup by `session_id`: resurface dismissed notifications, collapse duplicates, and update title/description/link; keep `first_shown` unless previously dismissed.
  - Atomic dismiss: `dismiss_notification(id, expected_version)` with API body support; stale versions are no-ops. `NotificationResponse.version` mirrors `last_shown`.
  - Web updates: send `expected_version` on dismiss; banner cookie uses `id_version` so resurfaced items show again; refresh both summary and infinite list after mutations.
  - Craft gate: approval notifications use `{ session_id, link }` identity; `approval_id` removed; callers explicitly commit.
  - Reliability: notification ensure checks run in isolated transactions (commit successes, rollback failures). Avoid mutating `last_shown` on reads; minor commit fix in doc processing.

<sup>Written for commit 9e1dd721d93f52c15c04e7fb7524718b36f58873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

