### PR TITLE
feat(security): admin UI for runtime security settings

### DIFF
--- a/web/src/app/admin/security/page.tsx
+++ b/web/src/app/admin/security/page.tsx
@@ -1,15 +1,5 @@
-"use client";
-
-import { SettingsLayouts } from "@opal/layouts";
-import { ADMIN_ROUTES } from "@/lib/admin-routes";
-
-const route = ADMIN_ROUTES.SECURITY_HARDENING;
+import SecurityHardeningPage from "@/refresh-pages/admin/SecurityHardeningPage";
 
 export default function Page() {
-  return (
-    <SettingsLayouts.Root>
-      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
-      <SettingsLayouts.Body />
-    </SettingsLayouts.Root>
-  );
+  return <SecurityHardeningPage />;
 }

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -236,8 +236,8 @@ export const ADMIN_ROUTES = {
   SECURITY_HARDENING: {
     path: "/admin/security",
     icon: SvgShield,
-    title: "Security and Hardening",
-    sidebarLabel: "Security and Hardening",
+    title: "Security & Hardening",
+    sidebarLabel: "Security & Hardening",
   },
   // Prefix-only entries used for layout matching — not rendered as sidebar
   // items or page headers.

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -19,6 +19,7 @@ export const SWR_KEYS = {
   enterpriseSettings: "/api/enterprise-settings",
   customAnalyticsScript: "/api/enterprise-settings/custom-analytics-script",
   authType: "/api/auth/type",
+  adminSecuritySettings: "/api/admin/security",
 
   // ── Agents / Personas ─────────────────────────────────────────────────────
   personas: "/api/persona",

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -391,29 +391,29 @@ export default function SecurityHardeningPage() {
                   <div className="w-60">
                     <InputSelect
                       value={
-                        draft.mask_credential_prefix ? "fully" : "partially"
+                        draft.mask_credential_prefix ? "masked" : "visible"
                       }
                       onValueChange={(value) =>
                         void saveSettings({
-                          mask_credential_prefix: value === "fully",
+                          mask_credential_prefix: value === "masked",
                         })
                       }
                     >
                       <InputSelect.Trigger />
                       <InputSelect.Content>
                         <InputSelect.Item
-                          value="fully"
+                          value="masked"
                           wrapDescription
-                          description="Mask all credential characters (e.g. ••••••••••)."
-                        >
-                          Fully Masked
-                        </InputSelect.Item>
-                        <InputSelect.Item
-                          value="partially"
-                          wrapDescription
-                          description="Show the first and last characters for identification (e.g. abcd••••wxyz)."
+                          description="Show only the first and last few characters (e.g. abcd...wxyz)."
                         >
                           Partially Masked
+                        </InputSelect.Item>
+                        <InputSelect.Item
+                          value="visible"
+                          wrapDescription
+                          description="Show the full credential value to admins."
+                        >
+                          Fully Visible
                         </InputSelect.Item>
                       </InputSelect.Content>
                     </InputSelect>

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import React, { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
-import { Section } from "@/layouts/general-layouts";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { toast } from "@/hooks/useToast";
@@ -11,8 +10,17 @@ import InputNumber from "@/refresh-components/inputs/InputNumber";
 import InputChipField, {
   type ChipItem,
 } from "@/refresh-components/inputs/InputChipField";
-import { InputHorizontal, InputVertical, SettingsLayouts } from "@opal/layouts";
-import { Card, Divider, Switch, Text } from "@opal/components";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
+import {
+  Content,
+  InputHorizontal,
+  InputVertical,
+  Section,
+  SettingsLayouts,
+} from "@opal/layouts";
+import { Card, Switch } from "@opal/components";
+import { markdown } from "@opal/utils";
+import type { RichStr } from "@opal/types";
 
 const route = ADMIN_ROUTES.SECURITY_HARDENING;
 
@@ -44,7 +52,7 @@ type SecuritySettingsUpdate = {
 
 interface ToggleRowProps {
   title: string;
-  description: string;
+  description?: string | RichStr;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
 }
@@ -71,6 +79,11 @@ export default function SecurityHardeningPage() {
   // Local state mirrors the loaded settings; we save on every change.
   const [draft, setDraft] = useState<SecuritySettings | null>(null);
   const [domainInput, setDomainInput] = useState("");
+  // The "Restrict Email Domains" toggle has no backing field — restriction is
+  // active iff the allowlist is non-empty. This lets an admin turn the toggle on
+  // and reveal the (still empty) input before typing the first domain. It stays
+  // independent of `draft` so unrelated saves don't collapse the open input.
+  const [forceShowDomains, setForceShowDomains] = useState(false);
 
   useEffect(() => {
     if (settings) setDraft(settings);
@@ -135,6 +148,10 @@ export default function SecurityHardeningPage() {
     label: domain,
   }));
 
+  // Show the domain allowlist when it's populated, or when the admin has
+  // explicitly turned the restriction on but not yet added a domain.
+  const showDomains = forceShowDomains || draft.valid_email_domains.length > 0;
+
   function addDomain(value: string) {
     const trimmed = value.trim().toLowerCase();
     if (!trimmed) return;
@@ -159,75 +176,86 @@ export default function SecurityHardeningPage() {
       <SettingsLayouts.Header
         icon={route.icon}
         title={route.title}
-        description="Runtime-configurable security and hardening settings. Unset values fall back to your deployment's environment configuration."
+        description="Runtime-configurable security settings. Unset values fall back to your deployment's environment configuration."
         divider
       />
 
       <SettingsLayouts.Body>
-        {/* Card 1 — Account & access */}
-        <Card border="solid" rounding="lg">
-          <Section>
-            <ToggleRow
-              title="Restrict User Directory to Admins"
-              description="When enabled, only admins can list users in the workspace. Curators and basic users see only themselves."
-              checked={draft.user_directory_admin_only}
-              onCheckedChange={(checked) =>
-                void saveSettings({ user_directory_admin_only: checked })
-              }
-            />
+        {/* Authentication */}
+        <div className="flex w-full flex-col gap-3">
+          <Content
+            title="Authentication"
+            sizePreset="main-content"
+            variant="section"
+          />
 
-            <ToggleRow
-              title="Track External IdP Session Expiry"
-              description="Sync session expiration from your OAuth/OIDC provider. Users are logged out when the upstream session expires."
-              checked={draft.track_external_idp_expiry}
-              onCheckedChange={(checked) =>
-                void saveSettings({ track_external_idp_expiry: checked })
-              }
-            />
+          <Card border="solid" rounding="lg">
+            <Section>
+              <ToggleRow
+                title="Sync Session Expiry with Identity Provider"
+                description="Log users out when the upstream OAuth/OIDC provider session expires."
+                checked={draft.track_external_idp_expiry}
+                onCheckedChange={(checked) =>
+                  void saveSettings({ track_external_idp_expiry: checked })
+                }
+              />
 
-            {!isMultiTenant && (
-              <>
-                <ToggleRow
-                  title="Mask Credential Prefix"
-                  description="Hide the leading characters of stored credentials when displayed in the UI."
-                  checked={draft.mask_credential_prefix}
-                  onCheckedChange={(checked) =>
-                    void saveSettings({ mask_credential_prefix: checked })
-                  }
-                />
-
-                <InputVertical
-                  title="Allowed Email Domains"
-                  subDescription="When set, only users with an email at one of these domains can register. Leave empty to allow any domain."
-                  withLabel
-                >
-                  <InputChipField
-                    chips={validDomains}
-                    onRemoveChip={removeDomain}
-                    onAdd={addDomain}
-                    value={domainInput}
-                    onChange={setDomainInput}
-                    placeholder="Add a domain (e.g. onyx.app) and press Enter"
+              {!isMultiTenant && (
+                <>
+                  <ToggleRow
+                    title="Restrict Email Domains"
+                    description="Limit new user registrations to specific email domains."
+                    checked={showDomains}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        setForceShowDomains(true);
+                      } else {
+                        // Clearing the allowlist disables the restriction.
+                        setForceShowDomains(false);
+                        void saveSettings({ valid_email_domains: [] });
+                      }
+                    }}
                   />
-                </InputVertical>
-              </>
-            )}
-          </Section>
-        </Card>
 
-        {/* Card 2 — Password policy (single-tenant only) */}
-        {!isMultiTenant && (
-          <>
-            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+                  {showDomains && (
+                    <InputVertical
+                      title="Allowed Email Domains"
+                      subDescription="New users can only register new accounts with emails in this domain list."
+                      withLabel
+                    >
+                      <InputChipField
+                        chips={validDomains}
+                        onRemoveChip={removeDomain}
+                        onAdd={addDomain}
+                        value={domainInput}
+                        onChange={setDomainInput}
+                        placeholder="Add a domain (e.g. onyx.app)"
+                      />
+                    </InputVertical>
+                  )}
+                </>
+              )}
+            </Section>
+          </Card>
 
+          {/* Password policy (single-tenant only) */}
+          {!isMultiTenant && (
             <Card border="solid" rounding="lg">
               <Section>
-                <Text font="heading-h3" color="text-04">
-                  Password Policy
-                </Text>
-                <div className="flex gap-4 w-full items-start pt-2">
+                <Content
+                  title="Password Policy"
+                  description="Requirements for all new passwords. Applies to basic auth only."
+                  sizePreset="main-ui"
+                  variant="section"
+                />
+
+                <div className="flex w-full items-start gap-4">
                   <div className="flex-1">
-                    <InputVertical title="Minimum Length" withLabel>
+                    <InputVertical
+                      title="Minimum Password Length"
+                      suffix="(characters)"
+                      withLabel
+                    >
                       <InputNumber
                         value={draft.password_min_length}
                         onChange={(value) =>
@@ -240,7 +268,11 @@ export default function SecurityHardeningPage() {
                     </InputVertical>
                   </div>
                   <div className="flex-1">
-                    <InputVertical title="Maximum Length" withLabel>
+                    <InputVertical
+                      title="Maximum Password Length"
+                      suffix="(characters)"
+                      withLabel
+                    >
                       <InputNumber
                         value={draft.password_max_length}
                         onChange={(value) =>
@@ -256,7 +288,6 @@ export default function SecurityHardeningPage() {
 
                 <ToggleRow
                   title="Require Uppercase Letter"
-                  description="Passwords must contain at least one uppercase character."
                   checked={draft.password_require_uppercase}
                   onCheckedChange={(checked) =>
                     void saveSettings({ password_require_uppercase: checked })
@@ -265,7 +296,6 @@ export default function SecurityHardeningPage() {
 
                 <ToggleRow
                   title="Require Lowercase Letter"
-                  description="Passwords must contain at least one lowercase character."
                   checked={draft.password_require_lowercase}
                   onCheckedChange={(checked) =>
                     void saveSettings({ password_require_lowercase: checked })
@@ -273,8 +303,7 @@ export default function SecurityHardeningPage() {
                 />
 
                 <ToggleRow
-                  title="Require Digit"
-                  description="Passwords must contain at least one numeric digit."
+                  title="Require Number"
                   checked={draft.password_require_digit}
                   onCheckedChange={(checked) =>
                     void saveSettings({ password_require_digit: checked })
@@ -282,8 +311,10 @@ export default function SecurityHardeningPage() {
                 />
 
                 <ToggleRow
-                  title="Require Special Character"
-                  description="Passwords must contain at least one special character."
+                  title="Require Special Characters"
+                  description={markdown(
+                    "Accepted characters: `!@#$%^&*()_+-=[]{}|;:,.<>?`"
+                  )}
                   checked={draft.password_require_special_char}
                   onCheckedChange={(checked) =>
                     void saveSettings({
@@ -293,8 +324,99 @@ export default function SecurityHardeningPage() {
                 />
               </Section>
             </Card>
-          </>
-        )}
+          )}
+        </div>
+
+        {/* Admin Controls */}
+        <div className="flex w-full flex-col gap-3">
+          <Content
+            title="Admin Controls"
+            sizePreset="main-content"
+            variant="section"
+          />
+
+          <Card border="solid" rounding="lg">
+            <Section>
+              <InputHorizontal
+                title="Full User Directory Visibility"
+                description="Exact name and email lookups work regardless of this setting."
+                withLabel
+              >
+                <div className="w-60">
+                  <InputSelect
+                    value={
+                      draft.user_directory_admin_only
+                        ? "admins_only"
+                        : "all_users"
+                    }
+                    onValueChange={(value) =>
+                      void saveSettings({
+                        user_directory_admin_only: value === "admins_only",
+                      })
+                    }
+                  >
+                    <InputSelect.Trigger />
+                    <InputSelect.Content>
+                      <InputSelect.Item
+                        value="all_users"
+                        wrapDescription
+                        description="Anyone signed in can see the full user list when sharing resources."
+                      >
+                        Visible to All Users
+                      </InputSelect.Item>
+                      <InputSelect.Item
+                        value="admins_only"
+                        wrapDescription
+                        description="Only admins can see the full user list."
+                      >
+                        Visible to Admins Only
+                      </InputSelect.Item>
+                    </InputSelect.Content>
+                  </InputSelect>
+                </div>
+              </InputHorizontal>
+
+              {!isMultiTenant && (
+                <InputHorizontal
+                  title="Mask Stored Credentials"
+                  description="Display format for saved API keys and credentials for admins."
+                  withLabel
+                >
+                  <div className="w-60">
+                    <InputSelect
+                      value={
+                        draft.mask_credential_prefix ? "fully" : "partially"
+                      }
+                      onValueChange={(value) =>
+                        void saveSettings({
+                          mask_credential_prefix: value === "fully",
+                        })
+                      }
+                    >
+                      <InputSelect.Trigger />
+                      <InputSelect.Content>
+                        <InputSelect.Item
+                          value="fully"
+                          wrapDescription
+                          description="Mask all credential characters (e.g. ••••••••••)."
+                        >
+                          Fully Masked
+                        </InputSelect.Item>
+                        <InputSelect.Item
+                          value="partially"
+                          wrapDescription
+                          description="Show the first and last characters for identification (e.g. abcd••••wxyz)."
+                        >
+                          Partially Masked
+                        </InputSelect.Item>
+                      </InputSelect.Content>
+                    </InputSelect>
+                  </div>
+                </InputHorizontal>
+              )}
+            </Section>
+          </Card>
+        </div>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { toast } from "@/hooks/useToast";
@@ -23,8 +24,6 @@ import { markdown } from "@opal/utils";
 import type { RichStr } from "@opal/types";
 
 const route = ADMIN_ROUTES.SECURITY_HARDENING;
-
-const SECURITY_SETTINGS_KEY = "/api/admin/security";
 
 // Read shape: the effective, env-merged settings returned by GET /admin/security.
 // Every field is concrete — the backend never returns null here (see
@@ -74,7 +73,10 @@ export default function SecurityHardeningPage() {
   const isMultiTenant = NEXT_PUBLIC_CLOUD_ENABLED;
 
   const { data: settings, isLoading: settingsLoading } =
-    useSWR<SecuritySettings>(SECURITY_SETTINGS_KEY, errorHandlingFetcher);
+    useSWR<SecuritySettings>(
+      SWR_KEYS.adminSecuritySettings,
+      errorHandlingFetcher
+    );
 
   // Local state mirrors the loaded settings; we save on every change.
   const [draft, setDraft] = useState<SecuritySettings | null>(null);
@@ -89,50 +91,54 @@ export default function SecurityHardeningPage() {
     if (settings) setDraft(settings);
   }, [settings]);
 
-  const saveSettings = useCallback(
-    async (updates: SecuritySettingsUpdate) => {
-      // Optimistically reflect concrete changes for snappy toggles. A `null`
-      // clears an override; its resolved env default only arrives with the PUT
-      // response, so we leave the current value in place rather than guess.
-      setDraft((prev) => {
-        if (!prev) return prev;
-        const concrete = Object.fromEntries(
-          Object.entries(updates).filter(([, value]) => value != null)
-        ) as Partial<SecuritySettings>;
-        return { ...prev, ...concrete };
+  const saveSettings = useCallback(async (updates: SecuritySettingsUpdate) => {
+    // Optimistically reflect concrete changes for snappy toggles. A `null`
+    // clears an override; its resolved env default only arrives with the PUT
+    // response, so we leave the current value in place rather than guess.
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const concrete = Object.fromEntries(
+        Object.entries(updates).filter(([, value]) => value != null)
+      ) as Partial<SecuritySettings>;
+      return { ...prev, ...concrete };
+    });
+    try {
+      const response = await fetch(SWR_KEYS.adminSecuritySettings, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        // Send ONLY the changed fields. The backend persists each present key
+        // as an explicit override and lets absent keys fall back to env
+        // defaults. Sending the full settings would freeze every env default
+        // as an override and 403 on operator-locked fields in multi-tenant.
+        body: JSON.stringify(updates),
       });
-      try {
-        const response = await fetch(SECURITY_SETTINGS_KEY, {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          // Send ONLY the changed fields. The backend persists each present key
-          // as an explicit override and lets absent keys fall back to env
-          // defaults. Sending the full settings would freeze every env default
-          // as an override and 403 on operator-locked fields in multi-tenant.
-          body: JSON.stringify(updates),
-        });
-        if (!response.ok) {
-          const errorMsg = (await response.json()).detail;
-          throw new Error(errorMsg);
-        }
-        // PUT returns the new effective settings — adopt them as the source of
-        // truth so the UI matches what was actually persisted/merged.
-        const effective: SecuritySettings = await response.json();
-        setDraft(effective);
-        await mutate(SECURITY_SETTINGS_KEY, effective, { revalidate: false });
-        toast.success("Security settings updated");
-      } catch (error) {
-        // Roll back the optimistic update to the last known-good settings.
-        setDraft(settings ?? null);
-        const message =
-          error instanceof Error
-            ? error.message
-            : "Failed to update security settings";
-        toast.error(message);
+      if (!response.ok) {
+        const errorMsg = (await response.json()).detail;
+        throw new Error(errorMsg);
       }
-    },
-    [settings]
-  );
+      // PUT returns the new effective settings — adopt them as the source of
+      // truth so the UI matches what was actually persisted/merged.
+      const effective: SecuritySettings = await response.json();
+      setDraft(effective);
+      await mutate(SWR_KEYS.adminSecuritySettings, effective, {
+        revalidate: false,
+      });
+      toast.success("Security settings updated");
+    } catch (error) {
+      // Re-sync from the server (the source of truth) rather than a possibly
+      // stale local snapshot — a late failure must not clobber other edits
+      // that may have succeeded while this request was in flight.
+      const fresh = await mutate<SecuritySettings>(
+        SWR_KEYS.adminSecuritySettings
+      );
+      if (fresh) setDraft(fresh);
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to update security settings";
+      toast.error(message);
+    }
+  }, []);
 
   if (settingsLoading || !draft) {
     return (

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { Section } from "@/layouts/general-layouts";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
+import { toast } from "@/hooks/useToast";
+import InputNumber from "@/refresh-components/inputs/InputNumber";
+import InputChipField, {
+  type ChipItem,
+} from "@/refresh-components/inputs/InputChipField";
+import { InputHorizontal, InputVertical, SettingsLayouts } from "@opal/layouts";
+import { Card, Divider, Switch, Text } from "@opal/components";
+
+const route = ADMIN_ROUTES.SECURITY_HARDENING;
+
+const SECURITY_SETTINGS_KEY = "/api/admin/security";
+
+// Read shape: the effective, env-merged settings returned by GET /admin/security.
+// Every field is concrete — the backend never returns null here (see
+// `SecuritySettings` in backend/onyx/server/security/models.py).
+interface SecuritySettings {
+  user_directory_admin_only: boolean;
+  track_external_idp_expiry: boolean;
+  mask_credential_prefix: boolean;
+  valid_email_domains: string[];
+  password_min_length: number;
+  password_max_length: number;
+  password_require_uppercase: boolean;
+  password_require_lowercase: boolean;
+  password_require_digit: boolean;
+  password_require_special_char: boolean;
+}
+
+// Write shape: a partial patch. The backend treats only the keys present in the
+// PUT body as explicit overrides; absent keys keep their stored value, while an
+// explicit `null` clears an override back to the env default (see
+// `SecuritySettingsOverrides` + `present_keys` in the backend).
+type SecuritySettingsUpdate = {
+  [K in keyof SecuritySettings]?: SecuritySettings[K] | null;
+};
+
+interface ToggleRowProps {
+  title: string;
+  description: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+function ToggleRow({
+  title,
+  description,
+  checked,
+  onCheckedChange,
+}: ToggleRowProps) {
+  return (
+    <InputHorizontal title={title} description={description} withLabel>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </InputHorizontal>
+  );
+}
+
+export default function SecurityHardeningPage() {
+  const isMultiTenant = NEXT_PUBLIC_CLOUD_ENABLED;
+
+  const { data: settings, isLoading: settingsLoading } =
+    useSWR<SecuritySettings>(SECURITY_SETTINGS_KEY, errorHandlingFetcher);
+
+  // Local state mirrors the loaded settings; we save on every change.
+  const [draft, setDraft] = useState<SecuritySettings | null>(null);
+  const [domainInput, setDomainInput] = useState("");
+
+  useEffect(() => {
+    if (settings) setDraft(settings);
+  }, [settings]);
+
+  const saveSettings = useCallback(
+    async (updates: SecuritySettingsUpdate) => {
+      // Optimistically reflect concrete changes for snappy toggles. A `null`
+      // clears an override; its resolved env default only arrives with the PUT
+      // response, so we leave the current value in place rather than guess.
+      setDraft((prev) => {
+        if (!prev) return prev;
+        const concrete = Object.fromEntries(
+          Object.entries(updates).filter(([, value]) => value != null)
+        ) as Partial<SecuritySettings>;
+        return { ...prev, ...concrete };
+      });
+      try {
+        const response = await fetch(SECURITY_SETTINGS_KEY, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          // Send ONLY the changed fields. The backend persists each present key
+          // as an explicit override and lets absent keys fall back to env
+          // defaults. Sending the full settings would freeze every env default
+          // as an override and 403 on operator-locked fields in multi-tenant.
+          body: JSON.stringify(updates),
+        });
+        if (!response.ok) {
+          const errorMsg = (await response.json()).detail;
+          throw new Error(errorMsg);
+        }
+        // PUT returns the new effective settings — adopt them as the source of
+        // truth so the UI matches what was actually persisted/merged.
+        const effective: SecuritySettings = await response.json();
+        setDraft(effective);
+        await mutate(SECURITY_SETTINGS_KEY, effective, { revalidate: false });
+        toast.success("Security settings updated");
+      } catch (error) {
+        // Roll back the optimistic update to the last known-good settings.
+        setDraft(settings ?? null);
+        const message =
+          error instanceof Error
+            ? error.message
+            : "Failed to update security settings";
+        toast.error(message);
+      }
+    },
+    [settings]
+  );
+
+  if (settingsLoading || !draft) {
+    return (
+      <SettingsLayouts.Root>
+        <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+        <SettingsLayouts.Body />
+      </SettingsLayouts.Root>
+    );
+  }
+
+  const validDomains: ChipItem[] = draft.valid_email_domains.map((domain) => ({
+    id: domain,
+    label: domain,
+  }));
+
+  function addDomain(value: string) {
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) return;
+    const current = draft?.valid_email_domains ?? [];
+    if (current.includes(trimmed)) {
+      setDomainInput("");
+      return;
+    }
+    void saveSettings({ valid_email_domains: [...current, trimmed] });
+    setDomainInput("");
+  }
+
+  function removeDomain(id: string) {
+    const current = draft?.valid_email_domains ?? [];
+    void saveSettings({
+      valid_email_domains: current.filter((domain) => domain !== id),
+    });
+  }
+
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header
+        icon={route.icon}
+        title={route.title}
+        description="Runtime-configurable security and hardening settings. Unset values fall back to your deployment's environment configuration."
+        divider
+      />
+
+      <SettingsLayouts.Body>
+        {/* Card 1 — Account & access */}
+        <Card border="solid" rounding="lg">
+          <Section>
+            <ToggleRow
+              title="Restrict User Directory to Admins"
+              description="When enabled, only admins can list users in the workspace. Curators and basic users see only themselves."
+              checked={draft.user_directory_admin_only}
+              onCheckedChange={(checked) =>
+                void saveSettings({ user_directory_admin_only: checked })
+              }
+            />
+
+            <ToggleRow
+              title="Track External IdP Session Expiry"
+              description="Sync session expiration from your OAuth/OIDC provider. Users are logged out when the upstream session expires."
+              checked={draft.track_external_idp_expiry}
+              onCheckedChange={(checked) =>
+                void saveSettings({ track_external_idp_expiry: checked })
+              }
+            />
+
+            {!isMultiTenant && (
+              <>
+                <ToggleRow
+                  title="Mask Credential Prefix"
+                  description="Hide the leading characters of stored credentials when displayed in the UI."
+                  checked={draft.mask_credential_prefix}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ mask_credential_prefix: checked })
+                  }
+                />
+
+                <InputVertical
+                  title="Allowed Email Domains"
+                  subDescription="When set, only users with an email at one of these domains can register. Leave empty to allow any domain."
+                  withLabel
+                >
+                  <InputChipField
+                    chips={validDomains}
+                    onRemoveChip={removeDomain}
+                    onAdd={addDomain}
+                    value={domainInput}
+                    onChange={setDomainInput}
+                    placeholder="Add a domain (e.g. onyx.app) and press Enter"
+                  />
+                </InputVertical>
+              </>
+            )}
+          </Section>
+        </Card>
+
+        {/* Card 2 — Password policy (single-tenant only) */}
+        {!isMultiTenant && (
+          <>
+            <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+            <Card border="solid" rounding="lg">
+              <Section>
+                <Text font="heading-h3" color="text-04">
+                  Password Policy
+                </Text>
+                <div className="flex gap-4 w-full items-start pt-2">
+                  <div className="flex-1">
+                    <InputVertical title="Minimum Length" withLabel>
+                      <InputNumber
+                        value={draft.password_min_length}
+                        onChange={(value) =>
+                          void saveSettings({ password_min_length: value })
+                        }
+                        min={1}
+                        max={1024}
+                        placeholder="Default"
+                      />
+                    </InputVertical>
+                  </div>
+                  <div className="flex-1">
+                    <InputVertical title="Maximum Length" withLabel>
+                      <InputNumber
+                        value={draft.password_max_length}
+                        onChange={(value) =>
+                          void saveSettings({ password_max_length: value })
+                        }
+                        min={1}
+                        max={1024}
+                        placeholder="Default"
+                      />
+                    </InputVertical>
+                  </div>
+                </div>
+
+                <ToggleRow
+                  title="Require Uppercase Letter"
+                  description="Passwords must contain at least one uppercase character."
+                  checked={draft.password_require_uppercase}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_uppercase: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Lowercase Letter"
+                  description="Passwords must contain at least one lowercase character."
+                  checked={draft.password_require_lowercase}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_lowercase: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Digit"
+                  description="Passwords must contain at least one numeric digit."
+                  checked={draft.password_require_digit}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({ password_require_digit: checked })
+                  }
+                />
+
+                <ToggleRow
+                  title="Require Special Character"
+                  description="Passwords must contain at least one special character."
+                  checked={draft.password_require_special_char}
+                  onCheckedChange={(checked) =>
+                    void saveSettings({
+                      password_require_special_char: checked,
+                    })
+                  }
+                />
+              </Section>
+            </Card>
+          </>
+        )}
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
+++ b/web/src/refresh-pages/admin/SecurityHardeningPage.tsx
@@ -128,10 +128,15 @@ export default function SecurityHardeningPage() {
       // Re-sync from the server (the source of truth) rather than a possibly
       // stale local snapshot — a late failure must not clobber other edits
       // that may have succeeded while this request was in flight.
-      const fresh = await mutate<SecuritySettings>(
-        SWR_KEYS.adminSecuritySettings
-      );
-      if (fresh) setDraft(fresh);
+      try {
+        const fresh = await mutate<SecuritySettings>(
+          SWR_KEYS.adminSecuritySettings
+        );
+        if (fresh) setDraft(fresh);
+      } catch {
+        // If revalidation also fails (e.g. network down), the optimistic
+        // update stays until the next successful SWR refresh (e.g. focus).
+      }
       const message =
         error instanceof Error
           ? error.message

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -131,6 +131,7 @@ function buildItems(
 
   // 6. Organization (admin only)
   if (!isCurator) {
+    add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);
     if (hasSubscription) {
       add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.BILLING);
     }

--- a/web/tests/e2e/admin/security-hardening.spec.ts
+++ b/web/tests/e2e/admin/security-hardening.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { loginAs } from "@tests/e2e/utils/auth";
+
+test.describe("Security Hardening Page @exclusive", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.context().clearCookies();
+    await loginAs(page, "admin");
+  });
+
+  test("admin can toggle a setting, reload, and see it persisted", async ({
+    page,
+  }) => {
+    await page.goto("/admin/security");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByText("Restrict User Directory to Admins")
+    ).toBeVisible({ timeout: 10000 });
+
+    // Read initial state of the User Directory toggle.
+    const toggleRow = page
+      .getByText("Restrict User Directory to Admins")
+      .locator("xpath=ancestor::label[1]");
+    const switchEl = toggleRow.getByRole("switch");
+    await expect(switchEl).toBeVisible();
+    const initial = (await switchEl.getAttribute("aria-checked")) === "true";
+
+    // Flip it.
+    await switchEl.click();
+    await expect(page.getByText("Security settings updated")).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Reload and confirm the flipped value persisted.
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+    const switchAfterReload = page
+      .getByText("Restrict User Directory to Admins")
+      .locator("xpath=ancestor::label[1]")
+      .getByRole("switch");
+    await expect(switchAfterReload).toHaveAttribute(
+      "aria-checked",
+      initial ? "false" : "true"
+    );
+
+    // Restore the original value.
+    await switchAfterReload.click();
+    await expect(page.getByText("Security settings updated")).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+});

--- a/web/tests/e2e/admin/security-hardening.spec.ts
+++ b/web/tests/e2e/admin/security-hardening.spec.ts
@@ -1,5 +1,6 @@
-import { test, expect } from "@playwright/test";
+import { test } from "@playwright/test";
 import { loginAs } from "@tests/e2e/utils/auth";
+import { AdminSecurityPage } from "@tests/e2e/pages/AdminSecurityPage";
 
 test.describe("Security Hardening Page @exclusive", () => {
   test.beforeEach(async ({ page }) => {
@@ -10,44 +11,21 @@ test.describe("Security Hardening Page @exclusive", () => {
   test("admin can toggle a setting, reload, and see it persisted", async ({
     page,
   }) => {
-    await page.goto("/admin/security");
-    await page.waitForLoadState("networkidle");
+    const securityPage = new AdminSecurityPage(page);
+    await securityPage.goto();
 
-    await expect(
-      page.getByText("Restrict User Directory to Admins")
-    ).toBeVisible({ timeout: 10000 });
+    const toggle = AdminSecurityPage.SESSION_EXPIRY_TOGGLE;
+    const initial = await securityPage.isToggleOn(toggle);
 
-    // Read initial state of the User Directory toggle.
-    const toggleRow = page
-      .getByText("Restrict User Directory to Admins")
-      .locator("xpath=ancestor::label[1]");
-    const switchEl = toggleRow.getByRole("switch");
-    await expect(switchEl).toBeVisible();
-    const initial = (await switchEl.getAttribute("aria-checked")) === "true";
-
-    // Flip it.
-    await switchEl.click();
-    await expect(page.getByText("Security settings updated")).toBeVisible({
-      timeout: 5000,
-    });
+    // Flip it and confirm the save.
+    await securityPage.clickToggleAndSave(toggle);
 
     // Reload and confirm the flipped value persisted.
-    await page.reload();
-    await page.waitForLoadState("networkidle");
-    const switchAfterReload = page
-      .getByText("Restrict User Directory to Admins")
-      .locator("xpath=ancestor::label[1]")
-      .getByRole("switch");
-    await expect(switchAfterReload).toHaveAttribute(
-      "aria-checked",
-      initial ? "false" : "true"
-    );
+    await securityPage.reload();
+    await securityPage.expectToggle(toggle, !initial);
 
-    // Restore the original value.
-    await switchAfterReload.click();
-    await expect(page.getByText("Security settings updated")).toBeVisible({
-      timeout: 5000,
-    });
+    // Restore the original value so the test leaves no residue.
+    await securityPage.clickToggleAndSave(toggle);
+    await securityPage.expectToggle(toggle, initial);
   });
-
 });

--- a/web/tests/e2e/pages/AdminSecurityPage.ts
+++ b/web/tests/e2e/pages/AdminSecurityPage.ts
@@ -1,0 +1,78 @@
+/**
+ * Page Object Model for the Security & Hardening admin page (/admin/security).
+ *
+ * Encapsulates the toggle rows (each rendered as an Opal <Switch> inside an
+ * InputHorizontal <label>) and the save-confirmation toast so specs stay
+ * declarative and locator churn is confined to this file.
+ */
+
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class AdminSecurityPage {
+  readonly page: Page;
+  readonly savedToast: Locator;
+
+  // A stable, always-present, tenant-editable toggle — used as the subject for
+  // round-trip persistence checks (visible in both single- and multi-tenant).
+  static readonly SESSION_EXPIRY_TOGGLE =
+    "Sync Session Expiry with Identity Provider";
+
+  constructor(page: Page) {
+    this.page = page;
+    this.savedToast = page.getByText("Security settings updated");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Navigation
+  // ---------------------------------------------------------------------------
+
+  /** Navigate to the page and wait for it to finish loading. */
+  async goto(): Promise<void> {
+    await this.page.goto("/admin/security");
+    await this.waitForLoaded();
+  }
+
+  /** Reload the page and wait for it to finish loading. */
+  async reload(): Promise<void> {
+    await this.page.reload();
+    await this.waitForLoaded();
+  }
+
+  private async waitForLoaded(): Promise<void> {
+    await this.page.waitForLoadState("networkidle");
+    await expect(
+      this.page.getByText(AdminSecurityPage.SESSION_EXPIRY_TOGGLE)
+    ).toBeVisible({ timeout: 10000 });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Toggle rows
+  // ---------------------------------------------------------------------------
+
+  /** The <Switch> control for the toggle row with the given title. */
+  toggle(title: string): Locator {
+    return this.page
+      .getByText(title)
+      .locator("xpath=ancestor::label[1]")
+      .getByRole("switch");
+  }
+
+  /** Whether the named toggle is currently on (aria-checked === "true"). */
+  async isToggleOn(title: string): Promise<boolean> {
+    return (await this.toggle(title).getAttribute("aria-checked")) === "true";
+  }
+
+  /** Flip the named toggle and wait for the save-confirmation toast. */
+  async clickToggleAndSave(title: string): Promise<void> {
+    await this.toggle(title).click();
+    await expect(this.savedToast).toBeVisible({ timeout: 5000 });
+  }
+
+  /** Assert the named toggle is in the expected on/off state. */
+  async expectToggle(title: string, on: boolean): Promise<void> {
+    await expect(this.toggle(title)).toHaveAttribute(
+      "aria-checked",
+      on ? "true" : "false"
+    );
+  }
+}


### PR DESCRIPTION
## What

Wires the new **Security & Hardening** admin page (`/admin/security`) to the runtime security-settings API (`GET`/`PUT /admin/security`) introduced in the backend feature, surfaces it in the admin sidebar, and lays the page out to match the [Figma spec](https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=6493-235188).

- `SecurityHardeningPage.tsx` — reads effective settings via SWR, renders the spec's controls, and saves on change.
- `app/admin/security/page.tsx` — renders the real page (was a placeholder).
- `AdminSidebar.tsx` / `admin-routes.ts` — adds the page to the **Organization** section (admin-only, ungated) and titles it "Security & Hardening".
- E2E test for toggle → persist → reload.

<img width="2547" height="2085" alt="20260609_14h51m11s_grim" src="https://github.com/user-attachments/assets/d2811be5-7b92-4963-8560-b18bc8e2e79f" />

## Layout (matches Figma)

The page is organized into the spec's labeled sections:

- **Authentication** — Sync Session Expiry with Identity Provider; Restrict Email Domains (a toggle that reveals the Allowed Email Domains chip input); and a Password Policy card (min/max length with a `(characters)` suffix, Require Uppercase / Lowercase / **Number**, and Require Special Characters with the accepted-characters hint rendered inline as mono code).
- **Admin Controls** — Full User Directory Visibility and Mask Stored Credentials rendered as `InputSelect` **dropdowns** with per-option help text, mapped onto the existing booleans.

## Key design decision: PUT only the changed field(s)

The backend keys its PATCH semantics off **which keys are present in the body** (`present_keys`). The page now sends only the field(s) that changed instead of the full settings object. Sending the full object (the prior wiring) would have:

1. **Frozen every env-derived default in as an explicit override** — breaking the page's own contract that *"unset values fall back to your deployment's environment configuration."*
2. **Returned 403 in multi-tenant** — the PUT rejects any body containing operator-locked fields, and the full object always includes them (even though their controls are hidden in cloud).

The `PUT` response (effective, env-merged settings) becomes the source of truth, with optimistic updates for snappy toggles and rollback on error. The read type is the concrete `SecuritySettings` (GET never returns null); the write type is a partial patch where an explicit `null` clears an override back to the env default — mirroring the backend `SecuritySettings` / `SecuritySettingsOverrides` split.

## Notes

- Operator-locked controls (password policy, email domains, mask-credential, etc.) are hidden in multi-tenant, matching the backend's locked-field rules. In cloud, only Session Expiry and User Directory Visibility are editable.

## Test plan

- [x] `tsc` clean, `oxfmt`/`oxlint` clean
- [ ] Playwright: `web/tests/e2e/admin/security-hardening.spec.ts` (toggle persists across reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Security & Hardening admin page at `/admin/security`, wired to the runtime settings API with save-on-change and optimistic UI. The page matches the Figma spec, appears under Organization, and uses server-validated saves for correctness in single- and multi-tenant.

- **New Features**
  - Reads effective settings via SWR; PUTs only changed fields; optimistic updates with rollback; uses the PUT response as source of truth to preserve env defaults and avoid multi-tenant 403s.
  - Restructured into “Authentication” and “Admin Controls”; relabeled fields; dropdowns for User Directory Visibility and Mask Stored Credentials with per-option help; renamed “Require Digit” to “Require Number”; inline special-character hint.
  - Hides operator-locked controls in multi-tenant; shows password policy, email domains, and mask-credential in single-tenant.
  - Updates route title/label to “Security & Hardening”; adds the page to the admin sidebar; includes a Playwright test verifying toggle persistence.

- **Bug Fixes**
  - Registered `SWR_KEYS.adminSecuritySettings` and used it for all fetch/SWR/mutate calls.
  - Corrected Mask Stored Credentials labels to match backend semantics: true → “Partially Masked”, false → “Fully Visible”.
  - Failed saves now roll back by revalidating from the server (not a local snapshot).
  - E2E refactored to a Page Object and retargeted to the session-expiry toggle for stable persistence checks.
  - Guarded rollback revalidation failures so the error toast always shows and optimistic UI doesn’t freeze on network errors.

<sup>Written for commit 5ff8574497b9709d9860b070a1217a01154b359e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




