### PR TITLE
fix: fall back to global default model when personal default's provider is gone

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -681,6 +681,16 @@ def remove_llm_provider(
     for persona in get_personas_using_provider(db_session, provider_id):
         persona.default_model_configuration_id = None
 
+    # Clear personal default models referencing this provider. They are stored
+    # as "<provider display name>__<provider type>__<model name>" strings, so
+    # they'd otherwise dangle forever and silently resolve to an arbitrary
+    # provider in the UI instead of the global default.
+    db_session.execute(
+        update(User)
+        .where(User.default_model.startswith(f"{provider.name}__", autoescape=True))
+        .values(default_model=None)
+    )
+
     db_session.execute(
         delete(LLMProvider__UserGroup).where(
             LLMProvider__UserGroup.llm_provider_id == provider_id

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,4 +1,5 @@
 from sqlalchemy import delete
+from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert
@@ -686,11 +687,19 @@ def remove_llm_provider(
     # they'd otherwise dangle forever and silently resolve to an arbitrary
     # provider in the UI instead of the global default. Display names are not
     # unique at the DB level, so include the provider type in the match.
+    # Nameless providers have been serialized with either an empty display
+    # name or the provider id depending on the frontend writer, so match both.
+    display_names = [provider.name] if provider.name else ["", str(provider.id)]
     db_session.execute(
         update(User)
         .where(
-            User.default_model.startswith(
-                f"{provider.name or ''}__{provider.provider}__", autoescape=True
+            or_(
+                *(
+                    User.default_model.startswith(
+                        f"{display_name}__{provider.provider}__", autoescape=True
+                    )
+                    for display_name in display_names
+                )
             )
         )
         .values(default_model=None)

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -684,10 +684,15 @@ def remove_llm_provider(
     # Clear personal default models referencing this provider. They are stored
     # as "<provider display name>__<provider type>__<model name>" strings, so
     # they'd otherwise dangle forever and silently resolve to an arbitrary
-    # provider in the UI instead of the global default.
+    # provider in the UI instead of the global default. Display names are not
+    # unique at the DB level, so include the provider type in the match.
     db_session.execute(
         update(User)
-        .where(User.default_model.startswith(f"{provider.name}__", autoescape=True))
+        .where(
+            User.default_model.startswith(
+                f"{provider.name or ''}__{provider.provider}__", autoescape=True
+            )
+        )
         .values(default_model=None)
     )
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
@@ -1,0 +1,62 @@
+"""
+Tests that deleting an LLM provider clears personal default models
+(User.default_model) referencing it, so users fall back to the global
+default instead of a dangling provider reference.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import upsert_llm_provider
+from onyx.llm.constants import LlmProviderNames
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _create_test_provider(db_session: Session, name: str) -> LLMProviderView:
+    return upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=name,
+            provider=LlmProviderNames.OPENAI,
+            api_key="sk-test-key-00000000000000000000000000000000000",
+            api_key_changed=True,
+            model_configurations=[
+                ModelConfigurationUpsertRequest(name="gpt-4o-mini", is_visible=True)
+            ],
+        ),
+        db_session=db_session,
+    )
+
+
+def test_remove_llm_provider_clears_matching_user_defaults(
+    db_session: Session,
+) -> None:
+    provider_to_delete = _create_test_provider(
+        db_session, f"test-provider-{uuid4().hex[:8]}"
+    )
+    provider_to_keep = _create_test_provider(
+        db_session, f"test-provider-{uuid4().hex[:8]}"
+    )
+
+    affected_user = create_test_user(db_session, "default_model_cleared")
+    unaffected_user = create_test_user(db_session, "default_model_kept")
+
+    kept_default = f"{provider_to_keep.name}__openai__gpt-4o-mini"
+    affected_user.default_model = f"{provider_to_delete.name}__openai__gpt-4o-mini"
+    unaffected_user.default_model = kept_default
+    db_session.commit()
+
+    try:
+        remove_llm_provider(db_session, provider_to_delete.id)
+
+        db_session.refresh(affected_user)
+        db_session.refresh(unaffected_user)
+
+        assert affected_user.default_model is None
+        assert unaffected_user.default_model == kept_default
+    finally:
+        remove_llm_provider(db_session, provider_to_keep.id)

--- a/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_provider_user_default_cleanup.py
@@ -6,10 +6,12 @@ default instead of a dangling provider reference.
 
 from uuid import uuid4
 
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import upsert_llm_provider
+from onyx.db.models import User
 from onyx.llm.constants import LlmProviderNames
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import LLMProviderView
@@ -60,3 +62,8 @@ def test_remove_llm_provider_clears_matching_user_defaults(
         assert unaffected_user.default_model == kept_default
     finally:
         remove_llm_provider(db_session, provider_to_keep.id)
+        # Bulk delete to avoid loading the users' relationship graph
+        db_session.execute(
+            delete(User).where(User.id.in_([affected_user.id, unaffected_user.id]))
+        )
+        db_session.commit()

--- a/web/src/lib/hooks.llmResolver.test.ts
+++ b/web/src/lib/hooks.llmResolver.test.ts
@@ -144,6 +144,54 @@ describe("LLM resolver helpers", () => {
     });
   });
 
+  test("falls back to the global default when the saved model's provider is gone", () => {
+    const providers: LLMProviderDescriptor[] = [
+      makeProvider({
+        id: 10,
+        name: "First Provider",
+        provider: "openai",
+        model_configurations: [
+          {
+            name: "gpt-first",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+      makeProvider({
+        id: 20,
+        name: "Global Default Provider",
+        provider: "anthropic",
+        model_configurations: [
+          {
+            name: "claude-global-default",
+            is_visible: true,
+            max_input_tokens: null,
+            supports_image_input: false,
+            supports_reasoning: false,
+          },
+        ],
+      }),
+    ];
+
+    // Personal default points at a provider that no longer exists (e.g. it
+    // was deleted by an admin). The admin-configured global default should
+    // win over the first provider in the list.
+    const descriptor = getValidLlmDescriptorForProviders(
+      structureValue("Deleted Provider", "litellm", "some-old-model"),
+      providers,
+      { provider_id: 20, model_name: "claude-global-default" }
+    );
+
+    expect(descriptor).toEqual({
+      name: "Global Default Provider",
+      provider: "anthropic",
+      modelName: "claude-global-default",
+    });
+  });
+
   test("uses first provider with models when no explicit default exists", () => {
     const providers: LLMProviderDescriptor[] = [
       makeProvider({

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -490,7 +490,8 @@ export function getDefaultLlmDescriptor(
 
 export function getValidLlmDescriptorForProviders(
   modelName: string | null | undefined,
-  llmProviders: LLMProviderDescriptor[] | undefined | null
+  llmProviders: LLMProviderDescriptor[] | undefined | null,
+  defaultText?: DefaultModel | null
 ): LlmDescriptor {
   // Return early if providers haven't loaded yet (undefined/null)
   // Empty arrays are valid (user has no provider access for this assistant)
@@ -556,9 +557,12 @@ export function getValidLlmDescriptorForProviders(
     }
   }
 
-  // Model not found in available providers - fall back to default model
+  // Model not found in available providers - fall back to the admin-configured
+  // global default before resorting to the first provider with visible models.
+  // Without this, a stale personal default (e.g. its provider was deleted)
+  // would silently land on an arbitrary provider instead of the global default.
   return (
-    getDefaultLlmDescriptor(llmProviders) ?? {
+    getDefaultLlmDescriptor(llmProviders, defaultText) ?? {
       name: "",
       provider: "",
       modelName: "",
@@ -641,7 +645,11 @@ export function useLlmManager(
   function getValidLlmDescriptor(
     modelName: string | null | undefined
   ): LlmDescriptor {
-    return getValidLlmDescriptorForProviders(modelName, llmProviders);
+    return getValidLlmDescriptorForProviders(
+      modelName,
+      llmProviders,
+      defaultText
+    );
   }
 
   // Compute the resolved LLM synchronously so it's never one render behind.
@@ -666,12 +674,14 @@ export function useLlmManager(
     } else if (currentChatSession?.current_alternate_model) {
       resolved = getValidLlmDescriptorForProviders(
         currentChatSession.current_alternate_model,
-        llmProviders
+        llmProviders,
+        defaultText
       );
     } else if (user?.preferences?.default_model) {
       resolved = getValidLlmDescriptorForProviders(
         user.preferences.default_model,
-        llmProviders
+        llmProviders,
+        defaultText
       );
     } else {
       resolved =


### PR DESCRIPTION
## Description

When a user has a personal default model set (`User.default_model`) and the LLM provider backing it is later deleted, the chat UI silently resolved to the **first provider with visible models** instead of the admin-configured global default. The not-found fallback inside `getValidLlmDescriptorForProviders` called `getDefaultLlmDescriptor(llmProviders)` without passing the global default (`defaultText`), so the global default was only honored for users with no personal default at all.

Two changes:

1. **Frontend**: thread `defaultText` through `getValidLlmDescriptorForProviders` so stale personal defaults (and stale per-session alternate models) fall back to the global default before resorting to the first available provider.
2. **Backend**: `remove_llm_provider` now nulls out `User.default_model` values referencing the deleted provider (it already did the equivalent for persona-level defaults), so stale `name__provider__model` strings don't dangle forever.

## How Has This Been Tested?

- New jest case in `web/src/lib/hooks.llmResolver.test.ts`: a personal default pointing at a removed provider resolves to the global default, not the first provider in the list.
- New external dependency unit test `test_llm_provider_user_default_cleanup.py`: deleting a provider clears matching `User.default_model` rows and leaves other users' defaults untouched.
- Existing `backend/tests/external_dependency_unit/llm/test_llm_provider.py` and `test_llm_provider_default_model_protection.py` still pass (14/14).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model fallback so when a user's personal default points to a deleted provider, the UI now uses the admin global default instead of the first available provider. Also clears `User.default_model` on provider deletion, including nameless provider cases, to prevent dangling defaults.

- **Bug Fixes**
  - Frontend: Passes `defaultText` into `getValidLlmDescriptorForProviders` so missing models fall back to the global default before any provider; applies to personal defaults and per-session alternates.
  - Backend: `remove_llm_provider` now nulls `User.default_model` values referencing the removed provider by matching `<display name>__<provider type>__` prefixes; handles non-unique names and nameless providers by matching both empty display name and provider id.

<sup>Written for commit f7e1c9332ae3201f7913a70b94c6639e0d7cf277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/11866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


