### PR TITLE
fix(craft): `pr-craft-compose-integration.yml` doesn't need to start FE containers

### DIFF
--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -110,12 +110,10 @@ jobs:
       # added to tools/ods/cmd/compose.go. Today `ods compose` doesn't support
       # the craft overlay, so we drop to raw docker compose.
       #
-      # Service list: only what the gate + posture tests need. compose's
+      # Service list: Only what the gate + posture tests need. compose's
       # depends_on graph pulls in relational_db / cache / opensearch / model
-      # servers / minio transitively. Deliberately excludes web_server and
-      # nginx -- the tests hit api_server on localhost:8080 directly, and the
-      # published web-server image's CI healthcheck is flaky enough to break
-      # `--wait` (which fails if ANY listed service is unhealthy).
+      # servers / minio transitively. Deliberately excludes web_server and nginx
+      # -- the tests hit api_server on localhost:8080 directly.
       - name: Bring up the stack (yml + dev + craft)
         working-directory: deployment/docker_compose
         run: |

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -109,6 +109,13 @@ jobs:
       # TODO(ods): Replace with `ods compose --craft` once that flag is
       # added to tools/ods/cmd/compose.go. Today `ods compose` doesn't support
       # the craft overlay, so we drop to raw docker compose.
+      #
+      # Service list: only what the gate + posture tests need. compose's
+      # depends_on graph pulls in relational_db / cache / opensearch / model
+      # servers / minio transitively. Deliberately excludes web_server and
+      # nginx -- the tests hit api_server on localhost:8080 directly, and the
+      # published web-server image's CI healthcheck is flaky enough to break
+      # `--wait` (which fails if ANY listed service is unhealthy).
       - name: Bring up the stack (yml + dev + craft)
         working-directory: deployment/docker_compose
         run: |
@@ -117,7 +124,8 @@ jobs:
             -f docker-compose.dev.yml \
             -f docker-compose.craft.yml \
             --env-file env.template \
-            up -d --wait --wait-timeout 600
+            up -d --wait --wait-timeout 600 \
+            api_server background sandbox-proxy
 
       - name: Sanity check stack health
         # --fail: without it, curl exits 0 on 4xx/5xx and the step would accept


### PR DESCRIPTION
## Description

The web server container failed to get healthy in [this run](https://github.com/onyx-dot-app/onyx/actions/runs/27172308778/job/80213877524) causing it to fail; We don't need it.

## How Has This Been Tested?
I'll look at https://github.com/onyx-dot-app/onyx/actions/workflows/pr-craft-compose-integration.yml

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pr-craft-compose-integration.yml` to start only the services needed for gate/posture tests and skip FE containers. This prevents flaky `web_server` health checks from failing `--wait`.

- **Bug Fixes**
  - Run `docker compose up -d --wait --wait-timeout 600` only for `api_server`, `background`, and `sandbox-proxy` (transitively brings up DB, cache, OpenSearch, model servers, MinIO).
  - Exclude `web_server` and `nginx`; tests hit `api_server` on `localhost:8080` directly.

<sup>Written for commit 7466a317b6eb2803824ff3be139c7ce52b7c37eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

