### PR TITLE
fix(craft): always register all supported providers in opencode config

### DIFF
--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -67,6 +67,11 @@ ENABLE_CRAFT = os.environ.get("ENABLE_CRAFT", "false").lower() == "true"
 # shared recommended-models config (served via /build/recommended-models).
 BUILD_MODE_ALLOWED_PROVIDER_TYPES = ["anthropic", "openai", "openrouter"]
 
+# apiKey sentinel for a supported provider the org hasn't configured. We register
+# every supported provider so a cross-provider override never hits "model not
+# found"; an unconfigured one fails closed instead (proxy 403 / upstream 401).
+BUILD_MODE_NOT_CONFIGURED_API_KEY = "onyx-provider-not-configured"
+
 # Dev/debug-only: exposes an SSE endpoint that tails the sandbox pod's
 # opencode-serve container logs. Never enable in prod — the logs include LLM I/O
 # and tool invocations that may contain sensitive data. When false, the endpoint

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -133,7 +133,7 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
     generate_agent_instructions,
 )
 from onyx.server.features.build.sandbox.util.opencode_config import (
-    build_opencode_config,
+    build_multi_provider_opencode_config,
 )
 from onyx.utils.logger import setup_logger
 
@@ -224,6 +224,30 @@ def _sandbox_container_name(sandbox_id: str | UUID) -> str:
 def _sandbox_volume_name(sandbox_id: str | UUID) -> str:
     """Per-sandbox named volume holding ``/workspace/sessions``."""
     return f"{SANDBOX_DOCKER_VOLUME_PREFIX}{str(sandbox_id)[:8]}"
+
+
+def _container_llm_configs(
+    all_llm_configs: list[LLMProviderConfig] | None,
+    llm_config: LLMProviderConfig,
+    *,
+    proxy_enabled: bool,
+) -> list[LLMProviderConfig]:
+    """Provider configs to bake into the container's opencode.json.
+
+    The Docker analog of K8s ``_placeholder_llm_configs``: when the egress proxy
+    is enabled, real keys are swapped for the placeholder (the proxy injects the
+    live key on the wire); ``api_key=None`` providers (e.g. Ollama) are left
+    untouched so the placeholder never reaches the LLM.
+    """
+    configs = all_llm_configs or [llm_config]
+    if not proxy_enabled:
+        return configs
+    return [
+        c.model_copy(update={"api_key": SANDBOX_PROXY_INJECTED_PLACEHOLDER})
+        if c.api_key
+        else c
+        for c in configs
+    ]
 
 
 def _sanitize_relative_path(path: str) -> str:
@@ -716,18 +740,6 @@ class DockerSandboxManager(SandboxManager):
                 "SANDBOX_API_SERVER_URL must be set for Docker sandbox provisioning."
             )
 
