### PR TITLE
feat(security): cross-process cache invalidation for runtime security settings

### DIFF
--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -1,4 +1,5 @@
 import abc
+from collections.abc import Iterator
 from enum import Enum
 
 from redis.exceptions import RedisError
@@ -115,3 +116,28 @@ class CacheBackend(abc.ABC):
         Returns ``(key, value)`` or ``None`` on timeout.
         """
         raise NotImplementedError
+
+    # -- pub/sub -----------------------------------------------------------
+    #
+    # Not abstract: only backends that genuinely support pub/sub override these.
+    # The default raises so callers that depend on pub/sub (e.g. cross-process
+    # cache invalidation) must gate on a backend that supports it rather than
+    # silently no-op'ing. Channels are global to the cache instance and are NOT
+    # tenant-prefixed — carry any tenant scope in the message payload.
+
+    def publish(self, channel: str, message: str | bytes) -> None:
+        """Publish *message* on *channel* to all subscribers.
+
+        Channels are not tenant-prefixed; every subscriber across all tenants
+        and processes receives the message.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support pub/sub.")
+
+    def subscribe(self, channel: str) -> Iterator[bytes]:
+        """Subscribe to *channel*, yielding each message payload as ``bytes``.
+
+        Blocks the calling thread between messages, so callers should run this
+        on a dedicated thread. Raises on connection loss; callers are expected
+        to reconnect.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support pub/sub.")

--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -119,25 +119,16 @@ class CacheBackend(abc.ABC):
 
     # -- pub/sub -----------------------------------------------------------
     #
-    # Not abstract: only backends that genuinely support pub/sub override these.
-    # The default raises so callers that depend on pub/sub (e.g. cross-process
-    # cache invalidation) must gate on a backend that supports it rather than
-    # silently no-op'ing. Channels are global to the cache instance and are NOT
-    # tenant-prefixed — carry any tenant scope in the message payload.
+    # Non-abstract so non-pub/sub backends (and test fakes) need not implement
+    # them; the default raises so dependent callers gate on a supporting backend
+    # rather than silently no-op'ing. Channels are global (not tenant-prefixed) —
+    # carry tenant scope in the payload.
 
     def publish(self, channel: str, message: str | bytes) -> None:
-        """Publish *message* on *channel* to all subscribers.
-
-        Channels are not tenant-prefixed; every subscriber across all tenants
-        and processes receives the message.
-        """
+        """Publish *message* on *channel* to all subscribers."""
         raise NotImplementedError(f"{type(self).__name__} does not support pub/sub.")
 
     def subscribe(self, channel: str) -> Iterator[bytes]:
-        """Subscribe to *channel*, yielding each message payload as ``bytes``.
-
-        Blocks the calling thread between messages, so callers should run this
-        on a dedicated thread. Raises on connection loss; callers are expected
-        to reconnect.
-        """
+        """Yield each message payload on *channel* as ``bytes``. Blocks between
+        messages (run on a dedicated thread) and raises on connection loss."""
         raise NotImplementedError(f"{type(self).__name__} does not support pub/sub.")

--- a/backend/onyx/cache/postgres_backend.py
+++ b/backend/onyx/cache/postgres_backend.py
@@ -8,6 +8,7 @@ import hashlib
 import struct
 import time
 import uuid
+from collections.abc import Iterator
 from contextlib import AbstractContextManager
 from datetime import datetime
 from datetime import timedelta
@@ -292,6 +293,22 @@ class PostgresCacheBackend(CacheBackend):
             if time.monotonic() >= deadline:
                 return None
             time.sleep(_BLPOP_POLL_INTERVAL)
+
+    # -- pub/sub -----------------------------------------------------------
+
+    def publish(self, channel: str, message: str | bytes) -> None:
+        raise NotImplementedError(
+            "PostgresCacheBackend does not support pub/sub. Deployments on the "
+            "Postgres cache backend (Onyx Lite) are single-process, so "
+            "cross-process invalidation is unnecessary."
+        )
+
+    def subscribe(self, channel: str) -> Iterator[bytes]:
+        raise NotImplementedError(
+            "PostgresCacheBackend does not support pub/sub. Deployments on the "
+            "Postgres cache backend (Onyx Lite) are single-process, so "
+            "cross-process invalidation is unnecessary."
+        )
 
     # -- helpers -----------------------------------------------------------
 

--- a/backend/onyx/cache/postgres_backend.py
+++ b/backend/onyx/cache/postgres_backend.py
@@ -296,19 +296,13 @@ class PostgresCacheBackend(CacheBackend):
 
     # -- pub/sub -----------------------------------------------------------
 
+    # Single-process (Onyx Lite), so cross-process invalidation is unnecessary.
+
     def publish(self, channel: str, message: str | bytes) -> None:
-        raise NotImplementedError(
-            "PostgresCacheBackend does not support pub/sub. Deployments on the "
-            "Postgres cache backend (Onyx Lite) are single-process, so "
-            "cross-process invalidation is unnecessary."
-        )
+        raise NotImplementedError("PostgresCacheBackend does not support pub/sub.")
 
     def subscribe(self, channel: str) -> Iterator[bytes]:
-        raise NotImplementedError(
-            "PostgresCacheBackend does not support pub/sub. Deployments on the "
-            "Postgres cache backend (Onyx Lite) are single-process, so "
-            "cross-process invalidation is unnecessary."
-        )
+        raise NotImplementedError("PostgresCacheBackend does not support pub/sub.")
 
     # -- helpers -----------------------------------------------------------
 

--- a/backend/onyx/cache/redis_backend.py
+++ b/backend/onyx/cache/redis_backend.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 from redis.lock import Lock as RedisLock
 
 from onyx.cache.interface import CacheBackend
@@ -80,3 +82,32 @@ class RedisCacheBackend(CacheBackend):
 
     def blpop(self, keys: list[str], timeout: int = 0) -> tuple[bytes, bytes] | None:
         return self._r.blpop(keys, timeout=timeout)
+
+    # -- pub/sub -----------------------------------------------------------
+    #
+    # Pub/sub channels are global to the Redis instance, so we deliberately go
+    # through the *raw* (non-prefixed) client: the channel name must be identical
+    # across tenants and processes for everyone to receive a message.
+
+    def publish(self, channel: str, message: str | bytes) -> None:
+        self._r.raw_client.publish(channel, message)
+
+    def subscribe(self, channel: str) -> Iterator[bytes]:
+        pubsub = self._r.raw_client.pubsub()
+        try:
+            pubsub.subscribe(channel)
+            for message in pubsub.listen():
+                # listen() emits a 'subscribe' confirmation first, then 'message'
+                # entries; only the latter carry a payload we care about.
+                if message.get("type") != "message":
+                    continue
+                data = message.get("data")
+                if isinstance(data, bytes):
+                    yield data
+        finally:
+            # Best-effort: the connection may already be dead if we're unwinding
+            # after an error, in which case close() can itself raise.
+            try:
+                pubsub.close()
+            except Exception:
+                pass

--- a/backend/onyx/cache/redis_backend.py
+++ b/backend/onyx/cache/redis_backend.py
@@ -85,9 +85,8 @@ class RedisCacheBackend(CacheBackend):
 
     # -- pub/sub -----------------------------------------------------------
     #
-    # Pub/sub channels are global to the Redis instance, so we deliberately go
-    # through the *raw* (non-prefixed) client: the channel name must be identical
-    # across tenants and processes for everyone to receive a message.
+    # Use the *raw* (non-prefixed) client: pub/sub channels are global, so the
+    # name must be identical across tenants and processes.
 
     def publish(self, channel: str, message: str | bytes) -> None:
         self._r.raw_client.publish(channel, message)
@@ -97,16 +96,14 @@ class RedisCacheBackend(CacheBackend):
         try:
             pubsub.subscribe(channel)
             for message in pubsub.listen():
-                # listen() emits a 'subscribe' confirmation first, then 'message'
-                # entries; only the latter carry a payload we care about.
+                # listen() also emits a 'subscribe' confirmation; skip non-messages.
                 if message.get("type") != "message":
                     continue
                 data = message.get("data")
                 if isinstance(data, bytes):
                     yield data
         finally:
-            # Best-effort: the connection may already be dead if we're unwinding
-            # after an error, in which case close() can itself raise.
+            # close() can itself raise if the connection already died.
             try:
                 pubsub.close()
             except Exception:

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -535,15 +535,12 @@ class OnyxRedisConstants:
 
 
 class OnyxRedisChannels:
-    """Redis pub/sub channel names.
-
-    Channels are global to the Redis instance — they are NOT tenant-prefixed, so
-    every subscribed process across all tenants receives every message. Carry the
-    tenant id (or other scope) in the message payload, not the channel name.
+    """Redis pub/sub channel names — global to the instance, NOT tenant-prefixed.
+    Every subscribed process across all tenants receives every message, so carry
+    any tenant scope in the payload rather than the channel name.
     """
 
