### PR TITLE
fix(craft): avoid event bus during opencode prewarm

### DIFF
--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -234,7 +234,11 @@ class _ServeMixin:
             session_path,
             opencode_session_id,
         )
-        with self._build_serve_client(sandbox_id, session_path) as client:
+        with self._build_serve_client(
+            sandbox_id,
+            session_path,
+            with_event_bus=False,
+        ) as client:
             return client.ensure_session(
                 opencode_session_id,
                 directory=session_path,
@@ -392,10 +396,18 @@ class _ServeMixin:
             return bus
 
     def _build_serve_client(
-        self, sandbox_id: UUID, directory: str
+        self,
+        sandbox_id: UUID,
+        directory: str,
+        *,
+        with_event_bus: bool = True,
     ) -> OpencodeServeClient:
         info = self._serve_connection_info(sandbox_id)
-        bus = self._get_or_create_event_bus(sandbox_id, directory)
+        bus = (
+            self._get_or_create_event_bus(sandbox_id, directory)
+            if with_event_bus
+            else None
+        )
         return OpencodeServeClient(
             base_url=info.base_url,
             password=info.password,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_opencode_session.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+
+from onyx.server.features.build.sandbox import serve_transport
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
+
+
+class _FakeOpencodeServeClient:
+    event_bus: object | None = object()
+
+    def __init__(
+        self,
+        base_url: str,
+        password: str | None,
+        *,
+        event_bus: object | None = None,
+        reload_password: Callable[[], str | None] | None = None,
+        **_: Any,
+    ) -> None:
+        self.base_url = base_url
+        self.password = password
+        self.reload_password = reload_password
+        _FakeOpencodeServeClient.event_bus = event_bus
+
+    def __enter__(self) -> _FakeOpencodeServeClient:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        pass
+
+    def ensure_session(
+        self,
+        opencode_session_id: str | None,
+        *,
+        directory: str,
+        title: str | None = None,
+    ) -> str:
+        assert opencode_session_id is None
+        assert directory.startswith("/workspace/sessions/")
+        assert title is not None
+        return "ses_fake"
+
+
+def test_ensure_opencode_session_uses_unary_client_without_event_bus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sandbox_id = uuid4()
+    build_session_id = uuid4()
+    manager: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    manager._init_serve_state()
+
+    def load_connection_info(_: UUID) -> ServeConnectionInfo:
+        return ServeConnectionInfo(
+            base_url="http://sandbox.invalid:4096", password=None
+        )
+
+    def fail_if_bus_created(_: UUID, __: str) -> object:
+        raise AssertionError("ensure_opencode_session should not create an event bus")
+
+    manager._load_serve_connection_info = load_connection_info  # type: ignore[method-assign]
+    manager._get_or_create_event_bus = fail_if_bus_created  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        serve_transport,
+        "OpencodeServeClient",
+        _FakeOpencodeServeClient,
+    )
+
+    assert manager.ensure_opencode_session(sandbox_id, build_session_id) == "ses_fake"
+    assert _FakeOpencodeServeClient.event_bus is None

--- a/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py
@@ -87,3 +87,4 @@ def test_prewarm_opencode_session_raises_when_runtime_returns_no_id() -> None:
 
     assert session.opencode_session_id is None
     assert db_session.flush_count == 0
+    assert sandbox_manager.calls == [(sandbox_id, session.id, None)]


### PR DESCRIPTION
## Description

Prevents Craft opencode session prewarm from creating a `PodEventBus`.

`_build_serve_client` now accepts `with_event_bus` and keeps the existing streaming default. `ensure_opencode_session` opts out because it only performs unary `GET/POST /session` calls. This keeps the event-bus DB guard on actual streaming paths while avoiding a stale committed `SLEEPING` read during sandbox revive.

Root cause: prewarm used the streaming client helper, which eagerly created an event bus. Event-bus creation opens a separate DB session and rejects `SLEEPING` sandboxes. During revive, the request transaction had flushed `RUNNING` but had not committed yet, so that separate DB session could still see `SLEEPING` and fail session creation.

## How Has This Been Tested?

- `source .venv/bin/activate && pytest -q backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_opencode_session.py`
- `source .venv/bin/activate && ruff check backend/onyx/server/features/build/sandbox/serve_transport.py backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_opencode_session.py backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py`
- `source .venv/bin/activate && ty check backend/onyx/server/features/build/sandbox/serve_transport.py backend/tests/unit/onyx/server/features/build/sandbox/test_ensure_opencode_session.py backend/tests/unit/onyx/server/features/build/session/test_prewarm_opencode_session.py`
- `git diff --check`
- Manual local kind/Telepresence validation: forced sandbox row to `SLEEPING`, deleted sandbox resources, then retried session creation. Session creation successfully provisioned/reused the sandbox, prewarmed the opencode session, and returned `POST /build/sessions` 200.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid creating a `PodEventBus` during Craft opencode session prewarm to prevent sandbox revive failures caused by stale reads. The prewarm path now uses a unary client without an event bus.

- **Bug Fixes**
  - Backend: `_build_serve_client` adds `with_event_bus` (default true). `ensure_opencode_session` sets it to false during prewarm to avoid a separate DB session.
  - Tests: Added a unit test to ensure the unary client runs with no event bus and updated the prewarm test to assert the bus is `None`.

<sup>Written for commit 67726df6c9b9192d8c8ea2cc6188cc622b352d12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

