### PR TITLE
fix(craft): move approval cards above input

### DIFF
--- a/web/src/app/craft/components/BuildMessageList.tsx
+++ b/web/src/app/craft/components/BuildMessageList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { cn } from "@opal/utils";
 import { AnimatePresence, motion } from "motion/react";
 import Logo from "@/refresh-components/Logo";
@@ -38,13 +38,6 @@ interface BuildMessageListProps {
    * rather than via scrollIntoView, which scrolls every ancestor.
    */
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
-  /**
-   * Trailing content attached to the last assistant block — either the
-   * in-progress streaming area (if visible) or the last saved assistant
-   * message. Used to render the approval cards inline so they read as
-   * part of the agent's last turn instead of a separate message.
-   */
-  trailingAssistantSlot?: React.ReactNode;
 }
 
 /**
@@ -62,7 +55,6 @@ export default function BuildMessageList({
   isStreaming = false,
   autoScrollEnabled = true,
   scrollContainerRef,
-  trailingAssistantSlot,
 }: BuildMessageListProps) {
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -212,10 +204,7 @@ export default function BuildMessageList({
     return { nodes, pinnedTodo };
   };
 
-  const renderAgentMessage = (
-    message: BuildMessage,
-    trailing?: React.ReactNode
-  ) => {
+  const renderAgentMessage = (message: BuildMessage) => {
     const savedStreamItems = message.message_metadata?.streamItems as
       | StreamItem[]
       | undefined;
@@ -252,22 +241,10 @@ export default function BuildMessageList({
           ) : (
             <TextChunk content={message.content} />
           )}
-          {trailing}
         </div>
       </div>
     );
   };
-
-  // Index of the last saved assistant message — used to anchor the
-  // trailingAssistantSlot (e.g. approval cards) when no streaming
-  // response is currently in-flight. When streaming, the slot rides
-  // along with the streaming area instead.
-  const lastAssistantIndex = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i]?.type === "assistant") return i;
-    }
-    return -1;
-  }, [messages]);
 
   const streamRender = hasStreamItems
     ? renderStreamItems(streamItems, {
@@ -284,15 +261,7 @@ export default function BuildMessageList({
             return <UserMessage key={message.id} content={message.content} />;
           }
           if (message.type === "assistant") {
-            // Anchor the trailing slot (e.g. approval cards) under the
-            // last saved assistant message — but only when there's no
-            // live streaming area, since that case has its own anchor
-            // below.
-            const trailing =
-              !showStreamingArea && idx === lastAssistantIndex
-                ? trailingAssistantSlot
-                : null;
-            return renderAgentMessage(message, trailing);
+            return renderAgentMessage(message);
           }
           return null;
         })}
@@ -320,7 +289,6 @@ export default function BuildMessageList({
                   {streamRender?.nodes}
                 </AnimatePresence>
               )}
-              {trailingAssistantSlot}
             </div>
           </div>
         )}

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -230,6 +230,7 @@ export default function BuildChatPanel({
   const [isAtBottom, setIsAtBottom] = useState(true);
   const [showScrollButton, setShowScrollButton] = useState(false);
   const prevScrollTopRef = useRef(0);
+  const liveApprovalCountRef = useRef(0);
 
   // Check if user is at bottom of scroll container
   const checkIfAtBottom = useCallback(() => {
@@ -274,8 +275,7 @@ export default function BuildChatPanel({
     prevScrollTopRef.current = currentScrollTop;
   }, [checkIfAtBottom]);
 
-  // Scroll to bottom and resume auto-scroll
-  const scrollToBottom = useCallback(() => {
+  const scrollChatToBottom = useCallback((behavior: ScrollBehavior) => {
     const container = scrollContainerRef.current;
     if (!container) return;
 
@@ -286,7 +286,7 @@ export default function BuildChatPanel({
       // Scroll to a value larger than scrollHeight - browsers will clamp to max
       // This ensures we always reach the absolute bottom
       const targetScroll = container.scrollHeight + 1000; // Add buffer to ensure we go all the way
-      container.scrollTo({ top: targetScroll, behavior: "smooth" });
+      container.scrollTo({ top: targetScroll, behavior });
 
       // Update state immediately
       setIsAtBottom(true);
@@ -301,10 +301,40 @@ export default function BuildChatPanel({
     });
   }, []);
 
+  // Scroll to bottom and resume auto-scroll
+  const scrollToBottom = useCallback(() => {
+    scrollChatToBottom("smooth");
+  }, [scrollChatToBottom]);
+
+  const handleLiveApprovalCountChange = useCallback(
+    (approvalCount: number) => {
+      const previousApprovalCount = liveApprovalCountRef.current;
+      liveApprovalCountRef.current = approvalCount;
+
+      if (approvalCount <= previousApprovalCount) {
+        return;
+      }
+
+      if (!isAtBottom) {
+        return;
+      }
+
+      // Approval cards live above the input bar, so a newly-rendered card
+      // shrinks the transcript viewport from below. Scroll once after the
+      // card appears and once more after the viewport resize has settled.
+      // Only do this while sticky bottom scrolling is active; users reading
+      // earlier history should not be moved by a new approval request.
+      scrollChatToBottom("auto");
+      requestAnimationFrame(() => scrollChatToBottom("auto"));
+    },
+    [isAtBottom, scrollChatToBottom]
+  );
+
   // Reset scroll state when session changes
   useEffect(() => {
     setIsAtBottom(true);
     setShowScrollButton(false);
+    liveApprovalCountRef.current = 0;
   }, [sessionId]);
 
   const handleSubmit = useCallback(
@@ -601,11 +631,6 @@ export default function BuildChatPanel({
                       isStreaming={displayIsRunning}
                       autoScrollEnabled={isAtBottom}
                       scrollContainerRef={scrollContainerRef}
-                      trailingAssistantSlot={
-                        <LiveApprovalsRegion
-                          sessionId={sessionId ?? existingSessionId ?? null}
-                        />
-                      }
                     />
                   )}
                 </motion.div>
@@ -681,6 +706,14 @@ export default function BuildChatPanel({
                     queuedMessages={queuedMessages}
                     onQueueMessage={handleQueueMessage}
                     onRemoveQueuedMessage={handleRemoveQueuedMessage}
+                    aboveInputSlot={
+                      isViewingSubagent ? null : (
+                        <LiveApprovalsRegion
+                          sessionId={sessionId ?? existingSessionId ?? null}
+                          onApprovalCountChange={handleLiveApprovalCountChange}
+                        />
+                      )
+                    }
                   />
                 </div>
               </div>

--- a/web/src/app/craft/components/CraftInputBar.stories.tsx
+++ b/web/src/app/craft/components/CraftInputBar.stories.tsx
@@ -4,6 +4,7 @@ import { UserProvider } from "@/providers/UserProvider";
 import { UploadFilesProvider } from "@/app/craft/contexts/UploadFilesContext";
 import CraftInputBar from "@/app/craft/components/CraftInputBar";
 import type { BuildFile } from "@/app/craft/contexts/UploadFilesContext";
+import ApprovalCard from "@/app/craft/components/approvals/ApprovalCard";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   appFixture,
@@ -14,6 +15,8 @@ import type { SkillsList } from "@/refresh-pages/admin/SkillsPage/interfaces";
 import type { PickerEntry } from "@/lib/skills/picker";
 import type { ExternalAppType } from "@/app/craft/v1/apps/registry";
 import type { LibraryEntry } from "@/app/craft/types/user-library";
+import type { QueuedMessage } from "@/app/app/interfaces";
+import type { ApprovalAction, ApprovalView } from "@/app/craft/types/approvals";
 
 const SWR_NO_FETCH = {
   provider: () => new Map(),
@@ -83,6 +86,48 @@ const appEntry = (
   authenticated: true,
 });
 
+const queuedMessages: QueuedMessage[] = [
+  { id: 1, text: "Then add a loading state to the deployment button" },
+  { id: 2, text: "After that, write a Playwright smoke test" },
+];
+
+const slackPostMessage: ApprovalAction = {
+  action_type: "slack.messages.write",
+  display_name: "Post a message",
+  description: "Post a message to a channel or conversation.",
+  policy: "ASK",
+};
+
+const approval: ApprovalView = {
+  approval_id: "appr-input-story",
+  session_id: "sess-input-story",
+  actions: [slackPostMessage],
+  app_name: "Slack",
+  payload: {
+    channel: "#eng-craft",
+    text: "The preview deployment is ready for review.",
+  },
+  display_payload: {
+    channel: "#eng-craft",
+    text: "The preview deployment is ready for review.",
+  },
+  created_at: "2026-05-28T15:42:11Z",
+  decision: null,
+  decided_at: null,
+  is_live: true,
+};
+
+function ApprovalAboveQueueSlot() {
+  return (
+    <div
+      data-testid="storybook-approval-stack"
+      className="flex flex-col pb-1.5"
+    >
+      <ApprovalCard approval={approval} />
+    </div>
+  );
+}
+
 const meta: Meta<typeof CraftInputBar> = {
   title: "Apps/Craft/Input Bar/Craft Input Bar",
   component: CraftInputBar,
@@ -122,6 +167,18 @@ export const Running: Story = {
     queuedMessages: [],
     onQueueMessage: (text: string) => console.log("queue", text),
     onRemoveQueuedMessage: (index: number) => console.log("remove", index),
+  },
+};
+
+/** Approval cards render above queued messages in the pre-input stack. */
+export const WithApprovalAndQueuedMessages: Story = {
+  args: {
+    isRunning: true,
+    aboveInputSlot: <ApprovalAboveQueueSlot />,
+    queuedMessages,
+    onQueueMessage: (text: string) => console.log("queue", text),
+    onRemoveQueuedMessage: (index: number) => console.log("remove", index),
+    onInterrupt: () => console.log("interrupt"),
   },
 };
 