-    # Published with a tenant id payload when an admin saves runtime security
-    # settings; subscribers drop that tenant's locally-cached SecuritySettings.
+    # Payload is a tenant id; subscribers drop that tenant's cached SecuritySettings.
     SECURITY_SETTINGS_INVALIDATE = "channel:security_settings_invalidate"
 
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -534,6 +534,19 @@ class OnyxRedisConstants:
     ACTIVE_FENCES = "active_fences"
 
 
+class OnyxRedisChannels:
+    """Redis pub/sub channel names.
+
+    Channels are global to the Redis instance — they are NOT tenant-prefixed, so
+    every subscribed process across all tenants receives every message. Carry the
+    tenant id (or other scope) in the message payload, not the channel name.
+    """
+
+    # Published with a tenant id payload when an admin saves runtime security
+    # settings; subscribers drop that tenant's locally-cached SecuritySettings.
+    SECURITY_SETTINGS_INVALIDATE = "channel:security_settings_invalidate"
+
+
 class OnyxCeleryPriority(int, Enum):
     HIGHEST = 0
     HIGH = auto()

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -7,7 +7,11 @@ from cachetools import TTLCache
 from pydantic import ValidationError
 
 from onyx.cache.factory import get_cache_backend
+from onyx.cache.factory import get_shared_cache_backend
+from onyx.cache.interface import CacheBackendType
 from onyx.configs import app_configs as _cfg