-        if all_llm_configs is not None and len(all_llm_configs) > 1:
-            # Docker is single-provider today: per-prompt agent_provider
-            # overrides will fail at opencode-serve with "provider not
-            # registered". Warn now so operators see it before the first turn.
-            logger.warning(
-                "DockerSandboxManager.provision received %d LLM configs but only the primary "
-                "provider %r is bootstrapped; per-prompt provider overrides will fail until Docker "
-                "grows multi-provider support.",
-                len(all_llm_configs),
-                llm_config.provider,
-            )
-
         logger.info(
             "Provisioning Docker sandbox %s for user %s, tenant %s.",
             sandbox_id,
@@ -759,19 +771,14 @@ class DockerSandboxManager(SandboxManager):
             container_onyx_pat = (
                 SANDBOX_PROXY_INJECTED_PLACEHOLDER if SANDBOX_PROXY_HOST else onyx_pat
             )
-            # api_key=None (e.g. Ollama) -> skip; The resolver has nothing to
-            # swap and the placeholder would reach the LLM verbatim.
-            container_llm_api_key = (
-                SANDBOX_PROXY_INJECTED_PLACEHOLDER
-                if SANDBOX_PROXY_HOST and llm_config.api_key
-                else llm_config.api_key
+            provider_configs = _container_llm_configs(
+                all_llm_configs, llm_config, proxy_enabled=bool(SANDBOX_PROXY_HOST)
             )
             opencode_config_json = json.dumps(
-                build_opencode_config(
-                    provider=llm_config.provider,
-                    model_name=llm_config.model_name,
-                    api_key=container_llm_api_key,
-                    api_base=llm_config.api_base,
+                build_multi_provider_opencode_config(
+                    providers=provider_configs,
+                    default_provider=llm_config.provider,
+                    default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
                     plugins=session_tag_plugins,
                 )

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -1,9 +1,10 @@
 """opencode.json builders.
 
 opencode-serve loads config once at startup and does not hot-reload
-(sst/opencode#22213). The K8s + serve path pre-loads every configured
-provider so per-prompt model overrides can cross providers without a
-pod restart; the docker path keeps single-provider per-session config.
+(sst/opencode#22213), so both the K8s and docker paths pre-load every
+supported provider — real key (or proxy placeholder) when configured, dummy
+key otherwise — letting per-prompt model overrides cross providers without a
+restart.
 """
 
 from typing import Any

--- a/backend/onyx/server/features/build/session/llm_config.py
+++ b/backend/onyx/server/features/build/session/llm_config.py
@@ -12,6 +12,7 @@ from onyx.llm.well_known_providers.llm_provider_options import (
     fetch_default_model_for_provider,
 )
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from onyx.server.features.build.configs import BUILD_MODE_NOT_CONFIGURED_API_KEY
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.utils.logger import setup_logger
@@ -87,13 +88,15 @@ def get_all_build_mode_llm_configs(
     providers: list[LLMProviderView],
     default: LLMProviderConfig,
 ) -> list[LLMProviderConfig]:
-    """``default`` first, then one config per other supported provider type
-    from ``providers``. Used at provision time so every configured provider
-    is pre-registered in opencode.json and per-prompt model overrides can
-    cross providers without a pod restart.
+    """Every supported provider type, ``default`` first — the org's real config
+    when present, else a dummy-key placeholder. Registering all types keeps the
+    opencode.json set independent of the org's configured providers, so a
+    per-prompt cross-provider override never hits "model not found"; an
+    unconfigured provider fails closed via the dummy key.
     """
     configs: list[LLMProviderConfig] = [default]
     seen: set[str] = {default.provider}
+
     for provider in providers:
         if provider.provider in seen:
             continue
@@ -102,4 +105,21 @@ def get_all_build_mode_llm_configs(
             continue
         seen.add(provider.provider)
         configs.append(_config_from_provider(provider, model_name))
+
+    # Backfill supported types the org hasn't configured with a dummy-key entry.
+    for provider_type in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
+        if provider_type in seen:
+            continue
+        model_name = fetch_default_model_for_provider(provider_type)
+        if model_name is None:
+            continue
+        seen.add(provider_type)
+        configs.append(
+            LLMProviderConfig(
+                provider=provider_type,
+                model_name=model_name,
+                api_key=BUILD_MODE_NOT_CONFIGURED_API_KEY,
+                api_base=None,
+            )
+        )
     return configs

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_multi_provider_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_multi_provider_config.py
@@ -1,0 +1,96 @@
+"""The Docker manager bakes a multi-provider opencode.json at container start.
+
+Every supported provider must be registered so a per-prompt cross-provider
+override never hits "model not found". When the egress proxy is enabled, real
+keys are swapped for the placeholder (the proxy injects the live key on the
+wire); without the proxy, keys (including the not-configured dummy) are baked
+verbatim so an unconfigured provider fails closed upstream (401).
+"""
+
+from __future__ import annotations
+
+import json
+
+import onyx.server.features.build.sandbox.docker.docker_sandbox_manager as dsm
+from onyx.server.features.build.configs import BUILD_MODE_NOT_CONFIGURED_API_KEY
+from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.util.opencode_config import (
+    build_multi_provider_opencode_config,
+)
+
+_REAL_KEY = "sk-real-secret-do-not-ship"
+
+
+def _config(
+    provider: str, api_key: str | None, api_base: str | None = None
+) -> LLMProviderConfig:
+    return LLMProviderConfig(
+        provider=provider, model_name="m", api_key=api_key, api_base=api_base
+    )
+
+
+_OPENAI = _config("openai", _REAL_KEY)
+_ANTHROPIC_CONFIGURED = _config("anthropic", _REAL_KEY)
+_OPENROUTER_DUMMY = _config("openrouter", BUILD_MODE_NOT_CONFIGURED_API_KEY)
+
+
+def test_all_configs_registered_no_proxy_keeps_keys_verbatim() -> None:
+    configs = dsm._container_llm_configs(
+        [_OPENAI, _ANTHROPIC_CONFIGURED, _OPENROUTER_DUMMY],
+        _OPENAI,
+        proxy_enabled=False,
+    )
+    by = {c.provider: c for c in configs}
+    assert set(by) == {"openai", "anthropic", "openrouter"}
+    # Real keys stay real (the proxy isn't there to inject them)...
+    assert by["openai"].api_key == _REAL_KEY
+    assert by["anthropic"].api_key == _REAL_KEY
+    # ...and the unconfigured provider keeps its dummy key -> fails closed (401).
+    assert by["openrouter"].api_key == BUILD_MODE_NOT_CONFIGURED_API_KEY
+
+
+def test_proxy_swaps_real_keys_for_placeholder() -> None:
+    configs = dsm._container_llm_configs(
+        [_OPENAI, _ANTHROPIC_CONFIGURED, _OPENROUTER_DUMMY],
+        _OPENAI,
+        proxy_enabled=True,
+    )
+    # Every truthy key (real AND the dummy) becomes the placeholder; on K8s/proxy
+    # the proxy decides per-provider whether a real key exists.
+    assert all(c.api_key == SANDBOX_PROXY_INJECTED_PLACEHOLDER for c in configs)
+    # Non-secret routing inputs survive.
+    assert {c.provider for c in configs} == {"openai", "anthropic", "openrouter"}
+
+
+def test_keyless_provider_stays_keyless_under_proxy() -> None:
+    # api_key=None (e.g. Ollama) must not get the placeholder, or it would reach
+    # the LLM verbatim.
+    configs = dsm._container_llm_configs(
+        [_config("ollama", None)], _config("ollama", None), proxy_enabled=True
+    )
+    assert configs[0].api_key is None
+
+
+def test_falls_back_to_single_config_when_all_is_none() -> None:
+    configs = dsm._container_llm_configs(None, _OPENAI, proxy_enabled=False)
+    assert configs == [_OPENAI]
+
+
+def test_rendered_config_registers_every_provider_and_leaks_no_real_key() -> None:
+    configs = dsm._container_llm_configs(
+        [_OPENAI, _ANTHROPIC_CONFIGURED, _OPENROUTER_DUMMY],
+        _OPENAI,
+        proxy_enabled=True,
+    )
+    config = build_multi_provider_opencode_config(
+        providers=configs,
+        default_provider="openai",
+        default_model="m",
+    )
+    # All three providers enabled so per-prompt overrides can target any of them.
+    assert set(config["enabled_providers"]) == {"openai", "anthropic", "openrouter"}
+    # Single prefix, no double-prefix.
+    assert config["model"] == "openai/m"
+    # No real key shipped to the container under the proxy posture.
+    assert _REAL_KEY not in json.dumps(config)

--- a/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py
@@ -24,6 +24,8 @@ from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
 from onyx.db.models import User
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from onyx.server.features.build.configs import BUILD_MODE_NOT_CONFIGURED_API_KEY
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.llm_config import get_all_build_mode_llm_configs
@@ -90,12 +92,35 @@ def _run(rows: list[LLMProviderView]) -> list[LLMProviderConfig]:
     return get_all_build_mode_llm_configs(rows, _OPENAI_DEFAULT)
 
 
-class TestGetAllBuildModeLlmConfigs:
-    def test_default_only_when_no_build_mode_rows(self) -> None:
-        configs = _run([])
-        assert configs == [_OPENAI_DEFAULT]
+def _by_provider(
+    configs: list[LLMProviderConfig],
+) -> dict[str, LLMProviderConfig]:
+    return {c.provider: c for c in configs}
 
-    def test_includes_build_mode_provider_with_visible_model(self) -> None:
+
+class TestGetAllBuildModeLlmConfigs:
+    """The config list is the set baked into ``OPENCODE_CONFIG_CONTENT``.
+
+    Every supported provider type is ALWAYS present so a per-prompt cross-
+    provider override can never hit "model not found"; types the org hasn't
+    configured are registered with the dummy key
+    (``BUILD_MODE_NOT_CONFIGURED_API_KEY``) and fail closed on use.
+    """
+
+    def test_all_supported_types_present_when_no_build_mode_rows(self) -> None:
+        configs = _run([])
+        # Default (real openai) first, then dummy entries for the other
+        # supported types.
+        assert configs[0] == _OPENAI_DEFAULT
+        by = _by_provider(configs)
+        assert set(by) == set(BUILD_MODE_ALLOWED_PROVIDER_TYPES)
+        for ptype in BUILD_MODE_ALLOWED_PROVIDER_TYPES:
+            if ptype == "openai":
+                continue
+            assert by[ptype].api_key == BUILD_MODE_NOT_CONFIGURED_API_KEY
+            assert by[ptype].model_name == _TEST_RECOMMENDED_BY_TYPE[ptype]
+
+    def test_configured_provider_uses_real_key_unconfigured_uses_dummy(self) -> None:
         configs = _run(
             [
                 _provider(
@@ -106,13 +131,20 @@ class TestGetAllBuildModeLlmConfigs:
                 )
             ]
         )
-        assert [(c.provider, c.model_name) for c in configs] == [
-            ("openai", "gpt-4o"),
-            ("anthropic", "claude-opus-4-8"),
-        ]
-        assert configs[1].api_key == "k-anthropic"
+        by = _by_provider(configs)
+        # All supported types registered.
+        assert set(by) == set(BUILD_MODE_ALLOWED_PROVIDER_TYPES)
+        # Configured anthropic carries its real key + recommended model.
+        assert by["anthropic"].api_key == "k-anthropic"
+        assert by["anthropic"].model_name == "claude-opus-4-8"
+        # openrouter is unconfigured -> dummy key.
+        assert by["openrouter"].api_key == BUILD_MODE_NOT_CONFIGURED_API_KEY
 
-    def test_skips_build_mode_provider_with_no_visible_models(self) -> None:
+    def test_unconfigured_type_with_hidden_models_still_registered_as_dummy(
+        self,
+    ) -> None:
+        # A provider with no *visible* model isn't usable as a real config, so it
+        # is backfilled as a dummy entry like any other unconfigured type.
         configs = _run(
             [
                 _provider(
@@ -122,19 +154,10 @@ class TestGetAllBuildModeLlmConfigs:
                 )
             ]
         )
-        assert configs == [_OPENAI_DEFAULT]
-
-    def test_skips_build_mode_provider_with_empty_model_list(self) -> None:
-        configs = _run(
-            [
-                _provider(
-                    name="Anthropic",
-                    provider="anthropic",
-                    models=[],
-                )
-            ]
-        )
-        assert configs == [_OPENAI_DEFAULT]
+        by = _by_provider(configs)
+        assert set(by) == set(BUILD_MODE_ALLOWED_PROVIDER_TYPES)
+        assert by["anthropic"].api_key == BUILD_MODE_NOT_CONFIGURED_API_KEY
+        assert by["anthropic"].model_name == _TEST_RECOMMENDED_BY_TYPE["anthropic"]
 
     def test_prefers_recommended_model_over_first_visible(self) -> None:
         # Anthropic's recommended model wins even though it isn't first in the list.
@@ -148,40 +171,31 @@ class TestGetAllBuildModeLlmConfigs:
                         _model("claude-opus-4-8"),
                         _model("claude-sonnet-4-6"),
                     ],
+                    api_key="k-anthropic",
                 )
             ]
         )
-        assert configs[1].model_name == "claude-opus-4-8"
+        assert _by_provider(configs)["anthropic"].model_name == "claude-opus-4-8"
 
-    def test_uses_first_visible_for_type_without_recommended(self) -> None:
-        # A provider type with no recommended-model entry falls back to first visible.
+    def test_extra_configured_type_kept_alongside_dummy_backfill(self) -> None:
+        # A configured provider whose type isn't in the supported list is still
+        # included (real key), AND the supported types are all backfilled.
         configs = _run(
             [
                 _provider(
                     name="Google",
                     provider="google",
                     models=[_model("gemini-2.5-pro"), _model("gemini-2.5-flash")],
+                    api_key="k-google",
                 )
             ]
         )
-        assert configs[1].model_name == "gemini-2.5-pro"
-
-    def test_skips_hidden_models_when_picking_first(self) -> None:
-        # A provider type without a recommended-model entry falls back to the
-        # first *visible* model, skipping hidden ones.
-        configs = _run(
-            [
-                _provider(
-                    name="Google",
-                    provider="google",
-                    models=[
-                        _model("gemini-hidden", is_visible=False),
-                        _model("gemini-2.5-pro"),
-                    ],
-                )
-            ]
-        )
-        assert configs[1].model_name == "gemini-2.5-pro"
+        by = _by_provider(configs)
+        assert by["google"].api_key == "k-google"
+        assert by["google"].model_name == "gemini-2.5-pro"
+        # Every supported type is present too.
+        assert set(BUILD_MODE_ALLOWED_PROVIDER_TYPES).issubset(set(by))
+        assert by["anthropic"].api_key == BUILD_MODE_NOT_CONFIGURED_API_KEY
 
     def test_dedupes_when_default_provider_also_in_build_mode_rows(self) -> None:
         """If the default's provider type is also tagged as build-mode, we
@@ -196,9 +210,12 @@ class TestGetAllBuildModeLlmConfigs:
                 )
             ]
         )
-        assert configs == [_OPENAI_DEFAULT]
+        by = _by_provider(configs)
         # The default's api_key wins; we never overwrite with the build-mode row's.
-        assert configs[0].api_key == "k-openai"
+        assert by["openai"] == _OPENAI_DEFAULT
+        assert by["openai"].api_key == "k-openai"
+        # openai appears exactly once.
+        assert [c.provider for c in configs].count("openai") == 1
 
     def test_multiple_distinct_build_mode_providers(self) -> None:
         configs = _run(
@@ -207,19 +224,22 @@ class TestGetAllBuildModeLlmConfigs:
                     name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-8")],
+                    api_key="k-anthropic",
                 ),
                 _provider(
-                    name="Google",
-                    provider="google",
-                    models=[_model("gemini-2.5-pro")],
+                    name="OpenRouter",
+                    provider="openrouter",
+                    models=[_model("minimax/minimax-m3")],
+                    api_key="k-openrouter",
                 ),
             ]
         )
