### PR TITLE
perf(llm): cache non-admin LLM provider listings per tenant

### DIFF
--- a/backend/onyx/server/manage/image_generation/api.py
+++ b/backend/onyx/server/manage/image_generation/api.py
@@ -29,6 +29,7 @@ from onyx.server.manage.image_generation.models import TestImageGenerationReques
 from onyx.server.manage.llm.api import _validate_llm_provider_change
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.manage.llm.provider_cache import invalidate_provider_listing_cache
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -341,6 +342,7 @@ def create_config(
             is_default=config_create.is_default,
         )
         db_session.commit()
+        invalidate_provider_listing_cache()
         db_session.refresh(config)
         return ImageGenerationConfigView.from_model(config)
     except HTTPException:
@@ -467,6 +469,7 @@ def update_config(
         remove_llm_provider(db_session, old_llm_provider_id, commit=False)
 
         db_session.commit()
+        invalidate_provider_listing_cache()
         db_session.refresh(existing_config)
         return ImageGenerationConfigView.from_model(existing_config)
 
@@ -501,6 +504,7 @@ def delete_config(
         remove_llm_provider(db_session, llm_provider_id, commit=False)
 
         db_session.commit()
+        invalidate_provider_listing_cache()
     except HTTPException:
         raise
     except ValueError as e:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -95,6 +95,9 @@ from onyx.server.manage.llm.models import OpenRouterModelsRequest
 from onyx.server.manage.llm.models import SyncModelEntry
 from onyx.server.manage.llm.models import TestLLMRequest
 from onyx.server.manage.llm.models import VisionProviderResponse
+from onyx.server.manage.llm.provider_cache import cache_provider_listing
+from onyx.server.manage.llm.provider_cache import get_cached_provider_listing
+from onyx.server.manage.llm.provider_cache import invalidate_provider_listing_cache
 from onyx.server.manage.llm.utils import generate_bedrock_display_name
 from onyx.server.manage.llm.utils import generate_ollama_display_name
 from onyx.server.manage.llm.utils import infer_vision_support
@@ -614,6 +617,7 @@ def put_llm_provider(
                     # Refresh result with synced models
                     result = LLMProviderView.from_model(updated_provider)
 
+        invalidate_provider_listing_cache()
         _mask_provider_credentials(result)
         return result
     except ValueError as e:
@@ -642,6 +646,8 @@ def delete_llm_provider(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
 
+    invalidate_provider_listing_cache()
+
 
 @admin_router.post("/default")
 def set_provider_as_default(
@@ -654,6 +660,7 @@ def set_provider_as_default(
         model_name=default_model_request.model_name,
         db_session=db_session,
     )
+    invalidate_provider_listing_cache()
 
 
 @admin_router.post("/default-vision")
@@ -667,6 +674,7 @@ def set_provider_as_default_vision(
         vision_model=default_model.model_name,
         db_session=db_session,
     )
+    invalidate_provider_listing_cache()
 
 
 @admin_router.get("/auto-config")
@@ -749,9 +757,16 @@ def list_llm_provider_basics(
     start_time = datetime.now(timezone.utc)
     logger.debug("Starting to fetch user-accessible LLM providers")
 
-    all_providers = fetch_existing_llm_providers(db_session, [])
     user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
+
+    cached_response = get_cached_provider_listing(
+        persona_id=None, is_admin=is_admin, user_group_ids=user_group_ids
+    )
+    if cached_response is not None:
+        return cached_response
+
+    all_providers = fetch_existing_llm_providers(db_session, [])
 
     accessible_providers = []
 
@@ -775,7 +790,7 @@ def list_llm_provider_basics(
         format(duration, ".2f"),
     )
 
-    return LLMProviderResponse[LLMProviderDescriptor].from_models(
+    response = LLMProviderResponse[LLMProviderDescriptor].from_models(
         providers=accessible_providers,
         default_text=DefaultModel.from_model_config(
             fetch_default_llm_model(db_session)
@@ -784,6 +799,13 @@ def list_llm_provider_basics(
             fetch_default_vision_model(db_session)
         ),
     )
+    cache_provider_listing(
+        persona_id=None,
+        is_admin=is_admin,
+        user_group_ids=user_group_ids,
+        response=response,
+    )
+    return response
 
 
 def get_valid_model_names_for_persona(
@@ -878,10 +900,17 @@ def list_llm_providers_for_persona(
         )
 
     is_admin = user.role == UserRole.ADMIN
+    user_group_ids = set() if is_admin else fetch_user_group_ids(db_session, user)
+
+    cached_response = get_cached_provider_listing(
+        persona_id=persona_id, is_admin=is_admin, user_group_ids=user_group_ids
+    )
+    if cached_response is not None:
+        return cached_response
+
     all_providers = fetch_existing_llm_providers(
         db_session, [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
     )
-    user_group_ids = set() if is_admin else fetch_user_group_ids(db_session, user)
 
     llm_provider_list: list[LLMProviderDescriptor] = []
 
@@ -923,11 +952,18 @@ def list_llm_providers_for_persona(
                 model_name=model_config.name,
             )
 
-    return LLMProviderResponse[LLMProviderDescriptor].from_models(
+    response = LLMProviderResponse[LLMProviderDescriptor].from_models(
         providers=llm_provider_list,
         default_text=default_text,
         default_vision=default_vision,
     )
+    cache_provider_listing(
+        persona_id=persona_id,
+        is_admin=is_admin,
+        user_group_ids=user_group_ids,
+        response=response,
+    )
+    return response
 
 
 @admin_router.get("/provider-contextual-cost")

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -761,8 +761,8 @@ def list_llm_provider_basics(
     start_time = datetime.now(timezone.utc)
     logger.debug("Starting to fetch user-accessible LLM providers")
 
-    user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
+    user_group_ids = set() if is_admin else fetch_user_group_ids(db_session, user)
 
     cache_lookup = get_cached_provider_listing(
         persona_id=None, is_admin=is_admin, user_group_ids=user_group_ids

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -187,6 +187,7 @@ def _sync_fetched_models(
                 source_label,
                 provider_name,
             )
+        invalidate_provider_listing_cache()
     except ValueError as e:
         logger.warning("Failed to sync %s models to DB: %s", source_label, e)
 
@@ -617,12 +618,15 @@ def put_llm_provider(
                     # Refresh result with synced models
                     result = LLMProviderView.from_model(updated_provider)
 
-        invalidate_provider_listing_cache()
         _mask_provider_credentials(result)
         return result
     except ValueError as e:
         logger.exception("Failed to upsert LLM Provider")
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, str(e))
+    finally:
+        # upsert_llm_provider and sync_auto_mode_models commit internally, so a
+        # post-commit failure must still drop cached listings
+        invalidate_provider_listing_cache()
 
 
 @admin_router.delete("/provider/{provider_id}")
@@ -760,11 +764,11 @@ def list_llm_provider_basics(
     user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
 
-    cached_response = get_cached_provider_listing(
+    cache_lookup = get_cached_provider_listing(
         persona_id=None, is_admin=is_admin, user_group_ids=user_group_ids
     )
-    if cached_response is not None:
-        return cached_response
+    if cache_lookup.response is not None:
+        return cache_lookup.response
 
     all_providers = fetch_existing_llm_providers(db_session, [])
 
@@ -804,6 +808,7 @@ def list_llm_provider_basics(
         is_admin=is_admin,
         user_group_ids=user_group_ids,
         response=response,
+        version=cache_lookup.version,
     )
     return response
 
@@ -902,11 +907,11 @@ def list_llm_providers_for_persona(
     is_admin = user.role == UserRole.ADMIN
     user_group_ids = set() if is_admin else fetch_user_group_ids(db_session, user)
 
-    cached_response = get_cached_provider_listing(
+    cache_lookup = get_cached_provider_listing(
         persona_id=persona_id, is_admin=is_admin, user_group_ids=user_group_ids
     )
-    if cached_response is not None:
-        return cached_response
+    if cache_lookup.response is not None:
+        return cache_lookup.response
 
     all_providers = fetch_existing_llm_providers(
         db_session, [LLMModelFlowType.CHAT, LLMModelFlowType.VISION]
@@ -962,6 +967,7 @@ def list_llm_providers_for_persona(
         is_admin=is_admin,
         user_group_ids=user_group_ids,
         response=response,
+        version=cache_lookup.version,
     )
     return response
 

--- a/backend/onyx/server/manage/llm/provider_cache.py
+++ b/backend/onyx/server/manage/llm/provider_cache.py
@@ -49,13 +49,28 @@ class ProviderListingCacheLookup(BaseModel):
     version: str | None
 
 
+def _decode_version(raw: bytes) -> str | None:
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("Corrupted LLM provider listing version key; reminting")
+        return None
+
+
 def _current_version(cache: CacheBackend) -> str:
     raw = cache.get(_VERSION_KEY)
-    if raw is not None:
-        return raw.decode("utf-8")
-    version = uuid.uuid4().hex
-    cache.set(_VERSION_KEY, version)
-    return version
+    version = _decode_version(raw) if raw is not None else None
+    if version is not None:
+        return version
+
+    # Missing or corrupted token: mint one, then re-read so concurrent
+    # initialisers converge on the winning write (CacheBackend has no NX set;
+    # entries filled under a losing token just expire via TTL).
+    minted = uuid.uuid4().hex
+    cache.set(_VERSION_KEY, minted)
+    raw = cache.get(_VERSION_KEY)
+    version = _decode_version(raw) if raw is not None else None
+    return version if version is not None else minted
 
 
 def build_entry_key(

--- a/backend/onyx/server/manage/llm/provider_cache.py
+++ b/backend/onyx/server/manage/llm/provider_cache.py
@@ -1,0 +1,118 @@
+"""Per-tenant cache for the non-admin LLM provider listing endpoints.
+
+GET /llm/provider and GET /llm/persona/{persona_id}/providers are hit on every
+chat page load and rebuild an identical payload from Postgres each time. The
+descriptor construction (ORM hydration + pydantic models over every provider x
+model configuration) is CPU-heavy enough to dominate api-server latency under
+load, so the final response is memoized here.
+
+Entries are keyed by everything that can change the response for a user
+(persona, admin status, group memberships) and namespaced by a per-tenant
+version token, so a single token rewrite invalidates every entry at once.
+Provider mutations bump the token explicitly; changes that bypass the LLM
+provider API (e.g. persona default-model edits) are bounded by the entry TTL.
+
+Cache failures are non-fatal: readers fall through to Postgres.
+"""
+
+import hashlib
+import uuid
+
+from pydantic import ValidationError
+
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.cache.interface import CacheBackend
+from onyx.server.manage.llm.models import LLMProviderDescriptor
+from onyx.server.manage.llm.models import LLMProviderResponse
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_VERSION_KEY = "llm_provider_listing:version"
+_ENTRY_KEY_PREFIX = "llm_provider_listing:entry"
+ENTRY_TTL_SECONDS = 60
+
+
+def _current_version(cache: CacheBackend) -> str:
+    raw = cache.get(_VERSION_KEY)
+    if raw is not None:
+        return raw.decode("utf-8")
+    version = uuid.uuid4().hex
+    cache.set(_VERSION_KEY, version)
+    return version
+
+
+def build_entry_key(
+    version: str,
+    persona_id: int | None,
+    is_admin: bool,
+    user_group_ids: set[int],
+) -> str:
+    discriminator = "|".join(
+        [
+            f"persona={persona_id if persona_id is not None else 'none'}",
+            f"admin={is_admin}",
+            f"groups={','.join(str(gid) for gid in sorted(user_group_ids))}",
+        ]
+    )
+    digest = hashlib.sha256(discriminator.encode("utf-8")).hexdigest()
+    return f"{_ENTRY_KEY_PREFIX}:{version}:{digest}"
+
+
+def get_cached_provider_listing(
+    persona_id: int | None,
+    is_admin: bool,
+    user_group_ids: set[int],
+) -> LLMProviderResponse[LLMProviderDescriptor] | None:
+    try:
+        cache = get_cache_backend()
+        raw = cache.get(
+            build_entry_key(
+                _current_version(cache), persona_id, is_admin, user_group_ids
+            )
+        )
+    except CACHE_TRANSIENT_ERRORS:
+        logger.warning("LLM provider listing cache read failed", exc_info=True)
+        return None
+
+    if raw is None:
+        return None
+
+    try:
+        return LLMProviderResponse[LLMProviderDescriptor].model_validate_json(raw)
+    except ValidationError:
+        logger.warning(
+            "Discarding cached LLM provider listing that failed validation",
+            exc_info=True,
+        )
+        return None
+
+
+def cache_provider_listing(
+    persona_id: int | None,
+    is_admin: bool,
+    user_group_ids: set[int],
+    response: LLMProviderResponse[LLMProviderDescriptor],
+) -> None:
+    try:
+        cache = get_cache_backend()
+        cache.set(
+            build_entry_key(
+                _current_version(cache), persona_id, is_admin, user_group_ids
+            ),
+            response.model_dump_json(),
+            ex=ENTRY_TTL_SECONDS,
+        )
+    except CACHE_TRANSIENT_ERRORS:
+        logger.warning("LLM provider listing cache write failed", exc_info=True)
+
+
+def invalidate_provider_listing_cache() -> None:
+    try:
+        get_cache_backend().set(_VERSION_KEY, uuid.uuid4().hex)
+    except CACHE_TRANSIENT_ERRORS:
+        logger.warning(
+            "LLM provider listing cache invalidation failed; entries expire via TTL",
+            exc_info=True,
+        )

--- a/backend/onyx/server/manage/llm/provider_cache.py
+++ b/backend/onyx/server/manage/llm/provider_cache.py
@@ -18,6 +18,7 @@ Cache failures are non-fatal: readers fall through to Postgres.
 import hashlib
 import uuid
 
+from pydantic import BaseModel
 from pydantic import ValidationError
 
 from onyx.cache.factory import get_cache_backend
@@ -32,6 +33,20 @@ logger = setup_logger()
 _VERSION_KEY = "llm_provider_listing:version"
 _ENTRY_KEY_PREFIX = "llm_provider_listing:entry"
 ENTRY_TTL_SECONDS = 60
+
+
+class ProviderListingCacheLookup(BaseModel):
+    """Result of a cache lookup.
+
+    `version` is the namespace token observed at lookup time. The subsequent
+    fill MUST write under this token (not a re-read one): a reader that loaded
+    pre-mutation DB state would otherwise write its stale payload under a token
+    minted after it read, resurrecting stale data past an invalidation.
+    `version` is None when the cache was unreachable — the fill is skipped.
+    """
+
+    response: LLMProviderResponse[LLMProviderDescriptor] | None
+    version: str | None
 
 
 def _current_version(cache: CacheBackend) -> str:
@@ -64,29 +79,31 @@ def get_cached_provider_listing(
     persona_id: int | None,
     is_admin: bool,
     user_group_ids: set[int],
-) -> LLMProviderResponse[LLMProviderDescriptor] | None:
+) -> ProviderListingCacheLookup:
     try:
         cache = get_cache_backend()
-        raw = cache.get(
-            build_entry_key(
-                _current_version(cache), persona_id, is_admin, user_group_ids
-            )
-        )
+        version = _current_version(cache)
+        raw = cache.get(build_entry_key(version, persona_id, is_admin, user_group_ids))
     except CACHE_TRANSIENT_ERRORS:
         logger.warning("LLM provider listing cache read failed", exc_info=True)
-        return None
+        return ProviderListingCacheLookup(response=None, version=None)
 
     if raw is None:
-        return None
+        return ProviderListingCacheLookup(response=None, version=version)
 
     try:
-        return LLMProviderResponse[LLMProviderDescriptor].model_validate_json(raw)
+        return ProviderListingCacheLookup(
+            response=LLMProviderResponse[LLMProviderDescriptor].model_validate_json(
+                raw
+            ),
+            version=version,
+        )
     except ValidationError:
         logger.warning(
             "Discarding cached LLM provider listing that failed validation",
             exc_info=True,
         )
-        return None
+        return ProviderListingCacheLookup(response=None, version=version)
 
 
 def cache_provider_listing(
@@ -94,13 +111,14 @@ def cache_provider_listing(
     is_admin: bool,
     user_group_ids: set[int],
     response: LLMProviderResponse[LLMProviderDescriptor],
+    version: str | None,
 ) -> None:
+    if version is None:
+        return
     try:
         cache = get_cache_backend()
         cache.set(
-            build_entry_key(
-                _current_version(cache), persona_id, is_admin, user_group_ids
-            ),
+            build_entry_key(version, persona_id, is_admin, user_group_ids),
             response.model_dump_json(),
             ex=ENTRY_TTL_SECONDS,
         )

--- a/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
@@ -211,3 +211,24 @@ def test_cache_failures_are_non_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
         version="v1",
     )
     provider_cache.invalidate_provider_listing_cache()
+
+
+def test_corrupted_version_key_self_heals(fake_cache: _FakeCache) -> None:
+    fake_cache._vals["llm_provider_listing:version"] = b"\xff\xfe"
+
+    lookup = provider_cache.get_cached_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set()
+    )
+    assert lookup.response is None
+    assert lookup.version is not None
+
+    response = _make_response()
+    _lookup_and_fill(
+        persona_id=None, is_admin=False, user_group_ids=set(), response=response
+    )
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        ).response
+        == response
+    )

--- a/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
@@ -1,0 +1,164 @@
+import pytest
+from redis.exceptions import RedisError
+
+from onyx.server.manage.llm import provider_cache
+from onyx.server.manage.llm.models import DefaultModel
+from onyx.server.manage.llm.models import LLMProviderDescriptor
+from onyx.server.manage.llm.models import LLMProviderResponse
+
+
+class _FakeCache:
+    def __init__(self) -> None:
+        self._vals: dict[str, bytes] = {}
+
+    def get(self, key: str) -> bytes | None:
+        return self._vals.get(key)
+
+    def set(
+        self,
+        key: str,
+        value: str | bytes,
+        ex: int | None = None,  # noqa: ARG002
+    ) -> None:
+        self._vals[key] = value.encode("utf-8") if isinstance(value, str) else value
+
+
+class _BrokenCache:
+    def get(self, key: str) -> bytes | None:  # noqa: ARG002
+        raise RedisError("redis down")
+
+    def set(
+        self,
+        key: str,  # noqa: ARG002
+        value: str | bytes,  # noqa: ARG002
+        ex: int | None = None,  # noqa: ARG002
+    ) -> None:
+        raise RedisError("redis down")
+
+
+def _make_response() -> LLMProviderResponse[LLMProviderDescriptor]:
+    descriptor = LLMProviderDescriptor(
+        id=1,
+        name="openai",
+        provider="openai",
+        provider_display_name="OpenAI",
+        model_configurations=[],
+    )
+    return LLMProviderResponse[LLMProviderDescriptor].from_models(
+        providers=[descriptor],
+        default_text=DefaultModel(provider_id=1, model_name="gpt-5-mini"),
+        default_vision=None,
+    )
+
+
+@pytest.fixture
+def fake_cache(monkeypatch: pytest.MonkeyPatch) -> _FakeCache:
+    cache = _FakeCache()
+    monkeypatch.setattr(provider_cache, "get_cache_backend", lambda: cache)
+    return cache
+
+
+@pytest.mark.usefixtures("fake_cache")
+def test_miss_returns_none() -> None:
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        )
+        is None
+    )
+
+
+@pytest.mark.usefixtures("fake_cache")
+def test_round_trip() -> None:
+    response = _make_response()
+    provider_cache.cache_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids={3, 1}, response=response
+    )
+    cached = provider_cache.get_cached_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids={1, 3}
+    )
+    assert cached == response
+
+
+@pytest.mark.usefixtures("fake_cache")
+def test_key_isolation_across_users_and_personas() -> None:
+    response = _make_response()
+    provider_cache.cache_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids={1}, response=response
+    )
+
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids={2}
+        )
+        is None
+    )
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=True, user_group_ids={1}
+        )
+        is None
+    )
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=7, is_admin=False, user_group_ids={1}
+        )
+        is None
+    )
+
+
+@pytest.mark.usefixtures("fake_cache")
+def test_invalidation_drops_all_entries() -> None:
+    response = _make_response()
+    provider_cache.cache_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set(), response=response
+    )
+    provider_cache.cache_provider_listing(
+        persona_id=7, is_admin=True, user_group_ids=set(), response=response
+    )
+
+    provider_cache.invalidate_provider_listing_cache()
+
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        )
+        is None
+    )
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=7, is_admin=True, user_group_ids=set()
+        )
+        is None
+    )
+
+
+def test_invalid_cached_payload_is_discarded(fake_cache: _FakeCache) -> None:
+    provider_cache.cache_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set(), response=_make_response()
+    )
+    for key in list(fake_cache._vals):
+        if key.startswith("llm_provider_listing:entry"):
+            fake_cache._vals[key] = b'{"providers": "not-a-list"}'
+
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        )
+        is None
+    )
+
+
+def test_cache_failures_are_non_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(provider_cache, "get_cache_backend", lambda: _BrokenCache())
+
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        )
+        is None
+    )
+    provider_cache.cache_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set(), response=_make_response()
+    )
+    provider_cache.invalidate_provider_listing_cache()