+from onyx.configs.app_configs import CACHE_BACKEND
+from onyx.configs.constants import OnyxRedisChannels
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.security_settings import load_overrides as _db_load_overrides
@@ -25,15 +29,29 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 logger = setup_logger()
 
 
-# Bounds cross-process staleness after an admin save — no pub/sub today, so
-# other api_server processes converge via TTL expiry.
-_CACHE_TTL_SECONDS = 10.0
+# Primary cross-process propagation is Redis pub/sub: an admin save publishes the
+# tenant id on OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE and every process'
+# listener drops its cached entry near-instantly. This long TTL is only the
+# fallback for messages a process missed (e.g. it was reconnecting), so it is
+# bounded staleness of last resort rather than the propagation mechanism.
+_CACHE_TTL_SECONDS = 3600.0
 
 
 _CACHE_LOCK = threading.RLock()
 _CACHE: TTLCache[str, SecuritySettings] = TTLCache(
     maxsize=10_000, ttl=_CACHE_TTL_SECONDS, timer=time.monotonic
 )
+
+
+# Lazily-started, one per process. Guards the pub/sub listener daemon so we only
+# ever run a single subscriber thread regardless of how many callers race in.
+_LISTENER_LOCK = threading.Lock()
+_LISTENER_STARTED = False
+
+# Reconnect backoff for the listener thread: start small, double on repeated
+# failures, cap so a Redis outage can't turn into a hot reconnect loop.
+_LISTENER_RECONNECT_BASE_SECONDS = 5.0
+_LISTENER_RECONNECT_MAX_SECONDS = 30.0
 
 
 # Lock lifetime; held during a single read+merge+write.
@@ -110,7 +128,12 @@ def _store_overrides_unlocked(overrides: SecuritySettingsOverrides) -> None:
         )
     with get_session_with_current_tenant() as db_session:
         _db_upsert_overrides(db_session, overrides)
