### PR TITLE
fix(connector): BookStack connector always indexing 0 documents due t…

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -2,6 +2,7 @@ import html
 import time
 from collections.abc import Callable
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
 from typing import Any
 
@@ -62,8 +63,10 @@ class BookstackConnector(LoadConnector, PollConnector):
             ).strftime("%Y-%m-%d")
 
         if end:
-            params["filter[updated_at:lte]"] = datetime.fromtimestamp(
-                end, tz=timezone.utc
+            # BookStack's lte filter is exclusive of the boundary day,
+            # so add 1 day to include content updated on the end date.
+            params["filter[updated_at:lte]"] = (
+                datetime.fromtimestamp(end, tz=timezone.utc) + timedelta(days=1)
             ).strftime("%Y-%m-%d")
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])


### PR DESCRIPTION
…o exclusive `lte` date filter

## Description

<!--- Provide a brief description of the changes in this PR --->
The BookStack connector's `_get_doc_batch()` method passes `filter[updated_at:lte]=YYYY-MM-DD` to the BookStack API using the end timestamp formatted as a date string. However, **BookStack's `lte` filter is exclusive of the boundary day** — documents updated *on* the `lte` date are excluded from results.

On an incremental sync where `end` is set to the current time, `lte` becomes today's date. Any content created or edited today falls outside the filter window, and the API returns an empty result set with HTTP 200. The connector reports success, making this issue hard to diagnose.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

- Verified the fix logic: `datetime.fromtimestamp(end, tz=timezone.utc) + timedelta(days=1)` correctly shifts the end date forward by one day, making the `lte` filter inclusive of the boundary day.
- The `gte` (start) filter is unchanged — BookStack's `gte` filter is inclusive of the boundary day, so no adjustment is needed there.
- The existing `ruff` and `ty` checks should continue to pass since only standard library imports and a simple date arithmetic operation were added.

Closes #11805

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the BookStack connector returning 0 documents on incremental sync by making the `lte` date filter inclusive. We add one day to the end date so content updated on the end day (including today) is indexed.

- **Bug Fixes**
  - In `_get_doc_batch`, set `filter[updated_at:lte]` to `end + 1 day` since BookStack’s `lte` is exclusive.
  - Keep `filter[updated_at:gte]` unchanged (inclusive) to avoid missing documents.

<sup>Written for commit 6fb3aa3c81707aed9e7883237187dd49bfe52330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