-        assert [(c.provider, c.model_name) for c in configs] == [
-            ("openai", "gpt-4o"),
-            ("anthropic", "claude-opus-4-8"),
-            ("google", "gemini-2.5-pro"),
-        ]
+        by = _by_provider(configs)
+        # All real, no dummy entries needed.
+        assert by["openai"].api_key == "k-openai"
+        assert by["anthropic"].api_key == "k-anthropic"
+        assert by["openrouter"].api_key == "k-openrouter"
+        assert BUILD_MODE_NOT_CONFIGURED_API_KEY not in {c.api_key for c in configs}
 
     def test_default_provider_preserved_first(self) -> None:
         """Default always stays at index 0 regardless of fetched-row order."""
@@ -229,10 +249,27 @@ class TestGetAllBuildModeLlmConfigs:
                     name="Anthropic",
                     provider="anthropic",
                     models=[_model("claude-opus-4-7")],
+                    api_key="k-anthropic",
                 )
             ]
         )
         assert configs[0] == _OPENAI_DEFAULT
+
+    def test_no_duplicate_provider_blocks(self) -> None:
+        # opencode.json uses one block per providerID; the result must never
+        # contain a type twice (else build_multi_provider_opencode_config raises).
+        configs = _run(
+            [
+                _provider(
+                    name="Anthropic",
+                    provider="anthropic",
+                    models=[_model("claude-opus-4-8")],
+                    api_key="k-anthropic",
+                )
+            ]
+        )
+        provider_types = [c.provider for c in configs]
+        assert len(provider_types) == len(set(provider_types))
 
 
 class TestGetLlmConfigFallback:


