### PR TITLE
feat(security): add dedicated security_settings table

### DIFF
--- a/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
+++ b/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
@@ -52,6 +52,14 @@ def upgrade() -> None:
         sa.Column("password_require_special_char", sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         sa.CheckConstraint("id = true", name="ck_security_settings_singleton"),
+        # Only constrains rows where both bounds are explicitly overridden; a
+        # NULL bound falls back to its env default, invisible to this CHECK.
+        sa.CheckConstraint(
+            "password_min_length IS NULL "
+            "OR password_max_length IS NULL "
+            "OR password_min_length <= password_max_length",
+            name="ck_security_settings_pw_length_range",
+        ),
     )
 
 

--- a/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
+++ b/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
@@ -1,0 +1,58 @@
+"""add security_settings table
+
+Replaces the per-tenant ``onyx_security_settings`` JSONB blob in
+``key_value_store`` with a dedicated, typed ``security_settings`` table.
+
+The table holds a single row per tenant schema (enforced by a boolean
+primary key pinned to ``true`` via CHECK). Every column is an *override*:
+``NULL`` means "fall back to the env-derived default", mirroring the
+``SecuritySettingsOverrides`` storage shape (absent field == env default).
+
+Revision ID: 1cb59a95b250
+Revises: 99ecd56cb2ce
+Create Date: 2026-06-09 17:36:09.181328
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "1cb59a95b250"
+down_revision = "99ecd56cb2ce"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "security_settings",
+        # Singleton row: pinned to true so a second INSERT collides on the PK.
+        sa.Column(
+            "id",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+        sa.Column("user_directory_admin_only", sa.Boolean(), nullable=True),
+        sa.Column("track_external_idp_expiry", sa.Boolean(), nullable=True),
+        sa.Column("mask_credential_prefix", sa.Boolean(), nullable=True),
+        sa.Column(
+            "valid_email_domains",
+            postgresql.ARRAY(sa.String()),
+            nullable=True,
+        ),
+        sa.Column("password_min_length", sa.Integer(), nullable=True),
+        sa.Column("password_max_length", sa.Integer(), nullable=True),
+        sa.Column("password_require_uppercase", sa.Boolean(), nullable=True),
+        sa.Column("password_require_lowercase", sa.Boolean(), nullable=True),
+        sa.Column("password_require_digit", sa.Boolean(), nullable=True),
+        sa.Column("password_require_special_char", sa.Boolean(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint("id = true", name="ck_security_settings_singleton"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("security_settings")

--- a/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
+++ b/backend/alembic/versions/1cb59a95b250_add_security_settings_table.py
@@ -13,6 +13,7 @@ Revises: 99ecd56cb2ce
 Create Date: 2026-06-09 17:36:09.181328
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -30,6 +30,7 @@ from sqlalchemy import Sequence
 from sqlalchemy import String
 from sqlalchemy import Text
 from sqlalchemy import text
+from sqlalchemy import true
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
@@ -4108,7 +4109,7 @@ class SecuritySettings(Base):
     __tablename__ = "security_settings"
 
     id: Mapped[bool] = mapped_column(
-        Boolean, primary_key=True, default=True, server_default=text("true")
+        Boolean, primary_key=True, default=True, server_default=true()
     )
 
     user_directory_admin_only: Mapped[bool | None] = mapped_column(
@@ -4144,6 +4145,15 @@ class SecuritySettings(Base):
 
     __table_args__ = (
         CheckConstraint("id = true", name="ck_security_settings_singleton"),
+        # Only constrains rows where both bounds are explicitly overridden; a
+        # bound left NULL falls back to its env default, which this CHECK can't
+        # see. App-layer validation still guards the mixed (override + env) case.
+        CheckConstraint(
+            "password_min_length IS NULL "
+            "OR password_max_length IS NULL "
+            "OR password_min_length <= password_max_length",
+            name="ck_security_settings_pw_length_range",
+        ),
     )
 
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4094,6 +4094,59 @@ class KVStore(Base):
     )
 
 
+class SecuritySettings(Base):
+    """Per-tenant runtime overrides for the env-derived security settings.
+
+    Singleton: one row per tenant schema, enforced by a boolean primary key
+    pinned to ``true`` via a CHECK constraint. Every column is an *override* —
+    ``None`` means "fall back to the env-derived default" — so this is the
+    typed, relational counterpart of the ``SecuritySettingsOverrides`` wire
+    shape (absent field == env default). Replaces the prior
+    ``onyx_security_settings`` JSONB blob in ``key_value_store``.
+    """
+
+    __tablename__ = "security_settings"
+
+    id: Mapped[bool] = mapped_column(
+        Boolean, primary_key=True, default=True, server_default=text("true")
+    )
+
+    user_directory_admin_only: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    track_external_idp_expiry: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    mask_credential_prefix: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    valid_email_domains: Mapped[list[str] | None] = mapped_column(
+        postgresql.ARRAY(String), nullable=True, default=None
+    )
+    password_min_length: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    password_max_length: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
+    )
+    password_require_uppercase: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_lowercase: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_digit: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+    password_require_special_char: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
+
+    __table_args__ = (
+        CheckConstraint("id = true", name="ck_security_settings_singleton"),
+    )
+
+
 class FileRecord(Base):
     __tablename__ = "file_record"
 


### PR DESCRIPTION
## Summary

Adds a dedicated, typed `security_settings` table to back the runtime security settings feature, replacing the per-tenant `onyx_security_settings` JSONB blob in `key_value_store` used by #11453.

- **Migration** (`1cb59a95b250`, revises `99ecd56cb2ce`): creates `security_settings` as a singleton row per tenant schema — a boolean primary key pinned to `true` via the `ck_security_settings_singleton` CHECK so a second insert collides on the PK.
- One nullable column per `SecuritySettingsOverrides` field; `NULL` means "use the env-derived default", preserving the override semantics. `valid_email_domains` is `ARRAY(String)`, the rest are `Boolean`/`Integer`.
- **ORM model** `SecuritySettings` in `onyx/db/models.py`, mirroring the migration column-for-column (placed next to `KVStore`).

Scope is the database layer only — **nothing reads the table yet**. The `store.py` KV→table wiring and removal of `KV_SECURITY_SETTINGS_KEY` / `OnyxRedisLocks.SECURITY_SETTINGS` are a follow-up to land alongside #11453.

## Test plan

- [x] `alembic upgrade head` applies `99ecd56cb2ce → 1cb59a95b250` cleanly
- [x] `alembic check` reports no diff for `security_settings` (ORM model matches the created table)
- [x] `alembic downgrade -1` drops the table and restores `99ecd56cb2ce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed `security_settings` table (singleton per tenant) to store runtime security settings overrides, replacing the `key_value_store` JSONB blob. Prepares the ground for the runtime settings feature in #11453; nothing reads this table yet.

- **Migration**
  - Create `security_settings` with a boolean PK pinned to `true` (singleton row per tenant).
  - Columns mirror `SecuritySettingsOverrides`; `NULL` uses env defaults. `valid_email_domains` is an array; others are boolean/integer.
  - Add CHECK `ck_security_settings_pw_length_range` enforcing `password_min_length <= password_max_length` when both are set.
  - Add matching `SecuritySettings` ORM model in `onyx/db/models.py` using `server_default=true()`.

<sup>Written for commit e450703dfe6409092f4602b3e5c04467c5563093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