--- a/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_provider_cache.py
@@ -51,6 +51,25 @@ def _make_response() -> LLMProviderResponse[LLMProviderDescriptor]:
     )
 
 
+def _lookup_and_fill(
+    persona_id: int | None,
+    is_admin: bool,
+    user_group_ids: set[int],
+    response: LLMProviderResponse[LLMProviderDescriptor],
+) -> None:
+    lookup = provider_cache.get_cached_provider_listing(
+        persona_id=persona_id, is_admin=is_admin, user_group_ids=user_group_ids
+    )
+    assert lookup.response is None
+    provider_cache.cache_provider_listing(
+        persona_id=persona_id,
+        is_admin=is_admin,
+        user_group_ids=user_group_ids,
+        response=response,
+        version=lookup.version,
+    )
+
+
 @pytest.fixture
 def fake_cache(monkeypatch: pytest.MonkeyPatch) -> _FakeCache:
     cache = _FakeCache()
@@ -60,49 +79,48 @@ def fake_cache(monkeypatch: pytest.MonkeyPatch) -> _FakeCache:
 
 @pytest.mark.usefixtures("fake_cache")
 def test_miss_returns_none() -> None:
-    assert (
-        provider_cache.get_cached_provider_listing(
-            persona_id=None, is_admin=False, user_group_ids=set()
-        )
-        is None
+    lookup = provider_cache.get_cached_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set()
     )