### PR DESCRIPTION
## Description

Per-turn cross-provider model overrides in Craft failed with **"Model not found: `<provider>/<model>`"** when the requested provider wasn't baked into the sandbox's opencode config at provision time.

Root cause: opencode reads its provider config from `OPENCODE_CONFIG_CONTENT` (K8s) / the container env (Docker) **once at pod/container start**, and the set we baked was derived from the org's *configured* providers at that moment. So the config drifted — a sandbox provisioned when only OpenAI was configured could never serve a later Anthropic override, and K8s can't refresh a running container's env.

Fix: make the provider set **independent of org state**. `get_all_build_mode_llm_configs` now always registers every `BUILD_MODE_ALLOWED_PROVIDER_TYPES` — real config when the org has it, else a dummy-key placeholder (`BUILD_MODE_NOT_CONFIGURED_API_KEY`). A cross-provider override can therefore never hit "model not found", and a turn targeting an unconfigured provider **fails closed** — egress-proxy 403 on K8s (no real key to inject), upstream 401 on Docker — surfacing as a real terminating error instead of confusing failures or indefinite keepalives.

- **K8s**: already builds the config from the full `all_llm_configs` list, so it picks up the expanded set with no manager changes.
- **Docker**: previously *ignored* `all_llm_configs` and baked a single-provider config (with a warning that overrides "will fail until Docker grows multi-provider support"). Switched to the multi-provider builder via a new testable `_container_llm_configs` helper (the Docker analog of K8s's `_placeholder_llm_configs`), which also fixes the single-provider regression there.

No new provider/model parsing scheme — provider and model are still passed separately; the config `model` stays a single `provider/model` (no double-prefix).

### Not in scope
Sandboxes provisioned **before** this change keep their frozen env until they recycle (sleep/terminate/re-provision); new sandboxes are immune. Auto-recreation of legacy pods (snapshot→recreate→restore) was discussed and intentionally deferred.

## How Has This Been Tested?

Unit tests (`uv run pytest`, all green):
- `test_get_all_build_mode_llm_configs.py` — rewritten for the new contract: all supported types always present, real key for configured, dummy key for unconfigured, default preserved first, no duplicate provider blocks.
- `test_docker_multi_provider_config.py` (new) — `_container_llm_configs` registers every provider; proxy swaps real keys for the placeholder while leaving keyless providers untouched; no-proxy keeps keys (incl. the dummy) verbatim; rendered config enables all providers, leaks no real key, single `provider/model` prefix.
- Existing `test_opencode_config.py` / `test_opencode_key_ripout.py` / `test_docker_manager_config.py` / proxy `test_llm_provider_key_resolver.py` (fail-closed → 403) still pass.

No live Docker craft stack was available in this environment to exercise an end-to-end cross-provider turn.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always register all supported LLM providers in sandbox `opencode.json` so cross‑provider overrides never hit “Model not found”. Unconfigured providers are included with a dummy key and fail closed (proxy 403; Docker 401).

- **Bug Fixes**
  - `get_all_build_mode_llm_configs` now returns the default plus every supported provider type: configured types keep real keys; others use the dummy `BUILD_MODE_NOT_CONFIGURED_API_KEY`. Default stays first; no duplicate provider blocks.
  - Docker now bakes a multi‑provider config via `build_multi_provider_opencode_config`. `_container_llm_configs` preloads all providers and, when the proxy is on, swaps any non‑empty key for `SANDBOX_PROXY_INJECTED_PLACEHOLDER` (keyless providers stay keyless); without proxy, keys are kept verbatim.

- **Refactors**
  - Added `BUILD_MODE_NOT_CONFIGURED_API_KEY` and the `_container_llm_configs` helper. New `test_docker_multi_provider_config` and updated `test_get_all_build_mode_llm_configs`.

<sup>Written for commit 6e96cbffec44a48d6574c9f3fdffca1613d9e44a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

