### PR TITLE
fix(chat): tolerate deleted files referenced in chat history

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -467,7 +467,22 @@ def load_chat_file(
             logger.warning("Failed to get token count for file %s: %s", file_id, e)
 
     def _load_content() -> bytes:
-        return get_default_file_store().read_file(file_id, mode="b").read()
+        # Chat messages keep file references in their JSONB `files` column, but
+        # user-file deletion does not scrub those references — a file in the
+        # history may no longer exist in the file store. Since this loader runs
+        # lazily (on first `.content` access, often mid-LLM-flow), a raised
+        # exception here would kill the whole send-message request, so degrade
+        # to empty content instead.
+        try:
+            return get_default_file_store().read_file(file_id, mode="b").read()
+        except Exception:
+            logger.warning(
+                "Failed to load content for chat file %s (file may have been "
+                "deleted); substituting empty content",
+                file_id,
+                exc_info=True,
+            )
+            return b""
 
     return ChatLoadedFile.lazy_loaded(
         file_id=file_id,

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -22,6 +22,7 @@ from onyx.context.search.utils import sandbox_filename_for_document
 from onyx.db.chat import create_chat_session
 from onyx.db.chat import get_chat_messages_by_session
 from onyx.db.chat import get_or_create_root_message
+from onyx.db.file_record import FileRecordNotFoundError
 from onyx.db.kg_config import get_kg_config_settings
 from onyx.db.kg_config import is_kg_config_settings_enabled_valid
 from onyx.db.models import ChatMessage
@@ -472,13 +473,22 @@ def load_chat_file(
         # history may no longer exist in the file store. Since this loader runs
         # lazily (on first `.content` access, often mid-LLM-flow), a raised
         # exception here would kill the whole send-message request, so degrade
-        # to empty content instead.
+        # to empty content instead. Deletion is expected and logs at warning;
+        # anything else (e.g. transient object-store failure) logs at error so
+        # outages remain distinguishable in alerting.
         try:
             return get_default_file_store().read_file(file_id, mode="b").read()
-        except Exception:
+        except FileRecordNotFoundError:
             logger.warning(
-                "Failed to load content for chat file %s (file may have been "
-                "deleted); substituting empty content",
+                "Chat file %s no longer exists (deleted after being referenced "
+                "in chat history); substituting empty content",
+                file_id,
+            )
+            return b""
+        except Exception:
+            logger.error(
+                "Unexpected error loading content for chat file %s; "
+                "substituting empty content",
                 file_id,
                 exc_info=True,
             )

--- a/backend/onyx/db/file_content.py
+++ b/backend/onyx/db/file_content.py
@@ -1,6 +1,7 @@
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
+from onyx.db.file_record import FileRecordNotFoundError
 from onyx.db.models import FileContent
 
 
@@ -10,7 +11,7 @@ def get_file_content_by_file_id(
 ) -> FileContent:
     record = db_session.query(FileContent).filter_by(file_id=file_id).first()
     if not record:
-        raise RuntimeError(
+        raise FileRecordNotFoundError(
             f"File content for file_id {file_id} does not exist or was deleted"
         )
     return record

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -36,6 +36,15 @@ def get_filerecord_by_file_id_optional(
     return db_session.query(FileRecord).filter_by(file_id=file_id).first()
 
 
+class FileRecordNotFoundError(RuntimeError):
+    """Raised when a file record does not exist (e.g. the file was deleted).
+
+    Subclasses RuntimeError so existing `except RuntimeError` call sites keep
+    working; callers that need to distinguish "file is gone" from transient
+    infrastructure failures can catch this type specifically.
+    """
+
+
 def get_filerecord_by_file_id(
     file_id: str,
     db_session: Session,
@@ -43,7 +52,9 @@ def get_filerecord_by_file_id(
     filestore = db_session.query(FileRecord).filter_by(file_id=file_id).first()
 
     if not filestore:
-        raise RuntimeError(f"File by id {file_id} does not exist or was deleted")
+        raise FileRecordNotFoundError(
+            f"File by id {file_id} does not exist or was deleted"
+        )
 
     return filestore
 

--- a/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
+++ b/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
@@ -299,6 +299,28 @@ class TestLoadChatFileLazy:
         assert loaded.content == b"sentinel-bytes"
         assert read_counter.hits_for(file_id) == 1
 
+    def test_deleted_file_yields_empty_content(
+        self,
+        read_counter: _ReadCounter,  # noqa: ARG002 — keeps store fixtures live
+        db_session: Session,
+    ) -> None:
+        """A file referenced in chat history but deleted from the file store
+        (user-file deletion doesn't scrub chat-message ``files`` references)
+        must degrade to empty content on ``.content`` access — not raise and
+        kill the send-message flow."""
+        file_id = _write_file(b"doomed-bytes", file_type="image/png")
+
+        loaded = load_chat_file(
+            {"id": file_id, "type": ChatFileType.IMAGE, "name": "gone.png"},
+            db_session,
+        )
+
+        # Delete the underlying file after construction but before the lazy
+        # bytes read — simulates user-file deletion racing chat history use.
+        get_default_file_store().delete_file(file_id)
+
+        assert loaded.content == b""
+
 
 class TestLoadAllChatFilesLazy:
     def test_returns_lazy_files_for_history(

--- a/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
+++ b/backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py
@@ -321,6 +321,30 @@ class TestLoadChatFileLazy:
 
         assert loaded.content == b""
 
+    def test_transient_read_error_yields_empty_content(
+        self,
+        read_counter: _ReadCounter,  # noqa: ARG002 — keeps store fixtures live
+        file_cleanup: list[str],
+        db_session: Session,
+    ) -> None:
+        """Non-not-found failures (e.g. transient object-store errors) must
+        also degrade to empty content rather than raise mid-LLM-flow — the
+        send-message request must never die on a history-file read."""
+        file_id = _write_file(b"unreachable-bytes", file_type="image/png")
+        file_cleanup.append(file_id)
+
+        loaded = load_chat_file(
+            {"id": file_id, "type": ChatFileType.IMAGE, "name": "flaky.png"},
+            db_session,
+        )
+
+        with patch.object(
+            file_store_module.S3BackedFileStore,
+            "read_file",
+            side_effect=ConnectionError("simulated transient store failure"),
+        ):
+            assert loaded.content == b""
+
 
 class TestLoadAllChatFilesLazy:
     def test_returns_lazy_files_for_history(


### PR DESCRIPTION
## Description

User-file deletion removes the file from the file store and the `UserFile` row, but does not scrub the file references stored in chat messages' `files` JSONB. When such a conversation is continued, the lazy content loader (`_load_content` in `chat_utils.py`) raises on first `.content` access mid-LLM-flow, killing the entire send-message request — surfacing to users as an ASGI ExceptionGroup / 500 and the appearance of a "crashed/erased" conversation.

This PR makes the lazy loader degrade to empty content with a warning instead of raising. Every downstream consumer already handles empty bytes gracefully:
- the image path (`llm_step.py`) wraps content access in try/except and skips the image
- the tool path (`_convert_loaded_files_to_chat_files`) explicitly documents zero-byte content as supported

## How Has This Been Tested?

Added `test_deleted_file_yields_empty_content` to the existing external-dependency-unit suite for lazy chat file loading (`backend/tests/external_dependency_unit/chat/test_lazy_chat_file_loading.py`) — writes a file, constructs the lazy `ChatLoadedFile`, deletes the underlying file, and asserts `.content` returns `b""` instead of raising. Full suite (12 tests) passes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents chat crashes when a conversation references a deleted file or when the store has a transient read error. The lazy loader now returns empty bytes instead of raising, warning on deletions and erroring (with traceback) on unexpected failures so messages continue without 500s.

- **Bug Fixes**
  - In `chat_utils._load_content`, return `b""` on read failures; log warning for `FileRecordNotFoundError` and error (with traceback) for other exceptions.
  - Introduced `FileRecordNotFoundError`; now raised by both `get_filerecord_by_file_id` and `get_file_content_by_file_id` so deletions are identified across backends and logged at warning level.
  - Tests cover both cases: `test_deleted_file_yields_empty_content` and `test_transient_read_error_yields_empty_content`.

<sup>Written for commit b15d925d849f2d2ca7b5ca1a87a319d494467e48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

