### PR TITLE
fix(external apps): show tooltip for why the creation modal is not complete

### DIFF
--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 import Modal from "@/refresh-components/Modal";
-import { Button, InputTypeIn, MessageCard, Text } from "@opal/components";
+import {
+  Button,
+  InputTypeIn,
+  MessageCard,
+  Text,
+  Tooltip,
+} from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
 import InputKeyValue, {
@@ -95,6 +101,26 @@ export default function CreateCustomAppModal({
     upstreamPatterns.length > 0 &&
     (isEdit || file !== null) &&
     !isSaving;
+  const disabledCreateReason = isSaving
+    ? "Save is already in progress."
+    : name.trim().length === 0
+      ? "Enter a name before creating this custom app."
+      : upstreamPatterns.length === 0
+        ? "Add at least one upstream URL pattern. Type a pattern and press Enter."
+        : !isEdit && file === null
+          ? "Upload a bundle .zip file before creating this custom app."
+          : null;
+  const createButton = (
+    <Button onClick={save} disabled={!canSave}>
+      {isSaving
+        ? isEdit
+          ? "Saving…"
+          : "Creating…"
+        : isEdit
+          ? "Save"
+          : "Create"}
+    </Button>
+  );
 
   async function save() {
     setIsSaving(true);
@@ -283,15 +309,13 @@ export default function CreateCustomAppModal({
             >
               Cancel
             </Button>
-            <Button onClick={save} disabled={!canSave}>
-              {isSaving
-                ? isEdit
-                  ? "Saving…"
-                  : "Creating…"
-                : isEdit
-                  ? "Save"
-                  : "Create"}
-            </Button>
+            {disabledCreateReason ? (
+              <Tooltip tooltip={disabledCreateReason}>
+                <span className="inline-flex">{createButton}</span>
+              </Tooltip>
+            ) : (
+              createButton
+            )}
           </div>
         </Modal.Footer>
       </Modal.Content>

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -96,20 +96,20 @@ export default function CreateCustomAppModal({
 
   // Headers and org credentials are optional; name + at least one upstream
   // pattern are required. A bundle is required only on create (optional on edit).
-  const canSave =
-    name.trim().length > 0 &&
-    upstreamPatterns.length > 0 &&
-    (isEdit || file !== null) &&
-    !isSaving;
-  const disabledCreateReason = isSaving
-    ? "Save is already in progress."
-    : name.trim().length === 0
-      ? "Enter a name before creating this custom app."
-      : upstreamPatterns.length === 0
-        ? "Add at least one upstream URL pattern. Type a pattern and press Enter."
-        : !isEdit && file === null
-          ? "Upload a bundle .zip file before creating this custom app."
-          : null;
+  const disabledCreateReason = (() => {
+    if (isSaving) return "Save is already in progress.";
+    if (name.trim().length === 0) {
+      return "Enter a name before creating this custom app.";
+    }
+    if (upstreamPatterns.length === 0) {
+      return "Add at least one upstream URL pattern. Type a pattern and press Enter.";
+    }
+    if (!isEdit && file === null) {
+      return "Upload a bundle .zip file before creating this custom app.";
+    }
+    return null;
+  })();
+  const canSave = disabledCreateReason === null;
   const createButton = (
     <Button onClick={save} disabled={!canSave}>
       {isSaving

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -109,9 +109,8 @@ export default function CreateCustomAppModal({
     }
     return null;
   })();
-  const canSave = disabledCreateReason === null;
   const createButton = (
-    <Button onClick={save} disabled={!canSave}>
+    <Button onClick={save} disabled={disabledCreateReason !== null}>
       {isSaving
         ? isEdit
           ? "Saving…"


### PR DESCRIPTION
## Description

<!--- Provide a brief description of the changes in this PR --->

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a tooltip on the disabled Create/Save button in the External Apps custom app modal to explain what’s missing. Covers empty name, no upstream URL pattern, no bundle `.zip` on create, or save already in progress, deduplicates the guard into a single reason helper, and removes a redundant save alias.

<sup>Written for commit 585f4e5ed1ee868a1a0798d1e7cae7bd75825e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