--- a/web/src/app/craft/components/CraftInputBar.tsx
+++ b/web/src/app/craft/components/CraftInputBar.tsx
@@ -3,6 +3,7 @@
 import {
   forwardRef,
   memo,
+  type ReactNode,
   useCallback,
   useImperativeHandle,
   useMemo,
@@ -56,6 +57,7 @@ export interface CraftInputBarProps {
   onRemoveQueuedMessage?: (index: number) => void;
   onInterrupt?: () => void;
   isInterrupting?: boolean;
+  aboveInputSlot?: ReactNode;
   /** Seed the active entry chips. For stories/tests; production callers leave unset. */
   initialEntries?: PickerEntry[];
 }
@@ -75,6 +77,7 @@ const CraftInputBar = memo(
         onRemoveQueuedMessage,
         onInterrupt,
         isInterrupting = false,
+        aboveInputSlot,
         initialEntries,
       },
       ref
@@ -256,6 +259,7 @@ const CraftInputBar = memo(
             onRemoveQueuedMessage={onRemoveQueuedMessage}
             onInterrupt={onInterrupt}
             isInterrupting={isInterrupting}
+            aboveInputSlot={aboveInputSlot}
             topSlot={topSlot}
             bottomLeftSlot={bottomLeftSlot}
             onPasteText={onPasteText}

--- a/web/src/app/craft/components/approvals/ApprovalCard.tsx
+++ b/web/src/app/craft/components/approvals/ApprovalCard.tsx
@@ -31,7 +31,7 @@ import CometEdge from "@/app/craft/components/CometEdge";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 // Hold the settled edge so the cross-fade is visible before the row unmounts.
-const SETTLE_HOLD_MS = 800;
+const SETTLE_HOLD_MS = 1800;
 
 interface ApprovalCardProps {
   approval: ApprovalView;
@@ -245,10 +245,8 @@ export default function ApprovalCard({
                   size="sm"
                   disabled={submitting}
                   onClick={() =>
-                    void submitDecision(
-                      "APPROVED",
-                      () => postApprovalSessionGrant(approval.approval_id),
-                      0
+                    void submitDecision("APPROVED", () =>
+                      postApprovalSessionGrant(approval.approval_id)
                     )
                   }
                   aria-label="Approve matching actions for this session"

--- a/web/src/app/craft/components/approvals/LiveApprovalsRegion.tsx
+++ b/web/src/app/craft/components/approvals/LiveApprovalsRegion.tsx
@@ -1,35 +1,49 @@
 "use client";
 
+import { useEffect, useMemo } from "react";
 import ApprovalCard from "@/app/craft/components/approvals/ApprovalCard";
 import { useLiveApprovals } from "@/app/craft/hooks/useLiveApprovals";
 
 interface LiveApprovalsRegionProps {
   sessionId: string | null;
+  onApprovalCountChange?: (count: number) => void;
 }
 
 // Renders one ApprovalCard per row returned by /live (already filtered
-// to undecided + within wait window). No outer logo/wrapper — caller is
-// responsible for placing this inside the previous assistant message
-// region so cards visually attach to the agent's last turn.
+// to undecided + within wait window). The region is intended for the
+// pre-input stack and should stay above queued messages.
 //
 // SWR cache invalidation is owned by useBuildStreaming's
 // approval_requested handler and by ApprovalCard itself after a
 // decision — this component just reads.
 export default function LiveApprovalsRegion({
   sessionId,
+  onApprovalCountChange,
 }: LiveApprovalsRegionProps) {
   const { data } = useLiveApprovals(sessionId);
 
-  if (!sessionId || !data || data.items.length === 0) {
-    return null;
-  }
-
-  const sorted = [...data.items].sort(
-    (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)
+  const sorted = useMemo(
+    () =>
+      data
+        ? [...data.items].sort(
+            (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)
+          )
+        : [],
+    [data]
   );
+  const approvalCount = sessionId ? sorted.length : 0;
+
+  useEffect(() => {
+    onApprovalCountChange?.(approvalCount);
+  }, [approvalCount, onApprovalCountChange]);
+
+  if (!sessionId || approvalCount === 0) return null;
 
   return (
-    <div data-testid="live-approvals-region" className="flex flex-col gap-3">
+    <div
+      data-testid="live-approvals-region"
+      className="flex flex-col gap-3 pb-1.5"
+    >
       {sorted.map((approval) => (
         <ApprovalCard key={approval.approval_id} approval={approval} />
       ))}

--- a/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolCard.stories.tsx
@@ -141,9 +141,9 @@ export const SearchGrep: Story = {
       kind: "search",
       toolName: "grep",
       title: "Searching content",
-      description: "trailingAssistantSlot",
+      description: "aboveInputSlot",
       rawOutput:
-        "web/src/app/craft/components/BuildMessageList.tsx:34:  trailingAssistantSlot?: React.ReactNode;\nweb/src/app/craft/components/ChatPanel.tsx:411:              trailingAssistantSlot={",
+        "web/src/sections/input/BaseInputBar.tsx:68:  aboveInputSlot?: ReactNode;\nweb/src/app/craft/components/ChatPanel.tsx:679:                    aboveInputSlot={",
     }),
   },
 };

--- a/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/CraftToolGroup.stories.tsx
@@ -51,13 +51,13 @@ const READ_CHAT_PANEL = call("g-read-2", {
   rawOutput: "// 482 lines",
 });
 
-const GREP_TRAILING_SLOT = call("g-grep-1", {
+const GREP_ABOVE_INPUT_SLOT = call("g-grep-1", {
   kind: "search",
   toolName: "grep",
   title: "Searching content",
-  description: "trailingAssistantSlot",
+  description: "aboveInputSlot",
   rawOutput:
-    "web/src/app/craft/components/BuildMessageList.tsx:34:  trailingAssistantSlot?: React.ReactNode;\nweb/src/app/craft/components/ChatPanel.tsx:411:              trailingAssistantSlot={",
+    "web/src/sections/input/BaseInputBar.tsx:68:  aboveInputSlot?: ReactNode;\nweb/src/app/craft/components/ChatPanel.tsx:679:                    aboveInputSlot={",
 });
 
 const EDIT_API_SERVICES = call("g-edit-1", {
@@ -89,7 +89,7 @@ export const AllCompleted: Story = {
     toolCalls: [
       READ_BUILD_LIST,
       READ_CHAT_PANEL,
-      GREP_TRAILING_SLOT,
+      GREP_ABOVE_INPUT_SLOT,
       EDIT_API_SERVICES,
       BASH_LINT,
     ],
@@ -195,7 +195,7 @@ export const ManyCalls: Story = {
     toolCalls: [
       READ_BUILD_LIST,
       READ_CHAT_PANEL,
-      GREP_TRAILING_SLOT,
+      GREP_ABOVE_INPUT_SLOT,
       EDIT_API_SERVICES,
       BASH_LINT,
       call("g-bash-format", {

--- a/web/src/app/craft/components/tool-cards/SearchBody.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/SearchBody.stories.tsx
@@ -48,14 +48,12 @@ web/src/app/craft/components/approvals/PayloadView.tsx:8:interface PayloadViewPr
 export const GrepDenseHits: Story = {
   args: {
     toolCall: search({
-      description: "trailingAssistantSlot",
-      rawOutput: `web/src/app/craft/components/BuildMessageList.tsx:28:   * Trailing content attached to the last assistant block — either the
-web/src/app/craft/components/BuildMessageList.tsx:34:  trailingAssistantSlot?: React.ReactNode;
-web/src/app/craft/components/BuildMessageList.tsx:53:  trailingAssistantSlot,
-web/src/app/craft/components/BuildMessageList.tsx:228:          {trailing}
-web/src/app/craft/components/BuildMessageList.tsx:294:              {trailingAssistantSlot}
-web/src/app/craft/components/ChatPanel.tsx:36:import LiveApprovalsRegion from "@/app/craft/components/approvals/LiveApprovalsRegion";
-web/src/app/craft/components/ChatPanel.tsx:411:              trailingAssistantSlot={`,
+      description: "aboveInputSlot",
+      rawOutput: `web/src/sections/input/BaseInputBar.tsx:68:  aboveInputSlot?: ReactNode;
+web/src/sections/input/BaseInputBar.tsx:278:          {aboveInputSlot}
+web/src/app/craft/components/CraftInputBar.tsx:60:  aboveInputSlot?: ReactNode;
+web/src/app/craft/components/CraftInputBar.tsx:262:            aboveInputSlot={aboveInputSlot}
+web/src/app/craft/components/ChatPanel.tsx:679:                    aboveInputSlot={`,
     }),
   },
 };

--- a/web/src/app/craft/components/tool-cards/TaskBody.stories.tsx
+++ b/web/src/app/craft/components/tool-cards/TaskBody.stories.tsx
@@ -58,8 +58,8 @@ Steps:
 1. git reset --hard origin/main
 2. Add types/approvals.ts, hooks/useLiveApprovals.ts, components/approvals/* (clean adds)
 3. Append fetchLiveApprovals + postApprovalDecision + ApprovalConflictError to apiServices.ts
-4. Re-implement trailingAssistantSlot in main's BuildMessageList.tsx
-5. Wire LiveApprovalsRegion into ChatPanel.tsx on main's structure
+4. Add aboveInputSlot to the shared input bar stack
+5. Wire LiveApprovalsRegion through CraftInputBar above queued messages
 6. Re-apply backend K8S_CONTEXT env support to k8s_client.py + env template
 7. Type-check + lint, commit as single feat
 

--- a/web/src/sections/input/BaseInputBar.test.tsx
+++ b/web/src/sections/input/BaseInputBar.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@tests/setup/test-utils";
+import BaseInputBar from "@/sections/input/BaseInputBar";
+import type { QueuedMessage } from "@/app/app/interfaces";
+
+const queuedMessages: QueuedMessage[] = [
+  { id: 1, text: "Write a follow-up Playwright smoke test" },
+];
+
+describe("BaseInputBar pre-input stack", () => {
+  it("renders the above-input slot before queued messages", () => {
+    render(
+      <BaseInputBar
+        onSubmit={jest.fn()}
+        isRunning
+        queuedMessages={queuedMessages}
+        onQueueMessage={jest.fn()}
+        onRemoveQueuedMessage={jest.fn()}
+        aboveInputSlot={
+          <div data-testid="approval-slot">Approval required</div>
+        }
+      />
+    );
+
+    const approvalSlot = screen.getByTestId("approval-slot");
+    const queuedMessage = screen.getByTestId("queued-message-bar");
+    const position = approvalSlot.compareDocumentPosition(queuedMessage);
+
+    expect(Boolean(position & Node.DOCUMENT_POSITION_FOLLOWING)).toBe(true);
+  });
+});

--- a/web/src/sections/input/BaseInputBar.tsx
+++ b/web/src/sections/input/BaseInputBar.tsx
@@ -64,6 +64,8 @@ export interface BaseInputBarProps {
   bottomLeftSlot?: ReactNode;
   /** Rendered in the right control group, left of Stop/Send (e.g. a mic button). */
   bottomRightSlot?: ReactNode;
+  /** Rendered above the composer stack, outside the input disabled state. */
+  aboveInputSlot?: ReactNode;
 
   /** Return true to consume the pasted text (skips pasteText). */
   onPasteText?: (text: string) => boolean;
@@ -93,6 +95,7 @@ const BaseInputBar = memo(
         topSlot,
         bottomLeftSlot,
         bottomRightSlot,
+        aboveInputSlot,
         onPasteText,
         onPasteFiles,
         onInputCallback,
@@ -271,138 +274,143 @@ const BaseInputBar = memo(
       }, [interruptible, isInterrupting, onInterrupt]);
 
       return (
-        <Disabled disabled={disabled}>
-          {queueEnabled && (
-            <QueuedMessageBar
-              messages={queue}
-              highlightedIndex={queueNav.highlightedIndex}
-              awaitingPreferredSelection={false}
-              onDiscard={(index) => onRemoveQueuedMessage?.(index)}
-              onHighlight={queueNav.setHighlightedIndex}
-            />
-          )}
-          <div
-            className={cn(
-              "w-full flex flex-col shadow-01 bg-background-neutral-00",
-              noBottomRounding ? "rounded-t-16 rounded-b-none" : "rounded-16"
-            )}
-          >
-            {/* Slot owns its own padding so it can animate (e.g. collapse). */}
-            {topSlot}
-
-            <div ref={inputWrapperRef} className="flex-1 overflow-hidden">
-              <div
-                ref={inputRef}
-                contentEditable={!disabled}
-                suppressContentEditableWarning
-                onPaste={handlePaste}
-                onInput={handleInput}
-                onCompositionStart={handleCompositionStart}
-                onCompositionEnd={handleCompositionEnd}
-                onKeyDown={handleKeyDown}
-                onKeyUp={handleSelectionChange}
-                onMouseUp={handleSelectionChange}
-                onBlur={() => queueNav.setHighlightedIndex(null)}
-                className={cn(
-                  "w-full h-full min-h-[44px] outline-hidden bg-transparent",
-                  "whitespace-pre-wrap wrap-break-word overscroll-contain",
-                  "overflow-y-auto px-3 pb-2 pt-3"
-                )}
-                tabIndex={disabled ? -1 : 0}
-                style={{
-                  scrollbarWidth: "thin",
-                  scrollbarColor: "var(--border-02) transparent",
-                }}
-                role="textbox"
-                aria-label="Message input"
-                aria-multiline={true}
-                aria-disabled={disabled}
-                aria-placeholder={placeholder}
-                data-placeholder={placeholder}
-                data-empty={!message ? "" : undefined}
-                onCopy={handleCopy}
-                onCut={handleCut}
-                onMouseDown={handleTileMouseDown}
-                onClick={handleTileClick}
+        <>
+          {aboveInputSlot}
+          <Disabled disabled={disabled}>
+            {queueEnabled && (
+              <QueuedMessageBar
+                messages={queue}
+                highlightedIndex={queueNav.highlightedIndex}
+                awaitingPreferredSelection={false}
+                onDiscard={(index) => onRemoveQueuedMessage?.(index)}
+                onHighlight={queueNav.setHighlightedIndex}
               />
-            </div>
+            )}
+            <div
+              className={cn(
+                "w-full flex flex-col shadow-01 bg-background-neutral-00",
+                noBottomRounding ? "rounded-t-16 rounded-b-none" : "rounded-16"
+              )}
+            >
+              {/* Slot owns its own padding so it can animate (e.g. collapse). */}
+              {topSlot}
 
-            <div className="flex justify-between items-center w-full p-1 min-h-[40px]">
-              <div className="flex flex-row items-center gap-2">
-                {bottomLeftSlot}
-                {pasteExpandHintVisible ? (
-                  <div className="flex items-center gap-1 select-none">
-                    <Text font="secondary-body" color="text-02">
-                      Paste again to expand
-                    </Text>
-                  </div>
-                ) : (
-                  !message &&
-                  queueEnabled &&
-                  queue.length > 0 && (
-                    <div className="flex items-center gap-1 select-none">
-                      <Keycap>↑</Keycap>
-                      <Text font="secondary-body" color="text-02">
-                        to edit queued messages
-                      </Text>
-                    </div>
-                  )
-                )}
-              </div>
-              <div className="flex flex-row items-center gap-1">
-                {bottomRightSlot}
+              <div ref={inputWrapperRef} className="flex-1 overflow-hidden">
                 <div
+                  ref={inputRef}
+                  contentEditable={!disabled}
+                  suppressContentEditableWarning
+                  onPaste={handlePaste}
+                  onInput={handleInput}
+                  onCompositionStart={handleCompositionStart}
+                  onCompositionEnd={handleCompositionEnd}
+                  onKeyDown={handleKeyDown}
+                  onKeyUp={handleSelectionChange}
+                  onMouseUp={handleSelectionChange}
+                  onBlur={() => queueNav.setHighlightedIndex(null)}
                   className={cn(
-                    "overflow-hidden transition-[width,opacity] duration-150 ease-out motion-reduce:transition-none",
-                    interruptible
-                      ? "w-9 opacity-100"
-                      : "w-0 opacity-0 pointer-events-none"
+                    "w-full h-full min-h-[44px] outline-hidden bg-transparent",
+                    "whitespace-pre-wrap wrap-break-word overscroll-contain",
+                    "overflow-y-auto px-3 pb-2 pt-3"
                   )}
-                >
-                  <IconButton
-                    main
-                    tertiary
-                    icon={isInterrupting ? SvgLoader : SvgStop}
-                    iconClassName={isInterrupting ? "animate-spin" : undefined}
-                    className={cn(
-                      "border-[1.5px] border-border-02",
-                      stopArmed && "bg-background-tint-02!"
-                    )}
-                    disabled={!interruptible || isInterrupting}
-                    onClick={handleInterrupt}
-                    tooltip="Stop · esc esc"
-                    aria-label="Stop generating"
-                  />
-                </div>
-                <IconButton
-                  icon={sandboxInitializing ? SvgLoader : SvgArrowUp}
-                  onClick={handleSubmit}
-                  disabled={!canSubmit}
-                  tooltip={
-                    sandboxInitializing
-                      ? "Initializing sandbox..."
-                      : isRunning
-                        ? "Queue message"
-                        : "Send"
-                  }
-                  aria-label={isRunning ? "Queue message" : "Send"}
-                  iconClassName={
-                    sandboxInitializing ? "animate-spin" : undefined
-                  }
+                  tabIndex={disabled ? -1 : 0}
+                  style={{
+                    scrollbarWidth: "thin",
+                    scrollbarColor: "var(--border-02) transparent",
+                  }}
+                  role="textbox"
+                  aria-label="Message input"
+                  aria-multiline={true}
+                  aria-disabled={disabled}
+                  aria-placeholder={placeholder}
+                  data-placeholder={placeholder}
+                  data-empty={!message ? "" : undefined}
+                  onCopy={handleCopy}
+                  onCut={handleCut}
+                  onMouseDown={handleTileMouseDown}
+                  onClick={handleTileClick}
                 />
               </div>
+
+              <div className="flex justify-between items-center w-full p-1 min-h-[40px]">
+                <div className="flex flex-row items-center gap-2">
+                  {bottomLeftSlot}
+                  {pasteExpandHintVisible ? (
+                    <div className="flex items-center gap-1 select-none">
+                      <Text font="secondary-body" color="text-02">
+                        Paste again to expand
+                      </Text>
+                    </div>
+                  ) : (
+                    !message &&
+                    queueEnabled &&
+                    queue.length > 0 && (
+                      <div className="flex items-center gap-1 select-none">
+                        <Keycap>↑</Keycap>
+                        <Text font="secondary-body" color="text-02">
+                          to edit queued messages
+                        </Text>
+                      </div>
+                    )
+                  )}
+                </div>
+                <div className="flex flex-row items-center gap-1">
+                  {bottomRightSlot}
+                  <div
+                    className={cn(
+                      "overflow-hidden transition-[width,opacity] duration-150 ease-out motion-reduce:transition-none",
+                      interruptible
+                        ? "w-9 opacity-100"
+                        : "w-0 opacity-0 pointer-events-none"
+                    )}
+                  >
+                    <IconButton
+                      main
+                      tertiary
+                      icon={isInterrupting ? SvgLoader : SvgStop}
+                      iconClassName={
+                        isInterrupting ? "animate-spin" : undefined
+                      }
+                      className={cn(
+                        "border-[1.5px] border-border-02",
+                        stopArmed && "bg-background-tint-02!"
+                      )}
+                      disabled={!interruptible || isInterrupting}
+                      onClick={handleInterrupt}
+                      tooltip="Stop · esc esc"
+                      aria-label="Stop generating"
+                    />
+                  </div>
+                  <IconButton
+                    icon={sandboxInitializing ? SvgLoader : SvgArrowUp}
+                    onClick={handleSubmit}
+                    disabled={!canSubmit}
+                    tooltip={
+                      sandboxInitializing
+                        ? "Initializing sandbox..."
+                        : isRunning
+                          ? "Queue message"
+                          : "Send"
+                    }
+                    aria-label={isRunning ? "Queue message" : "Send"}
+                    iconClassName={
+                      sandboxInitializing ? "animate-spin" : undefined
+                    }
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          {tilePopover && (
-            <PasteTilePopover
-              text={tilePopover.text}
-              tileElement={tilePopover.tile}
-              onDismiss={dismissTilePopover}
-              onTextChange={updateTileText}
-              onExpand={() => expandTile(tilePopover.tile)}
-            />
-          )}
-        </Disabled>
+            {tilePopover && (
+              <PasteTilePopover
+                text={tilePopover.text}
+                tileElement={tilePopover.tile}
+                onDismiss={dismissTilePopover}
+                onTextChange={updateTileText}
+                onExpand={() => expandTile(tilePopover.tile)}
+              />
+            )}
+          </Disabled>
+        </>
       );
     }
   )


### PR DESCRIPTION
## Description

Moves Craft approval cards out of the chat transcript and into the pre-input stack so they appear above the composer like queued messages. Approval cards now render above queued messages when both are present, and the old message-list trailing slot path is removed.

This also updates the Craft input Storybook coverage to show approval cards with queued messages, keeps approved/rejected cards visible slightly longer before revalidation removes them, and preserves sticky-bottom scrolling only when the user is already at the bottom of the chat.

## How Has This Been Tested?

- `bunx oxfmt --check ...`
- `bunx oxlint ...`
- `bun run types:check`
- `bun run test src/sections/input/BaseInputBar.test.tsx src/app/craft/components/BuildMessageList.test.tsx --runInBand`
- Commit/rebase pre-commit hooks: `oxfmt`, `oxlint`, and TypeScript type check passed

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Craft approval cards out of the transcript and into the pre-input stack so they appear above the composer and above queued messages. Improves readability and prevents unwanted scroll jumps by only sticking to bottom when the user is already there.

- **New Features**
  - Approval cards render above the composer, before queued messages.
  - Added an aboveInputSlot to the shared input bars and wired LiveApprovalsRegion through it (hidden in subagent view).

- **Refactors**
  - Removed the message-list trailingAssistantSlot and its anchoring logic.
  - Improved sticky-bottom behavior: only auto-scroll when at bottom; adjust when new approvals render to avoid jumps.
  - Extended approval settle hold to 1800ms for a clearer fade-out.
  - Updated Storybook to show approvals with queued messages and added a test to verify approval-above-queue order.

<sup>Written for commit 48566a5256948d7244909ae6783d39236a15140b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

