### PR TITLE
feat(mobile): add typed API client with TanStack Query

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,10 @@
+# Base URL of the Onyx backend the app talks to.
+# Expo inlines any EXPO_PUBLIC_* var into the bundle at build/start time.
+#
+# Copy this file to `.env.local` (gitignored) and set the value for your setup:
+#   iOS simulator:      http://localhost:8080
+#   Android emulator:   http://10.0.2.2:8080
+#   physical device:    http://<your-machine-LAN-IP>:8080
+#
+# NOTE: EXPO_PUBLIC_* values ship inside the client bundle — they are NOT secret.
+EXPO_PUBLIC_API_URL=http://localhost:8080

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -38,7 +38,8 @@
             "kotlinVersion": "2.1.20"
           }
         }
-      ]
+      ],
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "mobile",
       "dependencies": {
+        "@react-native-community/netinfo": "12.0.1",
         "@shopify/flash-list": "2.0.2",
         "@tanstack/query-sync-storage-persister": "^5.101.0",
         "@tanstack/react-query": "^5.101.0",
@@ -16,6 +17,7 @@
         "expo-font": "~56.0.5",
         "expo-linking": "~56.0.13",
         "expo-router": "~56.2.9",
+        "expo-secure-store": "~56.0.4",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
         "expo-system-ui": "~56.0.5",
@@ -378,6 +380,8 @@
     "@radix-ui/react-use-escape-keydown": ["@radix-ui/react-use-escape-keydown@1.1.2", "", { "dependencies": { "@radix-ui/react-use-callback-ref": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw=="],
 
     "@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA=="],
+
+    "@react-native-community/netinfo": ["@react-native-community/netinfo@12.0.1", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-P/3caXIvfYSJG8AWJVefukg+ZGRPs+M4Lp3pNJtgcTYoJxCjWrKQGNnCkj/Cz//zWa/avGed0i/wzm0T8vV2IQ=="],
 
     "@react-native-masked-view/masked-view": ["@react-native-masked-view/masked-view@0.3.2", "", { "peerDependencies": { "react": ">=16", "react-native": ">=0.57" } }, "sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ=="],
 
@@ -846,6 +850,8 @@
     "expo-modules-jsi": ["expo-modules-jsi@56.0.8", "", { "peerDependencies": { "react-native": "*" } }, "sha512-tXqFU1MHrf7Ctq+Pw0qOeIPDFl1W51p9nRRZy9vVUn4GNuAk1Av0vrj0SGLvcxJvDf3aGwSzr8o8dgUsX5sG0g=="],
 
     "expo-router": ["expo-router@56.2.9", "", { "dependencies": { "@expo/log-box": "^56.0.12", "@expo/metro-runtime": "^56.0.14", "@expo/schema-utils": "^56.0.0", "@expo/ui": "^56.0.16", "@radix-ui/react-slot": "^1.2.0", "@radix-ui/react-tabs": "^1.1.12", "@react-native-masked-view/masked-view": "^0.3.2", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "client-only": "^0.0.1", "color": "^4.2.3", "debug": "^4.3.4", "escape-string-regexp": "^4.0.0", "expo-glass-effect": "^56.0.4", "expo-server": "^56.0.5", "expo-symbols": "^56.0.6", "fast-deep-equal": "^3.1.3", "invariant": "^2.2.4", "nanoid": "^3.3.8", "query-string": "^7.1.3", "react-fast-compare": "^3.2.2", "react-is": "^19.1.0", "react-native-drawer-layout": "^4.2.2", "react-native-screens": "^4.25.2", "server-only": "^0.0.1", "sf-symbols-typescript": "^2.1.0", "shallowequal": "^1.1.0", "vaul": "^1.1.2" }, "peerDependencies": { "@testing-library/react-native": ">= 13.2.0", "expo": "*", "expo-constants": "^56.0.17", "expo-linking": "^56.0.13", "react": "*", "react-dom": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-safe-area-context": ">= 5.4.0", "react-native-web": "*", "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4" }, "optionalPeers": ["@testing-library/react-native", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-web", "react-server-dom-webpack"] }, "sha512-MuGL7Ht8hFTo1ddntyXGw5Lh+5rBw8S/0wHCwtI88nv4aCSyLEuFE19i4E/G0BXVCTKeDRu/hOww3jEqUlAN2w=="],
+
+    "expo-secure-store": ["expo-secure-store@56.0.4", "", { "peerDependencies": { "expo": "*" } }, "sha512-hjEi/gmpdFFJ9lYbdp3k3p/WchV7Gi0Qt8jt/m/0WJadqQrskafHAlDxbZkII1cN3Yd7zp9Lvkeq3UfGhSwirQ=="],
 
     "expo-server": ["expo-server@56.0.5", "", {}, "sha512-SmM2p2g3Jrktpiazcst+OxhjSzOHXKAY4BPURHYHXvApzzoybMmrNF4IEZ8DKZ145BhSe4ydAmlEFCRTsdtgUQ=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@react-native-community/netinfo": "12.0.1",
     "@shopify/flash-list": "2.0.2",
     "@tanstack/query-sync-storage-persister": "^5.101.0",
     "@tanstack/react-query": "^5.101.0",
@@ -14,6 +15,7 @@
     "expo-font": "~56.0.5",
     "expo-linking": "~56.0.13",
     "expo-router": "~56.2.9",
+    "expo-secure-store": "~56.0.4",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
     "expo-system-ui": "~56.0.5",

--- a/mobile/src/api/auth/tokenStore.ts
+++ b/mobile/src/api/auth/tokenStore.ts
@@ -1,0 +1,35 @@
+// Auth-token storage.
+//
+// `apiFetch` reads the access token via `getToken()`. The future login flow
+// calls `setToken(token)`; logout calls `setToken(null)`.
+//
+// Tokens are credentials, so they live in the device keychain via
+// expo-secure-store — NOT in MMKV (which is reserved for non-secret cache /
+// persisted UI state). Tests mock the `expo-secure-store` module.
+//
+// SECURITY TODO — must be handled when the login/logout flow lands (these are
+// dormant today only because no token exists, so /api/me always 403s and no
+// user data is ever cached):
+//   1. Logout must `queryClient.clear()` AND purge the persisted snapshot
+//      (`persister.removeClient()` / `queryStorage.clearAll()`) — otherwise the
+//      previous user's cached /api/me PII survives logout for up to 24h.
+//   2. Scope the cached-user query key to the authenticated identity (or bump a
+//      session epoch on login/logout) so user B can never read user A's cache.
+//   3. The query-cache MMKV instance (state/storage.ts) is unencrypted; once
+//      /api/me succeeds, email/role are written to disk in plaintext. Give that
+//      instance an `encryptionKey` (sourced from expo-secure-store), or exclude
+//      PII queries from persistence via `dehydrateOptions.shouldDehydrateQuery`.
+import * as SecureStore from "expo-secure-store";
+
+// SecureStore keys allow alphanumerics plus ".", "-", "_".
+const ACCESS_TOKEN_KEY = "onyx.auth.access_token";
+
+export function getToken(): Promise<string | null> {
+  return SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+}
+
+export function setToken(token: string | null): Promise<void> {
+  return token === null
+    ? SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY)
+    : SecureStore.setItemAsync(ACCESS_TOKEN_KEY, token);
+}

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,0 +1,148 @@
+// The single HTTP transport choke point. Every query/mutation goes through
+// `apiFetch`, so base-URL resolution, auth-header injection, JSON
+// (de)serialization, and error normalization all live in one place.
+import { getBaseUrl } from "@/api/config";
+import { getToken } from "@/api/auth/tokenStore";
+import { ApiError } from "@/api/errors";
+
+export interface ApiFetchInit extends Omit<RequestInit, "body"> {
+  // Plain objects are JSON-serialized; pass a string/FormData to send as-is.
+  body?: unknown;
+  // Inject `Authorization: Bearer <token>` when a token exists. Default true;
+  // set false for public endpoints.
+  auth?: boolean;
+}
+
+function isBodyInit(body: unknown): body is BodyInit {
+  return (
+    typeof body === "string" ||
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer
+  );
+}
+
+async function buildHeaders(
+  init: ApiFetchInit | undefined,
+  hasJsonBody: boolean,
+): Promise<Headers> {
+  const headers = new Headers(init?.headers);
+  if (!headers.has("Accept")) headers.set("Accept", "application/json");
+  if (hasJsonBody && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (init?.auth !== false) {
+    const token = await getToken();
+    if (token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+  }
+  return headers;
+}
+
+// The Onyx backend returns errors in a few different JSON shapes depending on
+// which handler caught the error (see backend/onyx/main.py +
+// backend/onyx/error_handling). We normalize all of them into ApiError:
+//
+//   OnyxError (global handler):         { error_code: string, detail: string }
+//   HTTPException (4xx/5xx log_http_error): { detail: string }   (detail may be non-string)
+//   RequestValidationError (422):       { status_code, message: string, data: null }
+//   ValueError (400):                   { message: string }
+//   raw FastAPI validation (sub-apps):  { detail: [{ loc, msg, type }, ...] }
+//   non-JSON / empty body:              no parseable body
+//
+// `error_code` (machine code) comes only from OnyxError; the human message
+// lives in `detail` (string) or `message`, or — for raw FastAPI validation —
+// in the joined `msg` fields of the `detail` array.
+function extractErrorCode(record: Record<string, unknown>): string | undefined {
+  return typeof record.error_code === "string" ? record.error_code : undefined;
+}
+
+function extractDetail(record: Record<string, unknown>): string | undefined {
+  // OnyxError / HTTPException string detail.
+  if (typeof record.detail === "string") return record.detail;
+  // Onyx validation (422) / ValueError (400) use `message`.
+  if (typeof record.message === "string") return record.message;
+  // Raw FastAPI validation: detail is an array of { loc, msg, type } items.
+  if (Array.isArray(record.detail)) {
+    const messages = record.detail
+      .map((item) =>
+        item && typeof item === "object"
+          ? (item as Record<string, unknown>).msg
+          : undefined,
+      )
+      .filter((msg): msg is string => typeof msg === "string");
+    if (messages.length > 0) return messages.join("; ");
+  }
+  return undefined;
+}
+
+async function toApiError(res: Response): Promise<ApiError> {
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    // Empty or non-JSON body (e.g. a proxy 502/504, or HTML error page).
+    body = undefined;
+  }
+  const record =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  return new ApiError({
+    status: res.status,
+    code: extractErrorCode(record),
+    detail: extractDetail(record),
+    body,
+  });
+}
+
+export async function apiFetch<T>(
+  path: string,
+  init?: ApiFetchInit,
+): Promise<T> {
+  const { body, auth: _auth, ...rest } = init ?? {};
+
+  const hasBody = body !== undefined && body !== null;
+  const serializedBody: BodyInit | undefined = !hasBody
+    ? undefined
+    : isBodyInit(body)
+      ? body
+      : JSON.stringify(body);
+  const hasJsonBody = hasBody && !isBodyInit(body);
+
+  const headers = await buildHeaders(init, hasJsonBody);
+
+  const res = await fetch(`${getBaseUrl()}${path}`, {
+    ...rest,
+    headers,
+    body: serializedBody,
+  });
+
+  if (!res.ok) {
+    throw await toApiError(res);
+  }
+
+  // 204 No Content / empty (or whitespace-only) body — resolve as undefined for
+  // `Promise<void>` callers.
+  if (res.status === 204) {
+    return undefined as T;
+  }
+  const text = await res.text();
+  if (text.trim().length === 0) {
+    return undefined as T;
+  }
+  // Guard the parse the same way the error path does: a 2xx with a non-JSON body
+  // (captive portal / proxy / maintenance HTML) would otherwise throw a raw
+  // SyntaxError that escapes ApiError normalization (and gets needlessly retried).
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new ApiError({
+      status: res.status,
+      detail: `Expected a JSON response but received ${
+        res.headers.get("content-type") ?? "an unknown content type"
+      }.`,
+      body: text,
+    });
+  }
+}

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -19,7 +19,12 @@ function isBodyInit(body: unknown): body is BodyInit {
     body instanceof FormData ||
     body instanceof URLSearchParams ||
     body instanceof Blob ||
-    body instanceof ArrayBuffer
+    body instanceof ArrayBuffer ||
+    // Typed arrays / DataView (Uint8Array, etc.) — without this they'd be
+    // JSON.stringified into `{"0":1,...}` and sent as application/json,
+    // silently corrupting binary uploads. (ReadableStream is intentionally
+    // omitted: RN's fetch doesn't support streamed request bodies.)
+    ArrayBuffer.isView(body)
   );
 }
 
@@ -136,13 +141,19 @@ export async function apiFetch<T>(
   // SyntaxError that escapes ApiError normalization (and gets needlessly retried).
   try {
     return JSON.parse(text) as T;
-  } catch {
+  } catch (parseError) {
+    // Keep the user-facing detail clean, but preserve the original parser error
+    // + raw text on `body` for observability (these would otherwise be lost).
     throw new ApiError({
       status: res.status,
       detail: `Expected a JSON response but received ${
         res.headers.get("content-type") ?? "an unknown content type"
       }.`,
-      body: text,
+      body: {
+        responseText: text,
+        parseError:
+          parseError instanceof Error ? parseError.message : String(parseError),
+      },
     });
   }
 }

--- a/mobile/src/api/config.ts
+++ b/mobile/src/api/config.ts
@@ -1,0 +1,30 @@
+// Backend connection config.
+//
+// TEMPORARY: for now the base URL comes from `EXPO_PUBLIC_API_URL` (build-time
+// env). In the future this will be supplied by the user at runtime — they'll
+// enter their Onyx instance URL (e.g. on a connect/login screen), and this
+// module will read that stored value instead of a hardcoded env var.
+//
+// `EXPO_PUBLIC_API_URL` is inlined by Expo into the JS bundle at build/start
+// time (any `EXPO_PUBLIC_`-prefixed var is available on `process.env`). Set it
+// in a gitignored `.env.local`; see `.env.example`.
+//
+// NOTE: `EXPO_PUBLIC_*` ships inside the client bundle — it is NOT a secret.
+// Fine for a base URL; never put tokens or keys here.
+//
+// Resolved LAZILY (per request, inside `apiFetch`) rather than at module load:
+// a throw during module evaluation can't be caught by a React error boundary
+// (it crashes the bundle), whereas a throw inside the fetch surfaces as a normal
+// rejected query the UI can render. This also fits the future runtime-URL model.
+
+export function getBaseUrl(): string {
+  const raw = process.env.EXPO_PUBLIC_API_URL;
+  if (!raw) {
+    throw new Error(
+      "EXPO_PUBLIC_API_URL is not set. Copy mobile/.env.example to " +
+        "mobile/.env.local and point it at the Onyx backend.",
+    );
+  }
+  // Trim a trailing slash so callers always pass paths like "/api/me".
+  return raw.replace(/\/+$/, "");
+}

--- a/mobile/src/api/errors.ts
+++ b/mobile/src/api/errors.ts
@@ -1,0 +1,53 @@
+// Normalized API error model.
+//
+// The Onyx backend returns errors as `{ error_code, detail }` (the global
+// OnyxError handler) or occasionally `{ detail }` / `{ message }`. `apiFetch`
+// flattens whichever shape it gets into these typed fields so call sites never
+// have to dig into a raw body. Mirrors the intent of web's `FetchError` while
+// exposing `status`/`code`/`detail` as first-class fields.
+
+interface ApiErrorArgs {
+  status: number;
+  code?: string;
+  detail?: string;
+  body?: unknown;
+}
+
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly detail?: string;
+  readonly body?: unknown;
+
+  constructor({ status, code, detail, body }: ApiErrorArgs) {
+    super(detail ?? `Request failed with status ${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.detail = detail;
+    this.body = body;
+  }
+}
+
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}
+
+// 401 (unauthenticated) / 403 (forbidden) — used both to skip retries and,
+// later, to drive the router auth-gate. 402 is included for tier-gated routes,
+// matching web's `skipRetryOnAuthError`.
+export function isAuthError(error: unknown): boolean {
+  return (
+    isApiError(error) &&
+    (error.status === 401 || error.status === 402 || error.status === 403)
+  );
+}
+
+export function getErrorMessage(
+  error: unknown,
+  fallback = "Something went wrong.",
+): string {
+  if (isApiError(error)) return error.detail ?? error.message ?? fallback;
+  if (error instanceof Error) return error.message || fallback;
+  return fallback;
+}

--- a/mobile/src/api/query-keys.ts
+++ b/mobile/src/api/query-keys.ts
@@ -1,0 +1,14 @@
+// Central TanStack Query key registry (mirrors web's src/lib/swr-keys.ts).
+//
+// All useQuery / invalidateQueries / setQueryData calls reference these instead
+// of inline arrays, so keys stay greppable and consistent. Keys are arrays (the
+// TanStack requirement); use `as const` so the literal types are preserved.
+// For dynamic keys (per-id endpoints), use a builder function.
+export const QUERY_KEYS = {
+  // ── User ──────────────────────────────────────────────────────────────────
+  me: ["me"] as const,
+
+  // Examples for when more endpoints land:
+  // settings: ["settings"] as const,
+  // persona: (id: string) => ["persona", id] as const,
+};

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -1,0 +1,24 @@
+// Shared API response types (mirrors web's src/lib/types.ts).
+//
+// Mobile-local and deliberately minimal — only the fields the app renders. Do
+// not mirror web's larger `User` type. If web later shares a DTO for one of
+// these via @onyx-ai/shared, reuse that instead (policy: extract-on-proven-reuse).
+// Mirrors the backend UserRole enum (backend/onyx/auth/schemas.py) exactly — all
+// 7 members. slack_user / ext_perm_user are non-web-login roles unlikely to reach
+// a mobile session, but the type must not claim values the API can return are
+// impossible (apiFetch casts the response without runtime validation).
+export type UserRole =
+  | "limited"
+  | "basic"
+  | "admin"
+  | "curator"
+  | "global_curator"
+  | "slack_user"
+  | "ext_perm_user";
+
+export interface CurrentUser {
+  id: string;
+  email: string;
+  role: UserRole;
+  is_active: boolean;
+}

--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -10,17 +10,29 @@ import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
 
 import { persister, persistMaxAge, queryClient } from "@/query/client";
+import { bindAppStateFocus } from "@/query/focus";
+import { bindOnlineManager } from "@/query/online";
 
 // Show the native Onyx splash until the first frame is ready, then reveal the app.
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   useEffect(() => {
+    // Wire React Native connectivity + foreground state into TanStack Query so
+    // queries pause offline and refetch on reconnect / app resume.
+    const unbindOnline = bindOnlineManager();
+    const unbindFocus = bindAppStateFocus();
+
     // No async init yet, so hide on the first render.
     // TODO(Subash-Mohan): once useFonts + @onyx-ai/shared init land, gate this
     // behind a readiness flag (return null until ready) so text never flashes in
     // the system font before custom fonts load.
     void SplashScreen.hideAsync();
+
+    return () => {
+      unbindOnline();
+      unbindFocus();
+    };
   }, []);
 
   return (

--- a/mobile/src/hooks/useCurrentUser.ts
+++ b/mobile/src/hooks/useCurrentUser.ts
@@ -1,0 +1,19 @@
+// Fetches the authenticated user from `/api/me`.
+//
+// Self-contained (key + queryFn inline), mirroring web's hook-per-file SWR
+// pattern. Returns the standard TanStack result: `{ data, error, isPending, ... }`.
+// `error` is an `ApiError`; until the login flow lands this resolves to a 403,
+// which the auth-aware retry in `query/client.ts` does not retry.
+import { useQuery } from "@tanstack/react-query";
+
+import { apiFetch } from "@/api/client";
+import { QUERY_KEYS } from "@/api/query-keys";
+import type { CurrentUser } from "@/api/types";
+
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: QUERY_KEYS.me,
+    // `signal` is forwarded so `cancelQueries` can abort the in-flight request.
+    queryFn: ({ signal }) => apiFetch<CurrentUser>("/api/me", { signal }),
+  });
+}

--- a/mobile/src/query/client.ts
+++ b/mobile/src/query/client.ts
@@ -3,13 +3,29 @@ import { QueryClient } from "@tanstack/react-query";
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 
 import { makeMmkvStorage, queryStorage } from "@/state/storage";
+import { isAuthError } from "@/api/errors";
+
+// How long a restored MMKV snapshot stays valid (24h). gcTime is pinned to this
+// below: an inactive query must live in the in-memory cache at least as long as
+// the persist window, otherwise it's garbage-collected after the default 5 min,
+// the persister rewrites an empty snapshot, and the 24h offline cache silently
+// collapses to ~5 min.
+export const persistMaxAge = 1000 * 60 * 60 * 24; // 24h
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000, // 30s — fresh enough to skip refetch storms
-      retry: 1,
-      refetchOnWindowFocus: false, // no-op on RN, explicit for parity
+      gcTime: persistMaxAge, // keep inactive queries for the full persist window
+      // Don't retry auth/tier errors (401/402/403) — retrying just spams the
+      // backend with requests that can't succeed without re-auth. Otherwise
+      // retry once. Mirrors web's `skipRetryOnAuthError`.
+      retry: (failureCount, error) => !isAuthError(error) && failureCount < 1,
+      // Refetch stale data when the app returns to the foreground. On RN this is
+      // driven by the AppState -> focusManager bridge in `query/focus.ts`; this
+      // flag must stay true (its default) or that bridge becomes a no-op.
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true, // refetch stale data when connectivity returns
     },
   },
 });
@@ -17,5 +33,3 @@ export const queryClient = new QueryClient({
 export const persister = createSyncStoragePersister({
   storage: makeMmkvStorage(queryStorage),
 });
-
-export const persistMaxAge = 1000 * 60 * 60 * 24; // 24h

--- a/mobile/src/query/focus.ts
+++ b/mobile/src/query/focus.ts
@@ -1,0 +1,14 @@
+// Bridges React Native's AppState into TanStack Query's focusManager so that
+// queries can refetch when the app returns to the foreground (the mobile
+// equivalent of browser window-focus refetching). Zero extra dependencies.
+import { AppState, type AppStateStatus } from "react-native";
+import { focusManager } from "@tanstack/react-query";
+
+// Call once at app startup; returns an unsubscribe for cleanup.
+export function bindAppStateFocus(): () => void {
+  function onChange(status: AppStateStatus): void {
+    focusManager.setFocused(status === "active");
+  }
+  const subscription = AppState.addEventListener("change", onChange);
+  return () => subscription.remove();
+}

--- a/mobile/src/query/online.ts
+++ b/mobile/src/query/online.ts
@@ -1,0 +1,17 @@
+// Bridges device connectivity (via @react-native-community/netinfo) into
+// TanStack Query's onlineManager. Without this, TanStack assumes it's always
+// online: offline queries error and retry in a loop, and `refetchOnReconnect`
+// has nothing to trigger it.
+import NetInfo from "@react-native-community/netinfo";
+import { onlineManager } from "@tanstack/react-query";
+
+// Call once at app startup; returns an unsubscribe for cleanup.
+export function bindOnlineManager(): () => void {
+  return NetInfo.addEventListener((state) => {
+    // `isInternetReachable` is null while NetInfo is still determining
+    // reachability — treat that as online to avoid false offline flashes.
+    onlineManager.setOnline(
+      Boolean(state.isConnected) && state.isInternetReachable !== false,
+    );
+  });
+}


### PR DESCRIPTION
## Description

- Add a typed `apiFetch` HTTP transport (base URL, Bearer-token injection, JSON (de)serialization) that normalizes every backend error shape into a single `ApiError`.
- Add a keychain-backed token seam (`expo-secure-store`), a central query-key registry, and a `useCurrentUser` hook against `/api/me`.
- Wire React Native connectivity into TanStack Query — AppState→`focusManager`, NetInfo→`onlineManager`, `refetchOnReconnect`, and `gcTime` pinned to the 24h MMKV persist window.
- Add `expo-secure-store` + `@react-native-community/netinfo` deps and an `EXPO_PUBLIC_API_URL` env (`.env.example`).

## How Has This Been Tested?

- `bun run typecheck` passes; error normalization verified against the running backend; reviewed via a multi-agent adversarial pass with fixes applied.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)