-    invalidate_security_cache(_current_tenant_id_or_default())
+    tenant_id = _current_tenant_id_or_default()
+    # Local invalidate is the immediate fast path for this process; pub/sub
+    # propagates to every other process. The DB write has already committed, so
+    # neither may fail the save.
+    invalidate_security_cache(tenant_id)
+    _publish_invalidation(tenant_id)
 
 
 def _apply_present_keys(
@@ -180,6 +203,78 @@ def invalidate_security_cache(tenant_id: str) -> None:
         _CACHE.pop(tenant_id, None)
 
 
+def _pubsub_supported() -> bool:
+    """Cross-process invalidation rides on Redis pub/sub. Onyx Lite runs
+    ``CACHE_BACKEND=postgres`` and is single-process anyway, so there local
+    invalidation alone is sufficient and we skip both publish and the listener.
+    """
+    return CACHE_BACKEND == CacheBackendType.REDIS
+
+
+def _publish_invalidation(tenant_id: str) -> None:
+    """Best-effort broadcast of an invalidation to other processes.
+
+    The caller has already committed the DB write and invalidated this process'
+    cache, so a pub/sub failure must never propagate — other processes still
+    converge via the TTL fallback. Logged, not raised.
+    """
+    if not _pubsub_supported():
+        return
+    try:
+        cache = get_shared_cache_backend()
+        cache.publish(OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE, tenant_id)
+    except Exception:
+        logger.exception("Failed to publish security settings invalidation")
+
+
+def _handle_invalidation_message(data: bytes) -> None:
+    """Drop the named tenant from this process' cache. The channel is global, so
+    a message for a tenant we never cached resolves to a harmless no-op pop."""
+    try:
+        tenant_id = data.decode()
+    except Exception:
+        logger.warning("Discarding undecodable security invalidation message")
+        return
+    invalidate_security_cache(tenant_id)
+
+
+def _listen_for_invalidations() -> None:
+    """Daemon loop: subscribe to the shared invalidation channel and apply every
+    message to the local cache. Reconnects with capped exponential backoff on any
+    error so a Redis blip can't become a hot loop. Never returns."""
+    backoff = _LISTENER_RECONNECT_BASE_SECONDS
+    while True:
+        try:
+            cache = get_shared_cache_backend()
+            for data in cache.subscribe(OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE):
+                backoff = _LISTENER_RECONNECT_BASE_SECONDS  # healthy → reset
+                _handle_invalidation_message(data)
+            # subscribe() returned without raising — treat as a disconnect.
+            logger.warning("Security settings invalidation stream ended; reconnecting")
+        except Exception:
+            logger.exception("Security settings invalidation listener error")
+        time.sleep(backoff)
+        backoff = min(backoff * 2, _LISTENER_RECONNECT_MAX_SECONDS)
+
+
+def _ensure_listener_started() -> None:
+    """Lazily start the single per-process invalidation listener. Idempotent and
+    cheap on the hot path — after the first start it is a flag read."""
+    global _LISTENER_STARTED
+    if _LISTENER_STARTED or not _pubsub_supported():
+        return
+    with _LISTENER_LOCK:
+        if _LISTENER_STARTED:
+            return
+        thread = threading.Thread(
+            target=_listen_for_invalidations,
+            name="security-settings-invalidation-listener",
+            daemon=True,
+        )
+        thread.start()
+        _LISTENER_STARTED = True
+
+
 def get_security_settings() -> SecuritySettings:
     """Effective, env-merged, immutable settings for the current tenant.
 
@@ -187,6 +282,9 @@ def get_security_settings() -> SecuritySettings:
     unset in multi-tenant. DB errors fall back to env defaults so a Postgres
     outage never bricks the auth path. Returned ``SecuritySettings`` is frozen.
     """
+    # Start the cross-process invalidation listener on first use (idempotent).
+    _ensure_listener_started()
+
     tenant_id = CURRENT_TENANT_ID_CONTEXTVAR.get()
     if tenant_id is None:
         # Single-tenant defaults the contextvar at module import; this branch

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -29,11 +29,8 @@ from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 logger = setup_logger()
 
 
-# Primary cross-process propagation is Redis pub/sub: an admin save publishes the
-# tenant id on OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE and every process'
-# listener drops its cached entry near-instantly. This long TTL is only the
-# fallback for messages a process missed (e.g. it was reconnecting), so it is
-# bounded staleness of last resort rather than the propagation mechanism.
+# Cross-process propagation is via pub/sub (see the listener below); this long
+# TTL is only a staleness bound for messages a process missed while reconnecting.
 _CACHE_TTL_SECONDS = 3600.0
 
 
@@ -43,15 +40,16 @@ _CACHE: TTLCache[str, SecuritySettings] = TTLCache(
 )
 
 
-# Lazily-started, one per process. Guards the pub/sub listener daemon so we only
-# ever run a single subscriber thread regardless of how many callers race in.
+# One listener daemon per process; the lock keeps racing starters to one thread.
 _LISTENER_LOCK = threading.Lock()
 _LISTENER_STARTED = False
 
-# Reconnect backoff for the listener thread: start small, double on repeated
-# failures, cap so a Redis outage can't turn into a hot reconnect loop.
+# Capped exponential backoff so a Redis outage can't become a hot reconnect loop.
 _LISTENER_RECONNECT_BASE_SECONDS = 5.0
 _LISTENER_RECONNECT_MAX_SECONDS = 30.0
+# A subscription that stayed up this long is treated as healthy, resetting the
+# backoff. Settings changes are rare, so we can't key "healthy" on message receipt.
+_LISTENER_HEALTHY_SECONDS = 60.0
 
 
 # Lock lifetime; held during a single read+merge+write.
@@ -129,9 +127,8 @@ def _store_overrides_unlocked(overrides: SecuritySettingsOverrides) -> None:
     with get_session_with_current_tenant() as db_session:
         _db_upsert_overrides(db_session, overrides)
     tenant_id = _current_tenant_id_or_default()
-    # Local invalidate is the immediate fast path for this process; pub/sub
-    # propagates to every other process. The DB write has already committed, so
-    # neither may fail the save.
+    # Local invalidate is this process' fast path; pub/sub reaches the rest. The
+    # DB write already committed, so neither may fail the save.
     invalidate_security_cache(tenant_id)
     _publish_invalidation(tenant_id)
 
@@ -204,20 +201,15 @@ def invalidate_security_cache(tenant_id: str) -> None:
 
 
 def _pubsub_supported() -> bool:
-    """Cross-process invalidation rides on Redis pub/sub. Onyx Lite runs
-    ``CACHE_BACKEND=postgres`` and is single-process anyway, so there local
-    invalidation alone is sufficient and we skip both publish and the listener.
-    """
+    """Pub/sub requires Redis. Postgres (Onyx Lite) is single-process, so it
+    skips both publish and the listener and relies on local invalidation."""
     return CACHE_BACKEND == CacheBackendType.REDIS
 
 
 def _publish_invalidation(tenant_id: str) -> None:
-    """Best-effort broadcast of an invalidation to other processes.
-
-    The caller has already committed the DB write and invalidated this process'
-    cache, so a pub/sub failure must never propagate — other processes still
-    converge via the TTL fallback. Logged, not raised.
-    """
+    """Best-effort broadcast to other processes. The DB write already committed
+    and the local cache is already invalidated, so a failure is logged, never
+    raised — other processes still converge via the TTL fallback."""
     if not _pubsub_supported():
         return
     try:
@@ -229,7 +221,7 @@ def _publish_invalidation(tenant_id: str) -> None:
 
 def _handle_invalidation_message(data: bytes) -> None:
     """Drop the named tenant from this process' cache. The channel is global, so
-    a message for a tenant we never cached resolves to a harmless no-op pop."""
+    a message for a tenant we never cached is a harmless no-op pop."""
     try:
         tenant_id = data.decode()
     except Exception:
@@ -239,27 +231,33 @@ def _handle_invalidation_message(data: bytes) -> None:
 
 
 def _listen_for_invalidations() -> None:
-    """Daemon loop: subscribe to the shared invalidation channel and apply every
-    message to the local cache. Reconnects with capped exponential backoff on any
-    error so a Redis blip can't become a hot loop. Never returns."""
+    """Daemon loop: subscribe to the invalidation channel and apply each message
+    to the local cache, reconnecting with backoff on error. Never returns."""
     backoff = _LISTENER_RECONNECT_BASE_SECONDS
     while True:
+        connected_at = time.monotonic()
         try:
             cache = get_shared_cache_backend()
             for data in cache.subscribe(OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE):
-                backoff = _LISTENER_RECONNECT_BASE_SECONDS  # healthy → reset
                 _handle_invalidation_message(data)
             # subscribe() returned without raising — treat as a disconnect.
             logger.warning("Security settings invalidation stream ended; reconnecting")
         except Exception:
             logger.exception("Security settings invalidation listener error")
+        # Reset after a connection that stayed up a while; keep growing (capped)
+        # only while connections fail fast, so a flapping Redis backs off but a
+        # healthy-but-quiet one reconnects promptly.
+        healthy = time.monotonic() - connected_at >= _LISTENER_HEALTHY_SECONDS
+        if healthy:
+            backoff = _LISTENER_RECONNECT_BASE_SECONDS
         time.sleep(backoff)
-        backoff = min(backoff * 2, _LISTENER_RECONNECT_MAX_SECONDS)
+        if not healthy:
+            backoff = min(backoff * 2, _LISTENER_RECONNECT_MAX_SECONDS)
 
 
 def _ensure_listener_started() -> None:
-    """Lazily start the single per-process invalidation listener. Idempotent and
-    cheap on the hot path — after the first start it is a flag read."""
+    """Lazily start the per-process listener. Idempotent; a flag read after the
+    first start."""
     global _LISTENER_STARTED
     if _LISTENER_STARTED or not _pubsub_supported():
         return
@@ -291,6 +289,13 @@ def get_security_settings() -> SecuritySettings:
         # fires only in multi-tenant before tenant resolution.
         return _build_env_defaults()
 
+    # The DB read is held under _CACHE_LOCK on purpose: invalidate_security_cache
+    # also takes this lock, so a concurrent write blocks until our fill completes
+    # and then pops it — a reader can't resurrect a pre-write value past an
+    # invalidation. Don't switch to read-outside-the-lock (double-checked) here;
+    # that race is exactly what this cache exists to avoid. The error path
+    # returns env defaults without caching so a transient DB blip can't pin them
+    # for the (long) TTL.
     with _CACHE_LOCK:
         cached = _CACHE.get(tenant_id)
         if cached is not None:

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py
@@ -1,0 +1,120 @@
+"""Cross-process invalidation tests for runtime security settings.
+
+These exercise the Redis pub/sub path that propagates an admin save to every
+api_server process. A single test process can't span processes, so we stand up a
+second listener thread against the *same* Redis and assert it both receives the
+published tenant id and drops the locally-cached entry — exactly what a sibling
+process would do on receipt.
+"""
+
+import threading
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from onyx.cache.interface import CacheBackendType
+from onyx.configs.constants import OnyxRedisChannels
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import SecuritySettings as SecuritySettingsRow
+from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.server.security import store as security_store
+from onyx.server.security.models import SecuritySettingsOverrides
+from onyx.server.security.store import apply_patch
+from onyx.server.security.store import get_security_settings
+from onyx.server.security.store import invalidate_security_cache
+from tests.external_dependency_unit.constants import TEST_TENANT_ID
+
+
+def _delete_security_settings_row() -> None:
+    with get_session_with_current_tenant() as session:
+        session.execute(delete(SecuritySettingsRow))
+        session.commit()
+
+
+@pytest.fixture(autouse=True)
+def _clean_db_and_cache(
+    db_session: Session,  # noqa: ARG001 — requested for side-effect (SQL engine init)
+    tenant_context: None,  # noqa: ARG001 — requested for side-effect (tenant contextvar)
+) -> Generator[None, None, None]:
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+    yield
+    _delete_security_settings_row()
+    invalidate_security_cache(TEST_TENANT_ID)
+
+
+def test_apply_patch_publishes_invalidation_to_subscriber() -> None:
+    """An admin save must publish the tenant id on the shared channel so other
+    processes drop their cached copy. We mirror the production listener loop in a
+    second thread and assert it receives the message and pops the cache entry.
+    """
+    received: list[str] = []
+    subscribed = threading.Event()
+    got_message = threading.Event()
+    stop = threading.Event()
+
+    def _listener() -> None:
+        # Drive a raw pubsub directly (rather than store.subscribe()) so the test
+        # can wait for the subscribe confirmation before publishing — pub/sub has
+        # no persistence, so a message sent before we subscribe would be lost.
+        pubsub = get_raw_redis_client().pubsub()
+        pubsub.subscribe(OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE)
+        try:
+            while not stop.is_set():
+                message = pubsub.get_message(timeout=0.5)
+                if message is None:
+                    continue
+                if message["type"] == "subscribe":
+                    subscribed.set()
+                    continue
+                if message["type"] != "message":
+                    continue
+                tenant_id = message["data"].decode()
+                received.append(tenant_id)
+                # Mirror what the production listener does on receipt.
+                invalidate_security_cache(tenant_id)
+                got_message.set()
+        finally:
+            pubsub.close()
+
+    listener = threading.Thread(target=_listener, daemon=True)
+    listener.start()
+    try:
+        assert subscribed.wait(timeout=2.0), "listener never subscribed"
+
+        # Warm the local cache so there is an entry to observe being dropped.
+        get_security_settings()
+        assert TEST_TENANT_ID in security_store._CACHE
+
+        apply_patch(
+            SecuritySettingsOverrides(user_directory_admin_only=True),
+            present_keys={"user_directory_admin_only"},
+        )
+
+        assert got_message.wait(timeout=2.0), "listener never received the message"
+        assert received == [TEST_TENANT_ID]
+        # The in-process fast path also pops this entry, but the subscriber's
+        # invalidate keeps it gone — i.e. a sibling process would converge too.
+        assert TEST_TENANT_ID not in security_store._CACHE
+    finally:
+        stop.set()
+        listener.join(timeout=2.0)
+
+
+def test_postgres_backend_skips_pubsub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Onyx Lite runs CACHE_BACKEND=postgres and is single-process, so pub/sub is
+    skipped entirely: no listener is started and the publish hook is a no-op."""
+    monkeypatch.setattr(security_store, "CACHE_BACKEND", CacheBackendType.POSTGRES)
+
+    assert security_store._pubsub_supported() is False
+
+    # The listener must not start under a non-Redis backend.
+    monkeypatch.setattr(security_store, "_LISTENER_STARTED", False)
+    security_store._ensure_listener_started()
+    assert security_store._LISTENER_STARTED is False
+
+    # The publish hook short-circuits before touching any cache backend, so it
+    # must complete without raising even though Postgres has no pub/sub.
+    security_store._publish_invalidation(TEST_TENANT_ID)

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py
@@ -56,9 +56,8 @@ def test_apply_patch_publishes_invalidation_to_subscriber() -> None:
     stop = threading.Event()
 
     def _listener() -> None:
-        # Drive a raw pubsub directly (rather than store.subscribe()) so the test
-        # can wait for the subscribe confirmation before publishing — pub/sub has
-        # no persistence, so a message sent before we subscribe would be lost.
+        # Raw pubsub (not store.subscribe()) so we can wait for the subscribe
+        # confirmation before publishing — pub/sub drops messages with no subscriber.
         pubsub = get_raw_redis_client().pubsub()
         pubsub.subscribe(OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE)
         try:
@@ -115,6 +114,5 @@ def test_postgres_backend_skips_pubsub(monkeypatch: pytest.MonkeyPatch) -> None:
     security_store._ensure_listener_started()
     assert security_store._LISTENER_STARTED is False
 
-    # The publish hook short-circuits before touching any cache backend, so it
-    # must complete without raising even though Postgres has no pub/sub.
+    # Publish hook short-circuits before touching any backend; must not raise.
     security_store._publish_invalidation(TEST_TENANT_ID)

--- a/backend/tests/integration/tests/security/test_runtime_security_settings.py
+++ b/backend/tests/integration/tests/security/test_runtime_security_settings.py
@@ -4,12 +4,10 @@ The integration api_server runs as a single uvicorn worker, so the PUT
 handler's local-cache invalidation takes effect on the very next request
 without any TTL wait.
 
-NOTE: Because this harness is single-worker, it does NOT exercise cross-process
-propagation (the Redis pub/sub path in ``onyx.server.security.store``). A true
-multi-worker test — asserting that a save on worker A is observed by worker B
-before the TTL fallback — belongs in a multi-process harness if/when one exists.
-The pub/sub publish→subscribe wiring itself is covered in
-``backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py``.
+Being single-worker, it does NOT exercise cross-process propagation (the pub/sub
+path in ``onyx.server.security.store``). A true multi-worker test belongs in a
+multi-process harness if/when one exists; the publish→subscribe wiring itself is
+covered in the external_dependency_unit ``test_security_settings_pubsub`` module.
 """
 
 from collections.abc import Generator

--- a/backend/tests/integration/tests/security/test_runtime_security_settings.py
+++ b/backend/tests/integration/tests/security/test_runtime_security_settings.py
@@ -3,6 +3,13 @@
 The integration api_server runs as a single uvicorn worker, so the PUT
 handler's local-cache invalidation takes effect on the very next request
 without any TTL wait.
+
+NOTE: Because this harness is single-worker, it does NOT exercise cross-process
+propagation (the Redis pub/sub path in ``onyx.server.security.store``). A true
+multi-worker test — asserting that a save on worker A is observed by worker B
+before the TTL fallback — belongs in a multi-process harness if/when one exists.
+The pub/sub publish→subscribe wiring itself is covered in
+``backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py``.
 """
 
 from collections.abc import Generator


### PR DESCRIPTION
## Summary

Makes admin saves of runtime security settings propagate across all `api_server` processes via Redis pub/sub, instead of relying on per-process TTL expiry.

Before this change, `SecuritySettings` are cached per-tenant in a process-local `TTLCache` (TTL 10s). An admin save invalidated only the saving process's entry; other processes converged passively via TTL — so a change could take up to ~10s to land everywhere.

Now:
- A save publishes the tenant id on a shared, global Redis channel (`OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE`).
- Each process lazily starts a single daemon listener that drops the named tenant's cache entry on receipt.
- The cache TTL is bumped 10s → 1h, demoting it to a fallback for missed messages rather than the propagation mechanism.

> Note: this branch also carries the foundational commit `b8758c0688` (*runtime-configurable security settings via KV store*), which is not yet on `main`. Reviewing per-commit keeps the two changes cleanly separated; the second commit (`5a32daf`) is the cross-process invalidation described here.

## Changes

- **`configs/constants.py`** — add `OnyxRedisChannels` with `SECURITY_SETTINGS_INVALIDATE`. Channels are global to the Redis instance (not tenant-prefixed); the tenant scope rides in the message payload.
- **`cache/interface.py`** — add non-abstract `publish()` / `subscribe()` to `CacheBackend` (default `NotImplementedError`, so existing fakes keep working).
- **`cache/redis_backend.py`** — implement pub/sub via the raw, non-prefixed client so the channel name is identical across tenants/processes.
- **`cache/postgres_backend.py`** — explicit `NotImplementedError` (Onyx Lite is single-process).
- **`server/security/store.py`** — publisher hook in `_store_overrides_unlocked` (best-effort, logged, never fails the already-committed write); lazy per-process listener with capped exponential reconnect backoff; TTL bump.

## Design notes

- **Best-effort publish:** the DB upsert has already committed and the local cache is already invalidated, so a pub/sub failure is logged and swallowed — other processes still converge via the TTL fallback.
- **Single global channel:** the cache key is `tenant_id`, so a message for a tenant a process never cached is a harmless no-op pop. Per-tenant channels would be O(tenants × processes) subscriptions — deliberately avoided.
- **No-Redis deployments:** under `CACHE_BACKEND=postgres` both the publish and the listener are skipped; single-process local invalidation is sufficient.
- **Reconnect storms:** the listener backs off 5s → 30s (capped, exponential) so a Redis blip can't become a hot reconnect loop. The daemon thread is `daemon=True` (process exit reclaims it).

## Tests

- New `backend/tests/external_dependency_unit/server/security/test_security_settings_pubsub.py`:
  - Stands up a second listener against the same Redis, invokes `apply_patch`, and asserts the listener receives the published tenant id and the cache entry is dropped.
  - Asserts the Postgres branch skips pub/sub (no listener, publish is a no-op) and still works.
- Added a note to the single-worker integration test (`test_runtime_security_settings.py`) that a true multi-worker test belongs in a multi-process harness if/when one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add runtime security settings with near-instant cross-process propagation via Redis pub/sub. Admin saves now invalidate caches across all `api_server` processes immediately; the cache TTL is 1h as a fallback.

- **New Features**
  - Added per-tenant `security_settings` table and admin API (`GET/PUT /admin/security`) for runtime overrides; env defaults apply and operator-locked fields are ignored.
  - Cross-process invalidation: saves publish the tenant id on `OnyxRedisChannels.SECURITY_SETTINGS_INVALIDATE` (global, non-prefixed); each process runs a lazy listener (started on first `get_security_settings()`) with capped exponential reconnect backoff that resets after a healthy (quiet) connection to avoid long resubscribe delays. Added `publish()`/`subscribe()` to `CacheBackend` (implemented on Redis via the raw client; Postgres backend raises).
  - Core flows now use runtime settings: credential prefix masking, external IDP expiry tracking, password policy (min/max and required classes), valid email domains, and user directory visibility.

- **Migration**
  - Run DB migrations to create `security_settings`.
  - For multi-process deployments, set `CACHE_BACKEND=redis` to get instant propagation; with `postgres` (Onyx Lite) pub/sub is skipped (single-process only).
  - Restart all `api_server` processes after deploy.

<sup>Written for commit 7ca5d7ab8805c588ddca3efadc9553aa4e3b8571. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

