### PR TITLE
fix(craft): cancel interrupted tool call spinner

### DIFF
--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -716,6 +716,7 @@ interface BuildSessionStore {
     toolCallId: string,
     updates: Partial<ToolCallState>
   ) => void;
+  cancelLatestInFlightToolCallStreamItem: (sessionId: string) => void;
   updateTodoListStreamItem: (
     sessionId: string,
     todoListId: string,
@@ -1370,6 +1371,47 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
           return {
             ...item,
             toolCall: { ...item.toolCall, ...updates },
+          };
+        }
+        return item;
+      }) as StreamItem[];
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        streamItems,
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  cancelLatestInFlightToolCallStreamItem: (sessionId: string) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      let latestInFlightIndex = -1;
+      for (let i = session.streamItems.length - 1; i >= 0; i--) {
+        const item = session.streamItems[i];
+        if (
+          item?.type === "tool_call" &&
+          (item.toolCall.status === "pending" ||
+            item.toolCall.status === "in_progress")
+        ) {
+          latestInFlightIndex = i;
+          break;
+        }
+      }
+
+      if (latestInFlightIndex === -1) return state;
+
+      const streamItems = session.streamItems.map((item, index) => {
+        if (index === latestInFlightIndex && item.type === "tool_call") {
+          return {
+            ...item,
+            toolCall: { ...item.toolCall, status: "cancelled" as const },
           };
         }
         return item;

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -37,6 +37,7 @@ const originalLoadSession = useBuildSessionStore.getState().loadSession;
 describe("useBuildStreaming thinking packets", () => {
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.clearAllMocks();
     useBuildSessionStore.setState({
       currentSessionId: null,
       sessions: new Map(),
@@ -54,6 +55,7 @@ describe("useBuildStreaming thinking packets", () => {
       turn_index: 0,
     });
     jest.mocked(fetchTurnEventStream).mockResolvedValue({} as Response);
+    jest.mocked(interruptMessageStream).mockResolvedValue();
     jest
       .mocked(processSSEStream)
       .mockImplementation(async (_response, onPacket) => {
@@ -904,6 +906,118 @@ describe("useBuildStreaming thinking packets", () => {
       content: "Partial answer",
       turn_index: 2,
     });
+  });
+
+  it("marks the latest in-flight tool call as cancelled when interrupting", async () => {
+    const { result } = renderHook(() => useBuildStreaming());
+
+    act(() => {
+      useBuildSessionStore.getState().updateSessionData(sessionId, {
+        status: "running",
+      });
+      useBuildSessionStore.getState().appendStreamItem(sessionId, {
+        type: "tool_call",
+        id: "tool-finished",
+        toolCall: {
+          id: "tool-finished",
+          kind: "read",
+          toolName: "read",
+          title: "Reading",
+          description: "finished.ts",
+          command: "",
+          status: "completed",
+          rawOutput: "",
+        },
+      });
+      useBuildSessionStore.getState().appendStreamItem(sessionId, {
+        type: "tool_call",
+        id: "tool-active",
+        toolCall: {
+          id: "tool-active",
+          kind: "execute",
+          toolName: "bash",
+          title: "Running command",
+          description: "long-running command",
+          command: "sleep 30",
+          status: "in_progress",
+          rawOutput: "",
+        },
+      });
+    });
+
+    await act(async () => {
+      await result.current.interruptStreaming(sessionId);
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    const toolStatuses = session?.streamItems
+      .filter((item) => item.type === "tool_call")
+      .map((item) => item.toolCall.status);
+
+    expect(interruptMessageStream).toHaveBeenCalledWith(sessionId);
+    expect(session?.isInterrupting).toBe(true);
+    expect(toolStatuses).toEqual(["completed", "cancelled"]);
+  });
+
+  it("persists an interrupted in-flight tool call as cancelled on prompt_response", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_start",
+          tool_call_id: "tool-active",
+          kind: "execute",
+          title: "Running command",
+          content: null,
+          locations: null,
+          raw_input: null,
+          raw_output: null,
+          status: "pending",
+          timestamp: "2026-01-01T00:00:00Z",
+        });
+        useBuildSessionStore.getState().updateSessionData(sessionId, {
+          isInterrupting: true,
+        });
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "tool-active",
+          kind: "execute",
+          raw_input: { command: "sleep 30" },
+          raw_output: null,
+          status: "in_progress",
+          timestamp: "2026-01-01T00:00:00.500Z",
+        });
+        onPacket({
+          type: "prompt_response",
+          timestamp: "2026-01-01T00:00:01Z",
+        });
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "build the app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    const assistantMessage = session?.messages.find(
+      (message) => message.type === "assistant"
+    );
+    const metadata = assistantMessage?.message_metadata as
+      | { streamItems?: StreamItem[] }
+      | undefined;
+
+    expect(session?.streamItems).toEqual([]);
+    expect(session?.isInterrupting).toBe(false);
+    expect(metadata?.streamItems).toEqual([
+      expect.objectContaining({
+        type: "tool_call",
+        toolCall: expect.objectContaining({
+          id: "tool-active",
+          status: "cancelled",
+        }),
+      }),
+    ]);
   });
 
   it("does not clear a newer turn when an older attach emits prompt_response late", async () => {

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -126,6 +126,9 @@ export function useBuildStreaming() {
   const updateToolCallStreamItem = useBuildSessionStore(
     (state) => state.updateToolCallStreamItem
   );
+  const cancelLatestInFlightToolCallStreamItem = useBuildSessionStore(
+    (state) => state.cancelLatestInFlightToolCallStreamItem
+  );
   const upsertTodoListStreamItem = useBuildSessionStore(
     (state) => state.upsertTodoListStreamItem
   );
@@ -483,7 +486,13 @@ export function useBuildStreaming() {
               break;
             }
 
-            const startedToolCall = toolCallStateFromStart(parsed);
+            const isInterrupting = useBuildSessionStore
+              .getState()
+              .sessions.get(sessionId)?.isInterrupting;
+            const startedToolCall = {
+              ...toolCallStateFromStart(parsed),
+              status: isInterrupting ? "cancelled" : "pending",
+            } satisfies ToolCallState;
 
             // Parent `task` start packets can carry the spawned child session
             // before any progress packet arrives. Seed immediately so the task
@@ -606,8 +615,15 @@ export function useBuildStreaming() {
               break;
             }
 
+            const status =
+              useBuildSessionStore.getState().sessions.get(sessionId)
+                ?.isInterrupting &&
+              (parsed.status === "pending" || parsed.status === "in_progress")
+                ? "cancelled"
+                : parsed.status;
+
             updateToolCallStreamItem(sessionId, parsed.toolCallId, {
-              status: parsed.status,
+              status,
               title: parsed.title,
               description: parsed.description,
               command: parsed.command,
@@ -667,6 +683,12 @@ export function useBuildStreaming() {
 
           case "prompt_response": {
             finalizeStreaming();
+            if (
+              useBuildSessionStore.getState().sessions.get(sessionId)
+                ?.isInterrupting
+            ) {
+              cancelLatestInFlightToolCallStreamItem(sessionId);
+            }
 
             const session = useBuildSessionStore
               .getState()
@@ -737,6 +759,7 @@ export function useBuildStreaming() {
       updateLastStreamingText,
       updateLastStreamingThinking,
       updateToolCallStreamItem,
+      cancelLatestInFlightToolCallStreamItem,
       upsertTodoListStreamItem,
       addArtifactToSession,
       appendMessageToSession,
@@ -968,6 +991,7 @@ export function useBuildStreaming() {
 
       const interruptedTurnId = session.activeTurnId;
       updateSessionData(sessionId, { isInterrupting: true });
+      cancelLatestInFlightToolCallStreamItem(sessionId);
       try {
         await interruptMessageStream(sessionId);
         void reconcileInterruptedTurn(sessionId, interruptedTurnId);
@@ -976,7 +1000,11 @@ export function useBuildStreaming() {
         updateSessionData(sessionId, { isInterrupting: false });
       }
     },
-    [reconcileInterruptedTurn, updateSessionData]
+    [
+      reconcileInterruptedTurn,
+      updateSessionData,
+      cancelLatestInFlightToolCallStreamItem,
+    ]
   );
 
   const streamScheduledRunEvents = useCallback(


### PR DESCRIPTION
## Summary
- mark the latest in-flight craft main-agent tool call as `cancelled` when the user interrupts a running turn
- keep interrupted sessions from resurrecting the spinner when late non-terminal tool progress arrives
- persist the cancelled tool state into assistant message metadata when the stream ends with `prompt_response`

## Root Cause
Interrupted streams can terminate without a terminal `tool_call_progress` packet for the active tool call, leaving the UI with a stale `pending` or `in_progress` status and an indefinite spinner.

## Impact
Users now see a settled cancelled state for the interrupted tool call in both the live transcript and saved assistant message instead of a permanently running spinner.

## Validation
- `bun run test src/app/craft/hooks/useBuildStreaming.test.tsx --runInBand`
- `bun run types:check`
- `bun run lint`
- `bun run format:check`

## Linear
- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops interrupted tool calls from spinning forever by cancelling the latest in-flight tool call when a user interrupts a turn. Cancellation is kept in the live transcript and saved assistant message, and late non-terminal progress packets won’t restart the spinner.

- **Bug Fixes**
  - Added `cancelLatestInFlightToolCallStreamItem`; call it on interrupt request and again on `prompt_response` if still interrupting.
  - While `isInterrupting`, coerce `tool_call_start` and `tool_call_progress` (pending/in_progress) to `cancelled`.
  - Persist the cancelled tool state into assistant message metadata so live and saved transcripts stay in sync.

<sup>Written for commit a1cf9cc2ce54c7c389d92a84bcb1de16d43c461a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