+    assert lookup.response is None
+    assert lookup.version is not None
 
 
 @pytest.mark.usefixtures("fake_cache")
 def test_round_trip() -> None:
     response = _make_response()
-    provider_cache.cache_provider_listing(
+    _lookup_and_fill(
         persona_id=None, is_admin=False, user_group_ids={3, 1}, response=response
     )
     cached = provider_cache.get_cached_provider_listing(
         persona_id=None, is_admin=False, user_group_ids={1, 3}
     )
-    assert cached == response
+    assert cached.response == response
 
 
 @pytest.mark.usefixtures("fake_cache")
 def test_key_isolation_across_users_and_personas() -> None:
     response = _make_response()
-    provider_cache.cache_provider_listing(
+    _lookup_and_fill(
         persona_id=None, is_admin=False, user_group_ids={1}, response=response
     )
 
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=None, is_admin=False, user_group_ids={2}
-        )
+        ).response
         is None
     )
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=None, is_admin=True, user_group_ids={1}
-        )
+        ).response
         is None
     )
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=7, is_admin=False, user_group_ids={1}
-        )
+        ).response
         is None
     )
 
@@ -110,10 +128,10 @@ def test_key_isolation_across_users_and_personas() -> None:
 @pytest.mark.usefixtures("fake_cache")
 def test_invalidation_drops_all_entries() -> None:
     response = _make_response()
