### PR TITLE
fix(craft): Prevent Craft model picker flash while sessions load

### DIFF
--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -644,7 +644,7 @@ export default function BuildChatPanel({
                   )}
                   {/* Model is locked once the session starts — show the picker
                   only before the first message. */}
-                  {session?.messages.length === 0 && (
+                  {session?.isLoaded && session.messages.length === 0 && (
                     <div className="flex justify-end pb-2">
                       <ModelPickerButton
                         selection={selectedModel}


### PR DESCRIPTION
## Description

Hide the Craft model picker while an existing session is still hydrating from its placeholder store entry. `loadSession()` sets the current Craft session before API data arrives, which creates a temporary session with `messages: []` and `isLoaded: false`; `ChatPanel` treated that as a pre-first-message session and briefly rendered the unlocked model picker on ongoing sessions.

The picker now requires `session.isLoaded` before rendering for zero-message sessions, preserving model selection for genuinely loaded empty sessions while removing the transient flash.

## How Has This Been Tested?

- `bun run lint`
- `bun run types:check`
- `bun run test -- --runInBand --findRelatedTests src/app/craft/components/ChatPanel.tsx --passWithNoTests`
- Commit hooks also passed `oxfmt`, `oxlint`, and TypeScript type check.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the Craft model picker from flashing on existing sessions while data hydrates. Gate the picker on `session.isLoaded` so it only shows for loaded sessions with zero messages.

<sup>Written for commit 40203e360066724c2fc04a25e10273635f2a695d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