-    provider_cache.cache_provider_listing(
+    _lookup_and_fill(
         persona_id=None, is_admin=False, user_group_ids=set(), response=response
     )
-    provider_cache.cache_provider_listing(
+    _lookup_and_fill(
         persona_id=7, is_admin=True, user_group_ids=set(), response=response
     )
 
@@ -122,19 +140,19 @@ def test_invalidation_drops_all_entries() -> None:
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=None, is_admin=False, user_group_ids=set()
-        )
+        ).response
         is None
     )
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=7, is_admin=True, user_group_ids=set()
-        )
+        ).response
         is None
     )
 
 
 def test_invalid_cached_payload_is_discarded(fake_cache: _FakeCache) -> None:
-    provider_cache.cache_provider_listing(
+    _lookup_and_fill(
         persona_id=None, is_admin=False, user_group_ids=set(), response=_make_response()
     )
     for key in list(fake_cache._vals):
@@ -144,7 +162,35 @@ def test_invalid_cached_payload_is_discarded(fake_cache: _FakeCache) -> None:
     assert (
         provider_cache.get_cached_provider_listing(
             persona_id=None, is_admin=False, user_group_ids=set()
-        )
+        ).response
+        is None
+    )
+
+
+@pytest.mark.usefixtures("fake_cache")
+def test_stale_fill_after_invalidation_is_unreachable() -> None:
+    """A fill races an invalidation: the reader looked up (and read the DB)
+    before a mutation flipped the version token. Its write must land under the
+    old token and never be served."""
+    lookup = provider_cache.get_cached_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set()
+    )
+    assert lookup.response is None
+
+    provider_cache.invalidate_provider_listing_cache()
+
+    provider_cache.cache_provider_listing(
+        persona_id=None,
+        is_admin=False,
+        user_group_ids=set(),
+        response=_make_response(),
+        version=lookup.version,
+    )
+
+    assert (
+        provider_cache.get_cached_provider_listing(
+            persona_id=None, is_admin=False, user_group_ids=set()
+        ).response
         is None
     )
 
@@ -152,13 +198,16 @@ def test_invalid_cached_payload_is_discarded(fake_cache: _FakeCache) -> None:
 def test_cache_failures_are_non_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(provider_cache, "get_cache_backend", lambda: _BrokenCache())
 
-    assert (
-        provider_cache.get_cached_provider_listing(
-            persona_id=None, is_admin=False, user_group_ids=set()
-        )
-        is None
+    lookup = provider_cache.get_cached_provider_listing(
+        persona_id=None, is_admin=False, user_group_ids=set()
     )
+    assert lookup.response is None
+    assert lookup.version is None
     provider_cache.cache_provider_listing(
-        persona_id=None, is_admin=False, user_group_ids=set(), response=_make_response()
+        persona_id=None,
+        is_admin=False,
+        user_group_ids=set(),
+        response=_make_response(),
+        version="v1",
     )
     provider_cache.invalidate_provider_listing_cache()


### PR DESCRIPTION
## Description

`GET /llm/provider` and `GET /llm/persona/{id}/providers` rebuild the same descriptor payload from Postgres on every chat page load — ~2.7s p90 in-handler in cloud (descriptor construction over providers × model configurations), stacking under peak concurrency until it trips the functional-frontend uptime monitor.

Fix: memoize the final response in the tenant-scoped cache backend (Redis; Postgres on Lite).

- Keyed by persona / admin status / group memberships — authz semantics unchanged (persona existence + access still checked per-request; groups are part of the key).
- Entries namespaced by a per-tenant version token; LLM provider mutation endpoints (PUT/DELETE provider, defaults, image-gen configs) rewrite it.
- 60s TTL bounds staleness for writes that bypass those endpoints (persona default-model edits, auto-mode sync, seeding).
- Cache failures fall through to Postgres.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check